### PR TITLE
Improve CLI reviewer agents: sync execution, model selection, codex-review split

### DIFF
--- a/packages/daemon/src/lib/room/agents/cli-agent-registry.ts
+++ b/packages/daemon/src/lib/room/agents/cli-agent-registry.ts
@@ -54,7 +54,14 @@ const KNOWN_CLI_AGENTS: CliAgentDefinition[] = [
 		name: 'Codex',
 		command: 'codex',
 		provider: 'OpenAI',
-		knownModels: ['gpt-5.3-codex', 'o3', 'o4-mini', 'gpt-4.1'],
+		knownModels: ['gpt-5.3-codex', 'gpt-5.4'],
+	},
+	{
+		id: 'codex-review',
+		name: 'Codex Review',
+		command: 'codex',
+		provider: 'OpenAI',
+		knownModels: ['gpt-5.3-codex', 'gpt-5.4'],
 	},
 	{
 		id: 'gemini',
@@ -76,6 +83,13 @@ const KNOWN_CLI_AGENTS: CliAgentDefinition[] = [
 		provider: 'GitHub',
 		versionCommand: 'gh copilot --help',
 		authCheckCommand: 'gh auth status',
+		knownModels: [
+			'claude-opus-4.6',
+			'claude-sonnet-4.6',
+			'gemini-3.1-pro-preview',
+			'gpt-5.3-codex',
+			'gpt-5.4',
+		],
 	},
 ];
 

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -175,6 +175,9 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 			sections.push(
 				`- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval`
 			);
+			sections.push(
+				`- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).`
+			);
 			sections.push(`- **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\``);
 			sections.push(
 				`\nDo NOT use \`complete_task\` for plans — plans must be reviewed by a human before tasks are created.`
@@ -257,6 +260,9 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 				`- **Any P0/P1/P2 issues** → \`send_to_worker\` with ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.`
 			);
 			sections.push(`- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL`);
