### PR TITLE
fix(daemon): restore MCP servers for planner/leader after restart

### DIFF
--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -241,7 +241,7 @@ export function buildPlannerTaskMessage(config: PlannerAgentConfig): string {
 /**
  * Create the MCP server with planning tools.
  */
-function createPlannerMcpServer(config: PlannerAgentConfig) {
+export function createPlannerMcpServer(config: PlannerAgentConfig) {
 	const phaseGateError = {
 		content: [
 			{

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -208,6 +208,14 @@ export class RoomRuntimeService {
 				// SDK waits for user input that never arrives.
 				return true;
 			},
+			setSessionMcpServers: (sessionId, mcpServers) => {
+				const session = agentSessions.get(sessionId);
+				if (!session) return false;
+				session.setRuntimeMcpServers(
+					mcpServers as Record<string, import('@neokai/shared').McpServerConfig>
+				);
+				return true;
+			},
 			createWorktree: async (basePath, sessionId, branchName) => {
 				try {
 					const result = await worktreeManager.createWorktree({
@@ -387,13 +395,18 @@ export class RoomRuntimeService {
 				);
 			}
 
-			// Inject continuation messages for restored sessions that need to resume work.
-			// Sessions are in cache (lazy-start) but SDK query hasn't started yet.
-			// injectMessage → ensureQueryStarted() starts the query lazily.
+			// Restore MCP servers and inject continuation messages for restored sessions.
+			// MCP servers are runtime-only (non-serializable) and lost on restart.
+			// Must be restored BEFORE continuation messages so the SDK query starts
+			// with the correct tools available (e.g. planner needs create_task).
 			if (result.restoredSessions > 0) {
 				const activeGroups = groupRepo.getActiveGroups(roomId);
 				for (const group of activeGroups) {
 					try {
+						// Restore MCP servers (planner-tools, leader-agent-tools)
+						await runtime.restoreMcpServersForGroup(group);
+
+						// Inject continuation message to resume work
 						if (group.state === 'awaiting_worker') {
 							await sessionFactory.injectMessage(
 								group.workerSessionId,
@@ -408,7 +421,7 @@ export class RoomRuntimeService {
 						// awaiting_human: no message needed — human will provide one
 					} catch (error) {
 						log.error(
-							`Failed to inject continuation for group ${group.id} (${group.state}):`,
+							`Failed to restore/inject continuation for group ${group.id} (${group.state}):`,
 							error
 						);
 					}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -31,8 +31,13 @@ import type { SessionFactory, WorkerConfig } from './task-group-manager';
 import { TaskGroupManager } from './task-group-manager';
 import type { DaemonHub } from '../../daemon-hub';
 import type { LeaderToolCallbacks, LeaderToolResult } from '../agents/leader-agent';
+import { createLeaderMcpServer } from '../agents/leader-agent';
 import type { PlannerCreateTaskParams, ReplanContext } from '../agents/planner-agent';
-import { createPlannerAgentInit, buildPlannerTaskMessage } from '../agents/planner-agent';
+import {
+	createPlannerAgentInit,
+	createPlannerMcpServer,
+	buildPlannerTaskMessage,
+} from '../agents/planner-agent';
 import { createCoderAgentInit, buildCoderTaskMessage } from '../agents/coder-agent';
 import { createGeneralAgentInit, buildGeneralTaskMessage } from '../agents/general-agent';
 import { buildLeaderTaskContext } from '../agents/leader-agent';
@@ -734,6 +739,86 @@ export class RoomRuntime {
 		return true;
 	}
 
+	/**
+	 * Restore MCP servers for a session group after daemon restart.
+	 *
+	 * MCP servers are runtime-only (non-serializable) and NOT persisted to DB.
+	 * Without this, restored planner sessions lose the create_task tool and
+	 * restored leader sessions lose send_to_worker/complete_task/etc.
+	 */
+	async restoreMcpServersForGroup(group: SessionGroup): Promise<void> {
+		// Restore planner MCP server (worker)
+		if (group.workerRole === 'planner') {
+			const task = await this.taskManager.getTask(group.taskId);
+			if (task) {
+				const isPlanApproved = () => {
+					return this.groupRepo.getGroup(group.id)?.approved ?? false;
+				};
+				const createDraftTask = async (
+					params: PlannerCreateTaskParams
+				): Promise<{ id: string; title: string }> => {
+					const goal = await this.goalManager.getGoalsForTask(task.id).then((g) => g[0] ?? null);
+					const newTask = await this.taskManager.createTask({
+						title: params.title,
+						description: params.description,
+						priority: params.priority,
+						dependsOn: params.dependsOn,
+						taskType: 'coding',
+						status: 'draft',
+						createdByTaskId: task.id,
+						assignedAgent: params.agent,
+					});
+					if (goal) {
+						await this.goalManager.linkTaskToGoal(goal.id, newTask.id);
+					}
+					log.info(`Planning (restored) created draft task: ${newTask.id} (${newTask.title})`);
+					return { id: newTask.id, title: newTask.title };
+				};
+				const updateDraftTask = async (
+					taskId: string,
+					updates: {
+						title?: string;
+						description?: string;
+						priority?: TaskPriority;
+						assignedAgent?: AgentType;
+					}
+				): Promise<{ id: string; title: string }> => {
+					return this.taskManager.updateDraftTask(taskId, updates);
+				};
+				const removeDraftTask = async (taskId: string): Promise<boolean> => {
+					return this.taskManager.removeDraftTask(taskId);
+				};
+
+				const goal = await this.goalManager.getGoalsForTask(task.id).then((g) => g[0] ?? null);
+				const mcpServer = createPlannerMcpServer({
+					task,
+					goal: goal!,
+					room: this.room,
+					sessionId: group.workerSessionId,
+					workspacePath: group.workspacePath ?? this.taskGroupManager.workspacePath,
+					createDraftTask,
+					updateDraftTask,
+					removeDraftTask,
+					isPlanApproved,
+				});
+				this.sessionFactory.setSessionMcpServers(group.workerSessionId, {
+					'planner-tools': mcpServer,
+				});
+				log.info(`Restored planner MCP server for group ${group.id}`);
+			}
+		}
+
+		// Restore leader MCP server
+		if (this.sessionFactory.hasSession(group.leaderSessionId)) {
+			const callbacks = this.createLeaderCallbacks(group.id);
+			const leaderMcpServer = createLeaderMcpServer(group.id, callbacks);
+			this.sessionFactory.setSessionMcpServers(group.leaderSessionId, {
+				'leader-agent-tools': leaderMcpServer,
+			});
+			log.info(`Restored leader MCP server for group ${group.id}`);
+		}
+	}
+
 	// =========================================================================
 	// Message Mirroring
 	// =========================================================================
@@ -1327,6 +1412,22 @@ export class RoomRuntime {
 	private async promoteDraftTasksIfPlanning(taskId: string): Promise<void> {
 		const task = await this.taskManager.getTask(taskId);
 		if (!task || task.taskType !== 'planning') return;
+
+		// Safety net: ensure all draft children are linked to the same goal
+		// as the planning task. MCP server closures may have been lost on
+		// daemon restart, so linkTaskToGoal may not have been called.
+		const goals = await this.goalManager.getGoalsForTask(taskId);
+		const goal = goals[0];
+		if (goal) {
+			const drafts = await this.taskManager.getDraftTasksByCreator(taskId);
+			const linked = new Set(goal.linkedTaskIds ?? []);
+			for (const draft of drafts) {
+				if (!linked.has(draft.id)) {
+					await this.goalManager.linkTaskToGoal(goal.id, draft.id);
+					log.info(`Linked draft task ${draft.id} to goal ${goal.id} (safety net)`);
+				}
+			}
+		}
 
 		const promoted = await this.taskManager.promoteDraftTasks(taskId);
 		if (promoted > 0) {

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -63,6 +63,11 @@ export interface SessionFactory {
 	 * Returns true if successful, false if session not found in DB.
 	 */
 	restoreSession(sessionId: string): Promise<boolean>;
+	/**
+	 * Set runtime MCP servers on a restored session.
+	 * MCP servers are non-serializable and lost on restart — must be re-created.
+	 */
+	setSessionMcpServers(sessionId: string, mcpServers: Record<string, unknown>): boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Root cause**: MCP servers (`planner-tools`, `leader-agent-tools`) are runtime-only (non-serializable) and lost on daemon restart. Restored planner sessions had no `create_task` tool, causing 9+ exit gate bounce loops. Created tasks also weren't linked to goals.
- Re-creates planner and leader MCP servers with correct closures during session recovery (`restoreMcpServersForGroup`)
- Adds `setSessionMcpServers()` to `SessionFactory` to inject MCP config into restored `AgentSession` instances
- Safety net in `promoteDraftTasksIfPlanning()` ensures all draft tasks are linked to the goal before promotion

## Test plan
- [ ] Typecheck passes
- [ ] 3007 unit tests pass (0 fail)
- [ ] Manual verification: restart daemon with active planner session, confirm `create_task` tool is available and draft tasks are goal-linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)