### PR TITLE
fix: make publish steps idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,4 +145,4 @@ jobs:
 
       - name: Publish main package
         run: |
-          cd dist/npm/neokai && npm publish --access public --provenance
+          cd dist/npm/neokai && npm publish --access public --provenance || echo "::warning::Failed to publish neokai, may already exist"


### PR DESCRIPTION
## Summary
- Added `|| echo "::warning::"` to the main package publish step (matching the platform packages step)
- This ensures re-running a release workflow doesn't fail if packages were already published

## Context
During the v0.1.0 release, partial publishes required multiple re-runs. The main `neokai` package step failed on re-run because it was already published.