### PR TITLE
feat: add Dev Proxy infrastructure for test environment

### DIFF
--- a/.devproxy/devproxyrc.json
+++ b/.devproxy/devproxyrc.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/rc.schema.json",
+	"plugins": [
+		{
+			"name": "MockResponsePlugin",
+			"enabled": true,
+			"pluginPath": "~appFolder/plugins/DevProxy.Plugins.dll",
+			"configSection": "mockResponsePlugin"
+		}
+	],
+	"urlsToWatch": ["https://api.anthropic.com/*"],
+	"mockResponsePlugin": {
+		"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.schema.json",
+		"mocksFile": "mocks.json"
+	},
+	"logLevel": "information",
+	"port": 8000,
+	"labelMode": "text"
+}

--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -1,0 +1,53 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"mocks": [
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST"
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-limit",
+						"value": "50"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-remaining",
+						"value": "49"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin"
+					}
+				],
+				"body": {
+					"id": "msg_mock123",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "[MOCKED BY DEV PROXY] Hello! This is a mocked response from Dev Proxy for testing purposes."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 12,
+						"output_tokens": 48,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		}
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ coverage-parts/
 **/coverage/
 browser-coverage.json
 browser-coverage.lcov
+
+# Dev Proxy runtime files
+.devproxy/.devproxy.pid
+.devproxy/devproxy.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev serve-random self self-test run run-e2e build test test-daemon test-web test-shared e2e e2e-ui lint lint-fix format typecheck check compile compile-all package-npm release sync-sdk-types setup-hooks setup
+.PHONY: dev serve-random self self-test run run-e2e build test test-daemon test-web test-shared e2e e2e-ui lint lint-fix format typecheck check compile compile-all package-npm release sync-sdk-types setup-hooks setup test-proxy-start test-proxy-stop test-proxy-status test-proxy-restart
 
 # Default workspace for development
 WORKSPACE ?= tmp/workspace
@@ -170,3 +170,17 @@ setup-hooks:
 # Full development environment setup
 setup: setup-hooks
 	@echo "✅ Development environment ready"
+
+# Dev Proxy management for tests
+# Usage: make test-proxy-start, make test-proxy-stop, etc.
+test-proxy-start:
+	@./scripts/dev-proxy.sh start
+
+test-proxy-stop:
+	@./scripts/dev-proxy.sh stop
+
+test-proxy-status:
+	@./scripts/dev-proxy.sh status
+
+test-proxy-restart:
+	@./scripts/dev-proxy.sh restart

--- a/docs/dev-proxy-integration.md
+++ b/docs/dev-proxy-integration.md
@@ -68,13 +68,63 @@ Per [GitHub Issue #169](https://github.com/anthropics/claude-agent-sdk-typescrip
 ### Directory Structure
 
 ```
-tests/dev-proxy/
+.devproxy/
 ├── devproxyrc.json    # Main configuration
 ├── mocks.json         # Mock response definitions
-└── certs/             # Dev Proxy certificates (auto-generated)
+├── .devproxy.pid      # PID file (generated at runtime)
+└── devproxy.log       # Log file (generated at runtime)
+```
+
+## Quick Start
+
+### 1. Install Dev Proxy
+
+**macOS (Homebrew):**
+```bash
+brew tap dotnet/dev-proxy
+brew install dev-proxy
+```
+
+**Linux:**
+```bash
+curl -sL https://aka.ms/install-dev-proxy | bash
+```
+
+**Windows:**
+```powershell
+winget install Microsoft.DevProxy
+```
+
+### 2. Start Dev Proxy
+
+Using npm scripts:
+```bash
+bun run test:proxy:start
+# or
+make test-proxy-start
+```
+
+### 3. Configure Environment
+
+Set these environment variables before running tests:
+```bash
+export HTTPS_PROXY=http://127.0.0.1:8000
+export HTTP_PROXY=http://127.0.0.1:8000
+export NODE_USE_ENV_PROXY=1
+export NODE_EXTRA_CA_CERTS=~/.proxy/rootCA.pem
+```
+
+### 4. Stop Dev Proxy
+
+```bash
+bun run test:proxy:stop
+# or
+make test-proxy-stop
 ```
 
 ### devproxyrc.json
+
+Located at `.devproxy/devproxyrc.json`:
 
 ```json
 {
@@ -84,23 +134,25 @@ tests/dev-proxy/
       "name": "MockResponsePlugin",
       "enabled": true,
       "pluginPath": "~appFolder/plugins/DevProxy.Plugins.dll",
-      "configSection": "anthropicMocks"
+      "configSection": "mockResponsePlugin"
     }
   ],
-  "urlsToWatch": [
-    "https://api.anthropic.com/*"
-  ],
-  "anthropicMocks": {
+  "urlsToWatch": ["https://api.anthropic.com/*"],
+  "mockResponsePlugin": {
     "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.schema.json",
     "mocksFile": "mocks.json"
   },
   "logLevel": "information",
-  "port": 8000
+  "port": 8000,
+  "labelMode": "text"
 }
 ```
 
 ### mocks.json
 
+Located at `.devproxy/mocks.json`. See the actual file for the current mock definitions.
+
+Example structure:
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
@@ -113,30 +165,15 @@ tests/dev-proxy/
       "response": {
         "statusCode": 200,
         "headers": [
-          { "name": "content-type", "value": "application/json" },
-          { "name": "anthropic-ratelimit-requests-limit", "value": "50" },
-          { "name": "anthropic-ratelimit-requests-remaining", "value": "49" }
+          { "name": "content-type", "value": "application/json" }
         ],
         "body": {
-          "id": "msg_test123",
+          "id": "msg_mock123",
           "type": "message",
           "role": "assistant",
-          "content": [
-            {
-              "type": "text",
-              "text": "This is a mock response from Dev Proxy."
-            }
-          ],
+          "content": [{ "type": "text", "text": "Mocked response" }],
           "model": "claude-sonnet-4-20250514",
-          "stop_reason": "end_turn",
-          "stop_sequence": null,
-          "usage": {
-            "input_tokens": 12,
-            "output_tokens": 48,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "service_tier": "standard"
-          }
+          "stop_reason": "end_turn"
         }
       }
     }
