### PR TITLE
fix: global settings configuration issues and missing UI options

### DIFF
--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -9,653 +9,572 @@
  * - Title generation and branch renaming
  */
 
-import type {
-  Session,
-  WorktreeMetadata,
-  MessageHub,
-  Provider,
-} from "@neokai/shared";
-import { generateUUID } from "@neokai/shared";
-import type { Database } from "../../storage/database";
-import type { DaemonHub } from "../daemon-hub";
-import type { WorktreeManager } from "../worktree-manager";
-import { Logger } from "../logger";
-import type { SessionCache, AgentSessionFactory } from "./session-cache";
-import type { ToolsConfigManager } from "./tools-config";
-import { getProviderService } from "../provider-service";
-import { deleteSDKSessionFiles } from "../sdk-session-file-manager";
-import {
-  resolveSDKCliPath,
-  isBundledBinary,
-} from "../agent/sdk-cli-resolver.js";
+import type { Session, WorktreeMetadata, MessageHub, Provider } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
+import type { Database } from '../../storage/database';
+import type { DaemonHub } from '../daemon-hub';
+import type { WorktreeManager } from '../worktree-manager';
+import { Logger } from '../logger';
+import type { SessionCache, AgentSessionFactory } from './session-cache';
+import type { ToolsConfigManager } from './tools-config';
+import { getProviderService } from '../provider-service';
+import { deleteSDKSessionFiles } from '../sdk-session-file-manager';
+import { resolveSDKCliPath, isBundledBinary } from '../agent/sdk-cli-resolver.js';
 
 export interface SessionLifecycleConfig {
-  defaultModel: string;
-  maxTokens: number;
-  temperature: number;
-  workspaceRoot: string;
-  disableWorktrees?: boolean;
+	defaultModel: string;
+	maxTokens: number;
+	temperature: number;
+	workspaceRoot: string;
+	disableWorktrees?: boolean;
 }
 
 export interface CreateSessionParams {
-  workspacePath?: string;
-  initialTools?: string[];
-  config?: Partial<Session["config"]>;
-  useWorktree?: boolean;
-  worktreeBaseBranch?: string;
-  title?: string; // Optional title - if provided, skips auto-title generation
+	workspacePath?: string;
+	initialTools?: string[];
+	config?: Partial<Session['config']>;
+	useWorktree?: boolean;
+	worktreeBaseBranch?: string;
+	title?: string; // Optional title - if provided, skips auto-title generation
 }
 
 export class SessionLifecycle {
-  private logger: Logger;
+	private logger: Logger;
 
-  constructor(
-    private db: Database,
-    private worktreeManager: WorktreeManager,
-    private sessionCache: SessionCache,
-    private eventBus: DaemonHub,
-    private messageHub: MessageHub,
-    private config: SessionLifecycleConfig,
-    private toolsConfigManager: ToolsConfigManager,
-    private createAgentSession: AgentSessionFactory,
-  ) {
-    this.logger = new Logger("SessionLifecycle");
-  }
+	constructor(
+		private db: Database,
+		private worktreeManager: WorktreeManager,
+		private sessionCache: SessionCache,
+		private eventBus: DaemonHub,
+		private messageHub: MessageHub,
+		private config: SessionLifecycleConfig,
+		private toolsConfigManager: ToolsConfigManager,
+		private createAgentSession: AgentSessionFactory
+	) {
+		this.logger = new Logger('SessionLifecycle');
+	}
 
-  /**
-   * Create a new session
-   */
-  async create(params: CreateSessionParams): Promise<string> {
-    const sessionId = generateUUID();
+	/**
+	 * Create a new session
+	 */
+	async create(params: CreateSessionParams): Promise<string> {
+		const sessionId = generateUUID();
 
-    const baseWorkspacePath = params.workspacePath || this.config.workspaceRoot;
+		const baseWorkspacePath = params.workspacePath || this.config.workspaceRoot;
 
-    // Read global settings for defaults (model, thinkingLevel, autoScroll)
-    const globalSettings = this.db.getGlobalSettings();
+		// Read global settings for defaults (model, thinkingLevel, autoScroll)
+		const globalSettings = this.db.getGlobalSettings();
 
-    // Validate and resolve model ID using cached models
-    // Priority: params.config.model > globalSettings.model > server default
-    const requestedModel = params.config?.model || globalSettings.model;
-    const modelId = await this.getValidatedModelId(requestedModel);
+		// Validate and resolve model ID using cached models
+		// Priority: params.config.model > globalSettings.model > server default
+		const requestedModel = params.config?.model || globalSettings.model;
+		const modelId = await this.getValidatedModelId(requestedModel);
 
-    // Determine if title should be auto-generated
-    // If title is provided, mark as generated to skip auto-title generation
-    const providedTitle = params.title?.trim();
-    const shouldSkipAutoTitle = Boolean(providedTitle);
+		// Determine if title should be auto-generated
+		// If title is provided, mark as generated to skip auto-title generation
+		const providedTitle = params.title?.trim();
+		const shouldSkipAutoTitle = Boolean(providedTitle);
 
-    // Create worktree with appropriate branch name
-    // If title provided, use meaningful branch name; otherwise use session/{uuid}
-    let worktreeMetadata: WorktreeMetadata | undefined;
-    let sessionWorkspacePath = baseWorkspacePath;
-    const initialBranchName = shouldSkipAutoTitle
-      ? generateBranchName(providedTitle!, sessionId) // Title is defined when shouldSkipAutoTitle is true
-      : `session/${sessionId}`;
+		// Create worktree with appropriate branch name
+		// If title provided, use meaningful branch name; otherwise use session/{uuid}
+		let worktreeMetadata: WorktreeMetadata | undefined;
+		let sessionWorkspacePath = baseWorkspacePath;
+		const initialBranchName = shouldSkipAutoTitle
+			? generateBranchName(providedTitle!, sessionId) // Title is defined when shouldSkipAutoTitle is true
+			: `session/${sessionId}`;
 
-    if (!this.config.disableWorktrees) {
-      try {
-        const result = await this.worktreeManager.createWorktree({
-          sessionId,
-          repoPath: baseWorkspacePath,
-          branchName: initialBranchName,
-          baseBranch: params.worktreeBaseBranch || "HEAD",
-        });
+		if (!this.config.disableWorktrees) {
+			try {
+				const result = await this.worktreeManager.createWorktree({
+					sessionId,
+					repoPath: baseWorkspacePath,
+					branchName: initialBranchName,
+					baseBranch: params.worktreeBaseBranch || 'HEAD',
+				});
 
-        if (result) {
-          worktreeMetadata = result;
-          sessionWorkspacePath = result.worktreePath;
-          this.logger.info(
-            `[SessionLifecycle] Created worktree at ${result.worktreePath} with branch ${result.branch}`,
-          );
-        }
-      } catch (error) {
-        this.logger.error(
-          "[SessionLifecycle] Failed to create worktree during session creation:",
-          error,
-        );
-        // Continue without worktree - fallback to base workspace
-      }
-    }
+				if (result) {
+					worktreeMetadata = result;
+					sessionWorkspacePath = result.worktreePath;
+					this.logger.info(
+						`[SessionLifecycle] Created worktree at ${result.worktreePath} with branch ${result.branch}`
+					);
+				}
+			} catch (error) {
+				this.logger.error(
+					'[SessionLifecycle] Failed to create worktree during session creation:',
+					error
+				);
+				// Continue without worktree - fallback to base workspace
+			}
+		}
 
-    const session: Session = {
-      id: sessionId,
-      title: providedTitle || "New Session",
-      workspacePath: sessionWorkspacePath,
-      createdAt: new Date().toISOString(),
-      lastActiveAt: new Date().toISOString(),
-      status: "active",
-      config: {
-        model: modelId, // Use validated model ID
-        maxTokens: params.config?.maxTokens || this.config.maxTokens,
-        temperature: params.config?.temperature || this.config.temperature,
-        // Apply global settings defaults for autoScroll and thinkingLevel
-        autoScroll: params.config?.autoScroll ?? globalSettings.autoScroll,
-        thinkingLevel:
-          params.config?.thinkingLevel ?? globalSettings.thinkingLevel,
-        permissionMode: params.config?.permissionMode,
-        // Provider: Allow explicit override, otherwise default to 'anthropic'
-        provider: params.config?.provider,
-        // Tools config: Use global defaults for new sessions
-        // SDK built-in tools are always enabled (not configurable)
-        // MCP and NeoKai tools are configurable based on global settings
-        tools:
-          params.config?.tools ??
-          this.toolsConfigManager.getDefaultForNewSession(),
-      },
-      metadata: {
-        messageCount: 0,
-        totalTokens: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        totalCost: 0,
-        toolCallCount: 0,
-        // Mark as generated if title was provided to skip auto-title generation
-        titleGenerated: shouldSkipAutoTitle,
-        // Workspace is already initialized (worktree created or using base path)
-        workspaceInitialized: true,
-      },
-      // Worktree set during creation (if enabled)
-      worktree: worktreeMetadata,
-      gitBranch: worktreeMetadata?.branch,
-    };
+		const session: Session = {
+			id: sessionId,
+			title: providedTitle || 'New Session',
+			workspacePath: sessionWorkspacePath,
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'active',
+			config: {
+				model: modelId, // Use validated model ID
+				maxTokens: params.config?.maxTokens || this.config.maxTokens,
+				temperature: params.config?.temperature || this.config.temperature,
+				// Apply global settings defaults for autoScroll and thinkingLevel
+				autoScroll: params.config?.autoScroll ?? globalSettings.autoScroll,
+				thinkingLevel: params.config?.thinkingLevel ?? globalSettings.thinkingLevel,
+				permissionMode: params.config?.permissionMode,
+				// Provider: Allow explicit override, otherwise default to 'anthropic'
+				provider: params.config?.provider,
+				// Tools config: Use global defaults for new sessions
+				// SDK built-in tools are always enabled (not configurable)
+				// MCP and NeoKai tools are configurable based on global settings
+				tools: params.config?.tools ?? this.toolsConfigManager.getDefaultForNewSession(),
+			},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+				// Mark as generated if title was provided to skip auto-title generation
+				titleGenerated: shouldSkipAutoTitle,
+				// Workspace is already initialized (worktree created or using base path)
+				workspaceInitialized: true,
+			},
+			// Worktree set during creation (if enabled)
+			worktree: worktreeMetadata,
+			gitBranch: worktreeMetadata?.branch,
+		};
 
-    // Save to database
-    this.db.createSession(session);
+		// Save to database
+		this.db.createSession(session);
 
-    // Create agent session and add to cache
-    const agentSession = this.createAgentSession(session);
-    this.sessionCache.set(sessionId, agentSession);
+		// Create agent session and add to cache
+		const agentSession = this.createAgentSession(session);
+		this.sessionCache.set(sessionId, agentSession);
 
-    // Emit event via EventBus (StateManager will handle publishing to MessageHub)
-    this.logger.info(
-      "[SessionLifecycle] Emitting session:created event for session:",
-      sessionId,
-    );
-    await this.eventBus.emit("session.created", { sessionId, session });
-    this.logger.info(
-      "[SessionLifecycle] Event emitted, returning sessionId:",
-      sessionId,
-    );
+		// Emit event via EventBus (StateManager will handle publishing to MessageHub)
+		this.logger.info('[SessionLifecycle] Emitting session:created event for session:', sessionId);
+		await this.eventBus.emit('session.created', { sessionId, session });
+		this.logger.info('[SessionLifecycle] Event emitted, returning sessionId:', sessionId);
 
-    return sessionId;
-  }
+		return sessionId;
+	}
 
-  /**
-   * Update a session
-   */
-  async update(sessionId: string, updates: Partial<Session>): Promise<void> {
-    this.db.updateSession(sessionId, updates);
+	/**
+	 * Update a session
+	 */
+	async update(sessionId: string, updates: Partial<Session>): Promise<void> {
+		this.db.updateSession(sessionId, updates);
 
-    // Update in-memory session if exists
-    const agentSession = this.sessionCache.has(sessionId)
-      ? this.sessionCache.get(sessionId)
-      : null;
-    if (agentSession) {
-      agentSession.updateMetadata(updates);
-    }
+		// Update in-memory session if exists
+		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
+		if (agentSession) {
+			agentSession.updateMetadata(updates);
+		}
 
-    // FIX: Emit event via EventBus - include data for decoupled state management
-    await this.eventBus.emit("session.updated", {
-      sessionId,
-      source: "update",
-      session: updates,
-    });
-  }
+		// FIX: Emit event via EventBus - include data for decoupled state management
+		await this.eventBus.emit('session.updated', {
+			sessionId,
+			source: 'update',
+			session: updates,
+		});
+	}
 
-  /**
-   * Delete a session with atomic cleanup
-   *
-   * Uses a phased approach with state tracking to ensure cleanup succeeds
-   * or fails gracefully without leaving orphaned resources.
-   *
-   * Phases:
-   * 1. Cleanup AgentSession (stops SDK subprocess)
-   * 2. Delete worktree and branch
-   * 3. Delete from database
-   * 4. Remove from cache
-   * 5. Broadcast deletion event
-   *
-   * If any phase fails, the error is logged but cleanup continues.
-   * Orphaned resources (worktrees, branches) can be cleaned up via global teardown.
-   */
-  async delete(sessionId: string): Promise<void> {
-    this.logger.info(
-      `[SessionLifecycle] Starting deletion for session ${sessionId}`,
-    );
+	/**
+	 * Delete a session with atomic cleanup
+	 *
+	 * Uses a phased approach with state tracking to ensure cleanup succeeds
+	 * or fails gracefully without leaving orphaned resources.
+	 *
+	 * Phases:
+	 * 1. Cleanup AgentSession (stops SDK subprocess)
+	 * 2. Delete worktree and branch
+	 * 3. Delete from database
+	 * 4. Remove from cache
+	 * 5. Broadcast deletion event
+	 *
+	 * If any phase fails, the error is logged but cleanup continues.
+	 * Orphaned resources (worktrees, branches) can be cleaned up via global teardown.
+	 */
+	async delete(sessionId: string): Promise<void> {
+		this.logger.info(`[SessionLifecycle] Starting deletion for session ${sessionId}`);
 
-    // Get references before deletion
-    const agentSession = this.sessionCache.has(sessionId)
-      ? this.sessionCache.get(sessionId)
-      : null;
-    const session = this.db.getSession(sessionId);
+		// Get references before deletion
+		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
+		const session = this.db.getSession(sessionId);
 
-    // Track completed phases for potential rollback
-    const completedPhases: string[] = [];
+		// Track completed phases for potential rollback
+		const completedPhases: string[] = [];
 
-    try {
-      // PHASE 1: Cleanup AgentSession (stops SDK subprocess)
-      // This is critical - must complete before other cleanup
-      if (agentSession) {
-        this.logger.info(
-          `[SessionLifecycle] PHASE 1: Cleaning up AgentSession`,
-        );
-        try {
-          await agentSession.cleanup();
-          completedPhases.push("agent-cleanup");
-        } catch (error) {
-          this.logger.error(
-            `[SessionLifecycle] AgentSession cleanup failed:`,
-            error,
-          );
-          // Continue with deletion - SDK subprocess will be terminated when process exits
-        }
-      }
+		try {
+			// PHASE 1: Cleanup AgentSession (stops SDK subprocess)
+			// This is critical - must complete before other cleanup
+			if (agentSession) {
+				this.logger.info(`[SessionLifecycle] PHASE 1: Cleaning up AgentSession`);
+				try {
+					await agentSession.cleanup();
+					completedPhases.push('agent-cleanup');
+				} catch (error) {
+					this.logger.error(`[SessionLifecycle] AgentSession cleanup failed:`, error);
+					// Continue with deletion - SDK subprocess will be terminated when process exits
+				}
+			}
 
-      // PHASE 1.5: Delete SDK session files from ~/.claude/projects/
-      // This removes the .jsonl files created by Claude Agent SDK
-      if (session) {
-        this.logger.info(
-          `[SessionLifecycle] PHASE 1.5: Removing SDK session files`,
-        );
-        try {
-          const deleteResult = deleteSDKSessionFiles(
-            session.workspacePath,
-            session.sdkSessionId ?? null,
-            sessionId,
-          );
-          if (deleteResult.deletedFiles.length > 0) {
-            this.logger.info(
-              `[SessionLifecycle] Deleted ${deleteResult.deletedFiles.length} SDK file(s), ` +
-                `${(deleteResult.deletedSize / 1024).toFixed(1)}KB freed`,
-            );
-          }
-          completedPhases.push(
-            deleteResult.success
-              ? "sdk-files-delete"
-              : "sdk-files-delete-partial",
-          );
-        } catch (error) {
-          this.logger.error(
-            `[SessionLifecycle] SDK file deletion failed:`,
-            error,
-          );
-          // Non-critical - continue with other cleanup
-        }
-      }
+			// PHASE 1.5: Delete SDK session files from ~/.claude/projects/
+			// This removes the .jsonl files created by Claude Agent SDK
+			if (session) {
+				this.logger.info(`[SessionLifecycle] PHASE 1.5: Removing SDK session files`);
+				try {
+					const deleteResult = deleteSDKSessionFiles(
+						session.workspacePath,
+						session.sdkSessionId ?? null,
+						sessionId
+					);
+					if (deleteResult.deletedFiles.length > 0) {
+						this.logger.info(
+							`[SessionLifecycle] Deleted ${deleteResult.deletedFiles.length} SDK file(s), ` +
+								`${(deleteResult.deletedSize / 1024).toFixed(1)}KB freed`
+						);
+					}
+					completedPhases.push(
+						deleteResult.success ? 'sdk-files-delete' : 'sdk-files-delete-partial'
+					);
+				} catch (error) {
+					this.logger.error(`[SessionLifecycle] SDK file deletion failed:`, error);
+					// Non-critical - continue with other cleanup
+				}
+			}
 
-      // PHASE 2: Delete worktree and branch
-      // Must happen before DB deletion (we need the worktree metadata)
-      if (session?.worktree) {
-        this.logger.info(
-          `[SessionLifecycle] PHASE 2: Removing worktree for session ${sessionId}`,
-        );
-        try {
-          await this.worktreeManager.removeWorktree(session.worktree, true);
+			// PHASE 2: Delete worktree and branch
+			// Must happen before DB deletion (we need the worktree metadata)
+			if (session?.worktree) {
+				this.logger.info(`[SessionLifecycle] PHASE 2: Removing worktree for session ${sessionId}`);
+				try {
+					await this.worktreeManager.removeWorktree(session.worktree, true);
 
-          // Verify worktree was actually removed
-          const stillExists = await this.worktreeManager.verifyWorktree(
-            session.worktree,
-          );
-          if (stillExists) {
-            this.logger.warn(
-              `[SessionLifecycle] Worktree still exists after removal: ${session.worktree.worktreePath}`,
-            );
-            // Track for global teardown
-            completedPhases.push("worktree-cleanup-partial");
-          } else {
-            this.logger.info(
-              `[SessionLifecycle] Worktree successfully removed`,
-            );
-            completedPhases.push("worktree-cleanup");
-          }
-        } catch (error) {
-          const errorMsg =
-            error instanceof Error ? error.message : String(error);
-          this.logger.error(
-            `[SessionLifecycle] Worktree removal failed (global teardown will handle): ${errorMsg}`,
-          );
-          // Don't add to completedPhases - worktree cleanup failed
-        }
-      }
+					// Verify worktree was actually removed
+					const stillExists = await this.worktreeManager.verifyWorktree(session.worktree);
+					if (stillExists) {
+						this.logger.warn(
+							`[SessionLifecycle] Worktree still exists after removal: ${session.worktree.worktreePath}`
+						);
+						// Track for global teardown
+						completedPhases.push('worktree-cleanup-partial');
+					} else {
+						this.logger.info(`[SessionLifecycle] Worktree successfully removed`);
+						completedPhases.push('worktree-cleanup');
+					}
+				} catch (error) {
+					const errorMsg = error instanceof Error ? error.message : String(error);
+					this.logger.error(
+						`[SessionLifecycle] Worktree removal failed (global teardown will handle): ${errorMsg}`
+					);
+					// Don't add to completedPhases - worktree cleanup failed
+				}
+			}
 
-      // PHASE 3: Delete from database
-      // This is the point of no return - session is considered deleted
-      this.logger.info(
-        `[SessionLifecycle] PHASE 3: Deleting session from database`,
-      );
-      try {
-        this.db.deleteSession(sessionId);
-        completedPhases.push("db-delete");
-      } catch (error) {
-        this.logger.error(
-          `[SessionLifecycle] Database deletion failed:`,
-          error,
-        );
-        throw error; // Re-throw - if we can't delete from DB, deletion failed
-      }
+			// PHASE 3: Delete from database
+			// This is the point of no return - session is considered deleted
+			this.logger.info(`[SessionLifecycle] PHASE 3: Deleting session from database`);
+			try {
+				this.db.deleteSession(sessionId);
+				completedPhases.push('db-delete');
+			} catch (error) {
+				this.logger.error(`[SessionLifecycle] Database deletion failed:`, error);
+				throw error; // Re-throw - if we can't delete from DB, deletion failed
+			}
 
-      // PHASE 4: Remove from cache
-      this.logger.info(
-        `[SessionLifecycle] PHASE 4: Removing session from cache`,
-      );
-      try {
-        this.sessionCache.remove(sessionId);
-        completedPhases.push("cache-remove");
-      } catch (error) {
-        this.logger.error(`[SessionLifecycle] Cache removal failed:`, error);
-        // Non-critical - session will be garbage collected
-      }
+			// PHASE 4: Remove from cache
+			this.logger.info(`[SessionLifecycle] PHASE 4: Removing session from cache`);
+			try {
+				this.sessionCache.remove(sessionId);
+				completedPhases.push('cache-remove');
+			} catch (error) {
+				this.logger.error(`[SessionLifecycle] Cache removal failed:`, error);
+				// Non-critical - session will be garbage collected
+			}
 
-      // PHASE 5: Broadcast deletion event
-      // Best-effort notification - failure doesn't affect deletion
-      this.logger.info(
-        `[SessionLifecycle] PHASE 5: Broadcasting deletion event`,
-      );
-      try {
-        await Promise.all([
-          this.messageHub.publish(
-            "session.deleted",
-            { sessionId, reason: "deleted" },
-            { sessionId: "global" },
-          ),
-          this.eventBus.emit("session.deleted", { sessionId }),
-        ]);
-        completedPhases.push("broadcast");
-      } catch (error) {
-        this.logger.error(
-          `[SessionLifecycle] Failed to broadcast deletion:`,
-          error,
-        );
-        // Non-critical - session is already deleted
-      }
+			// PHASE 5: Broadcast deletion event
+			// Best-effort notification - failure doesn't affect deletion
+			this.logger.info(`[SessionLifecycle] PHASE 5: Broadcasting deletion event`);
+			try {
+				await Promise.all([
+					this.messageHub.publish(
+						'session.deleted',
+						{ sessionId, reason: 'deleted' },
+						{ sessionId: 'global' }
+					),
+					this.eventBus.emit('session.deleted', { sessionId }),
+				]);
+				completedPhases.push('broadcast');
+			} catch (error) {
+				this.logger.error(`[SessionLifecycle] Failed to broadcast deletion:`, error);
+				// Non-critical - session is already deleted
+			}
 
-      this.logger.info(
-        `[SessionLifecycle] Session ${sessionId} deleted successfully (completed phases: ${completedPhases.join(", ")})`,
-      );
-    } catch (error) {
-      // Critical failure - log what was completed
-      this.logger.error(
-        `[SessionLifecycle] Session deletion FAILED (completed phases: ${completedPhases.join(", ")}):`,
-        error,
-      );
+			this.logger.info(
+				`[SessionLifecycle] Session ${sessionId} deleted successfully (completed phases: ${completedPhases.join(', ')})`
+			);
+		} catch (error) {
+			// Critical failure - log what was completed
+			this.logger.error(
+				`[SessionLifecycle] Session deletion FAILED (completed phases: ${completedPhases.join(', ')}):`,
+				error
+			);
 
-      // Note: True rollback isn't feasible because:
-      // - We can't restore a deleted DB record without original data
-      // - We can't recreate a deleted worktree/branch
-      // - AgentSession can't be "uncleaned"
-      //
-      // The strategy instead is:
-      // - Track completed phases for diagnostics
-      // - Allow global teardown to clean up orphaned resources
-      // - Log clearly what succeeded and what failed
+			// Note: True rollback isn't feasible because:
+			// - We can't restore a deleted DB record without original data
+			// - We can't recreate a deleted worktree/branch
+			// - AgentSession can't be "uncleaned"
+			//
+			// The strategy instead is:
+			// - Track completed phases for diagnostics
+			// - Allow global teardown to clean up orphaned resources
+			// - Log clearly what succeeded and what failed
 
-      throw error;
-    }
-  }
+			throw error;
+		}
+	}
 
