### PR TITLE
feat(web): add Context tab to room page

### DIFF
--- a/packages/web/src/components/room/RoomContext.tsx
+++ b/packages/web/src/components/room/RoomContext.tsx
@@ -1,0 +1,121 @@
+/**
+ * RoomContext - Edit room background context and instructions
+ *
+ * Provides editing for the two text fields that feed into agent system prompts:
+ * - Background: Project context, goals, architecture notes
+ * - Instructions: Behavioral guidelines for room agents
+ */
+
+import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+import type { Room } from '@neokai/shared';
+import { roomStore } from '../../lib/room-store';
+import { Button } from '../ui/Button';
+import { Spinner } from '../ui/Spinner';
+import { toast } from '../../lib/toast';
+
+export interface RoomContextProps {
+	room: Room;
+}
+
+export function RoomContext({ room }: RoomContextProps) {
+	const background = useSignal(room.background || '');
+	const instructions = useSignal(room.instructions || '');
+	const isSaving = useSignal(false);
+
+	// Sync with room props when they change
+	useEffect(() => {
+		background.value = room.background || '';
+		instructions.value = room.instructions || '';
+	}, [room]);
+
+	const hasChanges = () => {
+		return (
+			background.value !== (room.background || '') ||
+			instructions.value !== (room.instructions || '')
+		);
+	};
+
+	const handleSave = async () => {
+		if (!hasChanges()) return;
+
+		isSaving.value = true;
+		try {
+			await roomStore.updateContext(background.value || undefined, instructions.value || undefined);
+			toast.success('Context saved');
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to save context');
+		} finally {
+			isSaving.value = false;
+		}
+	};
+
+	const disabled = isSaving.value;
+
+	return (
+		<div class="flex flex-col h-full">
+			{/* Header */}
+			<div class="flex items-center justify-between pb-4 border-b border-dark-700">
+				<h2 class="text-lg font-semibold text-gray-100">Room Context</h2>
+			</div>
+
+			{/* Content */}
+			<div class="flex-1 overflow-y-auto py-4 space-y-6">
+				{/* Background */}
+				<div class="flex flex-col">
+					<label for="room-background" class="block text-sm font-medium text-gray-300 mb-1.5">
+						Background
+					</label>
+					<p class="text-xs text-gray-500 mb-2">
+						Project context shared with all room agents. Describe the project, its architecture,
+						goals, and any relevant technical details.
+					</p>
+					<textarea
+						id="room-background"
+						value={background.value}
+						onInput={(e) => (background.value = (e.target as HTMLTextAreaElement).value)}
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-3 text-sm text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-y font-mono"
+						rows={12}
+						placeholder="Describe the project context, architecture, and goals..."
+						disabled={disabled}
+					/>
+				</div>
+
+				{/* Instructions */}
+				<div class="flex flex-col">
+					<label for="room-instructions" class="block text-sm font-medium text-gray-300 mb-1.5">
+						Instructions
+					</label>
+					<p class="text-xs text-gray-500 mb-2">
+						Custom instructions for how room agents should behave. Coding standards, preferred
+						tools, workflow guidelines, etc.
+					</p>
+					<textarea
+						id="room-instructions"
+						value={instructions.value}
+						onInput={(e) => (instructions.value = (e.target as HTMLTextAreaElement).value)}
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-3 text-sm text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-y font-mono"
+						rows={8}
+						placeholder="Add behavioral guidelines for room agents..."
+						disabled={disabled}
+					/>
+				</div>
+			</div>
+
+			{/* Footer */}
+			<div class="flex items-center justify-end gap-3 pt-4 border-t border-dark-700">
+				{isSaving.value && (
+					<span class="text-sm text-gray-400 flex items-center gap-2">
+						<Spinner size="sm" />
+						Saving...
+					</span>
+				)}
+				<Button onClick={handleSave} disabled={!hasChanges() || disabled} loading={isSaving.value}>
+					Save Changes
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -9,5 +9,8 @@
 // @public - Library export
 export { GoalsEditor } from './GoalsEditor';
 // @public - Library export
+export { RoomContext } from './RoomContext';
+export type { RoomContextProps } from './RoomContext';
+// @public - Library export
 export { RoomSettings } from './RoomSettings';
 export type { RoomSettingsProps } from './RoomSettings';

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -13,13 +13,13 @@ import { roomStore } from '../lib/room-store';
 import { navigateToHome, navigateToRoomTask } from '../lib/router';
 import { RoomDashboard } from '../components/room/RoomDashboard';
 import ChatContainer from './ChatContainer';
-import { GoalsEditor, RoomSettings } from '../components/room';
+import { GoalsEditor, RoomContext, RoomSettings } from '../components/room';
 import { TaskView } from '../components/room/TaskView';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
 import { toast } from '../lib/toast';
 
-type RoomTab = 'overview' | 'goals' | 'settings';
+type RoomTab = 'overview' | 'context' | 'goals' | 'settings';
 
 interface RoomProps {
 	roomId: string;
@@ -144,6 +144,16 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 							</button>
 							<button
 								class={`px-4 py-2 text-sm font-medium transition-colors ${
+									activeTab === 'context'
+										? 'text-blue-400 border-b-2 border-blue-400'
+										: 'text-gray-400 hover:text-gray-200'
+								}`}
+								onClick={() => setActiveTab('context')}
+							>
+								Context
+							</button>
+							<button
+								class={`px-4 py-2 text-sm font-medium transition-colors ${
 									activeTab === 'goals'
 										? 'text-blue-400 border-b-2 border-blue-400'
 										: 'text-gray-400 hover:text-gray-200'
@@ -169,6 +179,11 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 							{activeTab === 'overview' && (
 								<div class="h-full overflow-y-auto">
 									<RoomDashboard />
+								</div>
+							)}
+							{activeTab === 'context' && (
+								<div class="h-full overflow-y-auto p-4">
+									<RoomContext room={room} />
 								</div>
 							)}
 							{activeTab === 'goals' && (


### PR DESCRIPTION
## Summary
- Added a new "Context" tab to the room page between Overview and Goals
- Two textarea fields for editing room **Background** (project context for agents) and **Instructions** (behavioral guidelines for agents)
- Wired to the existing `roomStore.updateContext()` which calls `room.update` RPC — backend was already fully implemented

## Test plan
- [ ] Navigate to a room, verify the "Context" tab appears between Overview and Goals
- [ ] Enter background text and save — verify toast success and persistence on reload
- [ ] Enter instructions text and save — verify toast success and persistence on reload
- [ ] Verify agents receive the updated context in their system prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)