### PR TITLE
chore: bump versions to 0.2.2 and add release version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,27 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Release version: $VERSION"
 
+      - name: Verify package.json versions match tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Checking all package.json versions match tag version: $VERSION"
+          MISMATCHES=()
+          for pkg in npm/neokai packages/cli packages/daemon packages/e2e packages/shared packages/web; do
+            PKG_VERSION=$(node -p "require('./$pkg/package.json').version")
+            if [ "$PKG_VERSION" != "$VERSION" ]; then
+              MISMATCHES+=("$pkg/package.json: $PKG_VERSION (expected $VERSION)")
+            fi
+          done
+          if [ ${#MISMATCHES[@]} -gt 0 ]; then
+            echo "ERROR: Version mismatches found!"
+            printf '  %s\n' "${MISMATCHES[@]}"
+            echo ""
+            echo "All package.json versions must match the release tag (v$VERSION)."
+            echo "Bump all package.json versions to $VERSION before tagging."
+            exit 1
+          fi
+          echo "All package.json versions match v$VERSION"
+
       - name: Verify commit is on main branch
         run: |
           if ! git branch -r --contains "$GITHUB_SHA" | grep -q 'origin/main'; then

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "neokai",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"
 	},
 	"optionalDependencies": {
-		"@neokai/cli-darwin-arm64": "0.1.1",
-		"@neokai/cli-darwin-x64": "0.1.1",
-		"@neokai/cli-linux-x64": "0.1.1",
-		"@neokai/cli-linux-arm64": "0.1.1"
+		"@neokai/cli-darwin-arm64": "0.2.2",
+		"@neokai/cli-darwin-x64": "0.2.2",
+		"@neokai/cli-linux-x64": "0.2.2",
+		"@neokai/cli-linux-arm64": "0.2.2"
 	},
 	"files": [
 		"bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.1.1",
+	"version": "0.2.2",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bump all package.json versions from 0.1.1 to 0.2.2 (v0.2.1 failed to publish npm binaries due to workflow issue, now fixed)
- Add version consistency check to release pipeline that verifies all package.json versions match the tag before building

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, tag v0.2.2 on main to trigger release with npm publish