### PR TITLE
feat: add mock response files for Dev Proxy test scenarios

### DIFF
--- a/.devproxy/README.md
+++ b/.devproxy/README.md
@@ -1,0 +1,173 @@
+# Dev Proxy Mock Files
+
+This directory contains mock response files for the NeoKai test suite. These files are used by Dev Proxy to simulate Anthropic API responses without making real API calls.
+
+## Quick Start
+
+```bash
+# Start Dev Proxy with default mocks
+bun run test:proxy:start
+
+# Set environment for tests
+export HTTPS_PROXY=http://127.0.0.1:8000
+export HTTP_PROXY=http://127.0.0.1:8000
+export NODE_USE_ENV_PROXY=1
+export NODE_EXTRA_CA_CERTS=~/.proxy/rootCA.pem
+
+# Run tests
+NEOKAI_TEST_ONLINE=true bun test packages/daemon/tests/online/
+```
+
+## Mock Files
+
+| File | Description | Use Case |
+|------|-------------|----------|
+| `mocks.json` | Default mock responses | General testing |
+| `mocks-basic.json` | Simple text responses | Basic conversation tests |
+| `mocks-tool-use.json` | Tool call scenarios | Tool execution tests |
+| `mocks-errors.json` | Error responses | Error handling tests |
+| `mocks-room.json` | Multi-agent scenarios | Room workflow tests |
+
+## Switching Mock Files
+
+Edit `devproxyrc.json`:
+
+```json
+{
+  "mockResponsePlugin": {
+    "mocksFile": "mocks-tool-use.json"
+  }
+}
+```
+
+Then restart Dev Proxy:
+
+```bash
+bun run test:proxy:restart
+```
+
+## Scenario Coverage
+
+### mocks-basic.json
+
+| Trigger | Response |
+|---------|----------|
+| Default | Generic greeting message |
+| "What is 2+2?..." | "4" |
+| "What is 1+1?..." | "2" |
+| "What is 3+3?..." | "6" |
+| "Say hello" | Greeting response |
+| "Tell me a joke" | Programmer joke |
+| "room ok" | Room chat acknowledgment |
+
+### mocks-tool-use.json
+
+| Trigger | Tool | Action |
+|---------|------|--------|
+| "Read the file test.txt" | Read | File read operation |
+| "Write a file called output.txt..." | Write | File write operation |
+| "List files in the current directory" | Glob | File listing |
+| "Search for TODO in all files" | Grep | Content search |
+| "Run the command echo hello" | Bash | Command execution |
+| "What is git status?" | Bash | Git status check |
+| "Call the MCP tool to create a task" | mcp_tool_call | MCP tool invocation |
+
+### mocks-errors.json
+
+| Trigger | Status | Error Type |
+|---------|--------|------------|
+| "trigger rate limit" | 429 | rate_limit_error |
+| "trigger server error" | 500 | api_error |
+| "trigger overloaded error" | 529 | overloaded_error |
+| "trigger invalid request" | 400 | invalid_request_error |
+| "trigger authentication error" | 401 | authentication_error |
+| "trigger permission error" | 403 | permission_error |
+| "trigger not found error" | 404 | not_found_error |
+| "trigger context length error" | 400 | invalid_request_error (context) |
+| "trigger tool error" | 200 | Tool error response |
+| "trigger max turns error" | 200 | Max turns message |
+
+### mocks-room.json
+
+| Agent | Scenario | Tools Used |
+|-------|----------|------------|
+| Chat | Simple text response | None |
+| Planner | Phase 1 - Create plan | Write |
+| Planner | Phase 2 - Create tasks | mcp_tool_call |
+| Coder | Implement task | Write |
+| Leader | Submit for review | mcp_tool_call (submit_for_review) |
+| Leader | Complete task | mcp_tool_call (complete_task) |
+| Reviewer | Review PR | Bash (gh pr view) |
+
+## Request Matching Priority
+
+Dev Proxy matches requests in this order:
+
+1. **Exact match** - URL + method + body fragment
+2. **URL match** - URL + method only
+3. **Wildcard match** - URL pattern with wildcards
+
+More specific matches take precedence over general ones.
+
+## Adding New Mocks
+
+1. Choose the appropriate mock file (or create a new one)
+2. Add a new mock entry with:
+   - `request.url` - The API endpoint
+   - `request.method` - HTTP method (usually POST)
+   - `request.bodyFragment` - Optional request body matcher
+   - `response.statusCode` - HTTP status code
+   - `response.headers` - Response headers
+   - `response.body` - Anthropic API response format
+
+Example:
+
+```json
+{
+  "request": {
+    "url": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "bodyFragment": {
+      "messages": [
+        {
+          "content": "your trigger phrase here"
+        }
+      ]
+    }
+  },
+  "response": {
+    "statusCode": 200,
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "application/json"
+      }
+    ],
+    "body": {
+      "id": "msg_custom_001",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "Your response text here"
+        }
+      ],
+      "model": "claude-sonnet-4-20250514",
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "usage": {
+        "input_tokens": 10,
+        "output_tokens": 10,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "service_tier": "standard"
+      }
+    }
+  }
+}
+```
+
+## Documentation
+
+For more details, see [docs/dev-proxy-integration.md](../docs/dev-proxy-integration.md).

