### PR TITLE
plan: adopt persistent job queue across daemon

### DIFF
--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -325,7 +325,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
   }
   ```
 - Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
-- After each tick handler completes, use `enqueueRoomTick()` (not direct `enqueue()`) for the heartbeat to preserve dedup guarantees:
+- After each tick handler completes, schedule the heartbeat with a direct `jobQueueRepo.enqueue({ runAt: Date.now() + 30_000 })` — this is unconditional and intentionally bypasses the dedup helper, since the 30s future job is semantically distinct from any immediate pending job:
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
@@ -334,11 +334,9 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     if (!runtime) {
       // Runtime not found: could be recovery in progress OR room was deleted.
       // Check DB to distinguish: if the room no longer exists, skip re-enqueue.
-      const roomExists = this.roomRepo.getRoom(roomId) !== null;
+      const roomExists = this.ctx.roomManager.getRoom(roomId) !== null;
       if (roomExists) {
-        // Recovery still in progress — re-enqueue with delay
-        enqueueRoomTick(this.jobQueueRepo, roomId, 0);
-        // Use runAt delay via direct enqueue for the re-enqueue-on-miss case:
+        // Recovery still in progress — re-enqueue with delay only (no immediate enqueue).
         this.jobQueueRepo.enqueue({
           queue: QUEUES.ROOM_TICK,
           payload: { roomId },
@@ -349,11 +347,15 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       return;
     }
     await runtime.tick();
-    // Heartbeat: use enqueueRoomTick to preserve dedup
-    enqueueRoomTick(this.jobQueueRepo, roomId);
+    // Heartbeat: always schedule a future tick unconditionally (bypasses dedup helper
+    // intentionally — the 30s future job is distinct from any immediate pending job).
+    this.jobQueueRepo.enqueue({
+      queue: QUEUES.ROOM_TICK,
+      payload: { roomId },
+      runAt: Date.now() + 30_000,
+    });
   });
   ```
-  Note: the heartbeat `runAt` delay (30s) is omitted from `enqueueRoomTick` since the helper doesn't support `runAt`. Use a direct `jobQueueRepo.enqueue({ runAt: Date.now() + 30_000 })` for the heartbeat — this is intentional and documented: heartbeat always adds a new job even if one is pending (the 30s future job is distinct from any immediate pending job for the same room).
 
 **Startup and recovery ordering**: `roomRuntimeService.start()` is called with `.catch()` (fire-and-forget) inside `setupRPCHandlers`. Because recovery may not be complete when the first tick jobs fire, the handler uses re-enqueue-on-miss (above) rather than silent drop. This ensures rooms always receive their tick once recovery completes, without requiring strict startup sequencing between the processor and recovery.
 
@@ -369,11 +371,12 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface.
 - Handler distinguishes "room deleted" from "runtime loading": no re-enqueue for deleted rooms.
-- Re-enqueue-on-miss: handler re-enqueues with `runAt = now + 5_000` if room exists but runtime not found.
+- Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`) via direct enqueue when room exists but runtime not found; no `enqueueRoomTick` call in this path.
 - Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs`; check-then-act race documented as accepted risk.
-- Heartbeat re-scheduling: after each successful tick, new job enqueued with `runAt = now + 30_000`.
+- Heartbeat re-scheduling: after each successful tick, direct `jobQueueRepo.enqueue({ runAt = now + 30_000 })` (unconditional, bypasses dedup helper intentionally).
+- Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (runtime loading), no-re-enqueue for deleted room, graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -430,6 +433,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 - At least 3 online tests covering job persistence and idempotency across processor restart.
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
 - Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 3`; verified by unit test.
+- Startup-time synchronous prune of `github_processed_events` rows older than 30 days runs on daemon start; verified by unit test.
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -31,8 +31,8 @@ All queue handlers must be idempotent. Agreed per-queue strategy:
 | Queue | Idempotency key | Strategy |
 |-------|-----------------|----------|
 | `session.title_generation` | `sessionId` | Handler queries DB; skip if `session.title IS NOT NULL` |
-| `github.poll` | n/a (singleton) | Dedup: skip enqueue if a `pending`/`processing` job already exists |
-| `github.event` | `eventId` (GitHub delivery ID) | Check `github_processed_events` table before processing; insert on success |
+| `github.poll` | n/a (singleton, payload `{}`) | Dedup: skip enqueue if a `pending`/`processing` job already exists |
+| `github.event` | `eventId` (stable deterministic ID — see Task 3) | Check `github_processed_events` table before processing; insert on success |
 | `room.tick` | `roomId` | Dedup: skip enqueue if a `pending`/`processing` job for this `roomId` exists |
 
 ## Processor Configuration (reconciled with ADR-0002)
@@ -58,26 +58,46 @@ new JobQueueProcessor(db.getJobQueueRepo(), {
 **Description**:
 Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. This is the foundational plumbing all subsequent tasks depend on.
 
-**Important**: `createDaemonApp` is a factory function, not a class with `start()`/`stop()` methods. The lifecycle entry point for shutdown is a `cleanup()` closure defined inside the factory. All processor lifecycle hooks must follow this existing pattern.
+**Important architectural notes**:
 
-Steps:
-1. Instantiate `JobQueueProcessor` using `db.getJobQueueRepo()`:
+1. **`createDaemonApp` is a factory function, not a class.** There are no `start()`/`stop()` methods. The shutdown entry point is the `cleanup()` closure defined inside the factory (line ~321 of `app.ts`).
+
+2. **`RoomRuntimeService` lives inside `setupRPCHandlers`, not `createDaemonApp` directly.** It is constructed at `packages/daemon/src/lib/rpc-handlers/index.ts` line 105. The plan accounts for this by passing `jobQueueProcessor` and `jobQueueRepo` as additional fields in the `deps` object passed to `setupRPCHandlers`. `setupRPCHandlers` passes them to the `RoomRuntimeService` constructor. No lifting of `RoomRuntimeService` into `createDaemonApp` is required.
+
+3. **Startup ordering**: `setupRPCHandlers` (which instantiates and starts `RoomRuntimeService`) is called before `jobQueueProcessor.start()`. This ensures handler registration happens before the processor begins polling. However, `roomRuntimeService.start()` is currently fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy (see Task 4).
+
+4. **Shutdown ordering**: In the `cleanup()` closure, add `await jobQueueProcessor.stop()` **before** the `rpcHandlerCleanup()` call at line 375 of `app.ts`. `rpcHandlerCleanup()` internally calls `roomRuntimeService.stop()`, so this ordering ensures all in-flight tick jobs drain before the runtimes map is cleared.
+
+**API extensions required** (implement alongside wiring):
+
+a. Extend `JobQueueRepository.listJobs()` to accept `status?: JobStatus | JobStatus[]`. When an array is passed, generate `AND status IN (?,?)` SQL. This is needed for the room tick dedup query in Task 4.
+
+b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inject the repository separately: each subsystem receives both `jobQueueProcessor` (for `register()`) and `jobQueueRepo` (for `enqueue()` and `listJobs()`). Both are available from the `db` facade via `db.getJobQueueRepo()`.
+
+**Steps**:
+1. Obtain `jobQueueRepo = db.getJobQueueRepo()` and instantiate:
    ```typescript
-   const jobQueueProcessor = new JobQueueProcessor(db.getJobQueueRepo(), {
+   const jobQueueRepo = db.getJobQueueRepo();
+   const jobQueueProcessor = new JobQueueProcessor(jobQueueRepo, {
      pollIntervalMs: 1000,
      maxConcurrent: 3,
      staleThresholdMs: 300_000,
    });
    ```
-2. Connect the processor's change notifier to `ReactiveDatabase` so job completions/failures trigger live query updates:
+2. Connect change notifier to `ReactiveDatabase`:
    ```typescript
    jobQueueProcessor.setChangeNotifier((table) => reactiveDb.notifyChange(table));
    ```
-3. Call `jobQueueProcessor.start()` inline after all subsystems are wired.
-4. Add `await jobQueueProcessor.stop()` to the existing `cleanup()` closure **before** `await roomRuntimeService.stop()` and `await sessionManager.cleanup()` — this ordering ensures in-flight jobs (including room ticks) finish before dependent services are torn down.
-5. Pass `jobQueueProcessor` via constructor injection to subsystems that need it (`SessionManager`, `GitHubService`, `RoomRuntimeService`), consistent with how `db` is passed today. Do not expose it as a separate context getter.
-6. Each subsystem registers its own queue handlers in a `start()` lifecycle method, called by `createDaemonApp` after `jobQueueProcessor.start()`.
-7. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts`:
+3. Add `jobQueueProcessor` and `jobQueueRepo` to the `deps` object passed to `setupRPCHandlers`.
+4. Call `jobQueueProcessor.start()` after `setupRPCHandlers` returns (handlers registered before polling begins).
+5. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure before `rpcHandlerCleanup()`:
+   ```typescript
+   // cleanup():
+   await jobQueueProcessor.stop(); // drain in-flight jobs first
+   rpcHandlerCleanup();            // stops RoomRuntimeService (via rpc-handlers cleanup)
+   await sessionManager.cleanup();
+   ```
+6. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts` with the idempotency strategy documented in comments:
    ```typescript
    export const QUEUES = {
      SESSION_TITLE_GENERATION: 'session.title_generation',
@@ -87,15 +107,16 @@ Steps:
      JOB_QUEUE_CLEANUP: 'job_queue.cleanup',
    } as const;
    ```
-8. Document the idempotency strategy (table above) as a comment in `job-queue-constants.ts`.
+7. Each subsystem registers queue handlers in its own `start()` method, called after `jobQueueProcessor.start()`.
 
 **Acceptance criteria**:
-- `JobQueueProcessor` is instantiated and `jobQueueProcessor.start()` is called in `createDaemonApp`.
-- `await jobQueueProcessor.stop()` is in the `cleanup()` closure, before other service teardowns.
+- `JobQueueProcessor` is instantiated; `jobQueueProcessor.start()` is called after `setupRPCHandlers`.
+- `await jobQueueProcessor.stop()` is in the `cleanup()` closure before `rpcHandlerCleanup()`.
 - Change notifier connected to `ReactiveDatabase`.
-- Queue name constants exported from `job-queue-constants.ts` with idempotency strategy documented.
-- `jobQueueProcessor` injected via constructor into `SessionManager`, `GitHubService`, `RoomRuntimeService`.
-- Unit test verifies processor start/stop lifecycle and that `stop()` is called before other cleanup.
+- `listJobs` extended to accept `status?: JobStatus | JobStatus[]`.
+- `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object.
+- Queue name constants exported from `job-queue-constants.ts`.
+- Unit test verifies processor starts and stops correctly; confirms `stop()` is awaited before `rpcHandlerCleanup()`.
 - All existing `JobQueueRepository` and `JobQueueProcessor` unit tests still pass.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
@@ -111,45 +132,51 @@ Steps:
 Replace the fire-and-forget title generation + git branch rename in `SessionManager` with a persistent job on the `session.title_generation` queue.
 
 **Files to modify**:
-- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a `session.title_generation` job instead of spawning a Promise; remove `pendingBackgroundTasks` Set; register the queue handler in `SessionManager.start()`
-- `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (already a method on `SessionLifecycle`, no extraction needed) into a job handler
+- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set; register handler in `SessionManager.start()` (called by `createDaemonApp` after `jobQueueProcessor.start()`)
+- `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (no extraction needed; already a method on `SessionLifecycle`) in the job handler
 
-**Handler registration** via constructor injection:
+**Behavioral change**: Currently the `message.persisted` event handler does `await titleGenTask` (line 162 of `session-manager.ts`), blocking until title generation completes. After this migration the handler enqueues a job synchronously and returns immediately. This is the intended change — the handler must NOT await title generation; the job queue provides durability instead.
+
+**Handler registration** via constructor injection (`SessionManager` receives `jobQueueProcessor` and `jobQueueRepo`):
 ```typescript
-class SessionManager {
-  constructor(private readonly jobQueueProcessor: JobQueueProcessor, ...) {}
-
-  start(): void {
-    this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
-      const { sessionId } = job.payload as { sessionId: string };
-      // Idempotency: skip if title already set
-      const session = this.sessionRepo.getSession(sessionId);
-      if (!session || session.title !== null) return;
-      await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
-    });
-  }
+start(): void {
+  this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
+    const { sessionId } = job.payload as { sessionId: string };
+    // Idempotency: skip if title already set
+    const session = this.sessionRepo.getSession(sessionId);
+    if (!session || session.title !== null) return;
+    // Note: generateTitleAndRenameBranch requires the session in the in-memory cache.
+    // On restart, if the session is not cached, fall back to DB-only title generation
+    // (set title from userMessageText without renaming the branch).
+    await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
+  });
 }
 ```
 
-**Enqueue point**: In the `message.persisted` event handler where the current fire-and-forget Promise is spawned:
+**Cache miss handling**: `generateTitleAndRenameBranch` reads from `sessionCache`. After a daemon restart the session may not be cached. The handler must check if the session is in cache; if not, apply a graceful fallback (title generation without branch rename, which is safe to retry).
+
+Job payload: `{ sessionId: string, userMessageText: string }`
+
+**Enqueue point** (replaces the `pendingBackgroundTasks` pattern):
 ```typescript
-this.jobQueueProcessor.getRepo().enqueue({
+jobQueueRepo.enqueue({
   queue: QUEUES.SESSION_TITLE_GENERATION,
   payload: { sessionId, userMessageText },
   maxRetries: 2,
 });
+// Return immediately — no await
 ```
 
-Job payload: `{ sessionId: string, userMessageText: string }`
-
-**Idempotency**: Handler queries DB; if `session.title IS NOT NULL`, returns immediately (safe to retry multiple times).
+**Idempotency**: Handler queries `session.title`; if non-null, returns immediately.
 
 **Acceptance criteria**:
 - `pendingBackgroundTasks` Set removed from `SessionManager`.
+- `message.persisted` handler returns immediately after enqueue (no `await` on title generation).
 - Title generation enqueues a persistent job; handler runs via `JobQueueProcessor`.
+- Cache miss fallback: handler completes gracefully even if session is not in memory.
 - If daemon restarts after enqueue but before handler runs, job is picked up on next start.
 - Idempotency: handler called twice for same session produces correct result (no double-rename).
-- Unit tests cover: enqueue on first message, idempotency guard (title already set), handler success, handler failure + retry (max 2 retries), dead-letter after max retries.
+- Unit tests cover: enqueue on first message, idempotency (title already set), handler success, cache miss fallback, failure + retry (max 2 retries), dead-letter after max retries.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -161,41 +188,85 @@ Job payload: `{ sessionId: string, userMessageText: string }`
 **Priority**: normal
 
 **Description**:
-Replace the in-memory GitHub event pipeline with a persistent job queue so events are durable and idempotent across restarts. Persist polling state and restore repository registrations on startup.
+Replace the in-memory GitHub event pipeline with a persistent job queue so events are durable and idempotent across restarts. Persist polling state, restore repository registrations on startup, and assign stable event IDs to polled events.
 
-**Schema addition** — new migration adds `github_processed_events` table:
-```sql
-CREATE TABLE github_processed_events (
-  event_id TEXT PRIMARY KEY,  -- GitHub delivery ID
-  processed_at INTEGER NOT NULL
-);
-CREATE INDEX idx_github_processed_events_at ON github_processed_events(processed_at);
-```
-Cleanup: prune rows older than 30 days in the Task 5 scheduled maintenance job.
+**Schema additions** (new migration):
+
+1. `github_processed_events` table (idempotency for `github.event` jobs):
+   ```sql
+   CREATE TABLE github_processed_events (
+     event_id TEXT PRIMARY KEY,
+     processed_at INTEGER NOT NULL
+   );
+   CREATE INDEX idx_github_processed_events_at ON github_processed_events(processed_at);
+   ```
+
+2. `github_poll_state` table (replaces in-memory etags/timestamps; the existing `global_settings` table is a single JSON blob and is not suitable for per-repo structured state):
+   ```sql
+   CREATE TABLE github_poll_state (
+     repo_full_name TEXT PRIMARY KEY,
+     etag TEXT,
+     last_poll_at INTEGER NOT NULL DEFAULT 0
+   );
+   ```
+
+**Stable event IDs for polled events**: The current `generateEventId()` in `event-normalizer.ts` produces a UUID, which is non-stable across restarts — the same polled event gets a different ID on re-poll, making `github_processed_events` ineffective. Task 3 must update `normalizePollingEvent` (and the individual `normalizeIssuePolling`, `normalizeCommentPolling`, `normalizePullRequestPolling` functions) to generate deterministic IDs:
+- Issues: `{fullName}/issues/{issueNumber}/{updatedAt}`
+- Comments: `{fullName}/comments/{commentId}/{updatedAt}`
+- Pull requests: `{fullName}/pulls/{prNumber}/{updatedAt}`
+
+Webhook events already have a stable `X-GitHub-Delivery` ID via `normalizeWebhookEvent`; no change needed there.
 
 **Files to modify**:
 
-1. `packages/daemon/src/lib/github/polling-service.ts`:
-   - Persist etags and last-poll timestamps to `settings` table (keyed by repo) instead of in-memory
-   - In `start()`, restore repository registrations by reading from `GitHubMappingRepository` (which persists room→repo mappings in `room_github_mappings`) — this ensures polled repos survive restart without manual re-registration
-   - Replace `setInterval` body: enqueue a `github.poll` job (singleton dedup — skip if `pending`/`processing` already exists); schedule next poll via `runAt = now + pollIntervalMs` after each poll completes
+1. `packages/daemon/src/lib/github/event-normalizer.ts`:
+   - Replace UUID generation with deterministic stable IDs for polling normalizers
 
-2. `packages/daemon/src/lib/github/github-service.ts`:
-   - Register `github.event` handler in `GitHubService.start()`
+2. `packages/daemon/src/lib/github/polling-service.ts`:
+   - Replace in-memory etag/timestamp state with reads/writes to `github_poll_state` table
+   - In `start()`, restore repo registrations by reading from `GitHubMappingRepository` (`room_github_mappings` table)
+   - Replace `setInterval` with a self-rescheduling `github.poll` job (singleton dedup)
+   - Re-scheduling uses a `finally` block to guarantee next poll is always enqueued regardless of handler success or failure:
+     ```typescript
+     handler = async (job) => {
+       try {
+         await runPollCycle();
+       } finally {
+         // Always schedule next poll, even on failure
+         jobQueueRepo.enqueue({
+           queue: QUEUES.GITHUB_POLL,
+           payload: {},
+           runAt: Date.now() + POLL_INTERVAL_MS,
+           maxRetries: 0,
+         });
+       }
+     };
+     ```
+   - On daemon startup, enqueue first `github.poll` job with `runAt = now` if none pending/processing
+
+3. `packages/daemon/src/lib/github/github-service.ts`:
+   - Register `github.event` handler in `GitHubService.start()` (receives `jobQueueProcessor` and `jobQueueRepo` via constructor)
+   - Handler checks `github_processed_events` for `eventId`; if found, returns (idempotent)
    - Handler runs existing filter→security→route pipeline
-   - Idempotency: check `github_processed_events` table for `eventId` before processing; insert row on success
+   - On success: inserts row into `github_processed_events`
 
-3. `packages/daemon/src/lib/github/webhook-handler.ts` (correct filename — not `webhook-service.ts`):
-   - Webhook path calls `handleWebhook()` in `github-service.ts`; update to enqueue a `github.event` job instead of calling the pipeline directly
+4. `packages/daemon/src/lib/github/webhook-handler.ts`:
+   - Update webhook path to enqueue a `github.event` job instead of calling the pipeline directly
 
-**Retry behavior**: `maxRetries: 3` for `github.event` (transient routing failures). `maxRetries: 0` for `github.poll` (failed polls are simply retried on the next scheduled interval).
+Job payloads:
+- `github.poll`: `{}` (singleton sentinel)
+- `github.event`: `{ eventType: string, eventId: string, payload: Record<string, unknown> }`
+
+**Retry behavior**: `maxRetries: 3` for `github.event`. `maxRetries: 0` for `github.poll` (re-scheduling handled in `finally` block; processor retry not needed).
 
 **Acceptance criteria**:
-- Polling etags and timestamps persist across daemon restarts.
-- Repository registrations are restored from `GitHubMappingRepository` on startup — no manual re-registration needed.
-- Same GitHub event (by delivery ID) cannot be processed twice, verified by `github_processed_events` table.
-- Events enqueued but not yet processed survive daemon restart and are processed on next start.
-- Unit tests cover: enqueue on poll, idempotency (event already in `github_processed_events`), filter/route pipeline via handler, retry on transient error, webhook path enqueues job.
+- Polled events use deterministic stable IDs (verified by unit test: normalizing same data twice produces same ID).
+- Per-repo poll state (etags, timestamps) stored in `github_poll_state` table, survives restart.
+- Repository registrations restored from `GitHubMappingRepository` on `start()`.
+- Same event cannot be processed twice (idempotency via `github_processed_events`).
+- `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error.
+- Enqueued `github.event` jobs survive daemon restart.
+- Unit tests cover: stable ID generation, idempotency check, poll re-scheduling on success and on error, webhook path enqueues job.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -212,49 +283,74 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **`RoomRuntime` has two tick trigger paths** — both must be migrated:
 1. `setInterval(() => this.tick(), this.tickInterval)` (~line 205) — periodic heartbeat
 2. `scheduleTick()` (~line 1550): `queueMicrotask(() => this.tick())` — event-driven immediate trigger with 9+ call sites (goal created, task updated, worker/leader terminal states, leader tool calls, etc.)
+3. `runtime-recovery.ts` calls `runtime.tick()` directly during recovery — this must also be replaced with `enqueueRoomTick()` so the tick mutex and dedup guarantees apply during recovery.
+
+**`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required.
 
 **Migration approach**:
 - Remove `setInterval`, `tickTimer` field, and `queueMicrotask` from `RoomRuntime`
-- Replace all `this.scheduleTick()` call sites with a shared `enqueueRoomTick(roomId, priority)` helper that checks dedup before enqueueing:
+- Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
-    const existing = repo.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending', 'processing'] })
-      .find(j => (j.payload as any).roomId === roomId);
+    // Dedup: skip if pending or processing job exists for this room
+    // listJobs now supports status array (extended in Task 1)
+    const existing = repo.listJobs({
+      queue: QUEUES.ROOM_TICK,
+      status: ['pending', 'processing'],
+    }).find(j => (j.payload as any).roomId === roomId);
     if (!existing) {
       repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority });
     }
-    // Note: listJobs is an O(n) scan; acceptable at current room scale.
-    // Future optimization: unique constraint on (queue, payload_roomId_hash) if needed.
+    // Note: listJobs is an O(n) scan with no index on payload contents.
+    // Acceptable at current scale (tens of rooms). Future optimization:
+    // add unique constraint or dedicated column if room count grows significantly.
   }
   ```
-- After each tick handler completes, enqueue next heartbeat job with `runAt = Date.now() + 30_000`
+- Replace all `this.scheduleTick()` call sites and the `runtime.tick()` call in `runtime-recovery.ts` with `enqueueRoomTick(repo, roomId, priority)`
+- After each tick handler completes, enqueue next heartbeat with `runAt = Date.now() + 30_000`
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
-  processor.register(QUEUES.ROOM_TICK, async (job) => {
+  this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
     const { roomId } = job.payload as { roomId: string };
     const runtime = this.runtimes.get(roomId);
-    if (!runtime) return; // Room removed mid-flight; tolerate gracefully
+    if (!runtime) {
+      // Runtime not ready yet (recovery in progress) or room deleted.
+      // Re-enqueue with a short delay so recovery has time to complete.
+      this.jobQueueRepo.enqueue({
+        queue: QUEUES.ROOM_TICK,
+        payload: { roomId },
+        runAt: Date.now() + 5_000,
+      });
+      return;
+    }
     await runtime.tick();
+    // Heartbeat: schedule next tick
+    this.jobQueueRepo.enqueue({
+      queue: QUEUES.ROOM_TICK,
+      payload: { roomId },
+      runAt: Date.now() + 30_000,
+    });
   });
   ```
 
-**Shutdown ordering** (enforced in `app.ts` cleanup closure):
+**Startup and recovery ordering**: `roomRuntimeService.start()` is called with `.catch()` (fire-and-forget) inside `setupRPCHandlers`. Because recovery may not be complete when the first tick jobs fire, the handler uses re-enqueue-on-miss (above) rather than silent drop. This ensures rooms always receive their tick once recovery completes, without requiring strict startup sequencing between the processor and recovery.
+
+**Shutdown ordering** (in `app.ts` cleanup closure — see Task 1 step 5):
 1. `await jobQueueProcessor.stop()` — drains in-flight tick jobs
-2. `await roomRuntimeService.stop()` — clears `runtimes` map
-3. `await sessionManager.cleanup()` — cleans up agent sessions
+2. `rpcHandlerCleanup()` — stops `RoomRuntimeService` (clears `runtimes` map)
+3. `await sessionManager.cleanup()`
 
-This ordering prevents the tick handler from referencing a cleared `runtimes` map.
-
-**Deduplication note**: The `listJobs` scan for dedup is O(n) with no composite index on `(queue, status, payload.roomId)`. At expected scale (tens of rooms), this is acceptable. If room count grows significantly, add a unique constraint or dedicated column. A comment documenting this trade-off must be included in the implementation.
+The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
 - `setInterval`, `tickTimer`, and `queueMicrotask` removed from `RoomRuntime`.
 - All `scheduleTick()` call sites replaced with `enqueueRoomTick()`.