@@ -144,26 +181,20 @@ tests/dev-proxy/
 }
 ```
 
-## Installation
-
-### macOS (Homebrew)
-
-```bash
-brew tap dotnet/dev-proxy
-brew install dev-proxy
-```
-
-### Other Platforms
-
-See [Dev Proxy Setup Guide](https://learn.microsoft.com/en-us/microsoft-cloud/dev/dev-proxy/get-started/set-up)
-
 ## Running Dev Proxy
 
 ### Start Dev Proxy
 
+Using npm scripts (recommended):
 ```bash
-cd tests/dev-proxy
-devproxy
+bun run test:proxy:start
+# or
+make test-proxy-start
+```
+
+Manual start:
+```bash
+cd .devproxy && devproxy
 ```
 
 ### Verify Proxy is Working
@@ -174,6 +205,32 @@ curl -ikx http://127.0.0.1:8000 https://api.anthropic.com/v1/messages \
   -H "content-type: application/json" \
   -H "x-api-key: test-key" \
   -H "anthropic-version: 2023-06-01"
+```
+
+### Status and Management
+
+```bash
+# Check if Dev Proxy is running
+bun run test:proxy:status
+# or
+make test-proxy-status
+
+# Stop Dev Proxy
+bun run test:proxy:stop
+# or
+make test-proxy-stop
+
+# Restart Dev Proxy
+bun run test:proxy:restart
+# or
+make test-proxy-restart
+```
+
+### Port Configuration
+
+The default port is 8000. To use a different port:
+```bash
+DEV_PROXY_PORT=9000 bun run test:proxy:start
 ```
 
 ## Integration with Tests

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
 		"typecheck": "tsc --build --noEmit",
 		"knip": "knip --include files,dependencies,exports --no-config-hints",
 		"knip:all": "knip",
-		"check": "bun run lint && bun run typecheck && bun run knip"
+		"check": "bun run lint && bun run typecheck && bun run knip",
+		"test:proxy:start": "./scripts/dev-proxy.sh start",
+		"test:proxy:stop": "./scripts/dev-proxy.sh stop",
+		"test:proxy:status": "./scripts/dev-proxy.sh status",
+		"test:proxy:restart": "./scripts/dev-proxy.sh restart"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.4",

