### PR TITLE
feat(room): show failed tasks first + configurable auto-retry (default 0)

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -131,6 +131,7 @@ export class RoomManager {
 			priority: task.priority,
 			progress: task.progress,
 			dependsOn: task.dependsOn,
+			error: task.error,
 		});
 		const nonTerminal = tasks.filter((t) => t.status !== 'completed' && t.status !== 'failed');
 		const taskSummaries = nonTerminal.map(toSummary);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -60,7 +60,8 @@ import {
 
 const log = new Logger('room-runtime');
 
-const MAX_PLANNING_ATTEMPTS = 3;
+/** Default when room config does not specify maxPlanningRetries (no auto-retry) */
+const DEFAULT_MAX_PLANNING_RETRIES = 0;
 
 export type { RuntimeState } from '@neokai/shared';
 
@@ -239,6 +240,21 @@ export class RoomRuntime {
 	 */
 	updateRoom(room: Room): void {
 		this.room = room;
+	}
+
+	/**
+	 * Maximum planning attempts for this room.
+	 * Reads from room.config.maxPlanningRetries (default: 0 = no auto-retry).
+	 */
+	private get maxPlanningAttempts(): number {
+		const cfg = this.room.config ?? {};
+		const value = (cfg as Record<string, unknown>)['maxPlanningRetries'];
+		if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+			// maxPlanningRetries is "how many retries after first failure":
+			// 0 = only 1 attempt (no retries), N = N+1 total attempts
+			return value + 1;
+		}
+		return DEFAULT_MAX_PLANNING_RETRIES + 1;
 	}
 
 	// =========================================================================
@@ -1122,9 +1138,9 @@ export class RoomRuntime {
 	 * - status is 'active'
 	 * - has no linked tasks at all, OR all linked tasks are 'failed'
 	 * - has no pending/in_progress/draft/escalated tasks
-	 * - planning_attempts < MAX_PLANNING_ATTEMPTS
+	 * - planning_attempts < this.maxPlanningAttempts
 	 *
-	 * Goals that exceed MAX_PLANNING_ATTEMPTS are transitioned to 'needs_human'.
+	 * Goals that exceed maxPlanningAttempts are transitioned to 'needs_human'.
 	 */
 	private async getNextGoalForPlanning(): Promise<RoomGoal | null> {
 		const activeGoals = await this.goalManager.listGoals('active');
@@ -1169,7 +1185,7 @@ export class RoomRuntime {
 
 			const attempts = goal.planning_attempts ?? 0;
 
-			if (attempts >= MAX_PLANNING_ATTEMPTS) {
+			if (attempts >= this.maxPlanningAttempts) {
 				// Too many failed planning attempts: escalate to human
 				log.warn(
 					`Goal ${goal.id} (${goal.title}) exceeded max planning attempts, marking needs_human`
@@ -1461,7 +1477,7 @@ export class RoomRuntime {
 	 * Guards:
 	 * - Task must be an execution task (not planning)
 	 * - Goal must be active with remaining pending tasks
-	 * - planning_attempts < MAX_PLANNING_ATTEMPTS
+	 * - planning_attempts < this.maxPlanningAttempts
 	 */
 	private async handleReplanGoal(
 		taskId: string,
@@ -1494,7 +1510,7 @@ export class RoomRuntime {
 		}
 
 		const attempts = goal.planning_attempts ?? 0;
-		if (attempts >= MAX_PLANNING_ATTEMPTS) {
+		if (attempts >= this.maxPlanningAttempts) {
 			// Fail the task and escalate instead of replanning
 			await this.taskGroupManager.fail(groupId, reason);
 			this.cleanupMirroring(groupId, `Task failed: ${reason}`);
@@ -1503,7 +1519,7 @@ export class RoomRuntime {
 			this.scheduleTick();
 			return jsonResult({
 				success: false,
-				error: `Max planning attempts (${MAX_PLANNING_ATTEMPTS}) reached. Goal escalated to human.`,
+				error: `Max planning attempts (${this.maxPlanningAttempts}) reached. Goal escalated to human.`,
 			});
 		}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1519,7 +1519,7 @@ export class RoomRuntime {
 			this.scheduleTick();
 			return jsonResult({
 				success: false,
-				error: `Max planning attempts (${this.maxPlanningAttempts}) reached. Goal escalated to human.`,
+				error: `Max planning retries (${this.maxPlanningAttempts - 1}) reached. Goal escalated to human.`,
 			});
 		}
 

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -376,7 +376,7 @@ describe('RoomRuntime leader tools', () => {
 			});
 			const parsed = JSON.parse(result.content[0].text);
 			expect(parsed.success).toBe(false);
-			expect(parsed.error).toContain('Max planning attempts');
+			expect(parsed.error).toContain('Max planning retries');
 
 			// Task should still be failed
 			const updatedTask = await ctx.taskManager.getTask(task1.id);

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import {
 	createRuntimeTestContext,
 	createGoalAndTask,
+	makeRoom,
 	spawnAndRouteToLeader,
 	type RuntimeTestContext,
 } from './room-runtime-test-helpers';
@@ -247,6 +248,11 @@ describe('RoomRuntime leader tools', () => {
 	});
 
 	describe('replan_goal', () => {
+		beforeEach(() => {
+			// Enable retries so replan_goal tests can trigger replanning
+			ctx.runtime.updateRoom({ ...makeRoom(), config: { maxPlanningRetries: 2 } });
+		});
+
 		async function setupGoalWithMultipleTasks() {
 			const goal = await ctx.goalManager.createGoal({
 				title: 'Build auth system',

--- a/packages/daemon/tests/unit/room/room-runtime.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime.test.ts
@@ -110,7 +110,10 @@ describe('RoomRuntime', () => {
 			expect(activeGroups).toHaveLength(1);
 		});
 
-		it('should trigger replanning when planning succeeded but all execution tasks failed', async () => {
+		it('should trigger replanning when planning succeeded but all execution tasks failed (maxPlanningRetries=2)', async () => {
+			// Use a room config with maxPlanningRetries=2 to allow retries
+			ctx.runtime.updateRoom({ ...ctx.runtime['room'], config: { maxPlanningRetries: 2 } });
+
 			// Create goal with a completed planning task and failed execution tasks
 			const goal = await ctx.goalManager.createGoal({
 				title: 'Build API',
@@ -156,6 +159,46 @@ describe('RoomRuntime', () => {
 			// planning_attempts should have incremented
 			const goalAfter = await ctx.goalManager.getGoal(goal.id);
 			expect(goalAfter!.planning_attempts).toBeGreaterThan(attemptsBefore);
+		});
+
+		it('should escalate to needs_human immediately when maxPlanningRetries=0 (default) and execution tasks all failed', async () => {
+			// Default room config: maxPlanningRetries = 0 (no retries)
+			const goal = await ctx.goalManager.createGoal({
+				title: 'Build API',
+				description: 'Build the REST API',
+			});
+			const planningTask = await ctx.taskManager.createTask({
+				title: 'Plan: Build API',
+				description: 'Plan the work',
+				taskType: 'planning',
+			});
+			await ctx.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+			await ctx.taskManager.completeTask(planningTask.id, 'Plan created');
+
+			const execTask = await ctx.taskManager.createTask({
+				title: 'Add endpoints',
+				description: 'Add REST endpoints',
+				taskType: 'coding',
+			});
+			await ctx.goalManager.linkTaskToGoal(goal.id, execTask.id);
+			await ctx.taskManager.failTask(execTask.id, 'Compilation error');
+
+			// planning_attempts = 1 (initial planning done), maxPlanningAttempts = 0+1 = 1
+			// So attempts >= maxPlanningAttempts → escalate immediately
+			await ctx.goalManager.incrementPlanningAttempts(goal.id);
+
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			// Should NOT have spawned a new planner session
+			const plannerCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'planner'
+			);
+			expect(plannerCalls.length).toBe(0);
+
+			// Goal should be escalated to needs_human
+			const goalAfter = await ctx.goalManager.getGoal(goal.id);
+			expect(goalAfter!.status).toBe('needs_human');
 		});
 
 		it('should NOT replan when execution tasks are still active', async () => {

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -277,6 +277,8 @@ export interface TaskSummary {
 	progress?: number;
 	/** IDs of tasks this task depends on */
 	dependsOn: string[];
+	/** Error message for failed tasks */
+	error?: string;
 }
 
 /**

--- a/packages/web/src/components/room/RoomSettings.tsx
+++ b/packages/web/src/components/room/RoomSettings.tsx
@@ -24,6 +24,7 @@ export interface RoomSettingsProps {
 		defaultPath?: string;
 		defaultModel?: string;
 		allowedModels?: string[];
+		config?: Record<string, unknown>;
 	}) => Promise<void>;
 	onArchive?: () => Promise<void>;
 	onDelete?: () => Promise<void>;
@@ -49,6 +50,11 @@ export function RoomSettings({
 	const defaultPath = useSignal(room.defaultPath || '');
 	// null = all allowed (no restriction); array = explicit set
 	const allowedModels = useSignal<string[] | null>(room.allowedModels ?? null);
+	const maxPlanningRetries = useSignal<number>(
+		typeof (room.config as Record<string, unknown> | undefined)?.['maxPlanningRetries'] === 'number'
+			? ((room.config as Record<string, unknown>)['maxPlanningRetries'] as number)
+			: 0
+	);
 	const isSaving = useSignal(false);
 	const [showArchiveModal, setShowArchiveModal] = useState(false);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -86,6 +92,9 @@ export function RoomSettings({
 		allowedPaths.value = [...room.allowedPaths];
 		defaultPath.value = room.defaultPath || '';
 		allowedModels.value = room.allowedModels ?? null;
+		const cfg = (room.config as Record<string, unknown> | undefined) ?? {};
+		maxPlanningRetries.value =
+			typeof cfg['maxPlanningRetries'] === 'number' ? (cfg['maxPlanningRetries'] as number) : 0;
 	}, [room]);
 
 	// Models visible in the default model dropdown (only allowed ones, or all if no restriction)
@@ -131,12 +140,19 @@ export function RoomSettings({
 		const modelsChanged =
 			JSON.stringify(origAllowed?.slice().sort()) !== JSON.stringify(currAllowed?.slice().sort());
 
+		const origMaxRetries =
+			typeof ((room.config as Record<string, unknown> | undefined) ?? {})['maxPlanningRetries'] ===
+			'number'
+				? ((room.config as Record<string, unknown>)['maxPlanningRetries'] as number)
+				: 0;
+
 		return (
 			name.value !== room.name ||
 			defaultModel.value !== (room.defaultModel || '') ||
 			JSON.stringify(allowedPaths.value) !== JSON.stringify(room.allowedPaths) ||
 			defaultPath.value !== (room.defaultPath || '') ||
-			modelsChanged
+			modelsChanged ||
+			maxPlanningRetries.value !== origMaxRetries
 		);
 	};
 
@@ -152,6 +168,10 @@ export function RoomSettings({
 				defaultPath: defaultPath.value || undefined,
 				// null → send empty array to mean "all allowed"; explicit list → send list
 				allowedModels: allowedModels.value ?? [],
+				config: {
+					...(room.config as Record<string, unknown> | undefined),
+					maxPlanningRetries: maxPlanningRetries.value,
+				},
 			});
 			toast.success('Settings saved');
 		} catch (err) {
@@ -225,6 +245,31 @@ export function RoomSettings({
 						onInput={(e) => (name.value = (e.target as HTMLInputElement).value)}
 						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
               placeholder-gray-500 focus:outline-none focus:border-blue-500"
+						disabled={disabled}
+					/>
+				</div>
+
+				{/* Max Planning Retries */}
+				<div>
+					<label for="max-planning-retries" class="block text-sm font-medium text-gray-300 mb-1.5">
+						Max Planning Retries
+					</label>
+					<p class="text-xs text-gray-500 mb-2">
+						How many times the room will retry planning a goal after failure before escalating to
+						human review. 0 means no automatic retries.
+					</p>
+					<input
+						id="max-planning-retries"
+						type="number"
+						min={0}
+						max={5}
+						value={maxPlanningRetries.value}
+						onInput={(e) => {
+							const v = parseInt((e.target as HTMLInputElement).value, 10);
+							if (!isNaN(v) && v >= 0 && v <= 5) maxPlanningRetries.value = v;
+						}}
+						class="w-24 bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
+              focus:outline-none focus:border-blue-500"
 						disabled={disabled}
 					/>
 				</div>

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -248,7 +248,7 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const header = container.querySelector('.text-red-400');
+			const header = container.querySelector('h3.text-red-400');
 			expect(header).toBeTruthy();
 			expect(header?.textContent).toContain('Failed (1)');
 		});
@@ -268,6 +268,45 @@ describe('RoomTasks', () => {
 
 			const redHeader = container.querySelector('.bg-red-900\\/20');
 			expect(redHeader).toBeTruthy();
+		});
+
+		it('should show error message for failed tasks with error', () => {
+			const tasks = [
+				createTask('t1', 'failed', { title: 'Broken task', error: 'Something went wrong' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Something went wrong');
+		});
+
+		it('should not show error message for failed tasks without error', () => {
+			const tasks = [createTask('t1', 'failed', { title: 'Broken task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// No error paragraph should appear
+			const errorEls = container.querySelectorAll('.text-red-400');
+			// Only the header elements should have text-red-400, no error paragraph
+			for (const el of Array.from(errorEls)) {
+				expect(el.tagName.toLowerCase()).not.toBe('p');
+			}
+		});
+
+		it('should appear before in-progress tasks in the DOM', () => {
+			const tasks = [createTask('t1', 'in_progress'), createTask('t2', 'failed')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const headers = container.querySelectorAll('h3');
+			const headerTexts = Array.from(headers).map((h) => h.textContent ?? '');
+
+			const failedIdx = headerTexts.findIndex((t) => t.includes('Failed'));
+			const inProgressIdx = headerTexts.findIndex((t) => t.includes('In Progress'));
+
+			expect(failedIdx).toBeGreaterThanOrEqual(0);
+			expect(inProgressIdx).toBeGreaterThanOrEqual(0);
+			expect(failedIdx).toBeLessThan(inProgressIdx);
 		});
 	});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -39,6 +39,33 @@ export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksPr
 
 	return (
 		<div class="space-y-4">
+			{/* Failed — shown first so failures are immediately visible */}
+			{failed.length > 0 && (
+				<div class="bg-dark-850 border border-red-800/60 rounded-lg overflow-hidden">
+					<div class="px-4 py-3 border-b border-red-800/60 bg-red-900/20 flex items-center gap-2">
+						<svg
+							class="w-4 h-4 text-red-400 flex-shrink-0"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+							/>
+						</svg>
+						<h3 class="font-semibold text-red-400">Failed ({failed.length})</h3>
+					</div>
+					<div class="divide-y divide-dark-700">
+						{failed.map((task) => (
+							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
+						))}
+					</div>
+				</div>
+			)}
+
 			{/* In Progress */}
 			{inProgress.length > 0 && (
 				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
@@ -110,20 +137,6 @@ export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksPr
 					</div>
 					<div class="divide-y divide-dark-700">
 						{completed.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Failed */}
-			{failed.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-red-900/20">
-						<h3 class="font-semibold text-red-400">Failed ({failed.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{failed.map((task) => (
 							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
 						))}
 					</div>
@@ -205,6 +218,11 @@ function TaskItem({
 					{isClickable && <span class="text-xs text-gray-600">&rarr;</span>}
 				</div>
 			</div>
+			{task.status === 'failed' && task.error && (
+				<p class="text-xs text-red-400 mt-1.5 line-clamp-2" title={task.error}>
+					{task.error}
+				</p>
+			)}
 			{hasDeps && (
 				<div class="flex items-center gap-1 mt-1.5 flex-wrap">
 					<span class="text-xs text-gray-500">Deps:</span>

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -709,6 +709,7 @@ class RoomStore {
 		defaultPath?: string;
 		defaultModel?: string;
 		allowedModels?: string[];
+		config?: Record<string, unknown>;
 	}): Promise<void> {
 		const roomId = this.roomId.value;
 		if (!roomId) {


### PR DESCRIPTION
## Summary

- **Part A**: Failed tasks now appear at the top of the RoomTasks overview with a warning icon and inline error message, so failures are immediately visible without scrolling.
- **Part B**: Auto-retry count for failed planning goals is now configurable per room (default 0 = no retries, immediately escalate to `needs_human`). A "Max Planning Retries" field (0–5) is added to Room Settings.

## Changes

### Shared types
- Added `error?: string` to `TaskSummary` so task error messages flow to the UI

### Backend (daemon)
- `room-manager.ts`: Include `task.error` in `toSummary()` mapping
- `room-runtime.ts`: Replaced hardcoded `MAX_PLANNING_ATTEMPTS = 3` with a `maxPlanningAttempts` getter that reads `room.config.maxPlanningRetries` (default `0` → 1 total attempt, no retries)

### Frontend (web)
- `RoomTasks.tsx`: Failed section moved to top; warning icon on header; error message shown inline in task cards
- `RoomSettings.tsx`: Added "Max Planning Retries" number input (0–5), synced to `room.config.maxPlanningRetries` via `room.update` RPC
- `room-store.ts`: `updateSettings` now accepts `config?: Record<string, unknown>`

## Test plan
- [x] `RoomTasks.test.tsx`: Updated selector for red header, added tests for error message display and Failed-first ordering
- [x] `room-runtime.test.ts`: Added test verifying immediate escalation with default 0 retries; existing replan test configured with `maxPlanningRetries=2`
- [x] `room-runtime-leader-tools.test.ts`: `replan_goal` describe now sets `maxPlanningRetries=2` in `beforeEach`
- [x] All 576 daemon tests pass, all 3571 web tests pass, TypeScript check clean