### PR TITLE
fix: provide Claude OAuth token to E2E binary for Anthropic provider availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             bunx playwright test "tests/${{ matrix.test }}.e2e.ts"
         env:
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           DEFAULT_MODEL: haiku
           CI: true
           COVERAGE: true


### PR DESCRIPTION
## Summary
- E2E tests were failing because the compiled binary only had `GLM_API_KEY` set, making GLM the sole available provider
- With 80 parallel E2E tests all hitting the GLM API simultaneously, the quota was exhausted (429 error code 1113: "余额不足或无可用资源包")
- Adding `CLAUDE_CODE_OAUTH_TOKEN` to the E2E test environment enables Anthropic as the default provider, matching the `DEFAULT_MODEL: haiku` setting

## Test plan
- [ ] CI E2E tests should pass with Anthropic as the default provider
- [ ] GLM-specific tests should still work if they exist