### PR TITLE
fix: prevent context.updated events from being dropped during session load

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -230,13 +230,10 @@ export class AgentSession
 		// Initialize core components (order matters - some handlers depend on earlier ones)
 		this.messageQueue = new MessageQueue();
 		this.stateManager = new ProcessingStateManager(session.id, daemonHub, db);
-		this.contextTracker = new ContextTracker(
-			session.id,
-			(contextInfo: ContextInfo) => {
-				this.session.metadata.lastContextInfo = contextInfo;
-				this.db.updateSession(this.session.id, { metadata: this.session.metadata });
-			}
-		);
+		this.contextTracker = new ContextTracker(session.id, (contextInfo: ContextInfo) => {
+			this.session.metadata.lastContextInfo = contextInfo;
+			this.db.updateSession(this.session.id, { metadata: this.session.metadata });
+		});
 
 		// Initialize SDKMessageHandler (handlers take AgentSession context directly)
 		this.messageHandler = new SDKMessageHandler(this);

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -375,7 +375,14 @@ export class SDKMessageHandler {
 	 * Handle result message (end of turn)
 	 */
 	private async handleResultMessage(message: SDKMessage): Promise<void> {
-		const { session, db, daemonHub, contextTracker, stateManager, messageQueue } = this.ctx;
+		const {
+			session,
+			db,
+			daemonHub,
+			contextTracker: _contextTracker,
+			stateManager,
+			messageQueue,
+		} = this.ctx;
 
 		// Type guard to ensure this is a successful result
 		if (!isSDKResultSuccess(message)) return;

--- a/packages/daemon/tests/integration/agent/context-tracking.integration.test.ts
+++ b/packages/daemon/tests/integration/agent/context-tracking.integration.test.ts
@@ -95,13 +95,10 @@ describe('Context Tracking Integration', () => {
 			const session = createTestSession(env.testWorkspace, { id: sessionId });
 			env.db.createSession(session);
 
-			const contextTracker = new ContextTracker(
-				sessionId,
-				(contextInfo: ContextInfo) => {
-					session.metadata.lastContextInfo = contextInfo;
-					env.db.updateSession(sessionId, { metadata: session.metadata });
-				}
-			);
+			const contextTracker = new ContextTracker(sessionId, (contextInfo: ContextInfo) => {
+				session.metadata.lastContextInfo = contextInfo;
+				env.db.updateSession(sessionId, { metadata: session.metadata });
+			});
 
 			const detailedContext: ContextInfo = {
 				model: 'claude-sonnet-4-5-20250929',

--- a/packages/daemon/tests/unit/agent/context-tracker.test.ts
+++ b/packages/daemon/tests/unit/agent/context-tracker.test.ts
@@ -35,7 +35,7 @@ describe('ContextTracker', () => {
 				percentUsed: 25,
 				breakdown: {
 					'System prompt': { tokens: 3000, percent: 1.5 },
-					'Messages': { tokens: 47000, percent: 23.5 },
+					Messages: { tokens: 47000, percent: 23.5 },
 					'Free space': { tokens: 150000, percent: 75 },
 				},
 			};
@@ -56,7 +56,7 @@ describe('ContextTracker', () => {
 				percentUsed: 15,
 				breakdown: {
 					'System prompt': { tokens: 5000, percent: 2.5 },
-					'Messages': { tokens: 25000, percent: 12.5 },
+					Messages: { tokens: 25000, percent: 12.5 },
 					'Free space': { tokens: 170000, percent: 85 },
 				},
 				source: 'context-command',

--- a/packages/e2e/tests/core/context-features.e2e.ts
+++ b/packages/e2e/tests/core/context-features.e2e.ts
@@ -54,6 +54,39 @@ test.describe('Context Usage - Display', () => {
 		await expect(loadingIndicator).toBeVisible({ timeout: 10000 });
 	});
 
+	test('should show non-zero context percentage after message exchange', async ({ page }) => {
+		// Create a new session
+		await page.getByRole('button', { name: 'New Session', exact: true }).click();
+		sessionId = await waitForSessionCreated(page);
+
+		// Send a message to populate context data
+		const input = page.locator('textarea[placeholder*="Ask"]').first();
+		await input.fill('Hello, please respond with a brief greeting');
+		await page.keyboard.press('Enter');
+
+		// Wait for assistant response
+		await waitForAssistantResponse(page);
+
+		// Wait for context indicator to have data (title changes from "Context data loading...")
+		const contextIndicator = page.locator('[title="Click for context details"]');
+		await expect(contextIndicator).toBeVisible({ timeout: 15000 });
+
+		// Get the context percentage element by data-testid
+		const contextPercentage = page.getByTestId('context-percentage');
+
+		// Should be visible
+		await expect(contextPercentage).toBeVisible({ timeout: 5000 });
+
+		// Get the text content and verify it's NOT "0.0%"
+		const percentageText = await contextPercentage.textContent();
+		expect(percentageText).not.toBe('0.0%');
+
+		// Should have some actual percentage value (e.g., "1.2%", "5.3%", etc.)
+		// Parse the percentage to verify it's a number greater than 0
+		const percentageValue = parseFloat(percentageText?.replace('%', '') || '0');
+		expect(percentageValue).toBeGreaterThan(0);
+	});
+
 	test('should toggle dropdown when clicking indicator again', async ({ page }) => {
 		// Create a new session
 		await page.getByRole('button', { name: 'New Session', exact: true }).click();

--- a/packages/e2e/tests/features/slash-cmd.e2e.ts
+++ b/packages/e2e/tests/features/slash-cmd.e2e.ts
@@ -522,7 +522,9 @@ test.describe('Slash Command Autocomplete - SDK Commands from system:init', () =
 		await expect(dropdown).toBeVisible({ timeout: 5000 });
 
 		// Should have multiple commands from SDK system:init (not just the built-in /merge-session)
-		const commandButtons = page.locator('[data-testid="command-autocomplete"] button, text=Slash Commands ~ button');
+		const commandButtons = page.locator(
+			'[data-testid="command-autocomplete"] button, text=Slash Commands ~ button'
+		);
 		// Verify at least /help is present (from SDK, not from NeoKai built-ins)
 		await expect(page.locator('button:has-text("help")')).toBeVisible({ timeout: 5000 });
 	});

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -58,9 +58,9 @@ class SessionStore {
 		() => this.sessionState.value?.agentState || { status: 'idle' }
 	);
 
-	/** Context info (token usage) */
+	/** Context info (token usage) - uses direct signal to avoid race condition */
 	readonly contextInfo = computed<ContextInfo | null>(
-		() => this.sessionState.value?.contextInfo || null
+		() => this._contextInfo.value || this.sessionState.value?.contextInfo || null
 	);
 
 	/** Available slash commands */
@@ -113,6 +113,13 @@ class SessionStore {
 	/** Track whether there are more messages to load (from server response) */
 	private readonly _hasMoreMessages = signal(false);
 
+	/**
+	 * Direct context info signal - updated independently via context.updated events.
+	 * This fixes a race condition where context.updated events arriving before
+	 * sessionState is loaded would be silently dropped.
+	 */
+	private readonly _contextInfo = signal<ContextInfo | null>(null);
+
 	// ========================================
 	// Session Selection (with Promise-Chain Lock)
 	// ========================================
@@ -156,6 +163,7 @@ class SessionStore {
 		this.sdkMessages.value = [];
 		this._initialMessageCount.value = 0;
 		this._hasMoreMessages.value = false;
+		this._contextInfo.value = null; // Clear context info on session switch
 		// Record session switch time to only show errors that occur AFTER this point
 		// This prevents showing stale errors that were already in the session state
 		this.sessionSwitchTime = Date.now();
@@ -224,10 +232,10 @@ class SessionStore {
 			// 2. Context updates (fast path - bypasses full state.session round-trip)
 			// The daemon also sends context via state.session, but subscribing directly here
 			// ensures the UI updates as soon as context.updated fires on the session channel.
+			// FIX: Use direct signal to avoid race condition where events are dropped
+			// when sessionState.value is null (during initial load)
 			const unsubContextUpdated = hub.onEvent<ContextInfo>('context.updated', (contextInfo) => {
-				if (this.sessionState.value) {
-					this.sessionState.value = { ...this.sessionState.value, contextInfo };
-				}
+				this._contextInfo.value = contextInfo;
 			});
 			this.cleanupFunctions.push(unsubContextUpdated);
 


### PR DESCRIPTION
## Summary

- Fixed race condition where `context.updated` events were silently dropped if they arrived before `sessionState` was loaded
- Added a dedicated `_contextInfo` signal that can be updated independently of `sessionState`
- Added E2E test to verify context percentage shows non-zero values after message exchange

## Root Cause

The context usage bar was always showing 0.0% due to a race condition in `session-store.ts`:

1. When a session is selected, subscriptions are set up first (including `context.updated` handler)
2. Then `fetchInitialState` loads the initial state via RPC

The bug was in the event handler:
```typescript
const unsubContextUpdated = hub.onEvent<ContextInfo>('context.updated', (contextInfo) => {
    if (this.sessionState.value) {  // <-- BUG: if null, event is dropped!
        this.sessionState.value = { ...this.sessionState.value, contextInfo };
    }
});
```

If a `context.updated` event arrived before `fetchInitialState` completed, the event was silently dropped.

## Fix

Added a dedicated `_contextInfo` signal that can be updated independently of `sessionState`, eliminating the race condition.

## Test Plan

- [x] All 33 existing session-store tests pass
- [x] TypeScript compilation passes
- [x] Pre-commit checks pass (lint, format, typecheck, knip)
- [ ] E2E test for context percentage (requires auth to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)