### PR TITLE
feat(room): extend update_task tool to support title and description edits

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -271,24 +271,6 @@ export class TaskManager {
 	}
 
 	/**
-	 * Update task priority
-	 */
-	async updateTaskPriority(taskId: string, priority: TaskPriority): Promise<NeoTask> {
-		const task = await this.getTask(taskId);
-		if (!task) {
-			throw new Error(`Task not found: ${taskId}`);
-		}
-
-		const updatedTask = this.taskRepo.updateTask(taskId, { priority });
-
-		if (!updatedTask) {
-			throw new Error(`Failed to update task: ${taskId}`);
-		}
-
-		return updatedTask;
-	}
-
-	/**
 	 * Update task fields (title, description, priority) without changing status.
 	 * Works for tasks in any status — used by the room agent.
 	 */

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -148,12 +148,13 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			if (args.title !== undefined) updates.title = args.title;
 			if (args.description !== undefined) updates.description = args.description;
 			if (args.priority !== undefined) updates.priority = args.priority;
-			if (Object.keys(updates).length > 0) {
-				await taskManager.updateTaskFields(args.task_id, updates);
-			}
-			const updated = await taskManager.getTask(args.task_id);
+			// Apply updates if any fields were provided; otherwise return existing task unchanged
+			const updated =
+				Object.keys(updates).length > 0
+					? await taskManager.updateTaskFields(args.task_id, updates)
+					: task;
 			// Notify UI of the update
-			if (daemonHub && updated) {
+			if (daemonHub) {
 				void daemonHub.emit('room.task.update', {
 					sessionId: `room:${roomId}`,
 					roomId,
@@ -383,11 +384,11 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'update_task',
-			'Update an existing task (title, description, and/or priority)',
+			'Update an existing task (title, description, and/or priority). Only provided fields are changed; omitted fields keep their current values.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
-				title: z.string().optional().describe('New title for the task'),
-				description: z.string().optional().describe('New description for the task'),
+				title: z.string().trim().min(1).optional().describe('New title for the task'),
+				description: z.string().trim().min(1).optional().describe('New description for the task'),
 				priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('New priority'),
 			},
 			(args) => handlers.update_task(args)

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -341,6 +341,19 @@ describe('Room Agent Tools', () => {
 			expect(task.id).toBe(taskId);
 			expect(task.title).toBe('New title');
 		});
+
+		it('should succeed and return task unchanged when no fields are provided (no-op)', async () => {
+			const created = parseResult(
+				await handlers.create_task({ title: 'Original', description: 'desc' })
+			);
+			const taskId = created.taskId as string;
+
+			const result = parseResult(await handlers.update_task({ task_id: taskId }));
+			expect(result.success).toBe(true);
+			const task = result.task as { id: string; title: string };
+			expect(task.id).toBe(taskId);
+			expect(task.title).toBe('Original');
+		});
 	});
 
 	describe('cancel_task', () => {

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -408,7 +408,7 @@ describe('TaskManager', () => {
 		});
 	});
 
-	describe('updateTaskPriority', () => {
+	describe('updateTaskFields', () => {
 		it('should update task priority', async () => {
 			const task = await taskManager.createTask({
 				title: 'Test Task',
@@ -416,15 +416,71 @@ describe('TaskManager', () => {
 				priority: 'normal',
 			});
 
-			const updated = await taskManager.updateTaskPriority(task.id, 'urgent');
+			const updated = await taskManager.updateTaskFields(task.id, { priority: 'urgent' });
 
 			expect(updated.priority).toBe('urgent');
 		});
 
+		it('should update task title', async () => {
+			const task = await taskManager.createTask({ title: 'Old title', description: 'desc' });
+
+			const updated = await taskManager.updateTaskFields(task.id, { title: 'New title' });
+
+			expect(updated.title).toBe('New title');
+			expect(updated.description).toBe('desc'); // unchanged
+		});
+
+		it('should update task description', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'Old desc' });
+
+			const updated = await taskManager.updateTaskFields(task.id, { description: 'New desc' });
+
+			expect(updated.description).toBe('New desc');
+			expect(updated.title).toBe('T'); // unchanged
+		});
+
+		it('should update all fields together', async () => {
+			const task = await taskManager.createTask({
+				title: 'Old',
+				description: 'Old desc',
+				priority: 'low',
+			});
+
+			const updated = await taskManager.updateTaskFields(task.id, {
+				title: 'New',
+				description: 'New desc',
+				priority: 'urgent',
+			});
+
+			expect(updated.title).toBe('New');
+			expect(updated.description).toBe('New desc');
+			expect(updated.priority).toBe('urgent');
+		});
+
+		it('should work for tasks with any status (status-agnostic)', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'd' });
+			await taskManager.startTask(task.id);
+
+			const updated = await taskManager.updateTaskFields(task.id, { title: 'Updated' });
+
+			expect(updated.title).toBe('Updated');
+			expect(updated.status).toBe('in_progress');
+		});
+
+		it('should work on completed tasks', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'd' });
+			await taskManager.completeTask(task.id, 'done');
+
+			const updated = await taskManager.updateTaskFields(task.id, { title: 'Fixed title' });
+
+			expect(updated.title).toBe('Fixed title');
+			expect(updated.status).toBe('completed');
+		});
+
 		it('should throw error for non-existent task', async () => {
-			await expect(taskManager.updateTaskPriority('non-existent', 'high')).rejects.toThrow(
-				'Task not found: non-existent'
-			);
+			await expect(
+				taskManager.updateTaskFields('non-existent', { priority: 'high' })
+			).rejects.toThrow('Task not found: non-existent');
 		});
 	});
 


### PR DESCRIPTION
The room agent's update_task tool previously only supported updating task
priority. This extends it to also accept optional title and description
parameters, allowing the room agent to refine task definitions without
cancelling and recreating tasks.

- Add TaskManager.updateTaskFields() for status-agnostic field updates
- Update update_task handler to accept title, description, priority
- Update MCP tool schema with new optional parameters
- Add unit tests covering all field combinations and partial updates
