### PR TITLE
fix: use npm Trusted Publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: package
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download npm packages
@@ -134,12 +137,8 @@ jobs:
         run: |
           for pkg in dist/npm/cli-*; do
             echo "Publishing $(basename $pkg)..."
-            cd "$pkg" && npm publish --access public && cd -
+            cd "$pkg" && npm publish --access public --provenance && cd -
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish main package
-        run: cd dist/npm/neokai && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd dist/npm/neokai && npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Switch from `NPM_TOKEN` secret to OIDC-based Trusted Publishing
- Add `id-token: write` permission for OIDC token exchange
- Add `--provenance` flag for npm supply chain attestation
- No secrets needed — npm authenticates via GitHub's OIDC provider

## Setup required
For each package on npmjs.com, configure Trusted Publishing:
1. Go to package Settings → Publishing access
2. Add Trusted Publisher: GitHub repo `lsm/neokai`, workflow `release.yml`, environment (leave blank)
3. Repeat for all 5 packages: `neokai`, `@neokai/cli-darwin-arm64`, `@neokai/cli-darwin-x64`, `@neokai/cli-linux-x64`, `@neokai/cli-linux-arm64`