### PR TITLE
fix: persist context usage across page refresh

### DIFF
--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -626,8 +626,8 @@ export class StateManager {
 					const fallbackState = {
 						sessionInfo: cachedSession,
 						agentState: cachedProcessingState,
-						commandsData: { availableCommands: [] },
-						contextInfo: null,
+						commandsData: { availableCommands: this.commandsCache.get(sessionId) || [] },
+						contextInfo: this.contextCache.get(sessionId) || null,
 						error: null,
 						timestamp: Date.now(),
 						version,

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -205,6 +205,12 @@ class SessionStore {
 			const unsubSessionState = hub.onEvent<SessionState>('state.session', (state) => {
 				this.sessionState.value = state;
 
+				// FIX: Persist contextInfo to direct signal so it survives subsequent
+				// state.session events that might have contextInfo: null (e.g. fallback broadcasts)
+				if (state.contextInfo) {
+					this._contextInfo.value = state.contextInfo;
+				}
+
 				// Sync slash commands signal (for autocomplete)
 				// Guard with Array.isArray: corrupted sessions may have a string stored in DB
 				// instead of an array, which would break the filter call in the hook.
@@ -290,6 +296,16 @@ class SessionStore {
 			// Update signals with initial state
 			if (sessionState) {
 				this.sessionState.value = sessionState;
+
+				// FIX: Persist contextInfo to direct signal so it survives page refresh.
+				// Without this, _contextInfo stays null until the next context.updated event
+				// (which only fires after a new agent turn). The contextInfo computed signal
+				// falls back to sessionState.value?.contextInfo, but that can be overwritten
+				// by subsequent state.session broadcasts with contextInfo: null.
+				if (sessionState.contextInfo) {
+					this._contextInfo.value = sessionState.contextInfo;
+				}
+
 				const initialCmds = sessionState.commandsData?.availableCommands;
 				if (Array.isArray(initialCmds) && initialCmds.length > 0) {
 					slashCommandsSignal.value = initialCmds;


### PR DESCRIPTION
## Summary
- Populate `_contextInfo` signal from initial state fetch and `state.session` events so context usage survives page refresh without waiting for a new agent turn
- Use cached context data in state-manager fallback broadcasts instead of `null`, preventing stale broadcasts from wiping valid context info

## Test plan
- [x] Daemon state-manager tests pass (37/37)
- [x] Web session-store comprehensive tests pass (86/86)
- [x] Format, lint, typecheck, knip all clean
- [ ] Manual: open a session, run a turn, note context usage %, refresh page — usage should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)