-- No duplicate `room.tick` jobs accumulate for the same room (dedup verified in tests).
-- Heartbeat re-scheduling: after each tick, a new job is enqueued with `runAt = now + 30_000`.
-- Handler tolerates a missing runtime (room deleted during flight) — returns without error.
+- `runtime-recovery.ts` uses `enqueueRoomTick()` instead of `runtime.tick()`.
+- Re-enqueue-on-miss: handler re-enqueues with `runAt = now + 5_000` if runtime not found.
+- Dedup: no duplicate `room.tick` jobs accumulate for the same room.
+- Heartbeat re-scheduling: after each successful tick, new job enqueued with `runAt = now + 30_000`.
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup (second enqueue skipped), heartbeat re-schedule, handler for unknown `roomId`, graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (runtime not found), graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -266,25 +362,38 @@ This ordering prevents the tick handler from referencing a cleared `runtimes` ma
 **Priority**: normal
 
 **Description**:
-Add integration/online tests validating crash-recovery and idempotency, add a scheduled DB maintenance job, add an E2E test for UI-observable reconnection, and clean up remaining in-memory patterns.
+Add integration/online tests validating job persistence and idempotency, add a scheduled DB maintenance job, add an E2E test for UI-observable reconnection, and clean up remaining stale patterns.
 
-**Online/integration tests** (`packages/daemon/tests/online/`), using `daemon-server.ts` spawned-process mode for restart simulation:
-1. **Session title generation recovery**: enqueue a `session.title_generation` job, stop the processor, restart it, verify the title is generated exactly once
-2. **GitHub event idempotency**: enqueue the same `github.event` job twice; verify it is processed exactly once (check `github_processed_events` table)
-3. **Room tick recovery**: enqueue a `room.tick` job, stop the processor, restart it, verify the room state progresses correctly
+**Online/integration tests** (`packages/daemon/tests/online/`):
+
+Note: `packages/daemon/tests/helpers/daemon-server.ts` provides only an in-process `createDaemonApp()` wrapper — there is no spawned-process mode for real kill/restart simulation. The crash-recovery scenarios below are validated by stopping and restarting the `JobQueueProcessor` within a single process, which is sufficient to verify that jobs persist across processor stop/start cycles (SQLite persistence is process-independent).
+
+1. **Session title generation persistence**: enqueue a `session.title_generation` job, stop and restart the processor in-process, verify the job is picked up and the title is set exactly once.
+2. **GitHub event idempotency**: enqueue the same `github.event` job payload twice (same `eventId`); verify it is processed exactly once (check `github_processed_events` table has one row).
+3. **Room tick re-enqueue-on-miss**: enqueue a `room.tick` job for a roomId not in the `runtimes` map; verify the job is re-enqueued with a 5-second delay and not silently dropped.
 
 **E2E test** (`packages/e2e/tests/`):
-- Verify UI reconnects and displays correct state after WebSocket close and restore (using existing `closeWebSocket()` / `restoreWebSocket()` helpers from `connection-helpers.ts`)
-- This is the correct E2E-compliant mechanism (pure browser-based Playwright, no RPC/internal state access)
-- Server-restart crash-recovery is covered by the online tests above, not E2E
+- Verify UI reconnects and displays correct state after WebSocket close and restore, using `closeWebSocket()` / `restoreWebSocket()` helpers from `connection-helpers.ts`.
+- This is the correct E2E-compliant mechanism (pure browser-based, no RPC/internal state access).
+- Server-restart crash-recovery is covered by online tests above, not E2E.
 
 **Scheduled DB maintenance job** (`QUEUES.JOB_QUEUE_CLEANUP`):
-- Register handler in `createDaemonApp` that runs `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` (prune `job_queue` rows older than 7 days) and prunes `github_processed_events` rows older than 30 days
-- Self-rescheduling pattern: after handler completes, enqueue next run with `runAt = Date.now() + 24 * 60 * 60 * 1000`
-- On daemon startup, enqueue first run with `runAt = now` if no pending/processing cleanup job exists
+- Register handler in `createDaemonApp` that: (1) calls `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` to prune old `job_queue` rows; (2) deletes `github_processed_events` rows older than 30 days
+- Self-rescheduling `finally` block (same pattern as `github.poll`):
+  ```typescript
+  finally {
+    jobQueueRepo.enqueue({
+      queue: QUEUES.JOB_QUEUE_CLEANUP,
+      payload: {},
+      runAt: Date.now() + 24 * 60 * 60 * 1000,
+      maxRetries: 3, // retry transient failures; prevents permanent schedule stall
+    });
+  }
+  ```
+- On daemon startup: enqueue first run with `runAt = now` if no pending/processing cleanup job exists
 
 **Cleanup scope** — patterns explicitly removed by this task:
-- `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no references remain)
+- `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no remaining references)
 - `scheduleTick()` method and `tickTimer` field in `room-runtime.ts` (removed in Task 4)
 - Any `void somePromise` usages replaced by queue jobs in Tasks 2–4
 
@@ -294,9 +403,9 @@ Add integration/online tests validating crash-recovery and idempotency, add a sc
 - Event-bus `.catch(() => {})` emissions in `rpc-handlers/` — in-process fanout
 
 **Acceptance criteria**:
-- At least 3 online tests covering crash-recovery/idempotency for the three migrated subsystems.
-- E2E test confirms UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
-- Scheduled cleanup job runs daily; self-rescheduling logic verified by unit test.
+- At least 3 online tests covering job persistence and idempotency across processor restart.
+- E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
+- Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 3`; verified by unit test.
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
@@ -306,7 +415,7 @@ Add integration/online tests validating crash-recovery and idempotency, add a sc
 ## Dependency Graph
 
 ```
-Task 1 (Foundation — wiring, DI, constants, idempotency design)
+Task 1 (Foundation — wiring, DI, constants, API extensions, idempotency design)
   ├── Task 2 (Session title generation)  ──┐
   ├── Task 3 (GitHub events + polling)   ──┼── Task 5 (Integration tests + cleanup)
   └── Task 4 (Room runtime tick)         ──┘
@@ -321,14 +430,17 @@ Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged
 | File | Relevance |
 |------|-----------|
 | `packages/daemon/src/app.ts` | Factory function with cleanup closure — Task 1 |
+| `packages/daemon/src/lib/rpc-handlers/index.ts` | `setupRPCHandlers` — where `RoomRuntimeService` is created; Task 1 adds `jobQueueProcessor`/`jobQueueRepo` to deps |
 | `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor — all tasks |
-| `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository — all tasks |
+| `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository; `listJobs` extended for array status — Task 1 |
 | `packages/daemon/src/lib/job-queue-constants.ts` | New queue name constants — Task 1 |
 | `packages/daemon/src/lib/session/session-manager.ts` | Task 2 |
 | `packages/daemon/src/lib/session/session-lifecycle.ts` | Task 2 |
+| `packages/daemon/src/lib/github/event-normalizer.ts` | Deterministic stable IDs for polled events — Task 3 |
 | `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
-| `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 (correct filename) |
+| `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 |
 | `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
+| `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — replace direct `tick()` call with `enqueueRoomTick()` |
 | `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -30,7 +30,7 @@ All queue handlers must be idempotent. Agreed per-queue strategy:
 
 | Queue | Idempotency key | Strategy |
 |-------|-----------------|----------|
-| `session.title_generation` | `sessionId` | Handler queries DB; skip if `session.title IS NOT NULL` |
+| `session.title_generation` | `sessionId` | Handler queries DB; skip if `session.metadata.titleGenerated === true` (sessions are always created with a non-null placeholder title; `title !== null` is always true and must NOT be used as the guard) |
 | `github.poll` | n/a (singleton, payload `{}`) | Dedup: skip enqueue if a `pending`/`processing` job already exists |
 | `github.event` | `eventId` (stable deterministic ID — see Task 3) | INSERT-first: `INSERT OR IGNORE INTO github_processed_events` at job start; if row already existed (affected rows = 0), skip pipeline — DB-level dedup, concurrency-safe with `maxConcurrent: 3` |
 | `room.tick` | `roomId` | Dedup: skip enqueue if a `pending`/`processing` job for this `roomId` exists |
@@ -66,7 +66,13 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy (see Task 4).
 
-4. **Shutdown ordering**: In the `cleanup()` closure, add `await jobQueueProcessor.stop()` **before** the `rpcHandlerCleanup()` call at line 375 of `app.ts`. `rpcHandlerCleanup()` internally calls `roomRuntimeService.stop()`, so this ordering ensures all in-flight tick jobs drain before the runtimes map is cleared.
+4. **Shutdown ordering**: In the `cleanup()` closure, add `await jobQueueProcessor.stop()` **before** both `rpcHandlerCleanup()` and `messageHub.cleanup()`. `app.ts` currently calls `messageHub.cleanup()` before `rpcHandlerCleanup()` (line ~369); in-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
+   ```typescript
+   await jobQueueProcessor.stop(); // drain all in-flight job handlers first
+   messageHub.cleanup();           // safe: no in-flight jobs remain
+   rpcHandlerCleanup();            // stops RoomRuntimeService (clears runtimes map)
+   await sessionManager.cleanup();
+   ```
 
 **API extensions required** (implement alongside wiring):
 
@@ -91,10 +97,11 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
 3. Add `jobQueueProcessor` and `jobQueueRepo` to the `deps` object passed to `setupRPCHandlers`.
 4. Call subsystem `start()` methods (`sessionManager.start()`, `roomRuntimeService.start()`, `githubService.start()`) **before** `jobQueueProcessor.start()` — this ensures all handlers are registered before the processor begins dequeuing.
 5. Call `jobQueueProcessor.start()` after all subsystem `start()` calls.
-6. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure before `rpcHandlerCleanup()`:
+6. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure **before both** `messageHub.cleanup()` and `rpcHandlerCleanup()`:
    ```typescript
    // cleanup():
-   await jobQueueProcessor.stop(); // drain in-flight jobs first
+   await jobQueueProcessor.stop(); // drain in-flight jobs first (handlers may call notifyChange)
+   messageHub.cleanup();           // safe: no in-flight jobs remain
    rpcHandlerCleanup();            // stops RoomRuntimeService (via rpc-handlers cleanup)
    await sessionManager.cleanup();
    ```
@@ -112,7 +119,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
 
 **Acceptance criteria**:
 - `JobQueueProcessor` is instantiated; subsystem `start()` methods are called after `setupRPCHandlers` but **before** `jobQueueProcessor.start()` to guarantee all handlers are registered before polling begins.
-- `await jobQueueProcessor.stop()` is in the `cleanup()` closure before `rpcHandlerCleanup()`.
+- `await jobQueueProcessor.stop()` is in the `cleanup()` closure before both `messageHub.cleanup()` and `rpcHandlerCleanup()` — ensures in-flight job handlers that call `notifyChange()` complete before `messageHub` is torn down.
 - Change notifier connected to `ReactiveDatabase`.
 - `listJobs` extended to accept `status?: JobStatus | JobStatus[]`.
 - `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object; `RPCHandlerDependencies` TypeScript interface updated to include both fields.
@@ -133,7 +140,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
 Replace the fire-and-forget title generation + git branch rename in `SessionManager` with a persistent job on the `session.title_generation` queue.
 
 **Files to modify**:
