### PR TITLE
fix(room): verify PR merge before marking task complete

### DIFF
--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -245,11 +245,11 @@ export async function checkWorkerPrMerged(
 			reason: `PR on branch "${branch}" is CLOSED (closed without merging). Cannot merge a closed PR directly.`,
 			bounceMessage:
 				`The PR for branch "${branch}" is CLOSED — it was closed without merging.\n\n` +
-				'A closed PR cannot be merged directly. To fix this:\n' +
-				'1. Reopen the PR: `gh pr reopen ${branch}`\n' +
-				'2. Then merge: `gh pr merge ${branch} --merge`\n' +
-				'3. Verify: `gh pr view ${branch} --json state --jq .state` (must return "MERGED")\n' +
-				'4. Then finish your response.',
+				`A closed PR cannot be merged directly. To fix this:\n` +
+				`1. Reopen the PR: \`gh pr reopen ${branch}\`\n` +
+				`2. Then merge: \`gh pr merge ${branch} --merge\`\n` +
+				`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
+				`4. Then finish your response.`,
 		};
 	}
 
@@ -258,11 +258,11 @@ export async function checkWorkerPrMerged(
 		reason: `PR on branch "${branch}" is not merged (state: ${prState}). Worker must merge before exiting.`,
 		bounceMessage:
 			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
-			'You were asked to merge the PR. Please complete this step:\n' +
-			'1. Run: `gh pr merge ${branch} --merge`\n' +
-			'2. If that fails, try: `gh pr merge ${branch} --squash`\n' +
-			'3. Verify: `gh pr view ${branch} --json state --jq .state` (must return "MERGED")\n' +
-			'4. Then finish your response.',
+			`You were asked to merge the PR. Please complete this step:\n` +
+			`1. Run: \`gh pr merge ${branch} --merge\`\n` +
+			`2. If that fails, try: \`gh pr merge ${branch} --squash\`\n` +
+			`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
+			`4. Then finish your response.`,
 	};
 }
 

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -233,6 +233,25 @@ export async function checkWorkerPrMerged(
 	if (prState === 'MERGED') {
 		return { pass: true };
 	}
+	// Empty/unexpected state is indeterminate — fail open rather than block with confusing message
+	if (!prState) {
+		log.debug(`checkWorkerPrMerged: gh returned empty state, skipping check`);
+		return { pass: true };
+	}
+
+	if (prState === 'CLOSED') {
+		return {
+			pass: false,
+			reason: `PR on branch "${branch}" is CLOSED (closed without merging). Cannot merge a closed PR directly.`,
+			bounceMessage:
+				`The PR for branch "${branch}" is CLOSED — it was closed without merging.\n\n` +
+				'A closed PR cannot be merged directly. To fix this:\n' +
+				'1. Reopen the PR: `gh pr reopen ${branch}`\n' +
+				'2. Then merge: `gh pr merge ${branch} --merge`\n' +
+				'3. Verify: `gh pr view ${branch} --json state --jq .state` (must return "MERGED")\n' +
+				'4. Then finish your response.',
+		};
+	}
 
 	return {
 		pass: false,
@@ -240,9 +259,9 @@ export async function checkWorkerPrMerged(
 		bounceMessage:
 			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
 			'You were asked to merge the PR. Please complete this step:\n' +
-			'1. Run: `gh pr merge --merge`\n' +
-			'2. If that fails, try: `gh pr merge --squash`\n' +
-			'3. Verify: `gh pr view --json state --jq .state` (must return "MERGED")\n' +
+			'1. Run: `gh pr merge ${branch} --merge`\n' +
+			'2. If that fails, try: `gh pr merge ${branch} --squash`\n' +
+			'3. Verify: `gh pr view ${branch} --json state --jq .state` (must return "MERGED")\n' +
 			'4. Then finish your response.',
 	};
 }
@@ -279,6 +298,25 @@ export async function checkLeaderPrMerged(
 	if (prState === 'MERGED') {
 		return { pass: true };
 	}
+	// Empty/unexpected state is indeterminate — fail open rather than block with confusing message
+	if (!prState) {
+		log.debug(`checkLeaderPrMerged: gh returned empty state, skipping check`);
+		return { pass: true };
+	}
+
+	if (prState === 'CLOSED') {
+		return {
+			pass: false,
+			reason: `PR on branch "${branch}" is CLOSED (closed without merging). Task cannot be completed.`,
+			bounceMessage:
+				`The PR for this task is CLOSED — it was closed without merging.\n\n` +
+				'A closed PR cannot be merged directly. To fix this:\n' +
+				'1. Use `send_to_worker` with: "The PR was closed without merging. ' +
+				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch} --merge\`, ` +
+				`and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
+				'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
+		};
+	}
 
 	return {
 		pass: false,
@@ -287,7 +325,7 @@ export async function checkLeaderPrMerged(
 			`The PR for this task is not merged (state: ${prState}). You cannot mark the task complete until the PR is actually merged.\n\n` +
 			'To fix this:\n' +
 			'1. Use `send_to_worker` to ask the worker: "The PR merge did not complete. ' +
-			'Please run `gh pr merge --merge` and verify with `gh pr view --json state --jq .state`"\n' +
+			`Please run \`gh pr merge ${branch} --merge\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 			'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 	};
 }

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -202,6 +202,97 @@ export async function checkPrSynced(
 }
 
 /**
+ * Check that the PR was actually merged (for post-approval coder tasks in worker exit gate).
+ * Verifies the worker successfully ran `gh pr merge` before exiting.
+ */
+export async function checkWorkerPrMerged(
+	ctx: WorkerExitHookContext,
+	opts?: HookOptions
+): Promise<HookResult> {
+	const run = getRunner(opts);
+
+	const { stdout: branch, exitCode: branchExit } = await run(
+		['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+		ctx.workspacePath
+	);
+	if (branchExit !== 0) {
+		log.debug(`checkWorkerPrMerged: git command failed, skipping check`);
+		return { pass: true };
+	}
+
+	const { stdout: state, exitCode: ghExit } = await run(
+		['gh', 'pr', 'view', branch, '--json', 'state', '--jq', '.state'],
+		ctx.workspacePath
+	);
+	if (ghExit !== 0) {
+		log.debug(`checkWorkerPrMerged: gh command failed, skipping check`);
+		return { pass: true };
+	}
+
+	const prState = state.trim();
+	if (prState === 'MERGED') {
+		return { pass: true };
+	}
+
+	return {
+		pass: false,
+		reason: `PR on branch "${branch}" is not merged (state: ${prState}). Worker must merge before exiting.`,
+		bounceMessage:
+			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
+			'You were asked to merge the PR. Please complete this step:\n' +
+			'1. Run: `gh pr merge --merge`\n' +
+			'2. If that fails, try: `gh pr merge --squash`\n' +
+			'3. Verify: `gh pr view --json state --jq .state` (must return "MERGED")\n' +
+			'4. Then finish your response.',
+	};
+}
+
+/**
+ * Check that the PR was actually merged (for post-approval coding tasks in leader complete gate).
+ * Prevents the leader from marking a task complete when the PR merge didn't succeed.
+ */
+export async function checkLeaderPrMerged(
+	ctx: LeaderCompleteHookContext,
+	opts?: HookOptions
+): Promise<HookResult> {
+	const run = getRunner(opts);
+
+	const { stdout: branch, exitCode: branchExit } = await run(
+		['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+		ctx.workspacePath
+	);
+	if (branchExit !== 0) {
+		log.debug(`checkLeaderPrMerged: git command failed, skipping check`);
+		return { pass: true };
+	}
+
+	const { stdout: state, exitCode: ghExit } = await run(
+		['gh', 'pr', 'view', branch, '--json', 'state', '--jq', '.state'],
+		ctx.workspacePath
+	);
+	if (ghExit !== 0) {
+		log.debug(`checkLeaderPrMerged: gh command failed, skipping check`);
+		return { pass: true };
+	}
+
+	const prState = state.trim();
+	if (prState === 'MERGED') {
+		return { pass: true };
+	}
+
+	return {
+		pass: false,
+		reason: `PR on branch "${branch}" is not merged (state: ${prState}). Task cannot be completed until the PR is merged.`,
+		bounceMessage:
+			`The PR for this task is not merged (state: ${prState}). You cannot mark the task complete until the PR is actually merged.\n\n` +
+			'To fix this:\n' +
+			'1. Use `send_to_worker` to ask the worker: "The PR merge did not complete. ' +
+			'Please run `gh pr merge --merge` and verify with `gh pr view --json state --jq .state`"\n' +
+			'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
+	};
+}
+
+/**
  * Check that at least one draft task was created (for planner tasks).
  */
 export async function checkDraftTasksCreated(
@@ -344,7 +435,11 @@ export async function runWorkerExitGate(
 				const result = await checkDraftTasksCreated(ctx, opts);
 				if (!result.pass) return result;
 			}
-			// Coder: worker merged the PR, skip all checks
+			if (ctx.workerRole === 'coder') {
+				// Phase 2: verify the worker actually merged the PR before exiting
+				const result = await checkWorkerPrMerged(ctx, opts);
+				if (!result.pass) return result;
+			}
 			return { pass: true };
 		}
 
@@ -390,11 +485,15 @@ export async function runLeaderCompleteGate(
 	ctx: LeaderCompleteHookContext,
 	opts?: HookOptions
 ): Promise<HookResult> {
-	// Human-approved tasks: PR was already merged, skip PR/review checks.
-	// For planning: still verify that draft tasks were created.
+	// Human-approved tasks: skip PR/review checks but verify merge for coding tasks.
+	// For planning: verify draft tasks were created.
+	// For coding: verify PR was actually merged (worker may have failed the merge).
 	if (ctx.approved) {
 		if (ctx.taskType === 'planning') {
 			return checkLeaderDraftsExist(ctx, opts);
+		}
+		if (ctx.workerRole === 'coder') {
+			return checkLeaderPrMerged(ctx, opts);
 		}
 		return { pass: true };
 	}

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -321,6 +321,7 @@ describe('checkWorkerPrMerged', () => {
 		expect(result.pass).toBe(false);
 		expect(result.bounceMessage).toContain('gh pr merge');
 		expect(result.bounceMessage).toContain('OPEN');
+		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});
 
 	test('fails when PR state is CLOSED with reopen instructions', async () => {
@@ -332,6 +333,7 @@ describe('checkWorkerPrMerged', () => {
 		expect(result.pass).toBe(false);
 		expect(result.reason).toContain('CLOSED');
 		expect(result.bounceMessage).toContain('gh pr reopen');
+		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});
 
 	test('passes gracefully when git fails', async () => {
@@ -380,6 +382,7 @@ describe('checkLeaderPrMerged', () => {
 		expect(result.pass).toBe(false);
 		expect(result.bounceMessage).toContain('send_to_worker');
 		expect(result.bounceMessage).toContain('OPEN');
+		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});
 
 	test('fails when PR state is CLOSED with reopen instructions', async () => {
@@ -391,6 +394,7 @@ describe('checkLeaderPrMerged', () => {
 		expect(result.pass).toBe(false);
 		expect(result.reason).toContain('CLOSED');
 		expect(result.bounceMessage).toContain('gh pr reopen');
+		expect(result.bounceMessage).toContain('feat/add-alerts');
 	});
 
 	test('passes gracefully when git fails', async () => {

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -7,6 +7,8 @@ import {
 	checkLeaderPrExists,
 	checkPrHasReviews,
 	checkLeaderDraftsExist,
+	checkWorkerPrMerged,
+	checkLeaderPrMerged,
 	runWorkerExitGate,
 	runLeaderCompleteGate,
 	runLeaderSubmitGate,
@@ -300,6 +302,104 @@ describe('checkLeaderDraftsExist', () => {
 	});
 });
 
+describe('checkWorkerPrMerged', () => {
+	test('passes when PR state is MERGED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'MERGED', exitCode: 0 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('fails when PR state is OPEN', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'OPEN', exitCode: 0 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('gh pr merge');
+		expect(result.bounceMessage).toContain('OPEN');
+	});
+
+	test('fails when PR state is CLOSED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'CLOSED', exitCode: 0 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.reason).toContain('CLOSED');
+	});
+
+	test('passes gracefully when git fails', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('passes gracefully when gh fails', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+});
+
+describe('checkLeaderPrMerged', () => {
+	test('passes when PR state is MERGED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'MERGED', exitCode: 0 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('fails when PR state is OPEN', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'OPEN', exitCode: 0 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('send_to_worker');
+		expect(result.bounceMessage).toContain('OPEN');
+	});
+
+	test('fails when PR state is CLOSED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'CLOSED', exitCode: 0 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.reason).toContain('CLOSED');
+	});
+
+	test('passes gracefully when git fails', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('passes gracefully when gh fails', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+});
+
 describe('runWorkerExitGate', () => {
 	test('runs coder hooks and passes when all succeed', async () => {
 		const opts = mockRunner({
@@ -494,33 +594,82 @@ describe('runLeaderCompleteGate', () => {
 		expect(result.bounceMessage).toContain('create_task');
 	});
 
-	test('passes for non-planning tasks with approved (edge case)', async () => {
+	test('passes for coder tasks with approved when PR is MERGED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'MERGED', exitCode: 0 },
+		});
 		const result = await runLeaderCompleteGate(
 			makeLeaderCtx({
 				workerRole: 'coder',
 				taskType: 'coding',
 				approved: true,
-			})
+			}),
+			opts
 		);
 		expect(result.pass).toBe(true);
 	});
 
-	test('passes for coder tasks with approved (PR already merged by worker)', async () => {
+	test('fails for coder tasks with approved when PR is still OPEN (merge failed)', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'OPEN', exitCode: 0 },
+		});
 		const result = await runLeaderCompleteGate(
 			makeLeaderCtx({
 				workerRole: 'coder',
 				taskType: 'coding',
 				approved: true,
-			})
+			}),
+			opts
+		);
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('send_to_worker');
+	});
+
+	test('passes gracefully for coder tasks with approved when gh unavailable', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 1 },
+		});
+		const result = await runLeaderCompleteGate(
+			makeLeaderCtx({
+				workerRole: 'coder',
+				taskType: 'coding',
+				approved: true,
+			}),
+			opts
 		);
 		expect(result.pass).toBe(true);
 	});
 });
 
 describe('runWorkerExitGate — approved bypass', () => {
-	test('passes for coder when approved is true (post-merge exit)', async () => {
-		// No mock runner — would fail branch/PR checks without approved
-		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }));
+	test('passes for coder when approved and PR is MERGED', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'MERGED', exitCode: 0 },
+		});
+		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('fails for coder when approved but PR is still OPEN (merge did not happen)', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'OPEN', exitCode: 0 },
+		});
+		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('gh pr merge');
+	});
+
+	test('passes gracefully for coder when approved but git/gh unavailable', async () => {
+		// When tools are unavailable, fail open (don't block)
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: '', exitCode: 1 },
+		});
+		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(true);
 	});
 

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -323,7 +323,7 @@ describe('checkWorkerPrMerged', () => {
 		expect(result.bounceMessage).toContain('OPEN');
 	});
 
-	test('fails when PR state is CLOSED', async () => {
+	test('fails when PR state is CLOSED with reopen instructions', async () => {
 		const opts = mockRunner({
 			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
 			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'CLOSED', exitCode: 0 },
@@ -331,6 +331,7 @@ describe('checkWorkerPrMerged', () => {
 		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(false);
 		expect(result.reason).toContain('CLOSED');
+		expect(result.bounceMessage).toContain('gh pr reopen');
 	});
 
 	test('passes gracefully when git fails', async () => {
@@ -345,6 +346,15 @@ describe('checkWorkerPrMerged', () => {
 		const opts = mockRunner({
 			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
 			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('passes gracefully when gh returns empty state with exit 0 (indeterminate)', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 0 },
 		});
 		const result = await checkWorkerPrMerged(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(true);
@@ -372,7 +382,7 @@ describe('checkLeaderPrMerged', () => {
 		expect(result.bounceMessage).toContain('OPEN');
 	});
 
-	test('fails when PR state is CLOSED', async () => {
+	test('fails when PR state is CLOSED with reopen instructions', async () => {
 		const opts = mockRunner({
 			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
 			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'CLOSED', exitCode: 0 },
@@ -380,6 +390,7 @@ describe('checkLeaderPrMerged', () => {
 		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
 		expect(result.pass).toBe(false);
 		expect(result.reason).toContain('CLOSED');
+		expect(result.bounceMessage).toContain('gh pr reopen');
 	});
 
 	test('passes gracefully when git fails', async () => {
@@ -394,6 +405,15 @@ describe('checkLeaderPrMerged', () => {
 		const opts = mockRunner({
 			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
 			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 1 },
+		});
+		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
+		expect(result.pass).toBe(true);
+	});
+
+	test('passes gracefully when gh returns empty state with exit 0 (indeterminate)', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: '', exitCode: 0 },
 		});
 		const result = await checkLeaderPrMerged(makeLeaderCtx({ approved: true }), opts);
 		expect(result.pass).toBe(true);
@@ -662,6 +682,16 @@ describe('runWorkerExitGate — approved bypass', () => {
 		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }), opts);
 		expect(result.pass).toBe(false);
 		expect(result.bounceMessage).toContain('gh pr merge');
+	});
+
+	test('fails for coder when approved but PR is CLOSED with reopen instructions', async () => {
+		const opts = mockRunner({
+			'git rev-parse --abbrev-ref HEAD': { stdout: 'feat/add-alerts', exitCode: 0 },
+			'gh pr view feat/add-alerts --json state --jq .state': { stdout: 'CLOSED', exitCode: 0 },
+		});
+		const result = await runWorkerExitGate(makeWorkerCtx({ approved: true }), opts);
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('gh pr reopen');
 	});
 
 	test('passes gracefully for coder when approved but git/gh unavailable', async () => {


### PR DESCRIPTION
## Summary

- **Bug**: Leader was marking tasks as `completed` with "PR #N has been merged" even when the PR was still open on GitHub
- **Root cause**: The `runWorkerExitGate` and `runLeaderCompleteGate` functions skipped all checks for approved coding tasks, assuming the merge had happened without verifying it

## Changes

### New lifecycle gate hooks in `lifecycle-hooks.ts`

**`checkWorkerPrMerged`** — Worker exit gate hook for post-approval coders:
- Runs `gh pr view <branch> --json state --jq .state`
- If state is `MERGED` → pass
- If state is `OPEN` or `CLOSED` → bounce worker back with instructions to retry `gh pr merge --merge`
- If git/gh unavailable → pass gracefully (fail open)

**`checkLeaderPrMerged`** — Leader complete gate hook for approved coders:
- Same check as above but in the leader's context
- If PR not merged → blocks `complete_task` and bounces leader with instructions to use `send_to_worker` to have the worker retry the merge
- If git/gh unavailable → pass gracefully

### Updated gate runners

- `runWorkerExitGate`: approved coders now must pass `checkWorkerPrMerged` before exiting
- `runLeaderCompleteGate`: approved coders now must pass `checkLeaderPrMerged` before completing

### Tests

Added 18 new unit tests covering:
- MERGED state passes
- OPEN state fails with correct bounce message
- CLOSED state fails
- Graceful pass when git unavailable
- Graceful pass when gh unavailable
- Gate integration tests for both approved-passes and approved-fails scenarios

## Test plan

- [x] `bun test tests/unit/room/lifecycle-hooks.test.ts` — 66 tests, all pass
- [x] `bun test tests/unit/` — 3166 tests, all pass
- [x] Pre-commit checks: lint, format, typecheck, knip — all pass