### PR TITLE
fix: remove E2E dependencies from check-release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,14 +396,12 @@ jobs:
   # ============================================
   # CHECK RELEASE TAG
   # Determine if current commit has a version tag
-  # On tags, E2E jobs are skipped (already ran on main)
+  # On tags, verify commit was tested on main via API
   # ============================================
   check-release:
     name: Check Release
     runs-on: ubuntu-latest
-    needs: [e2e, e2e-llm]
-    # On tags: skip E2E checks (jobs are skipped). On main: require e2e success.
-    if: github.ref_type == 'tag' || (always() && needs.e2e.result == 'success')
+    # No dependencies needed - uses GitHub status API for verification
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
       version: ${{ steps.check.outputs.version }}


### PR DESCRIPTION
## Summary
- Remove \`needs: [e2e, e2e-llm]\` from check-release job
- Fixes issue where downstream release jobs couldn't access check-release outputs when E2E jobs were skipped on tags

## Context
When running on tags, E2E jobs are skipped. The check-release job had
these as dependencies, which caused downstream jobs to be unable to
access its outputs properly.

The "Verify commit was tested on main" step already validates commit
status via GitHub API, making the E2E job dependency redundant.