### PR TITLE
fix(e2e): reuse external server when PLAYWRIGHT_BASE_URL is set

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -260,10 +260,11 @@ export default defineConfig({
 		// This avoids HMR overhead and tests against production-like environment
 		command: 'cd ../web && bun run build && cd ../cli && NODE_ENV=test bun run main.ts',
 		url: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:9283',
-		// NEVER reuse existing server - always start a fresh isolated test server
+		// When PLAYWRIGHT_BASE_URL is set externally (CI, self-test, run-test),
+		// reuse that server. Otherwise, start a fresh isolated test server.
 		// This prevents tests from accidentally connecting to production servers
-		// and ensures teardown can safely clean up all test data
-		reuseExistingServer: false,
+		// and ensures teardown can safely clean up all test data.
+		reuseExistingServer: !!process.env.PLAYWRIGHT_BASE_URL,
 		stdout: 'ignore',
 		stderr: 'pipe',
 		timeout: 120 * 1000,


### PR DESCRIPTION
## Summary
- Fixes E2E test failures caused by port conflict when `PLAYWRIGHT_BASE_URL` is set externally (CI, `make self-test`, `make run-test`)
- Changed `reuseExistingServer` from hardcoded `false` to conditional `!!process.env.PLAYWRIGHT_BASE_URL`

## Root Cause
When CI starts a binary on a random port (e.g., 44865) and sets `PLAYWRIGHT_BASE_URL=http://localhost:44865`, Playwright was:
1. Setting `webServer.url` to that external URL
2. But still trying to start its own server (`reuseExistingServer: false`)
3. Detecting the port was already in use
4. Failing with: `"http://localhost:44865 is already used"`

## Behavior After Fix
- **CI / `make self-test` / `make run-test`**: `PLAYWRIGHT_BASE_URL` is set → `reuseExistingServer: true` → reuses the existing server
- **Local E2E without external server**: `PLAYWRIGHT_BASE_URL` is not set → `reuseExistingServer: false` → starts a fresh isolated test server

## Test plan
- [ ] CI E2E tests pass (this PR will validate the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)