### PR TITLE
fix: resolve CI failures in sdk-message-handler tests and biome format

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -733,7 +733,11 @@ export function setupSessionHandlers(
 
 	// List user messages by send status for queue UX
 	messageHub.onRequest('session.messages.byStatus', async (data) => {
-		const { sessionId: targetSessionId, status, limit = 20 } = data as {
+		const {
+			sessionId: targetSessionId,
+			status,
+			limit = 20,
+		} = data as {
 			sessionId: string;
 			status: 'saved' | 'queued' | 'sent';
 			limit?: number;

--- a/packages/daemon/tests/integration/components/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/integration/components/sdk-message-handler.test.ts
@@ -70,6 +70,8 @@ describe('SDKMessageHandler', () => {
 			saveSDKMessage: dbSaveSpy,
 			updateSession: mock(() => {}),
 			getSDKMessages: mock(() => ({ messages: [], hasMore: false })),
+			getMessagesByStatus: mock(() => []),
+			updateMessageStatus: mock(() => {}),
 		} as unknown as Database;
 
 		// Mock MessageHub

--- a/packages/daemon/tests/unit/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/query-mode-handler.test.ts
@@ -372,10 +372,9 @@ describe('QueryModeHandler', () => {
 					message: { role: 'user', content: 'Next turn (saved)' },
 				} as unknown as SDKMessage,
 			];
-			getMessagesByStatusSpy
-				.mockImplementation((_: string, status: string) =>
-					status === 'queued' ? queuedMessages : savedMessages
-				);
+			getMessagesByStatusSpy.mockImplementation((_: string, status: string) =>
+				status === 'queued' ? queuedMessages : savedMessages
+			);
 			handler = createHandler();
 
 			await handler.replayPendingMessagesForImmediateMode();

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -405,7 +405,7 @@ describe('SDKMessageHandler', () => {
 
 			await handler.handleMessage(message);
 
-			expect(handleResultUsageSpy).not.toHaveBeenCalled();
+			expect(updateWithDetailedBreakdownSpy).not.toHaveBeenCalled();
 		});
 		it('should queue /context command', async () => {
 			const message: SDKMessage = {

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -142,7 +142,8 @@ export default function MessageInput({
 	}, [refreshQueuedMessages]);
 
 	useEffect(() => {
-		if (!agentWorking && queuedForCurrentTurn.length === 0 && queuedForNextTurn.length === 0) return;
+		if (!agentWorking && queuedForCurrentTurn.length === 0 && queuedForNextTurn.length === 0)
+			return;
 		const timer = setInterval(() => {
 			void refreshQueuedMessages();
 		}, 700);
@@ -150,38 +151,41 @@ export default function MessageInput({
 	}, [agentWorking, queuedForCurrentTurn.length, queuedForNextTurn.length, refreshQueuedMessages]);
 
 	// Submit handler
-	const handleSubmit = useCallback(async (deliveryMode: MessageDeliveryMode = 'current_turn') => {
-		if (disabled) {
-			return;
-		}
-		const outgoing = extractOutgoingMessage();
-		if (!outgoing) return;
+	const handleSubmit = useCallback(
+		async (deliveryMode: MessageDeliveryMode = 'current_turn') => {
+			if (disabled) {
+				return;
+			}
+			const outgoing = extractOutgoingMessage();
+			if (!outgoing) return;
 
-		// Clear UI
-		clearDraft();
-		clearAttachments();
+			// Clear UI
+			clearDraft();
+			clearAttachments();
 
-		// Send message with images
-		await onSend(outgoing.content, outgoing.images, deliveryMode);
-		if (
-			agentWorking ||
-			deliveryMode === 'next_turn' ||
-			queuedForCurrentTurn.length > 0 ||
-			queuedForNextTurn.length > 0
-		) {
-			await refreshQueuedMessages();
-		}
-	}, [
-		disabled,
-		extractOutgoingMessage,
-		clearDraft,
-		clearAttachments,
-		onSend,
-		agentWorking,
-		queuedForCurrentTurn.length,
-		queuedForNextTurn.length,
-		refreshQueuedMessages,
-	]);
+			// Send message with images
+			await onSend(outgoing.content, outgoing.images, deliveryMode);
+			if (
+				agentWorking ||
+				deliveryMode === 'next_turn' ||
+				queuedForCurrentTurn.length > 0 ||
+				queuedForNextTurn.length > 0
+			) {
+				await refreshQueuedMessages();
+			}
+		},
+		[
+			disabled,
+			extractOutgoingMessage,
+			clearDraft,
+			clearAttachments,
+			onSend,
+			agentWorking,
+			queuedForCurrentTurn.length,
+			queuedForNextTurn.length,
+			refreshQueuedMessages,
+		]
+	);
 
 	// Keyboard handler
 	const handleKeyDown = useCallback(

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -16,7 +16,12 @@
  * agent state from state.session channel.
  */
 
-import type { MessageDeliveryMode, MessageImage, ResolvedQuestion, SessionFeatures } from '@neokai/shared';
+import type {
+	MessageDeliveryMode,
+	MessageImage,
+	ResolvedQuestion,
+	SessionFeatures,
+} from '@neokai/shared';
 import { DEFAULT_WORKER_FEATURES, DEFAULT_ROOM_CHAT_FEATURES } from '@neokai/shared';
 import type { SDKMessage, SDKSystemMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useSignalEffect } from '@preact/signals';
@@ -48,7 +53,10 @@ import { useSessionActions } from '../hooks/useSessionActions.ts';
 import { switchCoordinatorMode, switchSandboxMode, updateSession } from '../lib/api-helpers.ts';
 import { connectionManager } from '../lib/connection-manager';
 import { borderColors } from '../lib/design-tokens.ts';
-import { getMessagesBottomPaddingPx, MIN_MESSAGES_BOTTOM_PADDING_PX } from '../lib/layout-metrics.ts';
+import {
+	getMessagesBottomPaddingPx,
+	MIN_MESSAGES_BOTTOM_PADDING_PX,
+} from '../lib/layout-metrics.ts';
 import { sessionStore } from '../lib/session-store.ts';
 import { connectionState } from '../lib/state.ts';
 import { getCurrentAction } from '../lib/status-actions.ts';
@@ -530,7 +538,8 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 
 		const updatePadding = () => {
 			const queueOverlay = footer.querySelector('[data-testid="queue-overlay"]');
-			const queueOverlayRows = queueOverlay instanceof HTMLElement ? queueOverlay.children.length : 0;
+			const queueOverlayRows =
+				queueOverlay instanceof HTMLElement ? queueOverlay.children.length : 0;
 			setMessagesBottomPadding(
 				getMessagesBottomPaddingPx(footer.getBoundingClientRect().height, queueOverlayRows)
 			);
@@ -575,7 +584,14 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 			});
 		}
 		previousMessagesBottomPaddingRef.current = messagesBottomPadding;
-	}, [messagesBottomPadding, autoScroll, loadingOlder, isNearBottom, showScrollButton, scrollToBottom]);
+	}, [
+		messagesBottomPadding,
+		autoScroll,
+		loadingOlder,
+		isNearBottom,
+		showScrollButton,
+		scrollToBottom,
+	]);
 
 	// ========================================
 	// Message Maps (for tool results/inputs)

--- a/packages/web/src/lib/__tests__/layout-metrics.test.ts
+++ b/packages/web/src/lib/__tests__/layout-metrics.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-	getMessagesBottomPaddingPx,
-	MIN_MESSAGES_BOTTOM_PADDING_PX,
-} from '../layout-metrics';
+import { getMessagesBottomPaddingPx, MIN_MESSAGES_BOTTOM_PADDING_PX } from '../layout-metrics';
 
 describe('layout-metrics', () => {
 	it('keeps a safe minimum padding for normal footer heights', () => {


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: handleResultUsageSpy is not defined` in unit test — replaced with the correct `updateWithDetailedBreakdownSpy`
- Add missing `getMessagesByStatus` and `updateMessageStatus` mocks to integration test's `mockDb`, fixing the `TypeError: db.getMessagesByStatus is not a function` errors across 5+ tests
- Run `biome format` to fix 5 formatting violations: `session-handlers.ts`, `MessageInput.tsx`, `ChatContainer.tsx`, `query-mode-handler.test.ts`, `layout-metrics.test.ts`

## Test plan
- [x] Unit test `SDKMessageHandler > handleResultMessage > should defer detailed context tracking to /context response` passes
- [x] All 17 integration tests in `sdk-message-handler.test.ts` pass
- [x] `bun run format:check` passes with no errors
- [x] Pre-commit hook passes (lint, format, typecheck, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)