-- `packages/daemon/src/lib/session/session-manager.ts` — add a `start()` lifecycle method (does not currently exist); enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set. `createDaemonApp` calls `sessionManager.start()` after `jobQueueProcessor.start()`.
+- `packages/daemon/src/lib/session/session-manager.ts` — add a `start()` lifecycle method (does not currently exist); enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set. `createDaemonApp` calls `sessionManager.start()` **before** `jobQueueProcessor.start()` (see Task 1 step 4: all subsystem `start()` methods registered before processor begins polling).
 - `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (no extraction needed; already a method on `SessionLifecycle`) in the job handler
 
 **Behavioral change**: Currently the `message.persisted` event handler does `await titleGenTask` (line 162 of `session-manager.ts`), blocking until title generation completes. After this migration the handler enqueues a job synchronously and returns immediately. This is the intended change — the handler must NOT await title generation; the job queue provides durability instead.
@@ -144,9 +151,13 @@ Replace the fire-and-forget title generation + git branch rename in `SessionMana
 start(): void {
   this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
     const { sessionId } = job.payload as { sessionId: string };
-    // Idempotency: skip if title already set
+    // Idempotency: skip if title was already generated.
+    // IMPORTANT: Do NOT use session.title !== null — sessions are always created with a
+    // placeholder title ('New Session'), so that check is ALWAYS true and would silently
+    // skip every job. The correct flag is session.metadata.titleGenerated (set to true
+    // by generateTitleAndRenameBranch / generateTitleOnly on completion).
     const session = this.sessionRepo.getSession(sessionId);
-    if (!session || session.title !== null) return;
+    if (!session || session.metadata.titleGenerated) return;
     if (this.sessionCache.has(sessionId)) {
       // Session in cache: full path (title generation + branch rename)
       await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
@@ -160,7 +171,7 @@ start(): void {
 
 **Cache miss handling**: `generateTitleAndRenameBranch` requires the session in the in-memory cache. After a daemon restart the session may not be cached. The handler checks the cache:
 - **Cache hit**: calls the full `generateTitleAndRenameBranch` (title + branch rename)
-- **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache. Both `generateTitleAndRenameBranch` and `generateTitleOnly` check `session.title !== null` to guard idempotency.
+- **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache. Both `generateTitleAndRenameBranch` and `generateTitleOnly` set `session.metadata.titleGenerated = true` on completion to guard idempotency (do NOT check `session.title !== null` — that is always true).
 
 Job payload: `{ sessionId: string, userMessageText: string }`
 
@@ -174,7 +185,7 @@ jobQueueRepo.enqueue({
 // Return immediately — no await
 ```
 
-**Idempotency**: Handler queries `session.title`; if non-null, returns immediately.
+**Idempotency**: Handler checks `session.metadata.titleGenerated`; if true, returns immediately. **Do not use `session.title !== null`** — every session is created with `title: 'New Session'` (a placeholder, not null), so that check would always be true and silently skip all title generation.
 
 **Acceptance criteria**:
 - `pendingBackgroundTasks` Set removed from `SessionManager`.
@@ -183,7 +194,8 @@ jobQueueRepo.enqueue({
 - Cache miss fallback: handler completes gracefully even if session is not in memory.
 - If daemon restarts after enqueue but before handler runs, job is picked up on next start.
 - Idempotency: handler called twice for same session produces correct result (no double-rename).
-- Unit tests cover: enqueue on first message, idempotency (title already set), handler success, cache miss fallback, failure + retry (max 2 retries), dead-letter after max retries.
+- Idempotency guard uses `session.metadata.titleGenerated` (not `session.title !== null`); verified by unit test that second handler invocation returns immediately when `titleGenerated` is true.
+- Unit tests cover: enqueue on first message, idempotency (`titleGenerated = true` → skip), handler success sets `titleGenerated = true`, cache miss fallback, failure + retry (max 2 retries), dead-letter after max retries.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -223,7 +235,17 @@ Replace the in-memory GitHub event pipeline with a persistent job queue so event
 - Comments: `{fullName}/comments/{commentId}/{updatedAt}`
 - Pull requests: `{fullName}/pulls/{prNumber}/{updatedAt}`
 
-Webhook events already have a stable `X-GitHub-Delivery` ID via `normalizeWebhookEvent`; no change needed there.
+Webhook events have a stable `X-GitHub-Delivery` delivery ID available in `webhook-handler.ts` (line ~141), but **the current `normalizeWebhookEvent` in `event-normalizer.ts` calls `generateEventId()` which returns a random UUID — not the delivery ID**. The delivery ID is not forwarded to the normalizer. To fix this, the webhook handler must pass the `X-GitHub-Delivery` header value directly as the `eventId` field in the `github.event` job payload, bypassing the normalizer's `generateEventId()`:
+```typescript
+// webhook-handler.ts, when enqueueing the github.event job:
+const deliveryId = req.header('X-GitHub-Delivery') ?? generateUUID();
+jobQueueRepo.enqueue({
+  queue: QUEUES.GITHUB_EVENT,
+  payload: { eventType, eventId: deliveryId, payload: webhookPayload },
+  maxRetries: 0,
+});
+```
+The polling path already uses deterministic IDs as described above. `normalizeWebhookEvent` may still be called for in-process pipeline use, but its output `eventId` should NOT be used as the job's `eventId`.
 
 **Files to modify**:
 
@@ -260,12 +282,20 @@ Webhook events already have a stable `X-GitHub-Delivery` ID via `normalizeWebhoo
 
 4. `packages/daemon/src/lib/github/webhook-handler.ts`:
    - Update webhook path to enqueue a `github.event` job instead of calling the pipeline directly
+   - Use the `X-GitHub-Delivery` header value (parsed at line ~141) as the `eventId` in the job payload — NOT `normalizeWebhookEvent`'s output `eventId` (which calls `generateEventId()` → random UUID, defeating idempotency)
 
 Job payloads:
 - `github.poll`: `{}` (singleton sentinel)
 - `github.event`: `{ eventType: string, eventId: string, payload: Record<string, unknown> }`
 
-**Retry behavior**: `maxRetries: 3` for `github.event`. `maxRetries: 0` for `github.poll` (re-scheduling handled in `finally` block; processor retry not needed).
+**Retry behavior**: `maxRetries: 0` for **both** `github.event` and `github.poll`.
+
+For `github.poll`: re-scheduling handled in `finally` block; processor retry not needed.
+
+For `github.event`: INSERT-first idempotency requires `maxRetries: 0`. With `maxRetries > 0`, if the pipeline fails after the INSERT succeeds (e.g. transient network error, agent crash), any retry sees the existing row (affected rows = 0) and permanently skips the pipeline — a **silent event drop**. Setting `maxRetries: 0` accepts at-most-once delivery for individual events. This is acceptable because:
+- GitHub webhooks have their own retry mechanism (3 delivery attempts with exponential backoff)
+- Polling events are re-polled on the next poll cycle; stable deterministic IDs prevent duplicate processing of successfully processed events
+- The alternative (insert-on-success + per-job in-flight concurrency key) adds significant complexity for marginal gain
 
 **Residual risk**: If `jobQueueRepo.enqueue()` inside the `finally` block throws (e.g., SQLite disk failure), the next poll will not be scheduled. This is an accepted risk: SQLite write failures at this level typically indicate a fatal daemon condition (disk full, WAL corruption) and the daemon will crash and restart, re-enqueuing the poll on startup. No additional fallback is specified.
 
@@ -273,11 +303,13 @@ Job payloads:
 - Polled events use deterministic stable IDs (verified by unit test: normalizing same data twice produces same ID).
 - Per-repo poll state (`issues_etag`, `comments_etag`, `last_poll_at`) stored in `github_poll_state` table, survives restart.
 - Repository registrations restored from `GitHubMappingRepository` on `start()`.
-- Same event cannot be processed twice: INSERT-first strategy (`INSERT OR IGNORE` at job start, skip pipeline if row already existed) is concurrency-safe with `maxConcurrent: 3` — SQLite serializes writes so two concurrent workers cannot both get `affected rows = 1` for the same `eventId`.
+- Same event cannot be processed twice: INSERT-first strategy (`INSERT OR IGNORE` at job start, skip pipeline if row already existed) is concurrency-safe with `maxConcurrent: 3`.
+- `github.event` jobs use `maxRetries: 0` (at-most-once delivery). This is required because INSERT-first + retry would cause permanent silent event drops: a retry sees the existing row and skips the pipeline. GitHub webhooks retry on their own; polled events reappear on next poll cycle.
 - `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error (modulo fatal SQLite failure, accepted risk).
 - Enqueued `github.event` jobs survive daemon restart.
 - DB migration for `github_processed_events` and `github_poll_state` tables is included and applied at daemon startup.
-- Unit tests cover: stable ID generation, INSERT-first idempotency (first insert succeeds, second is no-op), poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
+- Webhook `github.event` jobs use `X-GitHub-Delivery` header value as `eventId` (not `generateEventId()` which produces random UUIDs); verified by unit test that re-delivering the same webhook with same delivery ID is idempotent.
+- Unit tests cover: stable ID generation for polled events, stable delivery ID for webhooks, INSERT-first idempotency (first insert succeeds, second is no-op), poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -304,14 +336,21 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
-    // Dedup: skip if pending or processing job exists for this room.
+    const now = Date.now();
+    // Dedup: skip if an immediate (near-future) pending or processing job exists for this room.
+    // IMPORTANT: only dedup against jobs with runAt <= now (immediate/due jobs).
+    // Heartbeat jobs have runAt = now + 30_000 and must NOT suppress event-driven immediate
+    // ticks — otherwise rooms would be delayed up to 30 seconds between event-driven ticks.
     // listJobs now supports status array (extended in Task 1).
     // limit: 1000 overrides the default cap of 100 to avoid missed dedup under high job volume.
     const existing = repo.listJobs({
       queue: QUEUES.ROOM_TICK,
       status: ['pending', 'processing'],
       limit: 1000,
-    }).find(j => (j.payload as any).roomId === roomId);
+    }).find(j =>
+      (j.payload as any).roomId === roomId &&
+      (j.runAt === null || j.runAt <= now)
+    );
     if (!existing) {
       repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority, maxRetries: 0 });
     }
@@ -328,7 +367,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
   }
   ```
 - Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
-- After each tick handler attempt (success or failure), schedule the heartbeat in a `try/finally` block — this is unconditional and intentionally bypasses the dedup helper, since the 30s future job is semantically distinct from any immediate pending job. The `finally` placement ensures no room permanently stops ticking even if `runtime.tick()` throws. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
+- After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` placement ensures no room permanently stops ticking even if `runtime.tick()` throws. The heartbeat enqueue **deduplicates against existing pending future-scheduled jobs** (`runAt > now`) — when event-driven ticks fire frequently, without this dedup each tick's `finally` would create a new parallel heartbeat chain. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
@@ -353,27 +392,43 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     try {
       await runtime.tick();
     } finally {
-      // Heartbeat: always schedule a future tick even if runtime.tick() throws.
+      // Heartbeat: schedule a future tick if none already pending for this room.
       // Placing in finally ensures no room permanently stops ticking on handler error.
       // maxRetries: 0 is required: with the finally pattern, processor retries would
       // each also fire finally, creating duplicate heartbeat jobs (job multiplication).
-      // The finally block itself guarantees rescheduling without processor retries.
-      this.jobQueueRepo.enqueue({
+      //
+      // Dedup against future-scheduled jobs: if a pending heartbeat already exists
+      // (runAt > now), skip — prevents heartbeat chain multiplication when event-driven
+      // ticks fire frequently (each event-driven tick's finally would otherwise create
+      // an additional parallel heartbeat chain).
+      const now = Date.now();
+      const existingHeartbeat = this.jobQueueRepo.listJobs({
         queue: QUEUES.ROOM_TICK,
-        payload: { roomId },
-        runAt: Date.now() + 30_000,
-        maxRetries: 0,
-      });
+        status: ['pending'],
+        limit: 1000,
+      }).find(j =>
+        (j.payload as any).roomId === roomId &&
+        j.runAt !== null && j.runAt > now
+      );
+      if (!existingHeartbeat) {
+        this.jobQueueRepo.enqueue({
+          queue: QUEUES.ROOM_TICK,
+          payload: { roomId },
+          runAt: now + 30_000,
+          maxRetries: 0,
+        });
+      }
     }
   });
   ```
 
 **Startup and recovery ordering**: `roomRuntimeService.start()` is called with `.catch()` (fire-and-forget) inside `setupRPCHandlers`. Because recovery may not be complete when the first tick jobs fire, the handler uses re-enqueue-on-miss (above) rather than silent drop. This ensures rooms always receive their tick once recovery completes, without requiring strict startup sequencing between the processor and recovery.
 
-**Shutdown ordering** (in `app.ts` cleanup closure — see Task 1 step 5):
-1. `await jobQueueProcessor.stop()` — drains in-flight tick jobs
-2. `rpcHandlerCleanup()` — stops `RoomRuntimeService` (clears `runtimes` map)
-3. `await sessionManager.cleanup()`
+**Shutdown ordering** (in `app.ts` cleanup closure — see Task 1 step 6):
+1. `await jobQueueProcessor.stop()` — drains in-flight tick jobs (handlers may emit notifyChange)
+2. `messageHub.cleanup()` — safe: no in-flight jobs remain
+3. `rpcHandlerCleanup()` — stops `RoomRuntimeService` (clears `runtimes` map)
+4. `await sessionManager.cleanup()`
 
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
@@ -386,7 +441,9 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 - Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error.
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
 - Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`, `maxRetries: 0`) via direct enqueue when room exists but runtime not found; no `enqueueRoomTick` call in this path.
-- Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs`; check-then-act race documented as accepted risk.
+- Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs` and filters by `runAt === null || runAt <= now` — heartbeat jobs (future `runAt`) do NOT suppress event-driven immediate ticks.
+- Heartbeat dedup: `finally` block checks for existing pending future-scheduled job (`runAt > now`) before enqueuing, preventing heartbeat chain multiplication when event-driven ticks fire frequently.
+- Check-then-act race documented as accepted risk (for both `enqueueRoomTick` and heartbeat dedup path).
 - Shutdown ordering enforced in `app.ts` cleanup closure.
 - Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
@@ -430,7 +487,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
   }
   ```
 - On daemon startup: enqueue first run with `runAt = now` if no pending/processing cleanup job exists
-- On daemon startup: also run a synchronous one-time prune of `github_processed_events` rows older than 30 days to bound table size in case the daemon has been offline for an extended period (e.g., `> 30` days)
+- On daemon startup: also run a synchronous one-time prune of `github_processed_events` rows older than 30 days to bound table size in case the daemon has been offline for an extended period (e.g., `> 30` days). This prune must run **before** `jobQueueProcessor.start()` to prevent a stale `processing`-status job from a crashed instance being re-dispatched before old rows are cleaned up (which could cause double-execution of events whose `github_processed_events` row was pruned).
 
 **Cleanup scope** — patterns explicitly removed by this task:
 - `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no remaining references)
@@ -446,7 +503,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 - At least 3 online tests covering job persistence and idempotency across processor restart.
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
 - Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); verified by unit test.
-- Startup-time synchronous prune of `github_processed_events` rows older than 30 days runs on daemon start; verified by unit test.
+- Startup-time synchronous prune of `github_processed_events` rows older than 30 days runs on daemon start **before** `jobQueueProcessor.start()`; verified by unit test.
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -156,7 +156,12 @@ start(): void {
     // placeholder title ('New Session'), so that check is ALWAYS true and would silently
     // skip every job. The correct flag is session.metadata.titleGenerated (set to true
     // by generateTitleAndRenameBranch / generateTitleOnly on completion).
-    const session = this.sessionRepo.getSession(sessionId);
+    // NOTE: this.sessionRepo.getSession() is illustrative pseudocode. SessionManager
+    // does not have a sessionRepo field with a getSession() method. The implementor
+    // must use the actual SessionManager API to fetch session data (e.g., the session
+    // store, cache lookup, or whichever method SessionManager exposes for reading a
+    // session by ID). The key requirement is reading session.metadata.titleGenerated.
+    const session = /* actual SessionManager session fetch by sessionId */ ...;
     if (!session || session.metadata.titleGenerated) return;
     if (this.sessionCache.has(sessionId)) {
       // Session in cache: full path (title generation + branch rename)
@@ -171,7 +176,9 @@ start(): void {
 
 **Cache miss handling**: `generateTitleAndRenameBranch` requires the session in the in-memory cache. After a daemon restart the session may not be cached. The handler checks the cache:
 - **Cache hit**: calls the full `generateTitleAndRenameBranch` (title + branch rename)
-- **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache. Both `generateTitleAndRenameBranch` and `generateTitleOnly` set `session.metadata.titleGenerated = true` on completion to guard idempotency (do NOT check `session.title !== null` — that is always true).
+- **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache.
+
+**`titleGenerated` flag semantics**: Both `generateTitleAndRenameBranch` and `generateTitleOnly` must set `session.metadata.titleGenerated = true` **only on successful AI title generation** — not unconditionally. This is consistent with the existing `titleGenerated: !isFallback` pattern: if the AI generation fails and a fallback title is used, `titleGenerated` remains `false` so the job can be retried with a real AI title later. Do NOT check `session.title !== null` as the idempotency guard — that is always `true` since sessions are created with a placeholder title.
 
 Job payload: `{ sessionId: string, userMessageText: string }`
 
@@ -350,6 +357,11 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **Migration approach**:
 - Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes the main `scheduleTick()` at line ~1550 **and** an additional `queueMicrotask(() => this.tick())` at line ~954 inside the tick mutex path — both must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
 - Remove the `scheduleHeartbeat()` method (if present) from `RoomRuntimeService` — it uses `setInterval`/`setTimeout` internally and is superseded by the `finally`-based heartbeat in the tick handler.
+- **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` (line 83) does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
+  1. Add `private stoppedRooms: Set<string> = new Set()` field.
+  2. `stopRuntime(roomId)` must call `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`.
+  3. The tick handler's `!runtime` branch must check `this.stoppedRooms.has(roomId)` as the **first** check and return without re-enqueueing. Without this, when a tick job fires after `stopRuntime()` was called, the `!runtime` branch sees the room exists in DB and re-enqueues indefinitely (the perpetual churn loop).
+  4. After `stopRuntime()` deletes from the map, `this.runtimes.has(roomId)` in the heartbeat `finally` block correctly returns `false` for stopped rooms, making the liveness check effective for both individual stops and full shutdown.
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
@@ -398,8 +410,12 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     const { roomId } = job.payload as { roomId: string };
     const runtime = this.runtimes.get(roomId);
     if (!runtime) {
-      // Runtime not found: could be recovery in progress OR room was deleted.
-      // Check DB to distinguish: if the room no longer exists, skip re-enqueue.
+      // Runtime not found: three possible reasons —
+      //   (a) runtime was explicitly stopped (check stoppedRooms first)
+      //   (b) recovery still in progress after restart
+      //   (c) room was deleted from DB
+      // Check (a) first to avoid an expensive DB read for stopped rooms.
+      if (this.stoppedRooms.has(roomId)) return; // Explicitly stopped — do not re-enqueue
       const roomExists = this.ctx.roomManager.getRoom(roomId) !== null;
       if (roomExists) {
         // Recovery still in progress — re-enqueue with delay, but only if no pending
@@ -429,11 +445,16 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       // Heartbeat: schedule a future tick if (a) runtime is still tracked AND
       // (b) no future-scheduled heartbeat already exists.
       //
-      // CRITICAL: Check this.runtimes.has(roomId) first. stopRuntime() may be called
-      // concurrently while a tick is in-flight (room is stopped but tick is still running).
-      // Without this check, the finally block would re-enqueue a heartbeat for a stopped
-      // runtime, causing the re-enqueue-on-miss path to loop indefinitely (room exists in
-      // DB, runtime not in map → re-enqueue with 5s delay → repeat forever).
+      // CRITICAL: Check this.runtimes.has(roomId) first. stopRuntime() must call
+      // this.runtimes.delete(roomId) (see migration approach above — this is a required
+      // fix to the existing stopRuntime() implementation at room-runtime-service.ts:83).
+      // After that fix, this.runtimes.has(roomId) correctly returns false for stopped
+      // rooms, making this liveness check effective for individual room stops as well as
+      // full shutdown (runtimes.clear()). Without stopRuntime() deleting from the map,
+      // this check would always be true for stopped rooms and the heartbeat would chain
+      // indefinitely. The stoppedRooms check in the !runtime branch above handles the
+      // symmetric case where the tick handler fires after stopRuntime() but the finally
+      // block hasn't been reached yet.
       //
       // maxRetries: 0 is required: with the finally pattern, processor retries would
       // each also fire finally, creating duplicate heartbeat jobs (job multiplication).
@@ -482,13 +503,16 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface.
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
 - Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error. The `finally` block checks `this.runtimes.has(roomId)` before enqueueing: if the runtime was stopped while the tick was in-flight, skip re-enqueue to prevent the indefinite re-enqueue-on-miss loop.
+- `stopRuntime()` in `RoomRuntimeService` (line 83) calls `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`. Without `runtimes.delete()`, `this.runtimes.has(roomId)` returns `true` for stopped rooms and the heartbeat liveness check is ineffective for individual room stops.
+- `private stoppedRooms: Set<string> = new Set()` field added to `RoomRuntimeService`.
+- Tick handler's `!runtime` branch checks `this.stoppedRooms.has(roomId)` as the first check and returns without re-enqueueing for explicitly stopped rooms (prevents perpetual churn when a tick fires after `stopRuntime()`).
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
 - Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`, `maxRetries: 0`) when room exists but runtime not found; dedup against existing pending jobs prevents multiple concurrent workers (maxConcurrent: 3) from each enqueueing an independent delayed job.
 - Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs` and filters by `runAt === null || runAt <= now` — heartbeat jobs (future `runAt`) do NOT suppress event-driven immediate ticks.
 - Heartbeat dedup: `finally` block checks for existing pending future-scheduled job (`runAt > now`) before enqueuing, preventing heartbeat chain multiplication when event-driven ticks fire frequently.
 - Check-then-act race documented as accepted risk (for both `enqueueRoomTick` and heartbeat dedup path).
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), heartbeat NOT scheduled when runtime stopped during tick (liveness check), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), heartbeat NOT scheduled when runtime stopped during tick (liveness check), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, no-re-enqueue for explicitly stopped room (stoppedRooms membership), graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -517,19 +541,31 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 
 **Scheduled DB maintenance job** (`QUEUES.JOB_QUEUE_CLEANUP`):
 - Register handler in `createDaemonApp` that: (1) calls `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` to prune old `job_queue` rows; (2) deletes `github_processed_events` rows older than 30 days
-- Self-rescheduling `finally` block (same pattern as `github.poll`):
+- Self-rescheduling `finally` block (same pattern as `github.poll`). Must include dedup to prevent cleanup chain multiplication if two `job_queue.cleanup` jobs are ever simultaneously present:
   ```typescript
   finally {
-    jobQueueRepo.enqueue({
+    // Dedup: only enqueue next cleanup if no future-scheduled one already exists.
+    // Without dedup, if two cleanup jobs somehow run concurrently (e.g., crash during
+    // startup before dedup check), each job's finally would create an extra next-day
+    // cleanup, doubling the chain — same pattern as github.poll (now fixed).
+    const now = Date.now();
+    const existingCleanup = jobQueueRepo.listJobs({
       queue: QUEUES.JOB_QUEUE_CLEANUP,
-      payload: {},
-      runAt: Date.now() + 24 * 60 * 60 * 1000,
-      maxRetries: 0, // finally pattern self-reschedules; maxRetries > 0 causes job multiplication
-                     // (each retry also runs finally, creating an extra next-day cleanup job)
-    });
+      status: ['pending'],
+      limit: 10,
+    }).find(j => j.runAt !== null && j.runAt > now);
+    if (!existingCleanup) {
+      jobQueueRepo.enqueue({
+        queue: QUEUES.JOB_QUEUE_CLEANUP,
+        payload: {},
+        runAt: now + 24 * 60 * 60 * 1000,
+        maxRetries: 0, // finally pattern self-reschedules; maxRetries > 0 causes job multiplication
+                       // (each retry also runs finally, creating an extra next-day cleanup job)
+      });
+    }
   }
   ```
-- On daemon startup: enqueue first run with `runAt = now` if no pending/processing cleanup job exists
+- On daemon startup: enqueue first run with `runAt = Date.now() + 24 * 60 * 60 * 1000` (now + 24 hours) if no pending/processing cleanup job exists. **Do NOT use `runAt = now`**: the cleanup job deletes `github_processed_events` rows older than 30 days; if a daemon was offline for 31–89 days, an immediate first run would delete dedup rows for jobs whose stale reclaim (5-minute threshold) has not yet completed, causing duplicate event processing. Delaying the first run by 24 hours ensures the processor has fully completed stale job reclaim before cleanup runs.
 - On daemon startup: run a synchronous one-time prune of `github_processed_events` rows older than **90 days** (not 30 days) to bound table size after extended offline periods. This prune must run **before** `jobQueueProcessor.start()`.
 
   **Dedup gap and accepted risk**: If the daemon was offline for > 90 days AND had `github.event` jobs stuck in `processing` state at shutdown, the startup prune could delete those jobs' dedup rows. On restart, the processor reclaims those stale jobs and re-runs the pipeline (duplicate event processing). This is an accepted risk:
@@ -550,7 +586,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 **Acceptance criteria**:
 - At least 3 online tests covering job persistence and idempotency across processor restart.
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
-- Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); verified by unit test.
+- Scheduled cleanup job self-reschedules via `finally` block with dedup (only enqueues if no future-scheduled cleanup already exists) and `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); dedup prevents cleanup chain multiplication if duplicate `job_queue.cleanup` jobs are ever present; verified by unit test.
 - Startup-time synchronous prune of `github_processed_events` rows older than **90 days** runs on daemon start **before** `jobQueueProcessor.start()`; verified by unit test. (90-day window provides safety margin; ongoing cleanup job prunes at 30 days. Risk of dedup gap for daemon offline > 90 days is accepted — at-most-once delivery is already the guarantee.)
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -150,7 +150,7 @@ Replace the fire-and-forget title generation + git branch rename in `SessionMana
 // New method added to SessionManager:
 start(): void {
   this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
-    const { sessionId } = job.payload as { sessionId: string };
+    const { sessionId, userMessageText } = job.payload as { sessionId: string; userMessageText: string };
     // Idempotency: skip if title was already generated.
     // IMPORTANT: Do NOT use session.title !== null — sessions are always created with a
     // placeholder title ('New Session'), so that check is ALWAYS true and would silently
@@ -168,7 +168,9 @@ start(): void {
       await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
     } else {
       // Cache miss after restart: title-only fallback (no branch rename)
-      await this.sessionLifecycle.generateTitleOnly(sessionId, ...);
+      // userMessageText comes from the job payload — it is the original user message
+      // text captured at enqueue time and is the only source available after restart.
+      await this.sessionLifecycle.generateTitleOnly(sessionId, userMessageText);
     }
   });
 }
@@ -202,7 +204,9 @@ jobQueueRepo.enqueue({
 - If daemon restarts after enqueue but before handler runs, job is picked up on next start.
 - Idempotency: handler called twice for same session produces correct result (no double-rename).
 - Idempotency guard uses `session.metadata.titleGenerated` (not `session.title !== null`); verified by unit test that second handler invocation returns immediately when `titleGenerated` is true.
-- Unit tests cover: enqueue on first message, idempotency (`titleGenerated = true` → skip), handler success sets `titleGenerated = true`, cache miss fallback, failure + retry (max 2 retries), dead-letter after max retries.
+- `generateTitleOnly` is a new method on `SessionLifecycle` (does not yet exist in codebase); its creation is a required deliverable of this task alongside the handler integration.
+- `userMessageText` is destructured from the job payload alongside `sessionId` and forwarded to both `generateTitleAndRenameBranch` (cache hit) and `generateTitleOnly` (cache miss). The `userMessageText` is the only source of the original message text available after a restart.
+- Unit tests cover: enqueue on first message, idempotency (`titleGenerated = true` → skip), handler success sets `titleGenerated = true`, cache miss fallback (`generateTitleOnly` called with correct `userMessageText`), `generateTitleOnly` leaves `titleGenerated = false` on AI failure (fallback title used — allows retry), failure + retry (max 2 retries), dead-letter after max retries.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -266,6 +270,7 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
 
 2. `packages/daemon/src/lib/github/polling-service.ts`:
    - Replace in-memory etag/timestamp state with reads/writes to `github_poll_state` table
+   - **Injection**: `GitHubPollingService` currently receives only `PollingConfig` in its constructor. The migration adds `jobQueueProcessor`, `jobQueueRepo`, `githubPollStateRepo` (or equivalent DB accessor), and `githubMappingRepo` as constructor dependencies, injected by `GitHubService` (which already receives `jobQueueProcessor`/`jobQueueRepo` from Task 1 and the DB instance).
    - In `start()`, restore repo registrations by reading from `GitHubMappingRepository` (`room_github_mappings` table)
    - Replace `setInterval` with a self-rescheduling `github.poll` job (singleton dedup)
    - Re-scheduling uses a `finally` block with dedup to guarantee next poll is always enqueued but never doubled:
@@ -278,11 +283,18 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
          // Dedup prevents poll chain multiplication if two github.poll jobs are ever
          // simultaneously present (e.g., crash during startup before dedup check runs).
          // Without dedup, each job's finally would create another, doubling the chain.
+         //
+         // Accepted race: this is a check-then-enqueue sequence. Two workers could both
+         // observe "no future job exists" and both enqueue, momentarily doubling the chain.
+         // This is an accepted risk (same as the room tick dedup path): the duplicate is
+         // idempotent (extra poll cycle causes no harm), true atomic dedup would require a
+         // DB-level UNIQUE constraint, and the `github.poll` singleton is recovered by the
+         // dedup guard on the next finally.
          const now = Date.now();
          const existingPoll = jobQueueRepo.listJobs({
            queue: QUEUES.GITHUB_POLL,
            status: ['pending'],
-           limit: 10,
+           limit: 1, // existence check only — limit:1 is sufficient and semantically clearer
          }).find(j => j.runAt !== null && j.runAt > now);
          if (!existingPoll) {
            jobQueueRepo.enqueue({
@@ -355,13 +367,14 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~76).
 
 **Migration approach**:
-- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes the main `scheduleTick()` at line ~1550 **and** an additional `queueMicrotask(() => this.tick())` at line ~954 inside the tick mutex path — both must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
+- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes the main `scheduleTick()` at line ~1550 **and** an additional `queueMicrotask(() => this.tick())` at line ~954 inside the tick mutex path — both must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
 - Remove the `scheduleHeartbeat()` method (if present) from `RoomRuntimeService` — it uses `setInterval`/`setTimeout` internally and is superseded by the `finally`-based heartbeat in the tick handler.
 - **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` (line 83) does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
   1. Add `private stoppedRooms: Set<string> = new Set()` field.
   2. `stopRuntime(roomId)` must call `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`.
-  3. The tick handler's `!runtime` branch must check `this.stoppedRooms.has(roomId)` as the **first** check and return without re-enqueueing. Without this, when a tick job fires after `stopRuntime()` was called, the `!runtime` branch sees the room exists in DB and re-enqueues indefinitely (the perpetual churn loop).
-  4. After `stopRuntime()` deletes from the map, `this.runtimes.has(roomId)` in the heartbeat `finally` block correctly returns `false` for stopped rooms, making the liveness check effective for both individual stops and full shutdown.
+  3. **`startRuntime(roomId)` (at `room-runtime-service.ts:94`) must call `this.stoppedRooms.delete(roomId)` before creating the new runtime** — this clears the stopped marker when a room is restarted. Without this, a stop-then-restart sequence leaves `stoppedRooms` containing the `roomId`; any subsequent tick job hits `stoppedRooms.has(roomId) → true` and returns immediately, permanently preventing the restarted room from ever ticking. Also prevents `stoppedRooms` from growing unbounded across the daemon lifetime.
+  4. The tick handler's `!runtime` branch must check `this.stoppedRooms.has(roomId)` as the **first** check and return without re-enqueueing. Without this, when a tick job fires after `stopRuntime()` was called, the `!runtime` branch sees the room exists in DB and re-enqueues indefinitely (the perpetual churn loop).
+  5. After `stopRuntime()` deletes from the map, `this.runtimes.has(roomId)` in the heartbeat `finally` block correctly returns `false` for stopped rooms, making the liveness check effective for both individual stops and full shutdown.
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
@@ -497,13 +510,14 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
-- `setInterval`, `tickTimer`, `scheduleTick()`, and all `queueMicrotask` calls (including the one at line ~954 in the tick mutex path) removed from `RoomRuntime`.
+- `setInterval`, `tickTimer`, `scheduleTick()`, and all `queueMicrotask` calls (including the one at line ~954 in the tick mutex path) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
 - `scheduleHeartbeat()` method (if present) removed from `RoomRuntimeService` — replaced by the `finally`-based heartbeat in the tick handler.
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface.
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
 - Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error. The `finally` block checks `this.runtimes.has(roomId)` before enqueueing: if the runtime was stopped while the tick was in-flight, skip re-enqueue to prevent the indefinite re-enqueue-on-miss loop.
 - `stopRuntime()` in `RoomRuntimeService` (line 83) calls `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`. Without `runtimes.delete()`, `this.runtimes.has(roomId)` returns `true` for stopped rooms and the heartbeat liveness check is ineffective for individual room stops.
+- `startRuntime()` in `RoomRuntimeService` (at line 94) calls `this.stoppedRooms.delete(roomId)` before creating the new runtime. Without this, a stop-then-restart sequence permanently suppresses ticking for the restarted room (stale `stoppedRooms` entry causes the tick handler to return early indefinitely).
 - `private stoppedRooms: Set<string> = new Set()` field added to `RoomRuntimeService`.
 - Tick handler's `!runtime` branch checks `this.stoppedRooms.has(roomId)` as the first check and returns without re-enqueueing for explicitly stopped rooms (prevents perpetual churn when a tick fires after `stopRuntime()`).
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
@@ -512,7 +526,7 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 - Heartbeat dedup: `finally` block checks for existing pending future-scheduled job (`runAt > now`) before enqueuing, preventing heartbeat chain multiplication when event-driven ticks fire frequently.
 - Check-then-act race documented as accepted risk (for both `enqueueRoomTick` and heartbeat dedup path).
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), heartbeat NOT scheduled when runtime stopped during tick (liveness check), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, no-re-enqueue for explicitly stopped room (stoppedRooms membership), graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), heartbeat NOT scheduled when runtime stopped during tick (liveness check), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, no-re-enqueue for explicitly stopped room (stoppedRooms membership), stop-then-restart resumes ticking normally (stoppedRooms.delete on startRuntime), graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -540,7 +554,8 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 - Server-restart crash-recovery is covered by online tests above, not E2E.
 
 **Scheduled DB maintenance job** (`QUEUES.JOB_QUEUE_CLEANUP`):
-- Register handler in `createDaemonApp` that: (1) calls `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` to prune old `job_queue` rows; (2) deletes `github_processed_events` rows older than 30 days
+- Register handler in `createDaemonApp` **before** `jobQueueProcessor.start()` — the cleanup handler registration is inline in `createDaemonApp` (not in a subsystem `start()` method), but must still follow the same ordering rule: all `jobQueueProcessor.register()` calls complete before `jobQueueProcessor.start()` begins polling.
+- Handler: (1) calls `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` to prune old `job_queue` rows; (2) deletes `github_processed_events` rows older than 30 days
 - Self-rescheduling `finally` block (same pattern as `github.poll`). Must include dedup to prevent cleanup chain multiplication if two `job_queue.cleanup` jobs are ever simultaneously present:
   ```typescript
   finally {
@@ -548,11 +563,16 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
     // Without dedup, if two cleanup jobs somehow run concurrently (e.g., crash during
     // startup before dedup check), each job's finally would create an extra next-day
     // cleanup, doubling the chain — same pattern as github.poll (now fixed).
+    //
+    // Accepted race: this is a check-then-enqueue sequence (not atomic). Two concurrent
+    // workers could both observe "no future cleanup" and both enqueue. The duplicate is
+    // harmless (idempotent cleanup), and the dedup guard on the next finally re-collapses
+    // to a singleton. True atomic dedup would require a DB-level UNIQUE constraint.
     const now = Date.now();
     const existingCleanup = jobQueueRepo.listJobs({
       queue: QUEUES.JOB_QUEUE_CLEANUP,
       status: ['pending'],
-      limit: 10,
+      limit: 1, // existence check only — limit:1 is sufficient and semantically clearer
     }).find(j => j.runAt !== null && j.runAt > now);
     if (!existingCleanup) {
       jobQueueRepo.enqueue({

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -25,7 +25,7 @@ The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProces
 - `GitHubPollingService` still uses `setInterval` for polling; in-memory etag/state only
 - `event-normalizer.ts` uses `crypto.randomUUID()` for event IDs (non-deterministic)
 - GitHub webhook handler processes events directly (no job enqueue)
-- `RoomRuntime` still uses `setInterval` heartbeat (line ~305) + `queueMicrotask` tick scheduling (lines ~2021 and ~3180) — 19 `scheduleTick()` call sites throughout the 3233-line file
+- `RoomRuntime` still uses `setInterval` heartbeat (line ~305) + `queueMicrotask` tick scheduling (lines ~2021 and ~3180) — 24 `scheduleTick()` call sites throughout the 3233-line file
 - `stopRuntime()` in `RoomRuntimeService` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)` — heartbeat liveness guard requires this fix
 - No `github_processed_events` or `github_poll_state` DB tables
 
@@ -84,13 +84,14 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy.
 
-4. **Shutdown ordering**: The current `cleanup()` sequence is `messageHub.cleanup()` → `liveQueries.dispose()` → `rpcHandlerCleanup()` → `gitHubService.stop()` → `await sessionManager.cleanup()`. Add `await jobQueueProcessor.stop()` **before** both `messageHub.cleanup()` and `rpcHandlerCleanup()`. In-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
+4. **Shutdown ordering**: The current `cleanup()` sequence is `messageHub.cleanup()` → `liveQueries.dispose()` → `rpcHandlerCleanup()` → `gitHubService.stop()` → `await taskAgentManager.cleanupAll()` → `await sessionManager.cleanup()`. Add `await jobQueueProcessor.stop()` **before** both `messageHub.cleanup()` and `rpcHandlerCleanup()`. In-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
    ```typescript
    await jobQueueProcessor.stop(); // drain all in-flight job handlers first
    messageHub.cleanup();           // safe: no in-flight jobs remain
    liveQueries.dispose();
    rpcHandlerCleanup();            // stops RoomRuntimeService (clears runtimes map)
    if (gitHubService) gitHubService.stop();
+   await taskAgentManager.cleanupAll();
    await sessionManager.cleanup();
    ```
 
@@ -125,6 +126,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
    liveQueries.dispose();
    rpcHandlerCleanup();            // stops RoomRuntimeService (via rpc-handlers cleanup)
    if (gitHubService) gitHubService.stop();
+   await taskAgentManager.cleanupAll();
    await sessionManager.cleanup();
    ```
 7. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts` with the idempotency strategy documented in comments:
@@ -381,14 +383,14 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 
 **`RoomRuntime` has two tick trigger paths** — both must be migrated:
 1. `setInterval(() => this.tick(), this.tickInterval)` at line ~305 — periodic heartbeat. Default interval is 30 seconds (`this.tickInterval = config.tickInterval ?? 30_000` at line ~263).
-2. `scheduleTick()` at line ~3179 (method definition): `queueMicrotask(() => this.tick())` — event-driven immediate trigger. There are **19 call sites** of `scheduleTick()` throughout the 3233-line file. All 19 call sites must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
+2. `scheduleTick()` at line ~3179 (method definition): `queueMicrotask(() => this.tick())` — event-driven immediate trigger. There are **24 call sites** of `scheduleTick()` throughout the 3233-line file. All 24 call sites must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
 3. Tick mutex drain at line ~2021: inside `tick()`'s `finally` block — `if (this.tickQueued) { this.tickQueued = false; queueMicrotask(() => this.tick()); }`. This `queueMicrotask` must also be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`.
 4. Recovery paths via `runtime-recovery.ts`: that file calls `runtime.onWorkerTerminalState()` and `runtime.onLeaderTerminalState()`, which internally call `this.scheduleTick()`. No changes are needed to `runtime-recovery.ts` itself — replacing `scheduleTick()` in `room-runtime.ts` automatically covers the recovery paths.
 
 **`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~115).
 
 **Migration approach**:
-- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes all 19 `scheduleTick()` call sites, the `scheduleTick()` method definition at line ~3179, and the tick mutex drain `queueMicrotask` at line ~2021. All must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
+- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes all 24 `scheduleTick()` call sites, the `scheduleTick()` method definition at line ~3179, and the tick mutex drain `queueMicrotask` at line ~2021. All must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
 - No `scheduleHeartbeat()` method exists in `RoomRuntimeService` — no removal needed.
 - **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
   1. Add `private stoppedRooms: Set<string> = new Set()` field.
@@ -531,7 +533,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
-- `setInterval`, `tickTimer`, `scheduleTick()` method definition (at ~line 3179), and all `queueMicrotask` calls (all 19 `scheduleTick()` call sites throughout the file, plus the tick mutex drain at line ~2021) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
+- `setInterval`, `tickTimer`, `scheduleTick()` method definition (at ~line 3179), and all `queueMicrotask` calls (all 24 `scheduleTick()` call sites throughout the file, plus the tick mutex drain at line ~2021) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface (line ~115).
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
@@ -664,7 +666,7 @@ Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged
 | `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 |
-| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 — 3233 lines; setInterval at ~305; scheduleTick() definition at ~3179 (19 call sites); queueMicrotask tick mutex drain at ~2021; tickInterval defaults to 30_000ms at ~263 |
+| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 — 3233 lines; setInterval at ~305; scheduleTick() definition at ~3179 (24 call sites); queueMicrotask tick mutex drain at ~2021; tickInterval defaults to 30_000ms at ~263 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — no direct changes; covered by `scheduleTick()` replacement in `room-runtime.ts` |
 | `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -7,9 +7,27 @@ The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProces
 ## Current State
 
 ### Implemented (ready to use)
-- `packages/daemon/src/storage/repositories/job-queue-repository.ts` — CRUD on `job_queue` SQLite table
-- `packages/daemon/src/storage/job-queue-processor.ts` — background polling loop with handler registry, retry/backoff, stale reclaim
+
+- `packages/daemon/src/storage/repositories/job-queue-repository.ts` — CRUD on `job_queue` SQLite table; `listJobs(filter)` accepts single `status?: JobStatus` (does NOT yet support array form — Task 1 adds that)
+- `packages/daemon/src/storage/job-queue-processor.ts` — background polling loop; `register(queue, handler)`, `start()`, `stop()`, `tick()`, `setChangeNotifier()`; default `maxConcurrent: 1` (Task 1 overrides to 3)
+- `packages/daemon/src/storage/index.ts` — `Database` facade exposes `getJobQueueRepo(): JobQueueRepository` at line ~402
+- `job_queue` table created by schema migration (`packages/daemon/src/storage/schema/index.ts` ~line 307); indexes on `(queue, status, priority DESC, run_at ASC)` and `(status)`
 - Comprehensive unit tests in `packages/daemon/tests/unit/storage/`
+
+### NOT yet wired or implemented
+
+- `JobQueueProcessor` is never instantiated in `app.ts` — processor never starts
+- No queue name constants file
+- `JobQueueRepository.listJobs()` does not accept `status` as an array
+- `setupRPCHandlers` deps do not include `jobQueueProcessor` or `jobQueueRepo`
+- `SessionManager` still uses `pendingBackgroundTasks: Set<Promise<unknown>>` for title generation; no `start()` method; no persistent queue
+- `session-lifecycle.ts` has no `generateTitleOnly()` method
+- `GitHubPollingService` still uses `setInterval` for polling; in-memory etag/state only
+- `event-normalizer.ts` uses `crypto.randomUUID()` for event IDs (non-deterministic)
+- GitHub webhook handler processes events directly (no job enqueue)
+- `RoomRuntime` still uses `setInterval` heartbeat (line ~305) + `queueMicrotask` tick scheduling (lines ~2021 and ~3180) — 19 `scheduleTick()` call sites throughout the 3233-line file
+- `stopRuntime()` in `RoomRuntimeService` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)` — heartbeat liveness guard requires this fix
+- No `github_processed_events` or `github_poll_state` DB tables
 
 ### Full inventory of in-memory patterns and disposition
 
@@ -40,7 +58,7 @@ All queue handlers must be idempotent. Agreed per-queue strategy:
 ```typescript
 new JobQueueProcessor(db.getJobQueueRepo(), {
   pollIntervalMs: 1000,      // 1 second (ADR default)
-  maxConcurrent: 3,          // 3 concurrent jobs (ADR default)
+  maxConcurrent: 3,          // 3 concurrent jobs (ADR default; processor default is 1 — must be overridden)
   staleThresholdMs: 300_000, // 5 minutes (ADR recommendation; room ticks may take >1s)
 })
 ```
@@ -60,17 +78,19 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 **Important architectural notes**:
 
-1. **`createDaemonApp` is a factory function, not a class.** There are no `start()`/`stop()` methods. The shutdown entry point is the `cleanup()` closure defined inside the factory (line ~321 of `app.ts`).
+1. **`createDaemonApp` is a factory function, not a class.** There are no `start()`/`stop()` methods. The shutdown entry point is the `cleanup()` closure defined inside the factory.
 
-2. **`RoomRuntimeService` lives inside `setupRPCHandlers`, not `createDaemonApp` directly.** It is constructed at `packages/daemon/src/lib/rpc-handlers/index.ts` line 105. The plan accounts for this by passing `jobQueueProcessor` and `jobQueueRepo` as additional fields in the `deps` object passed to `setupRPCHandlers`. `setupRPCHandlers` passes them to the `RoomRuntimeService` constructor. No lifting of `RoomRuntimeService` into `createDaemonApp` is required.
+2. **`RoomRuntimeService` lives inside `setupRPCHandlers`, not `createDaemonApp` directly.** It is constructed at `packages/daemon/src/lib/rpc-handlers/index.ts`. The plan accounts for this by passing `jobQueueProcessor` and `jobQueueRepo` as additional fields in the `deps` object passed to `setupRPCHandlers`. Note: `db` is already in `RPCHandlerDependencies` and already passed at `app.ts` line ~220 — `jobQueueProcessor` and `jobQueueRepo` are added as explicit fields alongside it (not derived from `db` inside `setupRPCHandlers`). `setupRPCHandlers` passes them to the `RoomRuntimeService` constructor.
 
-3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy (see Task 4).
+3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy.
 
-4. **Shutdown ordering**: In the `cleanup()` closure, add `await jobQueueProcessor.stop()` **before** both `rpcHandlerCleanup()` and `messageHub.cleanup()`. `app.ts` currently calls `messageHub.cleanup()` before `rpcHandlerCleanup()` (line ~369); in-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
+4. **Shutdown ordering**: The current `cleanup()` sequence is `messageHub.cleanup()` → `liveQueries.dispose()` → `rpcHandlerCleanup()` → `gitHubService.stop()` → `await sessionManager.cleanup()`. Add `await jobQueueProcessor.stop()` **before** both `messageHub.cleanup()` and `rpcHandlerCleanup()`. In-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
    ```typescript
    await jobQueueProcessor.stop(); // drain all in-flight job handlers first
    messageHub.cleanup();           // safe: no in-flight jobs remain
+   liveQueries.dispose();
    rpcHandlerCleanup();            // stops RoomRuntimeService (clears runtimes map)
+   if (gitHubService) gitHubService.stop();
    await sessionManager.cleanup();
    ```
 
@@ -78,7 +98,7 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 a. Extend `JobQueueRepository.listJobs()` to accept `status?: JobStatus | JobStatus[]`. When an array is passed, generate `AND status IN (?,?)` SQL. This is needed for the room tick dedup query in Task 4.
 
-b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inject the repository separately: each subsystem receives both `jobQueueProcessor` (for `register()`) and `jobQueueRepo` (for `enqueue()` and `listJobs()`). Both are available from the `db` facade via `db.getJobQueueRepo()`.
+b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inject the repository separately: each subsystem receives both `jobQueueProcessor` (for `register()`) and `jobQueueRepo` (for `enqueue()` and `listJobs()`). Both are available from `db.getJobQueueRepo()`.
 
 **Steps**:
 1. Obtain `jobQueueRepo = db.getJobQueueRepo()` and instantiate:
@@ -86,7 +106,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
    const jobQueueRepo = db.getJobQueueRepo();
    const jobQueueProcessor = new JobQueueProcessor(jobQueueRepo, {
      pollIntervalMs: 1000,
-     maxConcurrent: 3,
+     maxConcurrent: 3,          // override default of 1
      staleThresholdMs: 300_000,
    });
    ```
@@ -102,7 +122,9 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
    // cleanup():
    await jobQueueProcessor.stop(); // drain in-flight jobs first (handlers may call notifyChange)
    messageHub.cleanup();           // safe: no in-flight jobs remain
+   liveQueries.dispose();
    rpcHandlerCleanup();            // stops RoomRuntimeService (via rpc-handlers cleanup)
+   if (gitHubService) gitHubService.stop();
    await sessionManager.cleanup();
    ```
 7. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts` with the idempotency strategy documented in comments:
@@ -115,14 +137,14 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
      JOB_QUEUE_CLEANUP: 'job_queue.cleanup',
    } as const;
    ```
-8. Each subsystem registers queue handlers in its own `start()` method. These `start()` calls happen before `jobQueueProcessor.start()` to guarantee handlers are registered before polling begins.
+8. Each subsystem registers queue handlers in its own `start()` method. The `JOB_QUEUE_CLEANUP` handler is an exception — it is registered inline in `createDaemonApp` before `jobQueueProcessor.start()`, not in a subsystem `start()`.
 
 **Acceptance criteria**:
-- `JobQueueProcessor` is instantiated; subsystem `start()` methods are called after `setupRPCHandlers` but **before** `jobQueueProcessor.start()` to guarantee all handlers are registered before polling begins.
+- `JobQueueProcessor` is instantiated with `maxConcurrent: 3` (overriding processor default of 1); subsystem `start()` methods are called **before** `jobQueueProcessor.start()` to guarantee all handlers are registered before polling begins.
 - `await jobQueueProcessor.stop()` is in the `cleanup()` closure before both `messageHub.cleanup()` and `rpcHandlerCleanup()` — ensures in-flight job handlers that call `notifyChange()` complete before `messageHub` is torn down.
 - Change notifier connected to `ReactiveDatabase`.
 - `listJobs` extended to accept `status?: JobStatus | JobStatus[]`.
-- `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object; `RPCHandlerDependencies` TypeScript interface updated to include both fields.
+- `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object; `RPCHandlerDependencies` TypeScript interface updated to include both fields (alongside the already-present `db` field).
 - Queue name constants exported from `job-queue-constants.ts`.
 - Unit test verifies processor starts and stops correctly; confirms `stop()` is awaited before `rpcHandlerCleanup()`.
 - All existing `JobQueueRepository` and `JobQueueProcessor` unit tests still pass.
@@ -143,7 +165,7 @@ Replace the fire-and-forget title generation + git branch rename in `SessionMana
 - `packages/daemon/src/lib/session/session-manager.ts` — add a `start()` lifecycle method (does not currently exist); enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set. `createDaemonApp` calls `sessionManager.start()` **before** `jobQueueProcessor.start()` (see Task 1 step 4: all subsystem `start()` methods registered before processor begins polling).
 - `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (no extraction needed; already a method on `SessionLifecycle`) in the job handler
 
-**Behavioral change**: Currently the `message.persisted` event handler does `await titleGenTask` (line 162 of `session-manager.ts`), blocking until title generation completes. After this migration the handler enqueues a job synchronously and returns immediately. This is the intended change — the handler must NOT await title generation; the job queue provides durability instead.
+**Behavioral change**: Currently the `message.persisted` event handler does `await titleGenTask` (line ~162 of `session-manager.ts`), blocking until title generation completes. After this migration the handler enqueues a job synchronously and returns immediately. This is the intended change — the handler must NOT await title generation; the job queue provides durability instead.
 
 **Handler registration** via constructor injection (`SessionManager` receives `jobQueueProcessor` and `jobQueueRepo`):
 ```typescript
@@ -155,12 +177,11 @@ start(): void {
     // IMPORTANT: Do NOT use session.title !== null — sessions are always created with a
     // placeholder title ('New Session'), so that check is ALWAYS true and would silently
     // skip every job. The correct flag is session.metadata.titleGenerated (set to true
-    // by generateTitleAndRenameBranch / generateTitleOnly on completion).
-    // NOTE: this.sessionRepo.getSession() is illustrative pseudocode. SessionManager
-    // does not have a sessionRepo field with a getSession() method. The implementor
-    // must use the actual SessionManager API to fetch session data (e.g., the session
-    // store, cache lookup, or whichever method SessionManager exposes for reading a
-    // session by ID). The key requirement is reading session.metadata.titleGenerated.
+    // by generateTitleAndRenameBranch / generateTitleOnly on successful AI generation).
+    // NOTE: The session fetch below is illustrative pseudocode. SessionManager does not
+    // have a sessionRepo.getSession() method. The implementor must use the actual
+    // SessionManager API to fetch session data (e.g., the session store, cache lookup,
+    // or whichever method SessionManager exposes for reading a session by ID).
     const session = /* actual SessionManager session fetch by sessionId */ ...;
     if (!session || session.metadata.titleGenerated) return;
     if (this.sessionCache.has(sessionId)) {
@@ -180,7 +201,7 @@ start(): void {
 - **Cache hit**: calls the full `generateTitleAndRenameBranch` (title + branch rename)
 - **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache.
 
-**`titleGenerated` flag semantics**: Both `generateTitleAndRenameBranch` and `generateTitleOnly` must set `session.metadata.titleGenerated = true` **only on successful AI title generation** — not unconditionally. This is consistent with the existing `titleGenerated: !isFallback` pattern: if the AI generation fails and a fallback title is used, `titleGenerated` remains `false` so the job can be retried with a real AI title later. Do NOT check `session.title !== null` as the idempotency guard — that is always `true` since sessions are created with a placeholder title.
+**`titleGenerated` flag semantics**: Both `generateTitleAndRenameBranch` and `generateTitleOnly` must set `session.metadata.titleGenerated = true` **only on successful AI title generation** — not unconditionally. This is consistent with the existing `titleGenerated: !isFallback` pattern at `session-lifecycle.ts` line ~663: if the AI generation fails and a fallback title is used, `titleGenerated` remains `false` so the job can be retried with a real AI title later. Do NOT check `session.title !== null` as the idempotency guard — that is always `true` since sessions are created with a placeholder title.
 
 Job payload: `{ sessionId: string, userMessageText: string }`
 
@@ -231,7 +252,7 @@ Replace the in-memory GitHub event pipeline with a persistent job queue so event
    CREATE INDEX idx_github_processed_events_at ON github_processed_events(processed_at);
    ```
 
-2. `github_poll_state` table (replaces in-memory etags/timestamps; the existing `global_settings` table is a single JSON blob and is not suitable for per-repo structured state). Note: `polling-service.ts` tracks two separate ETags per repo (`issuesEtag` and `commentsEtag` at lines 26–27), so the schema needs two separate columns:
+2. `github_poll_state` table (replaces in-memory etags/timestamps; the existing `global_settings` table is a single JSON blob and is not suitable for per-repo structured state). Note: `polling-service.ts` tracks two separate ETags per repo (`issuesEtag` and `commentsEtag`), so the schema needs two separate columns:
    ```sql
    CREATE TABLE github_poll_state (
      repo_full_name TEXT PRIMARY KEY,
@@ -241,12 +262,12 @@ Replace the in-memory GitHub event pipeline with a persistent job queue so event
    );
    ```
 
-**Stable event IDs for polled events**: The current `generateEventId()` in `event-normalizer.ts` produces a UUID, which is non-stable across restarts — the same polled event gets a different ID on re-poll, making `github_processed_events` ineffective. Task 3 must update `normalizePollingEvent` (and the individual `normalizeIssuePolling`, `normalizeCommentPolling`, `normalizePullRequestPolling` functions) to generate deterministic IDs:
+**Stable event IDs for polled events**: The current `generateEventId()` in `event-normalizer.ts` produces a `crypto.randomUUID()`, which is non-stable across restarts — the same polled event gets a different ID on re-poll, making `github_processed_events` ineffective. Task 3 must update `normalizePollingEvent` (and the individual `normalizeIssuePolling`, `normalizeCommentPolling`, `normalizePullRequestPolling` functions) to generate deterministic IDs:
 - Issues: `{fullName}/issues/{issueNumber}/{updatedAt}`
 - Comments: `{fullName}/comments/{commentId}/{updatedAt}`
 - Pull requests: `{fullName}/pulls/{prNumber}/{updatedAt}`
 
-Webhook events have a stable `X-GitHub-Delivery` delivery ID available in `webhook-handler.ts` (line ~141), but **the current `normalizeWebhookEvent` in `event-normalizer.ts` calls `generateEventId()` which returns a random UUID — not the delivery ID**. The delivery ID is not forwarded to the normalizer. To fix this, the webhook handler must pass the `X-GitHub-Delivery` header value directly as the `eventId` field in the `github.event` job payload, bypassing the normalizer's `generateEventId()`:
+Webhook events have a stable `X-GitHub-Delivery` delivery ID available in `webhook-handler.ts`, but **the current `normalizeWebhookEvent` in `event-normalizer.ts` calls `generateEventId()` which returns a random UUID — not the delivery ID**. The delivery ID is not forwarded to the normalizer. To fix this, the webhook handler must pass the `X-GitHub-Delivery` header value directly as the `eventId` field in the `github.event` job payload, bypassing the normalizer's `generateEventId()`:
 ```typescript
 // webhook-handler.ts, when enqueueing the github.event job:
 const deliveryId = req.header('X-GitHub-Delivery');
@@ -286,15 +307,14 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
          //
          // Accepted race: this is a check-then-enqueue sequence. Two workers could both
          // observe "no future job exists" and both enqueue, momentarily doubling the chain.
-         // This is an accepted risk (same as the room tick dedup path): the duplicate is
-         // idempotent (extra poll cycle causes no harm), true atomic dedup would require a
-         // DB-level UNIQUE constraint, and the `github.poll` singleton is recovered by the
-         // dedup guard on the next finally.
+         // This is an accepted risk: the duplicate is idempotent (extra poll cycle causes
+         // no harm), true atomic dedup would require a DB-level UNIQUE constraint, and the
+         // github.poll singleton is recovered by the dedup guard on the next finally.
          const now = Date.now();
          const existingPoll = jobQueueRepo.listJobs({
            queue: QUEUES.GITHUB_POLL,
            status: ['pending'],
-           limit: 1, // existence check only — limit:1 is sufficient and semantically clearer
+           limit: 1, // existence check only
          }).find(j => j.runAt !== null && j.runAt > now);
          if (!existingPoll) {
            jobQueueRepo.enqueue({
@@ -317,7 +337,7 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
 
 4. `packages/daemon/src/lib/github/webhook-handler.ts`:
    - Update webhook path to enqueue a `github.event` job instead of calling the pipeline directly
-   - Use the `X-GitHub-Delivery` header value (parsed at line ~141) as the `eventId` in the job payload — NOT `normalizeWebhookEvent`'s output `eventId` (which calls `generateEventId()` → random UUID, defeating idempotency)
+   - Use the `X-GitHub-Delivery` header value as the `eventId` in the job payload — NOT `normalizeWebhookEvent`'s output `eventId` (which calls `generateEventId()` → random UUID, defeating idempotency)
 
 Job payloads:
 - `github.poll`: `{}` (singleton sentinel)
@@ -340,7 +360,7 @@ For `github.event`: INSERT-first idempotency requires `maxRetries: 0`. With `max
 - Repository registrations restored from `GitHubMappingRepository` on `start()`.
 - Same event cannot be processed twice: INSERT-first strategy (`INSERT OR IGNORE` at job start, skip pipeline if row already existed) is concurrency-safe with `maxConcurrent: 3`.
 - `github.event` jobs use `maxRetries: 0` (at-most-once delivery). This is required because INSERT-first + retry would cause permanent silent event drops: a retry sees the existing row and skips the pipeline. GitHub webhooks retry on their own; polled events reappear on next poll cycle.
-- `github.poll` re-scheduling uses `finally` block with dedup (only enqueues if no future-scheduled poll already exists) — polling never permanently stalls after handler error, and the poll chain never multiplies if duplicate `github.poll` jobs are ever present (modulo fatal SQLite failure, accepted risk).
+- `github.poll` re-scheduling uses `finally` block with dedup (only enqueues if no future-scheduled poll already exists) and accepted-race documentation — polling never permanently stalls after handler error, and the poll chain never multiplies if duplicate `github.poll` jobs are ever present (modulo fatal SQLite failure, accepted risk).
 - Enqueued `github.event` jobs survive daemon restart.
 - DB migration for `github_processed_events` and `github_poll_state` tables is included and applied at daemon startup.
 - Webhook requests missing `X-GitHub-Delivery` header are rejected with HTTP 400 (fallback UUID would disable idempotency).
@@ -360,20 +380,21 @@ For `github.event`: INSERT-first idempotency requires `maxRetries: 0`. With `max
 Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMicrotask`) immediate-trigger in `RoomRuntime` with persistent `room.tick` jobs.
 
 **`RoomRuntime` has two tick trigger paths** — both must be migrated:
-1. `setInterval(() => this.tick(), this.tickInterval)` (~line 205) — periodic heartbeat
-2. `scheduleTick()` (~line 1550): `queueMicrotask(() => this.tick())` — event-driven immediate trigger with 9+ call sites (goal created, task updated, worker/leader terminal states, leader tool calls, etc.)
-3. Recovery paths via `runtime-recovery.ts`: that file calls `runtime.onWorkerTerminalState()` (line 153) and `runtime.onLeaderTerminalState()` (line 194), which internally call `this.scheduleTick()`. No changes are needed to `runtime-recovery.ts` itself — replacing `scheduleTick()` in `room-runtime.ts` automatically covers the recovery paths.
+1. `setInterval(() => this.tick(), this.tickInterval)` at line ~305 — periodic heartbeat. Default interval is 30 seconds (`this.tickInterval = config.tickInterval ?? 30_000` at line ~263).
+2. `scheduleTick()` at line ~3179 (method definition): `queueMicrotask(() => this.tick())` — event-driven immediate trigger. There are **19 call sites** of `scheduleTick()` throughout the 3233-line file. All 19 call sites must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
+3. Tick mutex drain at line ~2021: inside `tick()`'s `finally` block — `if (this.tickQueued) { this.tickQueued = false; queueMicrotask(() => this.tick()); }`. This `queueMicrotask` must also be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`.
+4. Recovery paths via `runtime-recovery.ts`: that file calls `runtime.onWorkerTerminalState()` and `runtime.onLeaderTerminalState()`, which internally call `this.scheduleTick()`. No changes are needed to `runtime-recovery.ts` itself — replacing `scheduleTick()` in `room-runtime.ts` automatically covers the recovery paths.
 
-**`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~76).
+**`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~115).
 
 **Migration approach**:
-- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes the main `scheduleTick()` at line ~1550 **and** an additional `queueMicrotask(() => this.tick())` at line ~954 inside the tick mutex path — both must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
-- Remove the `scheduleHeartbeat()` method (if present) from `RoomRuntimeService` — it uses `setInterval`/`setTimeout` internally and is superseded by the `finally`-based heartbeat in the tick handler.
-- **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` (line 83) does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
+- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes all 19 `scheduleTick()` call sites, the `scheduleTick()` method definition at line ~3179, and the tick mutex drain `queueMicrotask` at line ~2021. All must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
+- No `scheduleHeartbeat()` method exists in `RoomRuntimeService` — no removal needed.
+- **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
   1. Add `private stoppedRooms: Set<string> = new Set()` field.
   2. `stopRuntime(roomId)` must call `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`.
-  3. **`startRuntime(roomId)` (at `room-runtime-service.ts:94`) must call `this.stoppedRooms.delete(roomId)` before creating the new runtime** — this clears the stopped marker when a room is restarted. Without this, a stop-then-restart sequence leaves `stoppedRooms` containing the `roomId`; any subsequent tick job hits `stoppedRooms.has(roomId) → true` and returns immediately, permanently preventing the restarted room from ever ticking. Also prevents `stoppedRooms` from growing unbounded across the daemon lifetime.
-  4. The tick handler's `!runtime` branch must check `this.stoppedRooms.has(roomId)` as the **first** check and return without re-enqueueing. Without this, when a tick job fires after `stopRuntime()` was called, the `!runtime` branch sees the room exists in DB and re-enqueues indefinitely (the perpetual churn loop).
+  3. **`startRuntime(roomId)` must call `this.stoppedRooms.delete(roomId)` before creating the new runtime** — this clears the stopped marker when a room is restarted. Note: `startRuntime()` already calls `this.runtimes.delete(roomId)` on the old runtime at line ~143 before creating a fresh one; the `stoppedRooms.delete()` call should be added alongside it. Without `stoppedRooms.delete()`, a stop-then-restart sequence leaves `stoppedRooms` containing the `roomId`; any subsequent tick job hits `stoppedRooms.has(roomId) → true` and returns immediately, permanently preventing the restarted room from ever ticking. Also prevents `stoppedRooms` from growing unbounded across the daemon lifetime.
+  4. The tick handler's `!runtime` branch must check `this.stoppedRooms.has(roomId)` as the **first** check and return without re-enqueueing.
   5. After `stopRuntime()` deletes from the map, `this.runtimes.has(roomId)` in the heartbeat `finally` block correctly returns `false` for stopped rooms, making the liveness check effective for both individual stops and full shutdown.
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
@@ -415,8 +436,8 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     // complexity not warranted at current scale.
   }
   ```
-- Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
-- After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` block must first check `this.runtimes.has(roomId)` — if the runtime was stopped while the tick was in-flight, do NOT enqueue a heartbeat (otherwise the chain loops indefinitely via re-enqueue-on-miss). The heartbeat enqueue deduplicates against existing pending future-scheduled jobs (`runAt > now`) to prevent heartbeat chain multiplication. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
+- Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`, and replace the tick mutex drain `queueMicrotask(() => this.tick())` at line ~2021 with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`
+- After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` block must first check `this.runtimes.has(roomId)` — if the runtime was stopped while the tick was in-flight (i.e., `stopRuntime()` was called, which now also deletes from the map), this returns `false` and no heartbeat is enqueued. The heartbeat enqueue deduplicates against existing pending future-scheduled jobs (`runAt > now`) to prevent heartbeat chain multiplication. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
@@ -458,16 +479,14 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       // Heartbeat: schedule a future tick if (a) runtime is still tracked AND
       // (b) no future-scheduled heartbeat already exists.
       //
-      // CRITICAL: Check this.runtimes.has(roomId) first. stopRuntime() must call
+      // CRITICAL: Check this.runtimes.has(roomId) first. stopRuntime() is required to call
       // this.runtimes.delete(roomId) (see migration approach above — this is a required
-      // fix to the existing stopRuntime() implementation at room-runtime-service.ts:83).
-      // After that fix, this.runtimes.has(roomId) correctly returns false for stopped
-      // rooms, making this liveness check effective for individual room stops as well as
-      // full shutdown (runtimes.clear()). Without stopRuntime() deleting from the map,
-      // this check would always be true for stopped rooms and the heartbeat would chain
-      // indefinitely. The stoppedRooms check in the !runtime branch above handles the
-      // symmetric case where the tick handler fires after stopRuntime() but the finally
-      // block hasn't been reached yet.
+      // fix to the existing stopRuntime() implementation). After the fix, this.runtimes.has(roomId)
+      // correctly returns false for stopped rooms, making this liveness check effective.
+      // Without stopRuntime() deleting from the map, this check would always be true for
+      // stopped rooms and the heartbeat would chain indefinitely. The stoppedRooms check
+      // in the !runtime branch above handles the symmetric case where the tick handler
+      // fires after stopRuntime() but the finally block hasn't been reached yet.
       //
       // maxRetries: 0 is required: with the finally pattern, processor retries would
       // each also fire finally, creating duplicate heartbeat jobs (job multiplication).
@@ -504,20 +523,21 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **Shutdown ordering** (in `app.ts` cleanup closure — see Task 1 step 6):
 1. `await jobQueueProcessor.stop()` — drains in-flight tick jobs (handlers may emit notifyChange)
 2. `messageHub.cleanup()` — safe: no in-flight jobs remain
-3. `rpcHandlerCleanup()` — stops `RoomRuntimeService` (clears `runtimes` map)
-4. `await sessionManager.cleanup()`
+3. `liveQueries.dispose()`
+4. `rpcHandlerCleanup()` — stops `RoomRuntimeService` (clears `runtimes` map)
+5. `if (gitHubService) gitHubService.stop()`
+6. `await sessionManager.cleanup()`
 
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
-- `setInterval`, `tickTimer`, `scheduleTick()`, and all `queueMicrotask` calls (including the one at line ~954 in the tick mutex path) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
+- `setInterval`, `tickTimer`, `scheduleTick()` method definition (at ~line 3179), and all `queueMicrotask` calls (all 19 `scheduleTick()` call sites throughout the file, plus the tick mutex drain at line ~2021) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
-- `scheduleHeartbeat()` method (if present) removed from `RoomRuntimeService` — replaced by the `finally`-based heartbeat in the tick handler.
-- `jobQueueRepo` added to `RoomRuntimeConfig` interface.
+- `jobQueueRepo` added to `RoomRuntimeConfig` interface (line ~115).
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
-- Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error. The `finally` block checks `this.runtimes.has(roomId)` before enqueueing: if the runtime was stopped while the tick was in-flight, skip re-enqueue to prevent the indefinite re-enqueue-on-miss loop.
-- `stopRuntime()` in `RoomRuntimeService` (line 83) calls `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`. Without `runtimes.delete()`, `this.runtimes.has(roomId)` returns `true` for stopped rooms and the heartbeat liveness check is ineffective for individual room stops.
-- `startRuntime()` in `RoomRuntimeService` (at line 94) calls `this.stoppedRooms.delete(roomId)` before creating the new runtime. Without this, a stop-then-restart sequence permanently suppresses ticking for the restarted room (stale `stoppedRooms` entry causes the tick handler to return early indefinitely).
+- Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error. The `finally` block checks `this.runtimes.has(roomId)` before enqueueing: if the runtime was stopped while the tick was in-flight (and `stopRuntime()` has deleted from the map per the fix above), skip re-enqueue to prevent the indefinite re-enqueue-on-miss loop.
+- `stopRuntime()` in `RoomRuntimeService` calls `this.runtimes.delete(roomId)` AND `this.stoppedRooms.add(roomId)`. Without `runtimes.delete()`, `this.runtimes.has(roomId)` returns `true` for stopped rooms and the heartbeat liveness check is ineffective for individual room stops.
+- `startRuntime()` in `RoomRuntimeService` calls `this.stoppedRooms.delete(roomId)` alongside the existing `runtimes.delete()` call at line ~143. Without this, a stop-then-restart sequence permanently suppresses ticking for the restarted room (stale `stoppedRooms` entry causes the tick handler to return early indefinitely).
 - `private stoppedRooms: Set<string> = new Set()` field added to `RoomRuntimeService`.
 - Tick handler's `!runtime` branch checks `this.stoppedRooms.has(roomId)` as the first check and returns without re-enqueueing for explicitly stopped rooms (prevents perpetual churn when a tick fires after `stopRuntime()`).
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
@@ -542,7 +562,7 @@ Add integration/online tests validating job persistence and idempotency, add a s
 
 **Online/integration tests** (`packages/daemon/tests/online/`):
 
-Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer()` function (lines 78–189) that spawns a real child process, selectable via `DAEMON_TEST_SPAWN=true`. However, the crash-recovery scenarios below use in-process processor stop/start rather than real process kill, which is sufficient to verify SQLite job persistence (persistence is process-independent) and avoids the complexity of spawned-process lifecycle in test setup.
+Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer()` function that spawns a real child process, selectable via `DAEMON_TEST_SPAWN=true`. However, the crash-recovery scenarios below use in-process processor stop/start rather than real process kill, which is sufficient to verify SQLite job persistence (persistence is process-independent) and avoids the complexity of spawned-process lifecycle in test setup.
 
 1. **Session title generation persistence**: enqueue a `session.title_generation` job, stop and restart the processor in-process, verify the job is picked up and the title is set exactly once.
 2. **GitHub event idempotency**: enqueue the same `github.event` job payload twice (same `eventId`); verify it is processed exactly once (check `github_processed_events` table has one row).
@@ -572,7 +592,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
     const existingCleanup = jobQueueRepo.listJobs({
       queue: QUEUES.JOB_QUEUE_CLEANUP,
       status: ['pending'],
-      limit: 1, // existence check only — limit:1 is sufficient and semantically clearer
+      limit: 1, // existence check only
     }).find(j => j.runAt !== null && j.runAt > now);
     if (!existingCleanup) {
       jobQueueRepo.enqueue({
@@ -608,6 +628,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
 - Scheduled cleanup job self-reschedules via `finally` block with dedup (only enqueues if no future-scheduled cleanup already exists) and `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); dedup prevents cleanup chain multiplication if duplicate `job_queue.cleanup` jobs are ever present; verified by unit test.
 - Startup-time synchronous prune of `github_processed_events` rows older than **90 days** runs on daemon start **before** `jobQueueProcessor.start()`; verified by unit test. (90-day window provides safety margin; ongoing cleanup job prunes at 30 days. Risk of dedup gap for daemon offline > 90 days is accepted — at-most-once delivery is already the guarantee.)
+- First cleanup job enqueued at startup with `runAt = now + 24h` (not `now`); verified by unit test.
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
@@ -633,16 +654,17 @@ Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged
 |------|-----------|
 | `packages/daemon/src/app.ts` | Factory function with cleanup closure — Task 1 |
 | `packages/daemon/src/lib/rpc-handlers/index.ts` | `setupRPCHandlers` — where `RoomRuntimeService` is created; Task 1 adds `jobQueueProcessor`/`jobQueueRepo` to deps |
-| `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor — all tasks |
+| `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor (default maxConcurrent: 1 — override to 3 in Task 1) — all tasks |
 | `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository; `listJobs` extended for array status — Task 1 |
+| `packages/daemon/src/storage/index.ts` | `Database` facade; `getJobQueueRepo()` accessor at line ~402 — all tasks |
 | `packages/daemon/src/lib/job-queue-constants.ts` | New queue name constants — Task 1 |
 | `packages/daemon/src/lib/session/session-manager.ts` | Task 2 |
-| `packages/daemon/src/lib/session/session-lifecycle.ts` | Task 2 |
+| `packages/daemon/src/lib/session/session-lifecycle.ts` | Task 2; `titleGenerated: !isFallback` pattern at line ~663 |
 | `packages/daemon/src/lib/github/event-normalizer.ts` | Deterministic stable IDs for polled events — Task 3 |
 | `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 |
-| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 |
+| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 — 3233 lines; setInterval at ~305; scheduleTick() definition at ~3179 (19 call sites); queueMicrotask tick mutex drain at ~2021; tickInterval defaults to 30_000ms at ~263 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — no direct changes; covered by `scheduleTick()` replacement in `room-runtime.ts` |
 | `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -25,7 +25,7 @@ The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProces
 - `GitHubPollingService` still uses `setInterval` for polling; in-memory etag/state only
 - `event-normalizer.ts` uses `crypto.randomUUID()` for event IDs (non-deterministic)
 - GitHub webhook handler processes events directly (no job enqueue)
-- `RoomRuntime` still uses `setInterval` heartbeat (line ~305) + `queueMicrotask` tick scheduling (lines ~2021 and ~3180) — 24 `scheduleTick()` call sites throughout the 3233-line file
+- `RoomRuntime` still uses `setInterval` heartbeat (line ~422) + `queueMicrotask` tick scheduling (lines ~2241 and ~3421) — 17 `this.scheduleTick()` call sites throughout the 3474-line file; `scheduleTick()` method definition at line ~3418; `tickTimer` field at line ~157; `tickInterval` default at line ~275
 - `stopRuntime()` in `RoomRuntimeService` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)` — heartbeat liveness guard requires this fix
 - No `github_processed_events` or `github_poll_state` DB tables
 
@@ -82,7 +82,7 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 2. **`RoomRuntimeService` lives inside `setupRPCHandlers`, not `createDaemonApp` directly.** It is constructed at `packages/daemon/src/lib/rpc-handlers/index.ts`. The plan accounts for this by passing `jobQueueProcessor` and `jobQueueRepo` as additional fields in the `deps` object passed to `setupRPCHandlers`. Note: `db` is already in `RPCHandlerDependencies` and already passed at `app.ts` line ~220 — `jobQueueProcessor` and `jobQueueRepo` are added as explicit fields alongside it (not derived from `db` inside `setupRPCHandlers`). `setupRPCHandlers` passes them to the `RoomRuntimeService` constructor.
 
-3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy.
+3. **Startup ordering**: All handler registrations must complete before `jobQueueProcessor.start()` so no job is dequeued before its handler is registered. **`SessionManager.start()` does not exist yet — it is introduced in Task 2.** Task 1's implementor should call `roomRuntimeService.start()` and `githubService.start()` before `jobQueueProcessor.start()`. When Task 2 is implemented, it adds `sessionManager.start()` to this sequence (also before `jobQueueProcessor.start()`). Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy. **Critical: `RoomRuntimeService.start()` must register the `room.tick` handler synchronously (before any `await`) so it is guaranteed registered before `jobQueueProcessor.start()` is called.**
 
 4. **Shutdown ordering**: The current `cleanup()` sequence is `messageHub.cleanup()` → `liveQueries.dispose()` → `rpcHandlerCleanup()` → `gitHubService.stop()` → `await taskAgentManager.cleanupAll()` → `await sessionManager.cleanup()`. Add `await jobQueueProcessor.stop()` **before** both `messageHub.cleanup()` and `rpcHandlerCleanup()`. In-flight job handlers that call `notifyChange()` (which routes through `ReactiveDatabase` → `messageHub`) must complete before `messageHub` is torn down. The corrected cleanup sequence is:
    ```typescript
@@ -97,7 +97,7 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 **API extensions required** (implement alongside wiring):
 
-a. Extend `JobQueueRepository.listJobs()` to accept `status?: JobStatus | JobStatus[]`. When an array is passed, generate `AND status IN (?,?)` SQL. This is needed for the room tick dedup query in Task 4.
+a. Extend `JobQueueRepository.listJobs()` to accept `status?: JobStatus | JobStatus[]`. When an array is passed, generate `AND status IN (${placeholders})` SQL where the placeholder list is built dynamically from the array length (e.g. one-element array → `IN (?)`, two-element → `IN (?,?)`). An empty array should return no rows (add `AND 1=0` or treat as no-op returning `[]` — document the chosen behavior). When a single string is passed (backward-compatible), use the existing `AND status = ?` clause. This is needed for the `['pending', 'processing']` dedup queries in Tasks 3 and 4.
 
 b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inject the repository separately: each subsystem receives both `jobQueueProcessor` (for `register()`) and `jobQueueRepo` (for `enqueue()` and `listJobs()`). Both are available from `db.getJobQueueRepo()`.
 
@@ -116,7 +116,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
    jobQueueProcessor.setChangeNotifier((table) => reactiveDb.notifyChange(table));
    ```
 3. Add `jobQueueProcessor` and `jobQueueRepo` to the `deps` object passed to `setupRPCHandlers`.
-4. Call subsystem `start()` methods (`sessionManager.start()`, `roomRuntimeService.start()`, `githubService.start()`) **before** `jobQueueProcessor.start()` — this ensures all handlers are registered before the processor begins dequeuing.
+4. Call `roomRuntimeService.start()` and `githubService.start()` **before** `jobQueueProcessor.start()` — this ensures those handlers are registered before the processor begins dequeuing. (`sessionManager.start()` does not exist yet; Task 2 adds it and must also call it before `jobQueueProcessor.start()`.)
 5. Call `jobQueueProcessor.start()` after all subsystem `start()` calls.
 6. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure **before both** `messageHub.cleanup()` and `rpcHandlerCleanup()`:
    ```typescript
@@ -312,12 +312,23 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
          // This is an accepted risk: the duplicate is idempotent (extra poll cycle causes
          // no harm), true atomic dedup would require a DB-level UNIQUE constraint, and the
          // github.poll singleton is recovered by the dedup guard on the next finally.
+         //
+         // IMPORTANT — limit must be 1000, NOT 1. listJobs() sorts by created_at DESC.
+         // If a newer immediate job (runAt <= now) exists alongside an older future-scheduled
+         // job, limit:1 returns only the newest (immediate) job; the .find(runAt > now) fails;
+         // and a duplicate future job is enqueued even though one already exists. Using
+         // limit:1000 ensures both are scanned. Same reasoning as enqueueRoomTick (limit:1000).
+         //
+         // status must include 'processing': a currently-running github.poll job (status
+         // 'processing') must also block enqueue so the poll chain stays serial. If only
+         // 'pending' is checked, a new future poll is created while the current one is still
+         // running, violating the singleton invariant.
          const now = Date.now();
          const existingPoll = jobQueueRepo.listJobs({
            queue: QUEUES.GITHUB_POLL,
-           status: ['pending'],
-           limit: 1, // existence check only
-         }).find(j => j.runAt !== null && j.runAt > now);
+           status: ['pending', 'processing'],
+           limit: 1000,
+         }).find(j => j.runAt > now);
          if (!existingPoll) {
            jobQueueRepo.enqueue({
              queue: QUEUES.GITHUB_POLL,
@@ -382,15 +393,15 @@ For `github.event`: INSERT-first idempotency requires `maxRetries: 0`. With `max
 Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMicrotask`) immediate-trigger in `RoomRuntime` with persistent `room.tick` jobs.
 
 **`RoomRuntime` has two tick trigger paths** — both must be migrated:
-1. `setInterval(() => this.tick(), this.tickInterval)` at line ~305 — periodic heartbeat. Default interval is 30 seconds (`this.tickInterval = config.tickInterval ?? 30_000` at line ~263).
-2. `scheduleTick()` at line ~3179 (method definition): `queueMicrotask(() => this.tick())` — event-driven immediate trigger. There are **24 call sites** of `scheduleTick()` throughout the 3233-line file. All 24 call sites must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
-3. Tick mutex drain at line ~2021: inside `tick()`'s `finally` block — `if (this.tickQueued) { this.tickQueued = false; queueMicrotask(() => this.tick()); }`. This `queueMicrotask` must also be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`.
+1. `setInterval(() => this.tick(), this.tickInterval)` at line ~422 — periodic heartbeat. Default interval is 30 seconds (`this.tickInterval = config.tickInterval ?? 30_000` at line ~275).
+2. `scheduleTick()` at line ~3418 (method definition): `queueMicrotask(() => this.tick())` — event-driven immediate trigger. There are **17 `this.scheduleTick()` call sites** throughout the 3474-line file. All 17 must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
+3. Tick mutex drain at line ~2241: inside `tick()`'s `finally` block — `if (this.tickQueued) { this.tickQueued = false; queueMicrotask(() => this.tick()); }`. This `queueMicrotask` must also be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`.
 4. Recovery paths via `runtime-recovery.ts`: that file calls `runtime.onWorkerTerminalState()` and `runtime.onLeaderTerminalState()`, which internally call `this.scheduleTick()`. No changes are needed to `runtime-recovery.ts` itself — replacing `scheduleTick()` in `room-runtime.ts` automatically covers the recovery paths.
 
 **`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~115).
 
 **Migration approach**:
-- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes all 24 `scheduleTick()` call sites, the `scheduleTick()` method definition at line ~3179, and the tick mutex drain `queueMicrotask` at line ~2021. All must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
+- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes all 17 `this.scheduleTick()` call sites, the `scheduleTick()` method definition at line ~3418, and the tick mutex drain `queueMicrotask` at line ~2241. All must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`. **IMPORTANT: the `tickLocked` and `tickQueued` mutex fields must be RETAINED.** With `maxConcurrent: 3`, two `room.tick` jobs for the same `roomId` can run concurrently (dedup is check-then-act, documented as an accepted race); the mutex prevents concurrent `executeTick()` calls within a single runtime. Only the scheduling mechanism (`queueMicrotask`, `setInterval`) is replaced — the in-process tick mutex stays.
 - No `scheduleHeartbeat()` method exists in `RoomRuntimeService` — no removal needed.
 - **Fix `stopRuntime()` and add `stoppedRooms` tracking**: The current `stopRuntime()` in `room-runtime-service.ts` calls `runtime.stop()` but does NOT call `this.runtimes.delete(roomId)`. This means `this.runtimes.has(roomId)` returns `true` even after an individual room stop, making the heartbeat liveness check in the `finally` block ineffective for individual room stops (only effective on full shutdown via `runtimes.clear()`). Required changes to `RoomRuntimeService`:
   1. Add `private stoppedRooms: Set<string> = new Set()` field.
@@ -438,7 +449,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     // complexity not warranted at current scale.
   }
   ```
-- Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`, and replace the tick mutex drain `queueMicrotask(() => this.tick())` at line ~2021 with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`
+- Replace all 17 `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`, and replace the tick mutex drain `queueMicrotask(() => this.tick())` at line ~2241 with `enqueueRoomTick(this.jobQueueRepo, this.roomId)`
 - After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` block must first check `this.runtimes.has(roomId)` — if the runtime was stopped while the tick was in-flight (i.e., `stopRuntime()` was called, which now also deletes from the map), this returns `false` and no heartbeat is enqueued. The heartbeat enqueue deduplicates against existing pending future-scheduled jobs (`runAt > now`) to prevent heartbeat chain multiplication. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
@@ -455,12 +466,13 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       const roomExists = this.ctx.roomManager.getRoom(roomId) !== null;
       if (roomExists) {
         // Recovery still in progress — re-enqueue with delay, but only if no pending
-        // job for this room already exists. Dedup prevents multiple concurrent workers
-        // (maxConcurrent: 3) from each enqueueing an independent 5s delayed job when
-        // all arrive at this branch simultaneously.
+        // OR processing job for this room already exists. Must include 'processing': with
+        // maxConcurrent:3, three concurrent handlers can all enter this branch simultaneously;
+        // checking only 'pending' would miss a currently-executing job and each handler
+        // would enqueue its own 5s delayed job, defeating the dedup goal.
         const anyPending = this.jobQueueRepo.listJobs({
           queue: QUEUES.ROOM_TICK,
-          status: ['pending'],
+          status: ['pending', 'processing'],
           limit: 1000,
         }).find(j => (j.payload as any).roomId === roomId);
         if (!anyPending) {
@@ -533,7 +545,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
-- `setInterval`, `tickTimer`, `scheduleTick()` method definition (at ~line 3179), and all `queueMicrotask` calls (all 24 `scheduleTick()` call sites throughout the file, plus the tick mutex drain at line ~2021) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
+- `setInterval`, `tickTimer`, `scheduleTick()` method definition (at ~line 3179), and all `queueMicrotask` calls (all 17 `this.scheduleTick()` call sites throughout the file, plus the tick mutex drain at line ~2241) removed from `RoomRuntime`. `tickLocked` and `tickQueued` mutex fields are **retained** — they prevent concurrent `executeTick()` under `maxConcurrent: 3` when the check-then-enqueue race allows two `room.tick` jobs for the same room to run simultaneously.
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface (line ~115).
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
@@ -590,12 +602,16 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
     // workers could both observe "no future cleanup" and both enqueue. The duplicate is
     // harmless (idempotent cleanup), and the dedup guard on the next finally re-collapses
     // to a singleton. True atomic dedup would require a DB-level UNIQUE constraint.
+    //
+    // IMPORTANT — limit must be 1000, NOT 1. listJobs() sorts by created_at DESC.
+    // With limit:1, a newer immediate cleanup job shadows an older future-scheduled one;
+    // .find(runAt > now) returns undefined and a duplicate future cleanup is enqueued.
     const now = Date.now();
     const existingCleanup = jobQueueRepo.listJobs({
       queue: QUEUES.JOB_QUEUE_CLEANUP,
       status: ['pending'],
-      limit: 1, // existence check only
-    }).find(j => j.runAt !== null && j.runAt > now);
+      limit: 1000,
+    }).find(j => j.runAt > now);
     if (!existingCleanup) {
       jobQueueRepo.enqueue({
         queue: QUEUES.JOB_QUEUE_CLEANUP,
@@ -666,7 +682,7 @@ Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged
 | `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 |
-| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 — 3233 lines; setInterval at ~305; scheduleTick() definition at ~3179 (24 call sites); queueMicrotask tick mutex drain at ~2021; tickInterval defaults to 30_000ms at ~263 |
+| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 — 3474 lines; setInterval at ~422; scheduleTick() definition at ~3418 (17 call sites); queueMicrotask tick mutex drain at ~2241; tickInterval defaults to 30_000ms at ~275 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — no direct changes; covered by `scheduleTick()` replacement in `room-runtime.ts` |
 | `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -1,0 +1,184 @@
+# Plan: Complete and Adopt Persistent Job Queue for Codebase
+
+## Goal
+
+The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProcessor`) is fully implemented but not wired up or used by any daemon code. The goal is to adopt it across all background/async operations currently using in-memory patterns (fire-and-forget Promises, `setInterval` schedulers, in-memory state), replacing them with durable persistent jobs that survive daemon restarts.
+
+## Current State
+
+### Implemented (ready to use)
+- `packages/daemon/src/storage/repositories/job-queue-repository.ts` — CRUD operations on `job_queue` SQLite table
+- `packages/daemon/src/storage/job-queue-processor.ts` — Background polling loop with handler registry, retry/backoff, stale reclaim
+- Comprehensive unit tests in `packages/daemon/tests/unit/storage/`
+
+### Not yet adopted (in-memory patterns to replace)
+- **Session background tasks**: Title generation + git branch rename are fire-and-forget Promises tracked only in a `Set` (`pendingBackgroundTasks` in `session-manager.ts`)
+- **GitHub event processing pipeline**: Polling state (etags, timestamps) is in-memory only; events are processed via an event-bus chain with no durability; restart causes reprocessing or missed events
+- **Room runtime tick scheduling**: Room orchestration uses `setInterval` to drive the state machine; a crash mid-tick leaves worker/leader routing in inconsistent state
+- **`app.ts` has no `JobQueueProcessor` wiring**: The processor is never instantiated or started
+
+## Tasks
+
+### Task 1: Wire Up JobQueueProcessor in DaemonApp (Foundation)
+
+**Agent**: coder
+**Dependencies**: none
+**Priority**: high
+
+**Description**:
+Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. This is the foundational plumbing that all subsequent tasks depend on.
+
+Steps:
+1. Add `JobQueueProcessor` instantiation to `DaemonApp` in `app.ts`, using the existing `Database` facade (`db.getJobQueueRepo()`).
+2. Define a `QUEUES` constants object (e.g. in `packages/daemon/src/lib/job-queue-constants.ts`) enumerating all queue names: `session.title_generation`, `github.event`, `room.tick`.
+3. Call `processor.start()` in `DaemonApp.start()` and `await processor.stop()` in `DaemonApp.stop()` for graceful shutdown.
+4. Expose `getJobQueueProcessor(): JobQueueProcessor` on `DaemonApp` so subsystems can register handlers and enqueue jobs.
+5. Configure processor options: `pollIntervalMs: 500`, `maxConcurrent: 5`, `staleThresholdMs: 30_000`.
+
+**Acceptance criteria**:
+- `JobQueueProcessor` is created, started, and stopped as part of `DaemonApp` lifecycle.
+- Queue name constants are co-located and re-exported.
+- Existing unit tests for `JobQueueRepository` and `JobQueueProcessor` still pass.
+- New unit test verifies processor lifecycle integration in `DaemonApp`.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2: Migrate Session Background Tasks to Persistent Queue
+
+**Agent**: coder
+**Dependencies**: Task 1
+**Priority**: normal
+
+**Description**:
+Replace the fire-and-forget title generation + git branch rename in `SessionManager` with a persistent job on the `session.title_generation` queue.
+
+Files to modify:
+- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a job instead of spawning a Promise; remove `pendingBackgroundTasks` Set
+- `packages/daemon/src/lib/session/session-lifecycle.ts` — extract `generateTitleAndRenameBranch` into a standalone function usable as a queue handler
+- Register handler on `session.title_generation` queue in the session subsystem startup
+
+Job payload: `{ sessionId: string, userMessageText: string }`
+
+Handler behavior:
+- Load session from DB; skip if title already set (idempotent)
+- Call existing `generateTitleAndRenameBranch` logic
+- On success: mark complete; on failure: let the retry/dead-letter mechanism handle it (max 2 retries)
+
+**Acceptance criteria**:
+- `pendingBackgroundTasks` Set removed from `SessionManager`.
+- Title generation enqueues a persistent job; handler runs via `JobQueueProcessor`.
+- If daemon restarts after enqueue but before handler runs, job is picked up on next start.
+- Unit tests cover: enqueue on first message, idempotency (title already set), handler success and failure/retry paths.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 3: Migrate GitHub Event Processing to Persistent Queue
+
+**Agent**: coder
+**Dependencies**: Task 1
+**Priority**: normal
+
+**Description**:
+Replace the in-memory GitHub event pipeline with a persistent job queue so events are durable and processing is idempotent across restarts.
+
+Files to modify:
+- `packages/daemon/src/lib/github/polling-service.ts` — persist polling state (etags, last-poll timestamps) to DB settings; enqueue a `github.event` job for each new event instead of emitting directly
+- `packages/daemon/src/lib/github/github-service.ts` — register a handler on `github.event` queue that runs the existing filter→security→route pipeline; add idempotency check by storing processed event IDs in the `settings` table or a new `github_processed_events` table
+- `packages/daemon/src/lib/github/webhook-service.ts` (if it exists) — enqueue jobs instead of direct pipeline calls
+
+Job payload: `{ eventType: string, eventId: string, payload: Record<string, unknown> }`
+
+Handler behavior:
+- Skip if event ID already processed (idempotency)
+- Run filter → security → route pipeline
+- On success: mark processed; on failure: retry up to 3 times before dead-letter
+
+**Acceptance criteria**:
+- Polling state (etags, timestamps) survives daemon restart.
+- Same GitHub event cannot be processed twice (idempotency by event ID).
+- Events enqueued but not yet processed survive daemon restart and are picked up on next start.
+- Unit tests cover: enqueue on poll, idempotency, filter/route pipeline via handler, retry on transient error.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 4: Migrate Room Runtime Tick to Persistent Queue
+
+**Agent**: coder
+**Dependencies**: Task 1
+**Priority**: normal
+
+**Description**:
+Replace the `setInterval`-based room runtime tick with persistent job scheduling so room state machine operations are durable and crash-safe.
+
+Files to modify:
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` — remove `setInterval`; on each relevant event (goal created, task updated, worker/leader state change), enqueue a `room.tick` job with `{ roomId }` payload instead of calling `tick()` directly; also schedule a periodic `room.tick` job via `runAt` for heartbeat
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — register handler on `room.tick` queue; handler calls the existing `tick()` logic for the given roomId
+
+Key considerations:
+- Deduplication: if a `room.tick` job for a given roomId is already `pending` or `processing`, skip enqueueing a duplicate (check via `listJobs`)
+- Heartbeat: schedule a `room.tick` job with `runAt = now + 30_000` after each tick completes (replaces `setInterval`)
+- Idempotency: `tick()` handlers already claim idempotency; ensure they hold under job-queue retry
+
+**Acceptance criteria**:
+- `setInterval` removed from `RoomRuntime`; tick driven by job queue.
+- On daemon restart, pending `room.tick` jobs are picked up and rooms resume operation.
+- No duplicate `room.tick` jobs accumulate for the same room.
+- Unit tests cover: tick enqueue on event, deduplication, heartbeat re-scheduling, handler execution.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5: Integration Tests, Cleanup, and E2E Validation
+
+**Agent**: coder
+**Dependencies**: Tasks 2, 3, 4
+**Priority**: normal
+
+**Description**:
+Add integration and E2E tests validating crash-recovery scenarios, and clean up any remaining in-memory patterns.
+
+Steps:
+1. **Online/integration tests** (in `packages/daemon/tests/online/`):
+   - Session title generation: simulate daemon restart mid-job; verify title is generated after restart
+   - GitHub event durability: enqueue event, restart processor, verify event is processed exactly once
+   - Room tick recovery: enqueue tick, stop processor, restart it, verify room state progresses
+2. **E2E test** (`packages/e2e/tests/`): verify that after a simulated server restart, a pending session operation (title generation) completes correctly in the UI
+3. **Cleanup**: remove any obsolete fire-and-forget patterns, unused `pendingBackgroundTasks` references, or dead code revealed by this migration
+4. **Job queue maintenance**: add a scheduled `cleanup` job that runs `jobQueueRepo.cleanup()` daily to prune old completed/dead jobs from the DB
+
+**Acceptance criteria**:
+- At least 3 online tests covering crash-recovery scenarios across the three migrated subsystems.
+- E2E test confirms UI recovers gracefully from server restart during background operations.
+- No stale in-memory queue patterns remain in production code.
+- `bun run check` passes (lint + typecheck + knip).
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (Foundation)
+  └── Task 2 (Session tasks)    ──┐
+  └── Task 3 (GitHub events)    ──┼── Task 5 (Integration + Cleanup)
+  └── Task 4 (Room runtime)     ──┘
+```
+
+Tasks 2, 3, and 4 can be worked on in parallel after Task 1 is merged. Task 5 waits for Tasks 2–4.
+
+## Key Files Reference
+
+| File | Relevance |
+|------|-----------|
+| `packages/daemon/src/app.ts` | DaemonApp wiring (Task 1) |
+| `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor (all tasks) |
+| `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository (all tasks) |
+| `packages/daemon/src/lib/session/session-manager.ts` | Task 2 |
+| `packages/daemon/src/lib/session/session-lifecycle.ts` | Task 2 |
+| `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
+| `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
+| `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 |
+| `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -2,20 +2,50 @@
 
 ## Goal
 
-The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProcessor`) is fully implemented but not wired up or used by any daemon code. The goal is to adopt it across all background/async operations currently using in-memory patterns (fire-and-forget Promises, `setInterval` schedulers, in-memory state), replacing them with durable persistent jobs that survive daemon restarts.
+The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProcessor`) is fully implemented but not wired up or used by any daemon code. The goal is to adopt it across all background/async operations currently using in-memory patterns, replacing them with durable persistent jobs that survive daemon restarts.
 
 ## Current State
 
 ### Implemented (ready to use)
-- `packages/daemon/src/storage/repositories/job-queue-repository.ts` — CRUD operations on `job_queue` SQLite table
-- `packages/daemon/src/storage/job-queue-processor.ts` — Background polling loop with handler registry, retry/backoff, stale reclaim
+- `packages/daemon/src/storage/repositories/job-queue-repository.ts` — CRUD on `job_queue` SQLite table
+- `packages/daemon/src/storage/job-queue-processor.ts` — background polling loop with handler registry, retry/backoff, stale reclaim
 - Comprehensive unit tests in `packages/daemon/tests/unit/storage/`
 
-### Not yet adopted (in-memory patterns to replace)
-- **Session background tasks**: Title generation + git branch rename are fire-and-forget Promises tracked only in a `Set` (`pendingBackgroundTasks` in `session-manager.ts`)
-- **GitHub event processing pipeline**: Polling state (etags, timestamps) is in-memory only; events are processed via an event-bus chain with no durability; restart causes reprocessing or missed events
-- **Room runtime tick scheduling**: Room orchestration uses `setInterval` to drive the state machine; a crash mid-tick leaves worker/leader routing in inconsistent state
-- **`app.ts` has no `JobQueueProcessor` wiring**: The processor is never instantiated or started
+### Full inventory of in-memory patterns and disposition
+
+| Pattern | File | Disposition |
+|---------|------|-------------|
+| `pendingBackgroundTasks` Set (title generation + branch rename) | `session-manager.ts` | **Migrate** to `session.title_generation` queue |
+| GitHub polling `setInterval` + in-memory etag/repo-list state | `polling-service.ts` | **Migrate** to `github.poll` queue; restore state from DB on startup |
+| GitHub event pipeline (event-bus chain, no idempotency) | `github-service.ts`, `webhook-handler.ts` | **Migrate** to `github.event` queue |
+| Room runtime `setInterval` heartbeat + `scheduleTick()` (`queueMicrotask`) | `room-runtime.ts` | **Migrate** to `room.tick` queue |
+| WebSocket stale connection checker `setInterval` | `websocket-server-transport.ts` | **Intentionally ephemeral** — process-local connection management; no persistence value; keep as-is |
+| `triggerBackgroundRefresh` fire-and-forget (model cache) | `model-service.ts` | **Intentionally ephemeral** — best-effort cache warming; keep as-is |
+| Event-bus emissions with `.catch(() => {})` in room/message handlers | various `rpc-handlers/` | **Intentionally ephemeral** — in-process fanout; keep as-is |
+| `JobQueueProcessor` not wired to `ReactiveDatabase` change notifier | `app.ts` | **Wire up** in Task 1 |
+
+## Idempotency Key Design (cross-cutting, delivered in Task 1)
+
+All queue handlers must be idempotent. Agreed per-queue strategy:
+
+| Queue | Idempotency key | Strategy |
+|-------|-----------------|----------|
+| `session.title_generation` | `sessionId` | Handler queries DB; skip if `session.title IS NOT NULL` |
+| `github.poll` | n/a (singleton) | Dedup: skip enqueue if a `pending`/`processing` job already exists |
+| `github.event` | `eventId` (GitHub delivery ID) | Check `github_processed_events` table before processing; insert on success |
+| `room.tick` | `roomId` | Dedup: skip enqueue if a `pending`/`processing` job for this `roomId` exists |
+
+## Processor Configuration (reconciled with ADR-0002)
+
+```typescript
+new JobQueueProcessor(db.getJobQueueRepo(), {
+  pollIntervalMs: 1000,      // 1 second (ADR default)
+  maxConcurrent: 3,          // 3 concurrent jobs (ADR default)
+  staleThresholdMs: 300_000, // 5 minutes (ADR recommendation; room ticks may take >1s)
+})
+```
+
+---
 
 ## Tasks
 
@@ -26,20 +56,47 @@ The database-backed persistent job queue (`JobQueueRepository` + `JobQueueProces
 **Priority**: high
 
 **Description**:
-Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. This is the foundational plumbing that all subsequent tasks depend on.
+Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. This is the foundational plumbing all subsequent tasks depend on.
+
+**Important**: `createDaemonApp` is a factory function, not a class with `start()`/`stop()` methods. The lifecycle entry point for shutdown is a `cleanup()` closure defined inside the factory. All processor lifecycle hooks must follow this existing pattern.
 
 Steps:
-1. Add `JobQueueProcessor` instantiation to `DaemonApp` in `app.ts`, using the existing `Database` facade (`db.getJobQueueRepo()`).
-2. Define a `QUEUES` constants object (e.g. in `packages/daemon/src/lib/job-queue-constants.ts`) enumerating all queue names: `session.title_generation`, `github.event`, `room.tick`.
-3. Call `processor.start()` in `DaemonApp.start()` and `await processor.stop()` in `DaemonApp.stop()` for graceful shutdown.
-4. Expose `getJobQueueProcessor(): JobQueueProcessor` on `DaemonApp` so subsystems can register handlers and enqueue jobs.
-5. Configure processor options: `pollIntervalMs: 500`, `maxConcurrent: 5`, `staleThresholdMs: 30_000`.
+1. Instantiate `JobQueueProcessor` using `db.getJobQueueRepo()`:
+   ```typescript
+   const jobQueueProcessor = new JobQueueProcessor(db.getJobQueueRepo(), {
+     pollIntervalMs: 1000,
+     maxConcurrent: 3,
+     staleThresholdMs: 300_000,
+   });
+   ```
+2. Connect the processor's change notifier to `ReactiveDatabase` so job completions/failures trigger live query updates:
+   ```typescript
+   jobQueueProcessor.setChangeNotifier((table) => reactiveDb.notifyChange(table));
+   ```
+3. Call `jobQueueProcessor.start()` inline after all subsystems are wired.
+4. Add `await jobQueueProcessor.stop()` to the existing `cleanup()` closure **before** `await roomRuntimeService.stop()` and `await sessionManager.cleanup()` — this ordering ensures in-flight jobs (including room ticks) finish before dependent services are torn down.
+5. Pass `jobQueueProcessor` via constructor injection to subsystems that need it (`SessionManager`, `GitHubService`, `RoomRuntimeService`), consistent with how `db` is passed today. Do not expose it as a separate context getter.
+6. Each subsystem registers its own queue handlers in a `start()` lifecycle method, called by `createDaemonApp` after `jobQueueProcessor.start()`.
+7. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts`:
+   ```typescript
+   export const QUEUES = {
+     SESSION_TITLE_GENERATION: 'session.title_generation',
+     GITHUB_POLL: 'github.poll',
+     GITHUB_EVENT: 'github.event',
+     ROOM_TICK: 'room.tick',
+     JOB_QUEUE_CLEANUP: 'job_queue.cleanup',
+   } as const;
+   ```
+8. Document the idempotency strategy (table above) as a comment in `job-queue-constants.ts`.
 
 **Acceptance criteria**:
-- `JobQueueProcessor` is created, started, and stopped as part of `DaemonApp` lifecycle.
-- Queue name constants are co-located and re-exported.
-- Existing unit tests for `JobQueueRepository` and `JobQueueProcessor` still pass.
-- New unit test verifies processor lifecycle integration in `DaemonApp`.
+- `JobQueueProcessor` is instantiated and `jobQueueProcessor.start()` is called in `createDaemonApp`.
+- `await jobQueueProcessor.stop()` is in the `cleanup()` closure, before other service teardowns.
+- Change notifier connected to `ReactiveDatabase`.
+- Queue name constants exported from `job-queue-constants.ts` with idempotency strategy documented.
+- `jobQueueProcessor` injected via constructor into `SessionManager`, `GitHubService`, `RoomRuntimeService`.
+- Unit test verifies processor start/stop lifecycle and that `stop()` is called before other cleanup.
+- All existing `JobQueueRepository` and `JobQueueProcessor` unit tests still pass.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -53,23 +110,46 @@ Steps:
 **Description**:
 Replace the fire-and-forget title generation + git branch rename in `SessionManager` with a persistent job on the `session.title_generation` queue.
 
-Files to modify:
-- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a job instead of spawning a Promise; remove `pendingBackgroundTasks` Set
-- `packages/daemon/src/lib/session/session-lifecycle.ts` — extract `generateTitleAndRenameBranch` into a standalone function usable as a queue handler
-- Register handler on `session.title_generation` queue in the session subsystem startup
+**Files to modify**:
+- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a `session.title_generation` job instead of spawning a Promise; remove `pendingBackgroundTasks` Set; register the queue handler in `SessionManager.start()`
+- `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (already a method on `SessionLifecycle`, no extraction needed) into a job handler
+
+**Handler registration** via constructor injection:
+```typescript
+class SessionManager {
+  constructor(private readonly jobQueueProcessor: JobQueueProcessor, ...) {}
+
+  start(): void {
+    this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
+      const { sessionId } = job.payload as { sessionId: string };
+      // Idempotency: skip if title already set
+      const session = this.sessionRepo.getSession(sessionId);
+      if (!session || session.title !== null) return;
+      await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
+    });
+  }
+}
+```
+
+**Enqueue point**: In the `message.persisted` event handler where the current fire-and-forget Promise is spawned:
+```typescript
+this.jobQueueProcessor.getRepo().enqueue({
+  queue: QUEUES.SESSION_TITLE_GENERATION,
+  payload: { sessionId, userMessageText },
+  maxRetries: 2,
+});
+```
 
 Job payload: `{ sessionId: string, userMessageText: string }`
 
-Handler behavior:
-- Load session from DB; skip if title already set (idempotent)
-- Call existing `generateTitleAndRenameBranch` logic
-- On success: mark complete; on failure: let the retry/dead-letter mechanism handle it (max 2 retries)
+**Idempotency**: Handler queries DB; if `session.title IS NOT NULL`, returns immediately (safe to retry multiple times).
 
 **Acceptance criteria**:
 - `pendingBackgroundTasks` Set removed from `SessionManager`.
 - Title generation enqueues a persistent job; handler runs via `JobQueueProcessor`.
 - If daemon restarts after enqueue but before handler runs, job is picked up on next start.
-- Unit tests cover: enqueue on first message, idempotency (title already set), handler success and failure/retry paths.
+- Idempotency: handler called twice for same session produces correct result (no double-rename).
+- Unit tests cover: enqueue on first message, idempotency guard (title already set), handler success, handler failure + retry (max 2 retries), dead-letter after max retries.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -81,25 +161,41 @@ Handler behavior:
 **Priority**: normal
 
 **Description**:
-Replace the in-memory GitHub event pipeline with a persistent job queue so events are durable and processing is idempotent across restarts.
+Replace the in-memory GitHub event pipeline with a persistent job queue so events are durable and idempotent across restarts. Persist polling state and restore repository registrations on startup.
 
-Files to modify:
-- `packages/daemon/src/lib/github/polling-service.ts` — persist polling state (etags, last-poll timestamps) to DB settings; enqueue a `github.event` job for each new event instead of emitting directly
-- `packages/daemon/src/lib/github/github-service.ts` — register a handler on `github.event` queue that runs the existing filter→security→route pipeline; add idempotency check by storing processed event IDs in the `settings` table or a new `github_processed_events` table
-- `packages/daemon/src/lib/github/webhook-service.ts` (if it exists) — enqueue jobs instead of direct pipeline calls
+**Schema addition** — new migration adds `github_processed_events` table:
+```sql
+CREATE TABLE github_processed_events (
+  event_id TEXT PRIMARY KEY,  -- GitHub delivery ID
+  processed_at INTEGER NOT NULL
+);
+CREATE INDEX idx_github_processed_events_at ON github_processed_events(processed_at);
+```
+Cleanup: prune rows older than 30 days in the Task 5 scheduled maintenance job.
 
-Job payload: `{ eventType: string, eventId: string, payload: Record<string, unknown> }`
+**Files to modify**:
 
-Handler behavior:
-- Skip if event ID already processed (idempotency)
-- Run filter → security → route pipeline
-- On success: mark processed; on failure: retry up to 3 times before dead-letter
+1. `packages/daemon/src/lib/github/polling-service.ts`:
+   - Persist etags and last-poll timestamps to `settings` table (keyed by repo) instead of in-memory
+   - In `start()`, restore repository registrations by reading from `GitHubMappingRepository` (which persists room→repo mappings in `room_github_mappings`) — this ensures polled repos survive restart without manual re-registration
+   - Replace `setInterval` body: enqueue a `github.poll` job (singleton dedup — skip if `pending`/`processing` already exists); schedule next poll via `runAt = now + pollIntervalMs` after each poll completes
+
+2. `packages/daemon/src/lib/github/github-service.ts`:
+   - Register `github.event` handler in `GitHubService.start()`
+   - Handler runs existing filter→security→route pipeline
+   - Idempotency: check `github_processed_events` table for `eventId` before processing; insert row on success
+
+3. `packages/daemon/src/lib/github/webhook-handler.ts` (correct filename — not `webhook-service.ts`):
+   - Webhook path calls `handleWebhook()` in `github-service.ts`; update to enqueue a `github.event` job instead of calling the pipeline directly
+
+**Retry behavior**: `maxRetries: 3` for `github.event` (transient routing failures). `maxRetries: 0` for `github.poll` (failed polls are simply retried on the next scheduled interval).
 
 **Acceptance criteria**:
-- Polling state (etags, timestamps) survives daemon restart.
-- Same GitHub event cannot be processed twice (idempotency by event ID).
-- Events enqueued but not yet processed survive daemon restart and are picked up on next start.
-- Unit tests cover: enqueue on poll, idempotency, filter/route pipeline via handler, retry on transient error.
+- Polling etags and timestamps persist across daemon restarts.
+- Repository registrations are restored from `GitHubMappingRepository` on startup — no manual re-registration needed.
+- Same GitHub event (by delivery ID) cannot be processed twice, verified by `github_processed_events` table.
+- Events enqueued but not yet processed survive daemon restart and are processed on next start.
+- Unit tests cover: enqueue on poll, idempotency (event already in `github_processed_events`), filter/route pipeline via handler, retry on transient error, webhook path enqueues job.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -111,74 +207,128 @@ Handler behavior:
 **Priority**: normal
 
 **Description**:
-Replace the `setInterval`-based room runtime tick with persistent job scheduling so room state machine operations are durable and crash-safe.
+Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMicrotask`) immediate-trigger in `RoomRuntime` with persistent `room.tick` jobs.
 
-Files to modify:
-- `packages/daemon/src/lib/room/runtime/room-runtime.ts` — remove `setInterval`; on each relevant event (goal created, task updated, worker/leader state change), enqueue a `room.tick` job with `{ roomId }` payload instead of calling `tick()` directly; also schedule a periodic `room.tick` job via `runAt` for heartbeat
-- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` — register handler on `room.tick` queue; handler calls the existing `tick()` logic for the given roomId
+**`RoomRuntime` has two tick trigger paths** — both must be migrated:
+1. `setInterval(() => this.tick(), this.tickInterval)` (~line 205) — periodic heartbeat
+2. `scheduleTick()` (~line 1550): `queueMicrotask(() => this.tick())` — event-driven immediate trigger with 9+ call sites (goal created, task updated, worker/leader terminal states, leader tool calls, etc.)
 
-Key considerations:
-- Deduplication: if a `room.tick` job for a given roomId is already `pending` or `processing`, skip enqueueing a duplicate (check via `listJobs`)
-- Heartbeat: schedule a `room.tick` job with `runAt = now + 30_000` after each tick completes (replaces `setInterval`)
-- Idempotency: `tick()` handlers already claim idempotency; ensure they hold under job-queue retry
+**Migration approach**:
+- Remove `setInterval`, `tickTimer` field, and `queueMicrotask` from `RoomRuntime`
+- Replace all `this.scheduleTick()` call sites with a shared `enqueueRoomTick(roomId, priority)` helper that checks dedup before enqueueing:
+  ```typescript
+  function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
+    const existing = repo.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending', 'processing'] })
+      .find(j => (j.payload as any).roomId === roomId);
+    if (!existing) {
+      repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority });
+    }
+    // Note: listJobs is an O(n) scan; acceptable at current room scale.
+    // Future optimization: unique constraint on (queue, payload_roomId_hash) if needed.
+  }
+  ```
+- After each tick handler completes, enqueue next heartbeat job with `runAt = Date.now() + 30_000`
+- Register handler in `RoomRuntimeService.start()`:
+  ```typescript
+  processor.register(QUEUES.ROOM_TICK, async (job) => {
+    const { roomId } = job.payload as { roomId: string };
+    const runtime = this.runtimes.get(roomId);
+    if (!runtime) return; // Room removed mid-flight; tolerate gracefully
+    await runtime.tick();
+  });
+  ```
+
+**Shutdown ordering** (enforced in `app.ts` cleanup closure):
+1. `await jobQueueProcessor.stop()` — drains in-flight tick jobs
+2. `await roomRuntimeService.stop()` — clears `runtimes` map
+3. `await sessionManager.cleanup()` — cleans up agent sessions
+
+This ordering prevents the tick handler from referencing a cleared `runtimes` map.
+
+**Deduplication note**: The `listJobs` scan for dedup is O(n) with no composite index on `(queue, status, payload.roomId)`. At expected scale (tens of rooms), this is acceptable. If room count grows significantly, add a unique constraint or dedicated column. A comment documenting this trade-off must be included in the implementation.
 
 **Acceptance criteria**:
-- `setInterval` removed from `RoomRuntime`; tick driven by job queue.
-- On daemon restart, pending `room.tick` jobs are picked up and rooms resume operation.
-- No duplicate `room.tick` jobs accumulate for the same room.
-- Unit tests cover: tick enqueue on event, deduplication, heartbeat re-scheduling, handler execution.
+- `setInterval`, `tickTimer`, and `queueMicrotask` removed from `RoomRuntime`.
+- All `scheduleTick()` call sites replaced with `enqueueRoomTick()`.
+- No duplicate `room.tick` jobs accumulate for the same room (dedup verified in tests).
+- Heartbeat re-scheduling: after each tick, a new job is enqueued with `runAt = now + 30_000`.
+- Handler tolerates a missing runtime (room deleted during flight) — returns without error.
+- Shutdown ordering enforced in `app.ts` cleanup closure.
+- Unit tests cover: enqueue on event, dedup (second enqueue skipped), heartbeat re-schedule, handler for unknown `roomId`, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
 
-### Task 5: Integration Tests, Cleanup, and E2E Validation
+### Task 5: Integration Tests, Cleanup, and Scheduled Maintenance
 
 **Agent**: coder
 **Dependencies**: Tasks 2, 3, 4
 **Priority**: normal
 
 **Description**:
-Add integration and E2E tests validating crash-recovery scenarios, and clean up any remaining in-memory patterns.
+Add integration/online tests validating crash-recovery and idempotency, add a scheduled DB maintenance job, add an E2E test for UI-observable reconnection, and clean up remaining in-memory patterns.
 
-Steps:
-1. **Online/integration tests** (in `packages/daemon/tests/online/`):
-   - Session title generation: simulate daemon restart mid-job; verify title is generated after restart
-   - GitHub event durability: enqueue event, restart processor, verify event is processed exactly once
-   - Room tick recovery: enqueue tick, stop processor, restart it, verify room state progresses
-2. **E2E test** (`packages/e2e/tests/`): verify that after a simulated server restart, a pending session operation (title generation) completes correctly in the UI
-3. **Cleanup**: remove any obsolete fire-and-forget patterns, unused `pendingBackgroundTasks` references, or dead code revealed by this migration
-4. **Job queue maintenance**: add a scheduled `cleanup` job that runs `jobQueueRepo.cleanup()` daily to prune old completed/dead jobs from the DB
+**Online/integration tests** (`packages/daemon/tests/online/`), using `daemon-server.ts` spawned-process mode for restart simulation:
+1. **Session title generation recovery**: enqueue a `session.title_generation` job, stop the processor, restart it, verify the title is generated exactly once
+2. **GitHub event idempotency**: enqueue the same `github.event` job twice; verify it is processed exactly once (check `github_processed_events` table)
+3. **Room tick recovery**: enqueue a `room.tick` job, stop the processor, restart it, verify the room state progresses correctly
+
+**E2E test** (`packages/e2e/tests/`):
+- Verify UI reconnects and displays correct state after WebSocket close and restore (using existing `closeWebSocket()` / `restoreWebSocket()` helpers from `connection-helpers.ts`)
+- This is the correct E2E-compliant mechanism (pure browser-based Playwright, no RPC/internal state access)
+- Server-restart crash-recovery is covered by the online tests above, not E2E
+
+**Scheduled DB maintenance job** (`QUEUES.JOB_QUEUE_CLEANUP`):
+- Register handler in `createDaemonApp` that runs `jobQueueRepo.cleanup(Date.now() - 7 * 24 * 60 * 60 * 1000)` (prune `job_queue` rows older than 7 days) and prunes `github_processed_events` rows older than 30 days
+- Self-rescheduling pattern: after handler completes, enqueue next run with `runAt = Date.now() + 24 * 60 * 60 * 1000`
+- On daemon startup, enqueue first run with `runAt = now` if no pending/processing cleanup job exists
+
+**Cleanup scope** — patterns explicitly removed by this task:
+- `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no references remain)
+- `scheduleTick()` method and `tickTimer` field in `room-runtime.ts` (removed in Task 4)
+- Any `void somePromise` usages replaced by queue jobs in Tasks 2–4
+
+**Intentionally kept** (not in cleanup scope):
+- `triggerBackgroundRefresh` in `model-service.ts` — cache warming, ephemeral by design
+- WebSocket stale checker `setInterval` in `websocket-server-transport.ts` — process-local connection management
+- Event-bus `.catch(() => {})` emissions in `rpc-handlers/` — in-process fanout
 
 **Acceptance criteria**:
-- At least 3 online tests covering crash-recovery scenarios across the three migrated subsystems.
-- E2E test confirms UI recovers gracefully from server restart during background operations.
-- No stale in-memory queue patterns remain in production code.
+- At least 3 online tests covering crash-recovery/idempotency for the three migrated subsystems.
+- E2E test confirms UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
+- Scheduled cleanup job runs daily; self-rescheduling logic verified by unit test.
+- No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
 
-## Task Dependencies
+## Dependency Graph
 
 ```
-Task 1 (Foundation)
-  └── Task 2 (Session tasks)    ──┐
-  └── Task 3 (GitHub events)    ──┼── Task 5 (Integration + Cleanup)
-  └── Task 4 (Room runtime)     ──┘
+Task 1 (Foundation — wiring, DI, constants, idempotency design)
+  ├── Task 2 (Session title generation)  ──┐
+  ├── Task 3 (GitHub events + polling)   ──┼── Task 5 (Integration tests + cleanup)
+  └── Task 4 (Room runtime tick)         ──┘
 ```
 
-Tasks 2, 3, and 4 can be worked on in parallel after Task 1 is merged. Task 5 waits for Tasks 2–4.
+Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged. Task 5 waits for all three.
+
+---
 
 ## Key Files Reference
 
 | File | Relevance |
 |------|-----------|
-| `packages/daemon/src/app.ts` | DaemonApp wiring (Task 1) |
-| `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor (all tasks) |
-| `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository (all tasks) |
+| `packages/daemon/src/app.ts` | Factory function with cleanup closure — Task 1 |
+| `packages/daemon/src/storage/job-queue-processor.ts` | Existing processor — all tasks |
+| `packages/daemon/src/storage/repositories/job-queue-repository.ts` | Existing repository — all tasks |
+| `packages/daemon/src/lib/job-queue-constants.ts` | New queue name constants — Task 1 |
 | `packages/daemon/src/lib/session/session-manager.ts` | Task 2 |
 | `packages/daemon/src/lib/session/session-lifecycle.ts` | Task 2 |
 | `packages/daemon/src/lib/github/polling-service.ts` | Task 3 |
 | `packages/daemon/src/lib/github/github-service.ts` | Task 3 |
+| `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 (correct filename) |
 | `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
+| `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -32,7 +32,7 @@ All queue handlers must be idempotent. Agreed per-queue strategy:
 |-------|-----------------|----------|
 | `session.title_generation` | `sessionId` | Handler queries DB; skip if `session.title IS NOT NULL` |
 | `github.poll` | n/a (singleton, payload `{}`) | Dedup: skip enqueue if a `pending`/`processing` job already exists |
-| `github.event` | `eventId` (stable deterministic ID — see Task 3) | Check `github_processed_events` table before processing; insert on success |
+| `github.event` | `eventId` (stable deterministic ID — see Task 3) | INSERT-first: `INSERT OR IGNORE INTO github_processed_events` at job start; if row already existed (affected rows = 0), skip pipeline — DB-level dedup, concurrency-safe with `maxConcurrent: 3` |
 | `room.tick` | `roomId` | Dedup: skip enqueue if a `pending`/`processing` job for this `roomId` exists |
 
 ## Processor Configuration (reconciled with ADR-0002)
@@ -64,7 +64,7 @@ Initialize and start the `JobQueueProcessor` in `packages/daemon/src/app.ts`. Th
 
 2. **`RoomRuntimeService` lives inside `setupRPCHandlers`, not `createDaemonApp` directly.** It is constructed at `packages/daemon/src/lib/rpc-handlers/index.ts` line 105. The plan accounts for this by passing `jobQueueProcessor` and `jobQueueRepo` as additional fields in the `deps` object passed to `setupRPCHandlers`. `setupRPCHandlers` passes them to the `RoomRuntimeService` constructor. No lifting of `RoomRuntimeService` into `createDaemonApp` is required.
 
-3. **Startup ordering**: `setupRPCHandlers` (which instantiates and starts `RoomRuntimeService`) is called before `jobQueueProcessor.start()`. This ensures handler registration happens before the processor begins polling. However, `roomRuntimeService.start()` is currently fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy (see Task 4).
+3. **Startup ordering**: Handler registration (`start()` methods for `SessionManager`, `RoomRuntimeService`, `GitHubService`) must be called **before** `jobQueueProcessor.start()`, so all handlers are registered before the processor begins dequeuing jobs. `setupRPCHandlers` runs first (constructing `RoomRuntimeService`), then the subsystem `start()` methods register their handlers, then `jobQueueProcessor.start()` begins polling. Note: `roomRuntimeService.start()` is fire-and-forget (called with `.catch()` inside `setupRPCHandlers`) and the recovery pass may not be complete when the processor starts. The tick handler in Task 4 addresses this with a re-enqueue-on-miss strategy (see Task 4).
 
 4. **Shutdown ordering**: In the `cleanup()` closure, add `await jobQueueProcessor.stop()` **before** the `rpcHandlerCleanup()` call at line 375 of `app.ts`. `rpcHandlerCleanup()` internally calls `roomRuntimeService.stop()`, so this ordering ensures all in-flight tick jobs drain before the runtimes map is cleared.
 
@@ -89,15 +89,16 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
    jobQueueProcessor.setChangeNotifier((table) => reactiveDb.notifyChange(table));
    ```
 3. Add `jobQueueProcessor` and `jobQueueRepo` to the `deps` object passed to `setupRPCHandlers`.
-4. Call `jobQueueProcessor.start()` after `setupRPCHandlers` returns (handlers registered before polling begins).
-5. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure before `rpcHandlerCleanup()`:
+4. Call subsystem `start()` methods (`sessionManager.start()`, `roomRuntimeService.start()`, `githubService.start()`) **before** `jobQueueProcessor.start()` — this ensures all handlers are registered before the processor begins dequeuing.
+5. Call `jobQueueProcessor.start()` after all subsystem `start()` calls.
+6. Add `await jobQueueProcessor.stop()` to the `cleanup()` closure before `rpcHandlerCleanup()`:
    ```typescript
    // cleanup():
    await jobQueueProcessor.stop(); // drain in-flight jobs first
    rpcHandlerCleanup();            // stops RoomRuntimeService (via rpc-handlers cleanup)
    await sessionManager.cleanup();
    ```
-6. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts` with the idempotency strategy documented in comments:
+7. Define queue name constants in `packages/daemon/src/lib/job-queue-constants.ts` with the idempotency strategy documented in comments:
    ```typescript
    export const QUEUES = {
      SESSION_TITLE_GENERATION: 'session.title_generation',
@@ -107,10 +108,10 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
      JOB_QUEUE_CLEANUP: 'job_queue.cleanup',
    } as const;
    ```
-7. Each subsystem registers queue handlers in its own `start()` method, called after `jobQueueProcessor.start()`.
+8. Each subsystem registers queue handlers in its own `start()` method. These `start()` calls happen before `jobQueueProcessor.start()` to guarantee handlers are registered before polling begins.
 
 **Acceptance criteria**:
-- `JobQueueProcessor` is instantiated; `jobQueueProcessor.start()` is called after `setupRPCHandlers`.
+- `JobQueueProcessor` is instantiated; subsystem `start()` methods are called after `setupRPCHandlers` but **before** `jobQueueProcessor.start()` to guarantee all handlers are registered before polling begins.
 - `await jobQueueProcessor.stop()` is in the `cleanup()` closure before `rpcHandlerCleanup()`.
 - Change notifier connected to `ReactiveDatabase`.
 - `listJobs` extended to accept `status?: JobStatus | JobStatus[]`.
@@ -253,9 +254,9 @@ Webhook events already have a stable `X-GitHub-Delivery` ID via `normalizeWebhoo
 
 3. `packages/daemon/src/lib/github/github-service.ts`:
    - Register `github.event` handler in `GitHubService.start()` (receives `jobQueueProcessor` and `jobQueueRepo` via constructor)
-   - Handler checks `github_processed_events` for `eventId`; if found, returns (idempotent)
-   - Handler runs existing filter→security→route pipeline
-   - On success: inserts row into `github_processed_events`
+   - Handler uses INSERT-first idempotency: attempt `INSERT OR IGNORE INTO github_processed_events(event_id, processed_at) VALUES (?, ?)` at job start
+   - If the row already existed (affected rows = 0): return immediately — event was already processed. This check is concurrency-safe because SQLite serializes writes; two concurrent workers cannot both get `affected rows = 1` for the same `event_id`.
+   - If insert succeeded (affected rows = 1): run existing filter→security→route pipeline
 
 4. `packages/daemon/src/lib/github/webhook-handler.ts`:
    - Update webhook path to enqueue a `github.event` job instead of calling the pipeline directly
@@ -272,10 +273,11 @@ Job payloads:
 - Polled events use deterministic stable IDs (verified by unit test: normalizing same data twice produces same ID).
 - Per-repo poll state (`issues_etag`, `comments_etag`, `last_poll_at`) stored in `github_poll_state` table, survives restart.
 - Repository registrations restored from `GitHubMappingRepository` on `start()`.
-- Same event cannot be processed twice (idempotency via `github_processed_events`).
+- Same event cannot be processed twice: INSERT-first strategy (`INSERT OR IGNORE` at job start, skip pipeline if row already existed) is concurrency-safe with `maxConcurrent: 3` — SQLite serializes writes so two concurrent workers cannot both get `affected rows = 1` for the same `eventId`.
 - `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error (modulo fatal SQLite failure, accepted risk).
 - Enqueued `github.event` jobs survive daemon restart.
-- Unit tests cover: stable ID generation, idempotency check, poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
+- DB migration for `github_processed_events` and `github_poll_state` tables is included and applied at daemon startup.
+- Unit tests cover: stable ID generation, INSERT-first idempotency (first insert succeeds, second is no-op), poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -297,7 +299,8 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~76).
 
 **Migration approach**:
-- Remove `setInterval`, `tickTimer` field, and `queueMicrotask` from `RoomRuntime`
+- Remove `setInterval`, `tickTimer` field, `scheduleTick()` method, and all `queueMicrotask` calls from `RoomRuntime`. This includes the main `scheduleTick()` at line ~1550 **and** an additional `queueMicrotask(() => this.tick())` at line ~954 inside the tick mutex path — both must be replaced with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`.
+- Remove the `scheduleHeartbeat()` method (if present) from `RoomRuntimeService` — it uses `setInterval`/`setTimeout` internally and is superseded by the `finally`-based heartbeat in the tick handler.
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
@@ -310,7 +313,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       limit: 1000,
     }).find(j => (j.payload as any).roomId === roomId);
     if (!existing) {
-      repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority });
+      repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority, maxRetries: 0 });
     }
     // Note: listJobs is an O(n) scan with no index on payload contents.
     // Acceptable at current scale (tens of rooms). Future optimization:
@@ -325,7 +328,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
   }
   ```
 - Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
-- After each tick handler completes, schedule the heartbeat with a direct `jobQueueRepo.enqueue({ runAt: Date.now() + 30_000 })` — this is unconditional and intentionally bypasses the dedup helper, since the 30s future job is semantically distinct from any immediate pending job:
+- After each tick handler attempt (success or failure), schedule the heartbeat in a `try/finally` block — this is unconditional and intentionally bypasses the dedup helper, since the 30s future job is semantically distinct from any immediate pending job. The `finally` placement ensures no room permanently stops ticking even if `runtime.tick()` throws. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
@@ -341,19 +344,27 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
           queue: QUEUES.ROOM_TICK,
           payload: { roomId },
           runAt: Date.now() + 5_000,
+          maxRetries: 0,
         });
       }
       // Room deleted: do not re-enqueue (prevents perpetual churn)
       return;
     }
-    await runtime.tick();
-    // Heartbeat: always schedule a future tick unconditionally (bypasses dedup helper
-    // intentionally — the 30s future job is distinct from any immediate pending job).
-    this.jobQueueRepo.enqueue({
-      queue: QUEUES.ROOM_TICK,
-      payload: { roomId },
-      runAt: Date.now() + 30_000,
-    });
+    try {
+      await runtime.tick();
+    } finally {
+      // Heartbeat: always schedule a future tick even if runtime.tick() throws.
+      // Placing in finally ensures no room permanently stops ticking on handler error.
+      // maxRetries: 0 is required: with the finally pattern, processor retries would
+      // each also fire finally, creating duplicate heartbeat jobs (job multiplication).
+      // The finally block itself guarantees rescheduling without processor retries.
+      this.jobQueueRepo.enqueue({
+        queue: QUEUES.ROOM_TICK,
+        payload: { roomId },
+        runAt: Date.now() + 30_000,
+        maxRetries: 0,
+      });
+    }
   });
   ```
 
@@ -367,16 +378,17 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `runtimes` is cleared, because `jobQueueProcessor.stop()` drains all in-flight jobs before `rpcHandlerCleanup()` runs.
 
 **Acceptance criteria**:
-- `setInterval`, `tickTimer`, and `queueMicrotask` removed from `RoomRuntime`.
+- `setInterval`, `tickTimer`, `scheduleTick()`, and all `queueMicrotask` calls (including the one at line ~954 in the tick mutex path) removed from `RoomRuntime`.
 - All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
+- `scheduleHeartbeat()` method (if present) removed from `RoomRuntimeService` — replaced by the `finally`-based heartbeat in the tick handler.
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface.
-- Handler distinguishes "room deleted" from "runtime loading": no re-enqueue for deleted rooms.
-- Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`) via direct enqueue when room exists but runtime not found; no `enqueueRoomTick` call in this path.
-- Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs`; check-then-act race documented as accepted risk.
-- Heartbeat re-scheduling: after each successful tick, direct `jobQueueRepo.enqueue({ runAt = now + 30_000 })` (unconditional, bypasses dedup helper intentionally).
+- All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
+- Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error.
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
+- Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`, `maxRetries: 0`) via direct enqueue when room exists but runtime not found; no `enqueueRoomTick` call in this path.
+- Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs`; check-then-act race documented as accepted risk.
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -412,7 +424,8 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
       queue: QUEUES.JOB_QUEUE_CLEANUP,
       payload: {},
       runAt: Date.now() + 24 * 60 * 60 * 1000,
-      maxRetries: 3, // retry transient failures; prevents permanent schedule stall
+      maxRetries: 0, // finally pattern self-reschedules; maxRetries > 0 causes job multiplication
+                     // (each retry also runs finally, creating an extra next-day cleanup job)
     });
   }
   ```
@@ -432,7 +445,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 **Acceptance criteria**:
 - At least 3 online tests covering job persistence and idempotency across processor restart.
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
-- Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 3`; verified by unit test.
+- Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); verified by unit test.
 - Startup-time synchronous prune of `github_processed_events` rows older than 30 days runs on daemon start; verified by unit test.
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -114,7 +114,7 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
 - `await jobQueueProcessor.stop()` is in the `cleanup()` closure before `rpcHandlerCleanup()`.
 - Change notifier connected to `ReactiveDatabase`.
 - `listJobs` extended to accept `status?: JobStatus | JobStatus[]`.
-- `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object.
+- `jobQueueProcessor` and `jobQueueRepo` injected into `setupRPCHandlers` via the `deps` object; `RPCHandlerDependencies` TypeScript interface updated to include both fields.
 - Queue name constants exported from `job-queue-constants.ts`.
 - Unit test verifies processor starts and stops correctly; confirms `stop()` is awaited before `rpcHandlerCleanup()`.
 - All existing `JobQueueRepository` and `JobQueueProcessor` unit tests still pass.
@@ -132,28 +132,34 @@ b. `JobQueueProcessor` has no `getRepo()` accessor. Rather than adding one, inje
 Replace the fire-and-forget title generation + git branch rename in `SessionManager` with a persistent job on the `session.title_generation` queue.
 
 **Files to modify**:
-- `packages/daemon/src/lib/session/session-manager.ts` — enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set; register handler in `SessionManager.start()` (called by `createDaemonApp` after `jobQueueProcessor.start()`)
+- `packages/daemon/src/lib/session/session-manager.ts` — add a `start()` lifecycle method (does not currently exist); enqueue a `session.title_generation` job; remove `pendingBackgroundTasks` Set. `createDaemonApp` calls `sessionManager.start()` after `jobQueueProcessor.start()`.
 - `packages/daemon/src/lib/session/session-lifecycle.ts` — wrap the existing `generateTitleAndRenameBranch` method (no extraction needed; already a method on `SessionLifecycle`) in the job handler
 
 **Behavioral change**: Currently the `message.persisted` event handler does `await titleGenTask` (line 162 of `session-manager.ts`), blocking until title generation completes. After this migration the handler enqueues a job synchronously and returns immediately. This is the intended change — the handler must NOT await title generation; the job queue provides durability instead.
 
 **Handler registration** via constructor injection (`SessionManager` receives `jobQueueProcessor` and `jobQueueRepo`):
 ```typescript
+// New method added to SessionManager:
 start(): void {
   this.jobQueueProcessor.register(QUEUES.SESSION_TITLE_GENERATION, async (job) => {
     const { sessionId } = job.payload as { sessionId: string };
     // Idempotency: skip if title already set
     const session = this.sessionRepo.getSession(sessionId);
     if (!session || session.title !== null) return;
-    // Note: generateTitleAndRenameBranch requires the session in the in-memory cache.
-    // On restart, if the session is not cached, fall back to DB-only title generation
-    // (set title from userMessageText without renaming the branch).
-    await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
+    if (this.sessionCache.has(sessionId)) {
+      // Session in cache: full path (title generation + branch rename)
+      await this.sessionLifecycle.generateTitleAndRenameBranch(sessionId, ...);
+    } else {
+      // Cache miss after restart: title-only fallback (no branch rename)
+      await this.sessionLifecycle.generateTitleOnly(sessionId, ...);
+    }
   });
 }
 ```
 
-**Cache miss handling**: `generateTitleAndRenameBranch` reads from `sessionCache`. After a daemon restart the session may not be cached. The handler must check if the session is in cache; if not, apply a graceful fallback (title generation without branch rename, which is safe to retry).
+**Cache miss handling**: `generateTitleAndRenameBranch` requires the session in the in-memory cache. After a daemon restart the session may not be cached. The handler checks the cache:
+- **Cache hit**: calls the full `generateTitleAndRenameBranch` (title + branch rename)
+- **Cache miss**: calls a new `generateTitleOnly` helper on `SessionLifecycle` that sets the title from `userMessageText` without the branch rename. This is safe to retry and does not require the cache. Both `generateTitleAndRenameBranch` and `generateTitleOnly` check `session.title !== null` to guard idempotency.
 
 Job payload: `{ sessionId: string, userMessageText: string }`
 
@@ -201,11 +207,12 @@ Replace the in-memory GitHub event pipeline with a persistent job queue so event
    CREATE INDEX idx_github_processed_events_at ON github_processed_events(processed_at);
    ```
 
-2. `github_poll_state` table (replaces in-memory etags/timestamps; the existing `global_settings` table is a single JSON blob and is not suitable for per-repo structured state):
+2. `github_poll_state` table (replaces in-memory etags/timestamps; the existing `global_settings` table is a single JSON blob and is not suitable for per-repo structured state). Note: `polling-service.ts` tracks two separate ETags per repo (`issuesEtag` and `commentsEtag` at lines 26–27), so the schema needs two separate columns:
    ```sql
    CREATE TABLE github_poll_state (
      repo_full_name TEXT PRIMARY KEY,
-     etag TEXT,
+     issues_etag TEXT,
+     comments_etag TEXT,
      last_poll_at INTEGER NOT NULL DEFAULT 0
    );
    ```
@@ -259,14 +266,16 @@ Job payloads:
 
 **Retry behavior**: `maxRetries: 3` for `github.event`. `maxRetries: 0` for `github.poll` (re-scheduling handled in `finally` block; processor retry not needed).
 
+**Residual risk**: If `jobQueueRepo.enqueue()` inside the `finally` block throws (e.g., SQLite disk failure), the next poll will not be scheduled. This is an accepted risk: SQLite write failures at this level typically indicate a fatal daemon condition (disk full, WAL corruption) and the daemon will crash and restart, re-enqueuing the poll on startup. No additional fallback is specified.
+
 **Acceptance criteria**:
 - Polled events use deterministic stable IDs (verified by unit test: normalizing same data twice produces same ID).
-- Per-repo poll state (etags, timestamps) stored in `github_poll_state` table, survives restart.
+- Per-repo poll state (`issues_etag`, `comments_etag`, `last_poll_at`) stored in `github_poll_state` table, survives restart.
 - Repository registrations restored from `GitHubMappingRepository` on `start()`.
 - Same event cannot be processed twice (idempotency via `github_processed_events`).
-- `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error.
+- `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error (modulo fatal SQLite failure, accepted risk).
 - Enqueued `github.event` jobs survive daemon restart.
-- Unit tests cover: stable ID generation, idempotency check, poll re-scheduling on success and on error, webhook path enqueues job.
+- Unit tests cover: stable ID generation, idempotency check, poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -283,20 +292,22 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
 **`RoomRuntime` has two tick trigger paths** — both must be migrated:
 1. `setInterval(() => this.tick(), this.tickInterval)` (~line 205) — periodic heartbeat
 2. `scheduleTick()` (~line 1550): `queueMicrotask(() => this.tick())` — event-driven immediate trigger with 9+ call sites (goal created, task updated, worker/leader terminal states, leader tool calls, etc.)
-3. `runtime-recovery.ts` calls `runtime.tick()` directly during recovery — this must also be replaced with `enqueueRoomTick()` so the tick mutex and dedup guarantees apply during recovery.
+3. Recovery paths via `runtime-recovery.ts`: that file calls `runtime.onWorkerTerminalState()` (line 153) and `runtime.onLeaderTerminalState()` (line 194), which internally call `this.scheduleTick()`. No changes are needed to `runtime-recovery.ts` itself — replacing `scheduleTick()` in `room-runtime.ts` automatically covers the recovery paths.
 
-**`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required.
+**`jobQueueProcessor` and `jobQueueRepo` injection**: `RoomRuntimeService` receives them via the `deps` object passed to `setupRPCHandlers` (wired in Task 1). No refactoring of `RoomRuntimeService` out of `setupRPCHandlers` is required. `RoomRuntime` instances (created by `RoomRuntimeService`) need `jobQueueRepo` to call `enqueueRoomTick()` from within instance methods; add `jobQueueRepo: JobQueueRepository` to the `RoomRuntimeConfig` interface (defined at `room-runtime.ts` line ~76).
 
 **Migration approach**:
 - Remove `setInterval`, `tickTimer` field, and `queueMicrotask` from `RoomRuntime`
 - Add an `enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0)` helper function:
   ```typescript
   function enqueueRoomTick(repo: JobQueueRepository, roomId: string, priority = 0): void {
-    // Dedup: skip if pending or processing job exists for this room
-    // listJobs now supports status array (extended in Task 1)
+    // Dedup: skip if pending or processing job exists for this room.
+    // listJobs now supports status array (extended in Task 1).
+    // limit: 1000 overrides the default cap of 100 to avoid missed dedup under high job volume.
     const existing = repo.listJobs({
       queue: QUEUES.ROOM_TICK,
       status: ['pending', 'processing'],
+      limit: 1000,
     }).find(j => (j.payload as any).roomId === roomId);
     if (!existing) {
       repo.enqueue({ queue: QUEUES.ROOM_TICK, payload: { roomId }, priority });
@@ -304,34 +315,45 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     // Note: listJobs is an O(n) scan with no index on payload contents.
     // Acceptable at current scale (tens of rooms). Future optimization:
     // add unique constraint or dedicated column if room count grows significantly.
+    //
+    // Check-then-act race: with maxConcurrent: 3, two concurrent handlers could both
+    // pass this dedup check for the same room before either enqueue commits. SQLite
+    // serializes writes, so both will succeed and produce a duplicate. This is an
+    // accepted risk: the extra job is idempotent (tick handles duplicate execution),
+    // and true atomic dedup would require a DB-level UNIQUE constraint which adds
+    // complexity not warranted at current scale.
   }
   ```
-- Replace all `this.scheduleTick()` call sites and the `runtime.tick()` call in `runtime-recovery.ts` with `enqueueRoomTick(repo, roomId, priority)`
-- After each tick handler completes, enqueue next heartbeat with `runAt = Date.now() + 30_000`
+- Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
+- After each tick handler completes, use `enqueueRoomTick()` (not direct `enqueue()`) for the heartbeat to preserve dedup guarantees:
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
     const { roomId } = job.payload as { roomId: string };
     const runtime = this.runtimes.get(roomId);
     if (!runtime) {
-      // Runtime not ready yet (recovery in progress) or room deleted.
-      // Re-enqueue with a short delay so recovery has time to complete.
-      this.jobQueueRepo.enqueue({
-        queue: QUEUES.ROOM_TICK,
-        payload: { roomId },
-        runAt: Date.now() + 5_000,
-      });
+      // Runtime not found: could be recovery in progress OR room was deleted.
+      // Check DB to distinguish: if the room no longer exists, skip re-enqueue.
+      const roomExists = this.roomRepo.getRoom(roomId) !== null;
+      if (roomExists) {
+        // Recovery still in progress — re-enqueue with delay
+        enqueueRoomTick(this.jobQueueRepo, roomId, 0);
+        // Use runAt delay via direct enqueue for the re-enqueue-on-miss case:
+        this.jobQueueRepo.enqueue({
+          queue: QUEUES.ROOM_TICK,
+          payload: { roomId },
+          runAt: Date.now() + 5_000,
+        });
+      }
+      // Room deleted: do not re-enqueue (prevents perpetual churn)
       return;
     }
     await runtime.tick();
-    // Heartbeat: schedule next tick
-    this.jobQueueRepo.enqueue({
-      queue: QUEUES.ROOM_TICK,
-      payload: { roomId },
-      runAt: Date.now() + 30_000,
-    });
+    // Heartbeat: use enqueueRoomTick to preserve dedup
+    enqueueRoomTick(this.jobQueueRepo, roomId);
   });
   ```
+  Note: the heartbeat `runAt` delay (30s) is omitted from `enqueueRoomTick` since the helper doesn't support `runAt`. Use a direct `jobQueueRepo.enqueue({ runAt: Date.now() + 30_000 })` for the heartbeat — this is intentional and documented: heartbeat always adds a new job even if one is pending (the 30s future job is distinct from any immediate pending job for the same room).
 
 **Startup and recovery ordering**: `roomRuntimeService.start()` is called with `.catch()` (fire-and-forget) inside `setupRPCHandlers`. Because recovery may not be complete when the first tick jobs fire, the handler uses re-enqueue-on-miss (above) rather than silent drop. This ensures rooms always receive their tick once recovery completes, without requiring strict startup sequencing between the processor and recovery.
 
@@ -344,13 +366,14 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 
 **Acceptance criteria**:
 - `setInterval`, `tickTimer`, and `queueMicrotask` removed from `RoomRuntime`.
-- All `scheduleTick()` call sites replaced with `enqueueRoomTick()`.
-- `runtime-recovery.ts` uses `enqueueRoomTick()` instead of `runtime.tick()`.
-- Re-enqueue-on-miss: handler re-enqueues with `runAt = now + 5_000` if runtime not found.
-- Dedup: no duplicate `room.tick` jobs accumulate for the same room.
+- All `scheduleTick()` call sites in `room-runtime.ts` replaced with `enqueueRoomTick()` (recovery paths in `runtime-recovery.ts` are automatically covered since they call `onWorkerTerminalState`/`onLeaderTerminalState` which call `scheduleTick()`).
+- `jobQueueRepo` added to `RoomRuntimeConfig` interface.
+- Handler distinguishes "room deleted" from "runtime loading": no re-enqueue for deleted rooms.
+- Re-enqueue-on-miss: handler re-enqueues with `runAt = now + 5_000` if room exists but runtime not found.
+- Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs`; check-then-act race documented as accepted risk.
 - Heartbeat re-scheduling: after each successful tick, new job enqueued with `runAt = now + 30_000`.
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (runtime not found), graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule, re-enqueue-on-miss (runtime loading), no-re-enqueue for deleted room, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -366,7 +389,7 @@ Add integration/online tests validating job persistence and idempotency, add a s
 
 **Online/integration tests** (`packages/daemon/tests/online/`):
 
