### PR TITLE
fix: upgrade npm for Trusted Publishing OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for Trusted Publishing support
+        run: npm install -g npm@latest
+
       - name: Publish platform packages
         run: |
           for pkg in dist/npm/cli-*; do


### PR DESCRIPTION
## Summary
- Node 22's bundled npm doesn't properly handle the OIDC token exchange for npm Trusted Publishing, causing misleading "Access token expired" + E404 errors
- Added `npm install -g npm@latest` step to the publish job to get npm >= 11.5.1 which properly supports Trusted Publishing OIDC

## Context
The v0.1.0 release build/package succeeded but publish failed with:
```
npm notice Access token expired or revoked. Please try logging in again.
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@neokai%2fcli-darwin-arm64 - Not found
```

This is a [known issue](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/) with older npm versions and Trusted Publishing.

## Test plan
- [ ] Merge and re-tag release to verify publish succeeds