### PR TITLE
fix: resolve e2e test failures from duplicate data-message-uuid

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -400,7 +400,6 @@ jobs:
           # Tests to exclude entirely (disabled, pending refactor)
           EXCLUDED_TESTS=(
             model-selection-persistence
-            rewind-modal
           )
 
           # Build lookup sets

--- a/packages/e2e/tests/reconnection-basic.e2e.ts
+++ b/packages/e2e/tests/reconnection-basic.e2e.ts
@@ -95,7 +95,9 @@ test.describe('Reconnection - Basic Message Sync', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.getAttribute('data-message-uuid');
+			const uuid = await element.evaluate(
+				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
+			);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false); // Should not be duplicate
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-cycles.e2e.ts
+++ b/packages/e2e/tests/reconnection-cycles.e2e.ts
@@ -101,7 +101,9 @@ test.describe('Reconnection - Multiple Cycles', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.getAttribute('data-message-uuid');
+			const uuid = await element.evaluate(
+				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
+			);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false);
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-long-period.e2e.ts
+++ b/packages/e2e/tests/reconnection-long-period.e2e.ts
@@ -98,7 +98,9 @@ test.describe('Reconnection - Long Disconnection Period', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.getAttribute('data-message-uuid');
+			const uuid = await element.evaluate(
+				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
+			);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false);
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-message-sync-bug.e2e.ts
+++ b/packages/e2e/tests/reconnection-message-sync-bug.e2e.ts
@@ -77,7 +77,7 @@ test.describe('Reconnection - Message Sync Bug (Critical)', () => {
 		await sendButton.click();
 
 		// Wait for user message to appear
-		await page.getByText('Initial message before background').waitFor({ state: 'visible' });
+		await page.getByText('Initial message before background').first().waitFor({ state: 'visible' });
 
 		// Count initial messages (should be at least 1: the user message)
 		const initialMessageCount = await page.locator('[data-message-role]').count();
@@ -280,7 +280,7 @@ test.describe('Reconnection - Message Sync Bug (Critical)', () => {
 		await messageInput.click();
 		await messageInput.fill('Test message');
 		await page.locator('button[aria-label="Send message"]').click();
-		await page.getByText('Test message').waitFor({ state: 'visible' });
+		await page.getByText('Test message').first().waitFor({ state: 'visible' });
 
 		const initialMessageCount = await page.locator('[data-message-role]').count();
 		console.log(`[E2E] Initial message count: ${initialMessageCount}`);
@@ -399,7 +399,7 @@ test.describe('Reconnection - Message Sync Bug (Critical)', () => {
 		await messageInput.click();
 		await messageInput.fill('Cycle test message');
 		await sendButton.click();
-		await page.getByText('Cycle test message').waitFor({ state: 'visible' });
+		await page.getByText('Cycle test message').first().waitFor({ state: 'visible' });
 
 		const baselineCount = await page.locator('[data-message-role]').count();
 		console.log(`[E2E] Baseline message count: ${baselineCount}`);

--- a/packages/e2e/tests/reconnection-order.e2e.ts
+++ b/packages/e2e/tests/reconnection-order.e2e.ts
@@ -57,7 +57,7 @@ test.describe('Reconnection - Message Order', () => {
 		const timestampsBeforeDisconnect = await page.evaluate(() => {
 			const messages = Array.from(document.querySelectorAll('[data-message-role]'));
 			return messages.map((el) => ({
-				uuid: el.getAttribute('data-message-uuid'),
+				uuid: el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null,
 				timestamp: el.getAttribute('data-message-timestamp'),
 			}));
 		});
@@ -85,7 +85,7 @@ test.describe('Reconnection - Message Order', () => {
 		const timestampsAfterReconnect = await page.evaluate(() => {
 			const messages = Array.from(document.querySelectorAll('[data-message-role]'));
 			return messages.map((el) => ({
-				uuid: el.getAttribute('data-message-uuid'),
+				uuid: el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null,
 				timestamp: el.getAttribute('data-message-timestamp'),
 			}));
 		});

--- a/packages/e2e/tests/rewind-per-message.e2e.ts
+++ b/packages/e2e/tests/rewind-per-message.e2e.ts
@@ -16,11 +16,11 @@ import {
 /**
  * Helper to send a message and wait for it to be processed
  */
-async function sendMessage(page: Page, messageText: string, sessionId: string): Promise<void> {
+async function sendMessage(page: Page, messageText: string): Promise<void> {
 	const messageInput = 'textarea[placeholder*="Ask"]';
 	await page.fill(messageInput, messageText);
 	await page.click('button[aria-label*="Send message"]');
-	await waitForMessageProcessed(page, sessionId);
+	await waitForMessageProcessed(page, messageText);
 }
 
 test.describe('Per-Message Rewind Modal', () => {
@@ -44,7 +44,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message to have content to rewind
-		await sendMessage(page, 'Test message for rewind', sessionId);
+		await sendMessage(page, 'Test message for rewind');
 
 		// Wait for the message to appear
 		await page.waitForTimeout(1000);
@@ -65,7 +65,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message to get an assistant response
-		await sendMessage(page, 'Say hello', sessionId);
+		await sendMessage(page, 'Say hello');
 
 		// Wait for assistant message to appear
 		await page.waitForTimeout(2000);
@@ -86,7 +86,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test message for modal', sessionId);
+		await sendMessage(page, 'Test message for modal');
 		await page.waitForTimeout(1000);
 
 		// Click rewind button (no hover needed)
@@ -105,7 +105,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test radio options', sessionId);
+		await sendMessage(page, 'Test radio options');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -125,7 +125,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test default selection', sessionId);
+		await sendMessage(page, 'Test default selection');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -144,7 +144,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test mode switching', sessionId);
+		await sendMessage(page, 'Test mode switching');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -174,8 +174,8 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send multiple messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -194,9 +194,9 @@ test.describe('Per-Message Rewind Modal', () => {
 			timeout: 3000,
 		});
 
-		// Verify messages are still present
-		await expect(page.locator('text=First message')).toBeVisible();
-		await expect(page.locator('text=Second message')).toBeVisible();
+		// Verify messages are still present (use .first() since auto-title may also contain the text)
+		await expect(page.locator('text=First message').first()).toBeVisible();
+		await expect(page.locator('text=Second message').first()).toBeVisible();
 	});
 
 	test('should display warning text about action being irreversible', async ({ page }) => {
@@ -206,7 +206,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test warning text', sessionId);
+		await sendMessage(page, 'Test warning text');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -224,7 +224,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test explanatory text', sessionId);
+		await sendMessage(page, 'Test explanatory text');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -246,7 +246,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test rewind button', sessionId);
+		await sendMessage(page, 'Test rewind button');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -265,8 +265,8 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Try to enter rewind mode by opening the header menu
@@ -304,8 +304,8 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Try to enter rewind mode
@@ -340,7 +340,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test escape key', sessionId);
+		await sendMessage(page, 'Test escape key');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)
@@ -366,7 +366,7 @@ test.describe('Per-Message Rewind Modal', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test option persistence', sessionId);
+		await sendMessage(page, 'Test option persistence');
 		await page.waitForTimeout(1000);
 
 		// Open the rewind modal (no hover needed)

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -115,7 +115,6 @@ export function SDKAssistantMessage({
 			class="py-2 space-y-3"
 			data-testid="assistant-message"
 			data-message-role="assistant"
-			data-message-uuid={message.uuid}
 			data-message-timestamp={messageWithTimestamp.timestamp || 0}
 		>
 			{/* Tool use blocks - full width like result messages */}

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -202,7 +202,6 @@ export function SDKUserMessage({
 			class={cn(messageSpacing.user.container.combined, 'flex justify-end')}
 			data-testid="user-message"
 			data-message-role="user"
-			data-message-uuid={message.uuid}
 			data-message-timestamp={messageWithTimestamp.timestamp || 0}
 		>
 			<div class="max-w-[85%] md:max-w-[70%] w-auto">

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -199,13 +199,8 @@ describe('SDKAssistantMessage', () => {
 			expect(container.querySelector('[data-testid="assistant-message"]')).toBeTruthy();
 		});
 
-		it('should include message UUID in data attribute', () => {
-			const message = createTextOnlyMessage('Hello world');
-			const { container } = render(<SDKAssistantMessage message={message} />);
-
-			const element = container.querySelector('[data-message-uuid]');
-			expect(element?.getAttribute('data-message-uuid')).toBe(message.uuid);
-		});
+		// Note: data-message-uuid is now set by parent SDKMessageRenderer wrapper
+		// This test is removed as the child component no longer sets this attribute
 
 		it('should include message role in data attribute', () => {
 			const message = createTextOnlyMessage('Hello world');

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -168,13 +168,8 @@ describe('SDKUserMessage', () => {
 			expect(container.querySelector('[data-testid="user-message"]')).toBeTruthy();
 		});
 
-		it('should include message UUID in data attribute', () => {
-			const message = createTextMessage('Hello world');
-			const { container } = render(<SDKUserMessage message={message} />);
-
-			const element = container.querySelector('[data-message-uuid]');
-			expect(element?.getAttribute('data-message-uuid')).toBe(message.uuid);
-		});
+		// Note: data-message-uuid is now set by parent SDKMessageRenderer wrapper
+		// This test is removed as the child component no longer sets this attribute
 
 		it('should include message role in data attribute', () => {
 			const message = createTextMessage('Hello world');


### PR DESCRIPTION
## Summary
- Remove `data-message-uuid` from `SDKAssistantMessage` and `SDKUserMessage` (now only on parent wrapper in `SDKMessageRenderer`) to fix duplicate DOM elements
- Fix `rewind-per-message` tests passing `sessionId` instead of `messageText` to `waitForMessageProcessed`
- Update reconnection tests to read UUID via `closest()` since attribute moved to parent wrapper
- Add `.first()` to `getByText` calls that match both message text and auto-generated session title
- Remove `rewind-modal` from CI exclusion list (test file already removed)

## Test plan
- [x] All reconnection e2e tests pass locally (basic, cycles, long-period, order, message-sync-bug)
- [x] All 14 rewind-per-message e2e tests pass locally
- [x] Web unit tests pass (3,184 tests)
- [x] TypeScript type check passes
- [x] Lint and formatting pass