-Note: `packages/daemon/tests/helpers/daemon-server.ts` provides only an in-process `createDaemonApp()` wrapper — there is no spawned-process mode for real kill/restart simulation. The crash-recovery scenarios below are validated by stopping and restarting the `JobQueueProcessor` within a single process, which is sufficient to verify that jobs persist across processor stop/start cycles (SQLite persistence is process-independent).
+Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer()` function (lines 78–189) that spawns a real child process, selectable via `DAEMON_TEST_SPAWN=true`. However, the crash-recovery scenarios below use in-process processor stop/start rather than real process kill, which is sufficient to verify SQLite job persistence (persistence is process-independent) and avoids the complexity of spawned-process lifecycle in test setup.
 
 1. **Session title generation persistence**: enqueue a `session.title_generation` job, stop and restart the processor in-process, verify the job is picked up and the title is set exactly once.
 2. **GitHub event idempotency**: enqueue the same `github.event` job payload twice (same `eventId`); verify it is processed exactly once (check `github_processed_events` table has one row).
@@ -391,6 +414,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` provides only an in-proce
   }
   ```
 - On daemon startup: enqueue first run with `runAt = now` if no pending/processing cleanup job exists
+- On daemon startup: also run a synchronous one-time prune of `github_processed_events` rows older than 30 days to bound table size in case the daemon has been offline for an extended period (e.g., `> 30` days)
 
 **Cleanup scope** — patterns explicitly removed by this task:
 - `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no remaining references)
