### PR TITLE
fix(runtime): respect room's leader model selection

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -258,6 +258,10 @@ export class RoomRuntimeService {
 				? Math.min(Math.floor(rawGroups), MAX_CONCURRENT_GROUPS_LIMIT)
 				: undefined;
 
+		// Resolve leader model: agentModels.leader > room.defaultModel > global default
+		const agentModels = roomConfig.agentModels as Record<string, string> | undefined;
+		const leaderModel = agentModels?.leader ?? room.defaultModel ?? this.ctx.defaultModel;
+
 		const runtime = new RoomRuntime({
 			room,
 			groupRepo,
@@ -266,7 +270,7 @@ export class RoomRuntimeService {
 			goalManager,
 			sessionFactory,
 			workspacePath,
-			model: this.ctx.defaultModel,
+			model: leaderModel,
 			maxFeedbackIterations: maxReviewRounds,
 			maxConcurrentGroups,
 			getWorkerMessages: (sessionId, afterMessageId) =>

--- a/packages/daemon/tests/unit/room/leader-model-resolution.test.ts
+++ b/packages/daemon/tests/unit/room/leader-model-resolution.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'bun:test';
+
+// Test the model resolution logic directly
+// This mirrors the logic in room-runtime-service.ts createOrGetRuntime
+
+interface RoomConfig {
+	agentModels?: Record<string, string>;
+	[key: string]: unknown;
+}
+
+interface Room {
+	id: string;
+	defaultModel?: string;
+	config?: RoomConfig;
+}
+
+function resolveLeaderModel(room: Room, globalDefault: string): string {
+	const roomConfig = (room.config ?? {}) as RoomConfig;
+	const agentModels = roomConfig.agentModels as Record<string, string> | undefined;
+	const leaderModel = agentModels?.leader ?? room.defaultModel ?? globalDefault;
+	return leaderModel;
+}
+
+describe('Leader model resolution', () => {
+	describe('resolveLeaderModel', () => {
+		it('should use room.defaultModel when agentModels.leader is not set', () => {
+			const room: Room = {
+				id: 'room-1',
+				defaultModel: 'room-default-model',
+				config: {},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('room-default-model');
+		});
+
+		it('should prefer room.config.agentModels.leader over room.defaultModel', () => {
+			const room: Room = {
+				id: 'room-2',
+				defaultModel: 'room-default-model',
+				config: {
+					agentModels: {
+						leader: 'leader-specific-model',
+					},
+				},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('leader-specific-model');
+		});
+
+		it('should fall back to global default when neither room.defaultModel nor agentModels.leader is set', () => {
+			const room: Room = {
+				id: 'room-3',
+				config: {},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('global-default');
+		});
+
+		it('should use global default when room.defaultModel is undefined', () => {
+			const room: Room = {
+				id: 'room-4',
+				defaultModel: undefined,
+				config: {},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('global-default');
+		});
+
+		it('should use room.defaultModel when explicitly set to empty string (intentional override)', () => {
+			// Empty string is a valid value - if user sets it explicitly, it's used as-is
+			// The ?? operator only falls back on null/undefined
+			const room: Room = {
+				id: 'room-5',
+				defaultModel: '',
+				config: {},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe(''); // Empty string is a valid value
+		});
+
+		it('should use agentModels.leader even when empty string (explicit override)', () => {
+			// Empty string is treated as a valid value - intentional override
+			const room: Room = {
+				id: 'room-6',
+				defaultModel: 'room-default',
+				config: {
+					agentModels: {
+						leader: '',
+					},
+				},
+			};
+
+			// Empty string is used as-is (?? only falls back on null/undefined)
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('');
+		});
+
+		it('should prioritize agentModels.leader when set', () => {
+			const room: Room = {
+				id: 'room-7',
+				defaultModel: 'room-default',
+				config: {
+					agentModels: {
+						leader: 'glm-5',
+						coder: 'claude-sonnet',
+					},
+				},
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('glm-5');
+		});
+
+		it('should handle missing config object', () => {
+			const room: Room = {
+				id: 'room-8',
+			};
+
+			const result = resolveLeaderModel(room, 'global-default');
+			expect(result).toBe('global-default');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Fix leader model selection to respect room's configured model settings
- Use priority: `room.config.agentModels.leader` > `room.defaultModel` > global daemon default
- Previously both room settings were ignored and global default was always used

## Test plan

- [ ] Set a leader-specific model in Room Settings → Agents tab → Leader model picker
- [ ] Verify leader uses the selected model instead of global default
- [ ] Alternatively set room.defaultModel and verify leader uses that when agentModels.leader is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)