### PR TITLE
fix(room): coder and planner agents must pull/rebase on default branch before starting work

### DIFF
--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -53,9 +53,11 @@ export function buildCoderSystemPrompt(): string {
 			`The branch has already been created for you. Follow this workflow:`
 	);
 	sections.push(
-		`1. **Sync with the default branch first** — run this as a **single bash command** so the variable persists:\n` +
+		`1. **Sync with the default branch first** — run all three lines as a **single bash invocation** (variables persist within one call):\n` +
 			`   \`\`\`bash\n` +
-			`   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' || git remote show origin | sed -n '/HEAD branch/s/.*: //p') && git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
+			`   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n` +
+			`   [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
+			`   git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
 			`   \`\`\`\n` +
 			`   **If the rebase fails with conflicts, stop immediately and report the error** — do NOT continue on a stale base`
 	);
@@ -63,9 +65,9 @@ export function buildCoderSystemPrompt(): string {
 	sections.push(`3. Add or update tests to cover the new/changed behavior — tests are mandatory`);
 	sections.push(`4. Push your branch: \`git push -u origin HEAD\``);
 	sections.push(
-		`5. Create a pull request using inline branch resolution (no shell variable needed):\n` +
+		`5. Create a pull request — detect the default branch inside the subshell (no persistent variable needed):\n` +
 			`   \`\`\`bash\n` +
-			`   gh pr create --fill --base $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' || git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
+			`   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
 			`   \`\`\``
 	);
 	sections.push(`6. Finish your response`);

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -125,9 +125,11 @@ export function buildPlannerSystemPrompt(goalTitle?: string): string {
 	sections.push(`\n## Pre-Planning Setup (MANDATORY)\n`);
 	sections.push(
 		`Before reading any files or writing the plan, sync with the default branch.\n` +
-			`Run this as a **single bash command** (so the variable persists within the call):\n` +
+			`Run all three lines as a **single bash invocation** (variables persist within one call):\n` +
 			`\`\`\`bash\n` +
-			`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' || git remote show origin | sed -n '/HEAD branch/s/.*: //p') && git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
+			`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n` +
+			`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
+			`git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
 			`\`\`\`\n` +
 			`**If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase`
 	);
@@ -158,9 +160,9 @@ export function buildPlannerSystemPrompt(goalTitle?: string): string {
 	);
 	sections.push(`2. Create a feature branch, commit the plan file, and push it`);
 	sections.push(
-		`3. Create a GitHub PR using inline branch resolution with the plan summary as the PR description:\n` +
+		`3. Create a GitHub PR — detect the default branch inside the subshell with the plan summary as the PR description:\n` +
 			`   \`\`\`bash\n` +
-			`   gh pr create --base $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' || git remote show origin | sed -n '/HEAD branch/s/.*: //p') --fill\n` +
+			`   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
 			`   \`\`\``
 	);
 	sections.push(

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -86,24 +86,37 @@ describe('Coder Agent', () => {
 			expect(prompt).toContain('stop immediately and report the error');
 		});
 
-		it('uses --base flag with inline substitution when creating PR', () => {
+		it('uses subshell with empty-check fallback for gh pr create --base', () => {
 			const prompt = buildCoderSystemPrompt();
-			// Must use inline $() so shell variable doesn't need to persist across tool calls
-			expect(prompt).toContain('--base $(git symbolic-ref refs/remotes/origin/HEAD');
+			// Uses $() subshell so no persistent variable is required across tool calls
+			expect(prompt).toContain(
+				`gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")`
+			);
 		});
 
-		it('combines sync commands in a single bash call to avoid variable persistence issues', () => {
+		it('combines sync commands in a single bash invocation using the empty-check fallback pattern', () => {
 			const prompt = buildCoderSystemPrompt();
-			// All three sync operations must be && chained in one invocation
+			// Two-step empty check: symbolic-ref first, then remote show if empty.
+			// This avoids the || pipeline exit code bug where sed exits 0 even when
+			// git symbolic-ref fails, causing the || fallback to never trigger.
 			expect(prompt).toContain(
-				'DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed \'s@^refs/remotes/origin/@@\' || git remote show origin | sed -n \'/HEAD branch/s/.*: //p\') && git fetch origin && git rebase origin/$DEFAULT_BRANCH'
+				`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')`
 			);
+			expect(prompt).toContain(
+				`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')`
+			);
+			expect(prompt).toContain('git fetch origin && git rebase origin/$DEFAULT_BRANCH');
 		});
 
 		it('includes fallback for repos where origin/HEAD is not configured', () => {
 			const prompt = buildCoderSystemPrompt();
 			expect(prompt).toContain('git remote show origin');
 			expect(prompt).toContain("sed -n '/HEAD branch/s/.*: //p'");
+		});
+
+		it('suppresses git symbolic-ref stderr with 2>/dev/null', () => {
+			const prompt = buildCoderSystemPrompt();
+			expect(prompt).toContain('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
 		});
 
 		it('sync step appears before implementation step', () => {

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -59,23 +59,34 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('stop immediately and report the error');
 		});
 
-		it('should combine sync commands in single bash call to avoid variable persistence issues', () => {
+		it('should combine sync commands in single bash invocation using the empty-check fallback pattern', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
+			// Two-step empty check avoids the || pipeline exit code bug
 			expect(prompt).toContain(
-				'DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed \'s@^refs/remotes/origin/@@\' || git remote show origin | sed -n \'/HEAD branch/s/.*: //p\') && git fetch origin && git rebase origin/$DEFAULT_BRANCH'
+				`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')`
 			);
+			expect(prompt).toContain(
+				`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')`
+			);
+			expect(prompt).toContain('git fetch origin && git rebase origin/$DEFAULT_BRANCH');
 		});
 
-		it('should use --base flag with inline substitution when creating plan PR', () => {
+		it('should use subshell with empty-check fallback for gh pr create --base', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
-			// Must use inline $() so shell variable doesn't need to persist across tool calls
-			expect(prompt).toContain('--base $(git symbolic-ref refs/remotes/origin/HEAD');
+			expect(prompt).toContain(
+				`gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")`
+			);
 		});
 
 		it('should include fallback for repos where origin/HEAD is not configured', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
 			expect(prompt).toContain('git remote show origin');
 			expect(prompt).toContain("sed -n '/HEAD branch/s/.*: //p'");
+		});
+
+		it('should suppress git symbolic-ref stderr with 2>/dev/null', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
 		});
 
 		it('should place pre-planning setup before Phase 1 planning', () => {


### PR DESCRIPTION
## Summary

- **Coder agent**: Added a mandatory \"Sync with the default branch first\" step as step 1 of the Git Workflow. Agent identifies the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, then runs `git fetch origin` + `git rebase origin/$DEFAULT_BRANCH` before doing any work.
- **Planner agent**: Added a \"Pre-Planning Setup (MANDATORY)\" section that runs the same fetch+rebase before any codebase reads or plan writing.
- Both agents now use `--base $DEFAULT_BRANCH` when calling `gh pr create`.
- Both agents are explicitly instructed to **stop and report the error** if the rebase fails — no silent continuation on a stale base.

## Test plan

- [ ] `buildCoderSystemPrompt` includes sync step with `git fetch origin`, `git rebase`, and `--base $DEFAULT_BRANCH`
- [ ] Sync step appears before the implementation step in coder prompt
- [ ] Coder prompt includes instructions to stop on rebase conflict
- [ ] `buildPlannerSystemPrompt` includes Pre-Planning Setup with same fetch+rebase instructions
- [ ] Pre-Planning Setup appears before Phase 1 in planner prompt
- [ ] Planner `gh pr create` uses `--base $DEFAULT_BRANCH`
- [ ] All 38 coder+planner unit tests pass; all 3143 daemon unit tests pass