+			sections.push(
+				`- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).`
+			);
 			sections.push(`- **Fundamentally broken** → \`fail_task\` or \`replan_goal\``);
 		} else {
 			sections.push(`\n## Code Review Guidelines\n`);
@@ -410,10 +416,12 @@ interface SubagentConfig {
 	provider?: string;
 	/** For CLI-only models: use a driver model that calls the CLI via Bash */
 	type?: 'cli';
-	/** Model to use as driver when type is 'cli' */
+	/** Model to use as driver when type is 'cli'. Defaults to leader's model. */
 	driver_model?: string;
 	/** Full model ID when different from the short name in 'model' */
 	modelId?: string;
+	/** Model the CLI tool should use internally (e.g., copilot --model gpt-5.3-codex) */
+	cliModel?: string;
 }
 
 /**
@@ -433,12 +441,15 @@ function getLeaderSubagents(roomConfig: Record<string, unknown>): SubagentConfig
  * e.g., 'claude-sonnet-4-5-20250929' → 'sonnet'
  *       'claude-haiku-4-5-20251001' → 'haiku'
  *       'gpt-5.3-codex' → 'codex'
+ *       'codex-review' → 'codex-review'
  */
 export function toShortModelName(modelId: string): string {
 	const lower = modelId.toLowerCase();
 	if (lower.includes('opus')) return 'opus';
 	if (lower.includes('haiku')) return 'haiku';
 	if (lower.includes('sonnet')) return 'sonnet';
+	// 'codex-review' must be checked before 'codex' to avoid matching the shorter name
+	if (lower === 'codex-review') return 'codex-review';
 	if (lower.includes('codex')) return 'codex';
 	if (lower.includes('copilot')) return 'copilot';
 	// Fallback: take the first meaningful segment
@@ -570,8 +581,24 @@ ${REVIEWER_OUTPUT_FORMAT}`;
 /**
  * Return specific CLI invocation instructions based on the tool name.
  */
-function getCliInstructions(cliTool: string): string {
+function getCliInstructions(cliTool: string, cliModel?: string): string {
 	const tool = cliTool.toLowerCase();
+	const modelFlag = cliModel ? ` --model ${cliModel}` : '';
+
+	// 'codex-review' must be checked before 'codex' to avoid matching the shorter name
+	if (tool === 'codex-review') {
+		return `### Codex Review (OpenAI)
+
+Use the dedicated \`codex review\` subcommand which is purpose-built for code review:
+
+\`\`\`bash
+codex review${modelFlag} --base <BASE_BRANCH> "<YOUR REVIEW INSTRUCTIONS HERE>" 2>&1
+\`\`\`
+
+- \`--base <BASE_BRANCH>\` reviews changes against the specified base branch (e.g., \`main\`, \`dev\`).${cliModel ? '' : '\n- Do NOT pass `--model` — Codex uses its default model.'}
+- This uses the Codex review quota (separate from the exec/agent quota).
+- Capture stdout — the review output is printed there.`;
+	}
 
 	if (tool.includes('codex')) {
 		return `### Codex CLI (OpenAI)
@@ -579,34 +606,34 @@ function getCliInstructions(cliTool: string): string {
 Run Codex in non-interactive mode to review the code:
 
 \`\`\`bash
-codex exec --sandbox read-only "<YOUR REVIEW PROMPT HERE>" 2>&1
+codex exec${modelFlag} --sandbox read-only "<YOUR REVIEW PROMPT HERE>" 2>&1
 \`\`\`
 
-- Do NOT pass \`--model\` — Codex uses its default model (gpt-5.3-codex).
-- Do NOT pass \`--ask-for-approval\` — that flag does not exist.
-- The \`--sandbox read-only\` flag ensures Codex can read files but not modify them.
-- Capture stdout — the final review output is printed there.
-- If you need to run in background, use the Bash tool's background mode.`;
+- The \`--sandbox read-only\` flag ensures Codex can read files but not modify them.${cliModel ? '' : '\n- Do NOT pass `--model` — Codex uses its default model.'}
+- This uses the Codex agent/exec quota.
+- Capture stdout — the review output is printed there.`;
 	}
 
 	if (tool.includes('copilot')) {
 		return `### GitHub Copilot CLI
 
-Run Copilot CLI in autopilot mode to review the code:
+Run Copilot CLI in non-interactive mode to review the code:
 
 \`\`\`bash
-copilot --autopilot --yolo --max-autopilot-continues 10 \\
+copilot -s --autopilot --yolo --no-ask-user --max-autopilot-continues 10${modelFlag} \\
   -p "<YOUR REVIEW PROMPT HERE>" \\
   2>/dev/null
 \`\`\`
 
-Capture the output from stdout.`;
+- The \`-s\` (silent) flag outputs only the agent response with no stats — ideal for capturing output.
+- The \`--no-ask-user\` flag ensures the agent works autonomously.${cliModel ? '' : '\n- Do NOT pass `--model` — Copilot uses its default model.'}
+- Capture stdout — the final review output is printed there.`;
 	}
 
 	// Generic fallback for unknown CLI tools
 	return `### ${cliTool} CLI
 
-Run the ${cliTool} CLI tool to review the code. Consult the tool's documentation for the correct non-interactive invocation syntax. Pass the changed files as input and capture the review output.`;
+Run the ${cliTool} CLI tool to review the code.${cliModel ? ` Use model: ${cliModel}.` : ''} Consult the tool's documentation for the correct non-interactive invocation syntax. Pass the changed files as input and capture the review output.`;
 }
 
 /**
@@ -614,10 +641,15 @@ Run the ${cliTool} CLI tool to review the code. Consult the tool's documentation
  * The driver model MUST act as a strict relay — only orchestrate the CLI tool,
  * parse its output, and post. Do NOT do independent code review.
  */
