### PR TITLE
fix(room): inject createdAt as timestamp in TaskConversationRenderer

### DIFF
--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -35,10 +35,13 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 	}),
 }));
 
-// SDKMessageRenderer minimal mock
+// SDKMessageRenderer minimal mock — captures uuid and timestamp for assertions
 vi.mock('../sdk/SDKMessageRenderer.tsx', () => ({
-	SDKMessageRenderer: ({ message }: { message: { uuid?: string } }) => (
-		<div data-testid={`msg-${message.uuid ?? 'unknown'}`} />
+	SDKMessageRenderer: ({ message }: { message: { uuid?: string; timestamp?: number } }) => (
+		<div
+			data-testid={`msg-${message.uuid ?? 'unknown'}`}
+			data-timestamp={message.timestamp ?? ''}
+		/>
 	),
 }));
 
@@ -350,6 +353,36 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 		await act(async () => {}); // flush pending async effects
 		expect(onCountChange).not.toHaveBeenCalledWith(2);
+	});
+
+	it('injects createdAt from GroupMessage as timestamp on parsed SDKMessage', async () => {
+		// Use a fixed, non-current timestamp to prove it comes from the DB row, not Date.now()
+		const pastTimestamp = 1_700_000_000_000; // 2023-11-14 in ms
+		const msgWithPastCreatedAt = {
+			id: 1,
+			groupId: 'group-1',
+			sessionId: 'sess-1',
+			role: 'assistant',
+			messageType: 'assistant',
+			content: JSON.stringify({ type: 'assistant', uuid: 'uuid-ts', message: { content: [] } }),
+			createdAt: pastTimestamp,
+		};
+		mockRequest.mockImplementation(async () => ({
+			messages: [msgWithPastCreatedAt],
+			hasMore: false,
+		}));
+
+		const { container } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		await waitFor(() => {
+			const el = container.querySelector('[data-testid="msg-uuid-ts"]');
+			expect(el).not.toBeNull();
+		});
+
+		const el = container.querySelector('[data-testid="msg-uuid-ts"]') as HTMLElement;
+		expect(el.getAttribute('data-timestamp')).toBe(String(pastTimestamp));
 	});
 
 	it('preserves buffered deltas when the initial fetch fails', async () => {

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -58,6 +58,7 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 		return {
 			type: 'status',
 			text: msg.content,
+			timestamp: msg.createdAt,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',
@@ -67,7 +68,10 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 	try {
-		return JSON.parse(msg.content) as SDKMessage;
+		const parsed = JSON.parse(msg.content) as SDKMessage;
+		// Inject createdAt as timestamp so SDKMessageRenderer can display the correct time.
+		// Without this, SDKAssistantMessage/SDKUserMessage fall back to new Date() (current time).
+		return { ...parsed, timestamp: msg.createdAt } as SDKMessage;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
parseGroupMessage() was discarding the GroupMessage.createdAt field when
parsing stored messages. SDKAssistantMessage/SDKUserMessage fall back to
new Date() when no timestamp field is present, making all historical task
messages show "now" instead of their actual send time.

Fix: spread msg.createdAt as timestamp onto the parsed SDKMessage so the
existing timestamp display logic picks it up correctly.
