### PR TITLE
refactor: remove stale sequence tracking comments

### DIFF
--- a/packages/daemon/src/lib/websocket-server-transport.ts
+++ b/packages/daemon/src/lib/websocket-server-transport.ts
@@ -273,7 +273,7 @@ export class WebSocketServerTransport implements IMessageTransport {
 		// Unregister from router
 		this.router.unregisterConnection(clientId);
 
-		// Notify client disconnect handlers (for per-client cleanup like sequence tracking)
+		// Notify client disconnect handlers (for per-client cleanup)
 		for (const handler of this.clientDisconnectHandlers) {
 			try {
 				handler(clientId);

--- a/packages/shared/src/message-hub/types.ts
+++ b/packages/shared/src/message-hub/types.ts
@@ -295,7 +295,7 @@ export interface IMessageTransport {
 
 	/**
 	 * Register handler for client disconnect events (server-side only)
-	 * Used for per-client cleanup like sequence tracking
+	 * Used for per-client cleanup
 	 */
 	onClientDisconnect?(handler: (clientId: string) => void): () => void;
 }

--- a/packages/shared/tests/message-hub-fixes.test.ts
+++ b/packages/shared/tests/message-hub-fixes.test.ts
@@ -3,7 +3,6 @@
  *
  * Tests for features in the new simplified API:
  * - Runtime message validation
- * - Message sequence numbers
  * - PING/PONG handlers
  * - Method name validation
  */


### PR DESCRIPTION
## Summary
- The sequence tracking mechanism was removed in 8ec3f691, but 3 comments still referenced "sequence tracking"
- Cleaned up the leftover comment references in `types.ts`, `websocket-server-transport.ts`, and `message-hub-fixes.test.ts`

## Test plan
- [x] Pre-commit hooks pass (lint, format, typecheck, knip)
- [x] Comment-only changes — no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)