### PR TITLE
feat: add cancel/reject task actions to TaskView UI

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -39,7 +39,7 @@ export type GoalManagerLike = Pick<
 export type GoalManagerFactory = (roomId: string) => GoalManagerLike;
 export type TaskManagerFactory = (
 	roomId: string
-) => Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus'>;
+) => Pick<TaskManager, 'getTask' | 'reviewTask' | 'updateTaskStatus' | 'cancelTaskCascade'>;
 
 export function setupGoalHandlers(
 	messageHub: MessageHub,
@@ -332,6 +332,92 @@ export function setupGoalHandlers(
 		}
 
 		log.info(`Task ${params.taskId} approved by human in room ${params.roomId}`);
+		return { success: true };
+	});
+
+	// goal.cancelTask - Human cancels a task
+	messageHub.onRequest('goal.cancelTask', async (data) => {
+		const params = data as { roomId: string; taskId: string };
+
+		if (!params.roomId) {
+			throw new Error('Room ID is required');
+		}
+		if (!params.taskId) {
+			throw new Error('Task ID is required');
+		}
+		if (!taskManagerFactory) {
+			throw new Error('Task manager factory is required for goal.cancelTask');
+		}
+
+		const taskManager = taskManagerFactory(params.roomId);
+		const task = await taskManager.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		// Allow cancellation for pending, in_progress, or review tasks
+		if (!['pending', 'in_progress', 'review'].includes(task.status)) {
+			throw new Error(`Task cannot be cancelled (current status: ${task.status})`);
+		}
+
+		// Try runtime cancellation first if available
+		if (runtimeService) {
+			const runtime = runtimeService.getRuntime(params.roomId);
+			if (runtime) {
+				const result = await runtime.cancelTask(params.taskId);
+				if (!result.success) {
+					throw new Error(`Failed to cancel task ${params.taskId}`);
+				}
+				log.info(`Task ${params.taskId} cancelled via runtime in room ${params.roomId}`);
+				return { success: true };
+			}
+		}
+
+		// Fallback: direct task manager cancellation when no runtime
+		await taskManager.cancelTaskCascade(params.taskId);
+		log.info(`Task ${params.taskId} cancelled via task manager in room ${params.roomId}`);
+
+		return { success: true };
+	});
+
+	// goal.rejectTask - Human rejects a task in review
+	messageHub.onRequest('goal.rejectTask', async (data) => {
+		const params = data as { roomId: string; taskId: string; feedback?: string };
+
+		if (!params.roomId) {
+			throw new Error('Room ID is required');
+		}
+		if (!params.taskId) {
+			throw new Error('Task ID is required');
+		}
+		if (!taskManagerFactory || !runtimeService) {
+			throw new Error('Task manager factory and runtime service are required for goal.rejectTask');
+		}
+
+		const taskManager = taskManagerFactory(params.roomId);
+		const task = await taskManager.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (task.status !== 'review') {
+			throw new Error(`Task is not in review status (current: ${task.status})`);
+		}
+
+		const runtime = runtimeService.getRuntime(params.roomId);
+		if (!runtime) {
+			throw new Error(`No runtime found for room: ${params.roomId}`);
+		}
+
+		const feedback =
+			params.feedback || 'Human has rejected the PR. Please address the feedback and resubmit.';
+		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, feedback, {
+			approved: false,
+		});
+		if (!resumed) {
+			throw new Error(`Failed to reject task ${params.taskId} — no awaiting_human group found`);
+		}
+
+		log.info(`Task ${params.taskId} rejected by human in room ${params.roomId}`);
 		return { success: true };
 	});
 }

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -703,4 +703,393 @@ describe('Goal RPC Handlers', () => {
 			expect(result.success).toBe(false);
 		});
 	});
