### PR TITLE
feat(test): add mock SDK support for online tests

### DIFF
--- a/packages/daemon/tests/helpers/mock-sdk.ts
+++ b/packages/daemon/tests/helpers/mock-sdk.ts
@@ -516,3 +516,404 @@ export async function waitForIdle(
 
 /** @deprecated Use `waitForIdle` instead */
 export const waitForMockIdle = waitForIdle;
+
+// ============================================================================
+// Script-Based Mock System
+// ============================================================================
+
+/**
+ * Script-based mock system for more declarative response scripting.
+ *
+ * ## Script Format
+ *
+ * Each line in the script can be:
+ *
+ * - `500ms` - Pause for 500ms before the next message
+ * - `builtin:system:init` - Generate a system init message
+ * - `builtin:result` - Generate a success result message
+ * - `builtin:result:tokens:100:50` - Success with custom tokens (input:output)
+ * - `builtin:error` - Generate an error result
+ * - `builtin:error:rate_limit` - Generate a rate_limit error result
+ * - `ENV_VAR_NAME` - Look up env var and use its value as JSON message
+ * - `{"type": "assistant", ...}` - Raw JSON object (returned as-is)
+ *
+ * ## Example
+ *
+ * ```ts
+ * process.env.NEOKAI_MOCK_SCRIPT = `
+ *   builtin:system:init
+ *   100ms
+ *   {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]}}
+ *   builtin:result
+ * `;
+ *
+ * installScriptAutoMock(ctx);
+ * ```
+ *
+ * ## Multi-turn Support
+ *
+ * Use `---` to separate turns. Each turn consumes one user message:
+ *
+ * ```
+ * builtin:system:init
+ * builtin:result
+ * ---
+ * builtin:system:init
+ * builtin:error
+ * ```
+ */
+
+/**
+ * Built-in message generators
+ */
+const BUILTIN_MESSAGES: Record<string, () => SDKMessage> = {
+	'system:init': () => sdkSystemInit(),
+	result: () => sdkResultSuccess({ inputTokens: 1, outputTokens: 1 }),
+	error: () => sdkResultError('error_during_execution', 'Mock error'),
+	'error:rate_limit': () =>
+		({
+			type: 'result',
+			subtype: 'error_during_execution',
+			uuid: randomUUID() as UUID,
+			session_id: '',
+			error: 'rate_limit_error',
+			usage: {
+				input_tokens: 0,
+				output_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+			total_cost_usd: 0,
+		}) as unknown as SDKMessage,
+};
+
+/**
+ * Parse a single line of the script and return either a delay or a message.
+ */
+function parseScriptLine(line: string): { delay?: number; message?: SDKMessage } {
+	const trimmed = line.trim();
+
+	// Empty line - skip
+	if (!trimmed) {
+		return {};
+	}
+
+	// Delay: "500ms" or "100ms"
+	const delayMatch = trimmed.match(/^(\d+)ms$/);
+	if (delayMatch) {
+		return { delay: parseInt(delayMatch[1], 10) };
+	}
+
+	// Built-in message: "builtin:system:init", "builtin:result", "builtin:error:rate_limit"
+	if (trimmed.startsWith('builtin:')) {
+		const builtinKey = trimmed.slice(8); // Remove "builtin:" prefix
+		const generator = BUILTIN_MESSAGES[builtinKey];
+		if (generator) {
+			return { message: generator() };
+		}
+
+		// Handle "builtin:result:tokens:100:50" format
+		if (builtinKey.startsWith('result:tokens:')) {
+			const parts = builtinKey.split(':');
+			if (parts.length === 4) {
+				const inputTokens = parseInt(parts[2], 10);
+				const outputTokens = parseInt(parts[3], 10);
+				return { message: sdkResultSuccess({ inputTokens, outputTokens }) };
+			}
+		}
+
+		// Unknown builtin - treat as error
+		return { message: sdkResultError('error_during_execution', `Unknown builtin: ${builtinKey}`) };
+	}
+
+	// JSON object - parse and return
+	if (trimmed.startsWith('{')) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			// Add required fields if missing
+			if (!parsed.uuid) parsed.uuid = randomUUID();
+			if (!parsed.session_id) parsed.session_id = '';
+			return { message: parsed as SDKMessage };
+		} catch (e) {
+			return { message: sdkResultError('error_during_execution', `Invalid JSON: ${trimmed}`) };
+		}
+	}
+
+	// Environment variable reference - look up and parse as JSON
+	const envValue = process.env[trimmed];
+	if (envValue !== undefined) {
+		try {
+			const parsed = JSON.parse(envValue);
+			if (!parsed.uuid) parsed.uuid = randomUUID();
+			if (!parsed.session_id) parsed.session_id = '';
+			return { message: parsed as SDKMessage };
+		} catch {
+			// If not valid JSON, treat as plain text assistant message
+			return { message: sdkAssistantText(envValue) };
+		}
+	}
+
+	// Unknown format - treat as error
+	return { message: sdkResultError('error_during_execution', `Unknown script line: ${trimmed}`) };
+}
+
+/**
+ * Parse a full script into turns (array of arrays of message generators).
+ *
+ * @param script - The script string
+ * @returns Array of turns, each turn is array of { delay?, message }
+ */
+export function parseMockScript(
+	script: string
+): Array<Array<{ delay?: number; message?: SDKMessage }>> {
+	const turns: Array<Array<{ delay?: number; message?: SDKMessage }>> = [];
+	let currentTurn: Array<{ delay?: number; message?: SDKMessage }> = [];
+
+	for (const line of script.split('\n')) {
+		const trimmed = line.trim();
+
+		// Turn separator
+		if (trimmed === '---') {
+			if (currentTurn.length > 0) {
+				turns.push(currentTurn);
+				currentTurn = [];
+			}
+			continue;
+		}
+
+		// Skip empty lines and comments
+		if (!trimmed || trimmed.startsWith('#')) {
+			continue;
+		}
+
+		const parsed = parseScriptLine(trimmed);
+		if (parsed.delay !== undefined || parsed.message !== undefined) {
+			currentTurn.push(parsed);
+		}
+	}
+
+	if (currentTurn.length > 0) {
+		turns.push(currentTurn);
+	}
+
+	return turns;
+}
+
+/**
+ * Create a response factory from a script.
+ *
+ * @param script - The script string
+ * @returns MockResponseFactory compatible with existing mock system
+ */
+export function scriptToResponseFactory(script: string): MockResponseFactory {
+	return () => {
+		const turns = parseMockScript(script);
+		// Convert to SDKMessage[][] format for the existing mock system
+		return turns.map((turn) => {
+			const messages: SDKMessage[] = [];
+			for (const item of turn) {
+				if (item.message) {
+					messages.push(item.message);
+				}
+			}
+			return messages;
+		});
+	};
+}
+
+/**
+ * Create a script-based mock with timing support.
+ *
+ * Unlike scriptToResponseFactory, this actually applies the delays between messages.
+ * Use this when you need to test timing-sensitive behavior.
+ *
+ * @param sessionManager - The SessionManager instance
+ * @param sessionId - The session ID to mock
+ * @param script - The script string
+ */
+export function mockAgentSessionWithScript(
+	sessionManager: SessionManager,
+	sessionId: string,
+	script: string
+): ReturnType<typeof sessionManager.getSession> | null {
+	const agentSession = sessionManager.getSession(sessionId);
+	if (!agentSession) return null;
+
+	// biome-ignore lint/suspicious/noExplicitAny: accessing private fields for test mock
+	const ctx = agentSession as any;
+	const turns = parseMockScript(script);
+
+	// Replace queryRunner.start() with mock implementation that respects timing
+	ctx.queryRunner.start = async () => {
+		const { messageQueue, messageHandler, stateManager } = ctx;
+
+		if (messageQueue.isRunning()) return;
+
+		messageQueue.start();
+		ctx._queryGeneration++;
+		ctx.firstMessageReceived = false;
+
+		const currentGen = ctx._queryGeneration;
+
+		ctx.queryPromise = (async () => {
+			const gen = messageQueue.messageGenerator(sessionId);
+
+			try {
+				// Process each turn by consuming one user message per turn
+				for (let turnIndex = 0; turnIndex < turns.length; turnIndex++) {
+					const next = await gen.next();
+					if (!next.value || next.done) break;
+
+					const { message, onSent } = next.value;
+					const isInternal = (message as Record<string, unknown>).internal || false;
+					if (!isInternal) {
+						await stateManager.setProcessing(message.uuid ?? 'unknown', 'initializing');
+					}
+					onSent();
+
+					ctx.firstMessageReceived = true;
+
+					// Feed scripted SDK messages for this turn with timing
+					const turnItems = turns[turnIndex];
+
+					for (const item of turnItems) {
+						// Apply delay if specified
+						if (item.delay) {
+							await Bun.sleep(item.delay);
+						}
+						// Send message if specified
+						if (item.message) {
+							await messageHandler.handleMessage(item.message);
+						}
+					}
+				}
+			} catch (error) {
+				ctx.logger?.error?.('[MockSDK] Error processing messages:', error);
+			} finally {
+				if (ctx._queryGeneration === currentGen) {
+					messageQueue.clear();
+					messageQueue.stop();
+					ctx.queryPromise = null;
+
+					try {
+						await gen.return();
+					} catch {
+						// Ignore generator cleanup errors
+					}
+
+					if (!ctx._isCleaningUp) {
+						await stateManager.setIdle();
+					}
+				}
+			}
+		})();
+	};
+
+	return agentSession;
+}
+
+/**
+ * Install auto-mocking from NEOKAI_MOCK_SCRIPT environment variable.
+ *
+ * This is the simplest way to use the script-based mock system:
+ *
+ * ```ts
+ * // In test file or setup
+ * process.env.NEOKAI_MOCK_SCRIPT = `
+ *   builtin:system:init
+ *   100ms
+ *   {"type": "assistant", ...}
+ *   builtin:result
+ * `;
+ *
+ * // In beforeEach
+ * installScriptAutoMock(ctx);
+ *
+ * // Test code is identical to online tests
+ * const sessionId = await createSession();
+ * await sendMessage(sessionId, 'Hi');
+ * await waitForIdle(ctx.sessionManager, sessionId);
+ * ```
+ *
+ * @param ctx - Context with sessionManager and eventBus
+ * @returns Controls object to change the script
+ */
+export function installScriptAutoMock(ctx: MockableContext): {
+	setScript: (script: string) => void;
+} {
+	let currentScript = process.env.NEOKAI_MOCK_SCRIPT || '';
+
+	// Listen for session.created and auto-apply script-based mock
+	ctx.eventBus.on('session.created', async (data: { sessionId: string }) => {
+		const { sessionId } = data;
+		if (currentScript) {
+			mockAgentSessionWithScript(ctx.sessionManager, sessionId, currentScript);
+		} else {
+			// Fallback to simple text response if no script
+			mockAgentSessionWithResponses(
+				ctx.sessionManager,
+				sessionId,
+				simpleTextResponse('Mock response')
+			);
+		}
+	});
+
+	return {
+		setScript: (script: string) => {
+			currentScript = script;
+		},
+	};
+}
+
+/**
+ * Helper to create common script patterns.
+ */
+export const MockScripts = {
+	/**
+	 * Simple text response with optional delay
+	 */
+	simpleText: (text: string, delayMs = 0) => {
+		const delayLine = delayMs > 0 ? `${delayMs}ms\n` : '';
+		return `${delayLine}builtin:system:init\n{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"${text}"}]}}\nbuiltin:result`;
+	},
+
+	/**
+	 * Multi-turn conversation
+	 */
+	multiTurn: (responses: string[], delayMs = 100) => {
+		return responses
+			.map(
+				(text) =>
+					`builtin:system:init\n${delayMs}ms\n{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"${text}"}]}}\nbuiltin:result`
+			)
+			.join('\n---\n');
+	},
+
+	/**
+	 * Error response
+	 */
+	error: (message = 'Mock error') => {
+		return `builtin:system:init\nbuiltin:error`;
+	},
+
+	/**
+	 * Rate limit error
+	 */
+	rateLimit: () => {
+		return `builtin:system:init\nbuiltin:error:rate_limit`;
+	},
+
+	/**
+	 * Tool use and result flow
+	 */
+	toolUse: (toolName: string, input: Record<string, unknown>, result: string) => {
+		const toolUseId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId}","name":"${toolName}","input":${JSON.stringify(input)}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId}","content":"${result}"}]}}`,
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done"}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+};

--- a/packages/daemon/tests/helpers/mock-sdk.ts
+++ b/packages/daemon/tests/helpers/mock-sdk.ts
@@ -917,3 +917,325 @@ export const MockScripts = {
 		].join('\n');
 	},
 };
+
+// ============================================================================
+// Room Agent Mock Scripts
+// ============================================================================
+
+/**
+ * Room-specific mock scripts for multi-agent flow tests.
+ *
+ * LIMITATIONS:
+ * These scripts simulate AI responses but do NOT execute actual tools.
+ * Room tests with multi-agent flow (planner, coder, leader) require real
+ * tool execution (Write, Bash, MCP tools) which cannot be fully mocked.
+ *
+ * USE CASES:
+ * - `room-chat-constraints` test works with mock (only needs text responses)
+ * - Multi-agent flow tests require real API calls for tool execution
+ *
+ * The runtime's lifecycle hooks run against the real filesystem/git repo
+ * (with mock gh CLI from setupGitEnvironment), but the AI's tool calls
+ * still need to be executed by the real SDK.
+ */
+export const RoomMockScripts = {
+	/**
+	 * Simple text response for room chat sessions.
+	 * This is the only mock that works for room tests without real API.
+	 */
+	roomChatResponse: (text = 'room ok') => {
+		return MockScripts.simpleText(text);
+	},
+
+	/**
+	 * Planner Phase 1: Creates plan file, commits, pushes, creates PR.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with planner agents require real API calls for tool execution.
+	 */
+	plannerPhase1: (opts?: { planTitle?: string }) => {
+		const title = opts?.planTitle ?? 'Add utility function';
+		const toolUseId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			// Simulate reading/globbing files
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Let me examine the codebase and create a plan."}]}}`,
+			// Simulate creating plan file (Write tool call - SDK handles this)
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId}","name":"Write","input":{"file_path":"docs/plans/${title.toLowerCase().replace(/\\s+/g, '-')}.md","content":"# Plan: ${title}\\n\\n## Tasks\\n\\n1. Create utility file\\n2. Add tests\\n"}}]}}`,
+			// Tool result (simulated)
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId}","content":"File written successfully"}]}}`,
+			// Done message
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I have created the plan and pushed it to a PR. The plan is ready for review."}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+
+	/**
+	 * Planner Phase 2: After approval, creates tasks via create_task tool.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with planner agents require real API calls for tool execution.
+	 */
+	plannerPhase2: (opts?: { taskTitle?: string }) => {
+		const title = opts?.taskTitle ?? 'Create utility file';
+		const toolUseId1 = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		const toolUseId2 = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			// Acknowledge approval
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The plan is approved. Let me merge the PR and create the execution tasks."}]}}`,
+			// Create task 1 (MCP tool call)
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId1}","name":"mcp_tool_call","input":{"server_name":"planner-tools","tool_name":"create_task","arguments":{"title":"${title}","description":"Implement the utility function with proper typing and error handling.","agent":"coder"}}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId1}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId1}","content":"{\\"success\\":true,\\"taskId\\":\\"task-mock-1\\",\\"title\\":\\"${title}\\"}"}]}}`,
+			// Create task 2
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId2}","name":"mcp_tool_call","input":{"server_name":"planner-tools","tool_name":"create_task","arguments":{"title":"Add tests","description":"Add unit tests for the utility function.","agent":"coder","depends_on":["task-mock-1"]}}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId2}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId2}","content":"{\\"success\\":true,\\"taskId\\":\\"task-mock-2\\",\\"title\\":\\"Add tests\\"}"}]}}`,
+			// Done
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I have created the execution tasks. The plan is complete."}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+
+	/**
+	 * Planner full flow: Phase 1 + Phase 2 in a multi-turn script.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with planner agents require real API calls for tool execution.
+	 */
+	plannerFull: (opts?: { planTitle?: string; taskTitle?: string }) => {
+		const phase1 = RoomMockScripts.plannerPhase1(opts);
+		const phase2 = RoomMockScripts.plannerPhase2(opts);
+		return `${phase1}\n---\n${phase2}`;
+	},
+
+	/**
+	 * Coder: Implements task, creates feature branch, commits, pushes, creates PR.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with coder agents require real API calls for tool execution.
+	 */
+	coder: (opts?: { fileName?: string; content?: string }) => {
+		const fileName = opts?.fileName ?? 'src/util.ts';
+		const content = opts?.content ?? 'export function util(): string { return "ok"; }';
+		const toolUseId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			// Start message
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I will implement this task."}]}}`,
+			// Write file (simulated - actual file creation happens via Write tool)
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId}","name":"Write","input":{"file_path":"${fileName}","content":"${content}"}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId}","content":"File written successfully"}]}}`,
+			// Done - lifecycle hooks verify the git operations
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I have implemented the task, created a feature branch, committed, pushed, and created a PR: https://github.com/test/repo/pull/1"}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+
+	/**
+	 * Leader: Reviews worker output and calls submit_for_review.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with leader agents require real API calls for tool execution.
+	 */
+	leaderSubmitForReview: () => {
+		const toolUseId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			// Review message
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I have reviewed the worker's output. The implementation looks good. I will submit for review."}]}}`,
+			// Call submit_for_review MCP tool
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId}","name":"mcp_tool_call","input":{"server_name":"leader-agent-tools","tool_name":"submit_for_review","arguments":{"pr_url":"https://github.com/test/repo/pull/1"}}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId}","content":"{\\"success\\":true,\\"message\\":\\"Task submitted for review\\"}"}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+
+	/**
+	 * Leader: Reviews worker output and calls complete_task.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with leader agents require real API calls for tool execution.
+	 */
+	leaderCompleteTask: (opts?: { summary?: string }) => {
+		const summary = opts?.summary ?? 'Task completed successfully.';
+		const toolUseId = `toolu_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+		return [
+			'builtin:system:init',
+			// Review message
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The work has been approved. I will complete the task."}]}}`,
+			// Call complete_task MCP tool
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"${toolUseId}","name":"mcp_tool_call","input":{"server_name":"leader-agent-tools","tool_name":"complete_task","arguments":{"summary":"${summary}"}}}]}}`,
+			`{"type":"assistant","parent_tool_use_id":"${toolUseId}","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"${toolUseId}","content":"{\\"success\\":true,\\"message\\":\\"Task completed\\"}"}]}}`,
+			'builtin:result',
+		].join('\n');
+	},
+
+	/**
+	 * Leader full flow: submit_for_review -> (after human approval) -> complete_task.
+	 *
+	 * NOTE: This script simulates the AI response but does NOT execute tools.
+	 * Room tests with leader agents require real API calls for tool execution.
+	 */
+	leaderFull: (opts?: { summary?: string }) => {
+		const submit = RoomMockScripts.leaderSubmitForReview();
+		const complete = RoomMockScripts.leaderCompleteTask(opts);
+		return `${submit}\n---\n${complete}`;
+	},
+
+	/**
+	 * Complete room flow: planner -> coder -> leader.
+	 *
+	 * Multi-turn script that simulates the entire room lifecycle:
+	 * - Turn 1: Planner creates plan
+	 * - Turn 2: Planner creates tasks (after approval)
+	 * - Turn 3: Coder implements
+	 * - Turn 4: Leader submits for review
+	 * - Turn 5: Leader completes (after approval)
+	 *
+	 * NOTE: Each agent session gets its own script. Use roomAgentFlow instead
+	 * for per-session mock scripts.
+	 */
+	roomFullFlow: () => {
+		// This is a reference implementation - in practice, each agent
+		// session gets its own mock script installed at session creation time.
+		throw new Error('Use roomAgentFlow() instead - each agent session needs its own mock script');
+	},
+
+	/**
+	 * Create a mock script that responds based on session type.
+	 *
+	 * NOTE: Room tests with multi-agent flow (planner, coder, leader) require
+	 * real API calls for tool execution. Only room chat tests can be fully mocked.
+	 */
+	roomAgentFlow: (
+		sessionType: 'planner' | 'coder' | 'leader' | 'chat',
+		opts?: {
+			taskTitle?: string;
+			fileName?: string;
+			summary?: string;
+		}
+	) => {
+		switch (sessionType) {
+			case 'planner':
+				return RoomMockScripts.plannerFull(opts);
+			case 'coder':
+				return RoomMockScripts.coder(opts);
+			case 'leader':
+				return RoomMockScripts.leaderFull(opts);
+			case 'chat':
+				return RoomMockScripts.roomChatResponse();
+			default:
+				return MockScripts.simpleText('mock response');
+		}
+	},
+};
+
+// ============================================================================
+// Room Auto-Mock Installer
+// ============================================================================
+
+/**
+ * Detect session type from session ID.
+ *
+ * Session ID patterns:
+ * - `room:chat:${roomId}` → 'chat'
+ * - `planner:${roomId}:${taskId}:${uuid}` → 'planner'
+ * - `coder:${roomId}:${taskId}:${uuid}` → 'coder'
+ * - `general:${roomId}:${taskId}:${uuid}` → 'general'
+ * - `leader:${roomId}:${taskId}:${uuid}` → 'leader'
+ */
+export function detectRoomSessionType(
+	sessionId: string
+): 'planner' | 'coder' | 'general' | 'leader' | 'chat' | 'unknown' {
+	if (sessionId.startsWith('room:chat:')) return 'chat';
+	if (sessionId.startsWith('planner:')) return 'planner';
+	if (sessionId.startsWith('coder:')) return 'coder';
+	if (sessionId.startsWith('general:')) return 'general';
+	if (sessionId.startsWith('leader:')) return 'leader';
+	return 'unknown';
+}
+
+/**
+ * Options for room auto-mock installer.
+ */
+export interface RoomMockOptions {
+	/** Mock script options for planner sessions */
+	planner?: {
+		taskTitle?: string;
+	};
+	/** Mock script options for coder sessions */
+	coder?: {
+		fileName?: string;
+		content?: string;
+	};
+	/** Mock script options for leader sessions */
+	leader?: {
+		summary?: string;
+	};
+	/** Mock response for chat sessions */
+	chatResponse?: string;
+	/** Default response for unknown session types */
+	defaultResponse?: string;
+}
+
+/**
+ * Install auto-mocking for room tests with session-type-aware scripts.
+ *
+ * Detects session type from the session ID and installs the appropriate mock:
+ * - `room:chat:*` → Simple text response
+ * - `planner:*` → Planner mock script
+ * - `coder:*` → Coder mock script
+ * - `leader:*` → Leader mock script
+ *
+ * @param ctx - Context with sessionManager and eventBus
+ * @param options - Options for customizing mock scripts per session type
+ * @returns Controls object
+ *
+ * @example
+ * ```ts
+ * // In beforeEach
+ * daemon = await createDaemonServer();
+ *
+ * if (IS_MOCK && daemon.daemonContext) {
+ *     installRoomAutoMock(daemon.daemonContext, {
+ *         chatResponse: 'room ok',
+ *         coder: { fileName: 'src/util.ts' },
+ *     });
+ * }
+ * ```
+ */
+export function installRoomAutoMock(ctx: MockableContext, options: RoomMockOptions = {}) {
+	const {
+		planner = {},
+		coder = {},
+		leader = {},
+		chatResponse = 'room ok',
+		defaultResponse = 'mock response',
+	} = options;
+
+	// Listen for session.created and auto-apply session-type-aware mock
+	ctx.eventBus.on('session.created', async (data: { sessionId: string }) => {
+		const { sessionId } = data;
+		const sessionType = detectRoomSessionType(sessionId);
+
+		let script: string;
+		switch (sessionType) {
+			case 'planner':
+				script = RoomMockScripts.plannerFull(planner);
+				break;
+			case 'coder':
+				script = RoomMockScripts.coder(coder);
+				break;
+			case 'leader':
+				script = RoomMockScripts.leaderFull(leader);
+				break;
+			case 'chat':
+				script = MockScripts.simpleText(chatResponse);
+				break;
+			default:
+				script = MockScripts.simpleText(defaultResponse);
+		}
+
+		mockAgentSessionWithScript(ctx.sessionManager, sessionId, script);
+	});
+}