-  /**
-   * Get session metadata directly from database without loading SDK
-   * Used for operations that don't require SDK initialization (e.g., removing tool outputs)
-   */
-  getFromDB(sessionId: string): Session | null {
-    return this.db.getSession(sessionId);
-  }
+	/**
+	 * Get session metadata directly from database without loading SDK
+	 * Used for operations that don't require SDK initialization (e.g., removing tool outputs)
+	 */
+	getFromDB(sessionId: string): Session | null {
+		return this.db.getSession(sessionId);
+	}
 
-  /**
-   * Mark a message's tool output as removed from SDK session file
-   * This updates the session metadata to track which outputs were deleted
-   */
-  async markOutputRemoved(
-    sessionId: string,
-    messageUuid: string,
-  ): Promise<void> {
-    const session = this.db.getSession(sessionId);
-    if (!session) {
-      throw new Error("Session not found");
-    }
+	/**
+	 * Mark a message's tool output as removed from SDK session file
+	 * This updates the session metadata to track which outputs were deleted
+	 */
+	async markOutputRemoved(sessionId: string, messageUuid: string): Promise<void> {
+		const session = this.db.getSession(sessionId);
+		if (!session) {
+			throw new Error('Session not found');
+		}
 
-    // Add messageUuid to removedOutputs array (if not already present)
-    const removedOutputs = session.metadata.removedOutputs || [];
-    if (!removedOutputs.includes(messageUuid)) {
-      removedOutputs.push(messageUuid);
-    }
+		// Add messageUuid to removedOutputs array (if not already present)
+		const removedOutputs = session.metadata.removedOutputs || [];
+		if (!removedOutputs.includes(messageUuid)) {
+			removedOutputs.push(messageUuid);
+		}
 
-    // Update session metadata
-    await this.update(sessionId, {
-      metadata: {
-        ...session.metadata,
-        removedOutputs,
-      },
-    });
-  }
+		// Update session metadata
+		await this.update(sessionId, {
+			metadata: {
+				...session.metadata,
+				removedOutputs,
+			},
+		});
+	}
 
-  /**
-   * Generate title and rename branch for a session
-   * Called on first message to:
-   * - Generate meaningful title from user message
-   * - Rename branch from session/{uuid} to session/{slug}-{shortId}
-   * - Update session record
-   *
-   * NOTE: Worktree is already created during session creation with session/{uuid} branch.
-   * This method only generates title and renames the branch.
-   *
-   * @returns Object with title and isFallback flag indicating if title was actually generated
-   */
-  async generateTitleAndRenameBranch(
-    sessionId: string,
-    userMessageText: string,
-  ): Promise<{ title: string; isFallback: boolean }> {
-    const agentSession = this.sessionCache.has(sessionId)
-      ? this.sessionCache.get(sessionId)
-      : null;
-    if (!agentSession) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+	/**
+	 * Generate title and rename branch for a session
+	 * Called on first message to:
+	 * - Generate meaningful title from user message
+	 * - Rename branch from session/{uuid} to session/{slug}-{shortId}
+	 * - Update session record
+	 *
+	 * NOTE: Worktree is already created during session creation with session/{uuid} branch.
+	 * This method only generates title and renames the branch.
+	 *
+	 * @returns Object with title and isFallback flag indicating if title was actually generated
+	 */
+	async generateTitleAndRenameBranch(
+		sessionId: string,
+		userMessageText: string
+	): Promise<{ title: string; isFallback: boolean }> {
+		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
+		if (!agentSession) {
+			throw new Error(`Session ${sessionId} not found`);
+		}
 
-    const session = agentSession.getSessionData();
+		const session = agentSession.getSessionData();
 
-    // Check if title already generated
-    if (session.metadata.titleGenerated) {
-      this.logger.info(
-        `[SessionLifecycle] Session ${sessionId} title already generated`,
-      );
-      return { title: session.title, isFallback: false };
-    }
+		// Check if title already generated
+		if (session.metadata.titleGenerated) {
+			this.logger.info(`[SessionLifecycle] Session ${sessionId} title already generated`);
+			return { title: session.title, isFallback: false };
+		}
 
-    this.logger.info(
-      `[SessionLifecycle] Generating title for session ${sessionId}...`,
-    );
+		this.logger.info(`[SessionLifecycle] Generating title for session ${sessionId}...`);
 
-    try {
-      // Step 1: Generate title from user message using Haiku model
-      const { title, isFallback } = await this.generateTitleFromMessage(
-        userMessageText,
-        session.workspacePath,
-      );
+		try {
+			// Step 1: Generate title from user message using Haiku model
+			const { title, isFallback } = await this.generateTitleFromMessage(
+				userMessageText,
+				session.workspacePath
+			);
 
-      // Step 2: Rename branch if we have a worktree
-      let newBranchName = session.worktree?.branch;
-      if (session.worktree) {
-        const newBranch = generateBranchName(title, sessionId);
-        const oldBranch = session.worktree.branch;
+			// Step 2: Rename branch if we have a worktree
+			let newBranchName = session.worktree?.branch;
+			if (session.worktree) {
+				const newBranch = generateBranchName(title, sessionId);
+				const oldBranch = session.worktree.branch;
 
-        // Only rename if branch name is different (i.e., it's still session/{uuid})
-        if (oldBranch !== newBranch) {
-          const renamed = await this.worktreeManager.renameBranch(
-            session.worktree.mainRepoPath,
-            oldBranch,
-            newBranch,
-          );
+				// Only rename if branch name is different (i.e., it's still session/{uuid})
+				if (oldBranch !== newBranch) {
+					const renamed = await this.worktreeManager.renameBranch(
+						session.worktree.mainRepoPath,
+						oldBranch,
+						newBranch
+					);
 
-          if (renamed) {
-            newBranchName = newBranch;
-            this.logger.info(
-              `[SessionLifecycle] Renamed branch from ${oldBranch} to ${newBranch}`,
-            );
-          } else {
-            this.logger.info(
-              `[SessionLifecycle] Failed to rename branch, keeping ${oldBranch}`,
-            );
-          }
-        }
-      }
+					if (renamed) {
+						newBranchName = newBranch;
+						this.logger.info(`[SessionLifecycle] Renamed branch from ${oldBranch} to ${newBranch}`);
+					} else {
+						this.logger.info(`[SessionLifecycle] Failed to rename branch, keeping ${oldBranch}`);
+					}
+				}
+			}
 
-      // Step 3: Update session record
-      const updatedSession: Session = {
-        ...session,
-        title,
-        worktree: session.worktree
-          ? {
-              ...session.worktree,
-              branch: newBranchName || session.worktree.branch,
-            }
-          : undefined,
-        gitBranch: newBranchName || session.gitBranch,
-        metadata: {
-          ...session.metadata,
-          // Only mark as generated if not a fallback
-          titleGenerated: !isFallback,
-        },
-      };
+			// Step 3: Update session record
+			const updatedSession: Session = {
+				...session,
+				title,
+				worktree: session.worktree
+					? {
+							...session.worktree,
+							branch: newBranchName || session.worktree.branch,
+						}
+					: undefined,
+				gitBranch: newBranchName || session.gitBranch,
+				metadata: {
+					...session.metadata,
+					// Only mark as generated if not a fallback
+					titleGenerated: !isFallback,
+				},
+			};
 
-      // Save to DB
-      this.db.updateSession(sessionId, updatedSession);
+			// Save to DB
+			this.db.updateSession(sessionId, updatedSession);
 
-      // Update in-memory session
-      agentSession.updateMetadata(updatedSession);
+			// Update in-memory session
+			agentSession.updateMetadata(updatedSession);
 
-      // Broadcast updates - include session data for decoupled state management
-      await this.eventBus.emit("session.updated", {
-        sessionId,
-        source: "title-generated",
-        session: updatedSession,
-      });
+			// Broadcast updates - include session data for decoupled state management
+			await this.eventBus.emit('session.updated', {
+				sessionId,
+				source: 'title-generated',
+				session: updatedSession,
+			});
 
-      if (isFallback) {
-        this.logger.warn(
-          `[SessionLifecycle] Used fallback title for session ${sessionId}: "${title}"`,
-        );
-      } else {
-        this.logger.info(
-          `[SessionLifecycle] Title generated for session ${sessionId}: "${title}"`,
-        );
-      }
+			if (isFallback) {
+				this.logger.warn(
+					`[SessionLifecycle] Used fallback title for session ${sessionId}: "${title}"`
+				);
+			} else {
+				this.logger.info(`[SessionLifecycle] Title generated for session ${sessionId}: "${title}"`);
+			}
 
-      // Return result so caller can check if it was a fallback
-      return { title, isFallback };
-    } catch (error) {
-      this.logger.error("[SessionLifecycle] Failed to generate title:", error);
+			// Return result so caller can check if it was a fallback
+			return { title, isFallback };
+		} catch (error) {
+			this.logger.error('[SessionLifecycle] Failed to generate title:', error);
 
-      // Fallback: Use first 50 chars of message as title
-      const fallbackTitle =
-        userMessageText.substring(0, 50).trim() || "New Session";
-      const fallbackSession: Session = {
-        ...session,
-        title: fallbackTitle,
-        metadata: {
-          ...session.metadata,
-          titleGenerated: false, // Mark as not generated (user can retry)
-        },
-      };
+			// Fallback: Use first 50 chars of message as title
+			const fallbackTitle = userMessageText.substring(0, 50).trim() || 'New Session';
+			const fallbackSession: Session = {
+				...session,
+				title: fallbackTitle,
+				metadata: {
+					...session.metadata,
+					titleGenerated: false, // Mark as not generated (user can retry)
+				},
+			};
 
-      this.db.updateSession(sessionId, fallbackSession);
-      agentSession.updateMetadata(fallbackSession);
+			this.db.updateSession(sessionId, fallbackSession);
+			agentSession.updateMetadata(fallbackSession);
 
-      // Include session data for decoupled state management
-      await this.eventBus.emit("session.updated", {
-        sessionId,
-        source: "title-generated",
-        session: fallbackSession,
-      });
+			// Include session data for decoupled state management
+			await this.eventBus.emit('session.updated', {
+				sessionId,
+				source: 'title-generated',
+				session: fallbackSession,
+			});
 
-      this.logger.info(
-        `[SessionLifecycle] Used fallback title "${fallbackTitle}" for session ${sessionId}`,
-      );
+			this.logger.info(
+				`[SessionLifecycle] Used fallback title "${fallbackTitle}" for session ${sessionId}`
+			);
 
-      // Return result so caller can check if it was a fallback
-      return { title: fallbackTitle, isFallback: true };
-    }
-  }
+			// Return result so caller can check if it was a fallback
+			return { title: fallbackTitle, isFallback: true };
+		}
+	}
 
-  /**
-   * Generate title from first user message using direct API call
-   * This bypasses the SDK subprocess and calls the Anthropic-like API directly
-   *
-   * @returns Object with title and isFallback flag
-   */
-  private async generateTitleFromMessage(
-    messageText: string,
-    _sessionWorkspacePath: string,
-  ): Promise<{ title: string; isFallback: boolean }> {
-    // Get provider service to detect provider and get API configuration
-    const providerService = getProviderService();
-    const provider = await providerService.getDefaultProvider();
-    const apiKey = providerService.getProviderApiKey(provider);
+	/**
+	 * Generate title from first user message using direct API call
+	 * This bypasses the SDK subprocess and calls the Anthropic-like API directly
+	 *
+	 * @returns Object with title and isFallback flag
+	 */
+	private async generateTitleFromMessage(
+		messageText: string,
+		_sessionWorkspacePath: string
+	): Promise<{ title: string; isFallback: boolean }> {
+		// Get provider service to detect provider and get API configuration
+		const providerService = getProviderService();
+		const provider = await providerService.getDefaultProvider();
+		const apiKey = providerService.getProviderApiKey(provider);
 
-    if (!apiKey) {
-      this.logger.warn(
-        `[SessionLifecycle] No API key for provider ${provider}, using fallback title`,
-      );
-      return {
-        title: messageText.substring(0, 50).trim() || "New Session",
-        isFallback: true,
-      };
-    }
+		if (!apiKey) {
+			this.logger.warn(
+				`[SessionLifecycle] No API key for provider ${provider}, using fallback title`
+			);
+			return {
+				title: messageText.substring(0, 50).trim() || 'New Session',
+				isFallback: true,
+			};
+		}
 
-    // Get title generation configuration from provider service
-    const { modelId } =
-      await providerService.getTitleGenerationConfig(provider);
+		// Get title generation configuration from provider service
+		const { modelId } = await providerService.getTitleGenerationConfig(provider);
 
-    this.logger.info(
-      `[SessionLifecycle] Generating title with ${provider} provider using model ${modelId}...`,
-    );
+		this.logger.info(
+			`[SessionLifecycle] Generating title with ${provider} provider using model ${modelId}...`
+		);
 
-    try {
-      const title = await this.generateTitleWithSdk(
-        provider,
-        modelId,
-        messageText,
-      );
-      return { title, isFallback: false };
-    } catch (error) {
-      this.logger.error(
-        "[SessionLifecycle] SDK title generation failed:",
-        error,
-      );
-      // Fallback to first 50 chars of message
-      return {
-        title: messageText.substring(0, 50).trim() || "New Session",
-        isFallback: true,
-      };
-    }
-  }
+		try {
+			const title = await this.generateTitleWithSdk(provider, modelId, messageText);
+			return { title, isFallback: false };
+		} catch (error) {
+			this.logger.error('[SessionLifecycle] SDK title generation failed:', error);
+			// Fallback to first 50 chars of message
+			return {
+				title: messageText.substring(0, 50).trim() || 'New Session',
+				isFallback: true,
+			};
+		}
+	}
 