--- a/scripts/dev-proxy.sh
+++ b/scripts/dev-proxy.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Dev Proxy management script for NeoKai tests
+# Usage: ./scripts/dev-proxy.sh [start|stop|status|restart]
+
+set -e
+
+DEV_PROXY_DIR="$(cd "$(dirname "$0")/.." && pwd)/.devproxy"
+PID_FILE="$DEV_PROXY_DIR/.devproxy.pid"
+LOG_FILE="$DEV_PROXY_DIR/devproxy.log"
+PORT="${DEV_PROXY_PORT:-8000}"
+
+start_proxy() {
+	if [ -f "$PID_FILE" ]; then
+		PID=$(cat "$PID_FILE")
+		if ps -p "$PID" > /dev/null 2>&1; then
+			echo "Dev Proxy is already running (PID: $PID)"
+			return 0
+		else
+			echo "Removing stale PID file"
+			rm -f "$PID_FILE"
+		fi
+	fi
+
+	echo "Starting Dev Proxy on port $PORT..."
+
+	# Check if devproxy is installed
+	if ! command -v devproxy &> /dev/null; then
+		echo "Error: devproxy is not installed."
+		echo ""
+		echo "Install with Homebrew (macOS):"
+		echo "  brew tap dotnet/dev-proxy"
+		echo "  brew install dev-proxy"
+		echo ""
+		echo "Or follow instructions at:"
+		echo "  https://learn.microsoft.com/en-us/microsoft-cloud/dev/dev-proxy/get-started/set-up"
+		exit 1
+	fi
+
+	# Start Dev Proxy in detached mode (requires v2.2.0+)
+	cd "$DEV_PROXY_DIR"
+	nohup devproxy --port "$PORT" > "$LOG_FILE" 2>&1 &
+	PID=$!
+	echo $PID > "$PID_FILE"
+
+	# Wait a moment and check if it started successfully
+	sleep 2
+	if ps -p "$PID" > /dev/null 2>&1; then
+		echo "Dev Proxy started successfully (PID: $PID)"
+		echo "  Port: $PORT"
+		echo "  Log: $LOG_FILE"
+		echo ""
+		echo "Environment variables for tests:"
+		echo "  export HTTPS_PROXY=http://127.0.0.1:$PORT"
+		echo "  export HTTP_PROXY=http://127.0.0.1:$PORT"
+		echo "  export NODE_USE_ENV_PROXY=1"
+		echo "  export NODE_EXTRA_CA_CERTS=~/.proxy/rootCA.pem"
+	else
+		echo "Error: Dev Proxy failed to start. Check log file: $LOG_FILE"
+		rm -f "$PID_FILE"
+		exit 1
+	fi
+}
+
+stop_proxy() {
+	if [ ! -f "$PID_FILE" ]; then
+		echo "Dev Proxy is not running (no PID file found)"
+		return 0
+	fi
+
+	PID=$(cat "$PID_FILE")
+	if ps -p "$PID" > /dev/null 2>&1; then
+		echo "Stopping Dev Proxy (PID: $PID)..."
+		kill "$PID" 2>/dev/null || true
+
+		# Wait for process to terminate
+		for i in {1..10}; do
+			if ! ps -p "$PID" > /dev/null 2>&1; then
+				break
+			fi
+			sleep 0.5
+		done
+
+		# Force kill if still running
+		if ps -p "$PID" > /dev/null 2>&1; then
+			echo "Force killing Dev Proxy..."
+			kill -9 "$PID" 2>/dev/null || true
+		fi
+
+		rm -f "$PID_FILE"
+		echo "Dev Proxy stopped"
+	else
+		echo "Dev Proxy is not running (removing stale PID file)"
+		rm -f "$PID_FILE"
+	fi
+}
+
+status_proxy() {
+	if [ ! -f "$PID_FILE" ]; then
+		echo "Dev Proxy is not running"
+		return 1
+	fi
+
+	PID=$(cat "$PID_FILE")
+	if ps -p "$PID" > /dev/null 2>&1; then
+		echo "Dev Proxy is running (PID: $PID, Port: $PORT)"
+		return 0
+	else
+		echo "Dev Proxy is not running (stale PID file)"
+		return 1
+	fi
+}
+
+case "${1:-}" in
+	start)
+		start_proxy
+		;;
+	stop)
+		stop_proxy
+		;;
+	status)
+		status_proxy
+		;;
+	restart)
+		stop_proxy
+		start_proxy
+		;;
+	*)
+		echo "Usage: $0 {start|stop|status|restart}"
+		echo ""
+		echo "Environment variables:"
+		echo "  DEV_PROXY_PORT  Port to run Dev Proxy on (default: 8000)"
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Set up foundational Dev Proxy configuration for mocking Anthropic API
in tests to improve stability and reduce costs.

Changes:
- Add .devproxy/ directory with devproxyrc.json and mocks.json
- Create scripts/dev-proxy.sh for managing Dev Proxy lifecycle
- Add npm scripts: test:proxy:start, test:proxy:stop, test:proxy:status
- Add Makefile targets for Dev Proxy management
- Update docs/dev-proxy-integration.md with quick start guide
- Add .gitignore entries for Dev Proxy runtime files