--- a/packages/daemon/tests/online/agent/agent-session-sdk.test.ts
+++ b/packages/daemon/tests/online/agent/agent-session-sdk.test.ts
@@ -9,24 +9,26 @@
  * - Image handling
  * - Interrupts and aborts
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'haiku-4.5' (faster and cheaper than Sonnet for tests)
- * - Note: Short alias 'haiku' doesn't work with Claude OAuth (SDK hangs)
- * - Full names like 'claude-3-5-haiku-latest' also work
- *
- * These tests run in parallel with other tests for faster CI execution.
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/agent/agent-session-sdk.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-// Bun automatically loads .env from project root when running tests
 import { WebSocket } from 'undici';
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { getProcessingState, sendMessage, waitForIdle } from '../../helpers/daemon-actions';
+
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 30000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 150000;
 
 /**
  * Create a WebSocket connection and wait for the first message
@@ -129,275 +131,304 @@ describe('AgentSession SDK Integration', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
-	afterEach(
-		async () => {
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
-		},
-		{ timeout: 20000 }
-	);
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
 
 	describe('sendMessage', () => {
-		test('should send message and receive real SDK response', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Send Message Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should send message and receive real SDK response',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Send Message Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a simple message
-			const result = await sendMessage(
-				daemon,
-				sessionId,
-				'What is 1+1? Answer with just the number.'
-			);
+				// Send a simple message
+				const result = await sendMessage(
+					daemon,
+					sessionId,
+					'What is 1+1? Answer with just the number.'
+				);
 
-			expect(result.messageId).toBeString();
-			expect(result.messageId.length).toBeGreaterThan(0);
+				expect(result.messageId).toBeString();
+				expect(result.messageId.length).toBeGreaterThan(0);
 
-			// Wait for processing to complete (polls state until idle)
-			await waitForIdle(daemon, sessionId);
+				// Wait for processing to complete (polls state until idle)
+				await waitForIdle(daemon, sessionId);
 
-			// Verify state returned to idle after processing
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 20000); // 20 second timeout
+				// Verify state returned to idle after processing
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should handle message with images', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Image Message Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should handle message with images',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Image Message Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// 1x1 red pixel PNG
-			const result = await sendMessage(
-				daemon,
-				sessionId,
-				'What color is this image? Answer with just the color name.',
-				{
-					images: [
-						{
-							type: 'image',
-							source: {
-								type: 'base64',
-								media_type: 'image/png',
-								data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+				// 1x1 red pixel PNG
+				const result = await sendMessage(
+					daemon,
+					sessionId,
+					'What color is this image? Answer with just the color name.',
+					{
+						images: [
+							{
+								type: 'image',
+								source: {
+									type: 'base64',
+									media_type: 'image/png',
+									data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
+								},
 							},
-						},
-					],
-				}
-			);
+						],
+					}
+				);
 
-			expect(result.messageId).toBeString();
+				expect(result.messageId).toBeString();
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId);
 
-			// Verify state is idle
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 20000);
+				// Verify state is idle
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('enqueueMessage', () => {
-		test('should enqueue multiple messages in sequence', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Enqueue Messages Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should enqueue multiple messages in sequence',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Enqueue Messages Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send first message
-			await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
+				// Send first message
+				await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
 
-			// Wait for first message to complete
-			await waitForIdle(daemon, sessionId);
+				// Wait for first message to complete
+				await waitForIdle(daemon, sessionId);
 
-			// Send second message
-			const result = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
+				// Send second message
+				const result = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
 
-			expect(result.messageId).toBeString();
-			expect(result.messageId.length).toBeGreaterThan(0);
+				expect(result.messageId).toBeString();
+				expect(result.messageId.length).toBeGreaterThan(0);
 
-			// Wait for second message to process
-			await waitForIdle(daemon, sessionId);
-		}, 60000);
+				// Wait for second message to process
+				await waitForIdle(daemon, sessionId);
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('handleInterrupt', () => {
-		test('should interrupt ongoing processing', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Interrupt Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should interrupt ongoing processing',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Interrupt Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a simple message first and wait for it to complete
-			await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
-			await waitForIdle(daemon, sessionId);
+				// Send a simple message first and wait for it to complete
+				await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
+				await waitForIdle(daemon, sessionId);
 
-			// Now interrupt (should work even on idle - it's a no-op but shouldn't error)
-			await daemon.messageHub.request('client.interrupt', { sessionId });
+				// Now interrupt (should work even on idle - it's a no-op but shouldn't error)
+				await daemon.messageHub.request('client.interrupt', { sessionId });
 
-			// State should be idle after interrupt
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 20000);
+				// State should be idle after interrupt
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe.skip('WebSocket SDK message events (DEPRECATED - uses old SUBSCRIBE protocol)', () => {
-		test('should broadcast sdk.message events via WebSocket', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'WebSocket Events Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should broadcast sdk.message events via WebSocket',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'WebSocket Events Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			const { ws, firstMessagePromise } = createWebSocketWithFirstMessage(
-				daemon.baseUrl,
-				sessionId
-			);
-			await waitForWebSocketState(ws, 1); // OPEN
-			await firstMessagePromise;
+				const { ws, firstMessagePromise } = createWebSocketWithFirstMessage(
+					daemon.baseUrl,
+					sessionId
+				);
+				await waitForWebSocketState(ws, 1); // OPEN
+				await firstMessagePromise;
 
-			// Subscribe to state.sdkMessages.delta events
-			const subPromise = waitForWebSocketMessage(ws);
-			ws.send(
-				JSON.stringify({
-					id: 'sub-sdk-1',
-					type: 'SUBSCRIBE', // DEPRECATED - needs room-based rewrite
-					method: 'state.sdkMessages.delta',
-					sessionId,
-					timestamp: new Date().toISOString(),
-					version: '1.0.0',
-				})
-			);
-			await subPromise;
+				// Subscribe to state.sdkMessages.delta events
+				const subPromise = waitForWebSocketMessage(ws);
+				ws.send(
+					JSON.stringify({
+						id: 'sub-sdk-1',
+						type: 'SUBSCRIBE', // DEPRECATED - needs room-based rewrite
+						method: 'state.sdkMessages.delta',
+						sessionId,
+						timestamp: new Date().toISOString(),
+						version: '1.0.0',
+					})
+				);
+				await subPromise;
 
-			// CRITICAL: Start listening for SDK message BEFORE sending
-			const sdkEventPromise = waitForWebSocketMessage(ws, 10000);
+				// CRITICAL: Start listening for SDK message BEFORE sending
+				const sdkEventPromise = waitForWebSocketMessage(ws, 10000);
 
-			// Send a message to trigger SDK events
-			await sendMessage(daemon, sessionId, 'Say hello. Just respond "Hello".');
+				// Send a message to trigger SDK events
+				await sendMessage(daemon, sessionId, 'Say hello. Just respond "Hello".');
 
-			// Wait for SDK message event
-			const sdkEvent = (await sdkEventPromise) as Record<string, unknown>;
+				// Wait for SDK message event
+				const sdkEvent = (await sdkEventPromise) as Record<string, unknown>;
 
-			// Should receive a state.sdkMessages.delta event
-			expect(sdkEvent.type).toBe('EVENT');
-			expect(sdkEvent.method).toBe('state.sdkMessages.delta');
-			expect(sdkEvent.data).toBeDefined();
+				// Should receive a state.sdkMessages.delta event
+				expect(sdkEvent.type).toBe('EVENT');
+				expect(sdkEvent.method).toBe('state.sdkMessages.delta');
+				expect(sdkEvent.data).toBeDefined();
 
-			ws.close();
-		}, 20000);
+				ws.close();
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('State transitions', () => {
-		test('should transition through processing states', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'State Transitions Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should transition through processing states',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'State Transitions Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Initial state should be idle
-			const initialState = await getProcessingState(daemon, sessionId);
-			expect(initialState.status).toBe('idle');
+				// Initial state should be idle
+				const initialState = await getProcessingState(daemon, sessionId);
+				expect(initialState.status).toBe('idle');
 
-			// Send message
-			await sendMessage(daemon, sessionId, 'What is 5+5? Just the number.');
+				// Send message
+				await sendMessage(daemon, sessionId, 'What is 5+5? Just the number.');
 
-			// State should be queued or processing (depending on timing)
-			const stateAfterSend = await getProcessingState(daemon, sessionId);
-			expect(['queued', 'processing', 'idle']).toContain(stateAfterSend.status);
+				// State should be queued or processing (depending on timing)
+				const stateAfterSend = await getProcessingState(daemon, sessionId);
+				expect(['queued', 'processing', 'idle']).toContain(stateAfterSend.status);
 
-			// Wait for completion
-			await waitForIdle(daemon, sessionId);
+				// Wait for completion
+				await waitForIdle(daemon, sessionId);
 
-			// Should be back to idle
-			const finalState = await getProcessingState(daemon, sessionId);
-			expect(finalState.status).toBe('idle');
-		}, 15000);
+				// Should be back to idle
+				const finalState = await getProcessingState(daemon, sessionId);
+				expect(finalState.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should handle multiple messages in sequence', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Multiple Messages Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should handle multiple messages in sequence',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Multiple Messages Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send first message and wait for completion
-			const result1 = await sendMessage(daemon, sessionId, 'Count to 1');
-			await waitForIdle(daemon, sessionId);
+				// Send first message and wait for completion
+				const result1 = await sendMessage(daemon, sessionId, 'Count to 1');
+				await waitForIdle(daemon, sessionId);
 
-			// Send second message after first completes
-			const result2 = await sendMessage(daemon, sessionId, 'Count to 2');
+				// Send second message after first completes
+				const result2 = await sendMessage(daemon, sessionId, 'Count to 2');
 
-			// All should have unique message IDs
-			expect(result1.messageId).toBeString();
-			expect(result2.messageId).toBeString();
-			expect(result1.messageId).not.toBe(result2.messageId);
+				// All should have unique message IDs
+				expect(result1.messageId).toBeString();
+				expect(result2.messageId).toBeString();
+				expect(result1.messageId).not.toBe(result2.messageId);
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId);
-		}, 150000);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId);
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('session.interrupted event', () => {
-		test('should handle interrupt gracefully on active session', async () => {
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath: process.cwd(),
-				title: 'Interrupt Event Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+		test(
+			'should handle interrupt gracefully on active session',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'Interrupt Event Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message and let it complete
-			await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
-			await waitForIdle(daemon, sessionId);
+				// Send a message and let it complete
+				await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
+				await waitForIdle(daemon, sessionId);
 
-			// Verify state is idle
-			const state1 = await getProcessingState(daemon, sessionId);
-			expect(state1.status).toBe('idle');
+				// Verify state is idle
+				const state1 = await getProcessingState(daemon, sessionId);
+				expect(state1.status).toBe('idle');
 
-			// Call interrupt on idle session - should be a no-op
-			await daemon.messageHub.request('client.interrupt', { sessionId });
+				// Call interrupt on idle session - should be a no-op
+				await daemon.messageHub.request('client.interrupt', { sessionId });
 
-			// State should still be idle
-			const state2 = await getProcessingState(daemon, sessionId);
-			expect(state2.status).toBe('idle');
+				// State should still be idle
+				const state2 = await getProcessingState(daemon, sessionId);
+				expect(state2.status).toBe('idle');
 
-			// Send another message to verify session is still functional
-			await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
-			await waitForIdle(daemon, sessionId);
-		}, 60000);
+				// Send another message to verify session is still functional
+				await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
+				await waitForIdle(daemon, sessionId);
+			},
+			TEST_TIMEOUT
+		);
 	});
 });

--- a/packages/daemon/tests/online/convo/multiturn-conversation.test.ts
+++ b/packages/daemon/tests/online/convo/multiturn-conversation.test.ts
@@ -7,15 +7,12 @@
  * - SDK message persistence
  * - Processing state transitions
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'haiku-4.5' (faster and cheaper than Sonnet for tests)
- * - Note: Short alias 'haiku' doesn't work with Claude OAuth (SDK hangs)
- *
- * These tests run in parallel with other tests for faster CI execution.
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/convo/multiturn-conversation.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -23,145 +20,35 @@ import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { getProcessingState, sendMessage, waitForIdle } from '../../helpers/daemon-actions';
 
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 30000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 150000;
+
 describe('Multi-Turn Conversation', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
-	afterEach(
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
+
+	test(
+		'should handle multi-turn conversation with context retention',
 		async () => {
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
-		},
-		{ timeout: 30000 }
-	); // 30s timeout for cleanup (slower API + subprocess exit)
-
-	test('should handle multi-turn conversation with context retention', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: process.cwd(),
-			title: 'Context Retention Test',
-			config: {
-				model: 'haiku-4.5',
-				permissionMode: 'acceptEdits',
-			},
-		})) as { sessionId: string };
-
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
-
-		// Turn 1: Simple math question
-		const result1 = await sendMessage(
-			daemon,
-			sessionId,
-			'What is 5 + 7? Just reply with the number.'
-		);
-		expect(result1.messageId).toBeString();
-
-		await waitForIdle(daemon, sessionId, 30000);
-
-		// Turn 2: Follow-up question (tests context retention)
-		const result2 = await sendMessage(
-			daemon,
-			sessionId,
-			'Now add 3 to that result. Just reply with the number.'
-		);
-		expect(result2.messageId).toBeString();
-		expect(result2.messageId).not.toBe(result1.messageId);
-
-		await waitForIdle(daemon, sessionId, 30000);
-
-		// Verify state is idle after all turns
-		const finalState = await getProcessingState(daemon, sessionId);
-		expect(finalState.status).toBe('idle');
-	}, 90000); // 90 second timeout for 2 API calls
-
-	test('should handle multi-turn conversation with code analysis', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: process.cwd(),
-			title: 'Code Analysis Test',
-			config: {
-				model: 'haiku-4.5',
-				permissionMode: 'acceptEdits',
-			},
-		})) as { sessionId: string };
-
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
-
-		// Turn 1: Provide code context
-		await sendMessage(
-			daemon,
-			sessionId,
-			'I will show you a TypeScript function. Just reply "Ready, show me the code."'
-		);
-		await waitForIdle(daemon, sessionId, 45000);
-
-		// Turn 2: Show actual code
-		await sendMessage(
-			daemon,
-			sessionId,
-			'Here is the code:\n\n```typescript\nfunction add(a: number, b: number): number {\n  return a + b;\n}\n```\n\nWhat does this function do? Answer in one sentence.'
-		);
-		await waitForIdle(daemon, sessionId, 45000);
-
-		// Turn 3: Ask follow-up about the code
-		await sendMessage(
-			daemon,
-			sessionId,
-			'What are the parameter types? Just list them separated by commas.'
-		);
-		await waitForIdle(daemon, sessionId, 45000);
-
-		// Final state should be idle
-		const finalState = await getProcessingState(daemon, sessionId);
-		expect(finalState.status).toBe('idle');
-	}, 150000);
-
-	test('should handle rapid successive messages correctly', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: process.cwd(),
-			title: 'Rapid Messages Test',
-			config: {
-				model: 'haiku-4.5',
-				permissionMode: 'acceptEdits',
-			},
-		})) as { sessionId: string };
-
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
-
-		// Send three simple messages in quick succession
-		// They should be queued and processed sequentially
-		const msg1 = await sendMessage(daemon, sessionId, 'First message: Say "One".');
-		await waitForIdle(daemon, sessionId, 30000);
-
-		const msg2 = await sendMessage(daemon, sessionId, 'Second message: Say "Two".');
-		await waitForIdle(daemon, sessionId, 30000);
-
-		const msg3 = await sendMessage(daemon, sessionId, 'Third message: Say "Three".');
-		await waitForIdle(daemon, sessionId, 30000);
-
-		// All message IDs should be unique
-		expect(msg1.messageId).not.toBe(msg2.messageId);
-		expect(msg2.messageId).not.toBe(msg3.messageId);
-		expect(msg1.messageId).not.toBe(msg3.messageId);
-
-		// State should be idle
-		const finalState = await getProcessingState(daemon, sessionId);
-		expect(finalState.status).toBe('idle');
-	}, 60000); // 60 second timeout for 3 sequential API calls
-
-	describe('Processing state transitions across turns', () => {
-		test('should correctly transition through states for each turn', async () => {
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: process.cwd(),
-				title: 'State Transitions Test',
+				title: 'Context Retention Test',
 				config: {
-					model: 'haiku-4.5',
+					model: MODEL,
 					permissionMode: 'acceptEdits',
 				},
 			})) as { sessionId: string };
@@ -169,26 +56,156 @@ describe('Multi-Turn Conversation', () => {
 			const { sessionId } = createResult;
 			daemon.trackSession(sessionId);
 
-			// Track states through 3 turns
-			for (let i = 1; i <= 3; i++) {
-				// Initial state should be idle
-				const initialState = await getProcessingState(daemon, sessionId);
-				expect(initialState.status).toBe('idle');
+			// Turn 1: Simple math question
+			const result1 = await sendMessage(
+				daemon,
+				sessionId,
+				'What is 5 + 7? Just reply with the number.'
+			);
+			expect(result1.messageId).toBeString();
 
-				// Send message
-				await sendMessage(daemon, sessionId, `Turn ${i}: Say "Done". Just that word.`);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-				// State should change from idle
-				const processingState = await getProcessingState(daemon, sessionId);
-				expect(['queued', 'processing']).toContain(processingState.status);
+			// Turn 2: Follow-up question (tests context retention)
+			const result2 = await sendMessage(
+				daemon,
+				sessionId,
+				'Now add 3 to that result. Just reply with the number.'
+			);
+			expect(result2.messageId).toBeString();
+			expect(result2.messageId).not.toBe(result1.messageId);
 
-				// Wait for completion
-				await waitForIdle(daemon, sessionId, 30000);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-				// Should be back to idle
-				const finalState = await getProcessingState(daemon, sessionId);
-				expect(finalState.status).toBe('idle');
-			}
-		}, 120000);
+			// Verify state is idle after all turns
+			const finalState = await getProcessingState(daemon, sessionId);
+			expect(finalState.status).toBe('idle');
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'should handle multi-turn conversation with code analysis',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: process.cwd(),
+				title: 'Code Analysis Test',
+				config: {
+					model: MODEL,
+					permissionMode: 'acceptEdits',
+				},
+			})) as { sessionId: string };
+
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
+
+			// Turn 1: Provide code context
+			await sendMessage(
+				daemon,
+				sessionId,
+				'I will show you a TypeScript function. Just reply "Ready, show me the code."'
+			);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			// Turn 2: Show actual code
+			await sendMessage(
+				daemon,
+				sessionId,
+				'Here is the code:\n\n```typescript\nfunction add(a: number, b: number): number {\n  return a + b;\n}\n```\n\nWhat does this function do? Answer in one sentence.'
+			);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			// Turn 3: Ask follow-up about the code
+			await sendMessage(
+				daemon,
+				sessionId,
+				'What are the parameter types? Just list them separated by commas.'
+			);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			// Final state should be idle
+			const finalState = await getProcessingState(daemon, sessionId);
+			expect(finalState.status).toBe('idle');
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'should handle rapid successive messages correctly',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: process.cwd(),
+				title: 'Rapid Messages Test',
+				config: {
+					model: MODEL,
+					permissionMode: 'acceptEdits',
+				},
+			})) as { sessionId: string };
+
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
+
+			// Send three simple messages in quick succession
+			// They should be queued and processed sequentially
+			const msg1 = await sendMessage(daemon, sessionId, 'First message: Say "One".');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			const msg2 = await sendMessage(daemon, sessionId, 'Second message: Say "Two".');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			const msg3 = await sendMessage(daemon, sessionId, 'Third message: Say "Three".');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+			// All message IDs should be unique
+			expect(msg1.messageId).not.toBe(msg2.messageId);
+			expect(msg2.messageId).not.toBe(msg3.messageId);
+			expect(msg1.messageId).not.toBe(msg3.messageId);
+
+			// State should be idle
+			const finalState = await getProcessingState(daemon, sessionId);
+			expect(finalState.status).toBe('idle');
+		},
+		TEST_TIMEOUT
+	);
+
+	describe('Processing state transitions across turns', () => {
+		test(
+			'should correctly transition through states for each turn',
+			async () => {
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath: process.cwd(),
+					title: 'State Transitions Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+					},
+				})) as { sessionId: string };
+
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
+
+				// Track states through 3 turns
+				for (let i = 1; i <= 3; i++) {
+					// Initial state should be idle
+					const initialState = await getProcessingState(daemon, sessionId);
+					expect(initialState.status).toBe('idle');
+
+					// Send message
+					await sendMessage(daemon, sessionId, `Turn ${i}: Say "Done". Just that word.`);
+
+					// State should change from idle
+					const processingState = await getProcessingState(daemon, sessionId);
+					expect(['queued', 'processing']).toContain(processingState.status);
+
+					// Wait for completion
+					await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+					// Should be back to idle
+					const finalState = await getProcessingState(daemon, sessionId);
+					expect(finalState.status).toBe('idle');
+				}
+			},
+			TEST_TIMEOUT
+		);
 	});
 });

--- a/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
+++ b/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
@@ -6,9 +6,12 @@
  * - next_turn delivery while busy (saved queue + auto-dispatch)
  * - next_turn fallback while idle
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
+ *
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -23,22 +26,26 @@ import {
 
 const TMP_DIR = process.env.TMPDIR || '/tmp';
 
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 10000 : 90000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 60000 : 180000;
+
 describe('Message delivery mode queue flow', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
-	afterEach(
-		async () => {
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
-		},
-		{ timeout: 30000 }
-	);
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
 
 	async function getCountByStatus(
 		sessionId: string,
@@ -80,265 +87,287 @@ describe('Message delivery mode queue flow', () => {
 		return false;
 	}
 
-	test('next_turn while busy should be saved then auto-dispatched on turn end', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: `${TMP_DIR}/delivery-mode-flow-${Date.now()}`,
-			title: 'Delivery Mode Flow',
-			config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-		})) as { sessionId: string };
+	test(
+		'next_turn while busy should be saved then auto-dispatched on turn end',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: `${TMP_DIR}/delivery-mode-flow-${Date.now()}`,
+				title: 'Delivery Mode Flow',
+				config: { model: MODEL, permissionMode: 'acceptEdits' },
+			})) as { sessionId: string };
 
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
 
-		try {
-			const first = await sendMessage(
-				daemon,
-				sessionId,
-				'Set a timer for 15 seconds, so I can test message steering.'
-			);
-			expect(first.messageId).toBeString();
-			const becameBusy = await waitForBusy(sessionId, 20000);
-			if (!becameBusy) {
-				console.log('Skipping busy-turn queue assertions: agent did not enter busy state');
+			try {
+				const first = await sendMessage(
+					daemon,
+					sessionId,
+					'Set a timer for 15 seconds, so I can test message steering.'
+				);
+				expect(first.messageId).toBeString();
+				const becameBusy = await waitForBusy(sessionId, 20000);
+				if (!becameBusy) {
+					console.log('Skipping busy-turn queue assertions: agent did not enter busy state');
+					return;
+				}
+
+				const second = await sendMessage(
+					daemon,
+					sessionId,
+					'After your current response finishes, reply exactly: FOLLOWUP_OK',
+					{ deliveryMode: 'next_turn' }
+				);
+				expect(second.messageId).toBeString();
+				expect(second.messageId).not.toBe(first.messageId);
+
+				await waitForCount(sessionId, 'saved', (count) => count >= 1, 12000);
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+				await waitForCount(sessionId, 'saved', (count) => count === 0, 20000);
+				const sentCount = await getCountByStatus(sessionId, 'sent');
+				expect(sentCount).toBeGreaterThanOrEqual(2);
+			} finally {
+				try {
+					await daemon.messageHub.request('client.interrupt', { sessionId });
+				} catch {
+					// Best effort
+				}
+			}
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'next_turn while idle should fallback to immediate dispatch',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: `${TMP_DIR}/delivery-mode-idle-fallback-${Date.now()}`,
+				title: 'Delivery Mode Idle Fallback',
+				config: { model: MODEL, permissionMode: 'acceptEdits' },
+			})) as { sessionId: string };
+
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
+
+			const stateBefore = await getProcessingState(daemon, sessionId);
+			expect(stateBefore.status).toBe('idle');
+
+			await sendMessage(daemon, sessionId, 'Reply exactly: IDLE_FALLBACK_OK', {
+				deliveryMode: 'next_turn',
+			});
+
+			// next_turn while idle should not remain in saved queue
+			await waitForCount(sessionId, 'saved', (count) => count === 0, 10000);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+			const queuedCleared = await waitForCount(sessionId, 'queued', (count) => count === 0, 20000)
+				.then(() => true)
+				.catch(() => false);
+			if (!queuedCleared) {
+				console.log('Skipping idle fallback assertion: queued status did not clear in time');
 				return;
 			}
 
-			const second = await sendMessage(
-				daemon,
-				sessionId,
-				'After your current response finishes, reply exactly: FOLLOWUP_OK',
-				{ deliveryMode: 'next_turn' }
-			);
-			expect(second.messageId).toBeString();
-			expect(second.messageId).not.toBe(first.messageId);
-
-			await waitForCount(sessionId, 'saved', (count) => count >= 1, 12000);
-			await waitForIdle(daemon, sessionId, 90000);
-
-			await waitForCount(sessionId, 'saved', (count) => count === 0, 20000);
 			const sentCount = await getCountByStatus(sessionId, 'sent');
-			expect(sentCount).toBeGreaterThanOrEqual(2);
-		} finally {
+			expect(sentCount).toBeGreaterThanOrEqual(1);
+		},
+		TEST_TIMEOUT
+	);
+
+	test(
+		'current_turn steering while busy should have timestamp between assistant messages',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: `${TMP_DIR}/steer-position-${Date.now()}`,
+				title: 'Steer Position Test',
+				config: { model: MODEL, permissionMode: 'acceptEdits' },
+			})) as { sessionId: string };
+
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
+
 			try {
-				await daemon.messageHub.request('client.interrupt', { sessionId });
-			} catch {
-				// Best effort
+				// Send a message that makes the agent work for a while
+				const first = await sendMessage(
+					daemon,
+					sessionId,
+					'Write a detailed 5-paragraph essay about the history of computing. Take your time and be thorough.'
+				);
+				expect(first.messageId).toBeString();
+
+				const becameBusy = await waitForBusy(sessionId, 20000);
+				if (!becameBusy) {
+					console.log('Skipping: agent did not enter busy state');
+					return;
+				}
+
+				// Wait a moment to ensure some assistant content has been streamed
+				await new Promise((resolve) => setTimeout(resolve, 2000));
+
+				// Send a steering message (current_turn while busy)
+				const steerResult = await sendMessage(
+					daemon,
+					sessionId,
+					'Actually, stop what you are doing. Reply with exactly: STEERED_OK',
+					{ deliveryMode: 'current_turn' }
+				);
+				expect(steerResult.messageId).toBeString();
+
+				// The message should be queued initially
+				// Then transition to 'sent' when the generator yields it
+				await waitForCount(sessionId, 'queued', (count) => count === 0, 30000);
+
+				// Wait for the turn to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+				// Get all SDK messages and verify ordering
+				const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
+					minCount: 4, // system + user + assistant + (steered user) + result
+					timeout: 10000,
+				});
+
+				// Find the steered user message by UUID
+				const steeredMsg = sdkMessages.find(
+					(msg: Record<string, unknown>) =>
+						msg.type === 'user' && msg.uuid === steerResult.messageId
+				);
+				expect(steeredMsg).toBeDefined();
+
+				// The steered message should have a timestamp
+				const steeredTimestamp = (steeredMsg as Record<string, unknown>).timestamp as number;
+				expect(steeredTimestamp).toBeGreaterThan(0);
+
+				// Find the first user message
+				const firstUserMsg = sdkMessages.find(
+					(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === first.messageId
+				);
+				expect(firstUserMsg).toBeDefined();
+				const firstUserTimestamp = (firstUserMsg as Record<string, unknown>).timestamp as number;
+
+				// The steered message timestamp should be AFTER the first user message
+				expect(steeredTimestamp).toBeGreaterThan(firstUserTimestamp);
+
+				// Find the result message (should be last or second-to-last)
+				const resultMessages = sdkMessages.filter(
+					(msg: Record<string, unknown>) => msg.type === 'result'
+				);
+				expect(resultMessages.length).toBeGreaterThanOrEqual(1);
+				const lastResult = resultMessages[resultMessages.length - 1];
+				const resultTimestamp = (lastResult as Record<string, unknown>).timestamp as number;
+
+				// CRITICAL: The steered message timestamp must be BEFORE the final result
+				// This proves it was positioned at SDK insertion time, not at turn end
+				expect(steeredTimestamp).toBeLessThan(resultTimestamp);
+
+				// Verify the message status is now 'sent'
+				const sentCount = await getCountByStatus(sessionId, 'sent');
+				expect(sentCount).toBeGreaterThanOrEqual(2); // At least first + steered
+			} finally {
+				try {
+					await daemon.messageHub.request('client.interrupt', { sessionId });
+				} catch {
+					// Best effort
+				}
 			}
-		}
-	}, 180000);
+		},
+		TEST_TIMEOUT
+	);
 
-	test('next_turn while idle should fallback to immediate dispatch', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: `${TMP_DIR}/delivery-mode-idle-fallback-${Date.now()}`,
-			title: 'Delivery Mode Idle Fallback',
-			config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-		})) as { sessionId: string };
+	test(
+		'multiple current_turn steers while busy should all be acknowledged',
+		async () => {
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath: `${TMP_DIR}/multi-steer-${Date.now()}`,
+				title: 'Multi Steer Test',
+				config: { model: MODEL, permissionMode: 'acceptEdits' },
+			})) as { sessionId: string };
 
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
 
-		const stateBefore = await getProcessingState(daemon, sessionId);
-		expect(stateBefore.status).toBe('idle');
-
-		await sendMessage(daemon, sessionId, 'Reply exactly: IDLE_FALLBACK_OK', {
-			deliveryMode: 'next_turn',
-		});
-
-		// next_turn while idle should not remain in saved queue
-		await waitForCount(sessionId, 'saved', (count) => count === 0, 10000);
-		await waitForIdle(daemon, sessionId, 60000);
-		const queuedCleared = await waitForCount(sessionId, 'queued', (count) => count === 0, 20000)
-			.then(() => true)
-			.catch(() => false);
-		if (!queuedCleared) {
-			console.log('Skipping idle fallback assertion: queued status did not clear in time');
-			return;
-		}
-
-		const sentCount = await getCountByStatus(sessionId, 'sent');
-		expect(sentCount).toBeGreaterThanOrEqual(1);
-	}, 90000);
-
-	test('current_turn steering while busy should have timestamp between assistant messages', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: `${TMP_DIR}/steer-position-${Date.now()}`,
-			title: 'Steer Position Test',
-			config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-		})) as { sessionId: string };
-
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
-
-		try {
-			// Send a message that makes the agent work for a while
-			const first = await sendMessage(
-				daemon,
-				sessionId,
-				'Write a detailed 5-paragraph essay about the history of computing. Take your time and be thorough.'
-			);
-			expect(first.messageId).toBeString();
-
-			const becameBusy = await waitForBusy(sessionId, 20000);
-			if (!becameBusy) {
-				console.log('Skipping: agent did not enter busy state');
-				return;
-			}
-
-			// Wait a moment to ensure some assistant content has been streamed
-			await new Promise((resolve) => setTimeout(resolve, 2000));
-
-			// Send a steering message (current_turn while busy)
-			const steerResult = await sendMessage(
-				daemon,
-				sessionId,
-				'Actually, stop what you are doing. Reply with exactly: STEERED_OK',
-				{ deliveryMode: 'current_turn' }
-			);
-			expect(steerResult.messageId).toBeString();
-
-			// The message should be queued initially
-			// Then transition to 'sent' when the generator yields it
-			await waitForCount(sessionId, 'queued', (count) => count === 0, 30000);
-
-			// Wait for the turn to complete
-			await waitForIdle(daemon, sessionId, 120000);
-
-			// Get all SDK messages and verify ordering
-			const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
-				minCount: 4, // system + user + assistant + (steered user) + result
-				timeout: 10000,
-			});
-
-			// Find the steered user message by UUID
-			const steeredMsg = sdkMessages.find(
-				(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === steerResult.messageId
-			);
-			expect(steeredMsg).toBeDefined();
-
-			// The steered message should have a timestamp
-			const steeredTimestamp = (steeredMsg as Record<string, unknown>).timestamp as number;
-			expect(steeredTimestamp).toBeGreaterThan(0);
-
-			// Find the first user message
-			const firstUserMsg = sdkMessages.find(
-				(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === first.messageId
-			);
-			expect(firstUserMsg).toBeDefined();
-			const firstUserTimestamp = (firstUserMsg as Record<string, unknown>).timestamp as number;
-
-			// The steered message timestamp should be AFTER the first user message
-			expect(steeredTimestamp).toBeGreaterThan(firstUserTimestamp);
-
-			// Find the result message (should be last or second-to-last)
-			const resultMessages = sdkMessages.filter(
-				(msg: Record<string, unknown>) => msg.type === 'result'
-			);
-			expect(resultMessages.length).toBeGreaterThanOrEqual(1);
-			const lastResult = resultMessages[resultMessages.length - 1];
-			const resultTimestamp = (lastResult as Record<string, unknown>).timestamp as number;
-
-			// CRITICAL: The steered message timestamp must be BEFORE the final result
-			// This proves it was positioned at SDK insertion time, not at turn end
-			expect(steeredTimestamp).toBeLessThan(resultTimestamp);
-
-			// Verify the message status is now 'sent'
-			const sentCount = await getCountByStatus(sessionId, 'sent');
-			expect(sentCount).toBeGreaterThanOrEqual(2); // At least first + steered
-		} finally {
 			try {
-				await daemon.messageHub.request('client.interrupt', { sessionId });
-			} catch {
-				// Best effort
+				// Send initial message to make agent busy
+				await sendMessage(
+					daemon,
+					sessionId,
+					'Write a very long and detailed analysis of renewable energy sources. Cover at least solar, wind, hydro, and geothermal. Be thorough.'
+				);
+
+				const becameBusy = await waitForBusy(sessionId, 20000);
+				if (!becameBusy) {
+					console.log('Skipping: agent did not enter busy state');
+					return;
+				}
+
+				// Wait for some assistant content to stream
+				await new Promise((resolve) => setTimeout(resolve, 1500));
+
+				// Send TWO steering messages in quick succession
+				const steer1 = await sendMessage(
+					daemon,
+					sessionId,
+					'STEER_MESSAGE_ONE: Acknowledge this.',
+					{
+						deliveryMode: 'current_turn',
+					}
+				);
+				const steer2 = await sendMessage(
+					daemon,
+					sessionId,
+					'STEER_MESSAGE_TWO: Also acknowledge this.',
+					{ deliveryMode: 'current_turn' }
+				);
+
+				expect(steer1.messageId).toBeString();
+				expect(steer2.messageId).toBeString();
+
+				// Wait for all queued messages to be consumed
+				await waitForCount(sessionId, 'queued', (count) => count === 0, 60000);
+
+				// Wait for turns to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+
+				// Both steering messages should now be 'sent'
+				const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
+					minCount: 5,
+					timeout: 10000,
+				});
+
+				const steered1 = sdkMessages.find(
+					(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === steer1.messageId
+				);
+				const steered2 = sdkMessages.find(
+					(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === steer2.messageId
+				);
+
+				// Both messages should exist in the transcript
+				expect(steered1).toBeDefined();
+				expect(steered2).toBeDefined();
+
+				// Both should have timestamps
+				const ts1 = (steered1 as Record<string, unknown>).timestamp as number;
+				const ts2 = (steered2 as Record<string, unknown>).timestamp as number;
+				expect(ts1).toBeGreaterThan(0);
+				expect(ts2).toBeGreaterThan(0);
+
+				// Steer 2 should have a timestamp >= steer 1 (sent in order)
+				expect(ts2).toBeGreaterThanOrEqual(ts1);
+
+				// No messages should remain in queued status
+				const queuedCount = await getCountByStatus(sessionId, 'queued');
+				expect(queuedCount).toBe(0);
+
+				// All user messages should be sent
+				const sentCount = await getCountByStatus(sessionId, 'sent');
+				expect(sentCount).toBeGreaterThanOrEqual(3); // initial + steer1 + steer2
+			} finally {
+				try {
+					await daemon.messageHub.request('client.interrupt', { sessionId });
+				} catch {
+					// Best effort
+				}
 			}
-		}
-	}, 180000);
-
-	test('multiple current_turn steers while busy should all be acknowledged', async () => {
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath: `${TMP_DIR}/multi-steer-${Date.now()}`,
-			title: 'Multi Steer Test',
-			config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-		})) as { sessionId: string };
-
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
-
-		try {
-			// Send initial message to make agent busy
-			await sendMessage(
-				daemon,
-				sessionId,
-				'Write a very long and detailed analysis of renewable energy sources. Cover at least solar, wind, hydro, and geothermal. Be thorough.'
-			);
-
-			const becameBusy = await waitForBusy(sessionId, 20000);
-			if (!becameBusy) {
-				console.log('Skipping: agent did not enter busy state');
-				return;
-			}
-
-			// Wait for some assistant content to stream
-			await new Promise((resolve) => setTimeout(resolve, 1500));
-
-			// Send TWO steering messages in quick succession
-			const steer1 = await sendMessage(daemon, sessionId, 'STEER_MESSAGE_ONE: Acknowledge this.', {
-				deliveryMode: 'current_turn',
-			});
-			const steer2 = await sendMessage(
-				daemon,
-				sessionId,
-				'STEER_MESSAGE_TWO: Also acknowledge this.',
-				{ deliveryMode: 'current_turn' }
-			);
-
-			expect(steer1.messageId).toBeString();
-			expect(steer2.messageId).toBeString();
-
-			// Wait for all queued messages to be consumed
-			await waitForCount(sessionId, 'queued', (count) => count === 0, 60000);
-
-			// Wait for turns to complete
-			await waitForIdle(daemon, sessionId, 120000);
-
-			// Both steering messages should now be 'sent'
-			const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
-				minCount: 5,
-				timeout: 10000,
-			});
-
-			const steered1 = sdkMessages.find(
-				(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === steer1.messageId
-			);
-			const steered2 = sdkMessages.find(
-				(msg: Record<string, unknown>) => msg.type === 'user' && msg.uuid === steer2.messageId
-			);
-
-			// Both messages should exist in the transcript
-			expect(steered1).toBeDefined();
-			expect(steered2).toBeDefined();
-
-			// Both should have timestamps
-			const ts1 = (steered1 as Record<string, unknown>).timestamp as number;
-			const ts2 = (steered2 as Record<string, unknown>).timestamp as number;
-			expect(ts1).toBeGreaterThan(0);
-			expect(ts2).toBeGreaterThan(0);
-
-			// Steer 2 should have a timestamp >= steer 1 (sent in order)
-			expect(ts2).toBeGreaterThanOrEqual(ts1);
-
-			// No messages should remain in queued status
-			const queuedCount = await getCountByStatus(sessionId, 'queued');
-			expect(queuedCount).toBe(0);
-
-			// All user messages should be sent
-			const sentCount = await getCountByStatus(sessionId, 'sent');
-			expect(sentCount).toBeGreaterThanOrEqual(3); // initial + steer1 + steer2
-		} finally {
-			try {
-				await daemon.messageHub.request('client.interrupt', { sessionId });
-			} catch {
-				// Best effort
-			}
-		}
-	}, 180000);
+		},
+		TEST_TIMEOUT
+	);
 });

--- a/packages/daemon/tests/online/features/message-persistence.test.ts
+++ b/packages/daemon/tests/online/features/message-persistence.test.ts
@@ -10,17 +10,15 @@
  * 3. Messages persist correctly even with interruptions
  * 4. Message order is maintained
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'haiku-4.5' (faster and cheaper than Sonnet for tests)
- * - Note: Short alias 'haiku' doesn't work with Claude OAuth (SDK hangs)
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/features/message-persistence.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-// Bun automatically loads .env from project root when running tests
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import {
@@ -31,191 +29,217 @@ import {
 	waitForIdle,
 } from '../../helpers/daemon-actions';
 
-// Use temp directory for test database
 const TMP_DIR = process.env.TMPDIR || '/tmp';
 
-// Tests will FAIL if GLM credentials are not available
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 30000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 15000 : 90000;
+
 describe('Message Persistence', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
 		if (daemon) {
 			daemon.kill('SIGTERM');
 			await daemon.waitForExit();
 		}
-	}, 20000);
+	}, SETUP_TIMEOUT);
 
 	describe('Basic Message Persistence', () => {
-		test('should persist user messages to database', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-test-${Date.now()}`;
+		test(
+			'should persist user messages to database',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Persist Messages Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Persist Messages Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message
-			const result = await sendMessage(daemon, sessionId, 'What is 1+1?');
-			expect(result.messageId).toBeString();
+				// Send a message
+				const result = await sendMessage(daemon, sessionId, 'What is 1+1?');
+				expect(result.messageId).toBeString();
 
-			// Wait for message to be processed
-			await waitForIdle(daemon, sessionId, 30000);
+				// Wait for message to be processed
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Get session - should have messages
-			const session = await getSession(daemon, sessionId);
+				// Get session - should have messages
+				const session = await getSession(daemon, sessionId);
 
-			// Verify session exists and has proper metadata
-			expect(session).toBeDefined();
-			expect(session.id).toBe(sessionId);
-		}, 30000);
+				// Verify session exists and has proper metadata
+				expect(session).toBeDefined();
+				expect(session.id).toBe(sessionId);
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should maintain message order across multiple sends', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-order-test-${Date.now()}`;
+		test(
+			'should maintain message order across multiple sends',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-order-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Message Order Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Message Order Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send multiple messages
-			const msg1 = await sendMessage(daemon, sessionId, 'First message');
-			await waitForIdle(daemon, sessionId, 30000);
+				// Send multiple messages
+				const msg1 = await sendMessage(daemon, sessionId, 'First message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const msg2 = await sendMessage(daemon, sessionId, 'Second message');
-			await waitForIdle(daemon, sessionId, 30000);
+				const msg2 = await sendMessage(daemon, sessionId, 'Second message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const msg3 = await sendMessage(daemon, sessionId, 'Third message');
-			await waitForIdle(daemon, sessionId, 30000);
+				const msg3 = await sendMessage(daemon, sessionId, 'Third message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// All message IDs should be unique
-			expect(msg1.messageId).not.toBe(msg2.messageId);
-			expect(msg2.messageId).not.toBe(msg3.messageId);
-			expect(msg1.messageId).not.toBe(msg3.messageId);
+				// All message IDs should be unique
+				expect(msg1.messageId).not.toBe(msg2.messageId);
+				expect(msg2.messageId).not.toBe(msg3.messageId);
+				expect(msg1.messageId).not.toBe(msg3.messageId);
 
-			// Session should still be functional
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 60000);
+				// Session should still be functional
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT * 2
+		);
 	});
 
 	describe('Message Persistence with Interruption', () => {
-		test('should not lose messages when interrupted', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-interrupt-test-${Date.now()}`;
+		test(
+			'should not lose messages when interrupted',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-interrupt-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Interrupt Persistence Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Interrupt Persistence Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message that will take some time
-			await sendMessage(daemon, sessionId, 'Count from 1 to 100 slowly.');
+				// Send a message that will take some time
+				await sendMessage(daemon, sessionId, 'Count from 1 to 100 slowly.');
 
-			// Wait a bit for processing to start
-			await new Promise((resolve) => setTimeout(resolve, 2000));
+				// Wait a bit for processing to start (shorter in mock mode)
+				const interruptDelay = IS_MOCK ? 100 : 2000;
+				await new Promise((resolve) => setTimeout(resolve, interruptDelay));
 
-			// Interrupt the stream
-			await interrupt(daemon, sessionId);
+				// Interrupt the stream
+				await interrupt(daemon, sessionId);
 
-			// Wait for interrupt to complete
-			await new Promise((resolve) => setTimeout(resolve, 1000));
+				// Wait for interrupt to complete
+				await new Promise((resolve) => setTimeout(resolve, interruptDelay / 2));
 
-			// Session should still be functional after interrupt
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state).toBeDefined();
+				// Session should still be functional after interrupt
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state).toBeDefined();
 
-			// Send another message to verify session still works
-			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 30000);
+				// Send another message to verify session still works
+				await sendMessage(daemon, sessionId, 'What is 2+2?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Should be idle and functional
-			const finalState = await getProcessingState(daemon, sessionId);
-			expect(finalState.status).toBe('idle');
-		}, 60000);
+				// Should be idle and functional
+				const finalState = await getProcessingState(daemon, sessionId);
+				expect(finalState.status).toBe('idle');
+			},
+			TEST_TIMEOUT * 2
+		);
 	});
 
 	describe('Session State Consistency', () => {
-		test('should maintain consistent session state across operations', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-state-test-${Date.now()}`;
+		test(
+			'should maintain consistent session state across operations',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-state-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'State Consistency Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'State Consistency Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Initial state check
-			let session = await getSession(daemon, sessionId);
-			expect(session.id).toBe(sessionId);
-			expect(session.workspacePath).toBe(workspacePath);
+				// Initial state check
+				let session = await getSession(daemon, sessionId);
+				expect(session.id).toBe(sessionId);
+				expect(session.workspacePath).toBe(workspacePath);
 
-			// Send a message
-			await sendMessage(daemon, sessionId, 'Test message');
-			await waitForIdle(daemon, sessionId, 30000);
+				// Send a message
+				await sendMessage(daemon, sessionId, 'Test message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Session should still be consistent
-			session = await getSession(daemon, sessionId);
-			expect(session.id).toBe(sessionId);
-			expect(session.workspacePath).toBe(workspacePath);
+				// Session should still be consistent
+				session = await getSession(daemon, sessionId);
+				expect(session.id).toBe(sessionId);
+				expect(session.workspacePath).toBe(workspacePath);
 
-			// Agent should be in idle state
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 30000);
+				// Agent should be in idle state
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Concurrent Message Handling', () => {
-		test('should handle multiple message sends in sequence', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-concurrent-test-${Date.now()}`;
+		test(
+			'should handle multiple message sends in sequence',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-concurrent-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Concurrent Messages Test',
-				config: { model: 'haiku-4.5', permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Concurrent Messages Test',
+					config: { model: MODEL, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send messages in quick succession
-			const results = await Promise.all([
-				sendMessage(daemon, sessionId, 'Message 1'),
-				new Promise((resolve) => setTimeout(resolve, 100)).then(() =>
-					sendMessage(daemon, sessionId, 'Message 2')
-				),
-				new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
-					sendMessage(daemon, sessionId, 'Message 3')
-				),
-			]);
+				// Send messages in quick succession
+				const results = await Promise.all([
+					sendMessage(daemon, sessionId, 'Message 1'),
+					new Promise((resolve) => setTimeout(resolve, 100)).then(() =>
+						sendMessage(daemon, sessionId, 'Message 2')
+					),
+					new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
+						sendMessage(daemon, sessionId, 'Message 3')
+					),
+				]);
 
-			// All should have unique message IDs
-			expect(results[0].messageId).not.toBe(results[1].messageId);
-			expect(results[1].messageId).not.toBe(results[2].messageId);
+				// All should have unique message IDs
+				expect(results[0].messageId).not.toBe(results[1].messageId);
+				expect(results[1].messageId).not.toBe(results[2].messageId);
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId, 60000);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT * 2);
 
-			// Should be idle
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 90000);
+				// Should be idle
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT * 3
+		);
 	});
 });

--- a/packages/daemon/tests/online/lifecycle/session-resume.test.ts
+++ b/packages/daemon/tests/online/lifecycle/session-resume.test.ts
@@ -8,6 +8,13 @@
  *
  * The session resume feature ensures that when a session is reloaded,
  * the SDK session ID is preserved to allow continuous conversation.
+ *
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
+ *
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/lifecycle/session-resume.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -15,57 +22,67 @@ import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { getSession, sendMessage, waitForIdle } from '../../helpers/daemon-actions';
 
-// Use temp directory for test workspaces
 const TMP_DIR = process.env.TMPDIR || '/tmp';
+
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 45000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 15000 : 90000;
 
 describe('Session Resume', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
 		if (daemon) {
 			daemon.kill('SIGTERM');
 			await daemon.waitForExit();
 		}
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
-	test('should maintain session consistency across multiple operations', async () => {
-		const workspacePath = `${TMP_DIR}/session-resume-test-${Date.now()}`;
+	test(
+		'should maintain session consistency across multiple operations',
+		async () => {
+			const workspacePath = `${TMP_DIR}/session-resume-test-${Date.now()}`;
 
-		const createResult = (await daemon.messageHub.request('session.create', {
-			workspacePath,
-			title: 'Session Resume Test',
-			config: {
-				model: 'haiku-4.5',
-				permissionMode: 'acceptEdits',
-			},
-		})) as { sessionId: string };
+			const createResult = (await daemon.messageHub.request('session.create', {
+				workspacePath,
+				title: 'Session Resume Test',
+				config: {
+					model: MODEL,
+					permissionMode: 'acceptEdits',
+				},
+			})) as { sessionId: string };
 
-		const { sessionId } = createResult;
-		daemon.trackSession(sessionId);
+			const { sessionId } = createResult;
+			daemon.trackSession(sessionId);
 
-		// Initial session state
-		let session = await getSession(daemon, sessionId);
-		expect(session.id).toBe(sessionId);
+			// Initial session state
+			let session = await getSession(daemon, sessionId);
+			expect(session.id).toBe(sessionId);
 
-		// Send first message
-		await sendMessage(daemon, sessionId, 'First message');
-		await waitForIdle(daemon, sessionId, 45000);
+			// Send first message
+			await sendMessage(daemon, sessionId, 'First message');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-		// Verify session is still consistent
-		session = await getSession(daemon, sessionId);
-		expect(session.id).toBe(sessionId);
+			// Verify session is still consistent
+			session = await getSession(daemon, sessionId);
+			expect(session.id).toBe(sessionId);
 
-		// Send second message
-		await sendMessage(daemon, sessionId, 'Second message');
-		await waitForIdle(daemon, sessionId, 45000);
+			// Send second message
+			await sendMessage(daemon, sessionId, 'Second message');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-		// Session should still be consistent and functional
-		session = await getSession(daemon, sessionId);
-		expect(session.id).toBe(sessionId);
-		expect(session.workspacePath).toBe(workspacePath);
-	}, 90000);
+			// Session should still be consistent and functional
+			session = await getSession(daemon, sessionId);
+			expect(session.id).toBe(sessionId);
+			expect(session.workspacePath).toBe(workspacePath);
+		},
+		TEST_TIMEOUT
+	);
 });

--- a/packages/daemon/tests/online/rewind/rewind-feature.test.ts
+++ b/packages/daemon/tests/online/rewind/rewind-feature.test.ts
@@ -1,23 +1,22 @@
 /**
- * Rewind Feature Online Tests
+ * Rewind Feature Tests
  *
- * These tests verify the complete rewind feature with real SDK calls:
+ * These tests verify the complete rewind feature:
  * 1. Checkpoints are created when messages are sent
  * 2. Checkpoints can be retrieved via RPC
  * 3. Rewind preview shows expected file changes
  * 4. Rewind execute restores files correctly
  * 5. Conversation rewind removes messages after rewindPoint
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'haiku-4.5' (faster and cheaper than Sonnet for tests)
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/rewind/rewind-feature.test.ts
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-// Bun automatically loads .env from project root when running tests
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { sendMessage, waitForIdle, getProcessingState } from '../../helpers/daemon-actions';
@@ -27,28 +26,34 @@ import type { RewindPreview, RewindResult } from '@neokai/shared';
  * A rewind point derived from a user message
  */
 interface RewindPoint {
-	uuid: string; // User message UUID (used as rewindPoint ID)
-	timestamp: number; // Message timestamp (milliseconds)
-	content: string; // Message content preview
-	turnNumber: number; // Derived turn number (1-indexed position)
+	uuid: string;
+	timestamp: number;
+	content: string;
+	turnNumber: number;
 }
 
