### PR TITLE
feat(test): add Dev Proxy helper for test environment

### DIFF
--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -4,6 +4,15 @@
  * Provides two modes:
  * 1. In-process (default): Runs daemon in same process for coverage collection
  * 2. Spawned process: Runs daemon as separate process for true isolation
+ *
+ * ## Dev Proxy Integration
+ *
+ * When NEOKAI_USE_DEV_PROXY=1 is set, the helper will:
+ * 1. Start Dev Proxy before creating the daemon server
+ * 2. Set proxy environment variables (HTTPS_PROXY, NODE_USE_ENV_PROXY, etc.)
+ * 3. Stop Dev Proxy when the daemon server is cleaned up
+ *
+ * This allows tests to run without making real API calls to Anthropic.
  */
 
 import { spawn } from 'child_process';
@@ -12,6 +21,11 @@ import { MessageHub, WebSocketClientTransport } from '@neokai/shared';
 import { createDaemonApp, type DaemonAppContext } from '../../src/app';
 import { getConfig } from '../../src/config';
 import { installAutoMock, simpleTextResponse, type MockControls } from './mock-sdk';
+import {
+	createDevProxyController,
+	type DevProxyController,
+	type DevProxyOptions,
+} from './dev-proxy';
 
 export interface DaemonServerOptions {
 	/**
@@ -24,6 +38,18 @@ export interface DaemonServerOptions {
 	 * Environment variables to pass to the daemon process
 	 */
 	env?: Record<string, string>;
+
+	/**
+	 * Dev Proxy options for mocking HTTP requests
+	 * Only used when NEOKAI_USE_DEV_PROXY=1 is set
+	 */
+	devProxy?: DevProxyOptions;
+
+	/**
+	 * Force enable Dev Proxy even without NEOKAI_USE_DEV_PROXY=1
+	 * Default: false
+	 */
+	useDevProxy?: boolean;
 }
 
 export interface DaemonServerContext {
@@ -67,6 +93,12 @@ export interface DaemonServerContext {
 	 * Use to override responses per-session or change defaults.
 	 */
 	mockControls: MockControls | null;
+
+	/**
+	 * Dev Proxy controller (only when NEOKAI_USE_DEV_PROXY=1 or useDevProxy=true).
+	 * Use to switch mock files or check proxy status.
+	 */
+	devProxy: DevProxyController | null;
 }
 
 /**
@@ -76,21 +108,50 @@ export interface DaemonServerContext {
  * allowing true process isolation and proper WebSocket testing.
  */
 async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<DaemonServerContext> {
-	const { port: userPort = 19400 + Math.floor(Math.random() * 1000), env: customEnv = {} } =
-		options;
+	const {
+		port: userPort = 19400 + Math.floor(Math.random() * 1000),
+		env: customEnv = {},
+		devProxy: devProxyOptions,
+		useDevProxy = false,
+	} = options;
+
+	// Start Dev Proxy if requested
+	let devProxy: DevProxyController | null = null;
+	const shouldUseDevProxy = useDevProxy || process.env.NEOKAI_USE_DEV_PROXY === '1';
+
+	if (shouldUseDevProxy) {
+		devProxy = createDevProxyController({
+			setEnvVars: true,
+			...devProxyOptions,
+		});
+		await devProxy.start();
+	}
 
 	// Create a standalone daemon server entry point
 	const serverPath = path.join(__dirname, 'standalone-server.ts');
 
+	// Build environment for daemon process
+	const daemonEnv: Record<string, string> = {
+		...process.env,
+		PORT: userPort.toString(),
+		NODE_ENV: 'test',
+		NEOKAI_SDK_STARTUP_TIMEOUT_MS: process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS || '30000',
+		...customEnv,
+	};
+
+	// Include Dev Proxy env vars if proxy is running
+	if (devProxy?.isRunning()) {
+		daemonEnv.HTTPS_PROXY = devProxy.proxyUrl;
+		daemonEnv.HTTP_PROXY = devProxy.proxyUrl;
+		daemonEnv.NODE_USE_ENV_PROXY = '1';
+		if (process.env.NODE_EXTRA_CA_CERTS) {
+			daemonEnv.NODE_EXTRA_CA_CERTS = process.env.NODE_EXTRA_CA_CERTS;
+		}
+	}
+
 	// Spawn the daemon server
 	const daemonProcess = spawn('bun', ['run', serverPath], {
-		env: {
-			...process.env,
-			PORT: userPort.toString(),
-			NODE_ENV: 'test',
-			NEOKAI_SDK_STARTUP_TIMEOUT_MS: process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS || '30000',
-			...customEnv,
-		},
+		env: daemonEnv,
 		stdio: 'pipe',
 		// Don't use detached: true - we want to be able to track and kill the process
 		detached: false,
@@ -169,6 +230,7 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 		messageHub,
 		baseUrl: `http://127.0.0.1:${userPort}`,
 		mockControls: null, // Mock not available in spawned process mode
+		devProxy,
 		kill: (signal: NodeJS.Signals = 'SIGTERM') => daemonProcess.kill(signal),
 		waitForExit: async () => {
 			// Cleanup tracked sessions before exiting
@@ -180,6 +242,11 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 				}
 				daemonProcess.once('exit', () => resolve());
 			});
+			// Stop Dev Proxy if it was started
+			if (devProxy) {
+				await devProxy.stop();
+				devProxy.restoreEnv();
+			}
 		},
 		trackSession: (sessionId: string) => {
 			trackedSessions.push(sessionId);
@@ -202,8 +269,24 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 async function createInProcessDaemonServer(
 	options: DaemonServerOptions = {}
 ): Promise<DaemonServerContext & { daemonContext: DaemonAppContext }> {
-	const { port: userPort = 19400 + Math.floor(Math.random() * 1000), env: customEnv = {} } =
-		options;
+	const {
+		port: userPort = 19400 + Math.floor(Math.random() * 1000),
+		env: customEnv = {},
+		devProxy: devProxyOptions,
+		useDevProxy = false,
+	} = options;
+
+	// Start Dev Proxy if requested
+	let devProxy: DevProxyController | null = null;
+	const shouldUseDevProxy = useDevProxy || process.env.NEOKAI_USE_DEV_PROXY === '1';
+
+	if (shouldUseDevProxy) {
+		devProxy = createDevProxyController({
+			setEnvVars: true,
+			...devProxyOptions,
+		});
+		await devProxy.start();
+	}
 
 	// Apply custom env vars
 	for (const [key, value] of Object.entries(customEnv)) {
@@ -285,6 +368,7 @@ async function createInProcessDaemonServer(
 		baseUrl: `http://127.0.0.1:${userPort}`,
 		daemonContext, // Expose for advanced usage
 		mockControls,
+		devProxy,
 		kill: () => {
 			// For in-process, cleanup happens in waitForExit - just return true
 			return true;
@@ -316,6 +400,12 @@ async function createInProcessDaemonServer(
 			} catch {
 				// Timeout or error - force cleanup workspace anyway
 				await Bun.$`rm -rf ${workspace}`.quiet();
+			}
+
+			// Stop Dev Proxy if it was started
+			if (devProxy) {
+				await devProxy.stop();
+				devProxy.restoreEnv();
 			}
 		},
 		trackSession: (sessionId: string) => {

--- a/packages/daemon/tests/helpers/dev-proxy.ts
+++ b/packages/daemon/tests/helpers/dev-proxy.ts
@@ -1,0 +1,481 @@
+/**
+ * Dev Proxy Test Helper
+ *
+ * Manages Dev Proxy lifecycle for integration tests that need to mock
+ * HTTP requests to external APIs (like Anthropic API).
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { createDevProxyController, type DevProxyController } from './dev-proxy';
+ *
+ * describe('My API tests', () => {
+ *   let proxy: DevProxyController;
+ *
+ *   beforeEach(async () => {
+ *     proxy = createDevProxyController();
+ *     await proxy.start();
+ *   });
+ *
+ *   afterEach(async () => {
+ *     await proxy.stop();
+ *   });
+ *
+ *   it('should mock API response', async () => {
+ *     // Set environment for tests
+ *     process.env.HTTPS_PROXY = proxy.proxyUrl;
+ *     process.env.HTTP_PROXY = proxy.proxyUrl;
+ *     process.env.NODE_USE_ENV_PROXY = '1';
+ *     // ... test code
+ *   });
+ * });
+ * ```
+ *
+ * ## Environment Variables
+ *
+ * The helper automatically sets these env vars on start:
+ * - HTTPS_PROXY: The proxy URL for HTTPS requests
+ * - HTTP_PROXY: The proxy URL for HTTP requests
+ * - NODE_USE_ENV_PROXY: Enables Node.js to use proxy env vars
+ * - NODE_EXTRA_CA_CERTS: Path to Dev Proxy's CA certificate
+ *
+ * ## Prerequisites
+ *
+ * Dev Proxy must be installed. See:
+ * https://learn.microsoft.com/en-us/microsoft-cloud/dev/dev-proxy/get-started/set-up
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { setTimeout as sleep } from 'timers/promises';
+
+/**
+ * Configuration options for Dev Proxy controller
+ */
+export interface DevProxyOptions {
+	/**
+	 * Port to run Dev Proxy on
+	 * Default: 8000
+	 */
+	port?: number;
+
+	/**
+	 * Path to devproxyrc.json configuration file
+	 * Default: <repo-root>/.devproxy/devproxyrc.json
+	 */
+	configPath?: string;
+
+	/**
+	 * Path to mocks.json file
+	 * Default: <repo-root>/.devproxy/mocks.json
+	 */
+	mocksPath?: string;
+
+	/**
+	 * Timeout in ms to wait for proxy to start
+	 * Default: 10000
+	 */
+	startTimeout?: number;
+
+	/**
+	 * Whether to automatically set environment variables on start
+	 * Default: true
+	 */
+	setEnvVars?: boolean;
+
+	/**
+	 * Log level for Dev Proxy
+	 * Default: 'warning' (reduced output during tests)
+	 */
+	logLevel?: 'debug' | 'information' | 'warning' | 'error' | 'trace';
+}
+
+/**
+ * Controller interface for managing Dev Proxy lifecycle
+ */
+export interface DevProxyController {
+	/**
+	 * Start Dev Proxy process
+	 * @throws Error if proxy fails to start within timeout
+	 */
+	start(): Promise<void>;
+
+	/**
+	 * Stop Dev Proxy process gracefully
+	 */
+	stop(): Promise<void>;
+
+	/**
+	 * Check if Dev Proxy is currently running
+	 */
+	isRunning(): boolean;
+
+	/**
+	 * Wait for proxy to be ready (health check)
+	 * @param timeout - Timeout in ms
+	 */
+	waitForReady(timeout?: number): Promise<void>;
+
+	/**
+	 * Load a different mock file by updating devproxyrc.json
+	 * @param mockFilePath - Path to the new mock file (relative to .devproxy dir or absolute)
+	 */
+	loadMockFile(mockFilePath: string): void;
+
+	/**
+	 * Get the proxy URL (e.g., http://127.0.0.1:8000)
+	 */
+	readonly proxyUrl: string;
+
+	/**
+	 * Get the proxy port
+	 */
+	readonly port: number;
+
+	/**
+	 * Get the process PID (if running)
+	 */
+	readonly pid: number | undefined;
+
+	/**
+	 * Restore original environment variables that were modified
+	 */
+	restoreEnv(): void;
+}
+
+/**
+ * Find the repository root directory by looking for package.json with workspaces
+ */
+function findRepoRoot(startDir: string): string | null {
+	let dir = startDir;
+	while (dir !== path.dirname(dir)) {
+		const pkgPath = path.join(dir, 'package.json');
+		if (fs.existsSync(pkgPath)) {
+			try {
+				const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+				if (pkg.workspaces) {
+					return dir;
+				}
+			} catch {
+				// Continue searching
+			}
+		}
+		dir = path.dirname(dir);
+	}
+	return null;
+}
+
+/**
+ * Get the path to Dev Proxy's root CA certificate
+ */
+function getCaCertPath(): string {
+	// Dev Proxy stores CA cert in ~/.proxy/rootCA.pem on macOS/Linux
+	const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+	return path.join(homeDir, '.proxy', 'rootCA.pem');
+}
+
+/**
+ * Check if devproxy command is available
+ */
+async function isDevProxyInstalled(): Promise<boolean> {
+	return new Promise((resolve) => {
+		const proc = spawn('which', ['devproxy'], { stdio: 'ignore' });
+		proc.on('close', (code) => resolve(code === 0));
+		proc.on('error', () => resolve(false));
+	});
+}
+
+/**
+ * Create a Dev Proxy controller instance
+ */
+export function createDevProxyController(options: DevProxyOptions = {}): DevProxyController {
+	const {
+		port = 8000,
+		configPath: userConfigPath,
+		mocksPath: userMocksPath,
+		startTimeout = 10000,
+		setEnvVars = true,
+		logLevel = 'warning',
+	} = options;
+
+	// Resolve paths
+	const repoRoot = findRepoRoot(__dirname);
+	if (!repoRoot) {
+		throw new Error('Could not find repository root directory');
+	}
+
+	const devProxyDir = path.join(repoRoot, '.devproxy');
+	const configPath = userConfigPath || path.join(devProxyDir, 'devproxyrc.json');
+	const mocksPath = userMocksPath || path.join(devProxyDir, 'mocks.json');
+	const logPath = path.join(devProxyDir, 'devproxy.log');
+
+	// State
+	let process: ChildProcess | null = null;
+	let originalEnv: Record<string, string | undefined> = {};
+
+	// Helper to check if proxy is responding
+	const checkProxyReady = async (): Promise<boolean> => {
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/`, {
+				method: 'GET',
+			});
+			// Dev Proxy may return 502 for requests it doesn't intercept, but that means it's running
+			return response.status !== 0;
+		} catch {
+			return false;
+		}
+	};
+
+	// Store original env var
+	const saveEnvVar = (key: string) => {
+		if (!(key in originalEnv)) {
+			originalEnv[key] = process?.env?.[key] ?? globalThis.process.env[key];
+		}
+	};
+
+	// Set environment variables for proxy
+	const setProxyEnvVars = () => {
+		const proxyUrl = `http://127.0.0.1:${port}`;
+		const caCertPath = getCaCertPath();
+
+		saveEnvVar('HTTPS_PROXY');
+		saveEnvVar('HTTP_PROXY');
+		saveEnvVar('NODE_USE_ENV_PROXY');
+		saveEnvVar('NODE_EXTRA_CA_CERTS');
+		saveEnvVar('NO_PROXY');
+
+		globalThis.process.env.HTTPS_PROXY = proxyUrl;
+		globalThis.process.env.HTTP_PROXY = proxyUrl;
+		globalThis.process.env.NODE_USE_ENV_PROXY = '1';
+
+		// Set CA cert path if it exists
+		if (fs.existsSync(caCertPath)) {
+			globalThis.process.env.NODE_EXTRA_CA_CERTS = caCertPath;
+		}
+
+		// Don't proxy localhost
+		globalThis.process.env.NO_PROXY = 'localhost,127.0.0.1';
+	};
+
+	const controller: DevProxyController = {
+		get proxyUrl() {
+			return `http://127.0.0.1:${port}`;
+		},
+
+		get port() {
+			return port;
+		},
+
+		get pid() {
+			return process?.pid;
+		},
+
+		async start() {
+			if (process) {
+				throw new Error('Dev Proxy is already running');
+			}
+
+			// Check if devproxy is installed
+			if (!(await isDevProxyInstalled())) {
+				throw new Error(
+					'devproxy is not installed. Install with: brew tap dotnet/dev-proxy && brew install dev-proxy'
+				);
+			}
+
+			// Ensure log directory exists
+			const logDir = path.dirname(logPath);
+			if (!fs.existsSync(logDir)) {
+				fs.mkdirSync(logDir, { recursive: true });
+			}
+
+			// Start Dev Proxy
+			return new Promise((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					if (process) {
+						process.kill('SIGTERM');
+						process = null;
+					}
+					reject(new Error(`Dev Proxy failed to start within ${startTimeout}ms`));
+				}, startTimeout);
+
+				// Open log file for writing
+				const logFile = fs.openSync(logPath, 'w');
+
+				// Spawn devproxy process
+				process = spawn('devproxy', ['--port', String(port), '--log-level', logLevel], {
+					cwd: devProxyDir,
+					stdio: ['ignore', logFile, logFile],
+					detached: false,
+				});
+
+				process.on('error', (err) => {
+					clearTimeout(timeout);
+					process = null;
+					reject(new Error(`Failed to start Dev Proxy: ${err.message}`));
+				});
+
+				process.on('exit', (code, signal) => {
+					if (code !== 0 && code !== null) {
+						// Only reject if we haven't already resolved
+						clearTimeout(timeout);
+						if (process) {
+							process = null;
+							reject(new Error(`Dev Proxy exited with code ${code}`));
+						}
+					}
+				});
+
+				// Poll for proxy readiness
+				const checkReady = async () => {
+					try {
+						const ready = await checkProxyReady();
+						if (ready) {
+							clearTimeout(timeout);
+							if (setEnvVars) {
+								setProxyEnvVars();
+							}
+							resolve();
+						} else {
+							setTimeout(checkReady, 100);
+						}
+					} catch {
+						setTimeout(checkReady, 100);
+					}
+				};
+
+				// Give process a moment to start before checking
+				setTimeout(checkReady, 500);
+			});
+		},
+
+		async stop() {
+			if (!process) {
+				return;
+			}
+
+			return new Promise((resolve) => {
+				const proc = process;
+				process = null;
+
+				if (!proc) {
+					resolve();
+					return;
+				}
+
+				// Set up exit handler
+				const exitHandler = () => {
+					resolve();
+				};
+				proc.on('exit', exitHandler);
+
+				// Send SIGTERM for graceful shutdown
+				proc.kill('SIGTERM');
+
+				// Force kill after 5 seconds
+				setTimeout(() => {
+					if (proc.pid) {
+						try {
+							process?.kill('SIGKILL');
+						} catch {
+							// Process already dead
+						}
+					}
+					resolve();
+				}, 5000);
+			});
+		},
+
+		isRunning() {
+			return process !== null && process.pid !== undefined;
+		},
+
+		async waitForReady(timeout = 5000) {
+			const startTime = Date.now();
+			while (Date.now() - startTime < timeout) {
+				if (await checkProxyReady()) {
+					return;
+				}
+				await sleep(100);
+			}
+			throw new Error(`Dev Proxy not ready within ${timeout}ms`);
+		},
+
+		loadMockFile(mockFilePath: string) {
+			// Resolve relative paths to absolute
+			const absoluteMockPath = path.isAbsolute(mockFilePath)
+				? mockFilePath
+				: path.join(devProxyDir, mockFilePath);
+
+			if (!fs.existsSync(absoluteMockPath)) {
+				throw new Error(`Mock file not found: ${absoluteMockPath}`);
+			}
+
+			// Read and update devproxyrc.json
+			const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+			// Update the mocks file path (relative to .devproxy dir)
+			const relativeMockPath = path.relative(devProxyDir, absoluteMockPath);
+			config.mockResponsePlugin = config.mockResponsePlugin || {};
+			config.mockResponsePlugin.mocksFile = relativeMockPath;
+
+			fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+			// Note: Dev Proxy needs to be restarted for changes to take effect
+			// This is a known limitation
+		},
+
+		restoreEnv() {
+			for (const [key, value] of Object.entries(originalEnv)) {
+				if (value === undefined) {
+					delete globalThis.process.env[key];
+				} else {
+					globalThis.process.env[key] = value;
+				}
+			}
+			originalEnv = {};
+		},
+	};
+
+	return controller;
+}
+
+/**
+ * Global Dev Proxy controller for shared use across tests
+ *
+ * Use this when you want a single proxy instance for all tests.
+ * Call startGlobalDevProxy() in beforeAll and stopGlobalDevProxy() in afterAll.
+ */
+let globalController: DevProxyController | null = null;
+
+/**
+ * Start a global Dev Proxy instance
+ *
+ * This is useful for test suites that share a single proxy instance.
+ */
+export async function startGlobalDevProxy(options?: DevProxyOptions): Promise<DevProxyController> {
+	if (globalController) {
+		return globalController;
+	}
+	globalController = createDevProxyController(options);
+	await globalController.start();
+	return globalController;
+}
+
+/**
+ * Stop the global Dev Proxy instance
+ */
+export async function stopGlobalDevProxy(): Promise<void> {
+	if (globalController) {
+		await globalController.stop();
+		globalController.restoreEnv();
+		globalController = null;
+	}
+}
+
+/**
+ * Get the global Dev Proxy controller (if started)
+ */
+export function getGlobalDevProxy(): DevProxyController | null {
+	return globalController;
+}

--- a/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
+++ b/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for Dev Proxy helper module
+ *
+ * Note: Most tests skip when devproxy is not installed since
+ * the helper requires the actual devproxy binary to run.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import path from 'path';
+import fs from 'fs';
+import {
+	createDevProxyController,
+	startGlobalDevProxy,
+	stopGlobalDevProxy,
+	getGlobalDevProxy,
+	type DevProxyOptions,
+} from '../../helpers/dev-proxy';
+
+// Check if devproxy is available
+async function isDevProxyInstalled(): Promise<boolean> {
+	try {
+		const proc = Bun.spawn(['which', 'devproxy'], { stdout: 'pipe' });
+		const exitCode = await proc.exited;
+		return exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+const DEV_PROXY_INSTALLED = await isDevProxyInstalled();
+
+describe('Dev Proxy Helper', () => {
+	describe('createDevProxyController', () => {
+		it('should create controller with default options', () => {
+			const controller = createDevProxyController();
+			expect(controller).toBeDefined();
+			expect(controller.port).toBe(8000);
+			expect(controller.proxyUrl).toBe('http://127.0.0.1:8000');
+			expect(controller.isRunning()).toBe(false);
+			expect(controller.pid).toBeUndefined();
+		});
+
+		it('should create controller with custom port', () => {
+			const controller = createDevProxyController({ port: 9000 });
+			expect(controller.port).toBe(9000);
+			expect(controller.proxyUrl).toBe('http://127.0.0.1:9000');
+		});
+
+		it('should throw when loading non-existent mock file', () => {
+			const controller = createDevProxyController();
+			expect(() => controller.loadMockFile('/non/existent/file.json')).toThrow(
+				'Mock file not found'
+			);
+		});
+
+		it('should not be running initially', () => {
+			const controller = createDevProxyController();
+			expect(controller.isRunning()).toBe(false);
+		});
+	});
+
+	describe('start/stop lifecycle', () => {
+		// Skip these tests if devproxy is not installed
+		const itif = DEV_PROXY_INSTALLED ? it : it.skip;
+
+		itif(
+			'should start and stop proxy',
+			async () => {
+				const controller = createDevProxyController({
+					port: 8100 + Math.floor(Math.random() * 100),
+					logLevel: 'error', // Reduce log noise in tests
+				});
+
+				try {
+					await controller.start();
+					expect(controller.isRunning()).toBe(true);
+					expect(controller.pid).toBeDefined();
+
+					// Verify environment variables are set
+					expect(process.env.HTTPS_PROXY).toContain('127.0.0.1:');
+					expect(process.env.HTTP_PROXY).toContain('127.0.0.1:');
+					expect(process.env.NODE_USE_ENV_PROXY).toBe('1');
+				} finally {
+					await controller.stop();
+					expect(controller.isRunning()).toBe(false);
+				}
+			},
+			{ timeout: 15000 }
+		);
+
+		itif(
+			'should restore environment variables after stop',
+			async () => {
+				// Save original values
+				const originalHttpsProxy = process.env.HTTPS_PROXY;
+				const originalHttpProxy = process.env.HTTP_PROXY;
+				const originalNodeUseEnvProxy = process.env.NODE_USE_ENV_PROXY;
+
+				const controller = createDevProxyController({
+					port: 8200 + Math.floor(Math.random() * 100),
+					logLevel: 'error',
+				});
+
+				try {
+					await controller.start();
+					expect(process.env.HTTPS_PROXY).toBeDefined();
+
+					controller.restoreEnv();
+
+					// Should restore to original values
+					expect(process.env.HTTPS_PROXY).toBe(originalHttpsProxy);
+					expect(process.env.HTTP_PROXY).toBe(originalHttpProxy);
+					expect(process.env.NODE_USE_ENV_PROXY).toBe(originalNodeUseEnvProxy);
+				} finally {
+					await controller.stop();
+				}
+			},
+			{ timeout: 15000 }
+		);
+
+		itif(
+			'should throw error when starting twice',
+			async () => {
+				const controller = createDevProxyController({
+					port: 8300 + Math.floor(Math.random() * 100),
+					logLevel: 'error',
+				});
+
+				try {
+					await controller.start();
+					await expect(controller.start()).rejects.toThrow('already running');
+				} finally {
+					await controller.stop();
+				}
+			},
+			{ timeout: 15000 }
+		);
+
+		itif(
+			'should handle stop when not started',
+			async () => {
+				const controller = createDevProxyController();
+				// Should not throw
+				await controller.stop();
+			},
+			{ timeout: 5000 }
+		);
+
+		itif(
+			'should wait for proxy to be ready',
+			async () => {
+				const controller = createDevProxyController({
+					port: 8400 + Math.floor(Math.random() * 100),
+					logLevel: 'error',
+				});
+
+				try {
+					await controller.start();
+					await expect(controller.waitForReady(5000)).resolves.toBeUndefined();
+				} finally {
+					await controller.stop();
+				}
+			},
+			{ timeout: 15000 }
+		);
+	});
+
+	describe('Global Dev Proxy', () => {
+		const itif = DEV_PROXY_INSTALLED ? it : it.skip;
+
+		afterEach(async () => {
+			await stopGlobalDevProxy();
+		});
+
+		itif(
+			'should start and stop global proxy',
+			async () => {
+				const controller = await startGlobalDevProxy({
+					port: 8500 + Math.floor(Math.random() * 100),
+					logLevel: 'error',
+				});
+
+				expect(controller).toBeDefined();
+				expect(controller.isRunning()).toBe(true);
+				expect(getGlobalDevProxy()).toBe(controller);
+
+				await stopGlobalDevProxy();
+				expect(getGlobalDevProxy()).toBeNull();
+			},
+			{ timeout: 15000 }
+		);
+
+		itif(
+			'should return same controller on multiple start calls',
+			async () => {
+				const controller1 = await startGlobalDevProxy({
+					port: 8600 + Math.floor(Math.random() * 100),
+					logLevel: 'error',
+				});
+				const controller2 = await startGlobalDevProxy();
+
+				expect(controller1).toBe(controller2);
+			},
+			{ timeout: 15000 }
+		);
+	});
+
+	describe('loadMockFile', () => {
+		it('should throw for non-existent mock file', () => {
+			const controller = createDevProxyController();
+			expect(() => controller.loadMockFile('/path/to/nonexistent.json')).toThrow(
+				'Mock file not found'
+			);
+		});
+	});
+
+	describe('when devproxy is not installed', () => {
+		it('should throw error on start if not installed', async () => {
+			// This test only runs if devproxy IS installed, to verify the error message
+			// Skip if not installed since the test would pass trivially
+			if (DEV_PROXY_INSTALLED) {
+				// We can't easily test this case when devproxy IS installed
+				// So skip it
+				return;
+			}
+
+			const controller = createDevProxyController();
+			await expect(controller.start()).rejects.toThrow('devproxy is not installed');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -671,9 +671,7 @@ describe('Leader Agent', () => {
 		});
 
 		it('should pass selected model to pi cli reviewer prompt', () => {
-			const agents = buildReviewerAgents([
-				{ model: 'pi', type: 'cli', cliModel: 'gpt-5.3-codex' },
-			]);
+			const agents = buildReviewerAgents([{ model: 'pi', type: 'cli', cliModel: 'gpt-5.3-codex' }]);
 			const agent = agents['reviewer-pi'];
 			expect(agent.prompt).toContain('--provider github-copilot --model gpt-5.3-codex');
 			expect(agent.prompt).toContain('**Model:** gpt-5.3-codex');


### PR DESCRIPTION
Create a test helper module that manages Dev Proxy lifecycle:

- Add DevProxyController interface with start/stop/health check methods
- Support configurable port, mock files, and environment variables
- Integrate with daemon-server.ts via NEOKAI_USE_DEV_PROXY=1
- Auto-set proxy env vars (HTTPS_PROXY, NODE_USE_ENV_PROXY, etc.)
- Handle process cleanup on test failure
- Add unit tests for the helper module