### PR TITLE
fix(providers): add minimax- prefix to AnthropicProvider exclusion list

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-provider.ts
@@ -321,7 +321,15 @@ export class AnthropicProvider implements Provider {
 		}
 
 		// Known other provider prefixes (exclude these)
-		const otherProviderPrefixes = ['glm-', 'deepseek-', 'openai-', 'gpt-', 'qwen-', 'copilot-'];
+		const otherProviderPrefixes = [
+			'glm-',
+			'deepseek-',
+			'openai-',
+			'gpt-',
+			'qwen-',
+			'copilot-',
+			'minimax-',
+		];
 		if (otherProviderPrefixes.some((prefix) => lower.startsWith(prefix))) {
 			return false;
 		}


### PR DESCRIPTION
## Summary

- `AnthropicProvider.ownsModel()` had a hardcoded exclusion list of non-Anthropic prefixes, but `minimax-` was missing
- This caused `detectProvider('MiniMax-M2.5')` to return `AnthropicProvider` (via the fallthrough `return true`), since it's registered first
- As a result, `applyEnvVarsToProcess()` found no provider-specific env vars and **cleared** the routing env vars instead of setting them to MiniMax values
- SDK subprocesses then hit Anthropic's real endpoint, and `system:init` showed `claude-sonnet-4-6` instead of `MiniMax-M2.5`

## Test plan

- [ ] Select MiniMax model in a new session
- [ ] Verify `system:init` shows `MiniMax-M2.5` (not `claude-sonnet-4-6`)
- [ ] Verify GLM still shows `glm-5` in `system:init` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)