### PR TITLE
fix(daemon): add session recovery safety net for room runtime

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -436,6 +436,30 @@ export class AgentSession
 	}
 
 	/**
+	 * Restore an AgentSession from DB after daemon restart.
+	 *
+	 * Unlike fromInit(), this skips fingerprint comparison and init-derived config
+	 * updates. Used for worker/leader sessions that were persisted before restart.
+	 *
+	 * Returns null if the session doesn't exist in DB.
+	 */
+	static restore(
+		sessionId: string,
+		db: Database,
+		messageHub: MessageHub,
+		daemonHub: DaemonHub,
+		getApiKey: () => Promise<string | null>
+	): AgentSession | null {
+		const session = db.getSession(sessionId);
+		if (!session) return null;
+
+		const agentSession = new AgentSession(session, db, messageHub, daemonHub, getApiKey);
+		// Worker/leader sessions managed by room runtime should not auto-queue /context
+		agentSession.contextAutoQueueEnabled = false;
+		return agentSession;
+	}
+
+	/**
 	 * Create a Session object from AgentSessionInit
 	 *
 	 * This creates the session data structure that can be persisted to DB.

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -184,6 +184,23 @@ export class RoomRuntimeService {
 				await session.handleQuestionResponse(toolUseId, responses);
 				return true;
 			},
+			restoreSession: async (sessionId) => {
+				// Idempotent: already in cache
+				if (agentSessions.has(sessionId)) return true;
+
+				const session = AgentSession.restore(
+					sessionId,
+					ctx.db,
+					ctx.messageHub,
+					ctx.daemonHub,
+					ctx.getApiKey
+				);
+				if (!session) return false;
+
+				agentSessions.set(sessionId, session);
+				await session.startStreamingQuery();
+				return true;
+			},
 			createWorktree: async (basePath, sessionId, branchName) => {
 				try {
 					const result = await worktreeManager.createWorktree({
@@ -335,12 +352,15 @@ export class RoomRuntimeService {
 		const rawDb = this.ctx.db.getDatabase();
 		const groupRepo = new SessionGroupRepository(rawDb);
 		const taskManager = new TaskManager(rawDb, roomId);
+		const sessionFactory = this.createSessionFactory();
 
 		const checker: SessionStateChecker = {
 			sessionExists: (sessionId) => this.ctx.db.getSession(sessionId) !== null,
 			// Assume not terminal after restart — active groups stuck post-restart
 			// can be cancelled via the cancel_task Room Agent tool.
 			isTerminalState: () => false,
+			isLive: (sessionId) => this.agentSessions.has(sessionId),
+			restoreSession: (sessionId) => sessionFactory.restoreSession(sessionId),
 		};
 
 		try {
@@ -355,7 +375,8 @@ export class RoomRuntimeService {
 			if (result.recoveredGroups > 0) {
 				log.info(
 					`Room ${roomId}: recovered ${result.recoveredGroups} groups, ` +
-						`failed ${result.failedGroups}, reattached ${result.reattachedObservers} observers`
+						`failed ${result.failedGroups}, restored ${result.restoredSessions} sessions, ` +
+						`reattached ${result.reattachedObservers} observers`
 				);
 			}
 		} catch (error) {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -690,9 +690,17 @@ export class RoomRuntime {
 		// Move task back to in_progress
 		await this.taskManager.updateTaskStatus(group.taskId, 'in_progress');
 
-		// Delegate to TaskGroupManager (injects message into existing worker)
-		const updated = await this.taskGroupManager.resumeWorkerFromHuman(group.id, message);
-		if (!updated) return false;
+		// Delegate to TaskGroupManager (injects message into existing worker).
+		// If injection fails, TaskGroupManager rolls back group state. We also
+		// revert the task status so the task stays in review for retry.
+		try {
+			const updated = await this.taskGroupManager.resumeWorkerFromHuman(group.id, message);
+			if (!updated) return false;
+		} catch (error) {
+			await this.taskManager.reviewTask(group.taskId);
+			log.error(`Failed to resume worker from human for task ${taskId}:`, error);
+			return false;
+		}
 
 		await this.emitTaskUpdateById(group.taskId);
 		this.scheduleTick();
@@ -828,7 +836,100 @@ export class RoomRuntime {
 		}
 	}
 
+	/**
+	 * Safety net: detect groups whose worker/leader sessions are missing from the
+	 * in-memory cache. Returns zombie groups that need async restoration.
+	 *
+	 * Split into sync detection + async recovery to avoid unnecessary microtask
+	 * checkpoints when there are no zombies (common case).
+	 */
+	private findZombieGroups(): SessionGroup[] {
+		const allActiveGroups = this.groupRepo.getActiveGroups(this.room.id);
+		const zombies: SessionGroup[] = [];
+
+		for (const group of allActiveGroups) {
+			const workerMissing = !this.sessionFactory.hasSession(group.workerSessionId);
+			const leaderMissing =
+				group.state === 'awaiting_leader' && !this.sessionFactory.hasSession(group.leaderSessionId);
+
+			if (workerMissing || leaderMissing) {
+				zombies.push(group);
+			}
+		}
+
+		return zombies;
+	}
+
+	/**
+	 * Attempt to restore zombie groups. Called only when findZombieGroups()
+	 * returns non-empty results.
+	 */
+	private async recoverZombieGroups(zombies: SessionGroup[]): Promise<void> {
+		for (const group of zombies) {
+			// Check worker session liveness
+			if (!this.sessionFactory.hasSession(group.workerSessionId)) {
+				log.warn(
+					`Zombie detected: group ${group.id} (state=${group.state}) ` +
+						`worker ${group.workerSessionId} not in cache. Attempting restore.`
+				);
+				const restored = await this.sessionFactory.restoreSession(group.workerSessionId);
+				if (restored) {
+					log.info(`Restored worker session ${group.workerSessionId} for group ${group.id}`);
+					this.observer.observe(group.workerSessionId, (state) => {
+						this.onWorkerTerminalState(group.id, state);
+					});
+				} else {
+					log.error(
+						`Failed to restore worker ${group.workerSessionId}. Failing group ${group.id}.`
+					);
+					await this.taskGroupManager.fail(
+						group.id,
+						'Worker session lost and could not be restored'
+					);
+					this.cleanupMirroring(group.id, 'Worker session lost — could not be restored.');
+					await this.emitTaskUpdateById(group.taskId);
+					continue;
+				}
+			}
+
+			// Check leader session liveness (only when leader is the active actor)
+			if (
+				group.state === 'awaiting_leader' &&
+				!this.sessionFactory.hasSession(group.leaderSessionId)
+			) {
+				log.warn(
+					`Zombie detected: group ${group.id} (state=awaiting_leader) ` +
+						`leader ${group.leaderSessionId} not in cache. Attempting restore.`
+				);
+				const restored = await this.sessionFactory.restoreSession(group.leaderSessionId);
+				if (restored) {
+					log.info(`Restored leader session ${group.leaderSessionId} for group ${group.id}`);
+					this.observer.observe(group.leaderSessionId, (state) => {
+						this.onLeaderTerminalState(group.id, state);
+					});
+				} else {
+					log.error(
+						`Failed to restore leader ${group.leaderSessionId}. Failing group ${group.id}.`
+					);
+					await this.taskGroupManager.fail(
+						group.id,
+						'Leader session lost and could not be restored'
+					);
+					this.cleanupMirroring(group.id, 'Leader session lost — could not be restored.');
+					await this.emitTaskUpdateById(group.taskId);
+				}
+			}
+		}
+	}
+
 	private async executeTick(): Promise<void> {
+		// Safety net: detect and recover zombie groups (sessions missing from cache).
+		// Sync detection avoids unnecessary microtask checkpoints in the common case.
+		const zombies = this.findZombieGroups();
+		if (zombies.length > 0) {
+			await this.recoverZombieGroups(zombies);
+		}
+
 		// Check capacity — awaiting_human groups are paused and don't consume slots
 		const activeGroups = this.groupRepo
 			.getActiveGroups(this.room.id)

--- a/packages/daemon/src/lib/room/runtime/runtime-recovery.ts
+++ b/packages/daemon/src/lib/room/runtime/runtime-recovery.ts
@@ -3,9 +3,9 @@
  *
  * On startup:
  * 1. Find all in-progress tasks with active groups
- * 2. For each group, check session existence and state
+ * 2. For each group, restore sessions into in-memory cache
  * 3. Re-attach observers for active sessions
- * 4. Fail groups with lost sessions
+ * 4. Fail groups with lost or unrestorable sessions
  * 5. Resume tick loop
  *
  * Key insight: Recovery is proactive - checks current state before subscribing
@@ -19,12 +19,18 @@ import type { TaskManager } from '../managers/task-manager';
 import type { RoomRuntime } from './room-runtime';
 
 /**
- * Interface for checking session existence and state.
+ * Interface for checking session existence, liveness, and restoration.
  * Injected for testability.
  */
 export interface SessionStateChecker {
+	/** Check if the session row exists in DB */
 	sessionExists(sessionId: string): boolean;
+	/** Check if the session is in a terminal processing state */
 	isTerminalState(sessionId: string): boolean;
+	/** Check if the session is live in the in-memory AgentSession cache */
+	isLive(sessionId: string): boolean;
+	/** Restore a session from DB into the in-memory cache and start streaming. */
+	restoreSession(sessionId: string): Promise<boolean>;
 }
 
 export interface RecoveryResult {
@@ -32,12 +38,13 @@ export interface RecoveryResult {
 	failedGroups: number;
 	reattachedObservers: number;
 	immediateTerminals: number;
+	restoredSessions: number;
 }
 
 /**
  * Recover room runtime state after daemon restart.
  *
- * Scans active groups and either re-attaches observers or fails
+ * Scans active groups and either restores + re-attaches observers or fails
  * groups with lost sessions.
  */
 export async function recoverRuntime(
@@ -53,6 +60,7 @@ export async function recoverRuntime(
 		failedGroups: 0,
 		reattachedObservers: 0,
 		immediateTerminals: 0,
+		restoredSessions: 0,
 	};
 
 	// Find all active groups for this room
@@ -87,12 +95,39 @@ export async function recoverRuntime(
 				break;
 
 			case 'awaiting_human':
-				// No action needed - waiting for external input
+				await recoverAwaitingHuman(
+					group,
+					groupRepo,
+					taskManager,
+					observer,
+					sessionChecker,
+					runtime,
+					result
+				);
 				break;
 		}
 	}
 
 	return result;
+}
+
+/**
+ * Ensure a session is live (in the in-memory cache). If not, restore from DB.
+ * Returns true if session is live after this call, false if unrestorable.
+ */
+async function ensureLive(
+	sessionId: string,
+	sessionChecker: SessionStateChecker,
+	result: RecoveryResult
+): Promise<boolean> {
+	if (sessionChecker.isLive(sessionId)) return true;
+	if (!sessionChecker.sessionExists(sessionId)) return false;
+
+	const restored = await sessionChecker.restoreSession(sessionId);
+	if (restored) {
+		result.restoredSessions++;
+	}
+	return restored;
 }
 
 async function recoverAwaitingWorker(
@@ -104,8 +139,9 @@ async function recoverAwaitingWorker(
 	runtime: RoomRuntime,
 	result: RecoveryResult
 ): Promise<void> {
-	if (!sessionChecker.sessionExists(group.workerSessionId)) {
-		// Session lost - fail the group and task
+	// Restore worker into memory if not live
+	const workerLive = await ensureLive(group.workerSessionId, sessionChecker, result);
+	if (!workerLive) {
 		await failGroupAndTask(group, groupRepo, taskManager, 'Worker session lost during restart');
 		result.failedGroups++;
 		return;
@@ -126,8 +162,9 @@ async function recoverAwaitingWorker(
 		result.reattachedObservers++;
 	}
 
-	// Also observe Leader for when it becomes active
+	// Also restore and observe Leader for when it becomes active
 	if (sessionChecker.sessionExists(group.leaderSessionId)) {
+		await ensureLive(group.leaderSessionId, sessionChecker, result);
 		observer.observe(group.leaderSessionId, (state: TerminalState) => {
 			runtime.onLeaderTerminalState(group.id, state);
 		});
@@ -143,8 +180,9 @@ async function recoverAwaitingLeader(
 	runtime: RoomRuntime,
 	result: RecoveryResult
 ): Promise<void> {
-	if (!sessionChecker.sessionExists(group.leaderSessionId)) {
-		// Session lost - fail the group and task
+	// Restore leader into memory if not live
+	const leaderLive = await ensureLive(group.leaderSessionId, sessionChecker, result);
+	if (!leaderLive) {
 		await failGroupAndTask(group, groupRepo, taskManager, 'Leader session lost during restart');
 		result.failedGroups++;
 		return;
@@ -165,10 +203,54 @@ async function recoverAwaitingLeader(
 		result.reattachedObservers++;
 	}
 
-	// Also observe Worker for if it becomes active again
+	// Also restore and observe Worker for if it becomes active again
 	if (sessionChecker.sessionExists(group.workerSessionId)) {
+		await ensureLive(group.workerSessionId, sessionChecker, result);
 		observer.observe(group.workerSessionId, (state: TerminalState) => {
 			runtime.onWorkerTerminalState(group.id, state);
+		});
+	}
+}
+
+/**
+ * Recover awaiting_human groups by restoring sessions into memory.
+ *
+ * The worker session must be live so that when the human approves,
+ * injectMessage can deliver the approval to the worker.
+ */
+async function recoverAwaitingHuman(
+	group: SessionGroup,
+	groupRepo: SessionGroupRepository,
+	taskManager: TaskManager,
+	observer: SessionObserver,
+	sessionChecker: SessionStateChecker,
+	runtime: RoomRuntime,
+	result: RecoveryResult
+): Promise<void> {
+	// Restore worker into memory so injectMessage works on human approval
+	const workerLive = await ensureLive(group.workerSessionId, sessionChecker, result);
+	if (!workerLive) {
+		await failGroupAndTask(
+			group,
+			groupRepo,
+			taskManager,
+			'Worker session lost during restart (awaiting human)'
+		);
+		result.failedGroups++;
+		return;
+	}
+
+	// Attach observer so worker terminal state fires after human approval
+	observer.observe(group.workerSessionId, (state: TerminalState) => {
+		runtime.onWorkerTerminalState(group.id, state);
+	});
+	result.reattachedObservers++;
+
+	// Also restore leader if it exists (best-effort)
+	if (sessionChecker.sessionExists(group.leaderSessionId)) {
+		await ensureLive(group.leaderSessionId, sessionChecker, result);
+		observer.observe(group.leaderSessionId, (state: TerminalState) => {
+			runtime.onLeaderTerminalState(group.id, state);
 		});
 	}
 }

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -57,6 +57,12 @@ export interface SessionFactory {
 	 * Returns the worktree path, or null if not in a git repo.
 	 */
 	createWorktree(basePath: string, sessionId: string, branchName?: string): Promise<string | null>;
+	/**
+	 * Restore a session from DB after daemon restart.
+	 * Adds it to the in-memory cache and starts the streaming query.
+	 * Returns true if successful, false if session not found in DB.
+	 */
+	restoreSession(sessionId: string): Promise<boolean>;
 }
 
 /**
@@ -440,8 +446,19 @@ export class TaskGroupManager {
 			}),
 		});
 
-		// Inject approval message into existing worker session
-		await this.sessionFactory.injectMessage(group.workerSessionId, message);
+		// Inject approval message into existing worker session.
+		// If injection fails (e.g., session not in cache after restart), rollback
+		// the group state so the task stays in review for retry.
+		try {
+			await this.sessionFactory.injectMessage(group.workerSessionId, message);
+		} catch (error) {
+			// Rollback: revert group back to awaiting_human
+			const current = this.groupRepo.getGroup(groupId);
+			if (current && current.state === 'awaiting_worker') {
+				this.groupRepo.updateGroupState(groupId, 'awaiting_human', current.version);
+			}
+			throw error;
+		}
 
 		return true;
 	}

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for the session recovery safety net:
+ * 1. Zombie detection in tick — restores missing sessions or fails groups
+ * 2. resumeWorkerFromHuman rollback — reverts state when inject fails
+ * 3. Tick remains async and handles zombie recovery correctly
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+
+/**
+ * Helper: create a task + session group directly in DB (bypassing tick).
+ * Avoids race conditions from scheduleTick background ticks.
+ */
+async function createTaskWithGroup(
+	ctx: RuntimeTestContext,
+	groupState = 'awaiting_worker'
+): Promise<{ taskId: string; groupId: string; workerSessionId: string; leaderSessionId: string }> {
+	const { task } = await createGoalAndTask(ctx);
+	const group = ctx.groupRepo.createGroup(task.id, `worker:${task.id}`, `leader:${task.id}`);
+	await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
+
+	if (groupState !== 'awaiting_worker') {
+		ctx.groupRepo.updateGroupState(group.id, groupState as never, group.version);
+	}
+
+	return {
+		taskId: task.id,
+		groupId: group.id,
+		workerSessionId: group.workerSessionId,
+		leaderSessionId: group.leaderSessionId,
+	};
+}
+
+describe('Zombie detection in tick', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('should restore a zombie worker session during tick', async () => {
+		const { groupId, workerSessionId } = await createTaskWithGroup(ctx);
+
+		// Worker is missing from cache — becomes live after first restore
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		const originalRestore = ctx.sessionFactory.restoreSession.bind(ctx.sessionFactory);
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return originalRestore(sessionId);
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const restoreCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'restoreSession' && c.args[0] === workerSessionId
+		);
+		expect(restoreCalls).toHaveLength(1);
+
+		// Group should still be active (not failed)
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('awaiting_worker');
+	});
+
+	it('should fail group when zombie worker cannot be restored', async () => {
+		const { taskId, groupId, workerSessionId } = await createTaskWithGroup(ctx);
+
+		// Worker missing AND restoreSession fails
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async () => false;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Group should be failed
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('failed');
+
+		// Task should be failed
+		const updatedTask = await ctx.taskManager.getTask(taskId);
+		expect(updatedTask!.status).toBe('failed');
+	});
+
+	it('should restore a zombie leader session during tick', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+
+		// Leader is missing from cache — becomes live after first restore
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		const originalRestore = ctx.sessionFactory.restoreSession.bind(ctx.sessionFactory);
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return originalRestore(sessionId);
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const restoreCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'restoreSession' && c.args[0] === leaderSessionId
+		);
+		expect(restoreCalls).toHaveLength(1);
+
+		// Group should still be active
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('awaiting_leader');
+	});
+
+	it('should fail group when zombie leader cannot be restored', async () => {
+		const { taskId, groupId, leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+
+		// Leader missing and unrestorable
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async () => false;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('failed');
+
+		const updatedTask = await ctx.taskManager.getTask(taskId);
+		expect(updatedTask!.status).toBe('failed');
+	});
+
+	it('should not interfere with normal tick when no zombies exist', async () => {
+		await createGoalAndTask(ctx);
+		ctx.runtime.start();
+
+		// Normal tick — all sessions exist (hasSession returns true by default)
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		expect(groups).toHaveLength(1);
+
+		// No restore calls should have been made
+		const restoreCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'restoreSession');
+		expect(restoreCalls).toHaveLength(0);
+	});
+
+	it('should handle multiple zombie groups in a single tick', async () => {
+		// Create two zombie groups directly in DB
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Multi-task goal',
+			description: 'Test',
+		});
+		const task1 = await ctx.taskManager.createTask({
+			title: 'Task 1',
+			description: 'First task',
+			assignedAgent: 'general',
+		});
+		const task2 = await ctx.taskManager.createTask({
+			title: 'Task 2',
+			description: 'Second task',
+			assignedAgent: 'general',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, task1.id);
+		await ctx.goalManager.linkTaskToGoal(goal.id, task2.id);
+
+		const group1 = ctx.groupRepo.createGroup(task1.id, 'worker-1', 'leader-1');
+		const group2 = ctx.groupRepo.createGroup(task2.id, 'worker-2', 'leader-2');
+		await ctx.taskManager.updateTaskStatus(task1.id, 'in_progress');
+		await ctx.taskManager.updateTaskStatus(task2.id, 'in_progress');
+
+		// Both workers are zombies — mark as live after restore
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			return restoredSessions.has(sessionId);
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Both workers should be restored
+		expect(restoredSessions.has('worker-1')).toBe(true);
+		expect(restoredSessions.has('worker-2')).toBe(true);
+
+		// Both groups should remain active
+		expect(ctx.groupRepo.getGroup(group1.id)!.state).toBe('awaiting_worker');
+		expect(ctx.groupRepo.getGroup(group2.id)!.state).toBe('awaiting_worker');
+	});
+
+	it('should restore zombie worker in awaiting_human group during tick', async () => {
+		const { groupId, workerSessionId } = await createTaskWithGroup(ctx, 'awaiting_human');
+
+		// Worker is missing — becomes live after restore
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		const originalRestore = ctx.sessionFactory.restoreSession.bind(ctx.sessionFactory);
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return originalRestore(sessionId);
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const restoreCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'restoreSession' && c.args[0] === workerSessionId
+		);
+		expect(restoreCalls).toHaveLength(1);
+
+		// Group should remain in awaiting_human (not failed)
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('awaiting_human');
+	});
+
+	it('should fail awaiting_human group when worker cannot be restored', async () => {
+		const { taskId, groupId, workerSessionId } = await createTaskWithGroup(ctx, 'awaiting_human');
+
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async () => false;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('failed');
+
+		const updatedTask = await ctx.taskManager.getTask(taskId);
+		expect(updatedTask!.status).toBe('failed');
+	});
+
+	it('should reattach observer after restoring zombie worker', async () => {
+		const { workerSessionId } = await createTaskWithGroup(ctx);
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Observer should be watching the restored session
+		expect(ctx.observer.isObserving(workerSessionId)).toBe(true);
+	});
+
+	it('should reattach observer after restoring zombie leader', async () => {
+		const { leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		expect(ctx.observer.isObserving(leaderSessionId)).toBe(true);
+	});
+});
+
+describe('resumeWorkerFromHuman rollback', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('should rollback task and group state when injectMessage fails', async () => {
+		const { taskId, groupId } = await createTaskWithGroup(ctx, 'awaiting_human');
+		await ctx.taskManager.reviewTask(taskId);
+
+		// Make injectMessage fail (simulates session not in cache after restart)
+		ctx.sessionFactory.injectMessage = async () => {
+			throw new Error('Session not in service cache');
+		};
+
+		ctx.runtime.start();
+		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');
+		expect(result).toBe(false);
+
+		// Group should revert to awaiting_human (not stuck in awaiting_worker)
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('awaiting_human');
+
+		// Task should revert to review (not stuck in in_progress)
+		const updatedTask = await ctx.taskManager.getTask(taskId);
+		expect(updatedTask!.status).toBe('review');
+	});
+
+	it('should succeed normally when injectMessage works', async () => {
+		const { taskId, groupId } = await createTaskWithGroup(ctx, 'awaiting_human');
+		await ctx.taskManager.reviewTask(taskId);
+
+		ctx.runtime.start();
+		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');
+		expect(result).toBe(true);
+
+		// Group should be awaiting_worker
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.state).toBe('awaiting_worker');
+
+		// Task should be in_progress
+		const updatedTask = await ctx.taskManager.getTask(taskId);
+		expect(updatedTask!.status).toBe('in_progress');
+	});
+
+	it('should return false for non-existent task', async () => {
+		ctx.runtime.start();
+		const result = await ctx.runtime.resumeWorkerFromHuman('nonexistent', 'Approved');
+		expect(result).toBe(false);
+	});
+
+	it('should return false when group is not in awaiting_human', async () => {
+		const { taskId } = await createTaskWithGroup(ctx, 'awaiting_worker');
+
+		ctx.runtime.start();
+		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');
+		expect(result).toBe(false);
+	});
+});
+
+describe('Tick async behavior', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('tick should be async and await zombie recovery before proceeding', async () => {
+		const { workerSessionId } = await createTaskWithGroup(ctx);
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+
+		let restoreResolved = false;
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			// Simulate async restore with delay
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			restoredSessions.add(sessionId);
+			restoreResolved = true;
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// The tick should have awaited the async restore
+		expect(restoreResolved).toBe(true);
+	});
+
+	it('should handle concurrent ticks with zombie detection without double-processing', async () => {
+		const { workerSessionId } = await createTaskWithGroup(ctx);
+
+		let restoreCount = 0;
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && restoreCount === 0) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async () => {
+			restoreCount++;
+			return true;
+		};
+
+		ctx.runtime.start();
+		// Run two ticks concurrently - mutex should prevent double processing
+		await Promise.all([ctx.runtime.tick(), ctx.runtime.tick()]);
+
+		expect(restoreCount).toBe(1);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -57,6 +57,10 @@ export function createMockSessionFactory() {
 			// Return a synthetic worktree path so isolation enforcement passes in tests
 			return `/tmp/worktrees/${sessionId}`;
 		},
+		async restoreSession(sessionId: string) {
+			calls.push({ method: 'restoreSession', args: [sessionId] });
+			return true;
+		},
 	} satisfies SessionFactory & { calls: Array<{ method: string; args: unknown[] }> };
 }
 

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -44,6 +44,10 @@ function createMockSessionFactory() {
 		async createWorktree(_basePath: string, _sessionId: string) {
 			return null;
 		},
+		async restoreSession(sessionId: string) {
+			calls.push({ method: 'restoreSession', args: [sessionId] });
+			return true;
+		},
 	} satisfies SessionFactory & { calls: Array<{ method: string; args: unknown[] }> };
 }
 