-function buildCliReviewerPrompt(cliTool: string, provider?: string, modelId?: string): string {
-	const cliInstructions = getCliInstructions(cliTool);
+function buildCliReviewerPrompt(
+	cliTool: string,
+	provider?: string,
+	modelId?: string,
+	cliModel?: string
+): string {
+	const cliInstructions = getCliInstructions(cliTool, cliModel);
 	const displayProvider = provider ?? 'unknown';
-	const displayModel = modelId ?? cliTool;
+	const displayModel = cliModel ?? modelId ?? cliTool;
 
 	return `You are a RELAY agent that orchestrates the ${cliTool} CLI tool to perform code review. You MUST NOT review the code yourself — your ONLY job is to run the CLI tool, parse its output, and post the results.
 
@@ -634,14 +666,17 @@ You MUST include this identity block at the top of every PR comment you post.
 2. Do NOT add your own findings or analysis. Only relay what the CLI tool reports.
 3. If the CLI tool exits with an error, report the error — do not fall back to reviewing yourself.
 4. Your only tools interaction should be: extracting PR info, running the CLI tool, and posting the review.
+5. **ALWAYS run the CLI tool synchronously** — set \`timeout: 600000\` (10 minutes) on the Bash call. Do NOT use \`run_in_background\`. The output will be returned when the command completes. Do NOT poll, sleep, or check for output in separate steps.
+6. If the CLI tool times out or errors, do NOT retry. Do NOT post a GitHub review. Instead, output the structured block with \`recommendation: TIMEOUT\` (or \`ERROR\`), \`url: none\`, and a summary describing what happened. The leader will decide how to proceed.
 
 ## Review Process
 
 1. Read the task prompt carefully — extract the PR number and task description
-2. Run the CLI tool:
+2. Run the CLI tool synchronously (with \`timeout: 600000\`):
 
 ${cliInstructions}
 
+   The command will complete and return the full output in one response. Do NOT run it in background or poll for output.
 3. Parse the CLI tool's output and map findings to severity levels (P0/P1/P2/P3)
 4. Post findings as a proper PR review via the REST API (returns the review URL directly):
    \`\`\`bash
@@ -721,13 +756,17 @@ function resolveModelId(reviewer: SubagentConfig): string {
 	if (m === 'opus') return 'claude-opus-4-6';
 	if (m === 'sonnet') return 'claude-sonnet-4-6';
 	if (m === 'haiku') return 'claude-haiku-4-5';
-	if (m === 'codex') return 'gpt-5.3-codex';
+	if (m === 'codex' || m === 'codex-review') return 'gpt-5.3-codex';
 	return reviewer.model;
 }
 
-export function buildReviewerAgents(reviewers: SubagentConfig[]): Record<string, AgentDefinition> {
+export function buildReviewerAgents(
+	reviewers: SubagentConfig[],
+	leaderModel?: string
+): Record<string, AgentDefinition> {
 	const agents: Record<string, AgentDefinition> = {};
 	const usedNames = new Set<string>();
+	const defaultDriverModel = leaderModel ?? 'sonnet';
 
 	for (const reviewer of reviewers) {
 		const name = toReviewerName(reviewer, usedNames);
@@ -735,12 +774,13 @@ export function buildReviewerAgents(reviewers: SubagentConfig[]): Record<string,
 		const modelId = resolveModelId(reviewer);
 
 		if (reviewer.type === 'cli') {
+			const driverModel = reviewer.driver_model ?? defaultDriverModel;
 			// CLI-based reviewer: a driver model calls the external tool via Bash
 			agents[name] = {
-				description: `Code reviewer using ${reviewer.model} CLI (${provider} via ${reviewer.driver_model ?? 'sonnet'}). Runs the CLI tool via Bash and posts findings as PR reviews.`,
+				description: `Code reviewer using ${reviewer.model} CLI (${provider} via ${driverModel}). Runs the CLI tool via Bash and posts findings as PR reviews.`,
 				tools: REVIEWER_TOOLS,
-				model: toAgentModel(reviewer.driver_model ?? 'sonnet'),
-				prompt: buildCliReviewerPrompt(reviewer.model, provider, modelId),
+				model: toAgentModel(driverModel),
+				prompt: buildCliReviewerPrompt(reviewer.model, provider, modelId, reviewer.cliModel),
 			};
 		} else {
 			// Direct SDK reviewer: uses the specified model natively
@@ -787,9 +827,10 @@ export function createLeaderAgentInit(
 	// Build reviewer agents from room config (if any)
 	const roomConfig = config.room.config ?? {};
 	const reviewerConfigs = getLeaderSubagents(roomConfig);
+	const leaderModel = config.model ?? DEFAULT_LEADER_MODEL;
 	const reviewerAgents =
 		reviewerConfigs && reviewerConfigs.length > 0
-			? buildReviewerAgents(reviewerConfigs)
+			? buildReviewerAgents(reviewerConfigs, leaderModel)
 			: undefined;
 
 	// Only define the Leader agent definition and use agent/agents pattern

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -6,6 +6,7 @@ import {
 	createLeaderToolHandlers,
 	createLeaderAgentInit,
 	toAgentModel,
+	toShortModelName,
 	type LeaderAgentConfig,
 	type LeaderToolCallbacks,
 } from '../../../src/lib/room/agents/leader-agent';
@@ -561,6 +562,184 @@ describe('Leader Agent', () => {
 
 		it('should map claude-sonnet-4.6 style IDs to sonnet', () => {
 			expect(toAgentModel('claude-sonnet-4.6')).toBe('sonnet');
+		});
+	});
+
+	describe('toShortModelName', () => {
+		it('should return codex-review for exact match', () => {
+			expect(toShortModelName('codex-review')).toBe('codex-review');
+		});
+
+		it('should return codex for gpt-5.3-codex', () => {
+			expect(toShortModelName('gpt-5.3-codex')).toBe('codex');
+		});
+
+		it('should return copilot for copilot', () => {
+			expect(toShortModelName('copilot')).toBe('copilot');
+		});
+
+		it('should return opus for claude-opus-4-6', () => {
+			expect(toShortModelName('claude-opus-4-6')).toBe('opus');
+		});
+
+		it('should return sonnet for claude-sonnet-4-5-20250929', () => {
+			expect(toShortModelName('claude-sonnet-4-5-20250929')).toBe('sonnet');
+		});
+
+		it('should return haiku for claude-haiku-4-5', () => {
+			expect(toShortModelName('claude-haiku-4-5')).toBe('haiku');
+		});
+
+		it('should return truncated fallback for unknown models', () => {
+			const result = toShortModelName('some-unknown-model');
+			expect(result).toBe('some-unknown-model');
+		});
+	});
+
+	describe('buildReviewerAgents — CLI enhancements', () => {
+		it('should use leaderModel as default driver when no driver_model specified', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }], 'claude-opus-4-6');
+			const agent = agents['reviewer-copilot'];
+			expect(agent.model).toBe('opus');
+		});
+
+		it('should fall back to sonnet when neither driver_model nor leaderModel given', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }]);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.model).toBe('sonnet');
+		});
+
+		it('should prefer explicit driver_model over leaderModel', () => {
+			const agents = buildReviewerAgents(
+				[{ model: 'copilot', type: 'cli', driver_model: 'haiku' }],
+				'claude-opus-4-6'
+			);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.model).toBe('haiku');
+		});
+
+		it('should pass cliModel to CLI reviewer prompt', () => {
+			const agents = buildReviewerAgents([
+				{ model: 'copilot', type: 'cli', cliModel: 'gpt-5.3-codex' },
+			]);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.prompt).toContain('--model gpt-5.3-codex');
+		});
+
+		it('should warn against --model when cliModel is not set', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }]);
+			const agent = agents['reviewer-copilot'];
+			// When no cliModel, the bash command should not have --model flag
+			expect(agent.prompt).toContain('--max-autopilot-continues 10 \\');
+			expect(agent.prompt).not.toContain('--max-autopilot-continues 10 --model');
+			expect(agent.prompt).toContain('Do NOT pass `--model`');
+		});
+
+		it('should include synchronous execution rules in CLI reviewer prompt', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }]);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.prompt).toContain('timeout: 600000');
+			expect(agent.prompt).toContain('Do NOT use `run_in_background`');
+			expect(agent.prompt).toContain('recommendation: TIMEOUT');
+		});
+
+		it('should use codex review subcommand for codex-review model', () => {
+			const agents = buildReviewerAgents([{ model: 'codex-review', type: 'cli' }]);
+			const agent = agents['reviewer-codex-review'];
+			expect(agent).toBeDefined();
+			expect(agent.prompt).toContain('codex review');
+			expect(agent.prompt).toContain('--base <BASE_BRANCH>');
+			expect(agent.prompt).toContain('review quota');
+		});
+
+		it('should use codex exec for codex model', () => {
+			const agents = buildReviewerAgents([{ model: 'codex', type: 'cli' }]);
+			const agent = agents['reviewer-codex'];
+			expect(agent).toBeDefined();
+			expect(agent.prompt).toContain('codex exec');
+			expect(agent.prompt).toContain('--sandbox read-only');
+			expect(agent.prompt).toContain('agent/exec quota');
+		});
+
+		it('should include copilot-specific flags in copilot CLI prompt', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }]);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.prompt).toContain('-s');
+			expect(agent.prompt).toContain('--no-ask-user');
+			expect(agent.prompt).toContain('--autopilot');
+		});
+
+		it('should display cliModel in reviewer identity block', () => {
+			const agents = buildReviewerAgents([
+				{ model: 'copilot', type: 'cli', cliModel: 'claude-opus-4.6' },
+			]);
+			const agent = agents['reviewer-copilot'];
+			expect(agent.prompt).toContain('**Model:** claude-opus-4.6');
+		});
+
+		it('should resolve codex-review modelId to gpt-5.3-codex', () => {
+			const agents = buildReviewerAgents([{ model: 'codex-review', type: 'cli' }]);
+			const agent = agents['reviewer-codex-review'];
+			// The description should mention codex-review
+			expect(agent.description).toContain('codex-review');
+		});
+	});
+
+	describe('buildLeaderSystemPrompt — TIMEOUT/ERROR routing', () => {
+		it('should include TIMEOUT/ERROR routing in code review orchestration', () => {
+			const prompt = buildLeaderSystemPrompt(
+				makeConfig({
+					room: makeRoom({
+						config: {
+							agentSubagents: {
+								leader: [{ model: 'claude-opus-4-6' }],
+							},
+						},
+					}),
+				})
+			);
+			expect(prompt).toContain('TIMEOUT or ERROR');
+			expect(prompt).toContain('Ignore that reviewer');
+			expect(prompt).toContain('let human decide');
+		});
+
+		it('should include TIMEOUT/ERROR routing in plan review orchestration', () => {
+			const prompt = buildLeaderSystemPrompt(
+				makeConfig({
+					reviewContext: 'plan_review',
+					room: makeRoom({
+						config: {
+							agentSubagents: {
+								leader: [{ model: 'claude-opus-4-6' }],
+							},
+						},
+					}),
+				})
+			);
+			expect(prompt).toContain('TIMEOUT or ERROR');
+			expect(prompt).toContain('Ignore that reviewer');
+		});
+	});
+
+	describe('createLeaderAgentInit — leaderModel passed to reviewers', () => {
+		it('should pass leader model to buildReviewerAgents as default driver', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(
+				makeConfig({
+					model: 'claude-opus-4-6',
+					room: makeRoom({
+						config: {
+							agentSubagents: {
+								leader: [{ model: 'copilot', type: 'cli' }],
+							},
+						},
+					}),
+				}),
+				callbacks
+			);
+			const reviewerAgent = init.agents!['reviewer-copilot'];
+			// Driver model should be opus (inherited from leader model)
+			expect(reviewerAgent.model).toBe('opus');
 		});
 	});
 });

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -33,6 +33,7 @@ interface CliAgentInfo {
 	installed: boolean;
 	authenticated: boolean;
 	version?: string;
+	models?: string[];
 }
 
 const MODEL_FAMILY_ICONS: Record<string, string> = {
@@ -68,6 +69,7 @@ interface SubagentConfig {
 	provider?: string;
 	type?: 'cli';
 	driver_model?: string;
+	cliModel?: string;
 }
 
 interface AgentModels {
@@ -298,32 +300,39 @@ function ModelTagsInput({
 	);
 }
 
-/** Tags-style input for selecting CLI sub-agents */
+/** Tags-style input for selecting CLI sub-agents with per-agent model picker */
 function CliTagsInput({
 	agents,
-	selectedIds,
+	selectedConfigs,
 	disabled,
 	onToggle,
+	onChangeModel,
 }: {
 	agents: CliAgentInfo[];
-	selectedIds: string[];
+	selectedConfigs: SubagentConfig[];
 	disabled: boolean;
 	onToggle: (agent: CliAgentInfo) => void;
+	onChangeModel: (agentId: string, cliModel: string) => void;
 }) {
 	const isOpen = useSignal(false);
+	const modelOpenFor = useSignal<string | null>(null);
 	const ref = useRef<HTMLDivElement>(null);
 
+	const selectedIds = selectedConfigs.map((s) => s.model);
 	const installableAgents = agents.filter((a) => a.installed);
 	const availableToAdd = installableAgents.filter((a) => !selectedIds.includes(a.id));
 
 	useEffect(() => {
-		if (!isOpen.value) return;
+		if (!isOpen.value && !modelOpenFor.value) return;
 		const handler = (e: MouseEvent) => {
-			if (ref.current && !ref.current.contains(e.target as Node)) isOpen.value = false;
+			if (ref.current && !ref.current.contains(e.target as Node)) {
+				isOpen.value = false;
+				modelOpenFor.value = null;
+			}
 		};
 		document.addEventListener('mousedown', handler);
 		return () => document.removeEventListener('mousedown', handler);
-	}, [isOpen.value]);
+	}, [isOpen.value, modelOpenFor.value]);
 
 	return (
 		<div class="relative" ref={ref}>
@@ -333,16 +342,29 @@ function CliTagsInput({
 					if (!disabled && availableToAdd.length > 0) isOpen.value = !isOpen.value;
 				}}
 			>
-				{selectedIds.map((id) => {
-					const info = agents.find((a) => a.id === id);
+				{selectedConfigs.map((config) => {
+					const info = agents.find((a) => a.id === config.model);
 					if (!info) return null;
+					const hasModels = info.models && info.models.length > 0;
 					return (
 						<span
-							key={id}
-							class="inline-flex items-center gap-1 px-2 py-0.5 bg-dark-600 rounded text-xs text-gray-200"
+							key={config.model}
+							class="inline-flex items-center gap-1 px-2 py-0.5 bg-dark-600 rounded text-xs text-gray-200 relative"
 						>
 							{info.name}
-							<span class="text-[10px] text-gray-500">{info.provider}</span>
+							{hasModels && (
+								<button
+									class="text-[10px] text-blue-400 hover:text-blue-300 px-1 rounded hover:bg-dark-500"
+									onClick={(e) => {
+										e.stopPropagation();
+										modelOpenFor.value = modelOpenFor.value === config.model ? null : config.model;
+									}}
+									title="Select model"
+								>
+									{config.cliModel ?? 'default'}
+								</button>
+							)}
+							{!hasModels && <span class="text-[10px] text-gray-500">{info.provider}</span>}
 							{!disabled && (
 								<button
 									class="ml-0.5 text-red-400 hover:text-red-300 leading-none"
@@ -353,6 +375,37 @@ function CliTagsInput({
 								>
 									&times;
 								</button>
+							)}
+							{modelOpenFor.value === config.model && hasModels && (
+								<div class="absolute top-full mt-1 left-0 bg-dark-800 border border-dark-600 rounded-lg shadow-xl w-44 py-1 z-50 animate-slideIn">
+									<button
+										class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs ${
+											!config.cliModel ? 'text-blue-400' : 'text-gray-200'
+										}`}
+										onClick={(e) => {
+											e.stopPropagation();
+											onChangeModel(config.model, '');
+											modelOpenFor.value = null;
+										}}
+									>
+										default
+									</button>
+									{info.models!.map((m) => (
+										<button
+											key={m}
+											class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs ${
+												config.cliModel === m ? 'text-blue-400' : 'text-gray-200'
+											}`}
+											onClick={(e) => {
+												e.stopPropagation();
+												onChangeModel(config.model, m);
+												modelOpenFor.value = null;
+											}}
+										>
+											{m}
+										</button>
+									))}
+								</div>
 							)}
 						</span>
 					);
@@ -520,7 +573,24 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 		const current = getSubagentsForRole(role);
 		const updated = isCliAgentEnabledFor(role, agent.id)
 			? current.filter((r) => !(r.type === 'cli' && r.model === agent.id))
-			: [...current, { model: agent.id, type: 'cli' as const, driver_model: 'sonnet' }];
+			: [...current, { model: agent.id, type: 'cli' as const }];
+		agentSubagents.value = { ...agentSubagents.value, [role]: updated };
+	};
+
+	const changeCliModelFor = (role: string, agentId: string, cliModel: string) => {
+		const current = getSubagentsForRole(role);
+		const updated = current.map((r) => {
+			if (r.type === 'cli' && r.model === agentId) {
+				const next = { ...r };
+				if (cliModel) {
+					next.cliModel = cliModel;
+				} else {
+					delete next.cliModel;
+				}
+				return next;
+			}
+			return r;
+		});
 		agentSubagents.value = { ...agentSubagents.value, [role]: updated };
 	};
 
@@ -690,11 +760,14 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 											<div class="text-xs text-gray-500 mb-2">Sub Agent CLIs</div>
 											<CliTagsInput
 												agents={cliAgents.value}
-												selectedIds={getSubagentsForRole(agent.key)
-													.filter((s) => s.type === 'cli')
-													.map((s) => s.model)}
+												selectedConfigs={getSubagentsForRole(agent.key).filter(
+													(s) => s.type === 'cli'
+												)}
 												disabled={disabled}
 												onToggle={(cliAgent) => toggleCliAgentFor(agent.key, cliAgent)}
+												onChangeModel={(agentId, cliModel) =>
+													changeCliModelFor(agent.key, agentId, cliModel)
+												}
 											/>
 										</div>
 


### PR DESCRIPTION
## Summary
- Fix CLI-based reviewer agents (Copilot, Codex) wasting ~30 messages by polling for background output — now enforces synchronous execution with 10-min timeout
- Add TIMEOUT/ERROR handling so the leader agent routes gracefully when CLI tools fail instead of retrying
- Split Codex into `codex` (exec quota) and `codex-review` (review quota) as separate options
- Add `cliModel` field and per-CLI-agent model picker in the UI so users can choose which model the CLI tool runs internally (e.g., `copilot --model gpt-5.3-codex`)
- Default `driver_model` to leader's model instead of hardcoded `sonnet`
- Update Copilot flags: `-s` (silent), `--no-ask-user` for cleaner output capture
- Update model lists: Codex (`gpt-5.3-codex`, `gpt-5.4`), Copilot (`claude-opus-4.6`, `claude-sonnet-4.6`, `gemini-3.1-pro-preview`, `gpt-5.3-codex`, `gpt-5.4`)

## Test plan
- [x] All 71 leader-agent unit tests pass (4 new test groups with 20+ new cases)
- [x] Typecheck passes
- [x] Lint clean
- [x] Knip (dead code) clean
- [ ] Manual: verify CLI agent model picker in UI
- [ ] Manual: verify codex-review appears as separate option in sub-agent CLI list

🤖 Generated with [Claude Code](https://claude.com/claude-code)