### PR TITLE
fix: resolve E2E test failures blocking release

### DIFF
--- a/packages/e2e/tests/rewind-mode.e2e.ts
+++ b/packages/e2e/tests/rewind-mode.e2e.ts
@@ -17,11 +17,11 @@ import {
 /**
  * Helper to send a message and wait for it to be processed
  */
-async function sendMessage(page: Page, messageText: string, sessionId: string): Promise<void> {
+async function sendMessage(page: Page, messageText: string): Promise<void> {
 	const messageInput = 'textarea[placeholder*="Ask"]';
 	await page.fill(messageInput, messageText);
 	await page.click('button[aria-label*="Send message"]');
-	await waitForMessageProcessed(page, sessionId);
+	await waitForMessageProcessed(page, messageText);
 }
 
 /**
@@ -99,7 +99,7 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message to have content
-		await sendMessage(page, 'Test message for rewind mode', sessionId);
+		await sendMessage(page, 'Test message for rewind mode');
 		await page.waitForTimeout(1000);
 
 		// Open InputActionsMenu and click "Rewind Mode"
@@ -126,8 +126,8 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send multiple messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -150,7 +150,7 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message that triggers tool use
-		await sendMessage(page, 'What files are in the current directory?', sessionId);
+		await sendMessage(page, 'What files are in the current directory?');
 		await page.waitForTimeout(3000); // Wait for tool execution
 
 		// Enter rewind mode
@@ -176,9 +176,9 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send multiple messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
-		await sendMessage(page, 'Third message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
+		await sendMessage(page, 'Third message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -210,8 +210,8 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -242,8 +242,8 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -278,7 +278,7 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test message', sessionId);
+		await sendMessage(page, 'Test message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -322,7 +322,7 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send a message
-		await sendMessage(page, 'Test message', sessionId);
+		await sendMessage(page, 'Test message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode
@@ -350,8 +350,8 @@ test.describe('Rewind Mode', () => {
 		sessionId = await waitForSessionCreated(page);
 
 		// Send messages
-		await sendMessage(page, 'First message', sessionId);
-		await sendMessage(page, 'Second message', sessionId);
+		await sendMessage(page, 'First message');
+		await sendMessage(page, 'Second message');
 		await page.waitForTimeout(1000);
 
 		// Enter rewind mode

--- a/packages/e2e/tests/rewind-per-message.e2e.ts
+++ b/packages/e2e/tests/rewind-per-message.e2e.ts
@@ -58,7 +58,9 @@ test.describe('Per-Message Rewind Modal', () => {
 		await expect(rewindButton).toBeVisible({ timeout: 5000 });
 	});
 
-	test('should show rewind button for assistant messages', async ({ page }) => {
+	test('should NOT show rewind button for assistant messages (only user messages have rewind)', async ({
+		page,
+	}) => {
 		// Create a new session
 		const newSessionButton = page.locator('button:has-text("New Session")').first();
 		await newSessionButton.click();
@@ -74,9 +76,9 @@ test.describe('Per-Message Rewind Modal', () => {
 		const assistantMessage = page.locator('[data-message-uuid]').nth(1);
 		await expect(assistantMessage).toBeVisible({ timeout: 5000 });
 
-		// Verify rewind button is visible (no hover needed)
+		// Verify rewind button is NOT visible (only user messages get rewind buttons)
 		const rewindButton = assistantMessage.locator('button[title="Rewind to here"]');
-		await expect(rewindButton).toBeVisible({ timeout: 5000 });
+		await expect(rewindButton).not.toBeVisible({ timeout: 3000 });
 	});
 
 	test('should open rewind modal when rewind button is clicked', async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR fixes critical E2E test failures that are blocking the dev→main release PR (#63).

## Fixes

### 1. **rewind-mode.e2e.ts** - Fixed `sendMessage` helper function bug
- **Problem**: Function signature had incorrect `sessionId` parameter
- **Impact**: Tests searched for sessionId UUID in UI instead of message text, causing timeouts
- **Fix**: 
  - Removed `sessionId` parameter from function signature
  - Changed `waitForMessageProcessed(page, sessionId)` to `waitForMessageProcessed(page, messageText)`
  - Updated all 10+ test cases

### 2. **rewind-per-message.e2e.ts** - Updated outdated test expectations
- **Problem**: Test expected rewind buttons on assistant messages
- **Context**: Feature changed in commit 1ee1700 to show rewind buttons only on user messages
- **Fix**: Changed test to expect NO rewind button on assistant messages

## Test Plan

- [x] All E2E test fixes applied
- [x] Files formatted with biome
- [ ] CI checks will run on this PR
- [ ] After merge, PR #63 should have all passing checks

## Related Issues

Unblocks: PR #63 (dev → main for release)