### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "neokai",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"
 	},
 	"optionalDependencies": {
-		"@neokai/cli-darwin-arm64": "0.3.0",
-		"@neokai/cli-darwin-x64": "0.3.0",
-		"@neokai/cli-linux-x64": "0.3.0",
-		"@neokai/cli-linux-arm64": "0.3.0"
+		"@neokai/cli-darwin-arm64": "0.4.0",
+		"@neokai/cli-darwin-x64": "0.4.0",
+		"@neokai/cli-linux-x64": "0.4.0",
+		"@neokai/cli-linux-arm64": "0.4.0"
 	},
 	"files": [
 		"bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bump all package.json versions to 0.4.0 in preparation for release.

## Changes

- All package versions bumped from 0.3.0 to 0.4.0:
  - `npm/neokai/package.json`
  - `packages/cli/package.json`
  - `packages/daemon/package.json`
  - `packages/shared/package.json`
  - `packages/web/package.json`
  - `packages/e2e/package.json`

## Test Plan

- [x] Pre-commit checks passed (lint, format, typecheck, knip)