@@ -57,6 +61,17 @@ function makeRoom(): Room {
 		status: 'active',
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+	};
+}
+
+/** Create a checker where all sessions exist in DB and are live in cache */
+function createDefaultChecker(overrides?: Partial<SessionStateChecker>): SessionStateChecker {
+	return {
+		sessionExists: () => true,
+		isTerminalState: () => false,
+		isLive: () => true,
+		restoreSession: async () => true,
+		...overrides,
 	};
 }
 
@@ -168,10 +183,7 @@ describe('Runtime Recovery', () => {
 	}
 
 	it('should return empty result when no active groups', async () => {
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
-			isTerminalState: () => false,
-		};
+		const checker = createDefaultChecker();
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -189,10 +201,10 @@ describe('Runtime Recovery', () => {
 	it('should fail groups with lost worker sessions', async () => {
 		const { taskId, group } = createTaskAndGroup('awaiting_worker');
 
-		const checker: SessionStateChecker = {
+		const checker = createDefaultChecker({
 			sessionExists: (id) => !id.startsWith('worker:'),
-			isTerminalState: () => false,
-		};
+			isLive: (id) => !id.startsWith('worker:'),
+		});
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -214,10 +226,10 @@ describe('Runtime Recovery', () => {
 	it('should fail groups with lost leader sessions', async () => {
 		const { taskId, group } = createTaskAndGroup('awaiting_leader');
 
-		const checker: SessionStateChecker = {
+		const checker = createDefaultChecker({
 			sessionExists: (id) => !id.startsWith('leader:'),
-			isTerminalState: () => false,
-		};
+			isLive: (id) => !id.startsWith('leader:'),
+		});
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -239,10 +251,7 @@ describe('Runtime Recovery', () => {
 	it('should reattach observers for active worker sessions', async () => {
 		const { group } = createTaskAndGroup('awaiting_worker');
 
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
-			isTerminalState: () => false,
-		};
+		const checker = createDefaultChecker();
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -260,10 +269,7 @@ describe('Runtime Recovery', () => {
 	it('should reattach observers for active leader sessions', async () => {
 		const { group } = createTaskAndGroup('awaiting_leader');
 
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
-			isTerminalState: () => false,
-		};
+		const checker = createDefaultChecker();
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -281,10 +287,9 @@ describe('Runtime Recovery', () => {
 	it('should process immediately terminal worker sessions', async () => {
 		const { group } = createTaskAndGroup('awaiting_worker');
 
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
+		const checker = createDefaultChecker({
 			isTerminalState: (id) => id.startsWith('worker:'),
-		};
+		});
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -301,13 +306,13 @@ describe('Runtime Recovery', () => {
 		expect(updated!.state).toBe('awaiting_leader');
 	});
 
-	it('should skip awaiting_human groups', async () => {
-		createTaskAndGroup('awaiting_human');
+	it('should restore and observe awaiting_human groups', async () => {
+		const { group } = createTaskAndGroup('awaiting_human');
 
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
-			isTerminalState: () => false,
-		};
+		// Sessions exist in DB but not live in cache
+		const checker = createDefaultChecker({
+			isLive: () => false,
+		});
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -320,18 +325,69 @@ describe('Runtime Recovery', () => {
 
 		expect(result.recoveredGroups).toBe(1);
 		expect(result.failedGroups).toBe(0);
-		expect(result.reattachedObservers).toBe(0);
+		expect(result.restoredSessions).toBeGreaterThanOrEqual(1);
+		expect(result.reattachedObservers).toBe(1);
+		// Worker observer should be attached for future approval
+		expect(observer.isObserving(group!.workerSessionId)).toBe(true);
 	});
 
-	it('should handle multiple groups', async () => {
+	it('should fail awaiting_human group when worker cannot be restored', async () => {
+		const { taskId, group } = createTaskAndGroup('awaiting_human');
+
+		const checker = createDefaultChecker({
+			isLive: () => false,
+			restoreSession: async () => false,
+		});
+
+		const result = await recoverRuntime(
+			'room-1',
+			groupRepo,
+			taskManager,
+			observer,
+			checker,
+			runtime
+		);
+
+		expect(result.failedGroups).toBe(1);
+		const updatedGroup = groupRepo.getGroup(group!.id);
+		expect(updatedGroup!.state).toBe('failed');
+
+		const task = await taskManager.getTask(taskId);
+		expect(task!.status).toBe('failed');
+	});
+
+	it('should restore sessions not live in cache for awaiting_worker', async () => {
+		const { group } = createTaskAndGroup('awaiting_worker');
+		const restoreCalls: string[] = [];
+
+		const checker = createDefaultChecker({
+			isLive: () => false,
+			restoreSession: async (id) => {
+				restoreCalls.push(id);
+				return true;
+			},
+		});
+
+		const result = await recoverRuntime(
+			'room-1',
+			groupRepo,
+			taskManager,
+			observer,
+			checker,
+			runtime
+		);
+
+		expect(result.restoredSessions).toBeGreaterThanOrEqual(1);
+		expect(restoreCalls).toContain(group!.workerSessionId);
+		expect(result.reattachedObservers).toBe(1);
+	});
+
+	it('should handle multiple groups with mixed states', async () => {
 		createTaskAndGroup('awaiting_worker');
 		createTaskAndGroup('awaiting_leader');
 		createTaskAndGroup('awaiting_human');
 
-		const checker: SessionStateChecker = {
-			sessionExists: () => true,
-			isTerminalState: () => false,
-		};
+		const checker = createDefaultChecker();
 
 		const result = await recoverRuntime(
 			'room-1',
@@ -343,7 +399,7 @@ describe('Runtime Recovery', () => {
 		);
 
 		expect(result.recoveredGroups).toBe(3);
-		// 2 groups need observers (awaiting_worker + awaiting_leader)
-		expect(result.reattachedObservers).toBe(2);
+		// All 3 groups get observers (awaiting_human now restores and observes too)
+		expect(result.reattachedObservers).toBe(3);
 	});
 });


### PR DESCRIPTION
## Summary

- After daemon restart, in-memory AgentSession cache is cleared but DB state remains. Tasks in `awaiting_human` got stuck when humans approved post-restart because `injectMessage` failed (session not in memory)
- Adds three-layer defense: (1) startup recovery restores sessions from DB, (2) tick-based zombie detection as periodic safety net, (3) rollback on `injectMessage` failure prevents inconsistent state
- Rewrites `runtime-recovery.ts` to restore sessions before observing them, adds `awaiting_human` recovery (previously skipped entirely)

## Changes

**Core:**
- `AgentSession.restore()` — static factory for DB-only session loading (no fingerprint check)
- `SessionFactory.restoreSession` — interface extension + implementation in `RoomRuntimeService`
- `runtime-recovery.ts` — full rewrite with `ensureLive()` helper, restore-before-observe for all states
- Zombie detection in `executeTick()` — sync `findZombieGroups()` + async `recoverZombieGroups()`
- Rollback in `resumeWorkerFromHuman` — both group state and task status revert on inject failure

**Tests:**
- 16 new tests in `room-runtime-recovery-safety.test.ts` (zombie detection, rollback, async behavior)
- 10 updated tests in `runtime-recovery.test.ts` (new `SessionStateChecker` interface)
- All 528 room tests pass, 0 type errors, 0 lint errors

## Test plan

- [x] `bun test tests/unit/room/` — 528 tests pass
- [x] `bun run typecheck` — no errors
- [x] `bun run lint` — no errors
- [x] `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)