### PR TITLE
fix(web): resolve session loading state bugs

### DIFF
--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -178,8 +178,8 @@ export interface SessionError {
  * - state.context (context info)
  */
 export interface SessionState {
-	// Session metadata
-	sessionInfo: SessionInfo;
+	// Session metadata (null in error states when session doesn't exist)
+	sessionInfo: SessionInfo | null;
 
 	// Agent processing state
 	agentState: AgentProcessingState;

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -53,6 +53,7 @@ import { connectionState } from '../lib/state.ts';
 import { getCurrentAction } from '../lib/status-actions.ts';
 import { toast } from '../lib/toast.ts';
 import { cn } from '../lib/utils.ts';
+import { contextPanelOpenSignal } from '../lib/signals.ts';
 
 interface ChatContainerProps {
 	sessionId: string;
@@ -686,8 +687,29 @@ export default function ChatContainer({ sessionId }: ChatContainerProps) {
 		return (
 			<div class="flex-1 flex flex-col bg-dark-900">
 				<div class={`bg-dark-850/50 backdrop-blur-sm border-b ${borderColors.ui.default} p-4`}>
-					<Skeleton width="200px" height={24} class="mb-2" />
-					<Skeleton width="150px" height={16} />
+					<div class="max-w-4xl mx-auto w-full px-4 md:px-0 flex items-center gap-3">
+						{/* Hamburger menu button - visible only on mobile */}
+						<button
+							onClick={() => {
+								contextPanelOpenSignal.value = true;
+							}}
+							class={`md:hidden p-2 -ml-2 bg-dark-850 border ${borderColors.ui.default} rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0`}
+							title="Open menu"
+						>
+							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M4 6h16M4 12h16M4 18h16"
+								/>
+							</svg>
+						</button>
+						<div class="flex-1 min-w-0">
+							<Skeleton width="200px" height={24} class="mb-2" />
+							<Skeleton width="150px" height={16} />
+						</div>
+					</div>
 				</div>
 				<div class="flex-1 overflow-y-auto">
 					{Array.from({ length: 3 }).map((_, i) => (

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -261,6 +261,22 @@ class SessionStore {
 				if (sessionState.commandsData?.availableCommands) {
 					slashCommandsSignal.value = sessionState.commandsData.availableCommands;
 				}
+			} else {
+				// sessionState RPC returned null - set error state so UI shows error instead of infinite loading
+				logger.error('Session state RPC returned null for session:', sessionId);
+				this.sessionState.value = {
+					sessionInfo: null,
+					agentState: { status: 'idle' },
+					commandsData: { availableCommands: [] },
+					contextInfo: null,
+					error: {
+						message: 'Session not found',
+						details: { sessionId },
+						occurredAt: Date.now(),
+					},
+					timestamp: Date.now(),
+				};
+				return;
 			}
 
 			if (messagesState?.sdkMessages) {
@@ -327,7 +343,19 @@ class SessionStore {
 			}
 		} catch (err) {
 			logger.error('Failed to fetch initial state:', err);
-			// Don't show toast here - subscriptions are still active and will receive updates
+			// Set error state so UI shows error instead of infinite loading
+			this.sessionState.value = {
+				sessionInfo: null,
+				agentState: { status: 'idle' },
+				commandsData: { availableCommands: [] },
+				contextInfo: null,
+				error: {
+					message: 'Failed to load session',
+					details: err,
+					occurredAt: Date.now(),
+				},
+				timestamp: Date.now(),
+			};
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Bug 1**: Hamburger menu button was not visible during session loading, preventing users from accessing the sidebar
- **Bug 2**: Switching between sessions could get stuck in infinite loading state if the RPC call failed or returned null

## Changes

1. **ChatContainer.tsx**: Added hamburger menu button to the loading skeleton header so users can access the sidebar even while a session is loading

2. **session-store.ts**: Fixed error handling in `fetchInitialState()`:
   - When RPC returns null: Set error state with "Session not found" message
   - When RPC throws: Set error state with "Failed to load session" message
   - Previously, errors were silently caught leaving `sessionState.value` as `null` forever

3. **state-types.ts**: Made `SessionState.sessionInfo` nullable (`SessionInfo | null`) to properly support error states

## Root Cause

The bug was a latent issue from the original pure WebSocket architecture implementation (Dec 2025). The `fetchInitialState()` method had error handling that logged errors but never updated state, causing infinite loading when:
- Network issues occurred during session switch
- RPC returned null/undefined
- Any exception was thrown during the fetch

## Test Plan

- [x] All 3489 web tests pass
- [x] Lint and typecheck pass
- [x] Manual testing: hamburger menu visible during loading
- [x] Manual testing: error state shows with retry button on failed load

🤖 Generated with [Claude Code](https://claude.com/claude-code)