--- a/.devproxy/mocks-basic.json
+++ b/.devproxy/mocks-basic.json
@@ -1,0 +1,335 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"mocks": [
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST"
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-limit",
+						"value": "50"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-remaining",
+						"value": "49"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Hello! This is a simple mock response from Dev Proxy. I'm here to help with testing."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 25,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 2+2? Answer with just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json (math)"
+					}
+				],
+				"body": {
+					"id": "msg_basic_002",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "4"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 20,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 1+1? Just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_003",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "2"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 18,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 3+3? Answer with just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_004",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "6"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 20,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Say hello"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_005",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Hello! How can I help you today?"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 12,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Tell me a joke"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_006",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Why do programmers prefer dark mode? Because light attracts bugs!"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 12,
+						"output_tokens": 18,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "room ok"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json (room)"
+					}
+				],
+				"body": {
+					"id": "msg_basic_room",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Room chat response acknowledged. I'm ready to help with your room tasks."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 8,
+						"output_tokens": 20,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		}
+	]
+}

--- a/.devproxy/mocks-errors.json
+++ b/.devproxy/mocks-errors.json
@@ -1,0 +1,383 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"mocks": [
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger rate limit"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 429,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "retry-after",
+						"value": "30"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-limit",
+						"value": "50"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-remaining",
+						"value": "0"
+					},
+					{
+						"name": "anthropic-ratelimit-requests-reset",
+						"value": "2024-01-01T00:00:30Z"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (429)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "rate_limit_error",
+						"message": "Rate limit exceeded. Please wait before sending more requests."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger server error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 500,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (500)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "api_error",
+						"message": "Internal server error. Please try again later."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger overloaded error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 529,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "retry-after",
+						"value": "60"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (529)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "overloaded_error",
+						"message": "Overloaded. Please wait a while and try again."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger invalid request"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 400,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (400)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "invalid_request_error",
+						"message": "Invalid request: missing required field 'model'"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger authentication error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 401,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (401)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "authentication_error",
+						"message": "Invalid API key. Please check your credentials."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger permission error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 403,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (403)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "permission_error",
+						"message": "Permission denied. You do not have access to this resource."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger not found error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 404,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (404)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "not_found_error",
+						"message": "Resource not found."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger context length error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 400,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (context)"
+					}
+				],
+				"body": {
+					"type": "error",
+					"error": {
+						"type": "invalid_request_error",
+						"message": "messages: total token count exceeds the limit of 200000 tokens for this model. Please reduce the length of the messages or conversation history."
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger tool error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (tool_error)"
+					}
+				],
+				"body": {
+					"id": "msg_error_tool",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I encountered an error while executing the tool."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 20,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "trigger max turns error"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-errors.json (max_turns)"
+					}
+				],
+				"body": {
+					"id": "msg_error_max_turns",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I apologize, but I've reached the maximum number of allowed turns for this conversation."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 30,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		}
+	]
+}

