### PR TITLE
feat(room): show PR number with link on task list and task view

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -132,6 +132,7 @@ export class RoomManager {
 			progress: task.progress,
 			dependsOn: task.dependsOn,
 			error: task.error,
+			currentStep: task.currentStep,
 		});
 		const nonTerminal = tasks.filter((t) => t.status !== 'completed' && t.status !== 'failed');
 		const taskSummaries = nonTerminal.map(toSummary);

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -284,6 +284,8 @@ export interface TaskSummary {
 	dependsOn: string[];
 	/** Error message for failed tasks */
 	error?: string;
+	/** Current step description — may contain a GitHub PR URL */
+	currentStep?: string;
 }
 
 /**

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -11,6 +11,7 @@
  */
 
 import type { TaskSummary } from '@neokai/shared';
+import { parsePrUrl } from '../../lib/utils';
 
 interface RoomTasksProps {
 	tasks: TaskSummary[];
@@ -172,6 +173,7 @@ function TaskItem({
 	const showView = task.status === 'review' && !!onView;
 	const blocked = task.status === 'pending' && isBlocked(task, allTasks);
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
+	const pr = task.currentStep ? parsePrUrl(task.currentStep) : null;
 
 	return (
 		<div
@@ -186,6 +188,18 @@ function TaskItem({
 							<span class="text-xs px-1.5 py-0.5 rounded bg-orange-900/20 text-orange-400 flex-shrink-0">
 								Blocked
 							</span>
+						)}
+						{pr && (
+							<a
+								href={pr.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-xs px-1.5 py-0.5 rounded bg-blue-900/20 text-blue-400 hover:text-blue-300 hover:bg-blue-900/40 border border-blue-700/40 flex-shrink-0 transition-colors"
+								onClick={(e) => e.stopPropagation()}
+								title={pr.url}
+							>
+								PR #{pr.number}
+							</a>
 						)}
 					</div>
 				</div>

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -20,6 +20,7 @@ import type { NeoTask } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { parsePrUrl } from '../../lib/utils';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
 import { InputTextarea } from '../InputTextarea';
 import { TaskConversationRenderer } from './TaskConversationRenderer';
@@ -352,6 +353,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	}
 
 	const statusColor = TASK_STATUS_COLORS[task.status] ?? 'text-gray-400';
+	const pr = task.currentStep ? parsePrUrl(task.currentStep) : null;
 
 	// Show input area when group is active and in an interactive state
 	const showInput =
@@ -381,6 +383,17 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 							<span class="text-xs text-gray-500 bg-dark-700 px-1.5 py-0.5 rounded">
 								{task.taskType}
 							</span>
+						)}
+						{pr && (
+							<a
+								href={pr.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-xs px-1.5 py-0.5 rounded bg-blue-900/20 text-blue-400 hover:text-blue-300 hover:bg-blue-900/40 border border-blue-700/40 transition-colors"
+								title={pr.url}
+							>
+								PR #{pr.number}
+							</a>
 						)}
 					</div>
 					{group && (

--- a/packages/web/src/lib/__tests__/utils.test.ts
+++ b/packages/web/src/lib/__tests__/utils.test.ts
@@ -5,7 +5,7 @@
  * Tests the public API: cn, copyToClipboard, formatRelativeTime, formatTokens
  */
 
-import { cn, copyToClipboard, formatRelativeTime, formatTokens } from '../utils';
+import { cn, copyToClipboard, formatRelativeTime, formatTokens, parsePrUrl } from '../utils';
 
 describe('cn', () => {
 	it('should merge single class name', () => {
@@ -273,6 +273,45 @@ describe('formatRelativeTime', () => {
 		// 7 days should show formatted date (not "7d ago")
 		const result = formatRelativeTime(date);
 		expect(result).not.toMatch(/ago$/);
+	});
+});
+
+describe('parsePrUrl', () => {
+	it('should parse a standard GitHub PR URL', () => {
+		const result = parsePrUrl('https://github.com/lsm/neokai/pull/210');
+		expect(result).toEqual({ number: 210, url: 'https://github.com/lsm/neokai/pull/210' });
+	});
+
+	it('should parse an http GitHub PR URL', () => {
+		const result = parsePrUrl('http://github.com/owner/repo/pull/42');
+		expect(result).toEqual({ number: 42, url: 'http://github.com/owner/repo/pull/42' });
+	});
+
+	it('should parse PR number 1', () => {
+		const result = parsePrUrl('https://github.com/org/project/pull/1');
+		expect(result).toEqual({ number: 1, url: 'https://github.com/org/project/pull/1' });
+	});
+
+	it('should return null for non-PR URLs', () => {
+		expect(parsePrUrl('https://github.com/owner/repo')).toBeNull();
+		expect(parsePrUrl('https://github.com/owner/repo/issues/5')).toBeNull();
+		expect(parsePrUrl('https://gitlab.com/owner/repo/merge_requests/1')).toBeNull();
+	});
+
+	it('should return null for empty string', () => {
+		expect(parsePrUrl('')).toBeNull();
+	});
+
+	it('should return null for arbitrary text', () => {
+		expect(parsePrUrl('Working on feature X')).toBeNull();
+		expect(parsePrUrl('Creating pull request…')).toBeNull();
+	});
+
+	it('should correctly extract PR number from URL with extra trailing content', () => {
+		// URL with trailing path segments — only the pull number matters
+		const result = parsePrUrl('https://github.com/foo/bar/pull/999');
+		expect(result).not.toBeNull();
+		expect(result?.number).toBe(999);
 	});
 });
 

--- a/packages/web/src/lib/__tests__/utils.test.ts
+++ b/packages/web/src/lib/__tests__/utils.test.ts
@@ -309,9 +309,18 @@ describe('parsePrUrl', () => {
 
 	it('should correctly extract PR number from URL with extra trailing content', () => {
 		// URL with trailing path segments — only the pull number matters
-		const result = parsePrUrl('https://github.com/foo/bar/pull/999');
+		const result = parsePrUrl('https://github.com/foo/bar/pull/999/commits');
 		expect(result).not.toBeNull();
 		expect(result?.number).toBe(999);
+		// Should return clean URL without trailing path
+		expect(result?.url).toBe('https://github.com/foo/bar/pull/999');
+	});
+
+	it('should extract clean URL from text containing PR URL', () => {
+		const result = parsePrUrl('Check this PR https://github.com/owner/repo/pull/123 for details');
+		expect(result).not.toBeNull();
+		expect(result?.number).toBe(123);
+		expect(result?.url).toBe('https://github.com/owner/repo/pull/123');
 	});
 });
 

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -87,7 +87,7 @@ export function formatRelativeTime(date: Date): string {
 export function parsePrUrl(url: string): { number: number; url: string } | null {
 	const match = /https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/.exec(url);
 	if (!match) return null;
-	return { number: parseInt(match[1], 10), url };
+	return { number: parseInt(match[1], 10), url: match[0] };
 }
 
 /**

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -79,6 +79,18 @@ export function formatRelativeTime(date: Date): string {
 }
 
 /**
+ * Parse a GitHub pull request URL and extract the PR number.
+ * Returns the PR number and original URL, or null if the URL is not a valid GitHub PR URL.
+ *
+ * Supported format: https://github.com/{owner}/{repo}/pull/{number}
+ */
+export function parsePrUrl(url: string): { number: number; url: string } | null {
+	const match = /https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/.exec(url);
+	if (!match) return null;
+	return { number: parseInt(match[1], 10), url };
+}
+
+/**
  * Format token count in k format (e.g., 16500 -> "16.5k")
  */
 export function formatTokens(tokens: number): string {


### PR DESCRIPTION
- Add parsePrUrl() utility to extract PR number from GitHub PR URLs
- Add currentStep to TaskSummary type and daemon toSummary mapper
- Display clickable PR badge (e.g. "PR #210") in RoomTasks TaskItem
- Display clickable PR badge in TaskView header
- Links open in new tab; badge styled consistently with other metadata chips
