### PR TITLE
fix(test): set correct maxFeedbackIterations in escalation test

### DIFF
--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -154,7 +154,12 @@ describe('RoomRuntime flow', () => {
 		});
 
 		it('should escalate task to human review (not fail) when max feedback iterations reached', async () => {
-			// maxFeedbackIterations = 5 (set in test helpers).
+			// Create context with maxFeedbackIterations = 5 to match test expectations
+			ctx.runtime.stop();
+			ctx.db.close();
+			ctx = createRuntimeTestContext({ maxFeedbackIterations: 5 });
+
+			// maxFeedbackIterations = 5.
 			// feedbackIteration is incremented by routeWorkerToLeader (1-based).
 			// The check fires when feedbackIteration >= maxFeedbackIterations,
 			// i.e., on the 5th review round when the leader tries send_to_worker.


### PR DESCRIPTION
The test expected to run 4 feedback iterations with maxFeedbackIterations = 5,
but was using the default value of 3. This caused the test to fail because
after 3 iterations (feedbackIteration = 3), the condition
feedbackIteration >= maxFeedbackIterations would be true and trigger escalation.

Fix by creating a new test context with maxFeedbackIterations: 5.