@@ -442,5 +466,5 @@ Tasks 2, 3, and 4 are independent and can run in parallel after Task 1 is merged
 | `packages/daemon/src/lib/github/webhook-handler.ts` | Task 3 |
 | `packages/daemon/src/lib/room/runtime/room-runtime.ts` | Task 4 |
 | `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` | Task 4 |
-| `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — replace direct `tick()` call with `enqueueRoomTick()` |
+| `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` | Task 4 — no direct changes; covered by `scheduleTick()` replacement in `room-runtime.ts` |
 | `docs/adr/0002-job-queue-migration.md` | Reference ADR |

--- a/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-for-code-base.md
@@ -238,14 +238,19 @@ Replace the in-memory GitHub event pipeline with a persistent job queue so event
 Webhook events have a stable `X-GitHub-Delivery` delivery ID available in `webhook-handler.ts` (line ~141), but **the current `normalizeWebhookEvent` in `event-normalizer.ts` calls `generateEventId()` which returns a random UUID — not the delivery ID**. The delivery ID is not forwarded to the normalizer. To fix this, the webhook handler must pass the `X-GitHub-Delivery` header value directly as the `eventId` field in the `github.event` job payload, bypassing the normalizer's `generateEventId()`:
 ```typescript
 // webhook-handler.ts, when enqueueing the github.event job:
