### PR TITLE
feat: add MiniMax provider

### DIFF
--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -161,6 +161,9 @@ export class ProviderService {
 		if (providerId === 'glm') {
 			return process.env.GLM_API_KEY || process.env.ZHIPU_API_KEY;
 		}
+		if (providerId === 'minimax') {
+			return process.env.MINIMAX_API_KEY;
+		}
 
 		return undefined;
 	}

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -9,6 +9,7 @@
 
 import { AnthropicProvider } from './anthropic-provider.js';
 import { GlmProvider } from './glm-provider.js';
+import { MinimaxProvider } from './minimax-provider.js';
 import { OpenAiProvider } from './openai-provider.js';
 import { GitHubCopilotProvider } from './github-copilot-provider.js';
 import { getProviderRegistry, type ProviderRegistry } from './registry.js';
@@ -40,6 +41,9 @@ export function initializeProviders(): ProviderRegistry {
 
 	// Register GLM provider (will be available if API key is set)
 	registry.register(new GlmProvider());
+
+	// Register MiniMax provider (will be available if MINIMAX_API_KEY is set)
+	registry.register(new MinimaxProvider());
 
 	// Register OpenAI provider (will be available if OPENAI_API_KEY is set)
 	registry.register(new OpenAiProvider());

--- a/packages/daemon/src/lib/providers/minimax-provider.ts
+++ b/packages/daemon/src/lib/providers/minimax-provider.ts
@@ -1,0 +1,136 @@
+/**
+ * MiniMax Provider
+ *
+ * This provider uses MiniMax's Anthropic-compatible API endpoint.
+ * Requires environment variable mapping to work with the Claude Agent SDK.
+ *
+ * API Documentation: https://platform.minimax.io/docs/guides/text-ai-coding-tools
+ */
+
+import type {
+	Provider,
+	ProviderCapabilities,
+	ProviderSdkConfig,
+	ProviderSessionConfig,
+	ModelTier,
+} from '@neokai/shared/provider';
+import type { ModelInfo } from '@neokai/shared';
+
+/**
+ * MiniMax provider implementation
+ */
+export class MinimaxProvider implements Provider {
+	readonly id = 'minimax';
+	readonly displayName = 'MiniMax';
+
+	readonly capabilities: ProviderCapabilities = {
+		streaming: true,
+		extendedThinking: false,
+		maxContextWindow: 200000,
+		functionCalling: true,
+		vision: true,
+	};
+
+	/**
+	 * MiniMax API base URL (Anthropic-compatible endpoint)
+	 */
+	static readonly BASE_URL = 'https://api.minimax.io/anthropic';
+
+	/**
+	 * Static model definitions for MiniMax
+	 */
+	static readonly MODELS: ModelInfo[] = [
+		{
+			id: 'MiniMax-M2.5',
+			name: 'MiniMax-M2.5',
+			alias: 'minimax',
+			family: 'minimax',
+			provider: 'minimax',
+			contextWindow: 200000,
+			description: 'MiniMax-M2.5 · Flagship Coding Model',
+			releaseDate: '2026-01-01',
+			available: true,
+		},
+	];
+
+	constructor(private readonly env: NodeJS.ProcessEnv = process.env) {}
+
+	/**
+	 * Check if MiniMax is available
+	 * Requires MINIMAX_API_KEY
+	 */
+	isAvailable(): boolean {
+		return !!this.getApiKey();
+	}
+
+	/**
+	 * Get API key from environment
+	 */
+	getApiKey(): string | undefined {
+		return this.env.MINIMAX_API_KEY;
+	}
+
+	/**
+	 * Get available models from MiniMax
+	 */
+	async getModels(): Promise<ModelInfo[]> {
+		return this.isAvailable() ? MinimaxProvider.MODELS : [];
+	}
+
+	/**
+	 * Check if a model ID belongs to MiniMax
+	 */
+	ownsModel(modelId: string): boolean {
+		return modelId.toLowerCase().startsWith('minimax-');
+	}
+
+	/**
+	 * Get model for a specific tier
+	 * All tiers use MiniMax-M2.5 (flagship model)
+	 */
+	getModelForTier(_tier: ModelTier): string | undefined {
+		return 'MiniMax-M2.5';
+	}
+
+	/**
+	 * Build SDK configuration for MiniMax
+	 */
+	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
+		const apiKey = sessionConfig?.apiKey || this.getApiKey();
+		if (!apiKey) {
+			throw new Error('MiniMax API key not configured');
+		}
+
+		const baseUrl = sessionConfig?.baseUrl || MinimaxProvider.BASE_URL;
+
+		const envVars: Record<string, string> = {
+			ANTHROPIC_BASE_URL: baseUrl,
+			ANTHROPIC_AUTH_TOKEN: apiKey,
+			API_TIMEOUT_MS: '3000000',
+			CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+			ANTHROPIC_DEFAULT_HAIKU_MODEL: 'MiniMax-M2.5',
+			ANTHROPIC_DEFAULT_SONNET_MODEL: 'MiniMax-M2.5',
+			ANTHROPIC_DEFAULT_OPUS_MODEL: 'MiniMax-M2.5',
+		};
+
+		return {
+			envVars,
+			isAnthropicCompatible: true,
+			apiVersion: 'v1',
+		};
+	}
+
+	/**
+	 * Translate MiniMax model ID to SDK-compatible ID
+	 */
+	translateModelIdForSdk(_modelId: string): string {
+		return 'default';
+	}
+
+	/**
+	 * Get the title generation model for MiniMax
+	 */
+	getTitleGenerationModel(): string {
+		return 'MiniMax-M2.5';
+	}
+}

