### PR TITLE
chore: add shareable pre-commit hook setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-random serve-random self self-test run run-e2e build test test-daemon test-web test-shared e2e e2e-ui lint lint-fix format typecheck check compile compile-all package-npm release sync-sdk-types
+.PHONY: dev dev-random serve-random self self-test run run-e2e build test test-daemon test-web test-shared e2e e2e-ui lint lint-fix format typecheck check compile compile-all package-npm release sync-sdk-types setup-hooks setup
 
 dev:
 	@echo "Starting development server..."
@@ -169,3 +169,14 @@ update:
 	@cd packages/shared && bun update --interactive
 	@echo ""
 	@echo "✅ All packages updated!"
+
+# Install git hooks
+setup-hooks:
+	@echo "Installing git hooks..."
+	@cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-commit
+	@echo "✅ Git hooks installed"
+
+# Full development environment setup
+setup: setup-hooks
+	@echo "✅ Development environment ready"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Pre-commit hook for Neokai
+# Runs lint, format check, type checking, and knip before allowing commit
+#
+
+set -e
+
+echo "🔍 Running pre-commit checks..."
+
+# Run lint
+echo "📋 Running lint..."
+bun run lint
+if [ $? -ne 0 ]; then
+    echo "❌ Lint failed. Please fix linting errors before committing."
+    echo "💡 You can run 'bun run lint:fix' to auto-fix some issues."
+    exit 1
+fi
+
+# Run format check
+echo "🎨 Checking formatting..."
+bun run format:check
+if [ $? -ne 0 ]; then
+    echo "❌ Formatting check failed. Please format your code before committing."
+    echo "💡 Run 'bun run format' to fix formatting."
+    exit 1
+fi
+
+# Run type check
+echo "🔧 Running type check..."
+bun run typecheck 2>&1 | tee /tmp/typecheck-output.txt
+
+# Check the exit code of typecheck command
+TYPECHECK_EXIT_CODE=${PIPESTATUS[0]}
+
+if [ $TYPECHECK_EXIT_CODE -ne 0 ]; then
+    # Count errors by package
+    CLI_SRC_ERRORS=$(grep -E "packages/cli/src/" /tmp/typecheck-output.txt | grep -v "/tests/" | grep "error TS" | wc -l)
+    DAEMON_SRC_ERRORS=$(grep -E "packages/daemon/src/" /tmp/typecheck-output.txt | grep -v "/tests/" | grep "error TS" | wc -l)
+    SHARED_SRC_ERRORS=$(grep -E "packages/shared/src/" /tmp/typecheck-output.txt | grep -v "/tests/" | grep "error TS" | wc -l)
+    WEB_ERRORS=$(grep -E "packages/web/" /tmp/typecheck-output.txt | grep "error TS" | wc -l)
+    TEST_ERRORS=$(grep -E "/tests?/" /tmp/typecheck-output.txt | grep "error TS" | wc -l)
+
+    echo ""
+    echo "❌ Type check failed!"
+    echo "   CLI src:     $CLI_SRC_ERRORS error(s)"
+    echo "   Daemon src:  $DAEMON_SRC_ERRORS error(s)"
+    echo "   Shared src:  $SHARED_SRC_ERRORS error(s)"
+    echo "   Web package: $WEB_ERRORS error(s)"
+    echo "   Test files:  $TEST_ERRORS error(s)"
+    echo ""
+    echo "💡 Run 'bun run typecheck' to see all errors"
+    echo "⚠️  All type errors must be fixed before committing"
+    rm /tmp/typecheck-output.txt
+    exit 1
+fi
+
+rm /tmp/typecheck-output.txt
+
+# Run knip (dead code detection)
+echo "🔎 Running knip (dead code detection)..."
+bun run knip || {
+    echo "❌  Knip found unused code (see above). Please remove unused code before committing."
+    exit 1
+}
+
+echo "✅ All pre-commit checks passed!"
+exit 0


### PR DESCRIPTION
## Summary

- Adds a shareable pre-commit hook script at `scripts/git-hooks/pre-commit`
- Adds `make setup-hooks` target to install the hook locally
- Adds `make setup` target for full development environment setup

## Details

The pre-commit hook runs the same checks as CI:
- **lint**: Oxlint checks
- **format:check**: Biome formatting verification
- **typecheck**: TypeScript type checking
- **knip**: Dead code detection

After merging, new clones can run `make setup-hooks` to install the pre-commit hook.

## Test plan

- [x] Verify hook script is executable
- [x] Verify Makefile targets work correctly
- [x] Run `make setup-hooks` and verify hook is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)