-const deliveryId = req.header('X-GitHub-Delivery') ?? generateUUID();
+const deliveryId = req.header('X-GitHub-Delivery');
+if (!deliveryId) {
+  // Reject requests without a delivery ID — idempotency is impossible without it.
+  // GitHub always sends X-GitHub-Delivery; absence indicates a non-GitHub or malformed request.
+  return c.json({ error: 'Missing X-GitHub-Delivery header' }, 400);
+}
 jobQueueRepo.enqueue({
   queue: QUEUES.GITHUB_EVENT,
   payload: { eventType, eventId: deliveryId, payload: webhookPayload },
   maxRetries: 0,
 });
 ```
-The polling path already uses deterministic IDs as described above. `normalizeWebhookEvent` may still be called for in-process pipeline use, but its output `eventId` should NOT be used as the job's `eventId`.
+The polling path already uses deterministic IDs as described above. `normalizeWebhookEvent` may still be called for in-process pipeline use, but its output `eventId` should NOT be used as the job's `eventId`. Rejecting missing-header requests (HTTP 400) rather than using a fallback UUID is required to maintain idempotency guarantees — a fallback UUID would make the INSERT-first dedup check meaningless for those events.
 
 **Files to modify**:
 
@@ -256,19 +261,30 @@ The polling path already uses deterministic IDs as described above. `normalizeWe
    - Replace in-memory etag/timestamp state with reads/writes to `github_poll_state` table
    - In `start()`, restore repo registrations by reading from `GitHubMappingRepository` (`room_github_mappings` table)
    - Replace `setInterval` with a self-rescheduling `github.poll` job (singleton dedup)
