### PR TITLE
feat: add automated npm publish on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,10 +98,48 @@ jobs:
           mv dist/bin-flat dist/bin
 
       - name: Package npm packages
-        run: bun run scripts/package-npm.ts
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            bun run scripts/package-npm.ts --version ${GITHUB_REF_NAME#v}
+          else
+            bun run scripts/package-npm.ts
+          fi
 
       - name: Upload npm packages
         uses: actions/upload-artifact@v4
         with:
           name: npm-packages
           path: dist/npm/
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: package
+
+    steps:
+      - name: Download npm packages
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+          path: dist/npm/
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish platform packages
+        run: |
+          for pkg in dist/npm/cli-*; do
+            echo "Publishing $(basename $pkg)..."
+            cd "$pkg" && npm publish --access public && cd -
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish main package
+        run: cd dist/npm/neokai && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `publish` job to release workflow that publishes all 5 npm packages after build + smoke test + packaging
- Platform packages (`@neokai/cli-*`) are published first, then the main `neokai` wrapper
- Version is extracted from git tag (`v0.1.0` → `0.1.0`) for tag-triggered releases
- Falls back to `packages/cli/package.json` version for `workflow_dispatch`

## Prerequisites
- Add `NPM_TOKEN` secret to repo settings (npm automation token)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, `workflow_dispatch` trigger succeeds (publish step will fail without `NPM_TOKEN` — expected)
- [ ] Once `NPM_TOKEN` is set: `git tag v0.1.0 && git push origin v0.1.0` triggers full build → publish