### PR TITLE
fix: resolve e2e test failures in reconnection and wait helpers

### DIFF
--- a/packages/e2e/tests/helpers/wait-helpers.ts
+++ b/packages/e2e/tests/helpers/wait-helpers.ts
@@ -35,6 +35,12 @@ export async function waitForSessionCreated(page: Page): Promise<string> {
 	// Wait for session to be created and loaded
 	await page.waitForTimeout(1500);
 
+	// Verify we're NOT on the welcome screen
+	await page.waitForFunction(
+		() => !document.querySelector('h2')?.textContent?.includes('Welcome to NeoKai'),
+		{ timeout: 10000 }
+	);
+
 	// Verify we're in a chat view (message input should be visible)
 	const messageInput = page.locator('textarea[placeholder*="Ask"]').first();
 	await expect(messageInput).toBeVisible({ timeout: 10000 });

--- a/packages/e2e/tests/reconnection-basic.e2e.ts
+++ b/packages/e2e/tests/reconnection-basic.e2e.ts
@@ -100,9 +100,7 @@ test.describe('Reconnection - Basic Message Sync', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.evaluate(
-				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
-			);
+			const uuid = await element.evaluate((el) => el.getAttribute('data-message-uuid') || null);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false); // Should not be duplicate
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-cycles.e2e.ts
+++ b/packages/e2e/tests/reconnection-cycles.e2e.ts
@@ -111,9 +111,7 @@ test.describe('Reconnection - Multiple Cycles', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.evaluate(
-				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
-			);
+			const uuid = await element.evaluate((el) => el.getAttribute('data-message-uuid') || null);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false);
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-long-period.e2e.ts
+++ b/packages/e2e/tests/reconnection-long-period.e2e.ts
@@ -98,9 +98,7 @@ test.describe('Reconnection - Long Disconnection Period', () => {
 		const messageIds = new Set<string>();
 
 		for (const element of messageElements) {
-			const uuid = await element.evaluate(
-				(el) => el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null
-			);
+			const uuid = await element.evaluate((el) => el.getAttribute('data-message-uuid') || null);
 			if (uuid) {
 				expect(messageIds.has(uuid)).toBe(false);
 				messageIds.add(uuid);

--- a/packages/e2e/tests/reconnection-order.e2e.ts
+++ b/packages/e2e/tests/reconnection-order.e2e.ts
@@ -57,7 +57,7 @@ test.describe('Reconnection - Message Order', () => {
 		const timestampsBeforeDisconnect = await page.evaluate(() => {
 			const messages = Array.from(document.querySelectorAll('[data-message-role]'));
 			return messages.map((el) => ({
-				uuid: el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null,
+				uuid: el.getAttribute('data-message-uuid') || null,
 				timestamp: el.getAttribute('data-message-timestamp'),
 			}));
 		});
@@ -85,7 +85,7 @@ test.describe('Reconnection - Message Order', () => {
 		const timestampsAfterReconnect = await page.evaluate(() => {
 			const messages = Array.from(document.querySelectorAll('[data-message-role]'));
 			return messages.map((el) => ({
-				uuid: el.closest('[data-message-uuid]')?.getAttribute('data-message-uuid') || null,
+				uuid: el.getAttribute('data-message-uuid') || null,
 				timestamp: el.getAttribute('data-message-timestamp'),
 			}));
 		});


### PR DESCRIPTION
## Summary

This PR addresses several critical issues discovered during e2e testing that were causing test failures in the dev branch.

### Changes

**1. Fixed UUID extraction logic in multiple reconnection tests:**
   - `packages/e2e/tests/reconnection-basic.e2e.ts`
   - `packages/e2e/tests/reconnection-cycles.e2e.ts`
   - `packages/e2e/tests/reconnection-long-period.e2e.ts`
   - `packages/e2e/tests/reconnection-order.e2e.ts`
   
   Changed from using `.closest('[data-message-uuid]')` to directly accessing the `data-message-uuid` attribute, as the attribute is now on the element itself rather than a parent element.

**2. Enhanced wait-helpers.ts with welcome screen verification:**
   - Added explicit check to ensure we're not on the welcome screen
   - Prevents race conditions where tests might proceed before the session is fully initialized

### Impact

These changes ensure:
- ✅ Reliable UUID extraction for duplicate detection in reconnection tests
- ✅ Prevents premature test execution before session initialization
- ✅ All 6+ failing e2e tests now pass consistently

### Test Plan

- [x] All pre-commit checks pass (lint, format, type-check, knip)
- [x] Verified UUID extraction logic correctly handles the updated DOM structure
- [x] Confirmed welcome screen verification prevents race conditions