### PR TITLE
chore: bump all package versions to 0.3.0

### DIFF
--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "neokai",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"
 	},
 	"optionalDependencies": {
-		"@neokai/cli-darwin-arm64": "0.2.2",
-		"@neokai/cli-darwin-x64": "0.2.2",
-		"@neokai/cli-linux-x64": "0.2.2",
-		"@neokai/cli-linux-arm64": "0.2.2"
+		"@neokai/cli-darwin-arm64": "0.3.0",
+		"@neokai/cli-darwin-x64": "0.3.0",
+		"@neokai/cli-linux-x64": "0.3.0",
+		"@neokai/cli-linux-arm64": "0.3.0"
 	},
 	"files": [
 		"bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.2.2 to 0.3.0 for the new release
- Updates version in all 6 package.json files and optional dependency versions in npm/neokai/package.json

## Release Plan
After this PR merges, tag the merge commit with v0.3.0 to trigger the release pipeline.