### PR TITLE
fix(room): escalate task to human review at max feedback iterations

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -503,18 +503,21 @@ export class RoomRuntime {
 
 		switch (toolName) {
 			case 'send_to_worker': {
-				// Enforce max feedback iterations
+				// Enforce max feedback iterations — runtime escalates to human review
 				if (group.feedbackIteration >= this.maxFeedbackIterations) {
-					await this.taskGroupManager.fail(
+					await this.taskGroupManager.escalateToHumanReview(
 						groupId,
 						`Max feedback iterations (${this.maxFeedbackIterations}) reached`
 					);
-					this.cleanupMirroring(groupId, 'Max feedback iterations reached — task failed.');
+					this.cleanupMirroring(
+						groupId,
+						`Max feedback iterations (${this.maxFeedbackIterations}) reached — escalated for human review.`
+					);
 					await this.emitTaskUpdateById(group.taskId);
 					this.scheduleTick();
 					return jsonResult({
 						success: false,
-						error: `Max feedback iterations reached. Task failed.`,
+						error: `Max feedback iterations reached. Task escalated for human review.`,
 					});
 				}
 				const message = params.message ?? '';

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -503,17 +503,17 @@ export class RoomRuntime {
 
 		switch (toolName) {
 			case 'send_to_worker': {
-				// Enforce max feedback iterations — runtime escalates to human review
+				// Enforce max feedback iterations — runtime escalates to human review.
+				// Like submit_for_review, this transitions to awaiting_human so we deliberately
+				// do NOT call cleanupMirroring (keeps mirroring running, consistent behaviour).
+				// The reason is persisted in the group timeline by escalateToHumanReview().
 				if (group.feedbackIteration >= this.maxFeedbackIterations) {
 					await this.taskGroupManager.escalateToHumanReview(
 						groupId,
 						`Max feedback iterations (${this.maxFeedbackIterations}) reached`
 					);
-					this.cleanupMirroring(
-						groupId,
-						`Max feedback iterations (${this.maxFeedbackIterations}) reached — escalated for human review.`
-					);
 					await this.emitTaskUpdateById(group.taskId);
+					await this.emitGoalProgressForTask(group.taskId);
 					this.scheduleTick();
 					return jsonResult({
 						success: false,
@@ -757,6 +757,7 @@ export class RoomRuntime {
 		}
 
 		await this.emitTaskUpdateById(group.taskId);
+		await this.emitGoalProgressForTask(group.taskId);
 		this.scheduleTick();
 		return true;
 	}

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -428,9 +428,15 @@ export class TaskGroupManager {
 		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_worker', group.version);
 		if (!updated) return false;
 
-		// Reset state for the new review round
+		// Reset state for the new review round.
+		// feedbackIteration is reset to 0 so the resumed task gets a fresh iteration budget —
+		// without this the task would immediately re-escalate on the very next leader cycle.
 		this.groupRepo.resetLeaderContractViolations(groupId, updated.version);
 		this.groupRepo.setSubmittedForReview(groupId, false);
+		const afterReset = this.groupRepo.getGroup(groupId);
+		if (afterReset) {
+			this.groupRepo.resetFeedbackIteration(groupId, afterReset.version);
+		}
 
 		// Persist approval message in group timeline
 		this.groupRepo.appendMessage({
@@ -480,7 +486,7 @@ export class TaskGroupManager {
 	 * Unlike submitForReview (triggered by leader's submit_for_review tool call),
 	 * this escalation has no PR URL — it is a runtime-enforced lifecycle boundary.
 	 */
-	async escalateToHumanReview(groupId: string, _reason: string): Promise<SessionGroup | null> {
+	async escalateToHumanReview(groupId: string, reason: string): Promise<SessionGroup | null> {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
@@ -490,6 +496,14 @@ export class TaskGroupManager {
 
 		// Move task to review status (no PR URL — runtime-enforced escalation)
 		await this.taskManager.reviewTask(group.taskId);
+
+		// Append escalation reason to group timeline for diagnosability
+		this.groupRepo.appendMessage({
+			groupId,
+			role: 'system',
+			messageType: 'status',
+			content: `Escalated for human review: ${reason}`,
+		});
 
 		return updated;
 	}

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -471,6 +471,30 @@ export class TaskGroupManager {
 	}
 
 	/**
+	 * Escalate a group to human review because max feedback iterations were reached.
+	 *
+	 * Called by the runtime (NOT the leader) when feedbackIteration >= maxFeedbackIterations.
+	 * Transitions the group to 'awaiting_human' and the task to 'review' so a human
+	 * can inspect progress and decide whether to approve, reject, or provide guidance.
+	 *
+	 * Unlike submitForReview (triggered by leader's submit_for_review tool call),
+	 * this escalation has no PR URL — it is a runtime-enforced lifecycle boundary.
+	 */
+	async escalateToHumanReview(groupId: string, _reason: string): Promise<SessionGroup | null> {
+		const group = this.groupRepo.getGroup(groupId);
+		if (!group) return null;
+
+		// Pause the group in awaiting_human (slot stays occupied but paused)
+		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_human', group.version);
+		if (!updated) return null;
+
+		// Move task to review status (no PR URL — runtime-enforced escalation)
+		await this.taskManager.reviewTask(group.taskId);
+
+		return updated;
+	}
+
+	/**
 	 * Cancel a group - urgent control from human.
 	 */
 	async cancel(groupId: string): Promise<SessionGroup | null> {

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -319,6 +319,15 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Reset feedback iteration counter to 0.
+	 * Called when a human resumes a task after escalation so the resumed task
+	 * gets a fresh iteration budget and doesn't immediately re-escalate.
+	 */
+	resetFeedbackIteration(groupId: string, expectedVersion: number): SessionGroup | null {
+		return this.updateMetadata(groupId, expectedVersion, { feedbackIteration: 0 });
+	}
+
+	/**
 	 * Set leaderCalledTool flag without version check.
 	 * This is a soft signal — safe to race with state transitions.
 	 */

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -233,6 +233,59 @@ describe('RoomRuntime flow', () => {
 			expect(goalState!.status).toBe('active');
 		});
 
+		it('should reset feedbackIteration after human resumes an escalated task, preventing immediate re-escalation', async () => {
+			// This tests the P1 fix: without resetting feedbackIteration in resumeWorkerFromHuman,
+			// the leader's first send_to_worker after resume would immediately re-escalate.
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// Exhaust all 5 rounds (feedbackIteration reaches 5, escalation fires)
+			for (let i = 0; i < 4; i++) {
+				await ctx.runtime.onWorkerTerminalState(group.id, {
+					sessionId: group.workerSessionId,
+					kind: 'idle',
+				});
+				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+					message: `Round ${i + 1}`,
+				});
+			}
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', { message: 'Trigger' });
+
+			// Task is in review, group awaiting_human
+			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_human');
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
+
+			// Human resumes the task
+			await ctx.runtime.resumeWorkerFromHuman(task.id, 'Please try again with this approach');
+
+			// feedbackIteration must be reset to 0
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(0);
+			// Group should be back in awaiting_worker
+			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_worker');
+			// Task back in in_progress
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('in_progress');
+
+			// Worker finishes again → routeWorkerToLeader increments to 1 (not 6!)
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(1);
+
+			// Leader can now send feedback without triggering re-escalation (1 < 5)
+			const r = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Good, keep going',
+			});
+			expect(JSON.parse(r.content[0].text).success).toBe(true);
+			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_worker');
+		});
+
 		it('should complete a three-iteration cycle and track feedback iterations accurately', async () => {
 			await createGoalAndTask(ctx);
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -153,6 +153,86 @@ describe('RoomRuntime flow', () => {
 			expect(finalTask!.result).toBe('Error handling added');
 		});
 
+		it('should escalate task to human review (not fail) when max feedback iterations reached', async () => {
+			// maxFeedbackIterations = 5 (set in test helpers).
+			// feedbackIteration is incremented by routeWorkerToLeader (1-based).
+			// The check fires when feedbackIteration >= maxFeedbackIterations,
+			// i.e., on the 5th review round when the leader tries send_to_worker.
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// Complete 4 full feedback rounds (feedbackIteration reaches 4 after round 4)
+			for (let i = 0; i < 4; i++) {
+				await ctx.runtime.onWorkerTerminalState(group.id, {
+					sessionId: group.workerSessionId,
+					kind: 'idle',
+				});
+				// send_to_worker succeeds: feedbackIteration i+1 < 5
+				const r = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+					message: `Feedback round ${i + 1}`,
+				});
+				expect(JSON.parse(r.content[0].text).success).toBe(true);
+				expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(i + 1);
+			}
+
+			// 5th review round: routeWorkerToLeader increments feedbackIteration to 5
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(5);
+
+			// Leader tries send_to_worker: 5 >= 5 → runtime escalates
+			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'One more round',
+			});
+
+			// Runtime should reject and escalate — NOT fail the task
+			expect(JSON.parse(result.content[0].text).success).toBe(false);
+			expect(JSON.parse(result.content[0].text).error).toContain('human review');
+
+			// Group state: awaiting_human (not failed/completed)
+			const finalGroup = ctx.groupRepo.getGroup(group.id);
+			expect(finalGroup!.state).toBe('awaiting_human');
+
+			// Task status: review (not failed)
+			const finalTask = await ctx.taskManager.getTask(task.id);
+			expect(finalTask!.status).toBe('review');
+		});
+
+		it('should keep goal active when task is escalated for human review at max iterations', async () => {
+			const { task, goal } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// 4 full rounds + trigger escalation on the 5th
+			for (let i = 0; i < 4; i++) {
+				await ctx.runtime.onWorkerTerminalState(group.id, {
+					sessionId: group.workerSessionId,
+					kind: 'idle',
+				});
+				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+					message: `Feedback ${i + 1}`,
+				});
+			}
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', { message: 'Extra' });
+
+			// Task in review, not failed
+			const finalTask = await ctx.taskManager.getTask(task.id);
+			expect(finalTask!.status).toBe('review');
+
+			// Goal is NOT failed — only task-level escalation
+			const goalState = await ctx.goalManager.getGoal(goal.id);
+			expect(goalState!.status).toBe('active');
+		});
+
 		it('should complete a three-iteration cycle and track feedback iterations accurately', async () => {
 			await createGoalAndTask(ctx);
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -557,7 +557,7 @@ describe('TaskGroupManager', () => {
 			expect(taskResult!.status).toBe('review');
 		});
 
-		it('should keep sessions observed (not unobserve) so human can resume later', async () => {
+		it('should keep both sessions observed so human can resume later', async () => {
 			const task = await createTask();
 			const goal = makeGoal(db);
 			const callbacks = createMockLeaderCallbacks();
@@ -571,10 +571,14 @@ describe('TaskGroupManager', () => {
 				makeDefaultWorkerConfig()
 			);
 
+			// Trigger first review round so leader session is created and observed
+			await manager.routeWorkerToLeader(group.id, 'Worker output');
+
 			await manager.escalateToHumanReview(group.id, 'Max iterations');
 
-			// Worker session must remain observed for resumeWorkerFromHuman to work
+			// Both sessions must remain observed for resumeWorkerFromHuman to work
 			expect(observer.isObserving(group.workerSessionId)).toBe(true);
+			expect(observer.isObserving(group.leaderSessionId)).toBe(true);
 		});
 
 		it('should return null for unknown group', async () => {

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -534,6 +534,55 @@ describe('TaskGroupManager', () => {
 		});
 	});
 
+	describe('escalateToHumanReview', () => {
+		it('should set group to awaiting_human and task to review', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+			const group = await manager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			const updated = await manager.escalateToHumanReview(group.id, 'Max iterations reached');
+
+			expect(updated!.state).toBe('awaiting_human');
+
+			const taskResult = await taskManager.getTask(task.id);
+			expect(taskResult!.status).toBe('review');
+		});
+
+		it('should keep sessions observed (not unobserve) so human can resume later', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+			const group = await manager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			await manager.escalateToHumanReview(group.id, 'Max iterations');
+
+			// Worker session must remain observed for resumeWorkerFromHuman to work
+			expect(observer.isObserving(group.workerSessionId)).toBe(true);
+		});
+
+		it('should return null for unknown group', async () => {
+			const result = await manager.escalateToHumanReview('nonexistent-group', 'reason');
+			expect(result).toBeNull();
+		});
+	});
+
 	describe('cancel', () => {
 		it('should fail the group with cancel reason', async () => {
 			const task = await createTask();


### PR DESCRIPTION
## Summary

- When a task reaches `maxFeedbackIterations`, the **runtime** now transitions the task to `review` status and the group to `awaiting_human` — instead of marking the task as `failed`.
- Adds `TaskGroupManager.escalateToHumanReview()` method: sets group state to `awaiting_human` and task status to `review` (no PR URL needed — runtime-enforced escalation, not a leader submit).
- The iteration limit check was already in runtime code (`room-runtime.ts` → `handleLeaderTool`); only the resulting action changes from `fail` to `escalateToHumanReview`.
- Sessions remain observed (not unobserved) so `resumeWorkerFromHuman` can resume the task after human inspection.
- Goal status is unaffected — this is a task-level escalation only.

## Test plan

- [ ] `TaskGroupManager.escalateToHumanReview` sets group to `awaiting_human` and task to `review`
- [ ] Sessions remain observed after escalation (human can resume)
- [ ] Returns `null` for unknown group
- [ ] Runtime correctly escalates (not fails) when `feedbackIteration >= maxFeedbackIterations`
- [ ] Error response from `handleLeaderTool` references "human review"
- [ ] Goal remains `active` after task escalation
- [ ] Full daemon test suite: 3562 pass, 0 fail