### PR TITLE
fix(room): resolve agent models from DB and inherit reviewer runtime model

### DIFF
--- a/docs/design/pr-review-workflow.md
+++ b/docs/design/pr-review-workflow.md
@@ -227,7 +227,7 @@ Room agent configuration lives in the existing `Room.config` JSON field:
   "reviewers": [
     { "model": "claude-opus-4-6", "provider": "anthropic" },
     { "model": "glm-5", "provider": "glm" },
-    { "model": "codex", "type": "cli", "driver_model": "sonnet" }
+    { "model": "codex", "type": "cli" }
   ],
   "maxReviewRounds": 5
 }

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -414,10 +414,8 @@ interface SubagentConfig {
 	model: string;
 	/** Provider name (e.g., 'anthropic', 'openai', 'google') */
 	provider?: string;
-	/** For CLI-only models: use a driver model that calls the CLI via Bash */
+	/** Marks this reviewer as CLI-based (external tool orchestrated via Bash) */
 	type?: 'cli';
-	/** Model to use as driver when type is 'cli'. Defaults to leader's model. */
-	driver_model?: string;
 	/** Full model ID when different from the short name in 'model' */
 	modelId?: string;
 	/** Model the CLI tool should use internally (e.g., copilot --model gpt-5.3-codex) */
@@ -766,7 +764,7 @@ export function buildReviewerAgents(
 ): Record<string, AgentDefinition> {
 	const agents: Record<string, AgentDefinition> = {};
 	const usedNames = new Set<string>();
-	const defaultDriverModel = leaderModel ?? 'sonnet';
+	const runtimeModelLabel = leaderModel ?? 'sonnet';
 
 	for (const reviewer of reviewers) {
 		const name = toReviewerName(reviewer, usedNames);
@@ -774,20 +772,21 @@ export function buildReviewerAgents(
 		const modelId = resolveModelId(reviewer);
 
 		if (reviewer.type === 'cli') {
-			const driverModel = reviewer.driver_model ?? defaultDriverModel;
-			// CLI-based reviewer: a driver model calls the external tool via Bash
+			const orchestratorModel = runtimeModelLabel;
+			// CLI-based reviewer: always inherit Leader runtime model.
 			agents[name] = {
-				description: `Code reviewer using ${reviewer.model} CLI (${provider} via ${driverModel}). Runs the CLI tool via Bash and posts findings as PR reviews.`,
+				description: `Code reviewer using ${reviewer.model} CLI (${provider} via ${orchestratorModel}). Runs the CLI tool via Bash and posts findings as PR reviews.`,
 				tools: REVIEWER_TOOLS,
-				model: toAgentModel(driverModel),
+				model: 'inherit',
 				prompt: buildCliReviewerPrompt(reviewer.model, provider, modelId, reviewer.cliModel),
 			};
 		} else {
-			// Direct SDK reviewer: uses the specified model natively
+			// SDK reviewers also inherit Leader runtime model by default.
+			// The configured reviewer model is still used for identity/prompting.
 			agents[name] = {
 				description: `Code reviewer using ${modelId} (${provider}). Reviews code changes for correctness, quality, and security.`,
 				tools: REVIEWER_TOOLS,
-				model: toAgentModel(reviewer.model),
+				model: 'inherit',
 				prompt: buildSdkReviewerPrompt(modelId, provider),
 			};
 		}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -126,7 +126,7 @@ export class RoomRuntime {
 	private tickQueued = false;
 	private tickTimer: ReturnType<typeof setInterval> | null = null;
 
-	private room: Room;
+	private readonly roomId: string;
 	private readonly groupRepo: SessionGroupRepository;
 	private readonly observer: SessionObserver;
 	private readonly taskManager: TaskManager;
@@ -140,6 +140,7 @@ export class RoomRuntime {
 	private readonly messageHub?: MessageHub;
 	private readonly hookOptions?: HookOptions;
 	private readonly getRoomById: (roomId: string) => Room | null;
+	private readonly defaultModel: string;
 
 	/** Mirroring unsub functions per group ID */
 	private mirroringCleanups = new Map<string, () => void>();
@@ -153,8 +154,8 @@ export class RoomRuntime {
 	private emitTaskUpdate(task: NeoTask): void {
 		if (!this.daemonHub) return;
 		void this.daemonHub.emit('room.task.update', {
-			sessionId: `room:${this.room.id}`,
-			roomId: this.room.id,
+			sessionId: `room:${this.roomId}`,
+			roomId: this.roomId,
 			task,
 		});
 	}
@@ -177,8 +178,8 @@ export class RoomRuntime {
 		const goals = await this.goalManager.getGoalsForTask(taskId);
 		for (const goal of goals) {
 			void this.daemonHub.emit('goal.progressUpdated', {
-				sessionId: `room:${this.room.id}`,
-				roomId: this.room.id,
+				sessionId: `room:${this.roomId}`,
+				roomId: this.roomId,
 				goalId: goal.id,
 				progress: goal.progress,
 			});
@@ -186,7 +187,7 @@ export class RoomRuntime {
 	}
 
 	constructor(config: RoomRuntimeConfig) {
-		this.room = config.room;
+		this.roomId = config.room.id;
 		this.groupRepo = config.groupRepo;
 		this.observer = config.sessionObserver;
 		this.taskManager = config.taskManager;
@@ -200,6 +201,7 @@ export class RoomRuntime {
 		this.messageHub = config.messageHub;
 		this.hookOptions = config.hookOptions;
 		this.getRoomById = config.getRoom;
+		this.defaultModel = config.defaultModel ?? 'sonnet';
 
 		this.taskGroupManager = new TaskGroupManager({
 			groupRepo: config.groupRepo,
@@ -253,23 +255,39 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Update the room reference with the latest data.
-	 * Called when room config changes so lifecycle hooks see the current config.
-	 * Also picks up new maxConcurrentGroups and maxReviewRounds values reactively.
-	 * Stale or removed config keys fall back to their documented defaults.
+	 * Resolve model for a room agent role.
+	 * Priority: room.config.agentModels[role] > room.defaultModel > global default.
 	 */
-	updateRoom(room: Room): void {
-		this.room = room;
+	private resolveAgentModel(
+		room: Room,
+		role: 'leader' | 'planner' | 'coder' | 'general'
+	): string {
 		const config = (room.config ?? {}) as Record<string, unknown>;
-
-		// Update leader model: agentModels.leader > room.defaultModel > global default
-		// Filter out empty strings as they're not valid model identifiers
 		const agentModels = config.agentModels as Record<string, string> | undefined;
-		const leaderModel =
-			(agentModels?.leader && agentModels.leader.trim() !== '' ? agentModels.leader : undefined) ??
-			(room.defaultModel && room.defaultModel.trim() !== '' ? room.defaultModel : undefined) ??
-			this.defaultModel;
-		this.taskGroupManager.updateModel(leaderModel);
+		const roleModel = agentModels?.[role];
+		if (typeof roleModel === 'string' && roleModel.trim() !== '') {
+			return roleModel;
+		}
+		if (typeof room.defaultModel === 'string' && room.defaultModel.trim() !== '') {
+			return room.defaultModel;
+		}
+		return this.defaultModel;
+	}
+
+	/**
+	 * Update runtime config from the latest room state.
+	 * Called when room config changes so lifecycle hooks see current values.
+	 */
+	updateRoom(_room: Room): void {
+		const currentRoom = this.getRoomById(this.roomId);
+		if (!currentRoom) {
+			log.warn(`Cannot refresh room runtime config: room not found (${this.roomId})`);
+			return;
+		}
+		const config = (currentRoom.config ?? {}) as Record<string, unknown>;
+
+		// Keep TaskGroupManager model aligned to the current Leader model.
+		this.taskGroupManager.updateModel(this.resolveAgentModel(currentRoom, 'leader'));
 
 		const rawGroups = config.maxConcurrentGroups;
 		this.maxConcurrentGroups =
@@ -289,8 +307,8 @@ export class RoomRuntime {
 	 * Fetches fresh room from DB to get current config.
 	 */
 	private get maxPlanningAttempts(): number {
-		const currentRoom = this.getRoomById(this.room.id);
-		const cfg = currentRoom?.config ?? this.room.config ?? {};
+		const currentRoom = this.getRoomById(this.roomId);
+		const cfg = currentRoom?.config ?? {};
 		const value = (cfg as Record<string, unknown>)['maxPlanningRetries'];
 		if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
 			// maxPlanningRetries is "how many retries after first failure":
@@ -616,7 +634,7 @@ export class RoomRuntime {
 				{
 					const hookTask = await this.taskManager.getTask(group.taskId);
 					if (hookTask) {
-						const currentRoom = this.getRoomById(this.room.id);
+						const currentRoom = this.getRoomById(this.roomId);
 						const roomConfig = (currentRoom?.config ?? {}) as Record<string, unknown>;
 						const agentSubs = roomConfig.agentSubagents as Record<string, unknown[]> | undefined;
 						const hasReviewers = !!agentSubs?.leader?.length;
@@ -683,7 +701,7 @@ export class RoomRuntime {
 				{
 					const hookTask = await this.taskManager.getTask(group.taskId);
 					if (hookTask && (group.workerRole === 'coder' || group.workerRole === 'planner')) {
-						const currentRoom = this.getRoomById(this.room.id);
+						const currentRoom = this.getRoomById(this.roomId);
 						const roomConfig = (currentRoom?.config ?? {}) as Record<string, unknown>;
 						const agentSubs = roomConfig.agentSubagents as Record<string, unknown[]> | undefined;
 						const hasReviewers = !!agentSubs?.leader?.length;
@@ -883,7 +901,10 @@ export class RoomRuntime {
 				};
 
 				// Fetch fresh room from DB for MCP server init (config may have changed)
-				const currentRoom = this.getRoomById(this.room.id) ?? this.room;
+				const currentRoom = this.getRoomById(this.roomId);
+				if (!currentRoom) {
+					throw new Error(`Room not found while restoring planner MCP server: ${this.roomId}`);
+				}
 				const goal = await this.goalManager.getGoalsForTask(task.id).then((g) => g[0] ?? null);
 				const mcpServer = createPlannerMcpServer({
 					task,
@@ -1078,7 +1099,7 @@ export class RoomRuntime {
 	 * checkpoints when there are no zombies (common case).
 	 */
 	private findZombieGroups(): SessionGroup[] {
-		const allActiveGroups = this.groupRepo.getActiveGroups(this.room.id);
+		const allActiveGroups = this.groupRepo.getActiveGroups(this.roomId);
 		const zombies: SessionGroup[] = [];
 
 		for (const group of allActiveGroups) {
@@ -1190,7 +1211,7 @@ export class RoomRuntime {
 
 		// Check capacity — awaiting_human groups are paused and don't consume slots
 		const activeGroups = this.groupRepo
-			.getActiveGroups(this.room.id)
+			.getActiveGroups(this.roomId)
 			.filter((g) => g.state !== 'awaiting_human');
 		const availableSlots = this.maxConcurrentGroups - activeGroups.length;
 
@@ -1359,7 +1380,14 @@ export class RoomRuntime {
 		};
 
 		// Fetch fresh room from DB for worker/leader init (config may have changed)
-		const currentRoom = this.getRoomById(this.room.id) ?? this.room;
+		const currentRoom = this.getRoomById(this.roomId);
+		if (!currentRoom) {
+			await this.taskManager.failTask(planningTask.id, `Room not found: ${this.roomId}`);
+			await this.emitTaskUpdateById(planningTask.id);
+			return;
+		}
+		const plannerModel = this.resolveAgentModel(currentRoom, 'planner');
+		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
 
 		// Build WorkerConfig for the Planner agent
 		// isPlanApproved uses a mutable ref — groupId is set after spawn() returns
@@ -1374,7 +1402,7 @@ export class RoomRuntime {
 			room: currentRoom,
 			sessionId: '', // placeholder — overwritten by initFactory
 			workspacePath: this.taskGroupManager.workspacePath,
-			model: this.taskGroupManager.model,
+			model: plannerModel,
 			createDraftTask,
 			updateDraftTask,
 			removeDraftTask,
@@ -1393,7 +1421,7 @@ export class RoomRuntime {
 				sessionId: '', // not used by buildLeaderTaskContext
 				workspacePath: this.taskGroupManager.workspacePath,
 				groupId: '', // not used by buildLeaderTaskContext
-				model: this.taskGroupManager.model,
+				model: leaderModel,
 				reviewContext: 'plan_review',
 			}),
 		};
@@ -1451,10 +1479,18 @@ export class RoomRuntime {
 			.map((t) => `${t.title}: ${t.result ?? 'completed'}`);
 
 		// Fetch fresh room from DB for worker/leader init (config may have changed)
-		const currentRoom = this.getRoomById(this.room.id) ?? this.room;
+		const currentRoom = this.getRoomById(this.roomId);
+		if (!currentRoom) {
+			await this.taskManager.failTask(task.id, `Room not found: ${this.roomId}`);
+			await this.emitTaskUpdateById(task.id);
+			return;
+		}
 
 		// Determine worker config based on assigned agent type
 		const agentType = task.assignedAgent ?? 'coder';
+		const workerRole = agentType === 'general' ? 'general' : 'coder';
+		const workerModel = this.resolveAgentModel(currentRoom, workerRole);
+		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
 		let workerConfig: WorkerConfig;
 
 		// Shared leader context config (groupId not used by buildLeaderTaskContext)
@@ -1465,7 +1501,7 @@ export class RoomRuntime {
 			sessionId: '',
 			workspacePath: this.taskGroupManager.workspacePath,
 			groupId: '',
-			model: this.taskGroupManager.model,
+			model: leaderModel,
 			reviewContext: 'code_review' as const,
 		};
 
@@ -1476,7 +1512,7 @@ export class RoomRuntime {
 				room: currentRoom,
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
-				model: this.taskGroupManager.model,
+				model: workerModel,
 				previousTaskSummaries,
 			};
 			workerConfig = {
@@ -1494,7 +1530,7 @@ export class RoomRuntime {
 				room: currentRoom,
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
-				model: this.taskGroupManager.model,
+				model: workerModel,
 				previousTaskSummaries,
 			};
 			workerConfig = {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -470,12 +470,10 @@ describe('Leader Agent', () => {
 		});
 
 		it('should create CLI reviewer with review-posted output format in prompt', () => {
-			const agents = buildReviewerAgents([
-				{ model: 'custom-cli', type: 'cli', driver_model: 'haiku' },
-			]);
+			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
 			const agent = agents['reviewer-custom-cli'];
 			expect(agent).toBeDefined();
-			expect(agent.model).toBe('haiku');
+			expect(agent.model).toBe('inherit');
 			expect(agent.prompt).toContain('custom-cli');
 			expect(agent.prompt).toContain('---REVIEW_POSTED---');
 			expect(agent.prompt).toContain('---END_REVIEW_POSTED---');
@@ -492,26 +490,24 @@ describe('Leader Agent', () => {
 			expect(agent.tools).not.toContain('Write');
 		});
 
-		it('should map full model ID to valid AgentModel for SDK-native reviewer', () => {
+		it('should set SDK-native reviewer runtime model to inherit', () => {
 			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6-20250929' }]);
 			const agent = agents['reviewer-opus'];
 			expect(agent).toBeDefined();
-			expect(agent.model).toBe('opus');
+			expect(agent.model).toBe('inherit');
 		});
 
-		it('should map full model ID to valid AgentModel for CLI reviewer', () => {
-			const agents = buildReviewerAgents([
-				{ model: 'custom-cli', type: 'cli', driver_model: 'claude-sonnet-4-5-20250929' },
-			]);
-			const agent = agents['reviewer-custom-cli'];
-			expect(agent).toBeDefined();
-			expect(agent.model).toBe('sonnet');
-		});
-
-		it('should default CLI reviewer to sonnet when no driver_model given', () => {
+		it('should set CLI reviewer runtime model to inherit', () => {
 			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
 			const agent = agents['reviewer-custom-cli'];
-			expect(agent.model).toBe('sonnet');
+			expect(agent).toBeDefined();
+			expect(agent.model).toBe('inherit');
+		});
+
+		it('should default CLI reviewer runtime model to inherit', () => {
+			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
+			const agent = agents['reviewer-custom-cli'];
+			expect(agent.model).toBe('inherit');
 		});
 	});
 
@@ -597,25 +593,22 @@ describe('Leader Agent', () => {
 	});
 
 	describe('buildReviewerAgents — CLI enhancements', () => {
-		it('should use leaderModel as default driver when no driver_model specified', () => {
+		it('should use inherit reviewer runtime model', () => {
 			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }], 'claude-opus-4-6');
 			const agent = agents['reviewer-copilot'];
-			expect(agent.model).toBe('opus');
+			expect(agent.model).toBe('inherit');
 		});
 
-		it('should fall back to sonnet when neither driver_model nor leaderModel given', () => {
+		it('should still use inherit when leaderModel is absent', () => {
 			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }]);
 			const agent = agents['reviewer-copilot'];
-			expect(agent.model).toBe('sonnet');
+			expect(agent.model).toBe('inherit');
 		});
 
-		it('should prefer explicit driver_model over leaderModel', () => {
-			const agents = buildReviewerAgents(
-				[{ model: 'copilot', type: 'cli', driver_model: 'haiku' }],
-				'claude-opus-4-6'
-			);
+		it('should ignore leaderModel for reviewer runtime model and keep inherit', () => {
+			const agents = buildReviewerAgents([{ model: 'copilot', type: 'cli' }], 'claude-opus-4-6');
 			const agent = agents['reviewer-copilot'];
-			expect(agent.model).toBe('haiku');
+			expect(agent.model).toBe('inherit');
 		});
 
 		it('should pass cliModel to CLI reviewer prompt', () => {
@@ -721,8 +714,8 @@ describe('Leader Agent', () => {
 		});
 	});
 
-	describe('createLeaderAgentInit — leaderModel passed to reviewers', () => {
-		it('should pass leader model to buildReviewerAgents as default driver', () => {
+	describe('createLeaderAgentInit — reviewer runtime model inheritance', () => {
+		it('should set reviewer runtime model to inherit by default', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(
 				makeConfig({
@@ -738,8 +731,7 @@ describe('Leader Agent', () => {
 				callbacks
 			);
 			const reviewerAgent = init.agents!['reviewer-copilot'];
-			// Driver model should be opus (inherited from leader model)
-			expect(reviewerAgent.model).toBe('opus');
+			expect(reviewerAgent.model).toBe('inherit');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -19,6 +19,100 @@ describe('RoomRuntime flow', () => {
 		ctx.db.close();
 	});
 
+	describe('agent model resolution', () => {
+		it('should use planner and leader models from room.config.agentModels', async () => {
+			ctx.runtime.stop();
+			ctx.db.close();
+			ctx = createRuntimeTestContext({
+				room: makeRoom({
+					defaultModel: 'room-default-model',
+					config: {
+						agentModels: {
+							planner: 'planner-model',
+							leader: 'leader-model',
+						},
+					},
+				}),
+			});
+
+			await ctx.goalManager.createGoal({
+				title: 'Planning goal',
+				description: 'Needs a plan',
+			});
+
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const createCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession'
+			);
+			expect(createCalls).toHaveLength(1);
+			expect(createCalls[0].args[1]).toBe('planner');
+			expect((createCalls[0].args[0] as { model?: string }).model).toBe('planner-model');
+
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			const leaderCall = ctx.sessionFactory.calls
+				.filter((c) => c.method === 'createAndStartSession')
+				.find((c) => c.args[1] === 'leader');
+			expect(leaderCall).toBeDefined();
+			expect((leaderCall!.args[0] as { model?: string }).model).toBe('leader-model');
+		});
+
+		it('should use role-specific worker model for coder and general tasks', async () => {
+			ctx.runtime.stop();
+			ctx.db.close();
+			ctx = createRuntimeTestContext({
+				room: makeRoom({
+					defaultModel: 'room-default-model',
+					config: {
+						agentModels: {
+							coder: 'coder-model',
+							general: 'general-model',
+							leader: 'leader-model',
+						},
+					},
+				}),
+			});
+
+			await createGoalAndTask(ctx, { assignedAgent: 'coder' });
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			let createCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession'
+			);
+			expect(createCalls[0].args[1]).toBe('coder');
+			expect((createCalls[0].args[0] as { model?: string }).model).toBe('coder-model');
+
+			ctx.runtime.stop();
+			ctx.db.close();
+			ctx = createRuntimeTestContext({
+				room: makeRoom({
+					defaultModel: 'room-default-model',
+					config: {
+						agentModels: {
+							coder: 'coder-model',
+							general: 'general-model',
+							leader: 'leader-model',
+						},
+					},
+				}),
+			});
+			await createGoalAndTask(ctx, { assignedAgent: 'general' });
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			createCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession'
+			);
+			expect(createCalls[0].args[1]).toBe('general');
+			expect((createCalls[0].args[0] as { model?: string }).model).toBe('general-model');
+		});
+	});
+
 	describe('onWorkerTerminalState', () => {
 		it('should route worker output to leader', async () => {
 			await createGoalAndTask(ctx);

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -71,7 +71,6 @@ interface SubagentConfig {
 	model: string;
 	provider?: string;
 	type?: 'cli';
-	driver_model?: string;
 	cliModel?: string;
 }
 

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -491,7 +491,7 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 				availableModels.value = (modelsRes.models ?? []).map((m) => ({
 					id: m.id,
 					name: m.display_name ?? m.name ?? m.id,
-					provider: m.provider ?? 'anthropic',
+					provider: m.provider ?? 'unknown',
 					family: detectFamily(m.id, m.provider),
 				}));
 				cliAgents.value = cliRes.agents ?? [];

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -24,6 +24,7 @@ interface ModelInfo {
 	id: string;
 	name: string;
 	family: string;
+	provider: string;
 }
 
 interface CliAgentInfo {
@@ -46,11 +47,11 @@ const MODEL_FAMILY_ICONS: Record<string, string> = {
 	__default__: '💎',
 };
 
-function detectFamily(id: string): string {
+function detectFamily(id: string, provider?: string): string {
 	if (id.includes('opus')) return 'opus';
 	if (id.includes('haiku')) return 'haiku';
-	if (id.toLowerCase().startsWith('glm-')) return 'glm';
-	if (id.toLowerCase().startsWith('minimax-')) return 'minimax';
+	if (provider === 'glm' || id.toLowerCase().startsWith('glm-')) return 'glm';
+	if (provider === 'minimax' || id.toLowerCase().startsWith('minimax-')) return 'minimax';
 	return 'sonnet';
 }
 
@@ -476,7 +477,12 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 				const hub = await connectionManager.getHub();
 				const [modelsRes, cliRes] = await Promise.all([
 					hub.request<{
-						models: Array<{ id: string; display_name?: string; name?: string }>;
+						models: Array<{
+							id: string;
+							display_name?: string;
+							name?: string;
+							provider?: string;
+						}>;
 					}>('models.list'),
 					hub
 						.request<{ agents: CliAgentInfo[] }>('agents.cli.list')
@@ -485,7 +491,8 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 				availableModels.value = (modelsRes.models ?? []).map((m) => ({
 					id: m.id,
 					name: m.display_name ?? m.name ?? m.id,
-					family: detectFamily(m.id),
+					provider: m.provider ?? 'anthropic',
+					family: detectFamily(m.id, m.provider),
 				}));
 				cliAgents.value = cliRes.agents ?? [];
 			} catch {
@@ -552,6 +559,13 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 		const m = availableModels.value.find((m) => m.id === selectedDefaultModel.value);
 		return m ? `Default (${m.name})` : `Default (${selectedDefaultModel.value})`;
 	});
+
+	// SDK subagents currently run inside the parent SDK/provider context.
+	// Restrict subagent model selection to Anthropic models to avoid
+	// implying independent provider routing (e.g. glm/minimax per subagent).
+	const sdkSubagentModels = useComputed(() =>
+		availableModels.value.filter((m) => m.provider === 'anthropic')
+	);
 
 	const updateAgentModel = useCallback(
 		(key: string, model: string) => {
@@ -779,9 +793,9 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 										</div>
 
 										{/* Sub Agent Models */}
-										<div class="text-xs text-gray-500 mb-2">Sub Agent Models</div>
+										<div class="text-xs text-gray-500 mb-2">Sub Agent Models (Anthropic)</div>
 										<ModelTagsInput
-											models={availableModels.value}
+											models={sdkSubagentModels.value}
 											selected={getSdkSubagentsFor(agent.key)
 												.map((s) => s.model)
 												.filter(Boolean)}


### PR DESCRIPTION
## Summary
- remove reviewer runtime model pinning and set reviewer subagents to `inherit`
- remove `driver_model` from room subagent config (daemon + web type + design doc example)
- resolve planner/coder/general/leader models per-role from `room.config.agentModels`
- stop using cached room object in `RoomRuntime`; keep only `roomId` and re-query room config when needed
- add unit coverage for role-specific model resolution in room runtime flow tests

## Notes
- existing sessions in DB keep their old model snapshot; new sessions/groups use the new behavior

## Validation
- unable to run full checks in this environment (`oxlint`/`tsc` missing locally)
