### PR TITLE
fix(e2e): prevent production session deletion with isolated test directories

### DIFF
--- a/packages/e2e/global-teardown.ts
+++ b/packages/e2e/global-teardown.ts
@@ -1,217 +1,150 @@
 /**
  * Global Teardown - Runs after ALL tests complete
  *
- * Cleans up any orphaned sessions left behind by failed tests.
- * Uses direct database cleanup for maximum reliability.
+ * Cleans up:
+ * 1. Isolated temp directories from e2e test runs (database, workspace)
+ * 2. Orphaned git worktrees in the project's .worktrees directory
  */
 
-import { chromium, type FullConfig } from '@playwright/test';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { rmSync, existsSync, readdirSync } from 'fs';
+import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-async function globalTeardown(config: FullConfig) {
+async function globalTeardown() {
 	console.log('\n🧹 Running global teardown...');
 
-	try {
-		// Launch a browser to access the app
-		const browser = await chromium.launch();
-		const context = await browser.newContext();
-		const page = await context.newPage();
+	// ========================================
+	// Layer 1: Clean up isolated temp directories
+	// ========================================
+	console.log('🧹 Layer 1: Cleaning up isolated temp directories...');
 
-		// Navigate to the app
-		const baseURL = config.projects[0].use.baseURL || 'http://localhost:9283';
-		await page.goto(baseURL);
+	const e2eTempBase = join(tmpdir(), 'neokai-e2e');
 
-		// Wait for MessageHub to connect
-		await page.waitForTimeout(2000);
-
-		// Get list of all sessions via RPC
-		const sessions = await page.evaluate(async () => {
-			try {
-				const hub =
-					(
-						window as unknown as {
-							__messageHub?: unknown;
-							appState?: { messageHub?: unknown };
-						}
-					).__messageHub ||
-					(
-						window as unknown as {
-							__messageHub?: unknown;
-							appState?: { messageHub?: unknown };
-						}
-					).appState?.messageHub;
-				if (!hub || !hub.request) {
-					return { success: false, sessions: [] };
-				}
-
-				const result = await hub.request('session.list', {}, { timeout: 5000 });
-				return { success: true, sessions: result?.sessions || [] };
-			} catch (error: unknown) {
-				console.error('Failed to fetch sessions:', error);
-				return { success: false, sessions: [] };
-			}
-		});
-
-		if (!sessions.success || sessions.sessions.length === 0) {
-			console.log('✅ No sessions to clean up');
-			await browser.close();
-			return;
-		}
-
-		console.log(`📊 Found ${sessions.sessions.length} sessions in database`);
-
-		// Only clean up test sessions (created in the last hour)
-		const oneHourAgo = Date.now() - 60 * 60 * 1000;
-		const testSessions = sessions.sessions.filter((s: { createdAt: string; id: string }) => {
-			const createdAt = new Date(s.createdAt).getTime();
-			return createdAt > oneHourAgo;
-		});
-
-		if (testSessions.length === 0) {
-			console.log('✅ No recent test sessions to clean up');
-			await browser.close();
-			return;
-		}
-
-		console.log(`🗑️  Cleaning up ${testSessions.length} recent test sessions...`);
-
-		let cleaned = 0;
-		let failed = 0;
-
-		for (const session of testSessions) {
-			const result = await page.evaluate(async (sid) => {
-				try {
-					const hub =
-						(
-							window as unknown as {
-								__messageHub?: unknown;
-								appState?: { messageHub?: unknown };
-							}
-						).__messageHub ||
-						(
-							window as unknown as {
-								__messageHub?: unknown;
-								appState?: { messageHub?: unknown };
-							}
-						).appState?.messageHub;
-					if (!hub || !hub.request) {
-						return { success: false };
-					}
-
-					await hub.request('session.delete', { sessionId: sid }, { timeout: 5000 });
-					return { success: true };
-				} catch (error: unknown) {
-					return { success: false, error: (error as Error)?.message };
-				}
-			}, session.id);
-
-			if (result.success) {
-				cleaned++;
-			} else {
-				failed++;
-				console.warn(`  ❌ Failed to delete session ${session.id}: ${result.error}`);
-			}
-		}
-
-		console.log(`✅ Session cleanup complete: ${cleaned} cleaned, ${failed} failed\n`);
-
-		// ========================================
-		// Layer 2: Git-level worktree cleanup
-		// Catches any orphaned worktrees from:
-		// - Failed session deletions
-		// - Crashed daemon
-		// - Direct DB manipulation
-		// ========================================
-		console.log('🧹 Layer 2: Git-level worktree cleanup...');
-
+	if (existsSync(e2eTempBase)) {
 		try {
-			const { execSync } = await import('child_process');
-			const { existsSync, rmSync, readdirSync } = await import('fs');
+			const dirs = readdirSync(e2eTempBase);
+			console.log(`📊 Found ${dirs.length} e2e temp directories`);
 
-			// Get project root (2 levels up from packages/e2e)
-			const projectRoot = join(__dirname, '..', '..');
-			const worktreesDir = join(projectRoot, '.worktrees');
+			// Clean up directories older than 1 hour (safety measure for stale runs)
+			const oneHourAgo = Date.now() - 60 * 60 * 1000;
+			let cleaned = 0;
 
-			if (!existsSync(worktreesDir)) {
-				console.log('✅ No .worktrees directory found - clean state\n');
-				await browser.close();
-				return;
-			}
-
-			// Count worktrees before cleanup
-			const worktreeDirs = readdirSync(worktreesDir);
-			console.log(`📊 Found ${worktreeDirs.length} worktree directories`);
-
-			// Step 1: Prune git worktree metadata
-			console.log('🔧 Pruning git worktree metadata...');
-			try {
-				const pruneOutput = execSync('git worktree prune -v', {
-					cwd: projectRoot,
-					encoding: 'utf-8',
-				});
-				if (pruneOutput) {
-					console.log(`   ${pruneOutput.trim()}`);
-				}
-			} catch (error) {
-				console.warn('   ⚠️  Prune failed (continuing):', error);
-			}
-
-			// Step 2: Delete all session/* branches
-			console.log('🗑️  Deleting session branches...');
-			try {
-				const branchesOutput = execSync('git branch --list "session/*"', {
-					cwd: projectRoot,
-					encoding: 'utf-8',
-				});
-
-				const branches = branchesOutput
-					.split('\n')
-					.map((b) => b.trim())
-					.filter(Boolean);
-
-				if (branches.length > 0) {
-					console.log(`   Found ${branches.length} session branches`);
-
-					for (const branch of branches) {
-						try {
-							execSync(`git branch -D ${branch}`, {
-								cwd: projectRoot,
-								encoding: 'utf-8',
-							});
-						} catch {
-							console.warn(`   ⚠️  Failed to delete branch ${branch}`);
-						}
+			for (const dir of dirs) {
+				const dirPath = join(e2eTempBase, dir);
+				// Extract timestamp from directory name: e2e-{timestamp}-{uuid}
+				const match = dir.match(/^e2e-(\d+)-/);
+				if (match) {
+					const timestamp = parseInt(match[1], 10);
+					if (timestamp < oneHourAgo) {
+						rmSync(dirPath, { recursive: true, force: true });
+						cleaned++;
 					}
-
-					console.log(`   ✅ Deleted ${branches.length} branches`);
-				} else {
-					console.log('   ✅ No session branches to delete');
 				}
-			} catch (error) {
-				console.warn('   ⚠️  Branch cleanup failed (continuing):', error);
 			}
 
-			// Step 3: Force remove .worktrees directory
-			console.log('📁 Removing .worktrees directory...');
-			try {
-				rmSync(worktreesDir, { recursive: true, force: true });
-				console.log(`   ✅ Removed ${worktreeDirs.length} worktree directories`);
-			} catch (error) {
-				console.error('   ❌ Failed to remove .worktrees directory:', error);
-			}
-
-			console.log('✅ Git cleanup complete\n');
+			console.log(`✅ Cleaned ${cleaned} stale e2e temp directories`);
 		} catch (error) {
-			console.error('❌ Git cleanup failed (non-fatal):', error);
+			console.warn('⚠️  Failed to clean e2e temp directories:', error);
+		}
+	} else {
+		console.log('✅ No e2e temp directories found');
+	}
+
+	// ========================================
+	// Layer 2: Git-level worktree cleanup
+	// SAFETY: Only run in CI to avoid affecting production worktrees
+	// With isolated temp directories, this cleanup is only needed in CI
+	// where fresh checkouts might have stale worktree metadata.
+	// ========================================
+	if (!process.env.CI) {
+		console.log(
+			'🔵 Local environment - skipping git worktree cleanup to protect production sessions\n'
+		);
+		return;
+	}
+
+	console.log('🧹 Layer 2: Git-level worktree cleanup...');
+
+	try {
+		// Get project root (2 levels up from packages/e2e)
+		const projectRoot = join(__dirname, '..', '..');
+		const worktreesDir = join(projectRoot, '.worktrees');
+
+		if (!existsSync(worktreesDir)) {
+			console.log('✅ No .worktrees directory found - clean state\n');
+			return;
 		}
 
-		await browser.close();
+		// Count worktrees before cleanup
+		const worktreeDirs = readdirSync(worktreesDir);
+		console.log(`📊 Found ${worktreeDirs.length} worktree directories`);
+
+		// Step 1: Prune git worktree metadata
+		console.log('🔧 Pruning git worktree metadata...');
+		try {
+			const pruneOutput = execSync('git worktree prune -v', {
+				cwd: projectRoot,
+				encoding: 'utf-8',
+			});
+			if (pruneOutput) {
+				console.log(`   ${pruneOutput.trim()}`);
+			}
+		} catch (error) {
+			console.warn('   ⚠️  Prune failed (continuing):', error);
+		}
+
+		// Step 2: Delete all session/* branches
+		console.log('🗑️  Deleting session branches...');
+		try {
+			const branchesOutput = execSync('git branch --list "session/*"', {
+				cwd: projectRoot,
+				encoding: 'utf-8',
+			});
+
+			const branches = branchesOutput
+				.split('\n')
+				.map((b) => b.trim())
+				.filter(Boolean);
+
+			if (branches.length > 0) {
+				console.log(`   Found ${branches.length} session branches`);
+
+				for (const branch of branches) {
+					try {
+						execSync(`git branch -D ${branch}`, {
+							cwd: projectRoot,
+							encoding: 'utf-8',
+						});
+					} catch {
+						console.warn(`   ⚠️  Failed to delete branch ${branch}`);
+					}
+				}
+
+				console.log(`   ✅ Deleted ${branches.length} branches`);
+			} else {
+				console.log('   ✅ No session branches to delete');
+			}
+		} catch (error) {
+			console.warn('   ⚠️  Branch cleanup failed (continuing):', error);
+		}
+
+		// Step 3: Force remove .worktrees directory
+		console.log('📁 Removing .worktrees directory...');
+		try {
+			rmSync(worktreesDir, { recursive: true, force: true });
+			console.log(`   ✅ Removed ${worktreeDirs.length} worktree directories`);
+		} catch (error) {
+			console.error('   ❌ Failed to remove .worktrees directory:', error);
+		}
+
+		console.log('✅ Git cleanup complete\n');
 	} catch (error) {
-		console.error('❌ Global teardown failed:', error);
+		console.error('❌ Git cleanup failed (non-fatal):', error);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use isolated temp directories for e2e workspace and database (`{tmpdir}/neokai-e2e/e2e-{timestamp}-{uuid}/`)
- Set `reuseExistingServer: false` to never connect to production servers
- Add CI guard to git worktree cleanup in global teardown (only runs in CI, not locally)
- Clean up stale e2e temp dirs older than 1 hour

## Root Cause This Fixes

This fixes a critical bug where running e2e tests locally could:
1. Connect to a production server (if one was already running on port 9283)
2. Delete legitimate user sessions from the production database (global teardown deleted sessions created in the last hour)
3. Delete production git worktrees associated with those sessions

## Changes

### `packages/e2e/playwright.config.ts`
- Creates isolated temp directories for each test run
- Passes `NEOKAI_WORKSPACE_PATH` and `DB_PATH` env vars to isolated paths
- Sets `reuseExistingServer: false` to always start a fresh test server

### `packages/e2e/global-teardown.ts`
- Removes the aggressive "delete sessions from last hour" cleanup
- Adds CI-only guard for git worktree cleanup (protects local production sessions)
- Cleans up stale e2e temp directories older than 1 hour

## Test Plan

- [x] E2E tests use isolated temp directories
- [x] Local e2e runs do not affect production database
- [x] Global teardown only cleans up git worktrees in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)