-  /**
-   * Generate title using SDK query with proper environment setup
-   *
-   * Uses ProviderService to configure environment variables for the provider,
-   * then calls the SDK's query function to generate the title.
-   */
-  private async generateTitleWithSdk(
-    provider: Provider,
-    modelId: string,
-    messageText: string,
-  ): Promise<string> {
-    const { query } = await import("@anthropic-ai/claude-agent-sdk");
-    const providerService = getProviderService();
+	/**
+	 * Generate title using SDK query with proper environment setup
+	 *
+	 * Uses ProviderService to configure environment variables for the provider,
+	 * then calls the SDK's query function to generate the title.
+	 */
+	private async generateTitleWithSdk(
+		provider: Provider,
+		modelId: string,
+		messageText: string
+	): Promise<string> {
+		const { query } = await import('@anthropic-ai/claude-agent-sdk');
+		const providerService = getProviderService();
 
-    // Apply provider-specific environment variables to process.env
-    // Use explicit provider to avoid model ID detection issues with shorthands like 'haiku'
-    const originalEnv = providerService.applyEnvVarsToProcessForProvider(
-      provider,
-      modelId,
-    );
+		// Apply provider-specific environment variables to process.env
+		// Use explicit provider to avoid model ID detection issues with shorthands like 'haiku'
+		const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
 
-    this.logger.debug(
-      `[SessionLifecycle] Env vars applied for provider ${provider}, model ${modelId}`,
-    );
+		this.logger.debug(
+			`[SessionLifecycle] Env vars applied for provider ${provider}, model ${modelId}`
+		);
 
-    try {
-      const prompt = `Based on the user's request below, generate a concise 3-7 word title that captures the main intent or topic.
+		try {
+			const prompt = `Based on the user's request below, generate a concise 3-7 word title that captures the main intent or topic.
 
 IMPORTANT: Return ONLY the title text itself, with NO formatting whatsoever:
 - NO quotes around the title
@@ -667,140 +586,130 @@ IMPORTANT: Return ONLY the title text itself, with NO formatting whatsoever:
 User's request:
 ${messageText.slice(0, 2000)}`;
 
-      const agentQuery = query({
-        prompt,
-        options: {
-          model: provider === "glm" ? "haiku" : modelId,
-          maxTurns: 1,
-          permissionMode: "acceptEdits",
-          allowDangerouslySkipPermissions: false,
-          mcpServers: {},
-          settingSources: [],
-          tools: [],
-          pathToClaudeCodeExecutable: resolveSDKCliPath(),
-          executable: isBundledBinary() ? "bun" : undefined,
-        },
-      });
+			const agentQuery = query({
+				prompt,
+				options: {
+					model: provider === 'glm' ? 'haiku' : modelId,
+					maxTurns: 1,
+					permissionMode: 'acceptEdits',
+					allowDangerouslySkipPermissions: false,
+					mcpServers: {},
+					settingSources: [],
+					tools: [],
+					pathToClaudeCodeExecutable: resolveSDKCliPath(),
+					executable: isBundledBinary() ? 'bun' : undefined,
+				},
+			});
 
-      // Extract title from the response
-      const { isSDKAssistantMessage } =
-        await import("@neokai/shared/sdk/type-guards");
-      let title = "";
+			// Extract title from the response
+			const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
+			let title = '';
 
-      for await (const message of agentQuery) {
-        if (isSDKAssistantMessage(message)) {
-          const textBlocks = message.message.content.filter(
-            (b: { type: string }) => b.type === "text",
-          );
-          title = textBlocks
-            .map((b: { text?: string }) => b.text)
-            .join(" ")
-            .trim();
+			for await (const message of agentQuery) {
+				if (isSDKAssistantMessage(message)) {
+					const textBlocks = message.message.content.filter(
+						(b: { type: string }) => b.type === 'text'
+					);
+					title = textBlocks
+						.map((b: { text?: string }) => b.text)
+						.join(' ')
+						.trim();
 
-          if (title) {
-            break; // Got the title, exit early
-          }
-        }
-      }
+					if (title) {
+						break; // Got the title, exit early
+					}
+				}
+			}
 
-      if (!title) {
-        throw new Error("No text content in SDK response");
-      }
+			if (!title) {
+				throw new Error('No text content in SDK response');
+			}
 
-      // Clean up the title
-      title = title.replace(/\*\*(.+?)\*\*/g, "$1").replace(/\*(.+?)\*/g, "$1");
+			// Clean up the title
+			title = title.replace(/\*\*(.+?)\*\*/g, '$1').replace(/\*(.+?)\*/g, '$1');
 
-      // Remove wrapping quotes
-      while (
-        (title.startsWith('"') && title.endsWith('"')) ||
-        (title.startsWith("'") && title.endsWith("'"))
-      ) {
-        title = title.slice(1, -1).trim();
-      }
+			// Remove wrapping quotes
+			while (
+				(title.startsWith('"') && title.endsWith('"')) ||
+				(title.startsWith("'") && title.endsWith("'"))
+			) {
+				title = title.slice(1, -1).trim();
+			}
 
-      // Remove backticks
-      title = title.replace(/`/g, "");
+			// Remove backticks
+			title = title.replace(/`/g, '');
 
-      this.logger.info(`[SessionLifecycle] Generated title: "${title}"`);
-      return title;
-    } finally {
-      // Always restore original environment variables
-      providerService.restoreEnvVars(originalEnv);
-      this.logger.debug(`[SessionLifecycle] Env vars restored`);
-    }
-  }
+			this.logger.info(`[SessionLifecycle] Generated title: "${title}"`);
+			return title;
+		} finally {
+			// Always restore original environment variables
+			providerService.restoreEnvVars(originalEnv);
+			this.logger.debug(`[SessionLifecycle] Env vars restored`);
+		}
+	}
 
-  /**
-   * Get a validated model ID by using cached dynamic models
-   * Falls back to static model if dynamic loading failed or is unavailable
-   */
-  private async getValidatedModelId(requestedModel?: string): Promise<string> {
-    // Get available models from cache (already loaded on app startup)
-    try {
-      const { getAvailableModels } = await import("../model-service");
-      const availableModels = getAvailableModels("global");
+	/**
+	 * Get a validated model ID by using cached dynamic models
+	 * Falls back to static model if dynamic loading failed or is unavailable
+	 */
+	private async getValidatedModelId(requestedModel?: string): Promise<string> {
+		// Get available models from cache (already loaded on app startup)
+		try {
+			const { getAvailableModels } = await import('../model-service');
+			const availableModels = getAvailableModels('global');
 
-      if (availableModels.length > 0) {
-        // If a specific model was requested, validate it
-        if (requestedModel) {
-          const found = availableModels.find(
-            (m) => m.id === requestedModel || m.alias === requestedModel,
-          );
-          if (found) {
-            this.logger.info(
-              `[SessionLifecycle] Using requested model: ${found.id}`,
-            );
-            return found.id;
-          }
-          // Model not found - log warning but continue to try default
-          this.logger.info(
-            `[SessionLifecycle] Requested model "${requestedModel}" not found in available models:`,
-            availableModels.map((m) => m.id),
-          );
-        }
+			if (availableModels.length > 0) {
+				// If a specific model was requested, validate it
+				if (requestedModel) {
+					const found = availableModels.find(
+						(m) => m.id === requestedModel || m.alias === requestedModel
+					);
+					if (found) {
+						this.logger.info(`[SessionLifecycle] Using requested model: ${found.id}`);
+						return found.id;
+					}
+					// Model not found - log warning but continue to try default
+					this.logger.info(
+						`[SessionLifecycle] Requested model "${requestedModel}" not found in available models:`,
+						availableModels.map((m) => m.id)
+					);
+				}
 
-        // Use configured default model (from DEFAULT_MODEL env var or 'default')
-        // Try to find it by alias or ID in available models
-        const configuredDefault = this.config.defaultModel;
-        const defaultByConfig = availableModels.find(
-          (m) => m.id === configuredDefault || m.alias === configuredDefault,
-        );
+				// Use configured default model (from DEFAULT_MODEL env var or 'default')
+				// Try to find it by alias or ID in available models
+				const configuredDefault = this.config.defaultModel;
+				const defaultByConfig = availableModels.find(
+					(m) => m.id === configuredDefault || m.alias === configuredDefault
+				);
 
-        if (defaultByConfig) {
-          this.logger.info(
-            `[SessionLifecycle] Using configured default model: ${defaultByConfig.id} (from ${configuredDefault})`,
-          );
-          return defaultByConfig.id;
-        }
+				if (defaultByConfig) {
+					this.logger.info(
+						`[SessionLifecycle] Using configured default model: ${defaultByConfig.id} (from ${configuredDefault})`
+					);
+					return defaultByConfig.id;
+				}
 
-        // Fallback: prefer Sonnet family if no configured default found
-        const defaultModel =
-          availableModels.find((m) => m.family === "sonnet") ||
-          availableModels[0];
+				// Fallback: prefer Sonnet family if no configured default found
+				const defaultModel =
+					availableModels.find((m) => m.family === 'sonnet') || availableModels[0];
 
-        if (defaultModel) {
-          this.logger.info(
-            `[SessionLifecycle] Using fallback default model: ${defaultModel.id}`,
-          );
-          return defaultModel.id;
-        }
-      } else {
-        this.logger.info(
-          "[SessionLifecycle] No available models loaded from cache",
-        );
-      }
-    } catch (error) {
-      this.logger.info("[SessionLifecycle] Error getting models:", error);
-    }
+				if (defaultModel) {
+					this.logger.info(`[SessionLifecycle] Using fallback default model: ${defaultModel.id}`);
+					return defaultModel.id;
+				}
+			} else {
+				this.logger.info('[SessionLifecycle] No available models loaded from cache');
+			}
+		} catch (error) {
+			this.logger.info('[SessionLifecycle] Error getting models:', error);
+		}
 
-    // Fallback to config default model or requested model
-    // IMPORTANT: Always return full model ID, never aliases
-    const fallbackModel = requestedModel || this.config.defaultModel;
-    this.logger.info(
-      `[SessionLifecycle] Using fallback model: ${fallbackModel}`,
-    );
-    return fallbackModel;
-  }
+		// Fallback to config default model or requested model
+		// IMPORTANT: Always return full model ID, never aliases
+		const fallbackModel = requestedModel || this.config.defaultModel;
+		this.logger.info(`[SessionLifecycle] Using fallback model: ${fallbackModel}`);
+		return fallbackModel;
+	}
 }
 
 /**
@@ -808,26 +717,26 @@ ${messageText.slice(0, 2000)}`;
  * Creates a slugified branch name like "session/fix-login-bug-abc123"
  */
 export function generateBranchName(title: string, sessionId: string): string {
-  // Slugify title: "Fix login bug" -> "fix-login-bug"
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
-    .replace(/^-|-$/g, "") // Remove leading/trailing hyphens
-    .substring(0, 50); // Max 50 chars
+	// Slugify title: "Fix login bug" -> "fix-login-bug"
+	const slug = title
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric with hyphens
+		.replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+		.substring(0, 50); // Max 50 chars
 
-  // Add short UUID to prevent conflicts
-  const shortId = sessionId.substring(0, 8);
+	// Add short UUID to prevent conflicts
+	const shortId = sessionId.substring(0, 8);
 
-  return `session/${slug}-${shortId}`;
+	return `session/${slug}-${shortId}`;
 }
 
 /**
  * Slugify text for branch names
  */
 export function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .substring(0, 50);
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '')
+		.substring(0, 50);
 }

--- a/packages/daemon/tests/integration/session/settings-rpc.integration.test.ts
+++ b/packages/daemon/tests/integration/session/settings-rpc.integration.test.ts
@@ -4,651 +4,558 @@
  * Tests the complete flow: RPC call → Handler → SettingsManager → Database → File writes
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import type { TestContext } from "../../test-utils";
-import { createTestApp, callRPCHandler } from "../../test-utils";
-import type { GlobalSettings } from "@neokai/shared";
-
-describe("Settings RPC Integration", () => {
-  let ctx: TestContext;
-  let workspacePath: string;
-
-  beforeEach(async () => {
-    ctx = await createTestApp();
-    workspacePath = ctx.workspacePath;
-  });
-
-  afterEach(async () => {
-    await ctx.cleanup();
-  });
-
-  describe("settings.global.get", () => {
-    test("returns default settings", async () => {
-      const result = await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      );
-
-      expect(result).toMatchObject({
-        settingSources: ["user", "project", "local"],
-        disabledMcpServers: [],
-      });
-    });
-
-    test("returns saved settings", async () => {
-      // Pre-save settings
-      ctx.settingsManager.updateGlobalSettings({
-        model: "claude-opus-4-5-20251101",
-        disabledMcpServers: ["test-server"],
-      });
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      )) as GlobalSettings;
-
-      expect(result.model).toBe("claude-opus-4-5-20251101");
-      expect(result.disabledMcpServers).toEqual(["test-server"]);
-    });
-  });
-
-  describe("settings.global.update", () => {
-    test("updates global settings", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: {
-            model: "claude-haiku-3-5-20241022",
-            disabledMcpServers: ["server1", "server2"],
-          },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.model).toBe("claude-haiku-3-5-20241022");
-      expect(result.settings.disabledMcpServers).toEqual([
-        "server1",
-        "server2",
-      ]);
-    });
-
-    test("persists updates to database", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: {
-          model: "claude-opus-4-5-20251101",
-        },
-      });
-
-      // Verify persisted to database
-      const loaded = ctx.db.getGlobalSettings();
-      expect(loaded.model).toBe("claude-opus-4-5-20251101");
-    });
-
-    test("performs partial update", async () => {
-      // First update
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: {
-          model: "claude-sonnet-4-5-20250929",
-          disabledMcpServers: ["server1"],
-        },
-      });
-
-      // Second partial update
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: {
-            disabledMcpServers: ["server1", "server2"],
-          },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      // Model should remain unchanged
-      expect(result.settings.model).toBe("claude-sonnet-4-5-20250929");
-      // disabledMcpServers should be updated
-      expect(result.settings.disabledMcpServers).toEqual([
-        "server1",
-        "server2",
-      ]);
-    });
-  });
-
-  describe("settings.global.save", () => {
-    test("saves complete settings", async () => {
-      const completeSettings: GlobalSettings = {
-        settingSources: ["project", "local"],
-        model: "claude-opus-4-5-20251101",
-        permissionMode: "acceptEdits",
-        disabledMcpServers: ["server1"],
-      };
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.save",
-        {
-          settings: completeSettings,
-        },
-      )) as { success: boolean };
-
-      expect(result.success).toBe(true);
-
-      // Verify saved
-      const loaded = ctx.db.getGlobalSettings();
-      expect(loaded.settingSources).toEqual(["project", "local"]);
-      expect(loaded.model).toBe("claude-opus-4-5-20251101");
-      expect(loaded.permissionMode).toBe("acceptEdits");
-    });
-  });
-
-  describe("settings.mcp.toggle", () => {
-    test("disables MCP server", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.toggle",
-        {
-          serverName: "test-server",
-          enabled: false,
-        },
-      )) as { success: boolean };
-
-      expect(result.success).toBe(true);
-
-      // Verify disabled
-      const settings = ctx.settingsManager.getGlobalSettings();
-      expect(settings.disabledMcpServers).toContain("test-server");
-    });
-
-    test("enables MCP server", async () => {
-      // First disable
-      await callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-        serverName: "test-server",
-        enabled: false,
-      });
-
-      // Then enable
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.toggle",
-        {
-          serverName: "test-server",
-          enabled: true,
-        },
-      )) as { success: boolean };
-
-      expect(result.success).toBe(true);
-
-      // Verify enabled
-      const settings = ctx.settingsManager.getGlobalSettings();
-      expect(settings.disabledMcpServers).not.toContain("test-server");
-    });
-
-    test("writes to settings.local.json immediately", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-        serverName: "test-server",
-        enabled: false,
-      });
-
-      const settingsPath = join(workspacePath, ".claude/settings.local.json");
-      expect(existsSync(settingsPath)).toBe(true);
-
-      const content = JSON.parse(readFileSync(settingsPath, "utf-8"));
-      expect(content.disabledMcpjsonServers).toContain("test-server");
-    });
-  });
-
-  describe("settings.mcp.getDisabled", () => {
-    test("returns empty array by default", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.getDisabled",
-        {},
-      )) as {
-        disabledServers: string[];
-      };
-
-      expect(result.disabledServers).toEqual([]);
-    });
-
-    test("returns disabled servers", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-        serverName: "server1",
-        enabled: false,
-      });
-      await callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-        serverName: "server2",
-        enabled: false,
-      });
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.getDisabled",
-        {},
-      )) as {
-        disabledServers: string[];
-      };
-
-      expect(result.disabledServers).toEqual(["server1", "server2"]);
-    });
-  });
-
-  describe("settings.mcp.setDisabled", () => {
-    test("sets list of disabled servers", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.setDisabled",
-        {
-          disabledServers: ["server1", "server2", "server3"],
-        },
-      )) as { success: boolean };
-
-      expect(result.success).toBe(true);
-
-      // Verify set
-      const getResult = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.getDisabled",
-        {},
-      )) as {
-        disabledServers: string[];
-      };
-      expect(getResult.disabledServers).toEqual([
-        "server1",
-        "server2",
-        "server3",
-      ]);
-    });
-
-    test("replaces existing disabled servers", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.mcp.setDisabled", {
-        disabledServers: ["old-server"],
-      });
-
-      await callRPCHandler(ctx.messageHub, "settings.mcp.setDisabled", {
-        disabledServers: ["new-server1", "new-server2"],
-      });
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.mcp.getDisabled",
-        {},
-      )) as {
-        disabledServers: string[];
-      };
-      expect(result.disabledServers).toEqual(["new-server1", "new-server2"]);
-      expect(result.disabledServers).not.toContain("old-server");
-    });
-  });
-
-  describe("settings.fileOnly.read", () => {
-    test("returns empty object if file does not exist", async () => {
-      const result = await callRPCHandler(
-        ctx.messageHub,
-        "settings.fileOnly.read",
-        {},
-      );
-
-      expect(result).toEqual({});
-    });
-
-    test("reads disabledMcpServers from file", async () => {
-      // Write settings via toggle (which writes to file)
-      await callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-        serverName: "server1",
-        enabled: false,
-      });
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.fileOnly.read",
-        {},
-      )) as {
-        disabledMcpServers?: string[];
-      };
-
-      expect(result.disabledMcpServers).toContain("server1");
-    });
-  });
-
-  describe("showArchived Setting", () => {
-    test("defaults to false", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      )) as GlobalSettings;
-
-      expect(result.showArchived).toBe(false);
-    });
-
-    test("can be updated", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { showArchived: true },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.showArchived).toBe(true);
-    });
-
-    test("persists to database", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { showArchived: true },
-      });
-
-      // Verify persisted
-      const loaded = ctx.db.getGlobalSettings();
-      expect(loaded.showArchived).toBe(true);
-    });
-
-    test("can be toggled multiple times", async () => {
-      // Toggle on
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { showArchived: true },
-      });
-      let settings = ctx.db.getGlobalSettings();
-      expect(settings.showArchived).toBe(true);
-
-      // Toggle off
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { showArchived: false },
-      });
-      settings = ctx.db.getGlobalSettings();
-      expect(settings.showArchived).toBe(false);
-
-      // Toggle on again
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { showArchived: true },
-      });
-      settings = ctx.db.getGlobalSettings();
-      expect(settings.showArchived).toBe(true);
-    });
-  });
-
-  describe("thinkingLevel Setting", () => {
-    test("defaults to undefined", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      )) as GlobalSettings;
-
-      expect(result.thinkingLevel).toBeUndefined();
-    });
-
-    test("can be set to think8k", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { thinkingLevel: "think8k" },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.thinkingLevel).toBe("think8k");
-    });
-
-    test("can be set to think16k", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { thinkingLevel: "think16k" },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.thinkingLevel).toBe("think16k");
-    });
-
-    test("can be set to think32k", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { thinkingLevel: "think32k" },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.thinkingLevel).toBe("think32k");
-    });
-
-    test("can be reset to auto", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { thinkingLevel: "think16k" },
-      });
-
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { thinkingLevel: "auto" },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.thinkingLevel).toBe("auto");
-    });
-
-    test("persists to database", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { thinkingLevel: "think32k" },
-      });
-
-      const loaded = ctx.db.getGlobalSettings();
-      expect(loaded.thinkingLevel).toBe("think32k");
-    });
-  });
-
-  describe("autoScroll Setting", () => {
-    test("defaults to undefined", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      )) as GlobalSettings;
-
-      expect(result.autoScroll).toBeUndefined();
-    });
-
-    test("can be set to true", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { autoScroll: true },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.autoScroll).toBe(true);
-    });
-
-    test("can be set to false", async () => {
-      const result = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.update",
-        {
-          updates: { autoScroll: false },
-        },
-      )) as { success: boolean; settings: GlobalSettings };
-
-      expect(result.success).toBe(true);
-      expect(result.settings.autoScroll).toBe(false);
-    });
-
-    test("persists to database", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { autoScroll: false },
-      });
-
-      const loaded = ctx.db.getGlobalSettings();
-      expect(loaded.autoScroll).toBe(false);
-    });
-
-    test("can be toggled", async () => {
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { autoScroll: true },
-      });
-      let settings = ctx.db.getGlobalSettings();
-      expect(settings.autoScroll).toBe(true);
-
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { autoScroll: false },
-      });
-      settings = ctx.db.getGlobalSettings();
-      expect(settings.autoScroll).toBe(false);
-    });
-  });
-
-  describe("Global Settings Applied to New Sessions", () => {
-    test("new session uses global model setting", async () => {
-      // Set global model
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { model: "opus" },
-      });
-
-      // Create a new session without specifying a model
-      const result = (await callRPCHandler(ctx.messageHub, "session.create", {
-        workspacePath: ctx.workspacePath,
-      })) as { sessionId: string; session: { config: { model: string } } };
-
-      expect(result.session.config.model).toBe("opus");
-    });
-
-    test("new session uses global thinkingLevel setting", async () => {
-      // Set global thinking level
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { thinkingLevel: "think16k" },
-      });
-
-      // Create a new session
-      const result = (await callRPCHandler(ctx.messageHub, "session.create", {
-        workspacePath: ctx.workspacePath,
-      })) as {
-        sessionId: string;
-        session: { config: { thinkingLevel?: string } };
-      };
-
-      expect(result.session.config.thinkingLevel).toBe("think16k");
-    });
-
-    test("new session uses global autoScroll setting", async () => {
-      // Set global autoScroll to false
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: { autoScroll: false },
-      });
-
-      // Create a new session
-      const result = (await callRPCHandler(ctx.messageHub, "session.create", {
-        workspacePath: ctx.workspacePath,
-      })) as {
-        sessionId: string;
-        session: { config: { autoScroll?: boolean } };
-      };
-
-      expect(result.session.config.autoScroll).toBe(false);
-    });
-
-    test("session-level config overrides global defaults", async () => {
-      // Set global model
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: {
-          model: "opus",
-          thinkingLevel: "think32k",
-          autoScroll: false,
-        },
-      });
-
-      // Create a session with explicit overrides
-      const result = (await callRPCHandler(ctx.messageHub, "session.create", {
-        workspacePath: ctx.workspacePath,
-        config: {
-          model: "haiku",
-          thinkingLevel: "auto",
-          autoScroll: true,
-        },
-      })) as {
-        sessionId: string;
-        session: {
-          config: {
-            model: string;
-            thinkingLevel?: string;
-            autoScroll?: boolean;
-          };
-        };
-      };
-
-      expect(result.session.config.model).toBe("haiku");
-      expect(result.session.config.thinkingLevel).toBe("auto");
-      expect(result.session.config.autoScroll).toBe(true);
-    });
-  });
-
-  describe("Complete Flow", () => {
-    test("update settings → persist to DB → write to file", async () => {
-      // 1. Update settings via RPC
-      await callRPCHandler(ctx.messageHub, "settings.global.update", {
-        updates: {
-          model: "claude-opus-4-5-20251101",
-          disabledMcpServers: ["server1", "server2"],
-        },
-      });
-
-      // 2. Verify persisted to database
-      const dbSettings = ctx.db.getGlobalSettings();
-      expect(dbSettings.model).toBe("claude-opus-4-5-20251101");
-      expect(dbSettings.disabledMcpServers).toEqual(["server1", "server2"]);
-
-      // 3. Prepare SDK options (triggers file write)
-      await ctx.settingsManager.prepareSDKOptions();
-
-      // 4. Verify written to file
-      const settingsPath = join(workspacePath, ".claude/settings.local.json");
-      expect(existsSync(settingsPath)).toBe(true);
-
-      const fileContent = JSON.parse(readFileSync(settingsPath, "utf-8"));
-      expect(fileContent.disabledMcpjsonServers).toEqual([
-        "server1",
-        "server2",
-      ]);
-    });
-
-    test("multiple concurrent updates are handled correctly", async () => {
-      // Fire multiple updates concurrently
-      await Promise.all([
-        callRPCHandler(ctx.messageHub, "settings.global.update", {
-          updates: { model: "claude-opus-4-5-20251101" },
-        }),
-        callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-          serverName: "server1",
-          enabled: false,
-        }),
-        callRPCHandler(ctx.messageHub, "settings.mcp.toggle", {
-          serverName: "server2",
-          enabled: false,
-        }),
-      ]);
-
-      // Verify final state is consistent
-      const settings = (await callRPCHandler(
-        ctx.messageHub,
-        "settings.global.get",
-        {},
-      )) as GlobalSettings;
-      expect(settings.model).toBe("claude-opus-4-5-20251101");
-      expect(settings.disabledMcpServers).toContain("server1");
-      expect(settings.disabledMcpServers).toContain("server2");
-    });
-  });
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { TestContext } from '../../test-utils';
+import { createTestApp, callRPCHandler } from '../../test-utils';
+import type { GlobalSettings } from '@neokai/shared';
+
+describe('Settings RPC Integration', () => {
+	let ctx: TestContext;
+	let workspacePath: string;
+
+	beforeEach(async () => {
+		ctx = await createTestApp();
+		workspacePath = ctx.workspacePath;
+	});
+
+	afterEach(async () => {
+		await ctx.cleanup();
+	});
+
+	describe('settings.global.get', () => {
+		test('returns default settings', async () => {
+			const result = await callRPCHandler(ctx.messageHub, 'settings.global.get', {});
+
+			expect(result).toMatchObject({
+				settingSources: ['user', 'project', 'local'],
+				disabledMcpServers: [],
+			});
+		});
+
+		test('returns saved settings', async () => {
+			// Pre-save settings
+			ctx.settingsManager.updateGlobalSettings({
+				model: 'claude-opus-4-5-20251101',
+				disabledMcpServers: ['test-server'],
+			});
+
+			const result = (await callRPCHandler(
+				ctx.messageHub,
+				'settings.global.get',
+				{}
+			)) as GlobalSettings;
+
+			expect(result.model).toBe('claude-opus-4-5-20251101');
+			expect(result.disabledMcpServers).toEqual(['test-server']);
+		});
+	});
+
+	describe('settings.global.update', () => {
+		test('updates global settings', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					model: 'claude-haiku-3-5-20241022',
+					disabledMcpServers: ['server1', 'server2'],
+				},
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.model).toBe('claude-haiku-3-5-20241022');
+			expect(result.settings.disabledMcpServers).toEqual(['server1', 'server2']);
+		});
+
+		test('persists updates to database', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					model: 'claude-opus-4-5-20251101',
+				},
+			});
+
+			// Verify persisted to database
+			const loaded = ctx.db.getGlobalSettings();
+			expect(loaded.model).toBe('claude-opus-4-5-20251101');
+		});
+
+		test('performs partial update', async () => {
+			// First update
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					model: 'claude-sonnet-4-5-20250929',
+					disabledMcpServers: ['server1'],
+				},
+			});
+
+			// Second partial update
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					disabledMcpServers: ['server1', 'server2'],
+				},
+			})) as { success: boolean; settings: GlobalSettings };
+
+			// Model should remain unchanged
+			expect(result.settings.model).toBe('claude-sonnet-4-5-20250929');
+			// disabledMcpServers should be updated
+			expect(result.settings.disabledMcpServers).toEqual(['server1', 'server2']);
+		});
+	});
+
+	describe('settings.global.save', () => {
+		test('saves complete settings', async () => {
+			const completeSettings: GlobalSettings = {
+				settingSources: ['project', 'local'],
+				model: 'claude-opus-4-5-20251101',
+				permissionMode: 'acceptEdits',
+				disabledMcpServers: ['server1'],
+			};
+
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.save', {
+				settings: completeSettings,
+			})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+
+			// Verify saved
+			const loaded = ctx.db.getGlobalSettings();
+			expect(loaded.settingSources).toEqual(['project', 'local']);
+			expect(loaded.model).toBe('claude-opus-4-5-20251101');
+			expect(loaded.permissionMode).toBe('acceptEdits');
+		});
+	});
+
+	describe('settings.mcp.toggle', () => {
+		test('disables MCP server', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'test-server',
+				enabled: false,
+			})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+
+			// Verify disabled
+			const settings = ctx.settingsManager.getGlobalSettings();
+			expect(settings.disabledMcpServers).toContain('test-server');
+		});
+
+		test('enables MCP server', async () => {
+			// First disable
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'test-server',
+				enabled: false,
+			});
+
+			// Then enable
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'test-server',
+				enabled: true,
+			})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+
+			// Verify enabled
+			const settings = ctx.settingsManager.getGlobalSettings();
+			expect(settings.disabledMcpServers).not.toContain('test-server');
+		});
+
+		test('writes to settings.local.json immediately', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'test-server',
+				enabled: false,
+			});
+
+			const settingsPath = join(workspacePath, '.claude/settings.local.json');
+			expect(existsSync(settingsPath)).toBe(true);
+
+			const content = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+			expect(content.disabledMcpjsonServers).toContain('test-server');
+		});
+	});
+
+	describe('settings.mcp.getDisabled', () => {
+		test('returns empty array by default', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.getDisabled', {})) as {
+				disabledServers: string[];
+			};
+
+			expect(result.disabledServers).toEqual([]);
+		});
+
+		test('returns disabled servers', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'server1',
+				enabled: false,
+			});
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'server2',
+				enabled: false,
+			});
+
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.getDisabled', {})) as {
+				disabledServers: string[];
+			};
+
+			expect(result.disabledServers).toEqual(['server1', 'server2']);
+		});
+	});
+
+	describe('settings.mcp.setDisabled', () => {
+		test('sets list of disabled servers', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.setDisabled', {
+				disabledServers: ['server1', 'server2', 'server3'],
+			})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+
+			// Verify set
+			const getResult = (await callRPCHandler(ctx.messageHub, 'settings.mcp.getDisabled', {})) as {
+				disabledServers: string[];
+			};
+			expect(getResult.disabledServers).toEqual(['server1', 'server2', 'server3']);
+		});
+
+		test('replaces existing disabled servers', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.setDisabled', {
+				disabledServers: ['old-server'],
+			});
+
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.setDisabled', {
+				disabledServers: ['new-server1', 'new-server2'],
+			});
+
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.mcp.getDisabled', {})) as {
+				disabledServers: string[];
+			};
+			expect(result.disabledServers).toEqual(['new-server1', 'new-server2']);
+			expect(result.disabledServers).not.toContain('old-server');
+		});
+	});
+
+	describe('settings.fileOnly.read', () => {
+		test('returns empty object if file does not exist', async () => {
+			const result = await callRPCHandler(ctx.messageHub, 'settings.fileOnly.read', {});
+
+			expect(result).toEqual({});
+		});
+
+		test('reads disabledMcpServers from file', async () => {
+			// Write settings via toggle (which writes to file)
+			await callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+				serverName: 'server1',
+				enabled: false,
+			});
+
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.fileOnly.read', {})) as {
+				disabledMcpServers?: string[];
+			};
+
+			expect(result.disabledMcpServers).toContain('server1');
+		});
+	});
+
+	describe('showArchived Setting', () => {
+		test('defaults to false', async () => {
+			const result = (await callRPCHandler(
+				ctx.messageHub,
+				'settings.global.get',
+				{}
+			)) as GlobalSettings;
+
+			expect(result.showArchived).toBe(false);
+		});
+
+		test('can be updated', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { showArchived: true },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.showArchived).toBe(true);
+		});
+
+		test('persists to database', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { showArchived: true },
+			});
+
+			// Verify persisted
+			const loaded = ctx.db.getGlobalSettings();
+			expect(loaded.showArchived).toBe(true);
+		});
+
+		test('can be toggled multiple times', async () => {
+			// Toggle on
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { showArchived: true },
+			});
+			let settings = ctx.db.getGlobalSettings();
+			expect(settings.showArchived).toBe(true);
+
+			// Toggle off
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { showArchived: false },
+			});
+			settings = ctx.db.getGlobalSettings();
+			expect(settings.showArchived).toBe(false);
+
+			// Toggle on again
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { showArchived: true },
+			});
+			settings = ctx.db.getGlobalSettings();
+			expect(settings.showArchived).toBe(true);
+		});
+	});
+
+	describe('thinkingLevel Setting', () => {
+		test('defaults to undefined', async () => {
+			const result = (await callRPCHandler(
+				ctx.messageHub,
+				'settings.global.get',
+				{}
+			)) as GlobalSettings;
+
+			expect(result.thinkingLevel).toBeUndefined();
+		});
+
+		test('can be set to think8k', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think8k' },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.thinkingLevel).toBe('think8k');
+		});
+
+		test('can be set to think16k', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think16k' },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.thinkingLevel).toBe('think16k');
+		});
+
+		test('can be set to think32k', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think32k' },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.thinkingLevel).toBe('think32k');
+		});
+
+		test('can be reset to auto', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think16k' },
+			});
+
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'auto' },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.thinkingLevel).toBe('auto');
+		});
+
+		test('persists to database', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think32k' },
+			});
+
+			const loaded = ctx.db.getGlobalSettings();
+			expect(loaded.thinkingLevel).toBe('think32k');
+		});
+	});
+
+	describe('autoScroll Setting', () => {
+		test('defaults to undefined', async () => {
+			const result = (await callRPCHandler(
+				ctx.messageHub,
+				'settings.global.get',
+				{}
+			)) as GlobalSettings;
+
+			expect(result.autoScroll).toBeUndefined();
+		});
+
+		test('can be set to true', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: true },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.autoScroll).toBe(true);
+		});
+
+		test('can be set to false', async () => {
+			const result = (await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: false },
+			})) as { success: boolean; settings: GlobalSettings };
+
+			expect(result.success).toBe(true);
+			expect(result.settings.autoScroll).toBe(false);
+		});
+
+		test('persists to database', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: false },
+			});
+
+			const loaded = ctx.db.getGlobalSettings();
+			expect(loaded.autoScroll).toBe(false);
+		});
+
+		test('can be toggled', async () => {
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: true },
+			});
+			let settings = ctx.db.getGlobalSettings();
+			expect(settings.autoScroll).toBe(true);
+
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: false },
+			});
+			settings = ctx.db.getGlobalSettings();
+			expect(settings.autoScroll).toBe(false);
+		});
+	});
+
+	describe('Global Settings Applied to New Sessions', () => {
+		test('new session uses global model setting', async () => {
+			// Set global model
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { model: 'opus' },
+			});
+
+			// Create a new session without specifying a model
+			const result = (await callRPCHandler(ctx.messageHub, 'session.create', {
+				workspacePath: ctx.workspacePath,
+			})) as { sessionId: string; session: { config: { model: string } } };
+
+			expect(result.session.config.model).toBe('opus');
+		});
+
+		test('new session uses global thinkingLevel setting', async () => {
+			// Set global thinking level
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { thinkingLevel: 'think16k' },
+			});
+
+			// Create a new session
+			const result = (await callRPCHandler(ctx.messageHub, 'session.create', {
+				workspacePath: ctx.workspacePath,
+			})) as {
+				sessionId: string;
+				session: { config: { thinkingLevel?: string } };
+			};
+
+			expect(result.session.config.thinkingLevel).toBe('think16k');
+		});
+
+		test('new session uses global autoScroll setting', async () => {
+			// Set global autoScroll to false
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: { autoScroll: false },
+			});
+
+			// Create a new session
+			const result = (await callRPCHandler(ctx.messageHub, 'session.create', {
+				workspacePath: ctx.workspacePath,
+			})) as {
+				sessionId: string;
+				session: { config: { autoScroll?: boolean } };
+			};
+
+			expect(result.session.config.autoScroll).toBe(false);
+		});
+
+		test('session-level config overrides global defaults', async () => {
+			// Set global model
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					model: 'opus',
+					thinkingLevel: 'think32k',
+					autoScroll: false,
+				},
+			});
+
+			// Create a session with explicit overrides
+			const result = (await callRPCHandler(ctx.messageHub, 'session.create', {
+				workspacePath: ctx.workspacePath,
+				config: {
+					model: 'haiku',
+					thinkingLevel: 'auto',
+					autoScroll: true,
+				},
+			})) as {
+				sessionId: string;
+				session: {
+					config: {
+						model: string;
+						thinkingLevel?: string;
+						autoScroll?: boolean;
+					};
+				};
+			};
+
+			expect(result.session.config.model).toBe('haiku');
+			expect(result.session.config.thinkingLevel).toBe('auto');
+			expect(result.session.config.autoScroll).toBe(true);
+		});
+	});
+
+	describe('Complete Flow', () => {
+		test('update settings → persist to DB → write to file', async () => {
+			// 1. Update settings via RPC
+			await callRPCHandler(ctx.messageHub, 'settings.global.update', {
+				updates: {
+					model: 'claude-opus-4-5-20251101',
+					disabledMcpServers: ['server1', 'server2'],
+				},
+			});
+
+			// 2. Verify persisted to database
+			const dbSettings = ctx.db.getGlobalSettings();
+			expect(dbSettings.model).toBe('claude-opus-4-5-20251101');
+			expect(dbSettings.disabledMcpServers).toEqual(['server1', 'server2']);
+
+			// 3. Prepare SDK options (triggers file write)
+			await ctx.settingsManager.prepareSDKOptions();
+
+			// 4. Verify written to file
+			const settingsPath = join(workspacePath, '.claude/settings.local.json');
+			expect(existsSync(settingsPath)).toBe(true);
+
+			const fileContent = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+			expect(fileContent.disabledMcpjsonServers).toEqual(['server1', 'server2']);
+		});
+
+		test('multiple concurrent updates are handled correctly', async () => {
+			// Fire multiple updates concurrently
+			await Promise.all([
+				callRPCHandler(ctx.messageHub, 'settings.global.update', {
+					updates: { model: 'claude-opus-4-5-20251101' },
+				}),
+				callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+					serverName: 'server1',
+					enabled: false,
+				}),
+				callRPCHandler(ctx.messageHub, 'settings.mcp.toggle', {
+					serverName: 'server2',
+					enabled: false,
+				}),
+			]);
+
+			// Verify final state is consistent
+			const settings = (await callRPCHandler(
+				ctx.messageHub,
+				'settings.global.get',
+				{}
+			)) as GlobalSettings;
+			expect(settings.model).toBe('claude-opus-4-5-20251101');
+			expect(settings.disabledMcpServers).toContain('server1');
+			expect(settings.disabledMcpServers).toContain('server2');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/session/session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/session/session-lifecycle.test.ts
@@ -7,705 +7,685 @@
  * - Session deletion with cleanup cascade
  */
 
-import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { describe, expect, it, beforeEach, mock } from 'bun:test';
 import {
-  SessionLifecycle,
-  generateBranchName,
-  slugify,
-  type SessionLifecycleConfig,
-} from "../../../src/lib/session/session-lifecycle";
-import type { Database } from "../../../src/storage/database";
-import type { DaemonHub } from "../../../src/lib/daemon-hub";
-import type { WorktreeManager } from "../../../src/lib/worktree-manager";
-import type {
-  SessionCache,
-  AgentSessionFactory,
-} from "../../../src/lib/session/session-cache";
-import type { ToolsConfigManager } from "../../../src/lib/session/tools-config";
-import type { MessageHub } from "@neokai/shared";
-
-describe("SessionLifecycle", () => {
-  let lifecycle: SessionLifecycle;
-  let mockDb: Database;
-  let mockWorktreeManager: WorktreeManager;
-  let mockSessionCache: SessionCache;
-  let mockEventBus: DaemonHub;
-  let mockMessageHub: MessageHub;
-  let mockToolsConfigManager: ToolsConfigManager;
-  let mockAgentSessionFactory: AgentSessionFactory;
-  let config: SessionLifecycleConfig;
-
-  // Mock spies
-  let createSessionSpy: ReturnType<typeof mock>;
-  let updateSessionSpy: ReturnType<typeof mock>;
-  let deleteSessionSpy: ReturnType<typeof mock>;
-  let getSessionSpy: ReturnType<typeof mock>;
-  let createWorktreeSpy: ReturnType<typeof mock>;
-  let removeWorktreeSpy: ReturnType<typeof mock>;
-  let verifyWorktreeSpy: ReturnType<typeof mock>;
-  let emitSpy: ReturnType<typeof mock>;
-  let publishSpy: ReturnType<typeof mock>;
-  let cacheSetSpy: ReturnType<typeof mock>;
-  let cacheGetSpy: ReturnType<typeof mock>;
-  let cacheHasSpy: ReturnType<typeof mock>;
-  let cacheRemoveSpy: ReturnType<typeof mock>;
-
-  beforeEach(() => {
-    // Database mocks
-    createSessionSpy = mock(() => {});
-    updateSessionSpy = mock(() => {});
-    deleteSessionSpy = mock(() => {});
-    getSessionSpy = mock(() => null);
-    mockDb = {
-      createSession: createSessionSpy,
-      updateSession: updateSessionSpy,
-      deleteSession: deleteSessionSpy,
-      getSession: getSessionSpy,
-      getGlobalSettings: mock(() => ({
-        settingSources: ["user", "project", "local"],
-        disabledMcpServers: [],
-      })),
-    } as unknown as Database;
-
-    // Worktree manager mocks
-    createWorktreeSpy = mock(async () => null);
-    removeWorktreeSpy = mock(async () => {});
-    verifyWorktreeSpy = mock(async () => false);
-    mockWorktreeManager = {
-      createWorktree: createWorktreeSpy,
-      removeWorktree: removeWorktreeSpy,
-      verifyWorktree: verifyWorktreeSpy,
-      renameBranch: mock(async () => true),
-    } as unknown as WorktreeManager;
-
-    // Session cache mocks
-    const mockAgentSession = {
-      cleanup: mock(async () => {}),
-      updateMetadata: mock(() => {}),
-      getSessionData: mock(() => ({
-        id: "test-id",
-        title: "Test",
-        workspacePath: "/test",
-        metadata: { titleGenerated: false },
-      })),
-    };
-    cacheSetSpy = mock(() => {});
-    cacheGetSpy = mock(() => mockAgentSession);
-    cacheHasSpy = mock(() => false);
-    cacheRemoveSpy = mock(() => {});
-    mockSessionCache = {
-      set: cacheSetSpy,
-      get: cacheGetSpy,
-      has: cacheHasSpy,
-      remove: cacheRemoveSpy,
-    } as unknown as SessionCache;
-
-    // Event bus mocks
-    emitSpy = mock(async () => {});
-    mockEventBus = {
-      emit: emitSpy,
-    } as unknown as DaemonHub;
-
-    // MessageHub mocks
-    publishSpy = mock(async () => {});
-    mockMessageHub = {
-      publish: publishSpy,
-    } as unknown as MessageHub;
-
-    // Tools config manager
-    mockToolsConfigManager = {
-      getDefaultForNewSession: mock(() => ({ useClaudeCodePreset: true })),
-    } as unknown as ToolsConfigManager;
-
-    // Agent session factory
-    mockAgentSessionFactory = mock(() => ({
-      cleanup: mock(async () => {}),
-      updateMetadata: mock(() => {}),
-    }));
-
-    // Config
-    config = {
-      defaultModel: "default",
-      maxTokens: 8192,
-      temperature: 1.0,
-      workspaceRoot: "/default/workspace",
-      disableWorktrees: true, // Disable worktrees for most tests
-    };
-
-    lifecycle = new SessionLifecycle(
-      mockDb,
-      mockWorktreeManager,
-      mockSessionCache,
-      mockEventBus,
-      mockMessageHub,
-      config,
-      mockToolsConfigManager,
-      mockAgentSessionFactory,
-    );
-  });
-
-  describe("create", () => {
-    it("should create a session with default values", async () => {
-      const sessionId = await lifecycle.create({});
-
-      expect(sessionId).toBeDefined();
-      expect(sessionId).toMatch(/^[0-9a-f-]{36}$/);
-      expect(createSessionSpy).toHaveBeenCalled();
-    });
-
-    it("should use provided workspace path", async () => {
-      await lifecycle.create({ workspacePath: "/custom/path" });
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          workspacePath: "/custom/path",
-        }),
-      );
-    });
-
-    it("should use default workspace root when not provided", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          workspacePath: "/default/workspace",
-        }),
-      );
-    });
-
-    it("should set default title", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: "New Session",
-        }),
-      );
-    });
-
-    it("should set status to active", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: "active",
-        }),
-      );
-    });
-
-    it("should include config with model", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config: expect.objectContaining({
-            model: "default",
-            maxTokens: 8192,
-            temperature: 1.0,
-          }),
-        }),
-      );
-    });
-
-    it("should override config values from params", async () => {
-      await lifecycle.create({
-        config: {
-          model: "opus",
-          maxTokens: 4096,
-          temperature: 0.5,
-        },
-      });
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config: expect.objectContaining({
-            maxTokens: 4096,
-            temperature: 0.5,
-          }),
-        }),
-      );
-    });
-
-    it("should add session to cache", async () => {
-      const sessionId = await lifecycle.create({});
-
-      expect(cacheSetSpy).toHaveBeenCalledWith(sessionId, expect.anything());
-    });
-
-    it("should emit session.created event", async () => {
-      const sessionId = await lifecycle.create({});
-
-      expect(emitSpy).toHaveBeenCalledWith("session.created", {
-        sessionId,
-        session: expect.anything(),
-      });
-    });
-
-    it("should initialize metadata with zero counts", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            messageCount: 0,
-            totalTokens: 0,
-            inputTokens: 0,
-            outputTokens: 0,
-            totalCost: 0,
-            toolCallCount: 0,
-            titleGenerated: false,
-            workspaceInitialized: true,
-          }),
-        }),
-      );
-    });
-
-    it("should include tools config from tools manager", async () => {
-      await lifecycle.create({});
-
-      expect(createSessionSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config: expect.objectContaining({
-            tools: { useClaudeCodePreset: true },
-          }),
-        }),
-      );
-    });
-
-    describe("with worktrees enabled", () => {
-      beforeEach(() => {
-        config.disableWorktrees = false;
-        lifecycle = new SessionLifecycle(
-          mockDb,
-          mockWorktreeManager,
-          mockSessionCache,
-          mockEventBus,
-          mockMessageHub,
-          config,
-          mockToolsConfigManager,
-          mockAgentSessionFactory,
-        );
-      });
-
-      it("should create worktree when enabled", async () => {
-        createWorktreeSpy.mockResolvedValue({
-          worktreePath: "/worktree/path",
-          mainRepoPath: "/main/repo",
-          branch: "session/test",
-        });
-
-        await lifecycle.create({});
-
-        expect(createWorktreeSpy).toHaveBeenCalled();
-      });
-
-      it("should use worktree path as session workspace", async () => {
-        createWorktreeSpy.mockResolvedValue({
-          worktreePath: "/worktree/session",
-          mainRepoPath: "/main/repo",
-          branch: "session/test",
-        });
-
-        await lifecycle.create({});
-
-        expect(createSessionSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            workspacePath: "/worktree/session",
-          }),
-        );
-      });
-
-      it("should include worktree metadata in session", async () => {
-        const worktreeMetadata = {
-          worktreePath: "/worktree/session",
-          mainRepoPath: "/main/repo",
-          branch: "session/test-id",
-        };
-        createWorktreeSpy.mockResolvedValue(worktreeMetadata);
-
-        await lifecycle.create({});
-
-        expect(createSessionSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            worktree: worktreeMetadata,
-            gitBranch: "session/test-id",
-          }),
-        );
-      });
-
-      it("should fallback to base workspace on worktree error", async () => {
-        createWorktreeSpy.mockRejectedValue(new Error("Git error"));
-
-        await lifecycle.create({ workspacePath: "/my/workspace" });
-
-        expect(createSessionSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            workspacePath: "/my/workspace",
-            worktree: undefined,
-          }),
-        );
-      });
-
-      it("should use custom base branch", async () => {
-        createWorktreeSpy.mockResolvedValue({
-          worktreePath: "/worktree",
-          mainRepoPath: "/main",
-          branch: "session/test",
-        });
-
-        await lifecycle.create({ worktreeBaseBranch: "develop" });
-
-        expect(createWorktreeSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            baseBranch: "develop",
-          }),
-        );
-      });
-    });
-  });
-
-  describe("update", () => {
-    it("should update session in database", async () => {
-      await lifecycle.update("session-123", { title: "Updated Title" });
-
-      expect(updateSessionSpy).toHaveBeenCalledWith("session-123", {
-        title: "Updated Title",
-      });
-    });
-
-    it("should update in-memory session when cached", async () => {
-      const mockAgentSession = {
-        updateMetadata: mock(() => {}),
-      };
-      cacheHasSpy.mockReturnValue(true);
-      cacheGetSpy.mockReturnValue(mockAgentSession);
-
-      await lifecycle.update("session-123", { title: "New Title" });
-
-      expect(mockAgentSession.updateMetadata).toHaveBeenCalledWith({
-        title: "New Title",
-      });
-    });
-
-    it("should emit session.updated event", async () => {
-      await lifecycle.update("session-123", { title: "Updated" });
-
-      expect(emitSpy).toHaveBeenCalledWith("session.updated", {
-        sessionId: "session-123",
-        source: "update",
-        session: { title: "Updated" },
-      });
-    });
-  });
-
-  describe("delete", () => {
-    it("should delete session from database", async () => {
-      await lifecycle.delete("session-123");
-
-      expect(deleteSessionSpy).toHaveBeenCalledWith("session-123");
-    });
-
-    it("should remove session from cache", async () => {
-      await lifecycle.delete("session-123");
-
-      expect(cacheRemoveSpy).toHaveBeenCalledWith("session-123");
-    });
-
-    it("should cleanup agent session when cached", async () => {
-      const mockAgentSession = {
-        cleanup: mock(async () => {}),
-      };
-      cacheHasSpy.mockReturnValue(true);
-      cacheGetSpy.mockReturnValue(mockAgentSession);
-
-      await lifecycle.delete("session-123");
-
-      expect(mockAgentSession.cleanup).toHaveBeenCalled();
-    });
-
-    it("should broadcast session.deleted event", async () => {
-      await lifecycle.delete("session-123");
-
-      expect(publishSpy).toHaveBeenCalledWith(
-        "session.deleted",
-        { sessionId: "session-123", reason: "deleted" },
-        { sessionId: "global" },
-      );
-    });
-
-    it("should emit session.deleted via DaemonHub", async () => {
-      await lifecycle.delete("session-123");
-
-      expect(emitSpy).toHaveBeenCalledWith("session.deleted", {
-        sessionId: "session-123",
-      });
-    });
-
-    it("should remove worktree when session has one", async () => {
-      const sessionWithWorktree = {
-        workspacePath: "/worktree/path",
-        worktree: {
-          worktreePath: "/worktree/path",
-          mainRepoPath: "/main",
-          branch: "session/test",
-        },
-      };
-      getSessionSpy.mockReturnValue(sessionWithWorktree);
-
-      await lifecycle.delete("session-123");
-
-      expect(removeWorktreeSpy).toHaveBeenCalledWith(
-        sessionWithWorktree.worktree,
-        true,
-      );
-    });
-
-    it("should continue on worktree removal failure", async () => {
-      const sessionWithWorktree = {
-        workspacePath: "/worktree/path",
-        worktree: {
-          worktreePath: "/worktree/path",
-          mainRepoPath: "/main",
-          branch: "session/test",
-        },
-      };
-      getSessionSpy.mockReturnValue(sessionWithWorktree);
-      removeWorktreeSpy.mockRejectedValue(new Error("Git error"));
-
-      // Should not throw
-      await expect(lifecycle.delete("session-123")).resolves.toBeUndefined();
-      expect(deleteSessionSpy).toHaveBeenCalled();
-    });
-
-    it("should throw when database delete fails", async () => {
-      deleteSessionSpy.mockImplementation(() => {
-        throw new Error("DB error");
-      });
-
-      await expect(lifecycle.delete("session-123")).rejects.toThrow("DB error");
-    });
-  });
-
-  describe("getFromDB", () => {
-    it("should return session from database", () => {
-      const mockSession = { id: "test", title: "Test Session" };
-      getSessionSpy.mockReturnValue(mockSession);
-
-      const result = lifecycle.getFromDB("test");
-
-      expect(result).toEqual(mockSession);
-      expect(getSessionSpy).toHaveBeenCalledWith("test");
-    });
-
-    it("should return null for non-existent session", () => {
-      getSessionSpy.mockReturnValue(null);
-
-      const result = lifecycle.getFromDB("non-existent");
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe("markOutputRemoved", () => {
-    it("should add message UUID to removedOutputs", async () => {
-      const session = {
-        id: "session-123",
-        metadata: { removedOutputs: [] },
-      };
-      getSessionSpy.mockReturnValue(session);
-
-      await lifecycle.markOutputRemoved("session-123", "message-uuid-456");
-
-      expect(updateSessionSpy).toHaveBeenCalledWith("session-123", {
-        metadata: expect.objectContaining({
-          removedOutputs: ["message-uuid-456"],
-        }),
-      });
-    });
-
-    it("should not duplicate message UUID", async () => {
-      const session = {
-        id: "session-123",
-        metadata: { removedOutputs: ["existing-uuid"] },
-      };
-      getSessionSpy.mockReturnValue(session);
-
-      await lifecycle.markOutputRemoved("session-123", "existing-uuid");
-
-      expect(updateSessionSpy).toHaveBeenCalledWith("session-123", {
-        metadata: expect.objectContaining({
-          removedOutputs: ["existing-uuid"],
-        }),
-      });
-    });
-
-    it("should throw for non-existent session", async () => {
-      getSessionSpy.mockReturnValue(null);
-
-      await expect(
-        lifecycle.markOutputRemoved("non-existent", "uuid"),
-      ).rejects.toThrow("Session not found");
-    });
-  });
-
-  describe("generateTitleAndRenameBranch", () => {
-    it("should throw if session not found in cache", async () => {
-      cacheHasSpy.mockReturnValue(false);
-
-      await expect(
-        lifecycle.generateTitleAndRenameBranch("nonexistent-session", "Hello"),
-      ).rejects.toThrow("Session nonexistent-session not found");
-    });
-
-    it("should return existing title if already generated", async () => {
-      cacheHasSpy.mockReturnValue(true);
-      cacheGetSpy.mockReturnValue({
-        getSessionData: () => ({
-          id: "test-session",
-          title: "Existing Title",
-          workspacePath: "/test",
-          metadata: { titleGenerated: true },
-        }),
-        updateMetadata: mock(() => {}),
-      });
-
-      const result = await lifecycle.generateTitleAndRenameBranch(
-        "test-session",
-        "Hello",
-      );
-
-      expect(result.title).toBe("Existing Title");
-      expect(result.isFallback).toBe(false);
-      // Should not call updateSession since title is already generated
-      expect(updateSessionSpy).not.toHaveBeenCalled();
-    });
-
-    it("should use fallback title on error", async () => {
-      const longMessage =
-        "This is a test message that should be truncated for the fallback title";
-      const updateMetadataSpy = mock(() => {});
-
-      cacheHasSpy.mockReturnValue(true);
-      cacheGetSpy.mockReturnValue({
-        getSessionData: () => ({
-          id: "test-session",
-          title: "New Session",
-          workspacePath: "/nonexistent/path/that/will/fail",
-          metadata: { titleGenerated: false },
-        }),
-        updateMetadata: updateMetadataSpy,
-      });
-
-      const result = await lifecycle.generateTitleAndRenameBranch(
-        "test-session",
-        longMessage,
-      );
-
-      // Should return fallback title (truncated message)
-      expect(result.isFallback).toBe(true);
-      expect(result.title.length).toBeLessThanOrEqual(50);
-    });
-
-    it('should use "New Session" as fallback for empty message', async () => {
-      const updateMetadataSpy = mock(() => {});
-
-      cacheHasSpy.mockReturnValue(true);
-      cacheGetSpy.mockReturnValue({
-        getSessionData: () => ({
-          id: "test-session",
-          title: "New Session",
-          workspacePath: "/nonexistent",
-          metadata: { titleGenerated: false },
-        }),
-        updateMetadata: updateMetadataSpy,
-      });
-
-      const result = await lifecycle.generateTitleAndRenameBranch(
-        "test-session",
-        "   ",
-      );
-
-      // Empty/whitespace message should result in "New Session" fallback
-      expect(result.isFallback).toBe(true);
-      expect(result.title).toBe("New Session");
-    });
-  });
+	SessionLifecycle,
+	generateBranchName,
+	slugify,
+	type SessionLifecycleConfig,
+} from '../../../src/lib/session/session-lifecycle';
+import type { Database } from '../../../src/storage/database';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { WorktreeManager } from '../../../src/lib/worktree-manager';
+import type { SessionCache, AgentSessionFactory } from '../../../src/lib/session/session-cache';
+import type { ToolsConfigManager } from '../../../src/lib/session/tools-config';
+import type { MessageHub } from '@neokai/shared';
+
+describe('SessionLifecycle', () => {
+	let lifecycle: SessionLifecycle;
+	let mockDb: Database;
+	let mockWorktreeManager: WorktreeManager;
+	let mockSessionCache: SessionCache;
+	let mockEventBus: DaemonHub;
+	let mockMessageHub: MessageHub;
+	let mockToolsConfigManager: ToolsConfigManager;
+	let mockAgentSessionFactory: AgentSessionFactory;
+	let config: SessionLifecycleConfig;
+
+	// Mock spies
+	let createSessionSpy: ReturnType<typeof mock>;
+	let updateSessionSpy: ReturnType<typeof mock>;
+	let deleteSessionSpy: ReturnType<typeof mock>;
+	let getSessionSpy: ReturnType<typeof mock>;
+	let createWorktreeSpy: ReturnType<typeof mock>;
+	let removeWorktreeSpy: ReturnType<typeof mock>;
+	let verifyWorktreeSpy: ReturnType<typeof mock>;
+	let emitSpy: ReturnType<typeof mock>;
+	let publishSpy: ReturnType<typeof mock>;
+	let cacheSetSpy: ReturnType<typeof mock>;
+	let cacheGetSpy: ReturnType<typeof mock>;
+	let cacheHasSpy: ReturnType<typeof mock>;
+	let cacheRemoveSpy: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		// Database mocks
+		createSessionSpy = mock(() => {});
+		updateSessionSpy = mock(() => {});
+		deleteSessionSpy = mock(() => {});
+		getSessionSpy = mock(() => null);
+		mockDb = {
+			createSession: createSessionSpy,
+			updateSession: updateSessionSpy,
+			deleteSession: deleteSessionSpy,
+			getSession: getSessionSpy,
+			getGlobalSettings: mock(() => ({
+				settingSources: ['user', 'project', 'local'],
+				disabledMcpServers: [],
+			})),
+		} as unknown as Database;
+
+		// Worktree manager mocks
+		createWorktreeSpy = mock(async () => null);
+		removeWorktreeSpy = mock(async () => {});
+		verifyWorktreeSpy = mock(async () => false);
+		mockWorktreeManager = {
+			createWorktree: createWorktreeSpy,
+			removeWorktree: removeWorktreeSpy,
+			verifyWorktree: verifyWorktreeSpy,
+			renameBranch: mock(async () => true),
+		} as unknown as WorktreeManager;
+
+		// Session cache mocks
+		const mockAgentSession = {
+			cleanup: mock(async () => {}),
+			updateMetadata: mock(() => {}),
+			getSessionData: mock(() => ({
+				id: 'test-id',
+				title: 'Test',
+				workspacePath: '/test',
+				metadata: { titleGenerated: false },
+			})),
+		};
+		cacheSetSpy = mock(() => {});
+		cacheGetSpy = mock(() => mockAgentSession);
+		cacheHasSpy = mock(() => false);
+		cacheRemoveSpy = mock(() => {});
+		mockSessionCache = {
+			set: cacheSetSpy,
+			get: cacheGetSpy,
+			has: cacheHasSpy,
+			remove: cacheRemoveSpy,
+		} as unknown as SessionCache;
+
+		// Event bus mocks
+		emitSpy = mock(async () => {});
+		mockEventBus = {
+			emit: emitSpy,
+		} as unknown as DaemonHub;
+
+		// MessageHub mocks
+		publishSpy = mock(async () => {});
+		mockMessageHub = {
+			publish: publishSpy,
+		} as unknown as MessageHub;
+
+		// Tools config manager
+		mockToolsConfigManager = {
+			getDefaultForNewSession: mock(() => ({ useClaudeCodePreset: true })),
+		} as unknown as ToolsConfigManager;
+
+		// Agent session factory
+		mockAgentSessionFactory = mock(() => ({
+			cleanup: mock(async () => {}),
+			updateMetadata: mock(() => {}),
+		}));
+
+		// Config
+		config = {
+			defaultModel: 'default',
+			maxTokens: 8192,
+			temperature: 1.0,
+			workspaceRoot: '/default/workspace',
+			disableWorktrees: true, // Disable worktrees for most tests
+		};
+
+		lifecycle = new SessionLifecycle(
+			mockDb,
+			mockWorktreeManager,
+			mockSessionCache,
+			mockEventBus,
+			mockMessageHub,
+			config,
+			mockToolsConfigManager,
+			mockAgentSessionFactory
+		);
+	});
+
+	describe('create', () => {
+		it('should create a session with default values', async () => {
+			const sessionId = await lifecycle.create({});
+
+			expect(sessionId).toBeDefined();
+			expect(sessionId).toMatch(/^[0-9a-f-]{36}$/);
+			expect(createSessionSpy).toHaveBeenCalled();
+		});
+
+		it('should use provided workspace path', async () => {
+			await lifecycle.create({ workspacePath: '/custom/path' });
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workspacePath: '/custom/path',
+				})
+			);
+		});
+
+		it('should use default workspace root when not provided', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workspacePath: '/default/workspace',
+				})
+			);
+		});
+
+		it('should set default title', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'New Session',
+				})
+			);
+		});
+
+		it('should set status to active', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: 'active',
+				})
+			);
+		});
+
+		it('should include config with model', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						model: 'default',
+						maxTokens: 8192,
+						temperature: 1.0,
+					}),
+				})
+			);
+		});
+
+		it('should override config values from params', async () => {
+			await lifecycle.create({
+				config: {
+					model: 'opus',
+					maxTokens: 4096,
+					temperature: 0.5,
+				},
+			});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						maxTokens: 4096,
+						temperature: 0.5,
+					}),
+				})
+			);
+		});
+
+		it('should add session to cache', async () => {
+			const sessionId = await lifecycle.create({});
+
+			expect(cacheSetSpy).toHaveBeenCalledWith(sessionId, expect.anything());
+		});
+
+		it('should emit session.created event', async () => {
+			const sessionId = await lifecycle.create({});
+
+			expect(emitSpy).toHaveBeenCalledWith('session.created', {
+				sessionId,
+				session: expect.anything(),
+			});
+		});
+
+		it('should initialize metadata with zero counts', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						messageCount: 0,
+						totalTokens: 0,
+						inputTokens: 0,
+						outputTokens: 0,
+						totalCost: 0,
+						toolCallCount: 0,
+						titleGenerated: false,
+						workspaceInitialized: true,
+					}),
+				})
+			);
+		});
+
+		it('should include tools config from tools manager', async () => {
+			await lifecycle.create({});
+
+			expect(createSessionSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						tools: { useClaudeCodePreset: true },
+					}),
+				})
+			);
+		});
+
+		describe('with worktrees enabled', () => {
+			beforeEach(() => {
+				config.disableWorktrees = false;
+				lifecycle = new SessionLifecycle(
+					mockDb,
+					mockWorktreeManager,
+					mockSessionCache,
+					mockEventBus,
+					mockMessageHub,
+					config,
+					mockToolsConfigManager,
+					mockAgentSessionFactory
+				);
+			});
+
+			it('should create worktree when enabled', async () => {
+				createWorktreeSpy.mockResolvedValue({
+					worktreePath: '/worktree/path',
+					mainRepoPath: '/main/repo',
+					branch: 'session/test',
+				});
+
+				await lifecycle.create({});
+
+				expect(createWorktreeSpy).toHaveBeenCalled();
+			});
+
+			it('should use worktree path as session workspace', async () => {
+				createWorktreeSpy.mockResolvedValue({
+					worktreePath: '/worktree/session',
+					mainRepoPath: '/main/repo',
+					branch: 'session/test',
+				});
+
+				await lifecycle.create({});
+
+				expect(createSessionSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workspacePath: '/worktree/session',
+					})
+				);
+			});
+
+			it('should include worktree metadata in session', async () => {
+				const worktreeMetadata = {
+					worktreePath: '/worktree/session',
+					mainRepoPath: '/main/repo',
+					branch: 'session/test-id',
+				};
+				createWorktreeSpy.mockResolvedValue(worktreeMetadata);
+
+				await lifecycle.create({});
+
+				expect(createSessionSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						worktree: worktreeMetadata,
+						gitBranch: 'session/test-id',
+					})
+				);
+			});
+
+			it('should fallback to base workspace on worktree error', async () => {
+				createWorktreeSpy.mockRejectedValue(new Error('Git error'));
+
+				await lifecycle.create({ workspacePath: '/my/workspace' });
+
+				expect(createSessionSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workspacePath: '/my/workspace',
+						worktree: undefined,
+					})
+				);
+			});
+
+			it('should use custom base branch', async () => {
+				createWorktreeSpy.mockResolvedValue({
+					worktreePath: '/worktree',
+					mainRepoPath: '/main',
+					branch: 'session/test',
+				});
+
+				await lifecycle.create({ worktreeBaseBranch: 'develop' });
+
+				expect(createWorktreeSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						baseBranch: 'develop',
+					})
+				);
+			});
+		});
+	});
+
+	describe('update', () => {
+		it('should update session in database', async () => {
+			await lifecycle.update('session-123', { title: 'Updated Title' });
+
+			expect(updateSessionSpy).toHaveBeenCalledWith('session-123', {
+				title: 'Updated Title',
+			});
+		});
+
+		it('should update in-memory session when cached', async () => {
+			const mockAgentSession = {
+				updateMetadata: mock(() => {}),
+			};
+			cacheHasSpy.mockReturnValue(true);
+			cacheGetSpy.mockReturnValue(mockAgentSession);
+
+			await lifecycle.update('session-123', { title: 'New Title' });
+
+			expect(mockAgentSession.updateMetadata).toHaveBeenCalledWith({
+				title: 'New Title',
+			});
+		});
+
+		it('should emit session.updated event', async () => {
+			await lifecycle.update('session-123', { title: 'Updated' });
+
+			expect(emitSpy).toHaveBeenCalledWith('session.updated', {
+				sessionId: 'session-123',
+				source: 'update',
+				session: { title: 'Updated' },
+			});
+		});
+	});
+
+	describe('delete', () => {
+		it('should delete session from database', async () => {
+			await lifecycle.delete('session-123');
+
+			expect(deleteSessionSpy).toHaveBeenCalledWith('session-123');
+		});
+
+		it('should remove session from cache', async () => {
+			await lifecycle.delete('session-123');
+
+			expect(cacheRemoveSpy).toHaveBeenCalledWith('session-123');
+		});
+
+		it('should cleanup agent session when cached', async () => {
+			const mockAgentSession = {
+				cleanup: mock(async () => {}),
+			};
+			cacheHasSpy.mockReturnValue(true);
+			cacheGetSpy.mockReturnValue(mockAgentSession);
+
+			await lifecycle.delete('session-123');
+
+			expect(mockAgentSession.cleanup).toHaveBeenCalled();
+		});
+
+		it('should broadcast session.deleted event', async () => {
+			await lifecycle.delete('session-123');
+
+			expect(publishSpy).toHaveBeenCalledWith(
+				'session.deleted',
+				{ sessionId: 'session-123', reason: 'deleted' },
+				{ sessionId: 'global' }
+			);
+		});
+
+		it('should emit session.deleted via DaemonHub', async () => {
+			await lifecycle.delete('session-123');
+
+			expect(emitSpy).toHaveBeenCalledWith('session.deleted', {
+				sessionId: 'session-123',
+			});
+		});
+
+		it('should remove worktree when session has one', async () => {
+			const sessionWithWorktree = {
+				workspacePath: '/worktree/path',
+				worktree: {
+					worktreePath: '/worktree/path',
+					mainRepoPath: '/main',
+					branch: 'session/test',
+				},
+			};
+			getSessionSpy.mockReturnValue(sessionWithWorktree);
+
+			await lifecycle.delete('session-123');
+
+			expect(removeWorktreeSpy).toHaveBeenCalledWith(sessionWithWorktree.worktree, true);
+		});
+
+		it('should continue on worktree removal failure', async () => {
+			const sessionWithWorktree = {
+				workspacePath: '/worktree/path',
+				worktree: {
+					worktreePath: '/worktree/path',
+					mainRepoPath: '/main',
+					branch: 'session/test',
+				},
+			};
+			getSessionSpy.mockReturnValue(sessionWithWorktree);
+			removeWorktreeSpy.mockRejectedValue(new Error('Git error'));
+
+			// Should not throw
+			await expect(lifecycle.delete('session-123')).resolves.toBeUndefined();
+			expect(deleteSessionSpy).toHaveBeenCalled();
+		});
+
+		it('should throw when database delete fails', async () => {
+			deleteSessionSpy.mockImplementation(() => {
+				throw new Error('DB error');
+			});
+
+			await expect(lifecycle.delete('session-123')).rejects.toThrow('DB error');
+		});
+	});
+
+	describe('getFromDB', () => {
+		it('should return session from database', () => {
+			const mockSession = { id: 'test', title: 'Test Session' };
+			getSessionSpy.mockReturnValue(mockSession);
+
+			const result = lifecycle.getFromDB('test');
+
+			expect(result).toEqual(mockSession);
+			expect(getSessionSpy).toHaveBeenCalledWith('test');
+		});
+
+		it('should return null for non-existent session', () => {
+			getSessionSpy.mockReturnValue(null);
+
+			const result = lifecycle.getFromDB('non-existent');
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('markOutputRemoved', () => {
+		it('should add message UUID to removedOutputs', async () => {
+			const session = {
+				id: 'session-123',
+				metadata: { removedOutputs: [] },
+			};
+			getSessionSpy.mockReturnValue(session);
+
+			await lifecycle.markOutputRemoved('session-123', 'message-uuid-456');
+
+			expect(updateSessionSpy).toHaveBeenCalledWith('session-123', {
+				metadata: expect.objectContaining({
+					removedOutputs: ['message-uuid-456'],
+				}),
+			});
+		});
+
+		it('should not duplicate message UUID', async () => {
+			const session = {
+				id: 'session-123',
+				metadata: { removedOutputs: ['existing-uuid'] },
+			};
+			getSessionSpy.mockReturnValue(session);
+
+			await lifecycle.markOutputRemoved('session-123', 'existing-uuid');
+
+			expect(updateSessionSpy).toHaveBeenCalledWith('session-123', {
+				metadata: expect.objectContaining({
+					removedOutputs: ['existing-uuid'],
+				}),
+			});
+		});
+
+		it('should throw for non-existent session', async () => {
+			getSessionSpy.mockReturnValue(null);
+
+			await expect(lifecycle.markOutputRemoved('non-existent', 'uuid')).rejects.toThrow(
+				'Session not found'
+			);
+		});
+	});
+
+	describe('generateTitleAndRenameBranch', () => {
+		it('should throw if session not found in cache', async () => {
+			cacheHasSpy.mockReturnValue(false);
+
+			await expect(
+				lifecycle.generateTitleAndRenameBranch('nonexistent-session', 'Hello')
+			).rejects.toThrow('Session nonexistent-session not found');
+		});
+
+		it('should return existing title if already generated', async () => {
+			cacheHasSpy.mockReturnValue(true);
+			cacheGetSpy.mockReturnValue({
+				getSessionData: () => ({
+					id: 'test-session',
+					title: 'Existing Title',
+					workspacePath: '/test',
+					metadata: { titleGenerated: true },
+				}),
+				updateMetadata: mock(() => {}),
+			});
+
+			const result = await lifecycle.generateTitleAndRenameBranch('test-session', 'Hello');
+
+			expect(result.title).toBe('Existing Title');
+			expect(result.isFallback).toBe(false);
+			// Should not call updateSession since title is already generated
+			expect(updateSessionSpy).not.toHaveBeenCalled();
+		});
+
+		it('should use fallback title on error', async () => {
+			const longMessage = 'This is a test message that should be truncated for the fallback title';
+			const updateMetadataSpy = mock(() => {});
+
+			cacheHasSpy.mockReturnValue(true);
+			cacheGetSpy.mockReturnValue({
+				getSessionData: () => ({
+					id: 'test-session',
+					title: 'New Session',
+					workspacePath: '/nonexistent/path/that/will/fail',
+					metadata: { titleGenerated: false },
+				}),
+				updateMetadata: updateMetadataSpy,
+			});
+
+			const result = await lifecycle.generateTitleAndRenameBranch('test-session', longMessage);
+
+			// Should return fallback title (truncated message)
+			expect(result.isFallback).toBe(true);
+			expect(result.title.length).toBeLessThanOrEqual(50);
+		});
+
+		it('should use "New Session" as fallback for empty message', async () => {
+			const updateMetadataSpy = mock(() => {});
+
+			cacheHasSpy.mockReturnValue(true);
+			cacheGetSpy.mockReturnValue({
+				getSessionData: () => ({
+					id: 'test-session',
+					title: 'New Session',
+					workspacePath: '/nonexistent',
+					metadata: { titleGenerated: false },
+				}),
+				updateMetadata: updateMetadataSpy,
+			});
+
+			const result = await lifecycle.generateTitleAndRenameBranch('test-session', '   ');
+
+			// Empty/whitespace message should result in "New Session" fallback
+			expect(result.isFallback).toBe(true);
+			expect(result.title).toBe('New Session');
+		});
+	});
 });
 
-describe("generateBranchName", () => {
-  it("should create branch name from title and session ID", () => {
-    const result = generateBranchName("Fix login bug", "abc12345-def6-7890");
-    expect(result).toBe("session/fix-login-bug-abc12345");
-  });
+describe('generateBranchName', () => {
+	it('should create branch name from title and session ID', () => {
+		const result = generateBranchName('Fix login bug', 'abc12345-def6-7890');
+		expect(result).toBe('session/fix-login-bug-abc12345');
+	});
 
-  it("should slugify title", () => {
-    const result = generateBranchName("Add New Feature!", "test1234-5678-abcd");
-    expect(result).toBe("session/add-new-feature-test1234");
-  });
+	it('should slugify title', () => {
+		const result = generateBranchName('Add New Feature!', 'test1234-5678-abcd');
+		expect(result).toBe('session/add-new-feature-test1234');
+	});
 
-  it("should handle special characters", () => {
-    const result = generateBranchName("What's the bug?", "xyz98765-4321-efgh");
-    expect(result).toBe("session/what-s-the-bug-xyz98765");
-  });
+	it('should handle special characters', () => {
+		const result = generateBranchName("What's the bug?", 'xyz98765-4321-efgh');
+		expect(result).toBe('session/what-s-the-bug-xyz98765');
+	});
 
-  it("should truncate long titles", () => {
-    const longTitle =
-      "This is a very long title that should be truncated to fit within limits";
-    const result = generateBranchName(longTitle, "short123-4567-89ab");
-    expect(result.length).toBeLessThan(70); // session/ + 50 + - + 8
-  });
+	it('should truncate long titles', () => {
+		const longTitle = 'This is a very long title that should be truncated to fit within limits';
+		const result = generateBranchName(longTitle, 'short123-4567-89ab');
+		expect(result.length).toBeLessThan(70); // session/ + 50 + - + 8
+	});
 
-  it("should use short session ID", () => {
-    const result = generateBranchName(
-      "Test",
-      "12345678-abcd-efgh-ijkl-mnopqrstuvwx",
-    );
-    expect(result).toContain("12345678");
-    expect(result).not.toContain("mnopqrstuvwx");
-  });
+	it('should use short session ID', () => {
+		const result = generateBranchName('Test', '12345678-abcd-efgh-ijkl-mnopqrstuvwx');
+		expect(result).toContain('12345678');
+		expect(result).not.toContain('mnopqrstuvwx');
+	});
 
-  it("should lowercase the title", () => {
-    const result = generateBranchName("UPPERCASE TITLE", "test1234");
-    expect(result).toBe("session/uppercase-title-test1234");
-  });
+	it('should lowercase the title', () => {
+		const result = generateBranchName('UPPERCASE TITLE', 'test1234');
+		expect(result).toBe('session/uppercase-title-test1234');
+	});
 
-  it("should remove leading/trailing hyphens", () => {
-    const result = generateBranchName("  Spaces around  ", "test1234");
-    expect(result).toBe("session/spaces-around-test1234");
-  });
+	it('should remove leading/trailing hyphens', () => {
+		const result = generateBranchName('  Spaces around  ', 'test1234');
+		expect(result).toBe('session/spaces-around-test1234');
+	});
 });
 
-describe("slugify", () => {
-  it("should convert to lowercase", () => {
-    expect(slugify("HELLO")).toBe("hello");
-  });
+describe('slugify', () => {
+	it('should convert to lowercase', () => {
+		expect(slugify('HELLO')).toBe('hello');
+	});
 
-  it("should replace spaces with hyphens", () => {
-    expect(slugify("hello world")).toBe("hello-world");
-  });
+	it('should replace spaces with hyphens', () => {
+		expect(slugify('hello world')).toBe('hello-world');
+	});
 
-  it("should remove special characters", () => {
-    expect(slugify("what's up?")).toBe("what-s-up");
-  });
+	it('should remove special characters', () => {
+		expect(slugify("what's up?")).toBe('what-s-up');
+	});
 
-  it("should collapse multiple hyphens", () => {
-    expect(slugify("hello---world")).toBe("hello-world");
-  });
+	it('should collapse multiple hyphens', () => {
+		expect(slugify('hello---world')).toBe('hello-world');
+	});
 
-  it("should remove leading/trailing hyphens", () => {
-    expect(slugify("--hello--")).toBe("hello");
-  });
+	it('should remove leading/trailing hyphens', () => {
+		expect(slugify('--hello--')).toBe('hello');
+	});
 
-  it("should truncate to 50 characters", () => {
-    const long = "a".repeat(100);
-    expect(slugify(long).length).toBe(50);
-  });
+	it('should truncate to 50 characters', () => {
+		const long = 'a'.repeat(100);
+		expect(slugify(long).length).toBe(50);
+	});
 
-  it("should handle empty string", () => {
-    expect(slugify("")).toBe("");
-  });
+	it('should handle empty string', () => {
+		expect(slugify('')).toBe('');
+	});
 
-  it("should handle only special characters", () => {
-    expect(slugify("!@#$%")).toBe("");
-  });
+	it('should handle only special characters', () => {
+		expect(slugify('!@#$%')).toBe('');
+	});
 });

--- a/packages/e2e/tests/settings-modal-global-settings.e2e.ts
+++ b/packages/e2e/tests/settings-modal-global-settings.e2e.ts
@@ -4,229 +4,193 @@
  * Tests for global settings and tools settings in the Settings modal.
  */
 
-import { test, expect, type Page } from "../fixtures";
-import { waitForWebSocketConnected } from "./helpers/wait-helpers";
+import { test, expect, type Page } from '../fixtures';
+import { waitForWebSocketConnected } from './helpers/wait-helpers';
 
 /**
  * Open the Settings modal by clicking on Authentication row in sidebar footer
  */
 async function openSettingsModal(page: Page): Promise<void> {
-  // The settings button is the Authentication row in the sidebar footer
-  // It has a gear icon and shows auth status
-  const settingsButton = page
-    .locator('button:has(svg path[d*="M10.325 4.317"])')
-    .first();
-  await settingsButton.waitFor({ state: "visible", timeout: 5000 });
-  await settingsButton.click();
+	// The settings button is the Authentication row in the sidebar footer
+	// It has a gear icon and shows auth status
+	const settingsButton = page.locator('button:has(svg path[d*="M10.325 4.317"])').first();
+	await settingsButton.waitFor({ state: 'visible', timeout: 5000 });
+	await settingsButton.click();
 
-  // Wait for modal to appear
-  await page
-    .locator('h2:has-text("Settings")')
-    .waitFor({ state: "visible", timeout: 5000 });
+	// Wait for modal to appear
+	await page.locator('h2:has-text("Settings")').waitFor({ state: 'visible', timeout: 5000 });
 }
 
-test.describe("Settings Modal - Global Settings", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    await waitForWebSocketConnected(page);
-  });
+test.describe('Settings Modal - Global Settings', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+	});
 
-  test.skip("should display Global Settings section", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should display Global Settings section', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Verify Global Settings heading
-    await expect(page.locator('h3:has-text("Global Settings")')).toBeVisible();
-  });
+		// Verify Global Settings heading
+		await expect(page.locator('h3:has-text("Global Settings")')).toBeVisible();
+	});
 
-  test.skip("should show Model selection dropdown", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show Model selection dropdown', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find the model label and select
-    const modelLabel = page.locator('label:has-text("Model")');
-    await expect(modelLabel).toBeVisible();
+		// Find the model label and select
+		const modelLabel = page.locator('label:has-text("Model")');
+		await expect(modelLabel).toBeVisible();
 
-    // Should have a select element for model
-    const modelSelect = page
-      .locator("select")
-      .filter({ has: page.locator('option:has-text("Default")') });
-    await expect(modelSelect).toBeVisible();
-  });
+		// Should have a select element for model
+		const modelSelect = page
+			.locator('select')
+			.filter({ has: page.locator('option:has-text("Default")') });
+		await expect(modelSelect).toBeVisible();
+	});
 