-   - Re-scheduling uses a `finally` block to guarantee next poll is always enqueued regardless of handler success or failure:
+   - Re-scheduling uses a `finally` block with dedup to guarantee next poll is always enqueued but never doubled:
      ```typescript
      handler = async (job) => {
        try {
          await runPollCycle();
        } finally {
-         // Always schedule next poll, even on failure
-         jobQueueRepo.enqueue({
+         // Schedule next poll only if no future-scheduled poll already exists.
+         // Dedup prevents poll chain multiplication if two github.poll jobs are ever
+         // simultaneously present (e.g., crash during startup before dedup check runs).
+         // Without dedup, each job's finally would create another, doubling the chain.
+         const now = Date.now();
+         const existingPoll = jobQueueRepo.listJobs({
            queue: QUEUES.GITHUB_POLL,
-           payload: {},
-           runAt: Date.now() + POLL_INTERVAL_MS,
-           maxRetries: 0,
-         });
+           status: ['pending'],
+           limit: 10,
+         }).find(j => j.runAt !== null && j.runAt > now);
+         if (!existingPoll) {
+           jobQueueRepo.enqueue({
+             queue: QUEUES.GITHUB_POLL,
+             payload: {},
+             runAt: now + POLL_INTERVAL_MS,
+             maxRetries: 0,
+           });
+         }
        }
      };
      ```