--- a/.devproxy/mocks-room.json
+++ b/.devproxy/mocks-room.json
@@ -1,0 +1,460 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"mocks": [
+		{
+			"comment": "Room chat agent - simple text response",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "chat agent"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (chat)"
+					}
+				],
+				"body": {
+					"id": "msg_room_chat",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Room chat response acknowledged. I'm ready to help with your room tasks."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 50,
+						"output_tokens": 20,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Planner Phase 1 - Creates plan file",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "planner"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (planner)"
+					}
+				],
+				"body": {
+					"id": "msg_room_planner_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll examine the codebase and create a plan for this task."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_planner_write_001",
+							"name": "Write",
+							"input": {
+								"file_path": "docs/plans/mock-plan.md",
+								"content": "# Plan: Mock Task\n\n## Overview\n\nThis plan outlines the approach for implementing the mock task.\n\n## Tasks\n\n1. Create utility file\n2. Add tests\n3. Update documentation\n"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 100,
+						"output_tokens": 80,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Planner Phase 2 - After approval, creates tasks",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"contains": "approved"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (planner-approved)"
+					}
+				],
+				"body": {
+					"id": "msg_room_planner_002",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "The plan is approved. Let me merge the PR and create the execution tasks."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_planner_mcp_001",
+							"name": "mcp_tool_call",
+							"input": {
+								"server_name": "planner-tools",
+								"tool_name": "create_task",
+								"arguments": {
+									"title": "Create utility file",
+									"description": "Implement the utility function with proper typing and error handling.",
+									"agent": "coder"
+								}
+							}
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_planner_mcp_002",
+							"name": "mcp_tool_call",
+							"input": {
+								"server_name": "planner-tools",
+								"tool_name": "create_task",
+								"arguments": {
+									"title": "Add tests",
+									"description": "Add unit tests for the utility function.",
+									"agent": "coder",
+									"depends_on": ["task-mock-1"]
+								}
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 150,
+						"output_tokens": 120,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Coder agent - Implements task",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "coder"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (coder)"
+					}
+				],
+				"body": {
+					"id": "msg_room_coder_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll implement this task by creating the required files."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_coder_write_001",
+							"name": "Write",
+							"input": {
+								"file_path": "src/util.ts",
+								"content": "/**\n * Utility function for common operations\n */\nexport function util(): string {\n\treturn 'ok';\n}\n"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 100,
+						"output_tokens": 80,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Leader agent - Submit for review",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "leader"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (leader)"
+					}
+				],
+				"body": {
+					"id": "msg_room_leader_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I have reviewed the worker's output. The implementation looks good. I will submit for review."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_leader_mcp_001",
+							"name": "mcp_tool_call",
+							"input": {
+								"server_name": "leader-agent-tools",
+								"tool_name": "submit_for_review",
+								"arguments": {
+									"pr_url": "https://github.com/test/repo/pull/1"
+								}
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 100,
+						"output_tokens": 80,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Leader agent - Complete task after approval",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"contains": "submit_for_review"
+						},
+						{
+							"contains": "approved"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (leader-complete)"
+					}
+				],
+				"body": {
+					"id": "msg_room_leader_002",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "The work has been approved. I will complete the task."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_leader_mcp_002",
+							"name": "mcp_tool_call",
+							"input": {
+								"server_name": "leader-agent-tools",
+								"tool_name": "complete_task",
+								"arguments": {
+									"summary": "Task completed successfully."
+								}
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 150,
+						"output_tokens": 80,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Reviewer agent - Review PR",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "reviewer"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (reviewer)"
+					}
+				],
+				"body": {
+					"id": "msg_room_reviewer_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll review this PR and provide feedback."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_reviewer_bash_001",
+							"name": "Bash",
+							"input": {
+								"command": "gh pr view 1 --json title,body,files",
+								"description": "Get PR details for review"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 100,
+						"output_tokens": 60,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"comment": "Default room response - matches any room request",
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"system": {
+						"contains": "room"
+					}
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-room.json (default)"
+					}
+				],
+				"body": {
+					"id": "msg_room_default",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'm a room agent ready to help with your multi-agent workflow tasks."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 50,
+						"output_tokens": 25,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		}
+	]
+}