-  test.skip("should show Thinking Level selection dropdown", async ({
-    page,
-  }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show Thinking Level selection dropdown', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find the thinking level label
-    const thinkingLabel = page.locator('label:has-text("Thinking Level")');
-    await expect(thinkingLabel).toBeVisible();
+		// Find the thinking level label
+		const thinkingLabel = page.locator('label:has-text("Thinking Level")');
+		await expect(thinkingLabel).toBeVisible();
 
-    // Should have a select for thinking level with all options
-    const thinkingSelect = page.locator("select").filter({
-      has: page.locator('option:has-text("Auto")'),
-    });
-    await expect(thinkingSelect.first()).toBeVisible();
+		// Should have a select for thinking level with all options
+		const thinkingSelect = page.locator('select').filter({
+			has: page.locator('option:has-text("Auto")'),
+		});
+		await expect(thinkingSelect.first()).toBeVisible();
 
-    // Verify all thinking level options exist
-    await expect(page.locator('option:has-text("Think 8k")')).toBeAttached();
-    await expect(page.locator('option:has-text("Think 16k")')).toBeAttached();
-    await expect(page.locator('option:has-text("Think 32k")')).toBeAttached();
-  });
+		// Verify all thinking level options exist
+		await expect(page.locator('option:has-text("Think 8k")')).toBeAttached();
+		await expect(page.locator('option:has-text("Think 16k")')).toBeAttached();
+		await expect(page.locator('option:has-text("Think 32k")')).toBeAttached();
+	});
 
