### PR TITLE
fix(web): complete 3-column layout with mobile navigation and settings

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -13,6 +13,7 @@
  * - room.getPairs - List pairs for a room
  * - room.getPair - Get single pair details
  * - room.archivePair - Archive a pair
+ * - neo.status - Get global status (all rooms, sessions, pairs)
  *
  * Renamed from neo.room.* to room.* for cleaner API.
  */
@@ -186,6 +187,11 @@ export function setupRoomHandlers(
 		}
 
 		return { status };
+	});
+
+	// neo.status - Get global status (all rooms, sessions, pairs)
+	messageHub.onRequest('neo.status', async () => {
+		return roomManager.getGlobalStatus();
 	});
 
 	// room.assignSession - Assign a session to a room

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -8,7 +8,7 @@ import ToastContainer from './islands/ToastContainer.tsx';
 import { ConnectionOverlay } from './components/ConnectionOverlay.tsx';
 import { connectionManager } from './lib/connection-manager.ts';
 import { initializeApplicationState } from './lib/state.ts';
-import { currentSessionIdSignal, currentRoomIdSignal } from './lib/signals.ts';
+import { currentSessionIdSignal, currentRoomIdSignal, navRailOpenSignal } from './lib/signals.ts';
 import { initSessionStatusTracking } from './lib/session-status.ts';
 import { globalStore } from './lib/global-store.ts';
 import { sessionStore } from './lib/session-store.ts';
