### PR TITLE
feat(web): add filter tabs to RoomTasks component

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -1,15 +1,14 @@
 /**
  * Tests for RoomTasks Component
  *
- * Tests task grouping by status, empty state,
- * click handling, and section rendering for all statuses
- * including completed and failed.
+ * Tests task filter tabs, tab switching, task grouping by status,
+ * empty states, click handling, and section rendering for all tabs.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import type { TaskSummary } from '@neokai/shared';
-import { RoomTasks } from './RoomTasks';
+import { RoomTasks, selectedTabSignal } from './RoomTasks';
 
 describe('RoomTasks', () => {
 	afterEach(() => {
@@ -30,6 +29,18 @@ describe('RoomTasks', () => {
 		...overrides,
 	});
 
+	/** Helper to click a tab by label */
+	function clickTab(container: Element, label: string) {
+		const tabs = container.querySelectorAll('button');
+		for (const tab of Array.from(tabs)) {
+			if (tab.textContent?.includes(label)) {
+				fireEvent.click(tab);
+				return true;
+			}
+		}
+		return false;
+	}
+
 	describe('Empty State', () => {
 		it('should show empty state when no tasks', () => {
 			const { container } = render(<RoomTasks tasks={[]} />);
@@ -45,7 +56,50 @@ describe('RoomTasks', () => {
 		});
 	});
 
-	describe('In Progress Section', () => {
+	describe('Tab Bar', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
+		it('should show all four tabs with counts', () => {
+			const tasks = [
+				createTask('t1', 'in_progress'),
+				createTask('t2', 'review'),
+				createTask('t3', 'completed'),
+				createTask('t4', 'failed'),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Active');
+			expect(container.textContent).toContain('Review');
+			expect(container.textContent).toContain('Done');
+			expect(container.textContent).toContain('Failed');
+		});
+
+		it('should show correct counts on tabs', () => {
+			const tasks = [
+				createTask('t1', 'in_progress'),
+				createTask('t2', 'pending'),
+				createTask('t3', 'review'),
+				createTask('t4', 'completed'),
+				createTask('t5', 'failed'),
+				createTask('t6', 'cancelled'),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// Active: 2 (in_progress + pending)
+			expect(container.textContent).toContain('Active');
+			expect(container.textContent).toContain('2');
+		});
+	});
+
+	describe('Active Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
 		it('should render in progress section with yellow header', () => {
 			const tasks = [createTask('t1', 'in_progress')];
 
@@ -63,9 +117,30 @@ describe('RoomTasks', () => {
 
 			expect(container.textContent).toContain('Build feature');
 		});
+
+		it('should render pending section', () => {
+			const tasks = [createTask('t1', 'pending'), createTask('t2', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Pending (2)');
+		});
+
+		it('should show empty state for active tab when no active tasks', () => {
+			const tasks = [createTask('t1', 'completed')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('No active tasks');
+			expect(container.textContent).toContain('Active tasks will appear here');
+		});
 	});
 
-	describe('Review Section', () => {
+	describe('Review Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
 		it('should render review section with purple header', () => {
 			const tasks = [createTask('t1', 'review')];
 
@@ -186,31 +261,21 @@ describe('RoomTasks', () => {
 			expect(onView).toHaveBeenCalledWith('task-42');
 			expect(onTaskClick).not.toHaveBeenCalled();
 		});
-	});
 
-	describe('Pending Section', () => {
-		it('should render pending section', () => {
-			const tasks = [createTask('t1', 'pending'), createTask('t2', 'pending')];
+		it('should show empty state when no review tasks', () => {
+			const tasks = [createTask('t1', 'pending')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			expect(container.textContent).toContain('Pending (2)');
+			expect(container.textContent).toContain('No tasks to review');
 		});
 	});
 
-	describe('Draft Section', () => {
-		it('should render draft section with gray header', () => {
-			const tasks = [createTask('t1', 'draft')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const header = container.querySelector('.text-gray-400');
-			expect(header).toBeTruthy();
-			expect(header?.textContent).toContain('Draft');
+	describe('Done Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'done';
 		});
-	});
 
-	describe('Completed Section', () => {
 		it('should render completed section with green header', () => {
 			const tasks = [
 				createTask('t1', 'completed', { title: 'Finished task' }),
@@ -219,7 +284,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const header = container.querySelector('.text-green-400');
+			// Query for h3 specifically to avoid matching the tab button
+			const header = container.querySelector('h3.text-green-400');
 			expect(header).toBeTruthy();
 			expect(header?.textContent).toContain('Completed (2)');
 		});
@@ -240,9 +306,21 @@ describe('RoomTasks', () => {
 			const greenHeader = container.querySelector('.bg-green-900\\/20');
 			expect(greenHeader).toBeTruthy();
 		});
+
+		it('should show empty state when no completed tasks', () => {
+			const tasks = [createTask('t1', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('No completed tasks');
+		});
 	});
 
-	describe('Failed Section', () => {
+	describe('Failed Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'failed';
+		});
+
 		it('should render failed section with red header', () => {
 			const tasks = [createTask('t1', 'failed', { title: 'Broken task' })];
 
@@ -293,24 +371,6 @@ describe('RoomTasks', () => {
 			}
 		});
 
-		it('should appear before in-progress tasks in the DOM', () => {
-			const tasks = [createTask('t1', 'in_progress'), createTask('t2', 'failed')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const headers = container.querySelectorAll('h3');
-			const headerTexts = Array.from(headers).map((h) => h.textContent ?? '');
-
-			const failedIdx = headerTexts.findIndex((t) => t.includes('Failed'));
-			const inProgressIdx = headerTexts.findIndex((t) => t.includes('In Progress'));
-
-			expect(failedIdx).toBeGreaterThanOrEqual(0);
-			expect(inProgressIdx).toBeGreaterThanOrEqual(0);
-			expect(failedIdx).toBeLessThan(inProgressIdx);
-		});
-	});
-
-	describe('Cancelled Section', () => {
 		it('should render cancelled section with muted gray header', () => {
 			const tasks = [createTask('t1', 'cancelled', { title: 'Stopped task' })];
 
@@ -355,45 +415,77 @@ describe('RoomTasks', () => {
 			expect(headerTexts).toContain('Failed (1)');
 			expect(headerTexts).toContain('Cancelled (1)');
 		});
+
+		it('should show empty state when no failed or cancelled tasks', () => {
+			const tasks = [createTask('t1', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('No failed tasks');
+		});
 	});
 
-	describe('Multiple Status Groups', () => {
-		it('should render all status groups when tasks exist in each', () => {
+	describe('Tab Switching', () => {
+		it('should switch to review tab when clicked', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
-				createTask('t2', 'review'),
-				createTask('t3', 'pending'),
-				createTask('t4', 'draft'),
-				createTask('t5', 'completed'),
-				createTask('t6', 'failed'),
-				createTask('t7', 'cancelled'),
+				createTask('t2', 'review', { title: 'Review task' }),
 			];
 
+			// Set to active BEFORE render so initial state is correct
+			selectedTabSignal.value = 'active';
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const headers = container.querySelectorAll('h3');
-			const headerTexts = Array.from(headers).map((h) => h.textContent);
+			// Initially on active tab, should see in_progress task
+			expect(container.textContent).toContain('In Progress');
 
-			expect(headerTexts).toContain('In Progress (1)');
-			expect(headerTexts).toContain('Review (1)');
-			expect(headerTexts).toContain('Pending (1)');
-			expect(headerTexts).toContain('Draft (1)');
-			expect(headerTexts).toContain('Completed (1)');
-			expect(headerTexts).toContain('Failed (1)');
-			expect(headerTexts).toContain('Cancelled (1)');
+			// Click review tab
+			clickTab(container, 'Review');
+
+			// Now should see review task
+			expect(container.textContent).toContain('Awaiting Review');
 		});
 
-		it('should only render sections for statuses that have tasks', () => {
-			const tasks = [createTask('t1', 'pending'), createTask('t2', 'completed')];
+		it('should switch to done tab when clicked', () => {
+			const tasks = [
+				createTask('t1', 'in_progress'),
+				createTask('t2', 'completed', { title: 'Done task' }),
+			];
 
+			// Set to active BEFORE render
+			selectedTabSignal.value = 'active';
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const headers = container.querySelectorAll('h3');
-			expect(headers.length).toBe(2);
+			// Click done tab
+			clickTab(container, 'Done');
+
+			// Should see completed section
+			expect(container.textContent).toContain('Completed (1)');
+		});
+
+		it('should switch to failed tab when clicked', () => {
+			const tasks = [
+				createTask('t1', 'in_progress'),
+				createTask('t2', 'failed', { title: 'Failed task' }),
+			];
+
+			// Set to active BEFORE render
+			selectedTabSignal.value = 'active';
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// Click failed tab
+			clickTab(container, 'Failed');
+
+			// Should see failed section
+			expect(container.textContent).toContain('Failed (1)');
 		});
 	});
 
 	describe('Click Handling', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
 		it('should call onTaskClick with task id when task is clicked', () => {
 			const onTaskClick = vi.fn();
 			const tasks = [createTask('task-123', 'pending', { title: 'Click me' })];
@@ -434,6 +526,10 @@ describe('RoomTasks', () => {
 	});
 
 	describe('Task Progress', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
 		it('should show progress percentage when defined', () => {
 			const tasks = [createTask('t1', 'in_progress', { progress: 75 })];
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -1,17 +1,39 @@
 /**
  * RoomTasks Component
  *
- * Displays tasks grouped by status:
- * - In Progress
- * - Review (with Approve button)
- * - Pending (with "Blocked" badge for unmet dependencies)
- * - Draft
- * - Completed
- * - Failed
- * - Cancelled
+ * Displays tasks with filter tabs for organization:
+ * - Active: pending + in_progress
+ * - Review: review status (awaiting human action)
+ * - Done: completed
+ * - Failed: failed + cancelled
  */
 
+import { signal, effect } from '@preact/signals';
 import type { TaskSummary } from '@neokai/shared';
+
+/** Tab filter types */
+export type TaskFilterTab = 'active' | 'review' | 'done' | 'failed';
+
+/** Get initial tab from localStorage */
+function getInitialTab(): TaskFilterTab {
+	if (typeof window === 'undefined') return 'active';
+	const stored = localStorage.getItem('neokai:room:taskFilterTab');
+	if (stored === 'active' || stored === 'review' || stored === 'done' || stored === 'failed') {
+		return stored;
+	}
+	return 'active';
+}
+
+/** Persisted tab selection signal with localStorage sync - exported for testing */
+export const selectedTabSignal = signal<TaskFilterTab>(getInitialTab());
+
+// Sync signal changes to localStorage
+if (typeof window !== 'undefined') {
+	effect(() => {
+		const tab = selectedTabSignal.value;
+		localStorage.setItem('neokai:room:taskFilterTab', tab);
+	});
+}
 
 interface RoomTasksProps {
 	tasks: TaskSummary[];
@@ -20,7 +42,39 @@ interface RoomTasksProps {
 	onView?: (taskId: string) => void;
 }
 
+/** Get count of tasks for each filter tab */
+function getTabCounts(tasks: TaskSummary[]) {
+	return {
+		active: tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress').length,
+		review: tasks.filter((t) => t.status === 'review').length,
+		done: tasks.filter((t) => t.status === 'completed').length,
+		failed: tasks.filter((t) => t.status === 'failed' || t.status === 'cancelled').length,
+	};
+}
+
+/** Filter tasks based on selected tab */
+function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary[] {
+	switch (tab) {
+		case 'active':
+			return tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
+		case 'review':
+			return tasks.filter((t) => t.status === 'review');
+		case 'done':
+			return tasks.filter((t) => t.status === 'completed');
+		case 'failed':
+			return tasks.filter((t) => t.status === 'failed' || t.status === 'cancelled');
+	}
+}
+
 export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksProps) {
+	const selectedTab = selectedTabSignal.value;
+	const tabCounts = getTabCounts(tasks);
+	const filteredTasks = getFilteredTasks(tasks, selectedTab);
+
+	const handleTabClick = (tab: TaskFilterTab) => {
+		selectedTabSignal.value = tab;
+	};
+
 	if (tasks.length === 0) {
 		return (
 			<div class="bg-dark-850 border border-dark-700 rounded-lg p-6 text-center">
@@ -30,134 +84,340 @@ export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksPr
 		);
 	}
 
-	// Group by status
-	const inProgress = tasks.filter((t) => t.status === 'in_progress');
-	const review = tasks.filter((t) => t.status === 'review');
-	const pending = tasks.filter((t) => t.status === 'pending');
-	const draft = tasks.filter((t) => t.status === 'draft');
-	const completed = tasks.filter((t) => t.status === 'completed');
+	return (
+		<div class="space-y-4">
+			{/* Tab Bar */}
+			<div class="flex border-b border-dark-700">
+				<TabButton
+					label="Active"
+					count={tabCounts.active}
+					isActive={selectedTab === 'active'}
+					onClick={() => handleTabClick('active')}
+				/>
+				<TabButton
+					label="Review"
+					count={tabCounts.review}
+					isActive={selectedTab === 'review'}
+					onClick={() => handleTabClick('review')}
+					variant="purple"
+				/>
+				<TabButton
+					label="Done"
+					count={tabCounts.done}
+					isActive={selectedTab === 'done'}
+					onClick={() => handleTabClick('done')}
+					variant="green"
+				/>
+				<TabButton
+					label="Failed"
+					count={tabCounts.failed}
+					isActive={selectedTab === 'failed'}
+					onClick={() => handleTabClick('failed')}
+					variant="red"
+				/>
+			</div>
+
+			{/* Task List */}
+			{filteredTasks.length === 0 ? (
+				<EmptyTabState tab={selectedTab} />
+			) : (
+				<TaskList
+					tasks={filteredTasks}
+					allTasks={tasks}
+					tab={selectedTab}
+					onTaskClick={onTaskClick}
+					onApprove={onApprove}
+					onView={onView}
+				/>
+			)}
+		</div>
+	);
+}
+
+/** Tab button component */
+function TabButton({
+	label,
+	count,
+	isActive,
+	onClick,
+	variant = 'default',
+}: {
+	label: string;
+	count: number;
+	isActive: boolean;
+	onClick: () => void;
+	variant?: 'default' | 'purple' | 'green' | 'red';
+}) {
+	const baseClasses =
+		'px-4 py-2 text-sm font-medium transition-colors relative flex items-center gap-1.5';
+
+	const variantClasses: Record<string, string> = {
+		default: isActive
+			? 'text-blue-400 border-b-2 border-blue-400'
+			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+		purple: isActive
+			? 'text-purple-400 border-b-2 border-purple-400'
+			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+		green: isActive
+			? 'text-green-400 border-b-2 border-green-400'
+			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+		red: isActive
+			? 'text-red-400 border-b-2 border-red-400'
+			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+	};
+
+	return (
+		<button class={`${baseClasses} ${variantClasses[variant]}`} onClick={onClick}>
+			{label}
+			{count > 0 && (
+				<span
+					class={`text-xs px-1.5 py-0.5 rounded ${
+						variant === 'purple'
+							? 'bg-purple-900/30'
+							: variant === 'green'
+								? 'bg-green-900/30'
+								: variant === 'red'
+									? 'bg-red-900/30'
+									: 'bg-dark-700'
+					}`}
+				>
+					{count}
+				</span>
+			)}
+		</button>
+	);
+}
+
+/** Empty state for each tab */
+function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
+	const messages: Record<TaskFilterTab, { title: string; description: string }> = {
+		active: {
+			title: 'No active tasks',
+			description: 'Active tasks will appear here',
+		},
+		review: {
+			title: 'No tasks to review',
+			description: 'Tasks needing review will appear here',
+		},
+		done: {
+			title: 'No completed tasks',
+			description: 'Completed tasks will appear here',
+		},
+		failed: {
+			title: 'No failed tasks',
+			description: 'Failed and cancelled tasks will appear here',
+		},
+	};
+
+	const { title, description } = messages[tab];
+
+	return (
+		<div class="bg-dark-850 border border-dark-700 rounded-lg p-6 text-center">
+			<p class="text-gray-400">{title}</p>
+			<p class="text-sm text-gray-500 mt-1">{description}</p>
+		</div>
+	);
+}
+
+/** Task list renderer - groups tasks by status within the filtered view */
+function TaskList({
+	tasks,
+	allTasks,
+	tab,
+	onTaskClick,
+	onApprove,
+	onView,
+}: {
+	tasks: TaskSummary[];
+	allTasks: TaskSummary[];
+	tab: TaskFilterTab;
+	onTaskClick?: (taskId: string) => void;
+	onApprove?: (taskId: string) => void;
+	onView?: (taskId: string) => void;
+}) {
+	// For Active tab, group by in_progress and pending
+	// For Review tab - all are review status
+	// For Done tab - all are completed
+	// For Failed tab - group by failed and cancelled
+
+	if (tab === 'active') {
+		const inProgress = tasks.filter((t) => t.status === 'in_progress');
+		const pending = tasks.filter((t) => t.status === 'pending');
+
+		return (
+			<div class="space-y-4">
+				{inProgress.length > 0 && (
+					<TaskGroup
+						title="In Progress"
+						count={inProgress.length}
+						variant="yellow"
+						tasks={inProgress}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+					/>
+				)}
+				{pending.length > 0 && (
+					<TaskGroup
+						title="Pending"
+						count={pending.length}
+						variant="default"
+						tasks={pending}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+					/>
+				)}
+			</div>
+		);
+	}
+
+	if (tab === 'review') {
+		return (
+			<div class="space-y-4">
+				<TaskGroup
+					title="Awaiting Review"
+					count={tasks.length}
+					variant="purple"
+					tasks={tasks}
+					allTasks={allTasks}
+					onTaskClick={onTaskClick}
+					onApprove={onApprove}
+					onView={onView}
+				/>
+			</div>
+		);
+	}
+
+	if (tab === 'done') {
+		return (
+			<div class="space-y-4">
+				<TaskGroup
+					title="Completed"
+					count={tasks.length}
+					variant="green"
+					tasks={tasks}
+					allTasks={allTasks}
+					onTaskClick={onTaskClick}
+				/>
+			</div>
+		);
+	}
+
+	// Failed tab
 	const failed = tasks.filter((t) => t.status === 'failed');
 	const cancelled = tasks.filter((t) => t.status === 'cancelled');
 
 	return (
 		<div class="space-y-4">
-			{/* Failed — shown first so failures are immediately visible */}
 			{failed.length > 0 && (
-				<div class="bg-dark-850 border border-red-800/60 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-red-800/60 bg-red-900/20 flex items-center gap-2">
-						<svg
-							class="w-4 h-4 text-red-400 flex-shrink-0"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width={2}
-								d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
-							/>
-						</svg>
-						<h3 class="font-semibold text-red-400">Failed ({failed.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{failed.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
+				<TaskGroup
+					title="Failed"
+					count={failed.length}
+					variant="red"
+					tasks={failed}
+					allTasks={allTasks}
+					onTaskClick={onTaskClick}
+					showAlert
+				/>
 			)}
-
-			{/* In Progress */}
-			{inProgress.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-yellow-900/20">
-						<h3 class="font-semibold text-yellow-400">In Progress ({inProgress.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{inProgress.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Review */}
-			{review.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-purple-900/20">
-						<h3 class="font-semibold text-purple-400">Review ({review.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{review.map((task) => (
-							<TaskItem
-								key={task.id}
-								task={task}
-								allTasks={tasks}
-								onClick={onTaskClick}
-								onApprove={onApprove}
-								onView={onView}
-							/>
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Pending */}
-			{pending.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700">
-						<h3 class="font-semibold text-gray-100">Pending ({pending.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{pending.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Draft */}
-			{draft.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-dark-800">
-						<h3 class="font-semibold text-gray-400">Draft ({draft.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{draft.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Completed */}
-			{completed.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-green-900/20">
-						<h3 class="font-semibold text-green-400">Completed ({completed.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{completed.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
-			)}
-
-			{/* Cancelled */}
 			{cancelled.length > 0 && (
-				<div class="bg-dark-850 border border-dark-700 rounded-lg overflow-hidden">
-					<div class="px-4 py-3 border-b border-dark-700 bg-dark-800">
-						<h3 class="font-semibold text-gray-500">Cancelled ({cancelled.length})</h3>
-					</div>
-					<div class="divide-y divide-dark-700">
-						{cancelled.map((task) => (
-							<TaskItem key={task.id} task={task} allTasks={tasks} onClick={onTaskClick} />
-						))}
-					</div>
-				</div>
+				<TaskGroup
+					title="Cancelled"
+					count={cancelled.length}
+					variant="gray"
+					tasks={cancelled}
+					allTasks={allTasks}
+					onTaskClick={onTaskClick}
+				/>
 			)}
+		</div>
+	);
+}
+
+/** Task group component */
+function TaskGroup({
+	title,
+	count,
+	variant,
+	tasks,
+	allTasks,
+	onTaskClick,
+	onApprove,
+	onView,
+	showAlert = false,
+}: {
+	title: string;
+	count: number;
+	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
+	tasks: TaskSummary[];
+	allTasks: TaskSummary[];
+	onTaskClick?: (taskId: string) => void;
+	onApprove?: (taskId: string) => void;
+	onView?: (taskId: string) => void;
+	showAlert?: boolean;
+}) {
+	const headerStyles: Record<string, string> = {
+		default: '',
+		yellow: 'bg-yellow-900/20',
+		purple: 'bg-purple-900/20',
+		green: 'bg-green-900/20',
+		red: 'bg-red-900/20',
+		gray: 'bg-dark-800',
+	};
+
+	const titleStyles: Record<string, string> = {
+		default: 'text-gray-100',
+		yellow: 'text-yellow-400',
+		purple: 'text-purple-400',
+		green: 'text-green-400',
+		red: 'text-red-400',
+		gray: 'text-gray-500',
+	};
+
+	const borderStyles: Record<string, string> = {
+		default: 'border-dark-700',
+		yellow: 'border-dark-700',
+		purple: 'border-dark-700',
+		green: 'border-dark-700',
+		red: 'border-red-800/60',
+		gray: 'border-dark-700',
+	};
+
+	return (
+		<div class={`bg-dark-850 border rounded-lg overflow-hidden ${borderStyles[variant]}`}>
+			<div
+				class={`px-4 py-3 border-b ${borderStyles[variant]} ${headerStyles[variant]} flex items-center gap-1`}
+			>
+				{showAlert && (
+					<svg
+						class="w-4 h-4 text-red-400 flex-shrink-0"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={1.5}
+							d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+						/>
+					</svg>
+				)}
+				<h3 class={`font-semibold ${titleStyles[variant]}`}>
+					{title} ({count})
+				</h3>
+			</div>
+			<div class="divide-y divide-dark-700">
+				{tasks.map((task) => (
+					<TaskItem
+						key={task.id}
+						task={task}
+						allTasks={allTasks}
+						onClick={onTaskClick}
+						onApprove={onApprove}
+						onView={onView}
+					/>
+				))}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Add filter tabs to task view with 4 tabs:
- Active: pending + in_progress tasks
- Review: tasks awaiting review
- Done: completed tasks
- Failed: failed + cancelled tasks

Features:
- Tab bar with count badges showing task counts
- Default to Active tab
- Persisted tab selection in localStorage (neokai:room:taskFilterTab)
- Empty states for each tab when no tasks match
- Visual distinction with color-coded active indicators
