### PR TITLE
feat(room): remove Chat tab from Room dashboard

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,7 +12,6 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
-	currentRoomChatSignal,
 } from './lib/signals.ts';
 import { initSessionStatusTracking } from './lib/session-status.ts';
 import { globalStore } from './lib/global-store.ts';
@@ -23,13 +22,11 @@ import {
 	navigateToRoom,
 	navigateToRoomSession,
 	navigateToRoomTask,
-	navigateToRoomChat,
 	navigateToHome,
 	createSessionPath,
 	createRoomPath,
 	createRoomSessionPath,
 	createRoomTaskPath,
-	createRoomChatPath,
 } from './lib/router.ts';
 
 export function App() {
@@ -84,7 +81,6 @@ export function App() {
 			const roomId = currentRoomIdSignal.value;
 			const roomSessionId = currentRoomSessionIdSignal.value;
 			const roomTaskId = currentRoomTaskIdSignal.value;
-			const roomChatActive = currentRoomChatSignal.value;
 			const currentPath = window.location.pathname;
 			const expectedPath = sessionId
 				? createSessionPath(sessionId)
@@ -92,11 +88,9 @@ export function App() {
 					? createRoomTaskPath(roomId, roomTaskId)
 					: roomSessionId && roomId
 						? createRoomSessionPath(roomId, roomSessionId)
-						: roomChatActive && roomId
-							? createRoomChatPath(roomId)
-							: roomId
-								? createRoomPath(roomId)
-								: '/';
+						: roomId
+							? createRoomPath(roomId)
+							: '/';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops
@@ -107,8 +101,6 @@ export function App() {
 					navigateToRoomTask(roomId, roomTaskId, true);
 				} else if (roomSessionId && roomId) {
 					navigateToRoomSession(roomId, roomSessionId, true);
-				} else if (roomChatActive && roomId) {
-					navigateToRoomChat(roomId, true);
 				} else if (roomId) {
 					navigateToRoom(roomId, true);
 				} else {

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -2,8 +2,6 @@
  * Room components package
  *
  * Components for room-based task management and goals configuration.
- *
- * Note: Room chat uses unified session architecture via ChatContainer with sessionId="room:{roomId}"
  */
 
 // @public - Library export

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -3,7 +3,6 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
-	currentRoomChatSignal,
 	navSectionSignal,
 	settingsSectionSignal,
 } from '../lib/signals.ts';
@@ -26,7 +25,6 @@ export default function MainContent() {
 	const roomId = currentRoomIdSignal.value;
 	const roomSessionId = currentRoomSessionIdSignal.value;
 	const roomTaskId = currentRoomTaskIdSignal.value;
-	const roomChatActive = currentRoomChatSignal.value;
 	const sessionsList = sessions.value;
 	const navSection = navSectionSignal.value;
 	const settingsSection = settingsSectionSignal.value;
@@ -34,13 +32,7 @@ export default function MainContent() {
 	// Room route takes priority
 	if (roomId) {
 		return (
-			<Room
-				key={roomId}
-				roomId={roomId}
-				sessionViewId={roomSessionId}
-				taskViewId={roomTaskId}
-				chatTabActive={roomChatActive}
-			/>
+			<Room key={roomId} roomId={roomId} sessionViewId={roomSessionId} taskViewId={roomTaskId} />
 		);
 	}
 

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -5,17 +5,11 @@
  * - Room dashboard showing sessions and tasks
  * - Goals tab
  * - Real-time updates via state channels
- * - Room chat using unified session architecture (ChatContainer)
  */
 
 import { useEffect, useState } from 'preact/hooks';
 import { roomStore } from '../lib/room-store';
-import {
-	navigateToHome,
-	navigateToRoomTask,
-	navigateToRoomChat,
-	navigateToRoom,
-} from '../lib/router';
+import { navigateToHome, navigateToRoomTask, navigateToRoom } from '../lib/router';
 import { RoomDashboard } from '../components/room/RoomDashboard';
 import ChatContainer from './ChatContainer';
 import { GoalsEditor, RoomContext, RoomSettings, RoomAgents } from '../components/room';
@@ -25,69 +19,36 @@ import { Button } from '../components/ui/Button';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton';
 import { toast } from '../lib/toast';
 
-type RoomTab = 'chat' | 'overview' | 'context' | 'agents' | 'goals' | 'settings';
+type RoomTab = 'overview' | 'context' | 'agents' | 'goals' | 'settings';
 
 interface RoomProps {
 	roomId: string;
 	sessionViewId?: string | null; // When set, show this session content instead of room tabs
 	taskViewId?: string | null; // When set, show TaskView (Craft + Lead) for this task
-	chatTabActive?: boolean; // When true, activate the chat tab (from URL /room/:id/chat)
 }
 
-export default function Room({ roomId, sessionViewId, taskViewId, chatTabActive }: RoomProps) {
+export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 	const [initialLoad, setInitialLoad] = useState(true);
-	const [activeTab, setActiveTab] = useState<RoomTab>(chatTabActive ? 'chat' : 'overview');
-
-	// The room agent chat session ID
-	const chatSessionId = `room:chat:${roomId}`;
+	const [activeTab, setActiveTab] = useState<RoomTab>('overview');
 
 	useEffect(() => {
 		roomStore.select(roomId).finally(() => {
 			setInitialLoad(false);
-			// Auto-default to chat tab on initial plain room load when tasks are in review.
-			// Skip if already on a subroute (session view, task view, or chat tab via URL).
-			if (!chatTabActive && !sessionViewId && !taskViewId) {
-				const hasReviewTasks = roomStore.tasks.value.some((t) => t.status === 'review');
-				if (hasReviewTasks) {
-					// Use navigateToRoomChat so URL and signal stay in sync
-					navigateToRoomChat(roomId);
-				}
-			}
 		});
 		return () => {
 			roomStore.select(null);
 		};
 	}, [roomId]);
 
-	// Sync activeTab when chatTabActive prop changes (URL navigation, e.g. back button).
-	// Only reset to overview in the else branch if we're still showing chat — this avoids
-	// overriding a user-initiated tab click that already called setActiveTab() before the
-	// signal cleared.
-	useEffect(() => {
-		if (chatTabActive) {
-			setActiveTab('chat');
-		} else if (activeTab === 'chat') {
-			// chatTabActive went false while chat is still displayed → external navigation
-			setActiveTab('overview');
-		}
-	}, [chatTabActive]);
-
 	// Update URL when tab changes
 	const handleTabChange = (tab: RoomTab) => {
 		setActiveTab(tab);
-		if (tab === 'chat') {
-			navigateToRoomChat(roomId);
-		} else {
-			// Navigating away from any tab (including chat) to a non-chat tab
-			navigateToRoom(roomId);
-		}
+		navigateToRoom(roomId);
 	};
 
 	const loading = roomStore.loading.value;
 	const error = roomStore.error.value;
 	const room = roomStore.room.value;
-	// Count tasks in review status for notification badge
-	const reviewTaskCount = roomStore.tasks.value.filter((t) => t.status === 'review').length;
 
 	if (loading && initialLoad) {
 		return (
@@ -183,21 +144,6 @@ export default function Room({ roomId, sessionViewId, taskViewId, chatTabActive 
 						{/* Tab bar */}
 						<div class="flex border-b border-dark-700 bg-dark-850">
 							<button
-								class={`relative px-4 py-2 text-sm font-medium transition-colors ${
-									activeTab === 'chat'
-										? 'text-blue-400 border-b-2 border-blue-400'
-										: 'text-gray-400 hover:text-gray-200'
-								}`}
-								onClick={() => handleTabChange('chat')}
-							>
-								Chat
-								{reviewTaskCount > 0 && (
-									<span class="absolute top-1.5 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white px-0.5">
-										{reviewTaskCount}
-									</span>
-								)}
-							</button>
-							<button
 								class={`px-4 py-2 text-sm font-medium transition-colors ${
 									activeTab === 'overview'
 										? 'text-blue-400 border-b-2 border-blue-400'
@@ -251,9 +197,6 @@ export default function Room({ roomId, sessionViewId, taskViewId, chatTabActive 
 
 						{/* Tab content */}
 						<div class="flex-1 overflow-hidden">
-							{activeTab === 'chat' && (
-								<ChatContainer key={chatSessionId} sessionId={chatSessionId} />
-							)}
 							{activeTab === 'overview' && (
 								<div class="h-full overflow-y-auto">
 									<RoomDashboard />

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -434,9 +434,93 @@ describe('Router Utility', () => {
 			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
 		});
 
+		it('should extract room ID from room session path', () => {
+			const roomId = getRoomIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/session/abc-123-def'
+			);
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should extract room ID from legacy chat path (backwards compat)', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/chat');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
 		it('should return null for session path', () => {
 			const roomId = getRoomIdFromPath('/session/550e8400-e29b-41d4-a716-446655440000');
 			expect(roomId).toBeNull();
+		});
+	});
+
+	describe('initializeRouter with room routes', () => {
+		it('should set currentRoomIdSignal when URL is a plain room path', () => {
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
+
+			initializeRouter();
+
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should set currentRoomIdSignal when URL is a room task path', () => {
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/task/660e8400-e29b-41d4-a716-446655440001';
+
+			initializeRouter();
+
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should set currentRoomIdSignal when URL is a legacy chat path', () => {
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
+
+			initializeRouter();
+
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('Popstate handling for room routes', () => {
+		it('should update signals when popstate navigates to a plain room path', () => {
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
+
+			window.dispatchEvent(
+				new PopStateEvent('popstate', { state: { roomId: '550e8400-e29b-41d4-a716-446655440000' } })
+			);
+
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should update signals when popstate navigates to a room task path', () => {
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/task/660e8400-e29b-41d4-a716-446655440001';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should clear room signals when popstate navigates away from room to home', () => {
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
+			initializeRouter();
+			currentRoomIdSignal.value = '550e8400-e29b-41d4-a716-446655440000';
+
+			mockLocation.pathname = '/';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -13,18 +13,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
 	getSessionIdFromPath,
 	getRoomIdFromPath,
-	getRoomChatIdFromPath,
 	createSessionPath,
-	createRoomChatPath,
 	navigateToSession,
 	navigateToHome,
-	navigateToRoomChat,
 	initializeRouter,
 	cleanupRouter,
 	getRouterState,
 	isRouterInitialized,
 } from '../router';
-import { currentSessionIdSignal, currentRoomIdSignal, currentRoomChatSignal } from '../signals';
+import { currentSessionIdSignal, currentRoomIdSignal } from '../signals';
 
 // Store original values (use unknown to avoid type errors at module load time)
 let originalHistory: unknown;
@@ -67,7 +64,6 @@ describe('Router Utility', () => {
 		// Reset signals
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 
 		// Reset mocks
 		vi.clearAllMocks();
@@ -95,7 +91,6 @@ describe('Router Utility', () => {
 		// Reset signals
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 	});
 
 	describe('getSessionIdFromPath', () => {
@@ -428,136 +423,20 @@ describe('Router Utility', () => {
 		});
 	});
 
-	describe('getRoomChatIdFromPath', () => {
-		it('should extract room ID from room chat path', () => {
-			const roomId = getRoomChatIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/chat');
+	describe('getRoomIdFromPath', () => {
+		it('should extract room ID from room path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000');
 			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
 		});
 
-		it('should return null for non-chat room path', () => {
-			const roomId = getRoomChatIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000');
-			expect(roomId).toBeNull();
-		});
-
-		it('should return null for room task path', () => {
-			const roomId = getRoomChatIdFromPath(
-				'/room/550e8400-e29b-41d4-a716-446655440000/task/abc-123'
-			);
-			expect(roomId).toBeNull();
+		it('should extract room ID from room task path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/task/abc-123');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
 		});
 
 		it('should return null for session path', () => {
-			const roomId = getRoomChatIdFromPath('/session/550e8400-e29b-41d4-a716-446655440000');
+			const roomId = getRoomIdFromPath('/session/550e8400-e29b-41d4-a716-446655440000');
 			expect(roomId).toBeNull();
-		});
-	});
-
-	describe('getRoomIdFromPath (includes chat subpath)', () => {
-		it('should extract room ID from room chat path', () => {
-			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/chat');
-			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
-		});
-	});
-
-	describe('createRoomChatPath', () => {
-		it('should create correct chat path', () => {
-			const path = createRoomChatPath('550e8400-e29b-41d4-a716-446655440000');
-			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/chat');
-		});
-	});
-
-	describe('navigateToRoomChat', () => {
-		it('should update URL and signals when navigating to room chat', () => {
-			navigateToRoomChat('550e8400-e29b-41d4-a716-446655440000');
-
-			expect(mockHistory.pushState).toHaveBeenCalledWith(
-				{
-					roomId: '550e8400-e29b-41d4-a716-446655440000',
-					chat: true,
-					path: '/room/550e8400-e29b-41d4-a716-446655440000/chat',
-				},
-				'',
-				'/room/550e8400-e29b-41d4-a716-446655440000/chat'
-			);
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(true);
-		});
-
-		it('should use replaceState when replace is true', () => {
-			navigateToRoomChat('550e8400-e29b-41d4-a716-446655440000', true);
-
-			expect(mockHistory.replaceState).toHaveBeenCalledWith(
-				{
-					roomId: '550e8400-e29b-41d4-a716-446655440000',
-					chat: true,
-					path: '/room/550e8400-e29b-41d4-a716-446655440000/chat',
-				},
-				'',
-				'/room/550e8400-e29b-41d4-a716-446655440000/chat'
-			);
-		});
-
-		it('should not navigate if already on chat path', () => {
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
-
-			navigateToRoomChat('550e8400-e29b-41d4-a716-446655440000');
-
-			expect(mockHistory.pushState).not.toHaveBeenCalled();
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(true);
-		});
-	});
-
-	describe('initializeRouter with chat route', () => {
-		it('should set currentRoomChatSignal when URL is room chat path', () => {
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
-
-			initializeRouter();
-
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(true);
-		});
-
-		it('should not set currentRoomChatSignal for plain room path', () => {
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
-
-			initializeRouter();
-
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(false);
-		});
-	});
-
-	describe('Popstate handling for room chat', () => {
-		it('should update signals when popstate navigates to room chat path', () => {
-			mockLocation.pathname = '/';
-			initializeRouter();
-
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
-
-			const popstateEvent = new PopStateEvent('popstate', {
-				state: { roomId: '550e8400-e29b-41d4-a716-446655440000', chat: true },
-			});
-			window.dispatchEvent(popstateEvent);
-
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(true);
-		});
-
-		it('should clear currentRoomChatSignal when popstate navigates away from chat', () => {
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
-			initializeRouter();
-
-			// Navigate away
-			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
-
-			const popstateEvent = new PopStateEvent('popstate', {
-				state: { roomId: '550e8400-e29b-41d4-a716-446655440000' },
-			});
-			window.dispatchEvent(popstateEvent);
-
-			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
-			expect(currentRoomChatSignal.value).toBe(false);
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -522,6 +522,30 @@ describe('Router Utility', () => {
 			expect(currentRoomIdSignal.value).toBeNull();
 			expect(currentSessionIdSignal.value).toBeNull();
 		});
+
+		it('should call replaceState to canonicalize legacy /room/:id/chat URL on popstate', () => {
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			// Simulate pressing browser back to a legacy chat URL
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/chat';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			// Signals should point at the room
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentSessionIdSignal.value).toBeNull();
+
+			// URL must be canonicalized to /room/:id (not left as /room/:id/chat)
+			expect(mockHistory.replaceState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000'
+			);
+		});
 	});
 
 	describe('Integration scenarios', () => {

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -17,7 +17,6 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
-	currentRoomChatSignal,
 	navSectionSignal,
 } from './signals.ts';
 
@@ -26,7 +25,6 @@ const SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/;
 const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
-const ROOM_CHAT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
 
 /**
@@ -65,20 +63,7 @@ export function getRoomIdFromPath(path: string): string | null {
 
 	// Also check room task pattern
 	const roomTaskMatch = path.match(ROOM_TASK_ROUTE_PATTERN);
-	if (roomTaskMatch) return roomTaskMatch[1];
-
-	// Also check room chat pattern
-	const roomChatMatch = path.match(ROOM_CHAT_ROUTE_PATTERN);
-	return roomChatMatch ? roomChatMatch[1] : null;
-}
-
-/**
- * Extract room ID from a room chat URL path
- * Returns the room ID if on a room chat route, null otherwise
- */
-export function getRoomChatIdFromPath(path: string): string | null {
-	const match = path.match(ROOM_CHAT_ROUTE_PATTERN);
-	return match ? match[1] : null;
+	return roomTaskMatch ? roomTaskMatch[1] : null;
 }
 
 /**
@@ -139,13 +124,6 @@ export function createRoomTaskPath(roomId: string, taskId: string): string {
 }
 
 /**
- * Create room chat URL path (chat tab within room layout)
- */
-export function createRoomChatPath(roomId: string): string {
-	return `/room/${roomId}/chat`;
-}
-
-/**
  * Navigate to a session
  * Updates both the URL and the signal
  *
@@ -164,7 +142,6 @@ export function navigateToSession(sessionId: string, replace = false): void {
 	if (currentPath === targetPath) {
 		// Still update the signal in case it's out of sync
 		currentSessionIdSignal.value = sessionId;
-		currentRoomChatSignal.value = false;
 		return;
 	}
 
@@ -181,7 +158,6 @@ export function navigateToSession(sessionId: string, replace = false): void {
 
 		// Update the signal
 		currentSessionIdSignal.value = sessionId;
-		currentRoomChatSignal.value = false;
 		navSectionSignal.value = 'chats';
 	} finally {
 		// Use setTimeout to break the synchronous cycle
@@ -203,7 +179,6 @@ export function navigateToHome(replace = false): void {
 	if (currentPath === '/') {
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		return;
@@ -217,7 +192,6 @@ export function navigateToHome(replace = false): void {
 
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 	} finally {
@@ -246,7 +220,6 @@ export function navigateToRoom(roomId: string, replace = false): void {
 	if (currentPath === targetPath) {
 		// Still update the signal in case it's out of sync
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -264,9 +237,8 @@ export function navigateToRoom(roomId: string, replace = false): void {
 			targetPath
 		);
 
-		// Update the signals - room takes priority, clear session, room session, task, and chat
+		// Update the signals - room takes priority, clear session, room session, and task
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -299,7 +271,6 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 	if (currentPath === targetPath) {
 		// Still update the signal in case it's out of sync
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = sessionId;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -319,7 +290,6 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 
 		// Update the signals
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = sessionId;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -350,7 +320,6 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 
 	if (currentPath === targetPath) {
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomTaskIdSignal.value = taskId;
 		currentRoomSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -364,51 +333,7 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 		window.history[historyMethod]({ roomId, taskId, path: targetPath }, '', targetPath);
 
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomTaskIdSignal.value = taskId;
-		currentRoomSessionIdSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} finally {
-		setTimeout(() => {
-			routerState.isNavigating = false;
-		}, 0);
-	}
-}
-
-/**
- * Navigate to the room chat tab
- * Shows the Chat tab within the room layout at /room/:roomId/chat
- *
- * @param roomId - The room ID
- * @param replace - Whether to replace current history entry (default: false)
- */
-export function navigateToRoomChat(roomId: string, replace = false): void {
-	if (routerState.isNavigating) {
-		return; // Prevent recursive navigation
-	}
-
-	const targetPath = createRoomChatPath(roomId);
-	const currentPath = getCurrentPath();
-
-	if (currentPath === targetPath) {
-		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = true;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentSessionIdSignal.value = null;
-		return;
-	}
-
-	routerState.isNavigating = true;
-
-	try {
-		const historyMethod = replace ? 'replaceState' : 'pushState';
-		window.history[historyMethod]({ roomId, chat: true, path: targetPath }, '', targetPath);
-
-		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = true;
-		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
@@ -433,7 +358,6 @@ export function navigateToSessions(replace = false): void {
 		navSectionSignal.value = 'chats';
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		return;
 	}
@@ -446,7 +370,6 @@ export function navigateToSessions(replace = false): void {
 
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
 	} finally {
@@ -497,51 +420,38 @@ function handlePopState(_event: PopStateEvent): void {
 
 	const path = getCurrentPath();
 	const sessionId = getSessionIdFromPath(path);
-	const roomChatId = getRoomChatIdFromPath(path);
 	const roomId = getRoomIdFromPath(path);
 	const roomSession = getRoomSessionIdFromPath(path);
 	const roomTask = getRoomTaskIdFromPath(path);
 
 	// Update the signals to match the URL
-	// Chat route takes priority among room sub-routes, then task, then session, then room, then /sessions
-	if (roomChatId) {
-		currentRoomIdSignal.value = roomChatId;
-		currentRoomChatSignal.value = true;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomTask) {
+	// Task takes priority among room sub-routes, then session, then room, then /sessions
+	if (roomTask) {
 		currentRoomIdSignal.value = roomTask.roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomTaskIdSignal.value = roomTask.taskId;
 		currentRoomSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomSession) {
 		currentRoomIdSignal.value = roomSession.roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = roomSession.sessionId;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomId) {
 		currentRoomIdSignal.value = roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (SESSIONS_ROUTE_PATTERN.test(path)) {
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
 	} else {
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = sessionId;
@@ -567,50 +477,37 @@ export function initializeRouter(): string | null {
 	// Read initial session/room from URL
 	const initialPath = getCurrentPath();
 	const initialSessionId = getSessionIdFromPath(initialPath);
-	const initialRoomChatId = getRoomChatIdFromPath(initialPath);
 	const initialRoomId = getRoomIdFromPath(initialPath);
 	const initialRoomSession = getRoomSessionIdFromPath(initialPath);
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
 
-	// Set initial signals - chat route takes priority among room sub-routes, then task, then session, then room, then /sessions
-	if (initialRoomChatId) {
-		currentRoomIdSignal.value = initialRoomChatId;
-		currentRoomChatSignal.value = true;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (initialRoomTask) {
+	// Set initial signals - task takes priority among room sub-routes, then session, then room, then /sessions
+	if (initialRoomTask) {
 		currentRoomIdSignal.value = initialRoomTask.roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomTaskIdSignal.value = initialRoomTask.taskId;
 		currentRoomSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomSession) {
 		currentRoomIdSignal.value = initialRoomSession.roomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = initialRoomSession.sessionId;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomId) {
 		currentRoomIdSignal.value = initialRoomId;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (SESSIONS_ROUTE_PATTERN.test(initialPath)) {
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
 	} else {
 		currentRoomIdSignal.value = null;
-		currentRoomChatSignal.value = false;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = initialSessionId;

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -26,6 +26,8 @@ const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
+/** Legacy: /room/:id/chat was removed — treat as plain room route for backwards compat */
+const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
 
 /**
  * Router state and configuration
@@ -63,7 +65,11 @@ export function getRoomIdFromPath(path: string): string | null {
 
 	// Also check room task pattern
 	const roomTaskMatch = path.match(ROOM_TASK_ROUTE_PATTERN);
-	return roomTaskMatch ? roomTaskMatch[1] : null;
+	if (roomTaskMatch) return roomTaskMatch[1];
+
+	// Legacy chat sub-path — the Chat tab was removed; redirect old URLs to the room overview
+	const chatCompatMatch = path.match(ROOM_CHAT_COMPAT_PATTERN);
+	return chatCompatMatch ? chatCompatMatch[1] : null;
 }
 
 /**

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -450,6 +450,11 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
+		// Normalize legacy /room/:id/chat URL → /room/:id so the address bar stays clean
+		if (ROOM_CHAT_COMPAT_PATTERN.test(path)) {
+			const canonicalPath = createRoomPath(roomId);
+			window.history.replaceState({ roomId, path: canonicalPath }, '', canonicalPath);
+		}
 	} else if (SESSIONS_ROUTE_PATTERN.test(path)) {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -17,9 +17,6 @@ export const currentRoomSessionIdSignal = signal<string | null>(null);
 // When set, shows the TaskView (Craft + Lead sessions) for the selected task
 export const currentRoomTaskIdSignal = signal<string | null>(null);
 
-// Shared signal for whether the room chat tab is active (URL: /room/:id/chat)
-export const currentRoomChatSignal = signal<boolean>(false);
-
 // Shared signal for sidebar open/closed state on mobile
 export const sidebarOpenSignal = signal<boolean>(false);
 


### PR DESCRIPTION
The Chat tab was redundant since the room agent already surfaces this
functionality natively. Remove the tab, its route (/room/:id/chat),
the navigateToRoomChat helper, and all related signals and logic.