+
+	// Additional mock setup for task-related handlers
+	const mockTaskManager = {
+		getTask: mock(async () => ({
+			id: 'task-123',
+			roomId: 'room-123',
+			title: 'Test Task',
+			description: 'Test task description',
+			status: 'pending' as const,
+			priority: 'normal' as const,
+			dependsOn: [],
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})),
+		reviewTask: mock(async () => ({})),
+		updateTaskStatus: mock(async () => ({})),
+		cancelTaskCascade: mock(async () => [
+			{
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test task description',
+				status: 'cancelled' as const,
+				priority: 'normal' as const,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		]),
+	};
+
+	const mockRuntimeService = {
+		getRuntime: mock(() => ({
+			cancelTask: mock(async () => ({ success: true, cancelledTaskIds: ['task-123'] })),
+			resumeWorkerFromHuman: mock(async () => true),
+		})),
+	};
+
+	const createMockTaskManagerFactory = () => {
+		const factory = mock(() => mockTaskManager);
+		return factory;
+	};
+
+	describe('goal.cancelTask', () => {
+		beforeEach(() => {
+			// Re-setup handlers with task manager factory and runtime service
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createMockTaskManagerFactory(),
+				mockRuntimeService as unknown as any
+			);
+			mockTaskManager.getTask.mockClear();
+			mockTaskManager.cancelTaskCascade.mockClear();
+			(mockRuntimeService.getRuntime as ReturnType<typeof mock>).mockClear();
+		});
+
+		it('cancels a pending task using runtime', async () => {
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			const params = { roomId: 'room-123', taskId: 'task-123' };
+			const result = (await handler!(params, {})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+			expect(mockRuntimeService.getRuntime).toHaveBeenCalledWith('room-123');
+		});
+
+		it('cancels a task using task manager fallback when no runtime', async () => {
+			// Need a fresh mock for this test - create new instance
+			const freshTaskManager = {
+				getTask: mock(async () => ({
+					id: 'task-123',
+					roomId: 'room-123',
+					title: 'Test Task',
+					description: 'Test task description',
+					status: 'pending' as const,
+					priority: 'normal' as const,
+					dependsOn: [],
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				})),
+				reviewTask: mock(async () => ({})),
+				updateTaskStatus: mock(async () => ({})),
+				cancelTaskCascade: mock(async () => [
+					{
+						id: 'task-123',
+						roomId: 'room-123',
+						title: 'Test Task',
+						description: 'Test task description',
+						status: 'cancelled' as const,
+						priority: 'normal' as const,
+						dependsOn: [],
+						createdAt: Date.now(),
+						updatedAt: Date.now(),
+					},
+				]),
+			};
+			const createFreshTaskManager = () => freshTaskManager;
+
+			// Setup with no runtime service - this should trigger fallback
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createFreshTaskManager,
+				undefined
+			);
+
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			const params = { roomId: 'room-123', taskId: 'task-123' };
+			const result = (await handler!(params, {})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+			expect(freshTaskManager.cancelTaskCascade).toHaveBeenCalledWith('task-123');
+		});
+
+		it('throws error when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ taskId: 'task-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws error when taskId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Task ID is required');
+		});
+
+		it('throws error when task not found', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce(null);
+
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'non-existent' }, {})).rejects.toThrow(
+				'Task not found: non-existent'
+			);
+		});
+
+		it('throws error when task cannot be cancelled (completed status)', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce({
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test task description',
+				status: 'completed' as const,
+				priority: 'normal' as const,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			});
+
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Task cannot be cancelled (current status: completed)'
+			);
+		});
+
+		it('throws error when task manager factory is missing', async () => {
+			// Setup without task manager factory
+			setupGoalHandlers(messageHubData.hub, daemonHubData.daemonHub, createMockGoalManager());
+
+			const handler = messageHubData.handlers.get('goal.cancelTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Task manager factory is required for goal.cancelTask'
+			);
+		});
+	});
+
+	describe('goal.rejectTask', () => {
+		beforeEach(() => {
+			// Re-setup handlers with task manager factory and runtime service
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createMockTaskManagerFactory(),
+				mockRuntimeService as unknown as any
+			);
+			mockTaskManager.getTask.mockClear();
+			(mockRuntimeService.getRuntime as ReturnType<typeof mock>).mockClear();
+			const runtime = mockRuntimeService.getRuntime('room-123') as any;
+			if (runtime?.resumeWorkerFromHuman) {
+				runtime.resumeWorkerFromHuman.mockClear();
+			}
+		});
+
+		it('rejects a task in review status', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce({
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test task description',
+				status: 'review' as const,
+				priority: 'normal' as const,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			});
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			const params = { roomId: 'room-123', taskId: 'task-123' };
+			const result = (await handler!(params, {})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+			expect(mockRuntimeService.getRuntime).toHaveBeenCalledWith('room-123');
+		});
+
+		it('rejects a task with custom feedback', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce({
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test task description',
+				status: 'review' as const,
+				priority: 'normal' as const,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			});
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			const params = { roomId: 'room-123', taskId: 'task-123', feedback: 'Please fix the tests' };
+			const result = (await handler!(params, {})) as { success: boolean };
+
+			expect(result.success).toBe(true);
+		});
+
+		it('throws error when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ taskId: 'task-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws error when taskId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Task ID is required');
+		});
+
+		it('throws error when task not found', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce(null);
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'non-existent' }, {})).rejects.toThrow(
+				'Task not found: non-existent'
+			);
+		});
+
+		it('throws error when task is not in review status', async () => {
+			mockTaskManager.getTask.mockResolvedValueOnce({
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Test Task',
+				description: 'Test task description',
+				status: 'pending' as const,
+				priority: 'normal' as const,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			});
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Task is not in review status (current: pending)'
+			);
+		});
+
+		it('throws error when runtime service is missing', async () => {
+			// Setup without runtime service
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createMockTaskManagerFactory(),
+				undefined
+			);
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Task manager factory and runtime service are required for goal.rejectTask'
+			);
+		});
+
+		it('throws error when runtime returns null', async () => {
+			// Create fresh task manager that returns a review task
+			const freshTaskManager = {
+				getTask: mock(async () => ({
+					id: 'task-123',
+					roomId: 'room-123',
+					title: 'Test Task',
+					description: 'Test task description',
+					status: 'review' as const,
+					priority: 'normal' as const,
+					dependsOn: [],
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				})),
+				reviewTask: mock(async () => ({})),
+				updateTaskStatus: mock(async () => ({})),
+				cancelTaskCascade: mock(async () => []),
+			};
+			const createFreshTaskManager = () => freshTaskManager;
+
+			// Setup with runtime service that returns null
+			const nullRuntimeService = {
+				getRuntime: mock(() => null),
+			};
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createFreshTaskManager,
+				nullRuntimeService as unknown as any
+			);
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'No runtime found for room: room-123'
+			);
+		});
+
+		it('throws error when resumeWorkerFromHuman returns false', async () => {
+			// Create fresh task manager that returns a review task
+			const freshTaskManager = {
+				getTask: mock(async () => ({
+					id: 'task-123',
+					roomId: 'room-123',
+					title: 'Test Task',
+					description: 'Test task description',
+					status: 'review' as const,
+					priority: 'normal' as const,
+					dependsOn: [],
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				})),
+				reviewTask: mock(async () => ({})),
+				updateTaskStatus: mock(async () => ({})),
+				cancelTaskCascade: mock(async () => []),
+			};
+			const createFreshTaskManager = () => freshTaskManager;
+
+			const mockRuntime = {
+				cancelTask: mock(async () => ({ success: true, cancelledTaskIds: [] })),
+				resumeWorkerFromHuman: mock(async () => false),
+			};
+			const failRuntimeService = {
+				getRuntime: mock(() => mockRuntime),
+			};
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager(),
+				createFreshTaskManager,
+				failRuntimeService as unknown as any
+			);
+
+			const handler = messageHubData.handlers.get('goal.rejectTask');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Failed to reject task task-123 — no awaiting_human group found'
+			);
+		});
+	});
 });

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -112,29 +112,46 @@ const TASK_STATUS_COLORS: Record<string, string> = {
 interface HeaderReviewBarProps {
 	roomId: string;
 	taskId: string;
-	/** Called after approval to refresh the conversation */
-	onApproved: () => void;
+	/** Called after approval/rejection to refresh the conversation */
+	onActionComplete: () => void;
 }
 
-function HeaderReviewBar({ roomId, taskId, onApproved }: HeaderReviewBarProps) {
+function HeaderReviewBar({ roomId, taskId, onActionComplete }: HeaderReviewBarProps) {
 	const { request } = useMessageHub();
-	const [approving, setApproving] = useState(false);
+	const [action, setAction] = useState<'approve' | 'reject' | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	const approveTask = async () => {
-		if (approving) return;
-		setApproving(true);
+		if (action) return;
+		setAction('approve');
 		setError(null);
 		try {
 			await request('goal.approveTask', { roomId, taskId });
 			// Approval changes group state; re-fetch conversation to pick up the approval message
-			onApproved();
+			onActionComplete();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to approve task');
 		} finally {
-			setApproving(false);
+			setAction(null);
 		}
 	};
+
+	const rejectTask = async () => {
+		if (action) return;
+		setAction('reject');
+		setError(null);
+		try {
+			await request('goal.rejectTask', { roomId, taskId });
+			// Rejection changes group state; re-fetch conversation to pick up the rejection message
+			onActionComplete();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to reject task');
+		} finally {
+			setAction(null);
+		}
+	};
+
+	const isLoading = action !== null;
 
 	return (
 		<div class="border-b border-amber-700/30 bg-amber-900/20 px-4 py-2 flex items-center gap-3 flex-shrink-0">
@@ -144,13 +161,52 @@ function HeaderReviewBar({ roomId, taskId, onApproved }: HeaderReviewBarProps) {
 					Review the PR and approve or provide feedback below
 				</span>
 			</div>
+			{/* Reject button */}
+			<button
+				class="py-1.5 px-4 rounded bg-red-700 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center gap-1.5"
+				onClick={rejectTask}
+				disabled={isLoading}
+			>
+				{action === 'reject' ? (
+					<>
+						<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+							<circle
+								class="opacity-25"
+								cx="12"
+								cy="12"
+								r="10"
+								stroke="currentColor"
+								stroke-width="4"
+							/>
+							<path
+								class="opacity-75"
+								fill="currentColor"
+								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+							/>
+						</svg>
+						<span>Rejecting…</span>
+					</>
+				) : (
+					<>
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+						<span>Reject</span>
+					</>
+				)}
+			</button>
 			{/* Approve button */}
 			<button
 				class="py-1.5 px-4 rounded bg-green-700 hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center gap-1.5"
 				onClick={approveTask}
-				disabled={approving}
+				disabled={isLoading}
 			>
-				{approving ? (
+				{action === 'approve' ? (
 					<>
 						<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
 							<circle
@@ -365,6 +421,10 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const [showInfoPanel, setShowInfoPanel] = useState(false);
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 
+	// UI state for cancel confirmation dialog
+	const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+	const [cancelling, setCancelling] = useState(false);
+
 	// Tracks whether the conversation pane is showing its first batch of messages.
 	// Starts true, resets to true each time the conversation reloads (conversationKey bumps),
 	// and becomes false once the first non-zero messageCount arrives — at which point
@@ -408,6 +468,21 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		scrollToBottom(true);
 		setAutoScrollEnabled(true);
 	}, [scrollToBottom]);
+
+	// Cancel task handler
+	const handleCancelTask = useCallback(async () => {
+		setCancelling(true);
+		try {
+			await request('goal.cancelTask', { roomId, taskId });
+			// Navigate back to room after cancellation
+			navigateToRoom(roomId);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to cancel task');
+		} finally {
+			setCancelling(false);
+			setShowCancelConfirm(false);
+		}
+	}, [roomId, taskId, request]);
 
 	useEffect(() => {
 		const channel = `room:${roomId}`;
@@ -561,6 +636,47 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						<span class="text-xs text-gray-400">{task.progress}%</span>
 					</div>
 				)}
+				{/* Cancel button - shown for pending/in_progress/review tasks */}
+				{['pending', 'in_progress', 'review'].includes(task.status) && (
+					<button
+						class="py-1.5 px-3 rounded bg-red-700/80 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center gap-1.5 flex-shrink-0"
+						onClick={() => setShowCancelConfirm(true)}
+						disabled={cancelling}
+					>
+						{cancelling ? (
+							<>
+								<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+									<circle
+										class="opacity-25"
+										cx="12"
+										cy="12"
+										r="10"
+										stroke="currentColor"
+										stroke-width="4"
+									/>
+									<path
+										class="opacity-75"
+										fill="currentColor"
+										d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+									/>
+								</svg>
+								<span>Cancelling…</span>
+							</>
+						) : (
+							<>
+								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+								<span>Cancel</span>
+							</>
+						)}
+					</button>
+				)}
 				{/* Info toggle button */}
 				<button
 					class={`p-1.5 rounded transition-colors ${
@@ -587,8 +703,58 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				<HeaderReviewBar
 					roomId={roomId}
 					taskId={taskId}
-					onApproved={() => setConversationKey((k) => k + 1)}
+					onActionComplete={() => setConversationKey((k) => k + 1)}
 				/>
+			)}
+
+			{/* Cancel confirmation dialog */}
+			{showCancelConfirm && (
+				<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+					<div class="bg-dark-800 border border-dark-600 rounded-lg p-6 max-w-sm w-full mx-4 shadow-xl">
+						<h3 class="text-lg font-semibold text-gray-100 mb-2">Cancel Task?</h3>
+						<p class="text-gray-400 text-sm mb-4">
+							This will stop the task and any associated agent sessions. This action cannot be
+							undone.
+						</p>
+						<div class="flex gap-3 justify-end">
+							<button
+								class="px-4 py-2 rounded bg-dark-700 hover:bg-dark-600 text-gray-200 text-sm font-medium transition-colors"
+								onClick={() => setShowCancelConfirm(false)}
+								disabled={cancelling}
+							>
+								Keep Task
+							</button>
+							<button
+								class="px-4 py-2 rounded bg-red-700 hover:bg-red-600 text-white text-sm font-medium transition-colors flex items-center gap-1.5"
+								onClick={handleCancelTask}
+								disabled={cancelling}
+							>
+								{cancelling ? (
+									<>
+										<svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+											<circle
+												class="opacity-25"
+												cx="12"
+												cy="12"
+												r="10"
+												stroke="currentColor"
+												stroke-width="4"
+											/>
+											<path
+												class="opacity-75"
+												fill="currentColor"
+												d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+											/>
+										</svg>
+										<span>Cancelling…</span>
+									</>
+								) : (
+									'Cancel Task'
+								)}
+							</button>
+						</div>
+					</div>
+				</div>
 			)}
 
 			{/* Info panel */}


### PR DESCRIPTION
Add Cancel and Reject action buttons to TaskView UI for task lifecycle
management:

- Add goal.cancelTask RPC handler for cancelling pending/in_progress/review tasks
- Add goal.rejectTask RPC handler for rejecting review tasks with optional feedback
- Add Cancel button in task header (shown for pending/in_progress/review tasks)
- Add Reject button in HeaderReviewBar (shown when awaiting human review)
- Add confirmation dialog for destructive cancel action
- Add unit tests for both new RPC handlers

Task can now be controlled directly from UI without CLI/MCP tools.