--- a/.devproxy/mocks-tool-use.json
+++ b/.devproxy/mocks-tool-use.json
@@ -1,0 +1,454 @@
+{
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"mocks": [
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Read the file test.txt"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll read that file for you."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_read_001",
+							"name": "Read",
+							"input": {
+								"file_path": "test.txt"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 35,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"role": "user",
+							"content": [
+								{
+									"type": "tool_result",
+									"tool_use_id": "toolu_read_001",
+									"content": "Hello from test.txt!"
+								}
+							]
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_002",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "The file test.txt contains: \"Hello from test.txt!\""
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 45,
+						"output_tokens": 25,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Write a file called output.txt with content 'test content'"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_003",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll write that file for you."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_write_001",
+							"name": "Write",
+							"input": {
+								"file_path": "output.txt",
+								"content": "test content"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 30,
+						"output_tokens": 40,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "List files in the current directory"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_004",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll list the files for you."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_glob_001",
+							"name": "Glob",
+							"input": {
+								"pattern": "*"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 35,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Run the command echo hello"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_005",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll run that command."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_bash_001",
+							"name": "Bash",
+							"input": {
+								"command": "echo hello",
+								"description": "Echo hello to stdout"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 35,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Search for TODO in all files"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_006",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll search for TODO comments."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_grep_001",
+							"name": "Grep",
+							"input": {
+								"pattern": "TODO",
+								"output_mode": "content"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 35,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is git status?"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_007",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll check the git status for you."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_bash_git_001",
+							"name": "Bash",
+							"input": {
+								"command": "git status",
+								"description": "Show git working tree status"
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 35,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Call the MCP tool to create a task"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-tool-use.json"
+					}
+				],
+				"body": {
+					"id": "msg_tool_mcp_001",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I'll create a task using the MCP tool."
+						},
+						{
+							"type": "tool_use",
+							"id": "toolu_mcp_001",
+							"name": "mcp_tool_call",
+							"input": {
+								"server_name": "planner-tools",
+								"tool_name": "create_task",
+								"arguments": {
+									"title": "Test Task",
+									"description": "A test task created via MCP",
+									"agent": "coder"
+								}
+							}
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "tool_use",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 35,
+						"output_tokens": 55,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		}
+	]
+}

--- a/docs/dev-proxy-integration.md
+++ b/docs/dev-proxy-integration.md
@@ -351,21 +351,101 @@ Add the `LatencyPlugin` to simulate slow responses:
 }
 ```
 
-### Multiple Mock Scenarios
+## Mock Response Files
 
-Create different mock files for different test scenarios:
+The `.devproxy/` directory contains multiple mock files for different test scenarios:
 
+### Available Mock Files
+
+| File | Purpose | Scenarios Covered |
+|------|---------|------------------|
+| `mocks.json` | Default mock responses | Basic text response (default) |
+| `mocks-basic.json` | Simple text responses | Multi-turn conversations, math, greetings |
+| `mocks-tool-use.json` | Tool call scenarios | Read, Write, Glob, Grep, Bash, MCP tools |
+| `mocks-errors.json` | Error responses | Rate limiting (429), server errors (500), auth errors |
+| `mocks-room.json` | Multi-agent scenarios | Planner, Coder, Leader, Reviewer agents |
+
+### Switching Mock Files
+
+Update `devproxyrc.json` to use a different mock file:
+
+```json
+{
+  "mockResponsePlugin": {
+    "mocksFile": "mocks-tool-use.json"
+  }
+}
 ```
-tests/dev-proxy/
-├── mocks/
-│   ├── basic-response.json
-│   ├── tool-use-response.json
-│   ├── error-response.json
-│   └── streaming-response.json
-└── devproxyrc.json
+
+Or set the environment variable when starting Dev Proxy:
+
+```bash
+DEV_PROXY_MOCKS=mocks-tool-use.json bun run test:proxy:start
 ```
 
-Switch mocks by updating `mocksFile` in configuration or using presets.
+### Mock File Scenarios
+
+#### mocks-basic.json
+
+- Default text response
+- Math questions (2+2, 1+1, 3+3)
+- Greetings and jokes
+- Room chat responses
+
+#### mocks-tool-use.json
+
+- `Read` tool - Read file contents
+- `Write` tool - Write file contents
+- `Glob` tool - List files
+- `Grep` tool - Search file contents
+- `Bash` tool - Execute commands
+- `mcp_tool_call` - MCP server tool calls
+
+#### mocks-errors.json
+
+- `429` - Rate limit exceeded
+- `500` - Internal server error
+- `529` - Overloaded error
+- `400` - Invalid request
+- `401` - Authentication error
+- `403` - Permission error
+- `404` - Not found error
+- Context length exceeded error
+
+#### mocks-room.json
+
+- **Chat agent** - Simple text responses for room chat
+- **Planner Phase 1** - Creates plan file with Write tool
+- **Planner Phase 2** - Creates tasks with MCP tool calls
+- **Coder agent** - Implements task with Write tool
+- **Leader agent** - Submits for review and completes tasks
+- **Reviewer agent** - Reviews PRs with Bash/gh commands
+
+### Request Matching
+
+Dev Proxy matches requests by URL, method, and optional body fragments. More specific matches take precedence:
+
+1. Exact URL + method + body fragment match
+2. Exact URL + method match
+3. Wildcard URL match
+
+Example body fragment matching:
+
+```json
+{
+  "request": {
+    "url": "https://api.anthropic.com/v1/messages",
+    "method": "POST",
+    "bodyFragment": {
+      "messages": [
+        {
+          "content": "What is 2+2? Answer with just the number."
+        }
+      ]
+    }
+  }
+}
+```
 
 ## References
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -671,9 +671,7 @@ describe('Leader Agent', () => {
 		});
 
 		it('should pass selected model to pi cli reviewer prompt', () => {
-			const agents = buildReviewerAgents([
-				{ model: 'pi', type: 'cli', cliModel: 'gpt-5.3-codex' },
-			]);
+			const agents = buildReviewerAgents([{ model: 'pi', type: 'cli', cliModel: 'gpt-5.3-codex' }]);
 			const agent = agents['reviewer-pi'];
 			expect(agent.prompt).toContain('--provider github-copilot --model gpt-5.3-codex');
 			expect(agent.prompt).toContain('**Model:** gpt-5.3-codex');


### PR DESCRIPTION
Add comprehensive mock response files for testing common scenarios:

- mocks-basic.json: Simple text responses, multi-turn conversations, math
- mocks-tool-use.json: Tool call scenarios (Read, Write, Glob, Grep, Bash, MCP)
- mocks-errors.json: Error responses (429, 500, 401, 403, etc.)
- mocks-room.json: Multi-agent scenarios (planner, coder, leader, reviewer)

Also update dev-proxy-integration.md with mock file documentation and add README.md in .devproxy/ for quick reference.