--- a/packages/daemon/tests/unit/providers/minimax-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/minimax-provider.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for MiniMax Provider
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { MinimaxProvider } from '../../../src/lib/providers/minimax-provider';
+
+describe('MinimaxProvider', () => {
+	let provider: MinimaxProvider;
+	let originalEnv: NodeJS.ProcessEnv;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		delete process.env.MINIMAX_API_KEY;
+		provider = new MinimaxProvider();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	describe('basic properties', () => {
+		it('should have correct ID', () => {
+			expect(provider.id).toBe('minimax');
+		});
+
+		it('should have correct display name', () => {
+			expect(provider.displayName).toBe('MiniMax');
+		});
+
+		it('should have correct capabilities', () => {
+			expect(provider.capabilities).toEqual({
+				streaming: true,
+				extendedThinking: false,
+				maxContextWindow: 200000,
+				functionCalling: true,
+				vision: true,
+			});
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('should return true when MINIMAX_API_KEY is set', () => {
+			process.env.MINIMAX_API_KEY = 'test-key';
+			expect(provider.isAvailable()).toBe(true);
+		});
+
+		it('should return false when no API key is set', () => {
+			delete process.env.MINIMAX_API_KEY;
+			expect(provider.isAvailable()).toBe(false);
+		});
+	});
+
+	describe('getModels', () => {
+		it('should return MiniMax models when API key is available', async () => {
+			process.env.MINIMAX_API_KEY = 'test-key';
+
+			const models = await provider.getModels();
+
+			expect(models).toHaveLength(1);
+			expect(models.map((m) => m.id)).toEqual(['MiniMax-M2.5']);
+		});
+
+		it('should return empty array when API key is not available', async () => {
+			delete process.env.MINIMAX_API_KEY;
+
+			const models = await provider.getModels();
+			expect(models).toEqual([]);
+		});
+
+		it('should include provider field in models', async () => {
+			process.env.MINIMAX_API_KEY = 'test-key';
+
+			const models = await provider.getModels();
+
+			for (const model of models) {
+				expect(model.provider).toBe('minimax');
+			}
+		});
+	});
+
+	describe('ownsModel', () => {
+		it('should own minimax- prefixed models', () => {
+			expect(provider.ownsModel('MiniMax-M2.5')).toBe(true);
+			expect(provider.ownsModel('minimax-m2.5')).toBe(true);
+		});
+
+		it('should not own other provider models', () => {
+			expect(provider.ownsModel('default')).toBe(false);
+			expect(provider.ownsModel('opus')).toBe(false);
+			expect(provider.ownsModel('glm-5')).toBe(false);
+		});
+	});
+
+	describe('getModelForTier', () => {
+		it('should map all tiers to MiniMax-M2.5', () => {
+			expect(provider.getModelForTier('haiku')).toBe('MiniMax-M2.5');
+			expect(provider.getModelForTier('sonnet')).toBe('MiniMax-M2.5');
+			expect(provider.getModelForTier('opus')).toBe('MiniMax-M2.5');
+			expect(provider.getModelForTier('default')).toBe('MiniMax-M2.5');
+		});
+	});
+
+	describe('buildSdkConfig', () => {
+		it('should build correct config for MiniMax-M2.5', () => {
+			process.env.MINIMAX_API_KEY = 'test-key';
+
+			const config = provider.buildSdkConfig('MiniMax-M2.5');
+
+			expect(config.envVars).toEqual({
+				ANTHROPIC_BASE_URL: 'https://api.minimax.io/anthropic',
+				ANTHROPIC_AUTH_TOKEN: 'test-key',
+				API_TIMEOUT_MS: '3000000',
+				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+				ANTHROPIC_DEFAULT_HAIKU_MODEL: 'MiniMax-M2.5',
+				ANTHROPIC_DEFAULT_SONNET_MODEL: 'MiniMax-M2.5',
+				ANTHROPIC_DEFAULT_OPUS_MODEL: 'MiniMax-M2.5',
+			});
+			expect(config.isAnthropicCompatible).toBe(true);
+		});
+
+		it('should use session config API key override', () => {
+			process.env.MINIMAX_API_KEY = 'env-key';
+
+			const config = provider.buildSdkConfig('MiniMax-M2.5', {
+				apiKey: 'session-key',
+			});
+
+			expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('session-key');
+		});
+
+		it('should use session config baseUrl override', () => {
+			process.env.MINIMAX_API_KEY = 'test-key';
+
+			const config = provider.buildSdkConfig('MiniMax-M2.5', {
+				baseUrl: 'https://custom.example.com',
+			});
+
+			expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://custom.example.com');
+		});
+
+		it('should throw when no API key is configured', () => {
+			delete process.env.MINIMAX_API_KEY;
+
+			expect(() => provider.buildSdkConfig('MiniMax-M2.5')).toThrow(
+				'MiniMax API key not configured'
+			);
+		});
+	});
+
+	describe('translateModelIdForSdk', () => {
+		it('should translate MiniMax-M2.5 to default', () => {
+			expect(provider.translateModelIdForSdk('MiniMax-M2.5')).toBe('default');
+		});
+	});
+
+	describe('getTitleGenerationModel', () => {
+		it('should return MiniMax-M2.5 for title generation', () => {
+			expect(provider.getTitleGenerationModel()).toBe('MiniMax-M2.5');
+		});
+	});
+
+	describe('static models', () => {
+		it('should have static models defined', () => {
+			expect(MinimaxProvider.MODELS).toHaveLength(1);
+			expect(MinimaxProvider.MODELS.map((m) => m.id)).toEqual(['MiniMax-M2.5']);
+		});
+
+		it('should have correct base URL', () => {
+			expect(MinimaxProvider.BASE_URL).toBe('https://api.minimax.io/anthropic');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/setup.ts
+++ b/packages/daemon/tests/unit/setup.ts
@@ -38,3 +38,4 @@ process.env.ANTHROPIC_API_KEY = '';
 process.env.CLAUDE_CODE_OAUTH_TOKEN = '';
 process.env.GLM_API_KEY = '';
 process.env.ZHIPU_API_KEY = '';
+process.env.MINIMAX_API_KEY = '';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -181,8 +181,9 @@ export type SessionStatus = 'active' | 'pending_worktree_choice' | 'paused' | 'e
  * Supported AI providers
  * - 'anthropic': Default Claude API provider
  * - 'glm': GLM (智谱AI) via Anthropic-compatible API
+ * - 'minimax': MiniMax via Anthropic-compatible API
  */
-export type Provider = 'anthropic' | 'glm';
+export type Provider = 'anthropic' | 'glm' | 'minimax';
 
 /**
  * Provider-specific configuration


### PR DESCRIPTION
## Summary
- Add MiniMax as a new provider using the Anthropic-compatible API (`https://api.minimax.io/anthropic`)
- Follows the same pattern as the GLM provider
- Supports `MiniMax-M2.5` model, activated via `MINIMAX_API_KEY` env var

## Changes
- `packages/daemon/src/lib/providers/minimax-provider.ts` — New provider implementation
- `packages/daemon/src/lib/providers/factory.ts` — Register MiniMax provider
- `packages/shared/src/types.ts` — Add `'minimax'` to `Provider` union type
- `packages/daemon/src/lib/provider-service.ts` — Add `MINIMAX_API_KEY` lookup
- `packages/daemon/tests/unit/setup.ts` — Clear `MINIMAX_API_KEY` in test env
- `packages/daemon/tests/unit/providers/minimax-provider.test.ts` — 19 unit tests

## Test plan
- [x] All 19 MiniMax provider unit tests pass
- [x] Pre-commit checks pass (lint, format, typecheck, knip)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)