-  test.skip("should show Auto Scroll toggle", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show Auto Scroll toggle', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find auto scroll label
-    await expect(page.locator('label:has-text("Auto Scroll")')).toBeVisible();
+		// Find auto scroll label
+		await expect(page.locator('label:has-text("Auto Scroll")')).toBeVisible();
 
-    // Should show description
-    await expect(
-      page.locator("text=Auto-scroll to bottom when new messages arrive"),
-    ).toBeVisible();
+		// Should show description
+		await expect(page.locator('text=Auto-scroll to bottom when new messages arrive')).toBeVisible();
 
-    // Should have a checkbox
-    const autoScrollCheckbox = page
-      .locator('label:has-text("Enabled")')
-      .locator('input[type="checkbox"]');
-    await expect(autoScrollCheckbox).toBeVisible();
-  });
+		// Should have a checkbox
+		const autoScrollCheckbox = page
+			.locator('label:has-text("Enabled")')
+			.locator('input[type="checkbox"]');
+		await expect(autoScrollCheckbox).toBeVisible();
+	});
 
-  test.skip("should show Permission Mode selection", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show Permission Mode selection', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find the permission mode label
-    const permissionLabel = page.locator('label:has-text("Permission Mode")');
-    await expect(permissionLabel).toBeVisible();
+		// Find the permission mode label
+		const permissionLabel = page.locator('label:has-text("Permission Mode")');
+		await expect(permissionLabel).toBeVisible();
 
-    // Should have a select for permission mode
-    const permissionSelect = page.locator("select").filter({
-      has: page.locator('option:has-text("Default")'),
-    });
-    await expect(permissionSelect.first()).toBeVisible();
-  });
+		// Should have a select for permission mode
+		const permissionSelect = page.locator('select').filter({
+			has: page.locator('option:has-text("Default")'),
+		});
+		await expect(permissionSelect.first()).toBeVisible();
+	});
 
