### PR TITLE
fix: resolve release CI failures

### DIFF
--- a/.github/actions/setup-bun/setup.sh
+++ b/.github/actions/setup-bun/setup.sh
@@ -43,9 +43,17 @@ install_bun() {
         *)       echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
     esac
 
-    # Check for AVX2 support (x64 only)
+    # Detect OS
+    local os
+    case "$(uname -s)" in
+        Linux)  os="linux" ;;
+        Darwin) os="darwin" ;;
+        *)      echo "Unsupported OS: $(uname -s)"; exit 1 ;;
+    esac
+
+    # Check for AVX2 support (Linux x64 only)
     local avx2=""
-    if [[ "$arch" == "x64" ]]; then
+    if [[ "$os" == "linux" && "$arch" == "x64" ]]; then
         if grep -q avx2 /proc/cpuinfo 2>/dev/null; then
             avx2="true"
         else
@@ -54,7 +62,7 @@ install_bun() {
     fi
 
     # Build download URL
-    local url="https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-${arch}"
+    local url="https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-${os}-${arch}"
     if [[ "$avx2" == "false" ]]; then
         url="${url}-baseline"
     fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             target: bun-darwin-arm64
             binary: kai-darwin-arm64
             smoke: true
-          - runner: macos-13
+          - runner: macos-15-intel
             target: bun-darwin-x64
             binary: kai-darwin-x64
             smoke: true
@@ -55,6 +55,8 @@ jobs:
       - name: Smoke test
         if: matrix.smoke
         run: bun run scripts/smoke-test.ts ./dist/bin/${{ matrix.binary }}
+        env:
+          GLM_API_KEY: smoke-test
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Fix setup-bun action to detect OS via `uname -s` (was hardcoded to `linux`, failing on macOS runners)
- Replace retired `macos-13` runner with `macos-15-intel`
- Pass `GLM_API_KEY=smoke-test` env var to bypass auth check during smoke tests

## Test plan
- [ ] Release workflow passes on all platforms after merge