### PR TITLE
fix(e2e): prevent E2E tests from killing dev servers during self-development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,30 @@ E2E tests are **pure browser-based Playwright tests** simulating real end-user i
 - `waitForWebSocketConnected()` — may check hub state as fallback alongside UI indicator
 - Global teardown (`global-teardown.ts`) — RPC-based session/worktree cleanup
 
+---
+
+### Self-Development Mode E2E Testing
+
+> **IMPORTANT: Always use the correct test command for your scenario**
+>
+> When a development server is already running, you MUST reuse it instead of starting a new one.
+
+**If using `make self` (port 9983):**
+```bash
+make self-test TEST=tests/core/navigation-3-column.e2e.ts
+```
+
+**If using `make run` with a custom port:**
+```bash
+make run-test PORT=8399 TEST=tests/core/navigation-3-column.e2e.ts
+```
+
+**How it works:**
+- `make self` and `make run` create a lock file at `tmp/.dev-server-running`
+- E2E tests check for this lock file before starting
+- If the lock exists without `PLAYWRIGHT_BASE_URL`, tests fail with instructions
+- This prevents accidentally killing your development server
+
 **Other notes:**
 - Always run a single E2E test file at a time — too slow to run all together
 - If a test scenario can't be triggered through the UI (e.g., token expiry, malformed server responses), it belongs in daemon integration tests, not E2E

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,9 +1,36 @@
 import { defineConfig, devices } from '@playwright/test';
 import type { CoverageReportOptions } from 'monocart-reporter';
 import { tmpdir } from 'os';
-import { join } from 'path';
-import { mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { randomUUID } from 'crypto';
+
+// Safety check: Prevent running E2E tests when a dev server is running
+// This prevents accidentally killing the development server
+if (!process.env.PLAYWRIGHT_BASE_URL) {
+	// Look for dev server lock file by traversing up to repo root
+	let currentDir = __dirname;
+	for (let i = 0; i < 5; i++) {
+		const lockFile = join(currentDir, 'tmp', '.dev-server-running');
+		if (existsSync(lockFile)) {
+			const port = readFileSync(lockFile, 'utf-8').trim();
+			console.error(`
+ERROR: A development server appears to be running (lock file found).
+
+To run E2E tests against your dev server, use one of:
+  make self-test TEST=tests/your-test.e2e.ts     (for 'make self' on port 9983)
+  make run-test PORT=${port || 'YOUR_PORT'} TEST=tests/your-test.e2e.ts
+
+Or set PLAYWRIGHT_BASE_URL explicitly:
+  PLAYWRIGHT_BASE_URL=http://localhost:${port || 'YOUR_PORT'} bunx playwright test tests/your-test.e2e.ts
+`);
+			process.exit(1);
+		}
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) break;
+		currentDir = parentDir;
+	}
+}
 
 // Create isolated temp directories for this test run
 // This ensures e2e tests NEVER affect production databases or workspaces


### PR DESCRIPTION
## Summary

This PR adds defense-in-depth protection to prevent AI agents from accidentally killing development servers when running E2E tests during self-development sessions.

### The Problem

When using `make self` (self-development mode), AI agents sometimes ran E2E tests directly with `bunx playwright test`, which would:
1. Try to start a new dev server on the default port (9283)
2. Potentially kill the existing dev server running on port 9983
3. Disrupt the active development session

### The Solution

A three-layer protection mechanism:

1. **Lock File Mechanism**: `make self` and `make run` now create a lock file at `tmp/.dev-server-running` containing the port number when a dev server starts.

2. **Playwright Config Safety Check**: Before tests start, the config checks for the lock file. If found without `PLAYWRIGHT_BASE_URL`, tests fail immediately with helpful instructions on how to run tests correctly.

3. **Convenience Commands**: 
   - `make self-test TEST=tests/your-test.e2e.ts` - Run tests against `make self` instance (port 9983)
   - `make run-test PORT=xxxx TEST=tests/your-test.e2e.ts` - Run tests against `make run` instance

4. **Documentation Update**: Updated CLAUDE.md with positive instructions instead of scary warnings, showing agents exactly what to do for each scenario.

### How It Works

```
Agent wants to run E2E tests
         │
         ▼
┌─────────────────────┐
│ PLAYWRIGHT_BASE_URL │
│     set?            │
└─────────────────────┘
         │
    ┌────┴────┐
   Yes        No
    │         │
    ▼         ▼
┌────────┐  ┌─────────────────┐
│ Tests  │  │ Lock file       │
│ run    │  │ exists?         │
│ safely │  └─────────────────┘
└────────┘         │
             ┌─────┴─────┐
            Yes          No
             │           │
             ▼           ▼
      ┌──────────┐  ┌─────────────┐
      │ Fail and │  │ Tests start │
      │ instruct │  │ new server  │
      └──────────┘  └─────────────┘
```

### Files Changed

- `CLAUDE.md` - Updated documentation with positive instructions
- `Makefile` - Added `self-test` and `run-test` targets, lock file creation in `run`
- `packages/e2e/playwright.config.ts` - Added safety check for lock file

## Test plan

- [x] Run `make self` and verify lock file is created
- [x] Try running `bunx playwright test` directly - should fail with instructions
- [x] Run `make self-test TEST=tests/core/navigation-3-column.e2e.ts` - should work
- [x] Run `make run` with custom port and verify lock file contains correct port
- [x] Run `make run-test PORT=xxxx TEST=...` - should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)