### PR TITLE
feat: add clipboard paste support for images in chat input

### DIFF
--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -47,6 +47,7 @@ export interface InputTextareaProps {
 	// Interrupt
 	interrupting?: boolean;
 	onInterrupt?: () => void;
+	onPaste?: (e: ClipboardEvent) => void;
 }
 
 /**
@@ -67,6 +68,7 @@ export function InputTextarea({
 	isAgentWorking = false,
 	interrupting = false,
 	onInterrupt,
+	onPaste,
 }: InputTextareaProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [isMultiline, setIsMultiline] = useState(false);
@@ -160,6 +162,7 @@ export function InputTextarea({
 					ref={textareaRef}
 					onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
 					onKeyDown={onKeyDown}
+					onPaste={onPaste}
 					placeholder="Ask or make anything..."
 					maxLength={maxChars}
 					rows={1}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -66,6 +66,7 @@ export default function MessageInput({
 		clear: clearAttachments,
 		openFilePicker,
 		getImagesForSend,
+		handlePaste,
 	} = useFileAttachments();
 
 	// Command autocomplete
@@ -284,6 +285,7 @@ export default function MessageInput({
 							isAgentWorking={isAgentWorking.value}
 							interrupting={interrupting}
 							onInterrupt={handleInterrupt}
+							onPaste={disabled ? undefined : handlePaste}
 						/>
 					</div>
 				</form>

--- a/packages/web/src/components/__tests__/InputTextarea.test.tsx
+++ b/packages/web/src/components/__tests__/InputTextarea.test.tsx
@@ -557,4 +557,42 @@ describe('InputTextarea', () => {
 			expect(textarea.value).toBe('hellox');
 		});
 	});
+
+	describe('Paste Event Forwarding', () => {
+		it('should call onPaste callback when paste event fires on textarea', () => {
+			const onPaste = vi.fn(() => {});
+			const { container } = render(
+				<InputTextarea
+					content=""
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					onPaste={onPaste}
+				/>
+			);
+
+			const textarea = container.querySelector('textarea')!;
+			fireEvent.paste(textarea);
+
+			expect(onPaste).toHaveBeenCalled();
+		});
+
+		it('should not error when onPaste is undefined (default)', () => {
+			const { container } = render(
+				<InputTextarea
+					content=""
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+				/>
+			);
+
+			const textarea = container.querySelector('textarea')!;
+
+			// Should not throw when onPaste is undefined
+			expect(() => {
+				fireEvent.paste(textarea);
+			}).not.toThrow();
+		});
+	});
 });

--- a/packages/web/src/lib/file-utils.ts
+++ b/packages/web/src/lib/file-utils.ts
@@ -88,3 +88,20 @@ export function validateImageFile(file: File): string | null {
 
 	return null;
 }
+
+/**
+ * Extract image files from clipboard items
+ */
+export function extractImagesFromClipboard(items: DataTransferItemList): File[] {
+	const imageFiles: File[] = [];
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (item.kind === 'file' && SUPPORTED_IMAGE_TYPES.includes(item.type as SupportedImageType)) {
+			const file = item.getAsFile();
+			if (file) {
+				imageFiles.push(file);
+			}
+		}
+	}
+	return imageFiles;
+}


### PR DESCRIPTION
## Summary

Adds clipboard paste support for images in the chat input. Users can now paste images directly using Cmd+V (Mac) or Ctrl+V (Windows/Linux). This feature works for:

- Screenshots (Cmd+Shift+4 on Mac, Win+Shift+S on Windows)
- Images copied from web browsers
- Multiple images pasted simultaneously

## Key Design Decisions

**No preventDefault()**: The paste handler intentionally does NOT call `preventDefault()` on the clipboard event. This ensures text paste functionality continues to work normally while still capturing image data when present.

**Disabled guard**: The paste handler is only wired when the input is enabled (`disabled ? undefined : handlePaste`), preventing users from pasting images when input is locked.

**Reuses existing pipeline**: The `handlePaste` handler calls the existing `processFiles()` function, ensuring consistent validation, size checking, base64 conversion, and error handling across all upload methods (drag-and-drop, file picker, and now paste).

## Files Changed

### Source Files (4)
- `packages/web/src/lib/file-utils.ts` - Added `extractImagesFromClipboard()` utility
- `packages/web/src/hooks/useFileAttachments.ts` - Added `handlePaste` handler
- `packages/web/src/components/InputTextarea.tsx` - Added `onPaste` prop
- `packages/web/src/components/MessageInput.tsx` - Wired paste handler with disabled guard

### Test Files (3)
- `packages/web/src/lib/__tests__/file-utils.test.ts` - Added comprehensive tests for clipboard extraction
- `packages/web/src/hooks/__tests__/useFileAttachments.test.ts` - Added paste event tests including preventDefault verification
- `packages/web/src/components/__tests__/InputTextarea.test.tsx` - Added paste event forwarding tests

## Test Plan

- [ ] Paste a screenshot (Cmd+Shift+4 on Mac)
- [ ] Copy an image from a website and paste it
- [ ] Paste multiple images at once
- [ ] Verify text paste still works (paste regular text into input)
- [ ] Verify paste is blocked when input is disabled
- [ ] Verify error handling for oversized images
- [ ] Run all unit tests (`npm test`)
- [ ] Verify pre-commit hooks pass (lint, format, type check, knip)