### PR TITLE
fix(web): guard against undefined rateLimitType/resetsAt in SDKRateLimitEvent

### DIFF
--- a/packages/shared/src/sdk/sdk.d.ts
+++ b/packages/shared/src/sdk/sdk.d.ts
@@ -1848,8 +1848,8 @@ export declare type SDKRateLimitEvent = {
     type: 'rate_limit_event';
     rate_limit_info: {
         status: 'allowed' | 'rejected';
-        resetsAt: number;
-        rateLimitType: string;
+        resetsAt?: number;
+        rateLimitType?: string;
         overageStatus: 'allowed' | 'rejected';
         overageDisabledReason: string | null;
         isUsingOverage: boolean;

--- a/packages/web/src/components/sdk/SDKRateLimitEvent.tsx
+++ b/packages/web/src/components/sdk/SDKRateLimitEvent.tsx
@@ -9,7 +9,8 @@ function formatResetTime(resetsAt: number): string {
 	return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-function formatRateLimitType(type: string): string {
+function formatRateLimitType(type: string | undefined): string {
+	if (!type) return 'Rate Limit';
 	return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
@@ -56,15 +57,17 @@ export function SDKRateLimitEvent({ message }: Props) {
 						{isRejected ? 'rejected' : 'allowed'}
 					</span>
 				</span>
-				<span
-					class={
-						isRejected
-							? 'text-red-700/80 dark:text-red-300/80'
-							: 'text-amber-700/80 dark:text-amber-300/80'
-					}
-				>
-					Resets at {formatResetTime(info.resetsAt)}
-				</span>
+				{info.resetsAt !== undefined && (
+					<span
+						class={
+							isRejected
+								? 'text-red-700/80 dark:text-red-300/80'
+								: 'text-amber-700/80 dark:text-amber-300/80'
+						}
+					>
+						Resets at {formatResetTime(info.resetsAt)}
+					</span>
+				)}
 				{overageRejected && info.overageDisabledReason && (
 					<span
 						class={


### PR DESCRIPTION
## Root cause

The Claude Agent SDK builds `rate_limit_info` with conditional spreads:

```js
{ status, ...resetsAt !== undefined && { resetsAt }, ...rateLimitType !== undefined && { rateLimitType }, ... }
```

So `rateLimitType` and `resetsAt` are only present when defined. The TypeScript type declared them as required, hiding the mismatch from the type checker.

When a rate limit event arrived without `rateLimitType`, the component called `undefined.replace()` during render — an unhandled `TypeError` that crashed the Preact component tree, freezing the session page.

## Changes

- **`packages/shared/src/sdk/sdk.d.ts`** — mark `resetsAt` and `rateLimitType` as optional to match real SDK behavior
- **`packages/web/src/components/sdk/SDKRateLimitEvent.tsx`**:
  - `formatRateLimitType` now accepts `string | undefined`, returning `'Rate Limit'` as fallback
  - "Resets at …" only renders when `resetsAt` is present

## Test plan

- [ ] Verify session pages no longer crash when a `rate_limit_event` with missing `rateLimitType`/`resetsAt` is received
- [ ] Verify rate limit banners still render correctly when all fields are present