-  test.skip("should show Setting Sources checkboxes", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show Setting Sources checkboxes', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find Setting Sources label
-    await expect(
-      page.locator('label:has-text("Setting Sources")'),
-    ).toBeVisible();
+		// Find Setting Sources label
+		await expect(page.locator('label:has-text("Setting Sources")')).toBeVisible();
 
-    // Should show User, Project, and Local options
-    await expect(page.locator("text=User (~/.claude/)")).toBeVisible();
-    await expect(page.locator("text=Project (.claude/)")).toBeVisible();
-    await expect(
-      page.locator("text=Local (.claude/settings.local.json)"),
-    ).toBeVisible();
-  });
+		// Should show User, Project, and Local options
+		await expect(page.locator('text=User (~/.claude/)')).toBeVisible();
+		await expect(page.locator('text=Project (.claude/)')).toBeVisible();
+		await expect(page.locator('text=Local (.claude/settings.local.json)')).toBeVisible();
+	});
 
-  test.skip("should show auto-save notice", async ({ page }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show auto-save notice', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Should show auto-save text
-    await expect(
-      page.locator("text=Changes are saved automatically"),
-    ).toBeVisible();
-  });
+		// Should show auto-save text
+		await expect(page.locator('text=Changes are saved automatically')).toBeVisible();
+	});
 });
 
-test.describe("Settings Modal - Global Tools Settings", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    await waitForWebSocketConnected(page);
-  });
+test.describe('Settings Modal - Global Tools Settings', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+	});
 
-  test.skip("should display Global Tools Settings section", async ({
-    page,
-  }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should display Global Tools Settings section', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Verify Global Tools Settings heading
-    await expect(
-      page.locator('h3:has-text("Global Tools Settings")'),
-    ).toBeVisible();
-  });
+		// Verify Global Tools Settings heading
+		await expect(page.locator('h3:has-text("Global Tools Settings")')).toBeVisible();
+	});
 
-  test.skip("should show System Prompt section with Claude Code Preset", async ({
-    page,
-  }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show System Prompt section with Claude Code Preset', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find System Prompt section
-    await expect(page.locator('h4:has-text("System Prompt")')).toBeVisible();
+		// Find System Prompt section
+		await expect(page.locator('h4:has-text("System Prompt")')).toBeVisible();
 
-    // Should show Claude Code Preset
-    await expect(page.locator("text=Claude Code Preset")).toBeVisible();
-    await expect(
-      page.locator("text=Use official Claude Code system prompt"),
-    ).toBeVisible();
-  });
+		// Should show Claude Code Preset
+		await expect(page.locator('text=Claude Code Preset')).toBeVisible();
+		await expect(page.locator('text=Use official Claude Code system prompt')).toBeVisible();
+	});
 
-  test.skip("should NOT show NeoKai Tools section", async ({ page }) => {
-    // NeoKai Tools section has been removed
-    await openSettingsModal(page);
+	test.skip('should NOT show NeoKai Tools section', async ({ page }) => {
+		// NeoKai Tools section has been removed
+		await openSettingsModal(page);
 
-    // Verify NeoKai Tools heading does NOT exist
-    await expect(page.locator('h4:has-text("NeoKai Tools")')).not.toBeVisible();
+		// Verify NeoKai Tools heading does NOT exist
+		await expect(page.locator('h4:has-text("NeoKai Tools")')).not.toBeVisible();
 
-    // Memory tool should NOT be shown
-    await expect(
-      page.locator("text=Persistent key-value storage"),
-    ).not.toBeVisible();
-  });
+		// Memory tool should NOT be shown
+		await expect(page.locator('text=Persistent key-value storage')).not.toBeVisible();
+	});
 
-  test.skip("should show SDK Built-in section with full tool names", async ({
-    page,
-  }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should show SDK Built-in section with full tool names', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find SDK Built-in section
-    await expect(
-      page.locator('h4:has-text("Claude Agent SDK Built-in")'),
-    ).toBeVisible();
+		// Find SDK Built-in section
+		await expect(page.locator('h4:has-text("Claude Agent SDK Built-in")')).toBeVisible();
 
-    // Should list built-in tools without trailing "..."
-    await expect(
-      page.locator(
-        "text=Read, Write, Edit, Glob, Grep, Bash, NotebookEdit, TodoWrite",
-      ),
-    ).toBeVisible();
-    await expect(
-      page.locator("text=/help, /context, /clear, /config, /bug"),
-    ).toBeVisible();
-    await expect(
-      page.locator("text=Task agents (general-purpose, Explore, Plan, Bash)"),
-    ).toBeVisible();
-    await expect(page.locator("text=WebSearch, WebFetch")).toBeVisible();
-  });
+		// Should list built-in tools without trailing "..."
+		await expect(
+			page.locator('text=Read, Write, Edit, Glob, Grep, Bash, NotebookEdit, TodoWrite')
+		).toBeVisible();
+		await expect(page.locator('text=/help, /context, /clear, /config, /bug')).toBeVisible();
+		await expect(
+			page.locator('text=Task agents (general-purpose, Explore, Plan, Bash)')
+		).toBeVisible();
+		await expect(page.locator('text=WebSearch, WebFetch')).toBeVisible();
+	});
 
-  test.skip("should have Allowed and Default ON checkboxes for tools", async ({
-    page,
-  }) => {
-    // TODO: Update test to match current SettingsModal structure
-    await openSettingsModal(page);
+	test.skip('should have Allowed and Default ON checkboxes for tools', async ({ page }) => {
+		// TODO: Update test to match current SettingsModal structure
+		await openSettingsModal(page);
 
-    // Find Claude Code Preset row
-    const claudeCodeRow = page.locator("text=Claude Code Preset").locator("..");
+		// Find Claude Code Preset row
+		const claudeCodeRow = page.locator('text=Claude Code Preset').locator('..');
 
-    // Should have Allowed checkbox
-    await expect(claudeCodeRow.locator("text=Allowed")).toBeVisible();
-    await expect(
-      claudeCodeRow.locator('input[type="checkbox"]').first(),
-    ).toBeVisible();
+		// Should have Allowed checkbox
+		await expect(claudeCodeRow.locator('text=Allowed')).toBeVisible();
+		await expect(claudeCodeRow.locator('input[type="checkbox"]').first()).toBeVisible();
 
-    // Should have Default ON checkbox
-    await expect(claudeCodeRow.locator("text=Default ON")).toBeVisible();
-  });
+		// Should have Default ON checkbox
+		await expect(claudeCodeRow.locator('text=Default ON')).toBeVisible();
+	});
 });

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -6,56 +6,56 @@
  * .claude/settings.local.json).
  */
 
-import type { ThinkingLevel } from "../types.ts";
+import type { ThinkingLevel } from '../types.ts';
 
-export type SettingSource = "user" | "project" | "local";
+export type SettingSource = 'user' | 'project' | 'local';
 
 export type PermissionMode =
-  | "default"
-  | "acceptEdits"
-  | "bypassPermissions"
-  | "plan"
-  | "delegate"
-  | "dontAsk";
+	| 'default'
+	| 'acceptEdits'
+	| 'bypassPermissions'
+	| 'plan'
+	| 'delegate'
+	| 'dontAsk';
 
 /**
  * Settings that can be passed to the SDK via query options
  */
 export interface SDKSupportedSettings {
-  // Model
-  model?: string;
+	// Model
+	model?: string;
 
-  // Permissions
-  permissionMode?: PermissionMode;
-  allowedTools?: string[];
-  disallowedTools?: string[];
-  additionalDirectories?: string[];
+	// Permissions
+	permissionMode?: PermissionMode;
+	allowedTools?: string[];
+	disallowedTools?: string[];
+	additionalDirectories?: string[];
 
-  // Thinking
-  maxThinkingTokens?: number | null;
+	// Thinking
+	maxThinkingTokens?: number | null;
 
-  // Environment
-  env?: Record<string, string>;
+	// Environment
+	env?: Record<string, string>;
 
-  // Limits
-  maxTurns?: number;
-  maxBudgetUsd?: number;
+	// Limits
+	maxTurns?: number;
+	maxBudgetUsd?: number;
 
-  // Sandbox
-  sandbox?: {
-    enabled?: boolean;
-    autoAllowBashIfSandboxed?: boolean;
-    network?: {
-      allowUnixSockets?: string[];
-      allowLocalBinding?: boolean;
-    };
-  };
+	// Sandbox
+	sandbox?: {
+		enabled?: boolean;
+		autoAllowBashIfSandboxed?: boolean;
+		network?: {
+			allowUnixSockets?: string[];
+			allowLocalBinding?: boolean;
+		};
+	};
 
-  // Betas
-  betas?: Array<"context-1m-2025-08-07">;
+	// Betas
+	betas?: Array<'context-1m-2025-08-07'>;
 
-  // System prompt
-  systemPrompt?: string;
+	// System prompt
+	systemPrompt?: string;
 }
 
 /**
@@ -63,114 +63,114 @@ export interface SDKSupportedSettings {
  * These settings have no SDK option equivalent.
  */
 export interface FileOnlySettings {
-  // MCP Server Control (CRITICAL for NeoKai)
-  disabledMcpServers?: string[];
-  enabledMcpServers?: string[];
-  enableAllProjectMcpServers?: boolean;
+	// MCP Server Control (CRITICAL for NeoKai)
+	disabledMcpServers?: string[];
+	enabledMcpServers?: string[];
+	enableAllProjectMcpServers?: boolean;
 
-  // Permissions (file-only features)
-  askPermissions?: string[];
+	// Permissions (file-only features)
+	askPermissions?: string[];
 
-  // Sandbox (file-only features)
-  excludedCommands?: string[];
-  allowUnsandboxedCommands?: boolean;
+	// Sandbox (file-only features)
+	excludedCommands?: string[];
+	allowUnsandboxedCommands?: boolean;
 
-  // UI/Display
-  outputStyle?: string;
-  showArchived?: boolean;
+	// UI/Display
+	outputStyle?: string;
+	showArchived?: boolean;
 
-  // Attribution
-  attribution?: {
-    commit?: string;
-    pr?: string;
-  };
+	// Attribution
+	attribution?: {
+		commit?: string;
+		pr?: string;
+	};
 
-  // Output Limiter (NeoKai-specific)
-  outputLimiter?: {
-    enabled?: boolean;
-    bash?: {
-      headLines?: number; // First N lines to show (default: 100)
-      tailLines?: number; // Last N lines to show (default: 200)
-    };
-    read?: {
-      maxChars?: number; // Max characters to read (default: 50000)
-    };
-    grep?: {
-      maxMatches?: number; // Max search matches (default: 500)
-    };
-    glob?: {
-      maxFiles?: number; // Max files to list (default: 1000)
-    };
-    excludeTools?: string[]; // Tools to exclude from limiting
-  };
+	// Output Limiter (NeoKai-specific)
+	outputLimiter?: {
+		enabled?: boolean;
+		bash?: {
+			headLines?: number; // First N lines to show (default: 100)
+			tailLines?: number; // Last N lines to show (default: 200)
+		};
+		read?: {
+			maxChars?: number; // Max characters to read (default: 50000)
+		};
+		grep?: {
+			maxMatches?: number; // Max search matches (default: 500)
+		};
+		glob?: {
+			maxFiles?: number; // Max files to list (default: 1000)
+		};
+		excludeTools?: string[]; // Tools to exclude from limiting
+	};
 }
 
 /**
  * Per-server MCP settings (allowed/defaultOn)
  */
 export interface McpServerSettings {
-  allowed?: boolean;
-  defaultOn?: boolean;
+	allowed?: boolean;
+	defaultOn?: boolean;
 }
 
 /**
  * Global settings that apply across all sessions
  */
 export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
-  // Setting sources to load (all enabled by default)
-  settingSources: SettingSource[];
+	// Setting sources to load (all enabled by default)
+	settingSources: SettingSource[];
 
-  // Per-server MCP settings (keyed by server name)
-  mcpServerSettings?: Record<string, McpServerSettings>;
+	// Per-server MCP settings (keyed by server name)
+	mcpServerSettings?: Record<string, McpServerSettings>;
 
-  // Default thinking level for new sessions
-  // Maps to maxThinkingTokens in SDK options
-  thinkingLevel?: ThinkingLevel;
+	// Default thinking level for new sessions
+	// Maps to maxThinkingTokens in SDK options
+	thinkingLevel?: ThinkingLevel;
 
-  // Default auto-scroll setting for new sessions
-  autoScroll?: boolean;
+	// Default auto-scroll setting for new sessions
+	autoScroll?: boolean;
 }
 
 /**
  * Session-specific settings that can override global settings
  */
 export interface SessionSettings extends GlobalSettings {
-  sessionId: string;
+	sessionId: string;
 }
 
 /**
  * Default global settings
  */
 export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
-  settingSources: ["user", "project", "local"],
-  permissionMode: "default",
-  disabledMcpServers: [],
-  showArchived: false,
-  outputLimiter: {
-    enabled: true,
-    bash: {
-      headLines: 100,
-      tailLines: 200,
-    },
-    read: {
-      maxChars: 50000,
-    },
-    grep: {
-      maxMatches: 500,
-    },
-    glob: {
-      maxFiles: 1000,
-    },
-    excludeTools: [],
-  },
+	settingSources: ['user', 'project', 'local'],
+	permissionMode: 'default',
+	disabledMcpServers: [],
+	showArchived: false,
+	outputLimiter: {
+		enabled: true,
+		bash: {
+			headLines: 100,
+			tailLines: 200,
+		},
+		read: {
+			maxChars: 50000,
+		},
+		grep: {
+			maxMatches: 500,
+		},
+		glob: {
+			maxFiles: 1000,
+		},
+		excludeTools: [],
+	},
 };
 
 /**
  * MCP server information
  */
 export interface McpServerInfo {
-  name: string;
-  status: "connected" | "failed" | "pending" | "disabled";
-  enabled: boolean;
-  description?: string;
+	name: string;
+	status: 'connected' | 'failed' | 'pending' | 'disabled';
+	enabled: boolean;
+	description?: string;
 }