@@ -86,6 +86,25 @@ export function App() {
 	return (
 		<>
 			<div class="flex h-dvh overflow-hidden bg-dark-950 relative" style={{ height: '100dvh' }}>
+				{/* Mobile hamburger menu button - only show when not in a session (lobby/rooms view) */}
+				{!currentSessionIdSignal.value && (
+					<button
+						onClick={() => (navRailOpenSignal.value = true)}
+						class="fixed top-4 left-4 z-30 md:hidden p-2 rounded-lg bg-dark-900 hover:bg-dark-800 text-gray-400 hover:text-gray-100 transition-colors"
+						title="Open navigation"
+						aria-label="Open navigation menu"
+					>
+						<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M4 6h16M4 12h16M4 18h16"
+							/>
+						</svg>
+					</button>
+				)}
+
 				{/* Navigation Rail */}
 				<NavRail />
 

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -98,19 +98,52 @@ export default function Lobby() {
 
 	return (
 		<div class="flex-1 flex flex-col bg-dark-900 overflow-hidden">
-			{/* Header */}
-			<div class="bg-dark-850/50 backdrop-blur-sm border-b border-dark-700 p-4 flex items-center justify-between">
-				<div>
-					<h2 class="text-xl font-bold text-gray-100">Neo Lobby</h2>
-					<p class="text-sm text-gray-400">Manage your AI-powered workspaces</p>
-				</div>
-				<div class="flex gap-2">
-					<Button
-						variant="secondary"
-						onClick={() => {
-							lobbyManagerOpenSignal.value = !lobbyManagerOpenSignal.value;
-						}}
-						icon={
+			{/* Header - compact on mobile, expanded on desktop */}
+			<div class="bg-dark-850/50 backdrop-blur-sm border-b border-dark-700 px-3 py-2 md:px-4 md:py-4 pl-12 md:pl-4">
+				<div class="flex items-center justify-between gap-2">
+					{/* Mobile: title only (no subtitle to save space) */}
+					<div class="min-w-0">
+						<h2 class="text-lg md:text-xl font-bold text-gray-100 truncate">Neo Lobby</h2>
+						<p class="hidden md:block text-sm text-gray-400 mt-0.5">
+							Manage your AI-powered workspaces
+						</p>
+					</div>
+					{/* Desktop: full buttons with text */}
+					<div class="hidden md:flex gap-2 shrink-0">
+						<Button
+							variant="secondary"
+							onClick={() => {
+								lobbyManagerOpenSignal.value = !lobbyManagerOpenSignal.value;
+							}}
+							icon={
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+									/>
+								</svg>
+							}
+						>
+							Lobby Manager
+						</Button>
+						<Button variant="secondary" onClick={newSessionModal.open} icon="+">
+							New Session
+						</Button>
+						<Button onClick={createRoomModal.open} icon="+">
+							Create Room
+						</Button>
+					</div>
+					{/* Mobile: icon-only buttons */}
+					<div class="flex md:hidden gap-1.5 shrink-0">
+						<button
+							onClick={() => {
+								lobbyManagerOpenSignal.value = !lobbyManagerOpenSignal.value;
+							}}
+							class="p-1.5 rounded-md bg-dark-800 hover:bg-dark-700 text-gray-400 hover:text-gray-100 transition-colors"
+							title="Lobby Manager"
+						>
 							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path
 									stroke-linecap="round"
@@ -119,16 +152,36 @@ export default function Lobby() {
 									d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
 								/>
 							</svg>
-						}
-					>
-						Lobby Manager
-					</Button>
-					<Button variant="secondary" onClick={newSessionModal.open} icon="+">
-						New Session
-					</Button>
-					<Button onClick={createRoomModal.open} icon="+">
-						Create Room
-					</Button>
+						</button>
+						<button
+							onClick={newSessionModal.open}
+							class="p-1.5 rounded-md bg-dark-800 hover:bg-dark-700 text-gray-400 hover:text-gray-100 transition-colors"
+							title="New Session"
+						>
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M12 4v16m8-8H4"
+								/>
+							</svg>
+						</button>
+						<button
+							onClick={createRoomModal.open}
+							class="p-1.5 rounded-md bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+							title="Create Room"
+						>
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+								/>
+							</svg>
+						</button>
+					</div>
 				</div>
 			</div>
 

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -1,8 +1,16 @@
-import { currentSessionIdSignal, currentRoomIdSignal } from '../lib/signals.ts';
+import {
+	currentSessionIdSignal,
+	currentRoomIdSignal,
+	navSectionSignal,
+	settingsSectionSignal,
+} from '../lib/signals.ts';
 import { sessions } from '../lib/state.ts';
 import ChatContainer from './ChatContainer.tsx';
 import Room from './Room.tsx';
 import Lobby from './Lobby.tsx';
+import { GeneralSettings } from '../components/settings/GeneralSettings.tsx';
+import { McpServersSettings } from '../components/settings/McpServersSettings.tsx';
+import { AboutSection } from '../components/settings/AboutSection.tsx';
 
 export default function MainContent() {
 	// IMPORTANT: Access .value directly in component body to enable Preact Signals auto-tracking
@@ -10,6 +18,8 @@ export default function MainContent() {
 	const sessionId = currentSessionIdSignal.value;
 	const roomId = currentRoomIdSignal.value;
 	const sessionsList = sessions.value;
+	const navSection = navSectionSignal.value;
+	const settingsSection = settingsSectionSignal.value;
 
 	// Room route takes priority
 	if (roomId) {
@@ -23,6 +33,25 @@ export default function MainContent() {
 	// If there's a valid session, show the chat
 	if (sessionId && sessionExists) {
 		return <ChatContainer key={sessionId} sessionId={sessionId} />;
+	}
+
+	// If Settings is selected in NavRail, show the selected settings section content
+	if (navSection === 'settings') {
+		return (
+			<div class="flex-1 flex flex-col bg-dark-900 overflow-hidden">
+				{/* Settings Header */}
+				<div class="px-6 py-4 border-b border-dark-700">
+					<h2 class="text-lg font-semibold text-gray-100">Global Settings</h2>
+					<p class="text-sm text-gray-400">Default configurations for new sessions</p>
+				</div>
+				{/* Settings Content */}
+				<div class="flex-1 overflow-y-auto p-6">
+					{settingsSection === 'general' && <GeneralSettings />}
+					{settingsSection === 'mcp-servers' && <McpServersSettings />}
+					{settingsSection === 'about' && <AboutSection />}
+				</div>
+			</div>
+		);
 	}
 
 	// Default: Show Lobby (home page)

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -1,5 +1,16 @@
-import { navSectionSignal, type NavSection } from '../lib/signals.ts';
-import { navigateToChats, navigateToRooms, navigateToSettings } from '../lib/router.ts';
+import {
+	navSectionSignal,
+	navRailOpenSignal,
+	currentSessionIdSignal,
+	currentRoomIdSignal,
+	type NavSection,
+} from '../lib/signals.ts';
+import {
+	navigateToChats,
+	navigateToRooms,
+	navigateToSettings,
+	navigateToHome,
+} from '../lib/router.ts';
 import { NavIconButton } from '../components/ui/NavIconButton.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 import { connectionState } from '../lib/state.ts';
@@ -7,8 +18,13 @@ import { connectionManager } from '../lib/connection-manager.ts';
 
 export function NavRail() {
 	const navSection = navSectionSignal.value;
+	const isNavRailOpen = navRailOpenSignal.value;
+	const isHomeActive = currentSessionIdSignal.value === null && currentRoomIdSignal.value === null;
 
 	const handleNavClick = (section: NavSection) => {
+		// Close nav rail on mobile after navigation
+		navRailOpenSignal.value = false;
+
 		switch (section) {
 			case 'chats':
 				navigateToChats();
@@ -25,86 +41,124 @@ export function NavRail() {
 		}
 	};
 
+	const handleHomeClick = () => {
+		navRailOpenSignal.value = false;
+		navSectionSignal.value = 'chats'; // Reset to chats section to show lobby
+		navigateToHome();
+	};
+
+	const handleNavRailClose = () => {
+		navRailOpenSignal.value = false;
+	};
+
 	return (
-		<div
-			class={`hidden md:flex w-16 flex-col items-center py-4 bg-dark-950 border-r ${borderColors.ui.default}`}
-		>
-			{/* Logo */}
-			<div class="text-2xl mb-6" title="NeoKai">
-				🤖
+		<>
+			{/* Mobile backdrop */}
+			{isNavRailOpen && (
+				<div class="fixed inset-0 bg-black/50 z-35 md:hidden" onClick={handleNavRailClose} />
+			)}
+
+			<div
+				class={`
+					fixed md:relative
+					w-16 h-screen
+					bg-dark-950 border-r ${borderColors.ui.default}
+					flex flex-col items-center py-4
+					z-40 md:z-auto
+					transition-transform duration-300 ease-in-out
+					left-0 md:left-auto
+					${isNavRailOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
+				`}
+			>
+				{/* Logo */}
+				<div class="text-2xl mb-6" title="NeoKai">
+					🤖
+				</div>
+
+				{/* Nav Items */}
+				<nav class="flex-1 flex flex-col gap-1">
+					{/* Home Button */}
+					<NavIconButton active={isHomeActive} onClick={handleHomeClick} label="Home">
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+							/>
+						</svg>
+					</NavIconButton>
+
+					<NavIconButton
+						active={navSection === 'chats'}
+						onClick={() => handleNavClick('chats')}
+						label="Chats"
+					>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+							/>
+						</svg>
+					</NavIconButton>
+
+					<NavIconButton
+						active={navSection === 'rooms'}
+						onClick={() => handleNavClick('rooms')}
+						label="Rooms"
+					>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+							/>
+						</svg>
+					</NavIconButton>
+
+					<NavIconButton active={navSection === 'projects'} disabled label="Projects (Coming Soon)">
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+							/>
+						</svg>
+					</NavIconButton>
+				</nav>
+
+				{/* Bottom - Daemon Status & Settings */}
+				<div class="mt-auto flex flex-col gap-1">
+					{/* Daemon Connection Status Indicator */}
+					<DaemonStatusIndicator />
+
+					<NavIconButton
+						active={navSection === 'settings'}
+						onClick={() => handleNavClick('settings')}
+						label="Settings"
+					>
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+							/>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+							/>
+						</svg>
+					</NavIconButton>
+				</div>
 			</div>
-
-			{/* Nav Items */}
-			<nav class="flex-1 flex flex-col gap-1">
-				<NavIconButton
-					active={navSection === 'chats'}
-					onClick={() => handleNavClick('chats')}
-					label="Chats"
-				>
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-						/>
-					</svg>
-				</NavIconButton>
-
-				<NavIconButton
-					active={navSection === 'rooms'}
-					onClick={() => handleNavClick('rooms')}
-					label="Rooms"
-				>
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-						/>
-					</svg>
-				</NavIconButton>
-
-				<NavIconButton active={navSection === 'projects'} disabled label="Projects (Coming Soon)">
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-						/>
-					</svg>
-				</NavIconButton>
-			</nav>
-
-			{/* Bottom - Daemon Status & Settings */}
-			<div class="mt-auto flex flex-col gap-1">
-				{/* Daemon Connection Status Indicator */}
-				<DaemonStatusIndicator />
-
-				<NavIconButton
-					active={navSection === 'settings'}
-					onClick={() => handleNavClick('settings')}
-					label="Settings"
-				>
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-						/>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-						/>
-					</svg>
-				</NavIconButton>
-			</div>
-		</div>
+		</>
 	);
 }
 

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -37,6 +37,7 @@ let mockRoomsSignal: ReturnType<typeof signal<any[]>>;
 let mockSessionsSignal: ReturnType<typeof signal<any[]>>;
 let mockHasArchivedSessionsSignal: ReturnType<typeof signal<boolean>>;
 let mockGlobalSettingsSignal: ReturnType<typeof signal<any>>;
+let mockSettingsSectionSignal: ReturnType<typeof signal<string>>;
 
 // Mock the signals module
 vi.mock('../../lib/signals.ts', () => ({
@@ -45,6 +46,9 @@ vi.mock('../../lib/signals.ts', () => ({
 	},
 	get contextPanelOpenSignal() {
 		return mockContextPanelOpenSignal;
+	},
+	get settingsSectionSignal() {
+		return mockSettingsSectionSignal;
 	},
 }));
 
@@ -131,6 +135,7 @@ mockRoomsSignal = signal<any[]>([]);
 mockSessionsSignal = signal<any[]>([]);
 mockHasArchivedSessionsSignal = signal<boolean>(false);
 mockGlobalSettingsSignal = signal<any>({ showArchived: false });
+mockSettingsSectionSignal = signal<string>('general');
 
 import { ContextPanel } from '../ContextPanel';
 
@@ -147,6 +152,7 @@ describe('ContextPanel', () => {
 		mockSessionsSignal.value = [];
 		mockHasArchivedSessionsSignal.value = false;
 		mockGlobalSettingsSignal.value = { showArchived: false };
+		mockSettingsSectionSignal.value = 'general';
 	});
 
 	afterEach(() => {
@@ -181,15 +187,15 @@ describe('ContextPanel', () => {
 			expect(container.textContent).toContain('Organize rooms into projects');
 		});
 
-		it('should render settings content when navSection is settings', () => {
+		it('should render settings navigation when navSection is settings', () => {
 			mockNavSectionSignal.value = 'settings';
 
 			render(<ContextPanel />);
 
-			// Should render the settings components
-			expect(screen.getByTestId('general-settings')).toBeTruthy();
-			expect(screen.getByTestId('mcp-servers-settings')).toBeTruthy();
-			expect(screen.getByTestId('about-section')).toBeTruthy();
+			// Should render the settings navigation buttons
+			expect(screen.getByRole('button', { name: 'General' })).toBeTruthy();
+			expect(screen.getByRole('button', { name: 'MCP Servers' })).toBeTruthy();
+			expect(screen.getByRole('button', { name: 'About' })).toBeTruthy();
 		});
 	});
 

--- a/packages/web/src/islands/__tests__/NavRail.test.tsx
+++ b/packages/web/src/islands/__tests__/NavRail.test.tsx
@@ -174,18 +174,18 @@ describe('NavRail', () => {
 	});
 
 	describe('Mobile Visibility', () => {
-		it('should have hidden class for mobile (hidden on small screens)', () => {
+		it('should have -translate-x-full class for mobile (hidden via transform on small screens)', () => {
 			const { container } = render(<NavRail />);
 
 			const navRail = container.querySelector('div');
-			expect(navRail?.className).toContain('hidden');
+			expect(navRail?.className).toContain('-translate-x-full');
 		});
 
-		it('should have md:flex class for tablet/desktop visibility', () => {
+		it('should have md:translate-x-0 class for tablet/desktop visibility', () => {
 			const { container } = render(<NavRail />);
 
 			const navRail = container.querySelector('div');
-			expect(navRail?.className).toContain('md:flex');
+			expect(navRail?.className).toContain('md:translate-x-0');
 		});
 
 		it('should have correct width class (w-16)', () => {

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -35,3 +35,10 @@ export const neoChatOpenSignal = signal<boolean>(true);
 
 // Lobby Manager panel signal
 export const lobbyManagerOpenSignal = signal<boolean>(false);
+
+// NavRail mobile open state
+export const navRailOpenSignal = signal<boolean>(false);
+
+// Settings section signal - which settings section is active
+export type SettingsSection = 'general' | 'mcp-servers' | 'about';
+export const settingsSectionSignal = signal<SettingsSection>('general');


### PR DESCRIPTION
## Summary

This PR completes the 3-column layout architecture by addressing several UI/UX issues discovered during smoke testing:

- **neo.status RPC Handler** - Added missing `neo.status` handler in room-handlers.ts that calls `roomManager.getGlobalStatus()`

- **Home Button** - Added Home button to NavRail that navigates to `/` (lobby) and shows active state when not in a session or room

- **Mobile Navigation** - Added hamburger menu for mobile with slide-in NavRail panel, backdrop overlay, and auto-close on navigation. Added `navRailOpenSignal` to signals.ts

- **Settings Layout** - Fixed Settings to show section navigation in ContextPanel (middle column) and content in MainContent (right column). Added `settingsSectionSignal` for 'general' | 'mcp-servers' | 'about'

- **Compact Mobile Header** - Made Lobby header compact on mobile with icon-only buttons on same row as title

## Test Plan

- [ ] Verify Home button navigates to lobby and shows active state
- [ ] On mobile (<768px), verify hamburger menu opens NavRail slide-in panel
- [ ] Verify NavRail closes after selecting navigation item on mobile
- [ ] Verify Settings shows section list in middle column and content in right column
- [ ] Verify Lobby header is compact on mobile with icon-only buttons
- [ ] Run E2E tests: `cd packages/e2e && bunx playwright test tests/core/navigation-3-column.e2e.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)