### PR TITLE
refactor(room): reuse autoscroll and InputTextarea in TaskView

### DIFF
--- a/packages/web/src/components/ScrollToBottomButton.tsx
+++ b/packages/web/src/components/ScrollToBottomButton.tsx
@@ -10,11 +10,18 @@ import { borderColors } from '../lib/design-tokens';
 
 export interface ScrollToBottomButtonProps {
 	onClick: () => void;
+	/** Tailwind bottom-* class controlling vertical offset. Defaults to 'bottom-36'
+	 *  (sized for ChatContainer's large floating footer). Pass a smaller value like
+	 *  'bottom-4' when there is no large footer below the scroll container. */
+	bottomClass?: string;
 }
 
-export function ScrollToBottomButton({ onClick }: ScrollToBottomButtonProps) {
+export function ScrollToBottomButton({
+	onClick,
+	bottomClass = 'bottom-36',
+}: ScrollToBottomButtonProps) {
 	return (
-		<div class="absolute bottom-36 left-1/2 -translate-x-1/2 z-20">
+		<div class={`absolute ${bottomClass} left-1/2 -translate-x-1/2 z-20`}>
 			<button
 				onClick={onClick}
 				class={`w-10 h-10 rounded-full bg-dark-800 hover:bg-dark-700 text-gray-300 hover:text-gray-100 shadow-lg border ${borderColors.ui.secondary} flex items-center justify-center transition-all duration-150 animate-slideIn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -174,11 +174,14 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
 
-		// Should not throw even without the optional prop
-		expect(() => render(<TaskConversationRenderer groupId="group-1" />)).not.toThrow();
+		let container: HTMLElement | undefined;
+		expect(() => {
+			({ container } = render(<TaskConversationRenderer groupId="group-1" />));
+		}).not.toThrow();
 
+		// Component should mount and show the conversation (or loading/empty state)
 		await waitFor(() => {
-			// Just ensure it renders without crashing
+			expect(container?.firstChild).not.toBeNull();
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -246,4 +246,106 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 			expect(onCountChange).toHaveBeenCalledWith(1);
 		});
 	});
+
+	it('deduplicates within-buffer duplicates (same delta fires twice before fetch)', async () => {
+		let resolveFetch!: (value: { messages: typeof initial; hasMore: boolean }) => void;
+		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(
+			() =>
+				new Promise<{ messages: typeof initial; hasMore: boolean }>((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Same delta fires twice before the fetch resolves — buffer should deduplicate
+		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
+		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() }); // duplicate
+		});
+
+		act(() => {
+			resolveFetch({ messages: initial, hasMore: false });
+		});
+
+		// 1 fetched + 1 unique buffered delta (duplicate dropped) = 2 total
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(2);
+		});
+		expect(onCountChange).not.toHaveBeenCalledWith(3);
+	});
+
+	it('deduplicates live post-fetch delta replays (same uuid arrives again after fetch)', async () => {
+		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => ({ messages: initial, hasMore: false }));
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Wait for initial fetch to complete
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
+
+		// Same message replayed via delta after fetch (e.g. WebSocket reconnect)
+		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+
+		// Count must remain 1 — replay is silently dropped
+		expect(onCountChange).not.toHaveBeenCalledWith(2);
+	});
+
+	it('deduplicates status messages by turnId when buffered and fetched', async () => {
+		// Status messages have no uuid — dedup uses _taskMeta.turnId instead.
+		let resolveFetch!: (value: {
+			messages: ReturnType<typeof makeStatusMessage>[];
+			hasMore: boolean;
+		}) => void;
+		const statusMsg = makeStatusMessage(1, 'Task started');
+		mockRequest.mockImplementation(
+			() =>
+				new Promise<{ messages: ReturnType<typeof makeStatusMessage>[]; hasMore: boolean }>(
+					(resolve) => {
+						resolveFetch = resolve;
+					}
+				)
+		);
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Delta sends the already-parsed SDKMessage form of the same status message
+		const parsedStatus = {
+			type: 'status',
+			text: 'Task started',
+			_taskMeta: {
+				authorRole: 'system',
+				authorSessionId: '',
+				turnId: 'status-1',
+				iteration: 0,
+			},
+		};
+		act(() => {
+			deltaHandler?.({ added: [parsedStatus], timestamp: Date.now() });
+		});
+
+		// Fetch resolves with the same status message — should deduplicate via turnId
+		act(() => {
+			resolveFetch({ messages: [statusMsg], hasMore: false });
+		});
+
+		// Should be 1, not 2 — turnId-based dedup prevents the status divider appearing twice
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
+		expect(onCountChange).not.toHaveBeenCalledWith(2);
+	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Tests for TaskConversationRenderer Component
  *
@@ -18,7 +17,7 @@ import { render, cleanup, waitFor, act } from '@testing-library/preact';
 
 const mockRequest = vi.fn();
 let deltaHandler: ((event: { added: unknown[]; timestamp: number }) => void) | null = null;
-const mockOnEvent = vi.fn((eventName: string, handler) => {
+const mockOnEvent = vi.fn((eventName: string, handler: (event: unknown) => void) => {
 	if (eventName === 'state.groupMessages.delta') {
 		deltaHandler = handler;
 	}
@@ -174,7 +173,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
 
-		let container: HTMLElement | undefined;
+		let container: Element | undefined;
 		expect(() => {
 			({ container } = render(<TaskConversationRenderer groupId="group-1" />));
 		}).not.toThrow();
@@ -182,6 +181,69 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		// Component should mount and show the conversation (or loading/empty state)
 		await waitFor(() => {
 			expect(container?.firstChild).not.toBeNull();
+		});
+	});
+
+	it('merges delta messages that arrive while the initial fetch is in-flight', async () => {
+		// The fetch is delayed via a Promise that we resolve manually.
+		let resolveFetch!: (value: { messages: typeof initial; hasMore: boolean }) => void;
+		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(
+			() =>
+				new Promise<{ messages: typeof initial; hasMore: boolean }>((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Delta arrives BEFORE the fetch resolves — should be buffered
+		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
+		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+
+		// Resolve the fetch now
+		act(() => {
+			resolveFetch({ messages: initial, hasMore: false });
+		});
+
+		// Both the fetched message AND the buffered delta should appear
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(2);
+		});
+	});
+
+	it('deduplicates delta messages already included in the fetch response', async () => {
+		// The delta fires with uuid-1, which is also returned by the fetch.
+		let resolveFetch!: (value: { messages: typeof initial; hasMore: boolean }) => void;
+		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(
+			() =>
+				new Promise<{ messages: typeof initial; hasMore: boolean }>((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Delta arrives with uuid-1 — same as the fetch result
+		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+
+		// Fetch resolves with uuid-1 — the delta duplicate should be dropped
+		act(() => {
+			resolveFetch({ messages: initial, hasMore: false });
+		});
+
+		await waitFor(() => {
+			// Should be 1, not 2 — the duplicate is deduplicated
+			expect(onCountChange).toHaveBeenCalledWith(1);
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -1,0 +1,184 @@
+// @ts-nocheck
+/**
+ * Tests for TaskConversationRenderer Component
+ *
+ * Verifies that the component:
+ * - Renders messages fetched from task.getGroupMessages
+ * - Calls onMessageCountChange when the message list changes
+ * - Reacts to real-time state.groupMessages.delta events
+ * - Does NOT own a scroll container (no overflow-y-auto div)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor, act } from '@testing-library/preact';
+
+// -------------------------------------------------------
+// Mocks
+// -------------------------------------------------------
+
+const mockRequest = vi.fn();
+let deltaHandler: ((event: { added: unknown[]; timestamp: number }) => void) | null = null;
+const mockOnEvent = vi.fn((eventName: string, handler) => {
+	if (eventName === 'state.groupMessages.delta') {
+		deltaHandler = handler;
+	}
+	return () => {};
+});
+const mockJoinRoom = vi.fn();
+const mockLeaveRoom = vi.fn();
+
+vi.mock('../../hooks/useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		joinRoom: mockJoinRoom,
+		leaveRoom: mockLeaveRoom,
+	}),
+}));
+
+// SDKMessageRenderer minimal mock
+vi.mock('../sdk/SDKMessageRenderer.tsx', () => ({
+	SDKMessageRenderer: ({ message }: { message: { uuid?: string } }) => (
+		<div data-testid={`msg-${message.uuid ?? 'unknown'}`} />
+	),
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeRawMessage(id: number, role: string, uuid: string) {
+	return {
+		id,
+		groupId: 'group-1',
+		sessionId: 'sess-1',
+		role,
+		messageType: 'assistant',
+		content: JSON.stringify({ type: 'assistant', uuid, message: { content: [] } }),
+		createdAt: Date.now(),
+	};
+}
+
+function makeStatusMessage(id: number, text: string) {
+	return {
+		id,
+		groupId: 'group-1',
+		sessionId: null,
+		role: 'system',
+		messageType: 'status',
+		content: text,
+		createdAt: Date.now(),
+	};
+}
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+import { TaskConversationRenderer } from './TaskConversationRenderer';
+
+describe('TaskConversationRenderer — onMessageCountChange', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockClear();
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		deltaHandler = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('calls onMessageCountChange with the initial message count', async () => {
+		const messages = [
+			makeRawMessage(1, 'assistant', 'uuid-1'),
+			makeRawMessage(2, 'assistant', 'uuid-2'),
+		];
+		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(2);
+		});
+	});
+
+	it('calls onMessageCountChange with 0 during loading', () => {
+		// Request never resolves → still loading
+		mockRequest.mockImplementation(() => new Promise(() => {}));
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		expect(onCountChange).toHaveBeenCalledWith(0);
+	});
+
+	it('calls onMessageCountChange with updated count on delta event', async () => {
+		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => ({ messages: initial, hasMore: false }));
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
+
+		// Simulate a delta event adding one more message
+		const newMsg = makeRawMessage(2, 'assistant', 'uuid-2');
+		const parsed = JSON.parse(newMsg.content);
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(2);
+		});
+	});
+
+	it('does NOT render a scroll container (no overflow-y-auto on root element)', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
+
+		const { container } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		await waitFor(() => {
+			// Messages rendered means loading is done
+			expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
+		});
+
+		// The root element rendered by the component should NOT have overflow-y-auto
+		// (scroll ownership moved to TaskView)
+		const rootEl = container.firstChild as HTMLElement;
+		expect(rootEl?.className).not.toContain('overflow-y-auto');
+	});
+
+	it('renders status messages as centered dividers', async () => {
+		const messages = [makeStatusMessage(1, 'Task started')];
+		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
+
+		const { container } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('Task started');
+		});
+	});
+
+	it('works without onMessageCountChange prop', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => ({ messages, hasMore: false }));
+
+		// Should not throw even without the optional prop
+		expect(() => render(<TaskConversationRenderer groupId="group-1" />)).not.toThrow();
+
+		await waitFor(() => {
+			// Just ensure it renders without crashing
+		});
+	});
+});

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -278,6 +278,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		await waitFor(() => {
 			expect(onCountChange).toHaveBeenCalledWith(2);
 		});
+		await act(async () => {}); // flush pending async effects
 		expect(onCountChange).not.toHaveBeenCalledWith(3);
 	});
 
@@ -298,6 +299,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		act(() => {
 			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
 		});
+		await act(async () => {}); // flush pending async effects
 
 		// Count must remain 1 — replay is silently dropped
 		expect(onCountChange).not.toHaveBeenCalledWith(2);
@@ -346,6 +348,29 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		await waitFor(() => {
 			expect(onCountChange).toHaveBeenCalledWith(1);
 		});
+		await act(async () => {}); // flush pending async effects
 		expect(onCountChange).not.toHaveBeenCalledWith(2);
+	});
+
+	it('preserves buffered deltas when the initial fetch fails', async () => {
+		// The fetch rejects — buffered deltas should still be applied so live messages appear.
+		mockRequest.mockImplementation(async () => {
+			throw new Error('network error');
+		});
+
+		const onCountChange = vi.fn();
+		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+
+		// Delta arrives while the (doomed) fetch is in-flight
+		const liveMsg = makeRawMessage(1, 'assistant', 'uuid-live');
+		const parsed = JSON.parse(liveMsg.content) as { uuid?: string };
+		act(() => {
+			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+		});
+
+		// After the fetch rejects, buffered delta should surface
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
 	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -353,22 +353,31 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('preserves buffered deltas when the initial fetch fails', async () => {
-		// The fetch rejects — buffered deltas should still be applied so live messages appear.
-		mockRequest.mockImplementation(async () => {
-			throw new Error('network error');
-		});
+		// Use a deferred reject so the delta is guaranteed to be buffered before the error fires.
+		let rejectFetch!: (err: Error) => void;
+		mockRequest.mockImplementation(
+			() =>
+				new Promise<never>((_, reject) => {
+					rejectFetch = reject;
+				})
+		);
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
 
-		// Delta arrives while the (doomed) fetch is in-flight
+		// Delta arrives while the doomed fetch is in-flight (deterministically buffered now)
 		const liveMsg = makeRawMessage(1, 'assistant', 'uuid-live');
 		const parsed = JSON.parse(liveMsg.content) as { uuid?: string };
 		act(() => {
 			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
 		});
 
-		// After the fetch rejects, buffered delta should surface
+		// Reject the fetch now — delta is already in the buffer, guaranteed
+		act(() => {
+			rejectFetch(new Error('network error'));
+		});
+
+		// After the rejection, buffered delta should surface
 		await waitFor(() => {
 			expect(onCountChange).toHaveBeenCalledWith(1);
 		});

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -12,7 +12,7 @@
  * real-time updates.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
@@ -37,6 +37,8 @@ interface GroupMessage {
 
 interface TaskConversationRendererProps {
 	groupId: string;
+	/** Called whenever the message list length changes, so the parent can drive autoscroll */
+	onMessageCountChange?: (count: number) => void;
 }
 
 const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: string }> = {
@@ -76,11 +78,13 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
-export function TaskConversationRenderer({ groupId }: TaskConversationRendererProps) {
+export function TaskConversationRenderer({
+	groupId,
+	onMessageCountChange,
+}: TaskConversationRendererProps) {
 	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
 	const [messages, setMessages] = useState<SDKMessage[]>([]);
 	const [loading, setLoading] = useState(true);
-	const scrollRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const channel = `group:${groupId}`;
@@ -125,12 +129,6 @@ export function TaskConversationRenderer({ groupId }: TaskConversationRendererPr
 			(event) => {
 				if (event.added && event.added.length > 0) {
 					setMessages((prev) => [...prev, ...event.added]);
-					requestAnimationFrame(() => {
-						scrollRef.current?.scrollTo({
-							top: scrollRef.current.scrollHeight,
-							behavior: 'smooth',
-						});
-					});
 				}
 			}
 		);
@@ -140,6 +138,11 @@ export function TaskConversationRenderer({ groupId }: TaskConversationRendererPr
 			leaveRoom(channel);
 		};
 	}, [groupId]);
+
+	// Notify parent when message count changes so it can drive autoscroll
+	useEffect(() => {
+		onMessageCountChange?.(messages.length);
+	}, [messages.length, onMessageCountChange]);
 
 	const maps = useMessageMaps(messages, groupId);
 
@@ -175,7 +178,7 @@ export function TaskConversationRenderer({ groupId }: TaskConversationRendererPr
 	}
 
 	return (
-		<div ref={scrollRef} class="flex-1 overflow-y-auto px-4 py-3 space-y-0.5">
+		<div class="px-4 py-3 space-y-0.5">
 			{messages.map((msg, i) => {
 				const meta = getTaskMeta(msg);
 				const role = meta?.authorRole ?? 'system';

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -139,6 +139,7 @@ export function TaskConversationRenderer({
 		);
 
 		const fetchAllMessages = async () => {
+			let fetchError = false;
 			try {
 				const allGroupMessages: GroupMessage[] = [];
 				let afterId = 0;
@@ -186,8 +187,19 @@ export function TaskConversationRenderer({
 				}
 			} catch {
 				// Non-fatal: group may not have messages yet
+				fetchError = true;
 			} finally {
 				if (!cancelled) {
+					// On fetch error, flush any buffered deltas so live messages aren't lost.
+					if (fetchError && pendingDeltasRef.current.length > 0) {
+						const remainingDeltas = pendingDeltasRef.current.filter((m) => {
+							const id = getMessageId(m);
+							if (id && seenIdsRef.current.has(id)) return false;
+							if (id) seenIdsRef.current.add(id);
+							return true;
+						});
+						if (remainingDeltas.length > 0) setMessages(remainingDeltas);
+					}
 					fetchingRef.current = false;
 					pendingDeltasRef.current = [];
 					setLoading(false);

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -78,6 +78,17 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
+/**
+ * Returns a stable deduplication key for a message.
+ * Agent messages use their uuid; status messages use _taskMeta.turnId as a fallback.
+ * Returns null for messages with no identifiable key (they pass through unfiltered).
+ */
+function getMessageId(msg: SDKMessage): string | null {
+	const uuid = (msg as SDKMessage & { uuid?: string }).uuid;
+	if (uuid) return uuid;
+	return getTaskMeta(msg)?.turnId ?? null;
+}
+
 export function TaskConversationRenderer({
 	groupId,
 	onMessageCountChange,
@@ -85,16 +96,22 @@ export function TaskConversationRenderer({
 	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
 	const [messages, setMessages] = useState<SDKMessage[]>([]);
 	const [loading, setLoading] = useState(true);
-	// Guards against the fetch/delta race: delta events that arrive while the
-	// initial fetch is still in flight are buffered here and merged on resolve.
+	// Tracks every message ID (uuid or turnId) added to state, enabling deduplication
+	// across: the initial fetch, buffered pre-fetch deltas, and live post-fetch deltas
+	// (e.g. replays on WebSocket reconnect).
+	const seenIdsRef = useRef<Set<string>>(new Set());
+	// Guards the fetch/delta race: deltas received while the fetch is in-flight are
+	// buffered here and merged (with dedup) once the fetch resolves.
 	const fetchingRef = useRef(true);
 	const pendingDeltasRef = useRef<SDKMessage[]>([]);
 
 	useEffect(() => {
 		const channel = `group:${groupId}`;
 		joinRoom(channel);
+		seenIdsRef.current.clear();
 		fetchingRef.current = true;
 		pendingDeltasRef.current = [];
+		let cancelled = false;
 
 		// Subscribe first so no live messages can slip through before the fetch starts.
 		const unsub = onEvent<{ added: SDKMessage[]; timestamp: number }>(
@@ -105,7 +122,17 @@ export function TaskConversationRenderer({
 						// Buffer deltas that arrive while the initial fetch is in-flight.
 						pendingDeltasRef.current = [...pendingDeltasRef.current, ...event.added];
 					} else {
-						setMessages((prev) => [...prev, ...event.added]);
+						// Deduplicate against seenIds — handles replays on reconnect and
+						// the same event firing twice within the buffer.
+						const newMessages = event.added.filter((m) => {
+							const id = getMessageId(m);
+							if (id && seenIdsRef.current.has(id)) return false;
+							if (id) seenIdsRef.current.add(id);
+							return true;
+						});
+						if (newMessages.length > 0) {
+							setMessages((prev) => [...prev, ...newMessages]);
+						}
 					}
 				}
 			}
@@ -136,27 +163,42 @@ export function TaskConversationRenderer({
 					.map(parseGroupMessage)
 					.filter((m): m is SDKMessage => m !== null);
 
-				// Merge buffered deltas, deduplicating any messages already in the fetched set.
-				const fetchedUuids = new Set(
-					parsed.map((m) => (m as SDKMessage & { uuid?: string }).uuid).filter(Boolean)
-				);
-				const newDeltas = pendingDeltasRef.current.filter((m) => {
-					const uuid = (m as SDKMessage & { uuid?: string }).uuid;
-					return !uuid || !fetchedUuids.has(uuid);
-				});
-				setMessages([...parsed, ...newDeltas]);
+				if (!cancelled) {
+					// Register fetched messages in seenIds and collect unique ones.
+					const uniqueParsed = parsed.filter((m) => {
+						const id = getMessageId(m);
+						if (id && seenIdsRef.current.has(id)) return false;
+						if (id) seenIdsRef.current.add(id);
+						return true;
+					});
+
+					// Merge buffered deltas, deduplicating against seenIds.
+					// This handles: pre-fetch duplicates in the buffer itself, and
+					// messages already present in the fetch response (uuid or turnId match).
+					const newDeltas = pendingDeltasRef.current.filter((m) => {
+						const id = getMessageId(m);
+						if (id && seenIdsRef.current.has(id)) return false;
+						if (id) seenIdsRef.current.add(id);
+						return true;
+					});
+
+					setMessages([...uniqueParsed, ...newDeltas]);
+				}
 			} catch {
 				// Non-fatal: group may not have messages yet
 			} finally {
-				fetchingRef.current = false;
-				pendingDeltasRef.current = [];
-				setLoading(false);
+				if (!cancelled) {
+					fetchingRef.current = false;
+					pendingDeltasRef.current = [];
+					setLoading(false);
+				}
 			}
 		};
 
 		fetchAllMessages();
 
 		return () => {
+			cancelled = true;
 			unsub();
 			leaveRoom(channel);
 		};

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -139,9 +139,9 @@ export function TaskConversationRenderer({
 		);
 
 		const fetchAllMessages = async () => {
-			let fetchError = false;
+			// Declared outside the try so partial pages are committed even if a later page errors.
+			const allGroupMessages: GroupMessage[] = [];
 			try {
-				const allGroupMessages: GroupMessage[] = [];
 				let afterId = 0;
 				let hasMore = true;
 
@@ -159,13 +159,15 @@ export function TaskConversationRenderer({
 						break;
 					}
 				}
-
-				const parsed = allGroupMessages
-					.map(parseGroupMessage)
-					.filter((m): m is SDKMessage => m !== null);
-
+			} catch {
+				// Non-fatal: partial results in allGroupMessages are still committed below
+			} finally {
 				if (!cancelled) {
-					// Register fetched messages in seenIds and collect unique ones.
+					// Merge fetched pages (may be partial on error) with buffered deltas.
+					const parsed = allGroupMessages
+						.map(parseGroupMessage)
+						.filter((m): m is SDKMessage => m !== null);
+
 					const uniqueParsed = parsed.filter((m) => {
 						const id = getMessageId(m);
 						if (id && seenIdsRef.current.has(id)) return false;
@@ -183,22 +185,8 @@ export function TaskConversationRenderer({
 						return true;
 					});
 
-					setMessages([...uniqueParsed, ...newDeltas]);
-				}
-			} catch {
-				// Non-fatal: group may not have messages yet
-				fetchError = true;
-			} finally {
-				if (!cancelled) {
-					// On fetch error, flush any buffered deltas so live messages aren't lost.
-					if (fetchError && pendingDeltasRef.current.length > 0) {
-						const remainingDeltas = pendingDeltasRef.current.filter((m) => {
-							const id = getMessageId(m);
-							if (id && seenIdsRef.current.has(id)) return false;
-							if (id) seenIdsRef.current.add(id);
-							return true;
-						});
-						if (remainingDeltas.length > 0) setMessages(remainingDeltas);
+					if (uniqueParsed.length > 0 || newDeltas.length > 0) {
+						setMessages([...uniqueParsed, ...newDeltas]);
 					}
 					fetchingRef.current = false;
 					pendingDeltasRef.current = [];

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -12,7 +12,7 @@
  * real-time updates.
  */
 
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
@@ -85,10 +85,31 @@ export function TaskConversationRenderer({
 	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
 	const [messages, setMessages] = useState<SDKMessage[]>([]);
 	const [loading, setLoading] = useState(true);
+	// Guards against the fetch/delta race: delta events that arrive while the
+	// initial fetch is still in flight are buffered here and merged on resolve.
+	const fetchingRef = useRef(true);
+	const pendingDeltasRef = useRef<SDKMessage[]>([]);
 
 	useEffect(() => {
 		const channel = `group:${groupId}`;
 		joinRoom(channel);
+		fetchingRef.current = true;
+		pendingDeltasRef.current = [];
+
+		// Subscribe first so no live messages can slip through before the fetch starts.
+		const unsub = onEvent<{ added: SDKMessage[]; timestamp: number }>(
+			'state.groupMessages.delta',
+			(event) => {
+				if (event.added && event.added.length > 0) {
+					if (fetchingRef.current) {
+						// Buffer deltas that arrive while the initial fetch is in-flight.
+						pendingDeltasRef.current = [...pendingDeltasRef.current, ...event.added];
+					} else {
+						setMessages((prev) => [...prev, ...event.added]);
+					}
+				}
+			}
+		);
 
 		const fetchAllMessages = async () => {
 			try {
@@ -114,24 +135,26 @@ export function TaskConversationRenderer({
 				const parsed = allGroupMessages
 					.map(parseGroupMessage)
 					.filter((m): m is SDKMessage => m !== null);
-				setMessages(parsed);
+
+				// Merge buffered deltas, deduplicating any messages already in the fetched set.
+				const fetchedUuids = new Set(
+					parsed.map((m) => (m as SDKMessage & { uuid?: string }).uuid).filter(Boolean)
+				);
+				const newDeltas = pendingDeltasRef.current.filter((m) => {
+					const uuid = (m as SDKMessage & { uuid?: string }).uuid;
+					return !uuid || !fetchedUuids.has(uuid);
+				});
+				setMessages([...parsed, ...newDeltas]);
 			} catch {
 				// Non-fatal: group may not have messages yet
 			} finally {
+				fetchingRef.current = false;
+				pendingDeltasRef.current = [];
 				setLoading(false);
 			}
 		};
 
 		fetchAllMessages();
-
-		const unsub = onEvent<{ added: SDKMessage[]; timestamp: number }>(
-			'state.groupMessages.delta',
-			(event) => {
-				if (event.added && event.added.length > 0) {
-					setMessages((prev) => [...prev, ...event.added]);
-				}
-			}
-		);
 
 		return () => {
 			unsub();

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -42,19 +42,11 @@ vi.mock('../../lib/router.ts', () => ({
 	},
 }));
 
-// Mock TaskConversationRenderer so it doesn't need its own deps
+// Mock TaskConversationRenderer so it doesn't need its own deps.
+// We don't call onMessageCountChange here because useAutoScroll is fully mocked
+// and calling setState during render causes a "cannot update during render" warning.
 vi.mock('./TaskConversationRenderer.tsx', () => ({
-	TaskConversationRenderer: ({
-		onMessageCountChange,
-	}: {
-		onMessageCountChange?: (count: number) => void;
-	}) => {
-		// Simulate 5 messages to the parent (for autoscroll hook)
-		if (onMessageCountChange) {
-			onMessageCountChange(5);
-		}
-		return <div data-testid="conversation" />;
-	},
+	TaskConversationRenderer: () => <div data-testid="conversation" />,
 }));
 
 // Mock useAutoScroll so we can control showScrollButton
@@ -62,7 +54,7 @@ const mockScrollToBottom = vi.fn();
 const mockShowScrollButton = { value: false };
 
 vi.mock('../../hooks/useAutoScroll.ts', () => ({
-	useAutoScroll: vi.fn(({ messageCount: _mc }) => ({
+	useAutoScroll: vi.fn(() => ({
 		showScrollButton: mockShowScrollButton.value,
 		scrollToBottom: mockScrollToBottom,
 		isNearBottom: !mockShowScrollButton.value,

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -19,7 +19,7 @@ import { useAutoScroll } from '../../hooks/useAutoScroll.ts';
 // -------------------------------------------------------
 
 const mockRequest = vi.fn();
-const mockOnEvent = vi.fn(() => () => {}); // returns unsub noop
+const mockOnEvent = vi.fn((_eventName: string, _handler: (event: unknown) => void) => () => {});
 const mockJoinRoom = vi.fn();
 const mockLeaveRoom = vi.fn();
 
@@ -669,5 +669,42 @@ describe('TaskView — cancelled flag prevents post-unmount state updates', () =
 		expect(mockRequest).not.toHaveBeenCalledWith('task.getGroup', expect.anything());
 		// leaveRoom should have been called (cleanup ran)
 		expect(mockLeaveRoom).toHaveBeenCalledWith(`room:room-1`);
+	});
+
+	it('does not call task.getGroup when room.task.update fires after unmount', async () => {
+		// Capture the room.task.update event handler so we can fire it manually
+		let taskUpdateHandler: ((event: unknown) => void) | null = null;
+		mockOnEvent.mockImplementation((eventName: string, handler: (event: unknown) => void) => {
+			if (eventName === 'room.task.update') taskUpdateHandler = handler;
+			return () => {};
+		});
+		mockRequest.mockImplementation(async (method: unknown) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { unmount } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Wait for initial load to complete
+		await waitFor(() => {
+			expect(taskUpdateHandler).not.toBeNull();
+		});
+
+		// Reset call count to track only post-unmount calls
+		mockRequest.mockClear();
+
+		// Unmount the component
+		act(() => {
+			unmount();
+		});
+
+		// Fire room.task.update event after unmount
+		await act(async () => {
+			taskUpdateHandler?.({ task: makeTask('task-1', 'completed'), roomId: 'room-1' });
+		});
+
+		// The event fired after unmount must not trigger a task.getGroup request
+		expect(mockRequest).not.toHaveBeenCalledWith('task.getGroup', expect.anything());
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
+import { render, cleanup, waitFor, fireEvent, act } from '@testing-library/preact';
 import { useEffect } from 'preact/hooks';
 // Static import gives access to vi.mocked(useAutoScroll) for call assertions
 import { useAutoScroll } from '../../hooks/useAutoScroll.ts';
@@ -623,5 +623,51 @@ describe('TaskView — ScrollToBottomButton bottomClass', () => {
 		});
 
 		expect(getByTestId('scroll-to-bottom').getAttribute('data-bottom-class')).toBe('bottom-4');
+	});
+});
+
+describe('TaskView — cancelled flag prevents post-unmount state updates', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('does not call task.getGroup after unmount mid-fetch', async () => {
+		// Defer task.get so we can unmount before it resolves
+		let resolveTaskGet!: (value: { task: ReturnType<typeof makeTask> }) => void;
+		mockRequest.mockImplementation((method: unknown) =>
+			method === 'task.get'
+				? new Promise<{ task: ReturnType<typeof makeTask> }>((resolve) => {
+						resolveTaskGet = resolve;
+					})
+				: Promise.resolve({ group: null })
+		);
+
+		const { unmount } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Unmount before task.get resolves
+		act(() => {
+			unmount();
+		});
+
+		// Resolve task.get after unmount — cancelled flag should block fetchGroup call
+		await act(async () => {
+			resolveTaskGet({ task: makeTask('task-1') });
+		});
+
+		// task.getGroup must NOT have been called since the component was cancelled
+		expect(mockRequest).not.toHaveBeenCalledWith('task.getGroup', expect.anything());
+		// leaveRoom should have been called (cleanup ran)
+		expect(mockLeaveRoom).toHaveBeenCalledWith(`room:room-1`);
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -11,6 +11,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
+// Static import resolved to mocked version — gives access to .mock.calls for arg assertions
+import { useAutoScroll } from '../../hooks/useAutoScroll.ts';
 
 // -------------------------------------------------------
 // Mocks
@@ -49,7 +51,7 @@ vi.mock('./TaskConversationRenderer.tsx', () => ({
 	TaskConversationRenderer: () => <div data-testid="conversation" />,
 }));
 
-// Mock useAutoScroll so we can control showScrollButton
+// Mock useAutoScroll so we can control showScrollButton and inspect call args
 const mockScrollToBottom = vi.fn();
 const mockShowScrollButton = { value: false };
 
@@ -70,7 +72,8 @@ vi.mock('../ScrollToBottomButton.tsx', () => ({
 	),
 }));
 
-// Mock InputTextarea so we don't need its full dependencies
+// Mock InputTextarea so we don't need its full dependencies.
+// Forwards maxChars as maxLength so tests can verify the 50000 limit is passed.
 vi.mock('../InputTextarea.tsx', () => ({
 	InputTextarea: ({
 		content,
@@ -78,12 +81,14 @@ vi.mock('../InputTextarea.tsx', () => ({
 		onSubmit,
 		disabled,
 		placeholder,
+		maxChars,
 	}: {
 		content: string;
 		onContentChange: (v: string) => void;
 		onSubmit: () => void;
 		disabled?: boolean;
 		placeholder?: string;
+		maxChars?: number;
 	}) => (
 		<div data-testid="input-textarea">
 			<textarea
@@ -92,6 +97,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 				onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
 				disabled={disabled}
 				placeholder={placeholder}
+				maxLength={maxChars}
 			/>
 			<button data-testid="input-textarea-send" onClick={onSubmit} disabled={disabled}>
 				Send
@@ -144,6 +150,7 @@ describe('TaskView — awaiting_human badge', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		vi.mocked(useAutoScroll).mockClear();
 	});
 
 	afterEach(() => {
@@ -223,6 +230,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		vi.mocked(useAutoScroll).mockClear();
 	});
 
 	afterEach(() => {
@@ -286,6 +294,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		vi.mocked(useAutoScroll).mockClear();
 	});
 
 	afterEach(() => {
@@ -419,5 +428,89 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 				message: 'Please focus on auth first',
 			});
 		});
+	});
+});
+
+describe('TaskView — useAutoScroll call args', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('calls useAutoScroll with enabled:true and isInitialLoad:true on initial render', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(vi.mocked(useAutoScroll)).toHaveBeenCalled();
+		});
+
+		// On the initial render, autoScroll=true and isFirstLoad=true
+		const firstCall = vi.mocked(useAutoScroll).mock.calls[0][0];
+		expect(firstCall).toMatchObject({ enabled: true, isInitialLoad: true });
+	});
+});
+
+describe('TaskView — InputTextarea maxChars forwarding', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('passes maxChars=50000 to InputTextarea in awaiting_human state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.maxLength).toBe(50000);
+	});
+
+	it('passes maxChars=50000 to InputTextarea in awaiting_leader state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.maxLength).toBe(50000);
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -4,10 +4,13 @@
  *
  * Tests the "Awaiting your review" pulsing badge in the header
  * when group.state === 'awaiting_human', and its absence otherwise.
+ *
+ * Also covers the shared autoscroll/ScrollToBottomButton integration and
+ * InputTextarea usage in HumanInputArea.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor } from '@testing-library/preact';
+import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
 
 // -------------------------------------------------------
 // Mocks
@@ -41,7 +44,68 @@ vi.mock('../../lib/router.ts', () => ({
 
 // Mock TaskConversationRenderer so it doesn't need its own deps
 vi.mock('./TaskConversationRenderer.tsx', () => ({
-	TaskConversationRenderer: () => <div data-testid="conversation" />,
+	TaskConversationRenderer: ({
+		onMessageCountChange,
+	}: {
+		onMessageCountChange?: (count: number) => void;
+	}) => {
+		// Simulate 5 messages to the parent (for autoscroll hook)
+		if (onMessageCountChange) {
+			onMessageCountChange(5);
+		}
+		return <div data-testid="conversation" />;
+	},
+}));
+
+// Mock useAutoScroll so we can control showScrollButton
+const mockScrollToBottom = vi.fn();
+const mockShowScrollButton = { value: false };
+
+vi.mock('../../hooks/useAutoScroll.ts', () => ({
+	useAutoScroll: vi.fn(({ messageCount: _mc }) => ({
+		showScrollButton: mockShowScrollButton.value,
+		scrollToBottom: mockScrollToBottom,
+		isNearBottom: !mockShowScrollButton.value,
+	})),
+}));
+
+// Mock ScrollToBottomButton
+vi.mock('../ScrollToBottomButton.tsx', () => ({
+	ScrollToBottomButton: ({ onClick }: { onClick: () => void }) => (
+		<button data-testid="scroll-to-bottom" onClick={onClick}>
+			↓
+		</button>
+	),
+}));
+
+// Mock InputTextarea so we don't need its full dependencies
+vi.mock('../InputTextarea.tsx', () => ({
+	InputTextarea: ({
+		content,
+		onContentChange,
+		onSubmit,
+		disabled,
+		placeholder,
+	}: {
+		content: string;
+		onContentChange: (v: string) => void;
+		onSubmit: () => void;
+		disabled?: boolean;
+		placeholder?: string;
+	}) => (
+		<div data-testid="input-textarea">
+			<textarea
+				data-testid="input-textarea-field"
+				value={content}
+				onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
+				disabled={disabled}
+				placeholder={placeholder}
+			/>
+			<button data-testid="input-textarea-send" onClick={onSubmit} disabled={disabled}>
+				Send
+			</button>
+		</div>
+	),
 }));
 
 // -------------------------------------------------------
@@ -60,7 +124,7 @@ function makeTask(id: string, status = 'in_progress', title = `Task ${id}`) {
 	};
 }
 
-function makeGroup(state: string) {
+function makeGroup(state: string, feedbackIteration = 0) {
 	return {
 		id: 'group-1',
 		taskId: 'task-1',
@@ -68,7 +132,7 @@ function makeGroup(state: string) {
 		leaderSessionId: 'sess-l',
 		workerRole: 'worker',
 		state,
-		feedbackIteration: 0,
+		feedbackIteration,
 		createdAt: Date.now(),
 		completedAt: null,
 	};
@@ -87,6 +151,7 @@ describe('TaskView — awaiting_human badge', () => {
 		mockOnEvent.mockReturnValue(() => {});
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
 	});
 
 	afterEach(() => {
@@ -154,6 +219,213 @@ describe('TaskView — awaiting_human badge', () => {
 
 		await waitFor(() => {
 			expect(container.textContent).toContain('Leader reviewing');
+		});
+	});
+});
+
+describe('TaskView — autoscroll / ScrollToBottomButton', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('does NOT render scroll-to-bottom button when showScrollButton is false', async () => {
+		mockShowScrollButton.value = false;
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { queryByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(queryByTestId('scroll-to-bottom')).toBeNull();
+		});
+	});
+
+	it('renders scroll-to-bottom button when showScrollButton is true', async () => {
+		mockShowScrollButton.value = true;
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { queryByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(queryByTestId('scroll-to-bottom')).not.toBeNull();
+		});
+	});
+
+	it('calls scrollToBottom when scroll-to-bottom button is clicked', async () => {
+		mockShowScrollButton.value = true;
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('scroll-to-bottom')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('scroll-to-bottom'));
+		expect(mockScrollToBottom).toHaveBeenCalledWith(true);
+	});
+});
+
+describe('TaskView — HumanInputArea uses InputTextarea', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders InputTextarea in awaiting_human state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			return {};
+		});
+
+		const { queryByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(queryByTestId('input-textarea')).not.toBeNull();
+		});
+	});
+
+	it('renders InputTextarea in awaiting_leader state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
+			return {};
+		});
+
+		const { queryByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(queryByTestId('input-textarea')).not.toBeNull();
+		});
+	});
+
+	it('does NOT render InputTextarea in awaiting_worker state (disabled raw textarea)', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { queryByTestId, container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// awaiting_worker uses a raw disabled textarea, not InputTextarea
+		expect(queryByTestId('input-textarea')).toBeNull();
+		const rawTextarea = container.querySelector('textarea[disabled]');
+		expect(rawTextarea).not.toBeNull();
+	});
+
+	it('sends feedback via task.sendHumanMessage in awaiting_human state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Nice work!' } });
+
+		fireEvent.click(getByTestId('input-textarea-send'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Nice work!',
+			});
+		});
+	});
+
+	it('approves task via goal.approveTask in awaiting_human state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			if (method === 'goal.approveTask') return {};
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			const approveBtn = container.querySelector('button.bg-green-700');
+			expect(approveBtn).not.toBeNull();
+		});
+
+		const approveBtn = container.querySelector('button.bg-green-700') as HTMLButtonElement;
+		fireEvent.click(approveBtn);
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('goal.approveTask', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+			});
+		});
+	});
+
+	it('sends message to leader via task.sendHumanMessage in awaiting_leader state', async () => {
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Please focus on auth first' } });
+
+		fireEvent.click(getByTestId('input-textarea-send'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Please focus on auth first',
+			});
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Tests for TaskView Component
  *
@@ -11,7 +10,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
-// Static import resolved to mocked version — gives access to .mock.calls for arg assertions
+import { useEffect } from 'preact/hooks';
+// Static import gives access to vi.mocked(useAutoScroll) for call assertions
 import { useAutoScroll } from '../../hooks/useAutoScroll.ts';
 
 // -------------------------------------------------------
@@ -44,11 +44,23 @@ vi.mock('../../lib/router.ts', () => ({
 	},
 }));
 
-// Mock TaskConversationRenderer so it doesn't need its own deps.
-// We don't call onMessageCountChange here because useAutoScroll is fully mocked
-// and calling setState during render causes a "cannot update during render" warning.
+// mockMessageCount controls how many messages the TaskConversationRenderer mock reports.
+// Set before rendering to simulate message arrival (onMessageCountChange fires in useEffect).
+const mockMessageCount = { value: 0 };
+
+// Mock TaskConversationRenderer — calls onMessageCountChange in a useEffect so tests can
+// exercise the isFirstLoad flip without triggering "setState during render" warnings.
 vi.mock('./TaskConversationRenderer.tsx', () => ({
-	TaskConversationRenderer: () => <div data-testid="conversation" />,
+	TaskConversationRenderer: ({
+		onMessageCountChange,
+	}: {
+		onMessageCountChange?: (n: number) => void;
+	}) => {
+		useEffect(() => {
+			onMessageCountChange?.(mockMessageCount.value);
+		}, [onMessageCountChange]);
+		return <div data-testid="conversation" />;
+	},
 }));
 
 // Mock useAutoScroll so we can control showScrollButton and inspect call args
@@ -63,10 +75,16 @@ vi.mock('../../hooks/useAutoScroll.ts', () => ({
 	})),
 }));
 
-// Mock ScrollToBottomButton
+// Mock ScrollToBottomButton — forwards bottomClass as a data attribute so tests can assert it.
 vi.mock('../ScrollToBottomButton.tsx', () => ({
-	ScrollToBottomButton: ({ onClick }: { onClick: () => void }) => (
-		<button data-testid="scroll-to-bottom" onClick={onClick}>
+	ScrollToBottomButton: ({
+		onClick,
+		bottomClass,
+	}: {
+		onClick: () => void;
+		bottomClass?: string;
+	}) => (
+		<button data-testid="scroll-to-bottom" data-bottom-class={bottomClass} onClick={onClick}>
 			↓
 		</button>
 	),
@@ -150,6 +168,7 @@ describe('TaskView — awaiting_human badge', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 	});
 
@@ -158,7 +177,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('shows pulsing "Awaiting your review" badge when group.state === awaiting_human', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -176,7 +195,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('does NOT show pulsing badge when group.state is not awaiting_human', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -192,7 +211,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('does NOT show pulsing badge when group is null', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
 			if (method === 'task.getGroup') return { group: null };
 			return {};
@@ -208,7 +227,7 @@ describe('TaskView — awaiting_human badge', () => {
 	});
 
 	it('shows group state label in header', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -230,6 +249,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 	});
 
@@ -239,7 +259,8 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 
 	it('does NOT render scroll-to-bottom button when showScrollButton is false', async () => {
 		mockShowScrollButton.value = false;
-		mockRequest.mockImplementation(async (method: string) => {
+		mockMessageCount.value = 0;
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -254,7 +275,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 
 	it('renders scroll-to-bottom button when showScrollButton is true', async () => {
 		mockShowScrollButton.value = true;
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -269,7 +290,7 @@ describe('TaskView — autoscroll / ScrollToBottomButton', () => {
 
 	it('calls scrollToBottom when scroll-to-bottom button is clicked', async () => {
 		mockShowScrollButton.value = true;
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -294,6 +315,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 	});
 
@@ -302,7 +324,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('renders InputTextarea in awaiting_human state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -316,7 +338,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('renders InputTextarea in awaiting_leader state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -330,7 +352,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('does NOT render InputTextarea in awaiting_worker state (disabled raw textarea)', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -349,7 +371,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends feedback via task.sendHumanMessage in awaiting_human state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -377,7 +399,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('approves task via goal.approveTask in awaiting_human state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			if (method === 'goal.approveTask') return {};
@@ -403,7 +425,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 	});
 
 	it('sends message to leader via task.sendHumanMessage in awaiting_leader state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			if (method === 'task.sendHumanMessage') return {};
@@ -439,6 +461,7 @@ describe('TaskView — useAutoScroll call args', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 	});
 
@@ -447,7 +470,7 @@ describe('TaskView — useAutoScroll call args', () => {
 	});
 
 	it('calls useAutoScroll with enabled:true and isInitialLoad:true on initial render', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
 			return {};
@@ -473,6 +496,7 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
 		vi.mocked(useAutoScroll).mockClear();
 	});
 
@@ -481,7 +505,7 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 	});
 
 	it('passes maxChars=50000 to InputTextarea in awaiting_human state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
 			return {};
@@ -498,7 +522,7 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 	});
 
 	it('passes maxChars=50000 to InputTextarea in awaiting_leader state', async () => {
-		mockRequest.mockImplementation(async (method: string) => {
+		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
 			return {};
@@ -512,5 +536,92 @@ describe('TaskView — InputTextarea maxChars forwarding', () => {
 
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		expect(textarea.maxLength).toBe(50000);
+	});
+});
+
+describe('TaskView — isFirstLoad state transitions', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('flips isFirstLoad to false after first messages arrive via onMessageCountChange', async () => {
+		// Simulate TaskConversationRenderer reporting 3 messages on mount
+		mockMessageCount.value = 3;
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Wait until useAutoScroll is called with isInitialLoad:false (after messageCount > 0)
+		await waitFor(() => {
+			const calls = vi.mocked(useAutoScroll).mock.calls;
+			const lastCall = calls[calls.length - 1]?.[0];
+			expect(lastCall?.isInitialLoad).toBe(false);
+		});
+	});
+
+	it('starts with isInitialLoad:true when no messages have arrived yet', async () => {
+		// mockMessageCount.value = 0 (default) — mock never calls onMessageCountChange with > 0
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(vi.mocked(useAutoScroll)).toHaveBeenCalled();
+		});
+
+		const firstCall = vi.mocked(useAutoScroll).mock.calls[0][0];
+		expect(firstCall.isInitialLoad).toBe(true);
+	});
+});
+
+describe('TaskView — ScrollToBottomButton bottomClass', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = true;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('passes bottomClass="bottom-4" to ScrollToBottomButton', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('scroll-to-bottom')).toBeTruthy();
+		});
+
+		expect(getByTestId('scroll-to-bottom').getAttribute('data-bottom-class')).toBe('bottom-4');
 	});
 });

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -314,8 +314,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 
 		// Re-fetch group whenever the task status changes (e.g. group spawned or completed)
 		const unsub = onEvent<{ roomId: string; task: NeoTask }>('room.task.update', (event) => {
-			if (event.task.id === taskId) {
-				if (!cancelled) setTask(event.task);
+			if (event.task.id === taskId && !cancelled) {
+				setTask(event.task);
 				void fetchGroup();
 			}
 		});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -251,12 +251,18 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		setAutoScroll(isNearBottom);
 	}, [isNearBottom]);
 
-	// Reset conversation scroll state each time the conversation reloads
+	// Reset conversation scroll state whenever the rendered conversation changes.
+	// This covers two cases:
+	//   1. conversationKey bumps (manual reload after approve/feedback)
+	//   2. group.id changes (room.task.update event spawns a new group)
+	// Using the combined renderer key mirrors the `key` prop on TaskConversationRenderer,
+	// so any remount that causes the child to re-fetch messages also resets the parent scroll state.
+	const rendererKey = group ? `${group.id}-${conversationKey}` : `null-${conversationKey}`;
 	useEffect(() => {
 		setIsFirstLoad(true);
 		setMessageCount(0);
 		setAutoScroll(true);
-	}, [conversationKey]);
+	}, [rendererKey]);
 
 	// Mark initial load done after first messages arrive (fires after the render where
 	// useAutoScroll sees isFirstLoad:true and messageCount>0, so the initial scroll fires first)
@@ -447,8 +453,12 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 					<div ref={messagesEndRef} />
 				</div>
 
-				{/* Scroll-to-bottom button — shown when user has scrolled up */}
-				{showScrollButton && <ScrollToBottomButton onClick={handleScrollToBottom} />}
+				{/* Scroll-to-bottom button — shown when user has scrolled up.
+				    bottomClass="bottom-4" because HumanInputArea is a sibling
+				    outside this container, not an overlapping footer. */}
+				{showScrollButton && (
+					<ScrollToBottomButton onClick={handleScrollToBottom} bottomClass="bottom-4" />
+				)}
 			</div>
 
 			{/* Human input area */}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -15,7 +15,7 @@
  * appears when the user has scrolled up.
  */
 
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import type { NeoTask } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import { useAutoScroll } from '../../hooks/useAutoScroll';
@@ -149,7 +149,8 @@ function HumanInputArea({
 					>
 						{approving ? 'Approving…' : '✓ Approve'}
 					</button>
-					{/* Feedback input using shared InputTextarea */}
+					{/* Feedback input using shared InputTextarea.
+					    Large maxChars so users can paste diffs/logs freely. */}
 					<InputTextarea
 						content={feedbackText}
 						onContentChange={setFeedbackText}
@@ -162,6 +163,7 @@ function HumanInputArea({
 						onSubmit={() => void sendFeedback()}
 						disabled={sendingFeedback || approving}
 						placeholder="Or send feedback to request changes… (⌘↵ to send)"
+						maxChars={50000}
 					/>
 					{inputError && <p class="text-xs text-red-400">{inputError}</p>}
 				</div>
@@ -172,7 +174,8 @@ function HumanInputArea({
 	if (groupState === 'awaiting_leader') {
 		return (
 			<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
-				{/* Message input using shared InputTextarea */}
+				{/* Message input using shared InputTextarea.
+				    Large maxChars so users can paste context/diffs freely. */}
 				<InputTextarea
 					content={leaderText}
 					onContentChange={setLeaderText}
@@ -185,6 +188,7 @@ function HumanInputArea({
 					onSubmit={() => void sendToLeader()}
 					disabled={sendingLeader}
 					placeholder="Send a message to the leader… (⌘↵ to send)"
+					maxChars={50000}
 				/>
 				{inputError && <p class="text-xs text-red-400">{inputError}</p>}
 			</div>
@@ -218,17 +222,54 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const [conversationKey, setConversationKey] = useState(0);
 	const [messageCount, setMessageCount] = useState(0);
 
+	// Tracks whether the conversation pane is showing its first batch of messages.
+	// Starts true, resets to true each time the conversation reloads (conversationKey bumps),
+	// and becomes false once the first non-zero messageCount arrives — at which point
+	// useAutoScroll fires its initial-load scroll path.
+	const [isFirstLoad, setIsFirstLoad] = useState(true);
+
+	// autoScroll mirrors whether the user is near the bottom of the scroll container.
+	// Driven by isNearBottom from useAutoScroll so that arriving messages don't force-scroll
+	// the user back down when they've intentionally scrolled up to read history.
+	const [autoScroll, setAutoScroll] = useState(true);
+
 	// Refs for scroll container
 	const messagesContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-	const { showScrollButton, scrollToBottom } = useAutoScroll({
+	const { showScrollButton, scrollToBottom, isNearBottom } = useAutoScroll({
 		containerRef: messagesContainerRef,
 		endRef: messagesEndRef,
-		enabled: true,
+		enabled: autoScroll,
 		messageCount,
-		isInitialLoad: loading,
+		isInitialLoad: isFirstLoad,
 	});
+
+	// Keep autoScroll in sync with scroll position: disable when user scrolls up,
+	// re-enable automatically when they scroll back to the bottom.
+	useEffect(() => {
+		setAutoScroll(isNearBottom);
+	}, [isNearBottom]);
+
+	// Reset conversation scroll state each time the conversation reloads
+	useEffect(() => {
+		setIsFirstLoad(true);
+		setMessageCount(0);
+		setAutoScroll(true);
+	}, [conversationKey]);
+
+	// Mark initial load done after first messages arrive (fires after the render where
+	// useAutoScroll sees isFirstLoad:true and messageCount>0, so the initial scroll fires first)
+	useEffect(() => {
+		if (messageCount > 0 && isFirstLoad) {
+			setIsFirstLoad(false);
+		}
+	}, [messageCount, isFirstLoad]);
+
+	const handleScrollToBottom = useCallback(() => {
+		scrollToBottom(true);
+		setAutoScroll(true);
+	}, [scrollToBottom]);
 
 	const fetchGroup = async () => {
 		try {
@@ -407,7 +448,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				</div>
 
 				{/* Scroll-to-bottom button — shown when user has scrolled up */}
-				{showScrollButton && <ScrollToBottomButton onClick={() => scrollToBottom(true)} />}
+				{showScrollButton && <ScrollToBottomButton onClick={handleScrollToBottom} />}
 			</div>
 
 			{/* Human input area */}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -281,14 +281,16 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		const channel = `room:${roomId}`;
 		joinRoom(channel);
 		let cancelled = false;
+		let fetchGroupSeq = 0;
 
 		const fetchGroup = async () => {
+			const seq = ++fetchGroupSeq;
 			try {
 				const res = await request<{ group: TaskGroupInfo | null }>('task.getGroup', {
 					roomId,
 					taskId,
 				});
-				if (!cancelled) setGroup(res.group);
+				if (!cancelled && seq === fetchGroupSeq) setGroup(res.group);
 			} catch {
 				// Group fetch failure is non-fatal — task may not have a group yet
 			}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -277,31 +277,34 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		setAutoScroll(true);
 	}, [scrollToBottom]);
 
-	const fetchGroup = async () => {
-		try {
-			const res = await request<{ group: TaskGroupInfo | null }>('task.getGroup', {
-				roomId,
-				taskId,
-			});
-			setGroup(res.group);
-		} catch {
-			// Group fetch failure is non-fatal — task may not have a group yet
-		}
-	};
-
 	useEffect(() => {
 		const channel = `room:${roomId}`;
 		joinRoom(channel);
+		let cancelled = false;
+
+		const fetchGroup = async () => {
+			try {
+				const res = await request<{ group: TaskGroupInfo | null }>('task.getGroup', {
+					roomId,
+					taskId,
+				});
+				if (!cancelled) setGroup(res.group);
+			} catch {
+				// Group fetch failure is non-fatal — task may not have a group yet
+			}
+		};
 
 		const load = async () => {
 			try {
 				const taskRes = await request<{ task: NeoTask }>('task.get', { roomId, taskId });
-				setTask(taskRes.task);
-				await fetchGroup();
+				if (!cancelled) {
+					setTask(taskRes.task);
+					await fetchGroup();
+				}
 			} catch (err) {
-				setError(err instanceof Error ? err.message : 'Failed to load task');
+				if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load task');
 			} finally {
-				setLoading(false);
+				if (!cancelled) setLoading(false);
 			}
 		};
 
@@ -310,12 +313,13 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		// Re-fetch group whenever the task status changes (e.g. group spawned or completed)
 		const unsub = onEvent<{ roomId: string; task: NeoTask }>('room.task.update', (event) => {
 			if (event.task.id === taskId) {
-				setTask(event.task);
-				fetchGroup();
+				if (!cancelled) setTask(event.task);
+				void fetchGroup();
 			}
 		});
 
 		return () => {
+			cancelled = true;
 			unsub();
 			leaveRoom(channel);
 		};

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -9,12 +9,19 @@
  * Uses session group messages for a single merged timeline.
  *
  * Subscribes to room.task.update events to refresh group info when status changes.
+ *
+ * Autoscroll: uses the shared useAutoScroll hook + ScrollToBottomButton so the
+ * conversation area scrolls to the bottom on new messages and the floating button
+ * appears when the user has scrolled up.
  */
 
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import type { NeoTask } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
+import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { ScrollToBottomButton } from '../ScrollToBottomButton';
+import { InputTextarea } from '../InputTextarea';
 import { TaskConversationRenderer } from './TaskConversationRenderer';
 
 interface TaskGroupInfo {
@@ -142,32 +149,20 @@ function HumanInputArea({
 					>
 						{approving ? 'Approving…' : '✓ Approve'}
 					</button>
-					{/* Feedback input */}
-					<div class="space-y-1">
-						<textarea
-							class="w-full bg-dark-800 border border-dark-600 rounded px-3 py-2 text-sm text-gray-200 placeholder-gray-500 resize-none focus:outline-none focus:border-dark-500 focus:ring-1 focus:ring-dark-500"
-							placeholder="Or send feedback to request changes… (⌘↵ to send)"
-							rows={2}
-							value={feedbackText}
-							onInput={(e) => setFeedbackText((e.target as HTMLTextAreaElement).value)}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-									e.preventDefault();
-									void sendFeedback();
-								}
-							}}
-							disabled={sendingFeedback || approving}
-						/>
-						<div class="flex justify-end">
-							<button
-								class="py-1.5 px-3 rounded bg-dark-700 hover:bg-dark-600 disabled:opacity-50 disabled:cursor-not-allowed text-gray-200 text-xs transition-colors"
-								onClick={() => void sendFeedback()}
-								disabled={sendingFeedback || approving || !feedbackText.trim()}
-							>
-								{sendingFeedback ? 'Sending…' : 'Send Feedback'}
-							</button>
-						</div>
-					</div>
+					{/* Feedback input using shared InputTextarea */}
+					<InputTextarea
+						content={feedbackText}
+						onContentChange={setFeedbackText}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+								e.preventDefault();
+								void sendFeedback();
+							}
+						}}
+						onSubmit={() => void sendFeedback()}
+						disabled={sendingFeedback || approving}
+						placeholder="Or send feedback to request changes… (⌘↵ to send)"
+					/>
 					{inputError && <p class="text-xs text-red-400">{inputError}</p>}
 				</div>
 			</div>
@@ -177,29 +172,20 @@ function HumanInputArea({
 	if (groupState === 'awaiting_leader') {
 		return (
 			<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
-				<textarea
-					class="w-full bg-dark-800 border border-dark-600 rounded px-3 py-2 text-sm text-gray-200 placeholder-gray-500 resize-none focus:outline-none focus:border-dark-500 focus:ring-1 focus:ring-dark-500"
-					placeholder="Send a message to the leader… (⌘↵ to send)"
-					rows={2}
-					value={leaderText}
-					onInput={(e) => setLeaderText((e.target as HTMLTextAreaElement).value)}
+				{/* Message input using shared InputTextarea */}
+				<InputTextarea
+					content={leaderText}
+					onContentChange={setLeaderText}
 					onKeyDown={(e) => {
 						if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
 							e.preventDefault();
 							void sendToLeader();
 						}
 					}}
+					onSubmit={() => void sendToLeader()}
 					disabled={sendingLeader}
+					placeholder="Send a message to the leader… (⌘↵ to send)"
 				/>
-				<div class="flex justify-end">
-					<button
-						class="py-1.5 px-3 rounded bg-dark-700 hover:bg-dark-600 disabled:opacity-50 disabled:cursor-not-allowed text-gray-200 text-xs transition-colors"
-						onClick={() => void sendToLeader()}
-						disabled={sendingLeader || !leaderText.trim()}
-					>
-						{sendingLeader ? 'Sending…' : 'Send to Leader'}
-					</button>
-				</div>
 				{inputError && <p class="text-xs text-red-400">{inputError}</p>}
 			</div>
 		);
@@ -230,6 +216,19 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [conversationKey, setConversationKey] = useState(0);
+	const [messageCount, setMessageCount] = useState(0);
+
+	// Refs for scroll container
+	const messagesContainerRef = useRef<HTMLDivElement>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	const { showScrollButton, scrollToBottom } = useAutoScroll({
+		containerRef: messagesContainerRef,
+		endRef: messagesEndRef,
+		enabled: true,
+		messageCount,
+		isInitialLoad: loading,
+	});
 
 	const fetchGroup = async () => {
 		try {
@@ -375,29 +374,41 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				</div>
 			)}
 
-			{/* Conversation timeline */}
-			{group ? (
-				<TaskConversationRenderer key={`${group.id}-${conversationKey}`} groupId={group.id} />
-			) : (
-				<div class="flex-1 flex items-center justify-center text-center p-8">
-					<div>
-						<p class="text-gray-400 mb-1">No active agent group</p>
-						<p class="text-sm text-gray-500">
-							{task.status === 'pending'
-								? 'Waiting for the runtime to pick up this task.'
-								: task.status === 'completed'
-									? 'This task has been completed.'
-									: task.status === 'failed'
-										? 'This task has failed.'
-										: task.status === 'review'
-											? 'This task is awaiting human review.'
-											: task.status === 'draft'
-												? 'This task is a draft and has not been scheduled yet.'
-												: 'No agent group has been spawned yet.'}
-						</p>
-					</div>
+			{/* Conversation timeline — scroll container owned here for autoscroll support */}
+			<div class="flex-1 relative min-h-0">
+				<div ref={messagesContainerRef} class="absolute inset-0 overflow-y-auto flex flex-col">
+					{group ? (
+						<TaskConversationRenderer
+							key={`${group.id}-${conversationKey}`}
+							groupId={group.id}
+							onMessageCountChange={setMessageCount}
+						/>
+					) : (
+						<div class="flex-1 flex items-center justify-center text-center p-8">
+							<div>
+								<p class="text-gray-400 mb-1">No active agent group</p>
+								<p class="text-sm text-gray-500">
+									{task.status === 'pending'
+										? 'Waiting for the runtime to pick up this task.'
+										: task.status === 'completed'
+											? 'This task has been completed.'
+											: task.status === 'failed'
+												? 'This task has failed.'
+												: task.status === 'review'
+													? 'This task is awaiting human review.'
+													: task.status === 'draft'
+														? 'This task is a draft and has not been scheduled yet.'
+														: 'No agent group has been spawned yet.'}
+								</p>
+							</div>
+						</div>
+					)}
+					<div ref={messagesEndRef} />
 				</div>
-			)}
+
+				{/* Scroll-to-bottom button — shown when user has scrolled up */}
+				{showScrollButton && <ScrollToBottomButton onClick={() => scrollToBottom(true)} />}
+			</div>
 
 			{/* Human input area */}
 			{showInput && (


### PR DESCRIPTION
## Summary

- **TaskConversationRenderer** no longer owns its scroll container. A new `onMessageCountChange` prop lets the parent track the message count for driving autoscroll.
- **TaskView** now owns the scroll container and uses `useAutoScroll` + `ScrollToBottomButton`, so the conversation auto-scrolls to the bottom on new messages and shows a floating ↓ button when the user has scrolled up.
- **HumanInputArea** now uses the shared `InputTextarea` component for the `awaiting_human` feedback field and the `awaiting_leader` message field — gaining auto-resize, cursor preservation, and consistent styling for free.
- `SessionStatusBar`, model switcher, and other chat-only controls are intentionally not added to TaskView (they don't apply to the task context).

## What changed

| File | Change |
|------|--------|
| `TaskConversationRenderer.tsx` | Remove scroll container + manual `requestAnimationFrame` scroll; add `onMessageCountChange` prop |
| `TaskView.tsx` | Add `useAutoScroll` + `ScrollToBottomButton`; replace raw `<textarea>` with `InputTextarea` in `HumanInputArea` |
| `TaskConversationRenderer.test.tsx` | New test file: `onMessageCountChange` callback, delta events, scroll container absence |
| `TaskView.test.tsx` | New tests: scroll button visibility/click, `InputTextarea` rendering in each group state, send/approve actions |

## Test plan

- [ ] All 3579 web unit tests pass (`bunx vitest run` in `packages/web`)
- [ ] TypeScript check passes (`bun run typecheck`)
- [ ] Lint passes (`bun run lint`)
- [ ] TaskView conversation scrolls to bottom automatically when new messages arrive
- [ ] Scroll-to-bottom button appears in TaskView when scrolled up and disappears when at bottom
- [ ] `awaiting_human` state shows approve button + InputTextarea for feedback
- [ ] `awaiting_leader` state shows InputTextarea for leader message
- [ ] `awaiting_worker` state shows disabled placeholder textarea
- [ ] ChatContainer behavior is unchanged