--- a/packages/web/src/components/GlobalSettingsEditor.tsx
+++ b/packages/web/src/components/GlobalSettingsEditor.tsx
@@ -1,608 +1,553 @@
-import { useState, useEffect } from "preact/hooks";
-import type {
-  PermissionMode,
-  SettingSource,
-  ThinkingLevel,
-} from "@neokai/shared";
-import { toast } from "../lib/toast.ts";
+import { useState, useEffect } from 'preact/hooks';
+import type { PermissionMode, SettingSource, ThinkingLevel } from '@neokai/shared';
+import { toast } from '../lib/toast.ts';
 import {
-  updateGlobalSettings,
-  listMcpServersFromSources,
-  updateMcpServerSettings,
-  type McpServerFromSource,
-  type McpServersFromSourcesResponse,
-} from "../lib/api-helpers.ts";
-import { globalSettings } from "../lib/state.ts";
-import { borderColors } from "../lib/design-tokens.ts";
+	updateGlobalSettings,
+	listMcpServersFromSources,
+	updateMcpServerSettings,
+	type McpServerFromSource,
+	type McpServersFromSourcesResponse,
+} from '../lib/api-helpers.ts';
+import { globalSettings } from '../lib/state.ts';
+import { borderColors } from '../lib/design-tokens.ts';
 
 // Model options with human-readable names
 const MODEL_OPTIONS = [
-  { value: "", label: "Default (Sonnet)" },
-  { value: "claude-sonnet-4-5-20250929", label: "Sonnet 4.5" },
-  { value: "claude-opus-4-5-20251101", label: "Opus 4.5" },
-  { value: "claude-haiku-3-5-20241022", label: "Haiku 3.5" },
+	{ value: '', label: 'Default (Sonnet)' },
+	{ value: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5' },
+	{ value: 'claude-opus-4-5-20251101', label: 'Opus 4.5' },
+	{ value: 'claude-haiku-3-5-20241022', label: 'Haiku 3.5' },
 ] as const;
 
 // Permission mode options with descriptions
 const PERMISSION_MODE_OPTIONS: Array<{
-  value: PermissionMode;
-  label: string;
-  description: string;
+	value: PermissionMode;
+	label: string;
+	description: string;
 }> = [
-  {
-    value: "default",
-    label: "Default",
-    description: "Ask for permission on potentially dangerous actions",
-  },
-  {
-    value: "acceptEdits",
-    label: "Accept Edits",
-    description: "Auto-accept file edits, ask for other actions",
-  },
-  {
-    value: "bypassPermissions",
-    label: "Bypass All",
-    description: "Skip all permission prompts (use with caution)",
-  },
-  {
-    value: "plan",
-    label: "Plan Mode",
-    description: "Plan changes without executing them",
-  },
-  {
-    value: "dontAsk",
-    label: "Don't Ask",
-    description: "Never ask for permission (most permissive)",
-  },
+	{
+		value: 'default',
+		label: 'Default',
+		description: 'Ask for permission on potentially dangerous actions',
+	},
+	{
+		value: 'acceptEdits',
+		label: 'Accept Edits',
+		description: 'Auto-accept file edits, ask for other actions',
+	},
+	{
+		value: 'bypassPermissions',
+		label: 'Bypass All',
+		description: 'Skip all permission prompts (use with caution)',
+	},
+	{
+		value: 'plan',
+		label: 'Plan Mode',
+		description: 'Plan changes without executing them',
+	},
+	{
+		value: 'dontAsk',
+		label: "Don't Ask",
+		description: 'Never ask for permission (most permissive)',
+	},
 ];
 
 // Setting source options
 const SETTING_SOURCE_OPTIONS: Array<{
-  value: SettingSource;
-  label: string;
-  description: string;
+	value: SettingSource;
+	label: string;
+	description: string;
 }> = [
-  {
-    value: "user",
-    label: "User",
-    description: "Load settings from ~/.claude/",
-  },
-  {
-    value: "project",
-    label: "Project",
-    description: "Load settings from .claude/ in workspace",
-  },
-  {
-    value: "local",
-    label: "Local",
-    description: "Load settings from .claude/settings.local.json",
-  },
+	{
+		value: 'user',
+		label: 'User',
+		description: 'Load settings from ~/.claude/',
+	},
+	{
+		value: 'project',
+		label: 'Project',
+		description: 'Load settings from .claude/ in workspace',
+	},
+	{
+		value: 'local',
+		label: 'Local',
+		description: 'Load settings from .claude/settings.local.json',
+	},
 ];
 
 // Thinking level options
 const THINKING_LEVEL_OPTIONS: Array<{
-  value: ThinkingLevel;
-  label: string;
-  description: string;
+	value: ThinkingLevel;
+	label: string;
+	description: string;
 }> = [
-  {
-    value: "auto",
-    label: "Auto",
-    description: "No thinking budget - SDK default behavior",
-  },
-  {
-    value: "think8k",
-    label: "Think 8k",
-    description: "8,000 token thinking budget",
-  },
-  {
-    value: "think16k",
-    label: "Think 16k",
-    description: "16,000 token thinking budget",
-  },
-  {
-    value: "think32k",
-    label: "Think 32k",
-    description: "32,000 token thinking budget",
-  },
+	{
+		value: 'auto',
+		label: 'Auto',
+		description: 'No thinking budget - SDK default behavior',
+	},
+	{
+		value: 'think8k',
+		label: 'Think 8k',
+		description: '8,000 token thinking budget',
+	},
+	{
+		value: 'think16k',
+		label: 'Think 16k',
+		description: '16,000 token thinking budget',
+	},
+	{
+		value: 'think32k',
+		label: 'Think 32k',
+		description: '32,000 token thinking budget',
+	},
 ];
 
 // Source label mapping
 const SOURCE_LABELS: Record<SettingSource, string> = {
-  user: "User (~/.claude/)",
-  project: "Project (.claude/)",
-  local: "Local (.claude/settings.local.json)",
+	user: 'User (~/.claude/)',
+	project: 'Project (.claude/)',
+	local: 'Local (.claude/settings.local.json)',
 };
 
 export function GlobalSettingsEditor() {
-  const [saving, setSaving] = useState(false);
-  const [lastSaved, setLastSaved] = useState<string | null>(null);
-  const [mcpLoading, setMcpLoading] = useState(true);
-  const [mcpServers, setMcpServers] =
-    useState<McpServersFromSourcesResponse | null>(null);
-  const settings = globalSettings.value;
+	const [saving, setSaving] = useState(false);
+	const [lastSaved, setLastSaved] = useState<string | null>(null);
+	const [mcpLoading, setMcpLoading] = useState(true);
+	const [mcpServers, setMcpServers] = useState<McpServersFromSourcesResponse | null>(null);
+	const settings = globalSettings.value;
 
-  // Show brief "Saved" indicator then fade out
-  const showSavedIndicator = (field: string) => {
-    setLastSaved(field);
-    setTimeout(() => setLastSaved(null), 2000);
-  };
+	// Show brief "Saved" indicator then fade out
+	const showSavedIndicator = (field: string) => {
+		setLastSaved(field);
+		setTimeout(() => setLastSaved(null), 2000);
+	};
 
-  // Load MCP servers from enabled sources
-  const loadMcpServers = async () => {
-    try {
-      setMcpLoading(true);
-      const response = await listMcpServersFromSources();
-      setMcpServers(response);
-    } catch (error) {
-      console.error("Failed to load MCP servers:", error);
-    } finally {
-      setMcpLoading(false);
-    }
-  };
+	// Load MCP servers from enabled sources
+	const loadMcpServers = async () => {
+		try {
+			setMcpLoading(true);
+			const response = await listMcpServersFromSources();
+			setMcpServers(response);
+		} catch (error) {
+			console.error('Failed to load MCP servers:', error);
+		} finally {
+			setMcpLoading(false);
+		}
+	};
 
-  // Load MCP servers on mount and when setting sources change
-  useEffect(() => {
-    loadMcpServers();
-  }, [settings?.settingSources]);
+	// Load MCP servers on mount and when setting sources change
+	useEffect(() => {
+		loadMcpServers();
+	}, [settings?.settingSources]);
 
-  const handleModelChange = async (value: string) => {
-    try {
-      setSaving(true);
-      await updateGlobalSettings({ model: value || undefined });
-      showSavedIndicator("model");
-    } catch (error) {
-      console.error("Failed to update model:", error);
-      toast.error("Failed to update model");
-    } finally {
-      setSaving(false);
-    }
-  };
+	const handleModelChange = async (value: string) => {
+		try {
+			setSaving(true);
+			await updateGlobalSettings({ model: value || undefined });
+			showSavedIndicator('model');
+		} catch (error) {
+			console.error('Failed to update model:', error);
+			toast.error('Failed to update model');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  const handlePermissionModeChange = async (value: PermissionMode) => {
-    try {
-      setSaving(true);
-      await updateGlobalSettings({ permissionMode: value });
-      showSavedIndicator("permission");
-    } catch (error) {
-      console.error("Failed to update permission mode:", error);
-      toast.error("Failed to update permission mode");
-    } finally {
-      setSaving(false);
-    }
-  };
+	const handlePermissionModeChange = async (value: PermissionMode) => {
+		try {
+			setSaving(true);
+			await updateGlobalSettings({ permissionMode: value });
+			showSavedIndicator('permission');
+		} catch (error) {
+			console.error('Failed to update permission mode:', error);
+			toast.error('Failed to update permission mode');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  const handleThinkingLevelChange = async (value: ThinkingLevel) => {
-    try {
-      setSaving(true);
-      await updateGlobalSettings({ thinkingLevel: value });
-      showSavedIndicator("thinking");
-    } catch (error) {
-      console.error("Failed to update thinking level:", error);
-      toast.error("Failed to update thinking level");
-    } finally {
-      setSaving(false);
-    }
-  };
+	const handleThinkingLevelChange = async (value: ThinkingLevel) => {
+		try {
+			setSaving(true);
+			await updateGlobalSettings({ thinkingLevel: value });
+			showSavedIndicator('thinking');
+		} catch (error) {
+			console.error('Failed to update thinking level:', error);
+			toast.error('Failed to update thinking level');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  const handleAutoScrollChange = async (value: boolean) => {
-    try {
-      setSaving(true);
-      await updateGlobalSettings({ autoScroll: value });
-      showSavedIndicator("autoScroll");
-    } catch (error) {
-      console.error("Failed to update auto scroll:", error);
-      toast.error("Failed to update auto scroll");
-    } finally {
-      setSaving(false);
-    }
-  };
+	const handleAutoScrollChange = async (value: boolean) => {
+		try {
+			setSaving(true);
+			await updateGlobalSettings({ autoScroll: value });
+			showSavedIndicator('autoScroll');
+		} catch (error) {
+			console.error('Failed to update auto scroll:', error);
+			toast.error('Failed to update auto scroll');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  const handleSettingSourceToggle = async (
-    source: SettingSource,
-    enabled: boolean,
-  ) => {
-    try {
-      setSaving(true);
-      const currentSources = settings?.settingSources || [
-        "user",
-        "project",
-        "local",
-      ];
-      let newSources: SettingSource[];
+	const handleSettingSourceToggle = async (source: SettingSource, enabled: boolean) => {
+		try {
+			setSaving(true);
+			const currentSources = settings?.settingSources || ['user', 'project', 'local'];
+			let newSources: SettingSource[];
 
-      if (enabled) {
-        // Add source if not present
-        newSources = currentSources.includes(source)
-          ? currentSources
-          : [...currentSources, source];
-      } else {
-        // Remove source
-        newSources = currentSources.filter((s) => s !== source);
-      }
+			if (enabled) {
+				// Add source if not present
+				newSources = currentSources.includes(source) ? currentSources : [...currentSources, source];
+			} else {
+				// Remove source
+				newSources = currentSources.filter((s) => s !== source);
+			}
 
-      // Ensure at least one source is enabled
-      if (newSources.length === 0) {
-        toast.error("At least one setting source must be enabled");
-        return;
-      }
+			// Ensure at least one source is enabled
+			if (newSources.length === 0) {
+				toast.error('At least one setting source must be enabled');
+				return;
+			}
 
-      await updateGlobalSettings({ settingSources: newSources });
-      showSavedIndicator("sources");
-      // Reload MCP servers after source change
-      loadMcpServers();
-    } catch (error) {
-      console.error("Failed to update setting sources:", error);
-      toast.error("Failed to update setting sources");
-    } finally {
-      setSaving(false);
-    }
-  };
+			await updateGlobalSettings({ settingSources: newSources });
+			showSavedIndicator('sources');
+			// Reload MCP servers after source change
+			loadMcpServers();
+		} catch (error) {
+			console.error('Failed to update setting sources:', error);
+			toast.error('Failed to update setting sources');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  const handleMcpServerSettingChange = async (
-    serverName: string,
-    key: "allowed" | "defaultOn",
-    value: boolean,
-  ) => {
-    try {
-      setSaving(true);
-      const currentSettings = mcpServers?.serverSettings[serverName] || {};
-      const newSettings = { ...currentSettings, [key]: value };
+	const handleMcpServerSettingChange = async (
+		serverName: string,
+		key: 'allowed' | 'defaultOn',
+		value: boolean
+	) => {
+		try {
+			setSaving(true);
+			const currentSettings = mcpServers?.serverSettings[serverName] || {};
+			const newSettings = { ...currentSettings, [key]: value };
 
-      // If disabling allowed, also disable defaultOn
-      if (key === "allowed" && !value) {
-        newSettings.defaultOn = false;
-      }
+			// If disabling allowed, also disable defaultOn
+			if (key === 'allowed' && !value) {
+				newSettings.defaultOn = false;
+			}
 
-      await updateMcpServerSettings(serverName, newSettings);
+			await updateMcpServerSettings(serverName, newSettings);
 
-      // Update local state
-      if (mcpServers) {
-        setMcpServers({
-          ...mcpServers,
-          serverSettings: {
-            ...mcpServers.serverSettings,
-            [serverName]: newSettings,
-          },
-        });
-      }
-      showSavedIndicator(`mcp-${serverName}`);
-    } catch (error) {
-      console.error("Failed to update MCP server settings:", error);
-      toast.error("Failed to update MCP server settings");
-    } finally {
-      setSaving(false);
-    }
-  };
+			// Update local state
+			if (mcpServers) {
+				setMcpServers({
+					...mcpServers,
+					serverSettings: {
+						...mcpServers.serverSettings,
+						[serverName]: newSettings,
+					},
+				});
+			}
+			showSavedIndicator(`mcp-${serverName}`);
+		} catch (error) {
+			console.error('Failed to update MCP server settings:', error);
+			toast.error('Failed to update MCP server settings');
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  if (!settings) {
-    return <div class="text-gray-400 text-sm">Loading settings...</div>;
-  }
+	if (!settings) {
+		return <div class="text-gray-400 text-sm">Loading settings...</div>;
+	}
 
-  const currentModel = settings.model || "";
-  const currentPermissionMode = settings.permissionMode || "default";
-  const currentThinkingLevel = settings.thinkingLevel || "auto";
-  const currentAutoScroll = settings.autoScroll ?? true;
-  const currentSources = settings.settingSources || [
-    "user",
-    "project",
-    "local",
-  ];
+	const currentModel = settings.model || '';
+	const currentPermissionMode = settings.permissionMode || 'default';
+	const currentThinkingLevel = settings.thinkingLevel || 'auto';
+	const currentAutoScroll = settings.autoScroll ?? true;
+	const currentSources = settings.settingSources || ['user', 'project', 'local'];
 
-  // Saved checkmark component
-  const SavedIndicator = ({ field }: { field: string }) => (
-    <span
-      class={`inline-flex items-center gap-1 text-xs text-green-400 transition-opacity duration-300 ${
-        lastSaved === field ? "opacity-100" : "opacity-0"
-      }`}
-    >
-      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-        <path
-          fill-rule="evenodd"
-          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-          clip-rule="evenodd"
-        />
-      </svg>
-      Saved
-    </span>
-  );
+	// Saved checkmark component
+	const SavedIndicator = ({ field }: { field: string }) => (
+		<span
+			class={`inline-flex items-center gap-1 text-xs text-green-400 transition-opacity duration-300 ${
+				lastSaved === field ? 'opacity-100' : 'opacity-0'
+			}`}
+		>
+			<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+				<path
+					fill-rule="evenodd"
+					d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+					clip-rule="evenodd"
+				/>
+			</svg>
+			Saved
+		</span>
+	);
 
-  return (
-    <div class={`space-y-4 ${saving ? "opacity-50 pointer-events-none" : ""}`}>
-      {/* Auto-save notice */}
-      <div class="flex items-center gap-2 text-xs text-gray-500">
-        <svg
-          class="w-3.5 h-3.5 text-blue-400"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-            clip-rule="evenodd"
-          />
-        </svg>
-        <span>Changes are saved automatically</span>
-      </div>
+	return (
+		<div class={`space-y-4 ${saving ? 'opacity-50 pointer-events-none' : ''}`}>
+			{/* Auto-save notice */}
+			<div class="flex items-center gap-2 text-xs text-gray-500">
+				<svg class="w-3.5 h-3.5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+					<path
+						fill-rule="evenodd"
+						d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+						clip-rule="evenodd"
+					/>
+				</svg>
+				<span>Changes are saved automatically</span>
+			</div>
 
-      {/* Model Selection */}
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm text-gray-400">Model</label>
-          <SavedIndicator field="model" />
-        </div>
-        <select
-          value={currentModel}
-          onChange={(e) =>
-            handleModelChange((e.target as HTMLSelectElement).value)
-          }
-          class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
-        >
-          {MODEL_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </div>
+			{/* Model Selection */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-sm text-gray-400">Model</label>
+					<SavedIndicator field="model" />
+				</div>
+				<select
+					value={currentModel}
+					onChange={(e) => handleModelChange((e.target as HTMLSelectElement).value)}
+					class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
+				>
+					{MODEL_OPTIONS.map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</select>
+			</div>
 
-      {/* Permission Mode Selection */}
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm text-gray-400">Permission Mode</label>
-          <SavedIndicator field="permission" />
-        </div>
-        <select
-          value={currentPermissionMode}
-          onChange={(e) =>
-            handlePermissionModeChange(
-              (e.target as HTMLSelectElement).value as PermissionMode,
-            )
-          }
-          class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
-        >
-          {PERMISSION_MODE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <p class="text-xs text-gray-500">
-          {
-            PERMISSION_MODE_OPTIONS.find(
-              (o) => o.value === currentPermissionMode,
-            )?.description
-          }
-        </p>
-      </div>
+			{/* Permission Mode Selection */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-sm text-gray-400">Permission Mode</label>
+					<SavedIndicator field="permission" />
+				</div>
+				<select
+					value={currentPermissionMode}
+					onChange={(e) =>
+						handlePermissionModeChange((e.target as HTMLSelectElement).value as PermissionMode)
+					}
+					class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
+				>
+					{PERMISSION_MODE_OPTIONS.map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</select>
+				<p class="text-xs text-gray-500">
+					{PERMISSION_MODE_OPTIONS.find((o) => o.value === currentPermissionMode)?.description}
+				</p>
+			</div>
 
-      {/* Thinking Level Selection */}
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm text-gray-400">Thinking Level</label>
-          <SavedIndicator field="thinking" />
-        </div>
-        <select
-          value={currentThinkingLevel}
-          onChange={(e) =>
-            handleThinkingLevelChange(
-              (e.target as HTMLSelectElement).value as ThinkingLevel,
-            )
-          }
-          class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
-        >
-          {THINKING_LEVEL_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <p class="text-xs text-gray-500">
-          {
-            THINKING_LEVEL_OPTIONS.find((o) => o.value === currentThinkingLevel)
-              ?.description
-          }
-        </p>
-      </div>
+			{/* Thinking Level Selection */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-sm text-gray-400">Thinking Level</label>
+					<SavedIndicator field="thinking" />
+				</div>
+				<select
+					value={currentThinkingLevel}
+					onChange={(e) =>
+						handleThinkingLevelChange((e.target as HTMLSelectElement).value as ThinkingLevel)
+					}
+					class={`w-full px-3 py-2 bg-dark-900 border ${borderColors.ui.secondary} rounded text-gray-200 text-sm focus:outline-none focus:border-blue-500`}
+				>
+					{THINKING_LEVEL_OPTIONS.map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</select>
+				<p class="text-xs text-gray-500">
+					{THINKING_LEVEL_OPTIONS.find((o) => o.value === currentThinkingLevel)?.description}
+				</p>
+			</div>
 
-      {/* Auto Scroll Toggle */}
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm text-gray-400">Auto Scroll</label>
-          <SavedIndicator field="autoScroll" />
-        </div>
-        <label
-          class={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-            currentAutoScroll
-              ? `${borderColors.ui.secondary} bg-dark-800`
-              : "border-dark-700 bg-dark-900 opacity-60"
-          }`}
-        >
-          <input
-            type="checkbox"
-            checked={currentAutoScroll}
-            onChange={(e) =>
-              handleAutoScrollChange((e.target as HTMLInputElement).checked)
-            }
-            class="mt-0.5 w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
-          />
-          <div class="flex-1">
-            <div class="text-sm text-gray-200 font-medium">Enabled</div>
-            <div class="text-xs text-gray-500">
-              Auto-scroll to bottom when new messages arrive in sessions
-            </div>
-          </div>
-        </label>
-      </div>
+			{/* Auto Scroll Toggle */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-sm text-gray-400">Auto Scroll</label>
+					<SavedIndicator field="autoScroll" />
+				</div>
+				<label
+					class={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+						currentAutoScroll
+							? `${borderColors.ui.secondary} bg-dark-800`
+							: 'border-dark-700 bg-dark-900 opacity-60'
+					}`}
+				>
+					<input
+						type="checkbox"
+						checked={currentAutoScroll}
+						onChange={(e) => handleAutoScrollChange((e.target as HTMLInputElement).checked)}
+						class="mt-0.5 w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+					/>
+					<div class="flex-1">
+						<div class="text-sm text-gray-200 font-medium">Enabled</div>
+						<div class="text-xs text-gray-500">
+							Auto-scroll to bottom when new messages arrive in sessions
+						</div>
+					</div>
+				</label>
+			</div>
 
-      {/* Setting Sources Checkboxes */}
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <label class="text-sm text-gray-400">Setting Sources</label>
-          <SavedIndicator field="sources" />
-        </div>
-        <div class="space-y-2">
-          {SETTING_SOURCE_OPTIONS.map((option) => {
-            const isEnabled = currentSources.includes(option.value);
-            return (
-              <label
-                key={option.value}
-                class={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                  isEnabled
-                    ? `${borderColors.ui.secondary} bg-dark-800`
-                    : "border-dark-700 bg-dark-900 opacity-60"
-                }`}
-              >
-                <input
-                  type="checkbox"
-                  checked={isEnabled}
-                  onChange={(e) =>
-                    handleSettingSourceToggle(
-                      option.value,
-                      (e.target as HTMLInputElement).checked,
-                    )
-                  }
-                  class="mt-0.5 w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
-                />
-                <div class="flex-1">
-                  <div class="text-sm text-gray-200 font-medium">
-                    {option.label}
-                  </div>
-                  <div class="text-xs text-gray-500">{option.description}</div>
-                </div>
-              </label>
-            );
-          })}
-        </div>
-      </div>
+			{/* Setting Sources Checkboxes */}
+			<div class="space-y-2">
+				<div class="flex items-center justify-between">
+					<label class="text-sm text-gray-400">Setting Sources</label>
+					<SavedIndicator field="sources" />
+				</div>
+				<div class="space-y-2">
+					{SETTING_SOURCE_OPTIONS.map((option) => {
+						const isEnabled = currentSources.includes(option.value);
+						return (
+							<label
+								key={option.value}
+								class={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+									isEnabled
+										? `${borderColors.ui.secondary} bg-dark-800`
+										: 'border-dark-700 bg-dark-900 opacity-60'
+								}`}
+							>
+								<input
+									type="checkbox"
+									checked={isEnabled}
+									onChange={(e) =>
+										handleSettingSourceToggle(option.value, (e.target as HTMLInputElement).checked)
+									}
+									class="mt-0.5 w-4 h-4 rounded border-gray-600 bg-dark-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+								/>
+								<div class="flex-1">
+									<div class="text-sm text-gray-200 font-medium">{option.label}</div>
+									<div class="text-xs text-gray-500">{option.description}</div>
+								</div>
+							</label>
+						);
+					})}
+				</div>
+			</div>
 
-      {/* MCP Servers (from enabled sources) */}
-      <div class="space-y-2">
-        <label class="text-sm text-gray-400">MCP Servers</label>
-        <p class="text-xs text-gray-500">
-          MCP servers from enabled setting sources. Configure which servers are
-          allowed and enabled by default.
-        </p>
+			{/* MCP Servers (from enabled sources) */}
+			<div class="space-y-2">
+				<label class="text-sm text-gray-400">MCP Servers</label>
+				<p class="text-xs text-gray-500">
+					MCP servers from enabled setting sources. Configure which servers are allowed and enabled
+					by default.
+				</p>
 
-        {mcpLoading ? (
-          <div class="text-xs text-gray-500 py-2">Loading MCP servers...</div>
-        ) : mcpServers ? (
-          <div class="space-y-3 mt-2">
-            {/* Group servers by source */}
-            {(["user", "project", "local"] as SettingSource[])
-              .filter((source) => currentSources.includes(source))
-              .map((source) => {
-                const serversForSource = mcpServers.servers[source] || [];
-                if (serversForSource.length === 0) return null;
+				{mcpLoading ? (
+					<div class="text-xs text-gray-500 py-2">Loading MCP servers...</div>
+				) : mcpServers ? (
+					<div class="space-y-3 mt-2">
+						{/* Group servers by source */}
+						{(['user', 'project', 'local'] as SettingSource[])
+							.filter((source) => currentSources.includes(source))
+							.map((source) => {
+								const serversForSource = mcpServers.servers[source] || [];
+								if (serversForSource.length === 0) return null;
 
-                return (
-                  <div key={source} class="space-y-2">
-                    <div class="text-xs font-medium text-gray-400 uppercase tracking-wider">
-                      {SOURCE_LABELS[source]}
-                    </div>
-                    <div class="space-y-1">
-                      {serversForSource.map((server: McpServerFromSource) => {
-                        const serverSettings =
-                          mcpServers.serverSettings[server.name] || {};
-                        const isAllowed = serverSettings.allowed !== false; // Default to true
-                        const isDefaultOn = serverSettings.defaultOn === true; // Default to false
+								return (
+									<div key={source} class="space-y-2">
+										<div class="text-xs font-medium text-gray-400 uppercase tracking-wider">
+											{SOURCE_LABELS[source]}
+										</div>
+										<div class="space-y-1">
+											{serversForSource.map((server: McpServerFromSource) => {
+												const serverSettings = mcpServers.serverSettings[server.name] || {};
+												const isAllowed = serverSettings.allowed !== false; // Default to true
+												const isDefaultOn = serverSettings.defaultOn === true; // Default to false
 
-                        return (
-                          <div
-                            key={`${source}-${server.name}`}
-                            class={`flex items-center justify-between p-2 rounded-lg border ${borderColors.ui.secondary} bg-dark-800/50`}
-                          >
-                            <div class="flex items-center gap-2 flex-1 min-w-0">
-                              <svg
-                                class="w-4 h-4 text-purple-400 flex-shrink-0"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width={2}
-                                  d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
-                                />
-                              </svg>
-                              <div class="flex-1 min-w-0">
-                                <div class="text-sm text-gray-200 truncate">
-                                  {server.name}
-                                </div>
-                                {server.command && (
-                                  <div class="text-xs text-gray-500 truncate">
-                                    {server.command}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                            <div class="flex items-center gap-3 flex-shrink-0 ml-2">
-                              <SavedIndicator field={`mcp-${server.name}`} />
-                              <label class="flex items-center gap-1.5 cursor-pointer">
-                                <span class="text-xs text-gray-400">
-                                  Allowed
-                                </span>
-                                <input
-                                  type="checkbox"
-                                  checked={isAllowed}
-                                  onChange={(e) =>
-                                    handleMcpServerSettingChange(
-                                      server.name,
-                                      "allowed",
-                                      (e.target as HTMLInputElement).checked,
-                                    )
-                                  }
-                                  disabled={saving}
-                                  class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-                                />
-                              </label>
-                              <label
-                                class={`flex items-center gap-1.5 ${isAllowed ? "cursor-pointer" : "opacity-50 cursor-not-allowed"}`}
-                              >
-                                <span class="text-xs text-gray-400">
-                                  Default ON
-                                </span>
-                                <input
-                                  type="checkbox"
-                                  checked={isDefaultOn}
-                                  onChange={(e) =>
-                                    handleMcpServerSettingChange(
-                                      server.name,
-                                      "defaultOn",
-                                      (e.target as HTMLInputElement).checked,
-                                    )
-                                  }
-                                  disabled={saving || !isAllowed}
-                                  class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-                                />
-                              </label>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })}
+												return (
+													<div
+														key={`${source}-${server.name}`}
+														class={`flex items-center justify-between p-2 rounded-lg border ${borderColors.ui.secondary} bg-dark-800/50`}
+													>
+														<div class="flex items-center gap-2 flex-1 min-w-0">
+															<svg
+																class="w-4 h-4 text-purple-400 flex-shrink-0"
+																fill="none"
+																viewBox="0 0 24 24"
+																stroke="currentColor"
+															>
+																<path
+																	stroke-linecap="round"
+																	stroke-linejoin="round"
+																	stroke-width={2}
+																	d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
+																/>
+															</svg>
+															<div class="flex-1 min-w-0">
+																<div class="text-sm text-gray-200 truncate">{server.name}</div>
+																{server.command && (
+																	<div class="text-xs text-gray-500 truncate">{server.command}</div>
+																)}
+															</div>
+														</div>
+														<div class="flex items-center gap-3 flex-shrink-0 ml-2">
+															<SavedIndicator field={`mcp-${server.name}`} />
+															<label class="flex items-center gap-1.5 cursor-pointer">
+																<span class="text-xs text-gray-400">Allowed</span>
+																<input
+																	type="checkbox"
+																	checked={isAllowed}
+																	onChange={(e) =>
+																		handleMcpServerSettingChange(
+																			server.name,
+																			'allowed',
+																			(e.target as HTMLInputElement).checked
+																		)
+																	}
+																	disabled={saving}
+																	class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+																/>
+															</label>
+															<label
+																class={`flex items-center gap-1.5 ${isAllowed ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
+															>
+																<span class="text-xs text-gray-400">Default ON</span>
+																<input
+																	type="checkbox"
+																	checked={isDefaultOn}
+																	onChange={(e) =>
+																		handleMcpServerSettingChange(
+																			server.name,
+																			'defaultOn',
+																			(e.target as HTMLInputElement).checked
+																		)
+																	}
+																	disabled={saving || !isAllowed}
+																	class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+																/>
+															</label>
+														</div>
+													</div>
+												);
+											})}
+										</div>
+									</div>
+								);
+							})}
 
-            {/* No servers message */}
-            {(["user", "project", "local"] as SettingSource[])
-              .filter((source) => currentSources.includes(source))
-              .every(
-                (source) => (mcpServers.servers[source] || []).length === 0,
-              ) && (
-              <div class="text-xs text-gray-500 py-2 text-center">
-                No MCP servers found in enabled setting sources.
-              </div>
-            )}
-          </div>
-        ) : (
-          <div class="text-xs text-gray-500 py-2">
-            Failed to load MCP servers.
-          </div>
-        )}
-      </div>
-    </div>
-  );
+						{/* No servers message */}
+						{(['user', 'project', 'local'] as SettingSource[])
+							.filter((source) => currentSources.includes(source))
+							.every((source) => (mcpServers.servers[source] || []).length === 0) && (
+							<div class="text-xs text-gray-500 py-2 text-center">
+								No MCP servers found in enabled setting sources.
+							</div>
+						)}
+					</div>
+				) : (
+					<div class="text-xs text-gray-500 py-2">Failed to load MCP servers.</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/packages/web/src/components/GlobalToolsSettings.tsx
+++ b/packages/web/src/components/GlobalToolsSettings.tsx
@@ -12,285 +12,262 @@
  * - settingSources: ['project', 'local', 'user'] - Which config files to load
  */
 
-import { useSignal } from "@preact/signals";
-import { useEffect } from "preact/hooks";
-import { connectionManager } from "../lib/connection-manager.ts";
-import { toast } from "../lib/toast.ts";
-import { borderColors } from "../lib/design-tokens.ts";
-import type { GlobalToolsConfig } from "@neokai/shared";
+import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+import { connectionManager } from '../lib/connection-manager.ts';
+import { toast } from '../lib/toast.ts';
+import { borderColors } from '../lib/design-tokens.ts';
+import type { GlobalToolsConfig } from '@neokai/shared';
 
 const DEFAULT_CONFIG: GlobalToolsConfig = {
-  systemPrompt: {
-    claudeCodePreset: {
-      allowed: true,
-      defaultEnabled: true,
-    },
-  },
-  settingSources: {
-    project: {
-      allowed: true,
-      defaultEnabled: true,
-    },
-  },
-  mcp: {
-    allowProjectMcp: true,
-    defaultProjectMcp: false,
-  },
-  kaiTools: {
-    memory: {
-      allowed: true,
-      defaultEnabled: false,
-    },
-  },
+	systemPrompt: {
+		claudeCodePreset: {
+			allowed: true,
+			defaultEnabled: true,
+		},
+	},
+	settingSources: {
+		project: {
+			allowed: true,
+			defaultEnabled: true,
+		},
+	},
+	mcp: {
+		allowProjectMcp: true,
+		defaultProjectMcp: false,
+	},
+	kaiTools: {
+		memory: {
+			allowed: true,
+			defaultEnabled: false,
+		},
+	},
 };
 
 export function GlobalToolsSettings() {
-  const loading = useSignal(true);
-  const saving = useSignal(false);
-  const config = useSignal<GlobalToolsConfig>(DEFAULT_CONFIG);
+	const loading = useSignal(true);
+	const saving = useSignal(false);
+	const config = useSignal<GlobalToolsConfig>(DEFAULT_CONFIG);
 
-  useEffect(() => {
-    loadConfig();
-  }, []);
+	useEffect(() => {
+		loadConfig();
+	}, []);
 
-  const loadConfig = async () => {
-    try {
-      loading.value = true;
-      const hub = await connectionManager.getHub();
-      const response = await hub.call<{ config: GlobalToolsConfig }>(
-        "globalTools.getConfig",
-      );
-      config.value = response.config ?? DEFAULT_CONFIG;
-    } catch (error) {
-      console.error("Failed to load global tools config:", error);
-      config.value = DEFAULT_CONFIG;
-    } finally {
-      loading.value = false;
-    }
-  };
+	const loadConfig = async () => {
+		try {
+			loading.value = true;
+			const hub = await connectionManager.getHub();
+			const response = await hub.call<{ config: GlobalToolsConfig }>('globalTools.getConfig');
+			config.value = response.config ?? DEFAULT_CONFIG;
+		} catch (error) {
+			console.error('Failed to load global tools config:', error);
+			config.value = DEFAULT_CONFIG;
+		} finally {
+			loading.value = false;
+		}
+	};
 
-  const saveConfig = async (newConfig: GlobalToolsConfig) => {
-    try {
-      saving.value = true;
-      const hub = await connectionManager.getHub();
-      await hub.call("globalTools.saveConfig", { config: newConfig });
-      config.value = newConfig;
-      toast.success("Global tools settings saved");
-    } catch (error) {
-      console.error("Failed to save global tools config:", error);
-      toast.error("Failed to save global tools settings");
-    } finally {
-      saving.value = false;
-    }
-  };
+	const saveConfig = async (newConfig: GlobalToolsConfig) => {
+		try {
+			saving.value = true;
+			const hub = await connectionManager.getHub();
+			await hub.call('globalTools.saveConfig', { config: newConfig });
+			config.value = newConfig;
+			toast.success('Global tools settings saved');
+		} catch (error) {
+			console.error('Failed to save global tools config:', error);
+			toast.error('Failed to save global tools settings');
+		} finally {
+			saving.value = false;
+		}
+	};
 
-  const updateSystemPromptConfig = (
-    key: "allowed" | "defaultEnabled",
-    value: boolean,
-  ) => {
-    const newConfig = {
-      ...config.value,
-      systemPrompt: {
-        ...(config.value.systemPrompt ?? DEFAULT_CONFIG.systemPrompt),
-        claudeCodePreset: {
-          ...(config.value.systemPrompt?.claudeCodePreset ??
-            DEFAULT_CONFIG.systemPrompt.claudeCodePreset),
-          [key]: value,
-        },
-      },
-    };
-    // If disabling permission, also disable default
-    if (key === "allowed" && !value) {
-      newConfig.systemPrompt.claudeCodePreset.defaultEnabled = false;
-    }
-    saveConfig(newConfig);
-  };
+	const updateSystemPromptConfig = (key: 'allowed' | 'defaultEnabled', value: boolean) => {
+		const newConfig = {
+			...config.value,
+			systemPrompt: {
+				...(config.value.systemPrompt ?? DEFAULT_CONFIG.systemPrompt),
+				claudeCodePreset: {
+					...(config.value.systemPrompt?.claudeCodePreset ??
+						DEFAULT_CONFIG.systemPrompt.claudeCodePreset),
+					[key]: value,
+				},
+			},
+		};
+		// If disabling permission, also disable default
+		if (key === 'allowed' && !value) {
+			newConfig.systemPrompt.claudeCodePreset.defaultEnabled = false;
+		}
+		saveConfig(newConfig);
+	};
 
-  if (loading.value) {
-    return (
-      <div class="text-center py-4">
-        <div class="text-gray-400">Loading tools settings...</div>
-      </div>
-    );
-  }
+	if (loading.value) {
+		return (
+			<div class="text-center py-4">
+				<div class="text-gray-400">Loading tools settings...</div>
+			</div>
+		);
+	}
 
-  return (
-    <div class="space-y-4">
-      <div
-        class={`bg-dark-800 rounded-lg p-4 border ${borderColors.ui.secondary}`}
-      >
-        <h3 class="text-sm font-medium text-gray-300 mb-3">
-          Global Tools Settings
-        </h3>
-        <p class="text-xs text-gray-400 mb-4">
-          Configure which tools are allowed and their defaults for new sessions.
-          Changes apply to new sessions only.
-        </p>
+	return (
+		<div class="space-y-4">
+			<div class={`bg-dark-800 rounded-lg p-4 border ${borderColors.ui.secondary}`}>
+				<h3 class="text-sm font-medium text-gray-300 mb-3">Global Tools Settings</h3>
+				<p class="text-xs text-gray-400 mb-4">
+					Configure which tools are allowed and their defaults for new sessions. Changes apply to
+					new sessions only.
+				</p>
 
-        {/* System Prompt Section */}
-        <div class="mb-6">
-          <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
-            System Prompt
-          </h4>
+				{/* System Prompt Section */}
+				<div class="mb-6">
+					<h4 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
+						System Prompt
+					</h4>
 
-          <div class="space-y-3">
-            {/* Claude Code Preset */}
-            <div class="flex items-center justify-between p-3 rounded-lg bg-dark-700/50">
-              <div class="flex items-center gap-3">
-                <svg
-                  class="w-5 h-5 text-blue-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width={2}
-                    d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-                <div>
-                  <div class="text-sm text-gray-200">Claude Code Preset</div>
-                  <div class="text-xs text-gray-500">
-                    Use official Claude Code system prompt with tools
-                  </div>
-                </div>
-              </div>
-              <div class="flex items-center gap-4">
-                <label class="flex items-center gap-2 cursor-pointer">
-                  <span class="text-xs text-gray-400">Allowed</span>
-                  <input
-                    type="checkbox"
-                    checked={
-                      config.value.systemPrompt?.claudeCodePreset?.allowed ??
-                      true
-                    }
-                    onChange={(e) =>
-                      updateSystemPromptConfig(
-                        "allowed",
-                        (e.target as HTMLInputElement).checked,
-                      )
-                    }
-                    disabled={saving.value}
-                    class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-                  />
-                </label>
-                <label
-                  class={`flex items-center gap-2 ${config.value.systemPrompt?.claudeCodePreset?.allowed ? "cursor-pointer" : "opacity-50 cursor-not-allowed"}`}
-                >
-                  <span class="text-xs text-gray-400">Default ON</span>
-                  <input
-                    type="checkbox"
-                    checked={
-                      config.value.systemPrompt?.claudeCodePreset
-                        ?.defaultEnabled ?? true
-                    }
-                    onChange={(e) =>
-                      updateSystemPromptConfig(
-                        "defaultEnabled",
-                        (e.target as HTMLInputElement).checked,
-                      )
-                    }
-                    disabled={
-                      saving.value ||
-                      !config.value.systemPrompt?.claudeCodePreset?.allowed
-                    }
-                    class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
-                  />
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
+					<div class="space-y-3">
+						{/* Claude Code Preset */}
+						<div class="flex items-center justify-between p-3 rounded-lg bg-dark-700/50">
+							<div class="flex items-center gap-3">
+								<svg
+									class="w-5 h-5 text-blue-400"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+									/>
+								</svg>
+								<div>
+									<div class="text-sm text-gray-200">Claude Code Preset</div>
+									<div class="text-xs text-gray-500">
+										Use official Claude Code system prompt with tools
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-4">
+								<label class="flex items-center gap-2 cursor-pointer">
+									<span class="text-xs text-gray-400">Allowed</span>
+									<input
+										type="checkbox"
+										checked={config.value.systemPrompt?.claudeCodePreset?.allowed ?? true}
+										onChange={(e) =>
+											updateSystemPromptConfig('allowed', (e.target as HTMLInputElement).checked)
+										}
+										disabled={saving.value}
+										class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+									/>
+								</label>
+								<label
+									class={`flex items-center gap-2 ${config.value.systemPrompt?.claudeCodePreset?.allowed ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'}`}
+								>
+									<span class="text-xs text-gray-400">Default ON</span>
+									<input
+										type="checkbox"
+										checked={config.value.systemPrompt?.claudeCodePreset?.defaultEnabled ?? true}
+										onChange={(e) =>
+											updateSystemPromptConfig(
+												'defaultEnabled',
+												(e.target as HTMLInputElement).checked
+											)
+										}
+										disabled={saving.value || !config.value.systemPrompt?.claudeCodePreset?.allowed}
+										class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+									/>
+								</label>
+							</div>
+						</div>
+					</div>
+				</div>
 
-        {/* SDK Built-in Tools Info (read-only) */}
-        <div>
-          <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
-            Claude Agent SDK Built-in
-          </h4>
-          <p class="text-xs text-gray-500 mb-3">
-            These tools are provided by Claude Agent SDK and always available.
-          </p>
+				{/* SDK Built-in Tools Info (read-only) */}
+				<div>
+					<h4 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
+						Claude Agent SDK Built-in
+					</h4>
+					<p class="text-xs text-gray-500 mb-3">
+						These tools are provided by Claude Agent SDK and always available.
+					</p>
 
-          <div class="space-y-2 opacity-70">
-            {/* Tools list */}
-            <div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-              <svg
-                class="w-4 h-4 text-gray-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width={2}
-                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-              <span class="text-xs text-gray-400">
-                Read, Write, Edit, Glob, Grep, Bash, NotebookEdit, TodoWrite
-              </span>
-            </div>
-            {/* Slash Commands */}
-            <div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-              <svg
-                class="w-4 h-4 text-gray-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width={2}
-                  d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"
-                />
-              </svg>
-              <span class="text-xs text-gray-400">
-                /help, /context, /clear, /config, /bug
-              </span>
-            </div>
-            {/* Sub-agents */}
-            <div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-              <svg
-                class="w-4 h-4 text-gray-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width={2}
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              <span class="text-xs text-gray-400">
-                Task agents (general-purpose, Explore, Plan, Bash)
-              </span>
-            </div>
-            {/* Web tools */}
-            <div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
-              <svg
-                class="w-4 h-4 text-gray-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width={2}
-                  d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"
-                />
-              </svg>
-              <span class="text-xs text-gray-400">WebSearch, WebFetch</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+					<div class="space-y-2 opacity-70">
+						{/* Tools list */}
+						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
+							<svg
+								class="w-4 h-4 text-gray-500"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+								/>
+							</svg>
+							<span class="text-xs text-gray-400">
+								Read, Write, Edit, Glob, Grep, Bash, NotebookEdit, TodoWrite
+							</span>
+						</div>
+						{/* Slash Commands */}
+						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
+							<svg
+								class="w-4 h-4 text-gray-500"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14"
+								/>
+							</svg>
+							<span class="text-xs text-gray-400">/help, /context, /clear, /config, /bug</span>
+						</div>
+						{/* Sub-agents */}
+						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
+							<svg
+								class="w-4 h-4 text-gray-500"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+								/>
+							</svg>
+							<span class="text-xs text-gray-400">
+								Task agents (general-purpose, Explore, Plan, Bash)
+							</span>
+						</div>
+						{/* Web tools */}
+						<div class="flex items-center gap-3 p-2 rounded-lg bg-dark-700/30">
+							<svg
+								class="w-4 h-4 text-gray-500"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"
+								/>
+							</svg>
+							<span class="text-xs text-gray-400">WebSearch, WebFetch</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary
- Fix default model from global settings not applying to newly created sessions — `SessionLifecycle.create()` now reads `globalSettings.model` as fallback before server default
- Add **Thinking Level** dropdown (Auto / Think 8k / Think 16k / Think 32k) to global settings UI, persisted and inherited by new sessions
- Add **Auto Scroll** toggle to global settings UI, persisted and inherited by new sessions
- Remove **NeoKai Tools** section from settings (no tools exist)
- Show full builtin tool names without truncation (`...` removed from all tool lists)

## Test plan
- [x] 36 integration tests pass (`settings-rpc.integration.test.ts`) — 13 new tests added
- [x] TypeScript compiles without errors across daemon and web packages
- [ ] E2E tests updated for new UI elements and removed NeoKai section
- [ ] Manual: verify new session inherits global model/thinkingLevel/autoScroll
- [ ] Manual: verify NeoKai Tools section no longer appears in settings
- [ ] Manual: verify builtin tools list shows complete names