-// Use temp directory for test database
 const TMP_DIR = process.env.TMPDIR || '/tmp';
+
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 10000 : 60000;
+const SETUP_TIMEOUT = IS_MOCK ? 15000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 300000;
 
 describe('Rewind Feature', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
 		if (daemon) {
 			daemon.kill('SIGTERM');
 			await daemon.waitForExit();
 		}
-	}, 20000);
+	}, SETUP_TIMEOUT);
 
 	/**
 	 * Helper to get rewind points for a session
@@ -88,367 +93,403 @@ describe('Rewind Feature', () => {
 	}
 
 	describe('Rewind Point Creation', () => {
-		test('should create rewind points when messages are sent', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-point-test-${Date.now()}`;
+		test(
+			'should create rewind points when messages are sent',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-point-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Point Creation Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Point Creation Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Initially no rewind points
-			let rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints).toEqual([]);
+				// Initially no rewind points
+				let rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints).toEqual([]);
 
-			// Send first message
-			await sendMessage(daemon, sessionId, 'What is 2+2? Reply with just the number.');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send first message
+				await sendMessage(daemon, sessionId, 'What is 2+2? Reply with just the number.');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Should have 1 rewind point
-			rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
+				// Should have 1 rewind point
+				rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
 
-			// First rewind point should have turn number 1
-			const firstRewindPoint = rewindPoints.find((c) => c.turnNumber === 1);
-			expect(firstRewindPoint).toBeDefined();
-			expect(firstRewindPoint?.content).toContain('2+2');
+				// First rewind point should have turn number 1
+				const firstRewindPoint = rewindPoints.find((c) => c.turnNumber === 1);
+				expect(firstRewindPoint).toBeDefined();
+				expect(firstRewindPoint?.content).toContain('2+2');
 
-			// Send second message
-			await sendMessage(daemon, sessionId, 'What is 3+3? Reply with just the number.');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send second message
+				await sendMessage(daemon, sessionId, 'What is 3+3? Reply with just the number.');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Should have 2 rewind points
-			rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(2);
+				// Should have 2 rewind points
+				rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(2);
 
-			// Check second rewind point
-			const secondRewindPoint = rewindPoints.find((c) => c.turnNumber === 2);
-			expect(secondRewindPoint).toBeDefined();
-			expect(secondRewindPoint?.content).toContain('3+3');
-		}, 120000);
+				// Check second rewind point
+				const secondRewindPoint = rewindPoints.find((c) => c.turnNumber === 2);
+				expect(secondRewindPoint).toBeDefined();
+				expect(secondRewindPoint?.content).toContain('3+3');
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should return rewind points sorted by turn number (newest first)', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-sort-test-${Date.now()}`;
+		test(
+			'should return rewind points sorted by turn number (newest first)',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-sort-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Point Sorting Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Point Sorting Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send multiple messages
-			await sendMessage(daemon, sessionId, 'First message');
-			await waitForIdle(daemon, sessionId, 90000);
+				// Send multiple messages
+				await sendMessage(daemon, sessionId, 'First message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			await sendMessage(daemon, sessionId, 'Second message');
-			await waitForIdle(daemon, sessionId, 90000);
+				await sendMessage(daemon, sessionId, 'Second message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			await sendMessage(daemon, sessionId, 'Third message');
-			await waitForIdle(daemon, sessionId, 90000);
+				await sendMessage(daemon, sessionId, 'Third message');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(3);
+				const rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(3);
 
-			// Should be sorted newest first (highest turn number first)
-			for (let i = 0; i < rewindPoints.length - 1; i++) {
-				expect(rewindPoints[i].turnNumber).toBeGreaterThan(rewindPoints[i + 1].turnNumber);
-			}
-		}, 300000);
+				// Should be sorted newest first (highest turn number first)
+				for (let i = 0; i < rewindPoints.length - 1; i++) {
+					expect(rewindPoints[i].turnNumber).toBeGreaterThan(rewindPoints[i + 1].turnNumber);
+				}
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Rewind Preview', () => {
-		test('should show preview when rewindPoint exists', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-preview-test-${Date.now()}`;
+		test(
+			'should show preview when rewindPoint exists',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-preview-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Preview Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Preview Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send a message
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Get rewindPoint
-			const rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
+				// Get rewindPoint
+				const rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
 
-			const rewindPoint = rewindPoints[0];
+				const rewindPoint = rewindPoints[0];
 
-			// Preview rewind
-			const preview = await previewRewind(sessionId, rewindPoint.uuid);
+				// Preview rewind
+				const preview = await previewRewind(sessionId, rewindPoint.uuid);
 
-			// Preview should indicate whether rewind is possible
-			expect(preview).toBeDefined();
-			expect(typeof preview.canRewind).toBe('boolean');
+				// Preview should indicate whether rewind is possible
+				expect(preview).toBeDefined();
+				expect(typeof preview.canRewind).toBe('boolean');
 
-			// If can rewind, should have file info
-			if (preview.canRewind) {
-				expect(preview.filesChanged).toBeDefined();
-			}
-		}, 120000);
+				// If can rewind, should have file info
+				if (preview.canRewind) {
+					expect(preview.filesChanged).toBeDefined();
+				}
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should return error for non-existent rewindPoint', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-preview-invalid-test-${Date.now()}`;
+		test(
+			'should return error for non-existent rewindPoint',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-preview-invalid-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Preview Invalid Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Preview Invalid Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message to initialize SDK
-			await sendMessage(daemon, sessionId, 'Hello');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send a message to initialize SDK
+				await sendMessage(daemon, sessionId, 'Hello');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Preview with invalid rewindPoint ID
-			const preview = await previewRewind(sessionId, 'invalid-rewindPoint-id');
+				// Preview with invalid rewindPoint ID
+				const preview = await previewRewind(sessionId, 'invalid-rewindPoint-id');
 
-			expect(preview.canRewind).toBe(false);
-			expect(preview.error).toContain('not found');
-		}, 120000);
+				expect(preview.canRewind).toBe(false);
+				expect(preview.error).toContain('not found');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Rewind Execute - Files Mode', () => {
-		test('should execute files-only rewind successfully', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-execute-files-test-${Date.now()}`;
+		test(
+			'should execute files-only rewind successfully',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-execute-files-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Execute Files Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Execute Files Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send first message
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send first message
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Get first rewindPoint
-			let rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
-			const firstRewindPoint = rewindPoints[0];
+				// Get first rewindPoint
+				let rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
+				const firstRewindPoint = rewindPoints[0];
 
-			// Send second message
-			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send second message
+				await sendMessage(daemon, sessionId, 'What is 2+2?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Execute files-only rewind to first rewindPoint
-			const result = await executeRewind(sessionId, firstRewindPoint.uuid, 'files');
+				// Execute files-only rewind to first rewindPoint
+				const result = await executeRewind(sessionId, firstRewindPoint.uuid, 'files');
 
-			// Result should indicate success or provide reason for failure
-			expect(result).toBeDefined();
-			expect(typeof result.success).toBe('boolean');
+				// Result should indicate success or provide reason for failure
+				expect(result).toBeDefined();
+				expect(typeof result.success).toBe('boolean');
 
-			// After files rewind, rewindPoints should still exist (conversation not affected)
-			rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
-		}, 180000);
+				// After files rewind, rewindPoints should still exist (conversation not affected)
+				rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(1);
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Rewind Execute - Conversation Mode', () => {
-		test('should execute conversation-only rewind successfully', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-execute-conversation-test-${Date.now()}`;
+		test(
+			'should execute conversation-only rewind successfully',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-execute-conversation-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Execute Conversation Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Execute Conversation Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send multiple messages
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 90000);
+				// Send multiple messages
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const rewindPointsAfterFirst = await getRewindPoints(sessionId);
-			expect(rewindPointsAfterFirst.length).toBeGreaterThanOrEqual(1);
-			const firstRewindPoint = rewindPointsAfterFirst.find((c) => c.turnNumber === 1);
-			expect(firstRewindPoint).toBeDefined();
+				const rewindPointsAfterFirst = await getRewindPoints(sessionId);
+				expect(rewindPointsAfterFirst.length).toBeGreaterThanOrEqual(1);
+				const firstRewindPoint = rewindPointsAfterFirst.find((c) => c.turnNumber === 1);
+				expect(firstRewindPoint).toBeDefined();
 
-			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 90000);
+				await sendMessage(daemon, sessionId, 'What is 2+2?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			await sendMessage(daemon, sessionId, 'What is 3+3?');
-			await waitForIdle(daemon, sessionId, 90000);
+				await sendMessage(daemon, sessionId, 'What is 3+3?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Should have 3 rewindPoints
-			let rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(3);
+				// Should have 3 rewindPoints
+				let rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(3);
 
-			// Execute conversation rewind to first rewindPoint (rewindPoints sorted newest first, so first with turnNumber=1 is the earliest)
-			const result = await executeRewind(sessionId, firstRewindPoint!.uuid, 'conversation');
+				// Execute conversation rewind to first rewindPoint (rewindPoints sorted newest first, so first with turnNumber=1 is the earliest)
+				const result = await executeRewind(sessionId, firstRewindPoint!.uuid, 'conversation');
 
-			expect(result).toBeDefined();
-			expect(typeof result.success).toBe('boolean');
+				expect(result).toBeDefined();
+				expect(typeof result.success).toBe('boolean');
 
-			if (result.success) {
-				// After conversation rewind, should have fewer rewindPoints
-				rewindPoints = await getRewindPoints(sessionId);
+				if (result.success) {
+					// After conversation rewind, should have fewer rewindPoints
+					rewindPoints = await getRewindPoints(sessionId);
 
-				// Checkpoints after the rewind point should be removed
-				const hasLaterCheckpoints = rewindPoints.some((c) => c.turnNumber > 1);
-				expect(hasLaterCheckpoints).toBe(false);
+					// Checkpoints after the rewind point should be removed
+					const hasLaterCheckpoints = rewindPoints.some((c) => c.turnNumber > 1);
+					expect(hasLaterCheckpoints).toBe(false);
 
-				// Result should indicate messages were deleted
-				expect(result.conversationRewound).toBe(true);
-				expect(result.messagesDeleted).toBeGreaterThan(0);
-			}
-		}, 300000);
+					// Result should indicate messages were deleted
+					expect(result.conversationRewound).toBe(true);
+					expect(result.messagesDeleted).toBeGreaterThan(0);
+				}
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Rewind Execute - Both Mode', () => {
-		test('should execute both files and conversation rewind', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-execute-both-test-${Date.now()}`;
+		test(
+			'should execute both files and conversation rewind',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-execute-both-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Execute Both Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Execute Both Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send first message
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send first message
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const rewindPointsAfterFirst = await getRewindPoints(sessionId);
-			expect(rewindPointsAfterFirst.length).toBeGreaterThanOrEqual(1);
-			const firstRewindPoint = rewindPointsAfterFirst.find((c) => c.turnNumber === 1);
-			expect(firstRewindPoint).toBeDefined();
+				const rewindPointsAfterFirst = await getRewindPoints(sessionId);
+				expect(rewindPointsAfterFirst.length).toBeGreaterThanOrEqual(1);
+				const firstRewindPoint = rewindPointsAfterFirst.find((c) => c.turnNumber === 1);
+				expect(firstRewindPoint).toBeDefined();
 
-			// Send second message
-			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send second message
+				await sendMessage(daemon, sessionId, 'What is 2+2?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Execute both mode rewind to first rewindPoint
-			const result = await executeRewind(sessionId, firstRewindPoint!.uuid, 'both');
+				// Execute both mode rewind to first rewindPoint
+				const result = await executeRewind(sessionId, firstRewindPoint!.uuid, 'both');
 
-			expect(result).toBeDefined();
-			expect(typeof result.success).toBe('boolean');
+				expect(result).toBeDefined();
+				expect(typeof result.success).toBe('boolean');
 
-			if (result.success) {
-				// After both rewind, conversation should be truncated
-				const rewindPoints = await getRewindPoints(sessionId);
-				const hasLaterCheckpoints = rewindPoints.some((c) => c.turnNumber > 1);
-				expect(hasLaterCheckpoints).toBe(false);
-			}
-		}, 180000);
+				if (result.success) {
+					// After both rewind, conversation should be truncated
+					const rewindPoints = await getRewindPoints(sessionId);
+					const hasLaterCheckpoints = rewindPoints.some((c) => c.turnNumber > 1);
+					expect(hasLaterCheckpoints).toBe(false);
+				}
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Rewind Error Handling', () => {
-		test('should handle rewind with invalid rewindPoint gracefully', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-error-test-${Date.now()}`;
+		test(
+			'should handle rewind with invalid rewindPoint gracefully',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-error-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Error Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Error Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message to initialize
-			await sendMessage(daemon, sessionId, 'Hello');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send a message to initialize
+				await sendMessage(daemon, sessionId, 'Hello');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Try to rewind with invalid rewindPoint
-			const result = await executeRewind(sessionId, 'invalid-rewindPoint-id', 'files');
+				// Try to rewind with invalid rewindPoint
+				const result = await executeRewind(sessionId, 'invalid-rewindPoint-id', 'files');
 
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('not found');
-		}, 120000);
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('not found');
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should maintain session state after failed rewind', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-recovery-test-${Date.now()}`;
+		test(
+			'should maintain session state after failed rewind',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-recovery-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Rewind Recovery Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: true,
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Rewind Recovery Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: true,
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send a message
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Attempt failed rewind
-			await executeRewind(sessionId, 'invalid-rewindPoint-id', 'files');
+				// Attempt failed rewind
+				await executeRewind(sessionId, 'invalid-rewindPoint-id', 'files');
 
-			// Session should still be functional
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Session should still be functional
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			// Can still send messages
-			const msgResult = await sendMessage(daemon, sessionId, 'What is 2+2?');
-			expect(msgResult.messageId).toBeDefined();
+				// Can still send messages
+				const msgResult = await sendMessage(daemon, sessionId, 'What is 2+2?');
+				expect(msgResult.messageId).toBeDefined();
 
-			await waitForIdle(daemon, sessionId, 60000);
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Session still idle and working
-			const finalState = await getProcessingState(daemon, sessionId);
-			expect(finalState.status).toBe('idle');
-		}, 180000);
+				// Session still idle and working
+				const finalState = await getProcessingState(daemon, sessionId);
+				expect(finalState.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('enableFileCheckpointing Configuration', () => {
@@ -459,7 +500,7 @@ describe('Rewind Feature', () => {
 				workspacePath,
 				title: 'Checkpointing Enabled Test',
 				config: {
-					model: 'haiku-4.5',
+					model: MODEL,
 					permissionMode: 'acceptEdits',
 					enableFileCheckpointing: true, // Explicitly enabled
 				},
@@ -470,10 +511,10 @@ describe('Rewind Feature', () => {
 
 			// Send messages
 			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 90000);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
 			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 90000);
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
 			// With enableFileCheckpointing=true, rewindPoints SHOULD be created
 			const rewindPoints = await getRewindPoints(sessionId);
@@ -491,48 +532,52 @@ describe('Rewind Feature', () => {
 			expect(state.status).toBe('idle');
 		}, 240000);
 
-		test('should still have rewindPoints but file rewind disabled when enableFileCheckpointing is false', async () => {
-			const workspacePath = `${TMP_DIR}/rewind-disabled-test-${Date.now()}`;
+		test(
+			'should still have rewindPoints but file rewind disabled when enableFileCheckpointing is false',
+			async () => {
+				const workspacePath = `${TMP_DIR}/rewind-disabled-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Checkpointing Disabled Test',
-				config: {
-					model: 'haiku-4.5',
-					permissionMode: 'acceptEdits',
-					enableFileCheckpointing: false, // Explicitly disabled for SDK file tracking
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Checkpointing Disabled Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+						enableFileCheckpointing: false, // Explicitly disabled for SDK file tracking
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send messages
-			await sendMessage(daemon, sessionId, 'What is 1+1?');
-			await waitForIdle(daemon, sessionId, 60000);
+				// Send messages
+				await sendMessage(daemon, sessionId, 'What is 1+1?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			await sendMessage(daemon, sessionId, 'What is 2+2?');
-			await waitForIdle(daemon, sessionId, 60000);
+				await sendMessage(daemon, sessionId, 'What is 2+2?');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Checkpoints are STILL created for conversation tracking
-			// (enableFileCheckpointing only controls SDK's file change tracking)
-			const rewindPoints = await getRewindPoints(sessionId);
-			expect(rewindPoints.length).toBeGreaterThanOrEqual(2);
+				// Checkpoints are STILL created for conversation tracking
+				// (enableFileCheckpointing only controls SDK's file change tracking)
+				const rewindPoints = await getRewindPoints(sessionId);
+				expect(rewindPoints.length).toBeGreaterThanOrEqual(2);
 
-			// However, file rewind should not be available (SDK won't track file changes)
-			// Preview should indicate rewind is not possible for files
-			const preview = await previewRewind(sessionId, rewindPoints[0].uuid);
-			// Either canRewind is false or filesChanged is empty/undefined
-			if (preview.canRewind) {
-				const filesCount = Array.isArray(preview.filesChanged)
-					? preview.filesChanged.length
-					: (preview.filesChanged ?? 0);
-				expect(filesCount).toBe(0);
-			}
+				// However, file rewind should not be available (SDK won't track file changes)
+				// Preview should indicate rewind is not possible for files
+				const preview = await previewRewind(sessionId, rewindPoints[0].uuid);
+				// Either canRewind is false or filesChanged is empty/undefined
+				if (preview.canRewind) {
+					const filesCount = Array.isArray(preview.filesChanged)
+						? preview.filesChanged.length
+						: (preview.filesChanged ?? 0);
+					expect(filesCount).toBe(0);
+				}
 
-			// Session should still be functional
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
-		}, 180000);
+				// Session should still be functional
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
+			},
+			TEST_TIMEOUT
+		);
 	});
 });

--- a/packages/daemon/tests/online/rewind/selective-rewind.test.ts
+++ b/packages/daemon/tests/online/rewind/selective-rewind.test.ts
@@ -1,22 +1,21 @@
 /**
- * Selective Rewind Feature Online Tests
+ * Selective Rewind Feature Tests
  *
- * These tests verify the selective rewind feature with real SDK calls:
+ * These tests verify the selective rewind feature:
  * 1. Selective rewind can delete specific messages and all messages after
  * 2. Mode selection (conversation, both) works correctly
  * 3. Error handling for invalid inputs (empty/nonexistent messageIds)
  * 4. Message count verification after rewind
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'haiku-4.5' (faster and cheaper than Sonnet for tests)
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/rewind/selective-rewind.test.ts
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-// Bun automatically loads .env from project root when running tests
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { sendMessage, waitForIdle } from '../../helpers/daemon-actions';
@@ -45,22 +44,28 @@ interface SelectiveRewindResult {
 	rewindCase?: string;
 }
 
-// Use temp directory for test database
 const TMP_DIR = process.env.TMPDIR || '/tmp';
+
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 10000 : 90000;
+const SETUP_TIMEOUT = IS_MOCK ? 15000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 180000;
 
 describe('Selective Rewind Feature', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
 		if (daemon) {
 			daemon.kill('SIGTERM');
 			await daemon.waitForExit();
 		}
-	}, 20000);
+	}, SETUP_TIMEOUT);
 
 	/**
 	 * Helper to list messages for a session

--- a/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
+++ b/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
@@ -10,7 +10,7 @@
  *
  * REQUIREMENTS:
  * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls
+ * - Makes real API calls (mock mode not supported for multi-agent flow)
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';

--- a/packages/daemon/tests/online/room/room-chat-constraints.test.ts
+++ b/packages/daemon/tests/online/room/room-chat-constraints.test.ts
@@ -1,20 +1,31 @@
 /**
- * Room Chat Constraints (API-dependent)
+ * Room Chat Constraints
  *
  * Verifies room chat sessions:
  * - Do not use Claude Code preset system prompt
  * - Use restricted built-in tool allowlist
  * - Still respond to a simple user message
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
+ *
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/room/room-chat-constraints.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import { sendMessage, waitForIdle } from '../../helpers/daemon-actions';
+import { simpleTextResponse } from '../../helpers/mock-sdk';
+
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEARDOWN_TIMEOUT = IS_MOCK ? 10000 : 20000;
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 120000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 180000;
 
 const ROOM_CHAT_ALLOWED_TOOLS = [
 	'Read',
@@ -47,22 +58,24 @@ function getMainThreadAssistantText(messages: Array<Record<string, unknown>>): s
 	return texts.join('\n').trim();
 }
 
-describe('Room Chat Constraints (API-dependent)', () => {
+describe('Room Chat Constraints', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
 
-	afterEach(
-		async () => {
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
-		},
-		{ timeout: 20000 }
-	);
+		// Update mock response if in mock mode
+		if (IS_MOCK && daemon.mockControls) {
+			daemon.mockControls.setDefaultResponses(simpleTextResponse('room ok'));
+		}
+	}, SETUP_TIMEOUT);
+
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, TEARDOWN_TIMEOUT);
 
 	test(
 		'should disable Claude preset, keep restricted tools, and answer a simple message',
@@ -107,7 +120,7 @@ describe('Room Chat Constraints (API-dependent)', () => {
 			);
 
 			await sendMessage(daemon, roomChatSessionId, 'Reply with exactly: room ok');
-			await waitForIdle(daemon, roomChatSessionId, 120000);
+			await waitForIdle(daemon, roomChatSessionId, IDLE_TIMEOUT);
 
 			const messageResult = (await daemon.messageHub.request('message.sdkMessages', {
 				sessionId: roomChatSessionId,
@@ -121,6 +134,6 @@ describe('Room Chat Constraints (API-dependent)', () => {
 			expect(assistantText.toLowerCase()).toContain('room ok');
 			expect(resultMessages).toHaveLength(1);
 		},
-		{ timeout: 180000 }
+		TEST_TIMEOUT
 	);
 });

--- a/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
@@ -9,7 +9,7 @@
  *
  * REQUIREMENTS:
  * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls
+ * - Makes real API calls (mock mode not supported for multi-agent flow)
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';

--- a/packages/daemon/tests/online/sdk/sdk-streaming-failures.test.ts
+++ b/packages/daemon/tests/online/sdk/sdk-streaming-failures.test.ts
@@ -6,16 +6,15 @@
  * - Message processing
  * - Session state consistency
  *
- * REQUIREMENTS:
- * - Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
- * - Makes real API calls (costs money, uses rate limits)
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Mock SDK: Set NEOKAI_AGENT_SDK_MOCK=1 for offline testing
  *
- * MODEL:
- * - Uses 'default' model which maps to Sonnet
+ * Run with mock:
+ *   NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/sdk/sdk-streaming-failures.test.ts
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-// Bun automatically loads .env from project root when running tests
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
 import {
@@ -28,218 +27,242 @@ import {
 // Use temp directory for test workspaces
 const TMP_DIR = process.env.TMPDIR || '/tmp';
 
+// Detect mock mode for faster timeouts
+const IS_MOCK = !!process.env.NEOKAI_AGENT_SDK_MOCK;
+const MODEL = IS_MOCK ? 'haiku' : 'haiku-4.5';
+const IDLE_TIMEOUT = IS_MOCK ? 5000 : 30000;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
+const TEST_TIMEOUT = IS_MOCK ? 30000 : 90000;
+
 // Tests will FAIL if no credentials are available
 describe('SDK Streaming Behavior', () => {
 	let daemon: DaemonServerContext;
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, SETUP_TIMEOUT);
 
-	afterEach(
-		async () => {
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
-		},
-		{ timeout: 20000 }
-	);
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, SETUP_TIMEOUT);
 
 	describe('Permission Mode Handling', () => {
-		test('should work with acceptEdits permission mode', async () => {
-			const workspacePath = `${TMP_DIR}/accept-edits-test-${Date.now()}`;
+		test(
+			'should work with acceptEdits permission mode',
+			async () => {
+				const workspacePath = `${TMP_DIR}/accept-edits-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Accept Edits Test',
-				config: {
-					model: 'default',
-					permissionMode: 'acceptEdits', // Works on root and non-root
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Accept Edits Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits', // Works on root and non-root
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message
-			const result = await sendMessage(
-				daemon,
-				sessionId,
-				'What is 2+2? Answer with just the number.'
-			);
+				// Send a message
+				const result = await sendMessage(
+					daemon,
+					sessionId,
+					'What is 2+2? Answer with just the number.'
+				);
 
-			expect(result.messageId).toBeString();
+				expect(result.messageId).toBeString();
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId, 30000);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Verify session is idle
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Verify session is idle
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			console.log('[ACCEPT-EDITS TEST] ✓ PASSED - acceptEdits mode works correctly');
-		}, 30000);
+				console.log('[ACCEPT-EDITS TEST] ✓ PASSED - acceptEdits mode works correctly');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Message Processing', () => {
-		test('should process messages correctly through WebSocket API', async () => {
-			const workspacePath = `${TMP_DIR}/message-processing-test-${Date.now()}`;
+		test(
+			'should process messages correctly through WebSocket API',
+			async () => {
+				const workspacePath = `${TMP_DIR}/message-processing-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Message Processing Test',
-				config: {
-					model: 'default',
-					permissionMode: 'acceptEdits',
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Message Processing Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send multiple messages
-			const msg1 = await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
-			await waitForIdle(daemon, sessionId, 30000);
+				// Send multiple messages
+				const msg1 = await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const msg2 = await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
-			await waitForIdle(daemon, sessionId, 30000);
+				const msg2 = await sendMessage(daemon, sessionId, 'What is 2+2? Just the number.');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			const msg3 = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
-			await waitForIdle(daemon, sessionId, 30000);
+				const msg3 = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// All should have unique message IDs
-			expect(msg1.messageId).not.toBe(msg2.messageId);
-			expect(msg2.messageId).not.toBe(msg3.messageId);
-			expect(msg1.messageId).not.toBe(msg3.messageId);
+				// All should have unique message IDs
+				expect(msg1.messageId).not.toBe(msg2.messageId);
+				expect(msg2.messageId).not.toBe(msg3.messageId);
+				expect(msg1.messageId).not.toBe(msg3.messageId);
 
-			// Session should be idle and functional
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Session should be idle and functional
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			console.log('[MESSAGE PROCESSING TEST] ✓ PASSED - All messages processed correctly');
-		}, 60000);
+				console.log('[MESSAGE PROCESSING TEST] ✓ PASSED - All messages processed correctly');
+			},
+			TEST_TIMEOUT
+		);
 
-		test('should handle simple prompt pattern correctly', async () => {
-			const workspacePath = `${TMP_DIR}/simple-prompt-test-${Date.now()}`;
+		test(
+			'should handle simple prompt pattern correctly',
+			async () => {
+				const workspacePath = `${TMP_DIR}/simple-prompt-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Simple Prompt Test',
-				config: {
-					model: 'default',
-					permissionMode: 'acceptEdits',
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Simple Prompt Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Simple prompt pattern (same as other passing tests)
-			const result = await sendMessage(
-				daemon,
-				sessionId,
-				'What is 3+3? Answer with just the number.'
-			);
+				// Simple prompt pattern (same as other passing tests)
+				const result = await sendMessage(
+					daemon,
+					sessionId,
+					'What is 3+3? Answer with just the number.'
+				);
 
-			expect(result.messageId).toBeString();
+				expect(result.messageId).toBeString();
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId, 30000);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Verify session is idle
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Verify session is idle
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			console.log('[SIMPLE PROMPT TEST] ✓ PASSED - Simple prompt pattern works');
-		}, 30000);
+				console.log('[SIMPLE PROMPT TEST] ✓ PASSED - Simple prompt pattern works');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Session State Consistency', () => {
-		test('should maintain consistent session state', async () => {
-			const workspacePath = `${TMP_DIR}/session-state-test-${Date.now()}`;
+		test(
+			'should maintain consistent session state',
+			async () => {
+				const workspacePath = `${TMP_DIR}/session-state-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Session State Test',
-				config: {
-					model: 'default',
-					permissionMode: 'acceptEdits',
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Session State Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Initial state check
-			let session = await getSession(daemon, sessionId);
-			expect(session.id).toBe(sessionId);
-			expect(session.workspacePath).toBe(workspacePath);
+				// Initial state check
+				let session = await getSession(daemon, sessionId);
+				expect(session.id).toBe(sessionId);
+				expect(session.workspacePath).toBe(workspacePath);
 
-			// Send a message
-			await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
+				// Send a message
+				await sendMessage(daemon, sessionId, 'What is 1+1? Just the number.');
 
-			// Wait for SDK to process and return to idle
-			await waitForIdle(daemon, sessionId, 30000);
+				// Wait for SDK to process and return to idle
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Session should still be consistent
-			session = await getSession(daemon, sessionId);
-			expect(session.id).toBe(sessionId);
-			expect(session.workspacePath).toBe(workspacePath);
+				// Session should still be consistent
+				session = await getSession(daemon, sessionId);
+				expect(session.id).toBe(sessionId);
+				expect(session.workspacePath).toBe(workspacePath);
 
-			// Agent should be in idle state
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Agent should be in idle state
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			console.log('[SESSION STATE TEST] ✓ PASSED - Session state is consistent');
-		}, 30000);
+				console.log('[SESSION STATE TEST] ✓ PASSED - Session state is consistent');
+			},
+			TEST_TIMEOUT
+		);
 	});
 
 	describe('Message Persistence and Reload', () => {
-		test('should persist messages across session operations', async () => {
-			const workspacePath = `${TMP_DIR}/persistence-reload-test-${Date.now()}`;
+		test(
+			'should persist messages across session operations',
+			async () => {
+				const workspacePath = `${TMP_DIR}/persistence-reload-test-${Date.now()}`;
 
-			const createResult = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Persistence Reload Test',
-				config: {
-					model: 'default',
-					permissionMode: 'acceptEdits',
-				},
-			})) as { sessionId: string };
+				const createResult = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Persistence Reload Test',
+					config: {
+						model: MODEL,
+						permissionMode: 'acceptEdits',
+					},
+				})) as { sessionId: string };
 
-			const { sessionId } = createResult;
-			daemon.trackSession(sessionId);
+				const { sessionId } = createResult;
+				daemon.trackSession(sessionId);
 
-			// Send a message to the real SDK
-			const result = await sendMessage(
-				daemon,
-				sessionId,
-				'What is 2+2? Answer with just the number.'
-			);
+				// Send a message to the real SDK
+				const result = await sendMessage(
+					daemon,
+					sessionId,
+					'What is 2+2? Answer with just the number.'
+				);
 
-			expect(result.messageId).toBeString();
+				expect(result.messageId).toBeString();
 
-			// Wait for processing to complete
-			await waitForIdle(daemon, sessionId, 30000);
+				// Wait for processing to complete
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Get session data - should be consistent
-			const session = await getSession(daemon, sessionId);
-			expect(session.id).toBe(sessionId);
-			expect(session.workspacePath).toBe(workspacePath);
+				// Get session data - should be consistent
+				const session = await getSession(daemon, sessionId);
+				expect(session.id).toBe(sessionId);
+				expect(session.workspacePath).toBe(workspacePath);
 
-			// Send another message to verify session still works
-			const result2 = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
-			expect(result2.messageId).toBeString();
-			expect(result2.messageId).not.toBe(result.messageId);
+				// Send another message to verify session still works
+				const result2 = await sendMessage(daemon, sessionId, 'What is 3+3? Just the number.');
+				expect(result2.messageId).toBeString();
+				expect(result2.messageId).not.toBe(result.messageId);
 
-			await waitForIdle(daemon, sessionId, 30000);
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-			// Session should still be functional
-			const state = await getProcessingState(daemon, sessionId);
-			expect(state.status).toBe('idle');
+				// Session should still be functional
+				const state = await getProcessingState(daemon, sessionId);
+				expect(state.status).toBe('idle');
 
-			console.log('[PERSISTENCE RELOAD TEST] ✓ PASSED - Messages persisted correctly');
-		}, 60000);
+				console.log('[PERSISTENCE RELOAD TEST] ✓ PASSED - Messages persisted correctly');
+			},
+			TEST_TIMEOUT
+		);
 	});
 });

--- a/packages/daemon/tests/unit/mock-script.test.ts
+++ b/packages/daemon/tests/unit/mock-script.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for script-based mock SDK system
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+	parseMockScript,
+	MockScripts,
+	simpleTextResponse,
+	normalizeTurns,
+} from '../helpers/mock-sdk';
+
+describe('Mock Script Parser', () => {
+	describe('parseMockScript', () => {
+		test('should parse simple text response', () => {
+			const script = MockScripts.simpleText('Hello!', 0);
+			const turns = parseMockScript(script);
+
+			expect(turns.length).toBe(1);
+			expect(turns[0].length).toBe(3); // system:init, assistant message, result
+
+			// First message should be system:init
+			expect(turns[0][0].message?.type).toBe('system');
+			expect(turns[0][0].message?.subtype).toBe('init');
+
+			// Last should be result
+			const lastItem = turns[0][turns[0].length - 1];
+			expect(lastItem.message?.type).toBe('result');
+			expect(lastItem.message?.subtype).toBe('success');
+		});
+
+		test('should parse timing delays', () => {
+			const script = `
+				100ms
+				builtin:system:init
+				50ms
+				builtin:result
+			`;
+			const turns = parseMockScript(script);
+
+			expect(turns.length).toBe(1);
+			expect(turns[0].length).toBe(4); // 100ms delay, init, 50ms delay, result
+
+			expect(turns[0][0].delay).toBe(100);
+			expect(turns[0][1].message?.type).toBe('system');
+			expect(turns[0][2].delay).toBe(50);
+			expect(turns[0][3].message?.type).toBe('result');
+		});
+
+		test('should parse multi-turn scripts with --- separator', () => {
+			const script = MockScripts.multiTurn(['First', 'Second'], 0);
+			const turns = parseMockScript(script);
+
+			expect(turns.length).toBe(2);
+		});
+
+		test('should parse JSON objects', () => {
+			const script = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}`;
+			const turns = parseMockScript(script);
+
+			expect(turns.length).toBe(1);
+			expect(turns[0].length).toBe(1);
+			expect(turns[0][0].message?.type).toBe('assistant');
+		});
+
+		test('should parse builtin messages', () => {
+			const script = 'builtin:system:init\nbuiltin:result';
+			const turns = parseMockScript(script);
+
+			expect(turns[0].length).toBe(2);
+			expect(turns[0][0].message?.type).toBe('system');
+			expect(turns[0][1].message?.type).toBe('result');
+		});
+
+		test('should parse builtin with custom tokens', () => {
+			const script = 'builtin:result:tokens:100:50';
+			const turns = parseMockScript(script);
+
+			expect(turns[0].length).toBe(1);
+			expect(turns[0][0].message?.type).toBe('result');
+			expect(turns[0][0].message?.usage?.input_tokens).toBe(100);
+			expect(turns[0][0].message?.usage?.output_tokens).toBe(50);
+		});
+
+		test('should parse error messages', () => {
+			const script = 'builtin:error';
+			const turns = parseMockScript(script);
+
+			expect(turns[0][0].message?.type).toBe('result');
+			expect(turns[0][0].message?.subtype).toBe('error_during_execution');
+		});
+
+		test('should parse rate_limit error', () => {
+			const script = 'builtin:error:rate_limit';
+			const turns = parseMockScript(script);
+
+			expect(turns[0][0].message?.type).toBe('result');
+			expect((turns[0][0].message as Record<string, unknown>).error).toBe('rate_limit_error');
+		});
+
+		test('should skip comments and empty lines', () => {
+			const script = `
+				# This is a comment
+				builtin:system:init
+
+				# Another comment
+				builtin:result
+			`;
+			const turns = parseMockScript(script);
+
+			expect(turns[0].length).toBe(2);
+		});
+
+		test('should handle environment variable references', () => {
+			const originalValue = process.env.TEST_MOCK_MESSAGE;
+			process.env.TEST_MOCK_MESSAGE =
+				'{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"From env"}]}}';
+
+			try {
+				const script = 'TEST_MOCK_MESSAGE';
+				const turns = parseMockScript(script);
+
+				expect(turns[0][0].message?.type).toBe('assistant');
+			} finally {
+				if (originalValue !== undefined) {
+					process.env.TEST_MOCK_MESSAGE = originalValue;
+				} else {
+					delete process.env.TEST_MOCK_MESSAGE;
+				}
+			}
+		});
+
+		test('should treat plain text env var as assistant text', () => {
+			const originalValue = process.env.TEST_PLAIN_MESSAGE;
+			process.env.TEST_PLAIN_MESSAGE = 'Plain text response';
+
+			try {
+				const script = 'TEST_PLAIN_MESSAGE';
+				const turns = parseMockScript(script);
+
+				expect(turns[0][0].message?.type).toBe('assistant');
+				const content = turns[0][0].message?.message?.content as Array<{ text: string }>;
+				expect(content?.[0]?.text).toBe('Plain text response');
+			} finally {
+				if (originalValue !== undefined) {
+					process.env.TEST_PLAIN_MESSAGE = originalValue;
+				} else {
+					delete process.env.TEST_PLAIN_MESSAGE;
+				}
+			}
+		});
+	});
+
+	describe('MockScripts helpers', () => {
+		test('simpleText should generate valid script', () => {
+			const script = MockScripts.simpleText('Test', 100);
+
+			expect(script).toContain('100ms');
+			expect(script).toContain('builtin:system:init');
+			expect(script).toContain('builtin:result');
+			expect(script).toContain('Test');
+		});
+
+		test('multiTurn should separate turns with ---', () => {
+			const script = MockScripts.multiTurn(['A', 'B', 'C'], 50);
+
+			expect(script).toContain('---');
+			const parts = script.split('---');
+			expect(parts.length).toBe(3);
+		});
+
+		test('error should generate error result', () => {
+			const script = MockScripts.error();
+
+			expect(script).toContain('builtin:system:init');
+			expect(script).toContain('builtin:error');
+		});
+
+		test('rateLimit should generate rate_limit error', () => {
+			const script = MockScripts.rateLimit();
+
+			expect(script).toContain('builtin:error:rate_limit');
+		});
+
+		test('toolUse should generate tool use flow', () => {
+			const script = MockScripts.toolUse('Read', { file_path: '/test.txt' }, 'File contents');
+
+			expect(script).toContain('tool_use');
+			expect(script).toContain('Read');
+			expect(script).toContain('tool_result');
+			expect(script).toContain('File contents');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a script-based mock SDK system for declarative response scripting
- Updates 8 online tests to support both real API and mock SDK modes

### Script-Based Mock System

The new mock system allows tests to define mock SDK responses declaratively using a simple DSL:

- **Timing delays**: `100ms`
- **Built-in messages**: `builtin:system:init`, `builtin:result`, `builtin:error`
- **Custom JSON**: `{"type": "assistant", ...}`
- **Environment variable lookup**: `ENV_VAR_NAME`
- **Multi-turn support**: Use `---` to separate turns

Includes `MockScripts` helper class with common patterns:
- `simpleText(text, delay)` - Simple text response
- `multiTurn(responses, delay)` - Multiple turns
- `toolUse(name, input, result)` - Tool use flow
- `error()` / `rateLimit()` - Error scenarios

### Mock SDK Support in Online Tests

Tests now detect mock mode via `NEOKAI_AGENT_SDK_MOCK` environment variable and adjust:
- Timeout values (faster when mocked)
- Model selection (short aliases work with mock)

Run tests with mock:
```bash
NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/
```

### Tests Updated

| Test File | Description |
|-----------|-------------|
| `agent-session-sdk.test.ts` | SDK integration tests |
| `multiturn-conversation.test.ts` | Multi-turn conversations |
| `message-delivery-mode-queue.test.ts` | Queue-based delivery |
| `message-persistence.test.ts` | Message persistence |
| `session-resume.test.ts` | Session resume |
| `rewind-feature.test.ts` | Rewind feature |
| `selective-rewind.test.ts` | Selective rewind |
| `sdk-streaming-failures.test.ts` | Streaming failure handling |

## Test plan

- [x] Run unit tests for mock script parser: `bun test packages/daemon/tests/unit/mock-script.test.ts`
- [x] Verify pre-commit hooks pass (lint, format, typecheck, knip)
- [ ] Run online tests with mock SDK: `NEOKAI_AGENT_SDK_MOCK=1 bun test packages/daemon/tests/online/`
- [ ] Run online tests with real API (optional, requires credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)