@@ -305,9 +321,10 @@ For `github.event`: INSERT-first idempotency requires `maxRetries: 0`. With `max
 - Repository registrations restored from `GitHubMappingRepository` on `start()`.
 - Same event cannot be processed twice: INSERT-first strategy (`INSERT OR IGNORE` at job start, skip pipeline if row already existed) is concurrency-safe with `maxConcurrent: 3`.
 - `github.event` jobs use `maxRetries: 0` (at-most-once delivery). This is required because INSERT-first + retry would cause permanent silent event drops: a retry sees the existing row and skips the pipeline. GitHub webhooks retry on their own; polled events reappear on next poll cycle.
-- `github.poll` re-scheduling uses `finally` block — polling never permanently stalls after handler error (modulo fatal SQLite failure, accepted risk).
+- `github.poll` re-scheduling uses `finally` block with dedup (only enqueues if no future-scheduled poll already exists) — polling never permanently stalls after handler error, and the poll chain never multiplies if duplicate `github.poll` jobs are ever present (modulo fatal SQLite failure, accepted risk).
 - Enqueued `github.event` jobs survive daemon restart.
 - DB migration for `github_processed_events` and `github_poll_state` tables is included and applied at daemon startup.
+- Webhook requests missing `X-GitHub-Delivery` header are rejected with HTTP 400 (fallback UUID would disable idempotency).
 - Webhook `github.event` jobs use `X-GitHub-Delivery` header value as `eventId` (not `generateEventId()` which produces random UUIDs); verified by unit test that re-delivering the same webhook with same delivery ID is idempotent.
 - Unit tests cover: stable ID generation for polled events, stable delivery ID for webhooks, INSERT-first idempotency (first insert succeeds, second is no-op), poll re-scheduling on success and on error, webhook path enqueues job, two-ETag persistence per repo.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
@@ -358,6 +375,13 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     // Acceptable at current scale (tens of rooms). Future optimization:
     // add unique constraint or dedicated column if room count grows significantly.
     //
+    // Known trade-off: dedup checks against `processing` status means event-driven
+    // ticks are suppressed while a tick is already executing. New state changes during
+    // a long-running tick will not trigger an immediate re-tick; they will be picked up
+    // by the heartbeat (30s). This is an accepted trade-off: removing `processing` from
+    // dedup would allow concurrent tick execution for the same room, which could cause
+    // inconsistent state; separate per-room queuing would add significant complexity.
+    //
     // Check-then-act race: with maxConcurrent: 3, two concurrent handlers could both
     // pass this dedup check for the same room before either enqueue commits. SQLite
     // serializes writes, so both will succeed and produce a duplicate. This is an
@@ -367,7 +391,7 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
   }
   ```
 - Replace all `this.scheduleTick()` call sites in `room-runtime.ts` with `enqueueRoomTick(this.jobQueueRepo, this.roomId, priority)`
-- After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` placement ensures no room permanently stops ticking even if `runtime.tick()` throws. The heartbeat enqueue **deduplicates against existing pending future-scheduled jobs** (`runAt > now`) — when event-driven ticks fire frequently, without this dedup each tick's `finally` would create a new parallel heartbeat chain. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
+- After each tick handler attempt (success or failure), attempt to schedule a heartbeat in a `try/finally` block. The `finally` block must first check `this.runtimes.has(roomId)` — if the runtime was stopped while the tick was in-flight, do NOT enqueue a heartbeat (otherwise the chain loops indefinitely via re-enqueue-on-miss). The heartbeat enqueue deduplicates against existing pending future-scheduled jobs (`runAt > now`) to prevent heartbeat chain multiplication. All `room.tick` jobs must use `maxRetries: 0` because the `finally` pattern self-reschedules — with `maxRetries > 0`, each processor retry also fires `finally`, creating duplicate heartbeat jobs.
 - Register handler in `RoomRuntimeService.start()`:
   ```typescript
   this.jobQueueProcessor.register(QUEUES.ROOM_TICK, async (job) => {
@@ -378,13 +402,23 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       // Check DB to distinguish: if the room no longer exists, skip re-enqueue.
       const roomExists = this.ctx.roomManager.getRoom(roomId) !== null;
       if (roomExists) {
-        // Recovery still in progress — re-enqueue with delay only (no immediate enqueue).
-        this.jobQueueRepo.enqueue({
+        // Recovery still in progress — re-enqueue with delay, but only if no pending
+        // job for this room already exists. Dedup prevents multiple concurrent workers
+        // (maxConcurrent: 3) from each enqueueing an independent 5s delayed job when
+        // all arrive at this branch simultaneously.
+        const anyPending = this.jobQueueRepo.listJobs({
           queue: QUEUES.ROOM_TICK,
-          payload: { roomId },
-          runAt: Date.now() + 5_000,
-          maxRetries: 0,
-        });
+          status: ['pending'],
+          limit: 1000,
+        }).find(j => (j.payload as any).roomId === roomId);
+        if (!anyPending) {
+          this.jobQueueRepo.enqueue({
+            queue: QUEUES.ROOM_TICK,
+            payload: { roomId },
+            runAt: Date.now() + 5_000,
+            maxRetries: 0,
+          });
+        }
       }
       // Room deleted: do not re-enqueue (prevents perpetual churn)
       return;
@@ -392,8 +426,15 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
     try {
       await runtime.tick();
     } finally {
-      // Heartbeat: schedule a future tick if none already pending for this room.
-      // Placing in finally ensures no room permanently stops ticking on handler error.
+      // Heartbeat: schedule a future tick if (a) runtime is still tracked AND
+      // (b) no future-scheduled heartbeat already exists.
+      //
+      // CRITICAL: Check this.runtimes.has(roomId) first. stopRuntime() may be called
+      // concurrently while a tick is in-flight (room is stopped but tick is still running).
+      // Without this check, the finally block would re-enqueue a heartbeat for a stopped
+      // runtime, causing the re-enqueue-on-miss path to loop indefinitely (room exists in
+      // DB, runtime not in map → re-enqueue with 5s delay → repeat forever).
+      //
       // maxRetries: 0 is required: with the finally pattern, processor retries would
       // each also fire finally, creating duplicate heartbeat jobs (job multiplication).
       //
@@ -401,22 +442,24 @@ Replace **both** the `setInterval` heartbeat and the `scheduleTick()` (`queueMic
       // (runAt > now), skip — prevents heartbeat chain multiplication when event-driven
       // ticks fire frequently (each event-driven tick's finally would otherwise create
       // an additional parallel heartbeat chain).
-      const now = Date.now();
-      const existingHeartbeat = this.jobQueueRepo.listJobs({
-        queue: QUEUES.ROOM_TICK,
-        status: ['pending'],
-        limit: 1000,
-      }).find(j =>
-        (j.payload as any).roomId === roomId &&
-        j.runAt !== null && j.runAt > now
-      );
-      if (!existingHeartbeat) {
-        this.jobQueueRepo.enqueue({
+      if (this.runtimes.has(roomId)) {
+        const now = Date.now();
+        const existingHeartbeat = this.jobQueueRepo.listJobs({
           queue: QUEUES.ROOM_TICK,
-          payload: { roomId },
-          runAt: now + 30_000,
-          maxRetries: 0,
-        });
+          status: ['pending'],
+          limit: 1000,
+        }).find(j =>
+          (j.payload as any).roomId === roomId &&
+          j.runAt !== null && j.runAt > now
+        );
+        if (!existingHeartbeat) {
+          this.jobQueueRepo.enqueue({
+            queue: QUEUES.ROOM_TICK,
+            payload: { roomId },
+            runAt: now + 30_000,
+            maxRetries: 0,
+          });
+        }
       }
     }
   });
@@ -438,14 +481,14 @@ The re-enqueue-on-miss tick handler avoids the risk of processing a tick after `
 - `scheduleHeartbeat()` method (if present) removed from `RoomRuntimeService` — replaced by the `finally`-based heartbeat in the tick handler.
 - `jobQueueRepo` added to `RoomRuntimeConfig` interface.
 - All `room.tick` jobs enqueued with `maxRetries: 0` (both `enqueueRoomTick` helper and direct enqueues): prevents job multiplication from retry + finally interaction.
-- Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error.
+- Heartbeat enqueue is inside a `try/finally` block so it fires even if `runtime.tick()` throws — no room permanently stops ticking on handler error. The `finally` block checks `this.runtimes.has(roomId)` before enqueueing: if the runtime was stopped while the tick was in-flight, skip re-enqueue to prevent the indefinite re-enqueue-on-miss loop.
 - Handler distinguishes "room deleted" from "runtime loading" via `ctx.roomManager.getRoom(roomId)`; no re-enqueue for deleted rooms.
-- Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`, `maxRetries: 0`) via direct enqueue when room exists but runtime not found; no `enqueueRoomTick` call in this path.
+- Re-enqueue-on-miss: single delayed job (`runAt = now + 5_000`, `maxRetries: 0`) when room exists but runtime not found; dedup against existing pending jobs prevents multiple concurrent workers (maxConcurrent: 3) from each enqueueing an independent delayed job.
 - Dedup: `enqueueRoomTick` uses `limit: 1000` on `listJobs` and filters by `runAt === null || runAt <= now` — heartbeat jobs (future `runAt`) do NOT suppress event-driven immediate ticks.
 - Heartbeat dedup: `finally` block checks for existing pending future-scheduled job (`runAt > now`) before enqueuing, preventing heartbeat chain multiplication when event-driven ticks fire frequently.
 - Check-then-act race documented as accepted risk (for both `enqueueRoomTick` and heartbeat dedup path).
 - Shutdown ordering enforced in `app.ts` cleanup closure.
-- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
+- Unit tests cover: enqueue on event, dedup, heartbeat re-schedule (fires even on tick() throw), heartbeat NOT scheduled when runtime stopped during tick (liveness check), re-enqueue-on-miss (single delayed job), no-re-enqueue for deleted room, graceful tick execution.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
@@ -487,7 +530,12 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
   }
   ```
 - On daemon startup: enqueue first run with `runAt = now` if no pending/processing cleanup job exists
-- On daemon startup: also run a synchronous one-time prune of `github_processed_events` rows older than 30 days to bound table size in case the daemon has been offline for an extended period (e.g., `> 30` days). This prune must run **before** `jobQueueProcessor.start()` to prevent a stale `processing`-status job from a crashed instance being re-dispatched before old rows are cleaned up (which could cause double-execution of events whose `github_processed_events` row was pruned).
+- On daemon startup: run a synchronous one-time prune of `github_processed_events` rows older than **90 days** (not 30 days) to bound table size after extended offline periods. This prune must run **before** `jobQueueProcessor.start()`.
+
+  **Dedup gap and accepted risk**: If the daemon was offline for > 90 days AND had `github.event` jobs stuck in `processing` state at shutdown, the startup prune could delete those jobs' dedup rows. On restart, the processor reclaims those stale jobs and re-runs the pipeline (duplicate event processing). This is an accepted risk:
+  - The stale reclaim threshold is 5 minutes — any job stuck for > 5 minutes is reclaimed. For a dedup row to be pruned, the daemon must have been offline for > 90 days with those 5-minute-old processing jobs.
+  - Even in that scenario, at-most-once delivery is already the documented guarantee for `github.event` (maxRetries: 0).
+  - The 90-day window was chosen to provide a practical safety margin well beyond normal daemon restart scenarios (typical offline < hours). The ongoing scheduled cleanup prunes rows older than 30 days.
 
 **Cleanup scope** — patterns explicitly removed by this task:
 - `pendingBackgroundTasks` Set in `session-manager.ts` (removed in Task 2; confirm no remaining references)
@@ -503,7 +551,7 @@ Note: `packages/daemon/tests/helpers/daemon-server.ts` has a `spawnDaemonServer(
 - At least 3 online tests covering job persistence and idempotency across processor restart.
 - E2E test verifies UI recovers after WebSocket close/restore using `closeWebSocket()` / `restoreWebSocket()`.
 - Scheduled cleanup job self-reschedules via `finally` block with `maxRetries: 0` (prevents job multiplication: with `maxRetries > 0`, each retry also fires `finally`, creating extra next-day cleanup jobs); verified by unit test.
-- Startup-time synchronous prune of `github_processed_events` rows older than 30 days runs on daemon start **before** `jobQueueProcessor.start()`; verified by unit test.
+- Startup-time synchronous prune of `github_processed_events` rows older than **90 days** runs on daemon start **before** `jobQueueProcessor.start()`; verified by unit test. (90-day window provides safety margin; ongoing cleanup job prunes at 30 days. Risk of dedup gap for daemon offline > 90 days is accepted — at-most-once delivery is already the guarantee.)
 - No stale `pendingBackgroundTasks`, `scheduleTick()`, or `setInterval`-based tick patterns remain in production code.
 - `bun run check` passes (lint + typecheck + knip).
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.


### PR DESCRIPTION
## Summary

This plan document breaks down the goal of wiring up and adopting the existing (but unused) persistent job queue across the NeoKai daemon.

## Background

`JobQueueRepository` and `JobQueueProcessor` are fully implemented with comprehensive unit tests, but `app.ts` never instantiates the processor and no subsystem enqueues jobs. All background work currently uses fire-and-forget Promises, `setInterval`, or in-memory state that is lost on daemon restart.

## Proposed Tasks

### Task 1 — Wire Up JobQueueProcessor in DaemonApp (Foundation)
Initialize `JobQueueProcessor` in `app.ts`, define queue name constants, and hook it into the daemon start/stop lifecycle. All subsequent tasks depend on this.

### Task 2 — Migrate Session Background Tasks (depends on Task 1)
Replace the fire-and-forget title generation + git branch rename (currently tracked in a `Set<Promise>`) with a persistent `session.title_generation` job. Removes `pendingBackgroundTasks` from `SessionManager`.

### Task 3 — Migrate GitHub Event Processing (depends on Task 1)
Persist polling state (etags, timestamps) to DB; enqueue a `github.event` job per new event instead of firing directly through the event bus. Adds idempotency so the same event cannot be processed twice across restarts.

### Task 4 — Migrate Room Runtime Tick (depends on Task 1)
Remove the `setInterval` heartbeat from `RoomRuntime`; drive ticks via `room.tick` jobs with deduplication and heartbeat re-scheduling after each tick. Room state machine operations become durable.

### Task 5 — Integration Tests, Cleanup, and E2E Validation (depends on Tasks 2–4)
Online tests for crash-recovery across all three migrated subsystems, an E2E test for UI recovery after restart, removal of stale in-memory patterns, and a scheduled DB cleanup job.

## Dependency Graph

```
Task 1 (Foundation)
  ├── Task 2 (Session tasks)    ──┐
  ├── Task 3 (GitHub events)    ──┼── Task 5 (Integration + Cleanup)
  └── Task 4 (Room runtime)     ──┘
```