### PR TITLE
feat: add dependsOn, taskType, and assignedAgent support to task tools

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -100,10 +100,16 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 	// Tool contract
 	sections.push(`\n## Tool Contract (CRITICAL)\n`);
 	sections.push(`You MUST call tools (no text-only final responses).`);
-	sections.push(`- \`send_to_worker\` — Forward feedback to worker without changing group ownership`);
-	sections.push(`  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)`);
+	sections.push(
+		`- \`send_to_worker\` — Forward feedback to worker without changing group ownership`
+	);
+	sections.push(
+		`  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)`
+	);
 	sections.push(`  - mode=\`steer\`: inject for current-turn steering`);
-	sections.push(`- \`handoff_to_worker\` — Explicitly return ownership to worker (awaiting_worker)`);
+	sections.push(
+		`- \`handoff_to_worker\` — Explicitly return ownership to worker (awaiting_worker)`
+	);
 	sections.push(`- \`complete_task\` — Accept the work if it meets all requirements`);
 	sections.push(`- \`fail_task\` — Mark the task as not achievable`);
 	sections.push(
@@ -299,9 +305,7 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 			sections.push(
 				`   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.`
 			);
-			sections.push(
-				`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.`
-			);
+			sections.push(`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.`);
 			sections.push(
 				`   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).`
 			);

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -313,7 +313,7 @@ export class TaskManager {
 	}
 
 	/**
-	 * Update task fields (title, description, priority) without changing status.
+	 * Update task fields (title, description, priority, dependsOn) without changing status.
 	 * Works for tasks in any status — used by the room agent.
 	 */
 	async updateTaskFields(
@@ -322,11 +322,22 @@ export class TaskManager {
 			title?: string;
 			description?: string;
 			priority?: TaskPriority;
+			dependsOn?: string[];
 		}
 	): Promise<NeoTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		// Validate that all new dependency task IDs exist in this room
+		if (updates.dependsOn && updates.dependsOn.length > 0) {
+			for (const depId of updates.dependsOn) {
+				const depTask = await this.getTask(depId);
+				if (!depTask) {
+					throw new Error(`Dependency task not found in room: ${depId}`);
+				}
+			}
 		}
 
 		const updatedTask = this.taskRepo.updateTask(taskId, updates);

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -12,7 +12,7 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { TaskStatus } from '@neokai/shared';
+import type { TaskStatus, TaskType, AgentType } from '@neokai/shared';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
@@ -98,12 +98,24 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			description: string;
 			goal_id?: string;
 			priority?: 'low' | 'normal' | 'high' | 'urgent';
+			depends_on?: string[];
+			task_type?: TaskType;
+			assigned_agent?: AgentType;
 		}): Promise<ToolResult> {
-			const task = await taskManager.createTask({
-				title: args.title,
-				description: args.description,
-				priority: args.priority,
-			});
+			let task;
+			try {
+				task = await taskManager.createTask({
+					title: args.title,
+					description: args.description,
+					priority: args.priority,
+					dependsOn: args.depends_on,
+					taskType: args.task_type,
+					assignedAgent: args.assigned_agent,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return jsonResult({ success: false, error: message });
+			}
 			if (args.goal_id) {
 				await goalManager.linkTaskToGoal(args.goal_id, task.id);
 			}
@@ -135,6 +147,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			title?: string;
 			description?: string;
 			priority?: 'low' | 'normal' | 'high' | 'urgent';
+			depends_on?: string[];
 		}): Promise<ToolResult> {
 			const task = await taskManager.getTask(args.task_id);
 			if (!task) {
@@ -144,15 +157,23 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				title?: string;
 				description?: string;
 				priority?: 'low' | 'normal' | 'high' | 'urgent';
+				dependsOn?: string[];
 			} = {};
 			if (args.title !== undefined) updates.title = args.title;
 			if (args.description !== undefined) updates.description = args.description;
 			if (args.priority !== undefined) updates.priority = args.priority;
+			if (args.depends_on !== undefined) updates.dependsOn = args.depends_on;
 			// Apply updates if any fields were provided; otherwise return existing task unchanged
-			const updated =
-				Object.keys(updates).length > 0
-					? await taskManager.updateTaskFields(args.task_id, updates)
-					: task;
+			let updated;
+			try {
+				updated =
+					Object.keys(updates).length > 0
+						? await taskManager.updateTaskFields(args.task_id, updates)
+						: task;
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return jsonResult({ success: false, error: message });
+			}
 			// Notify UI of the update
 			if (daemonHub) {
 				void daemonHub.emit('room.task.update', {
@@ -395,6 +416,18 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 					.optional()
 					.default('normal')
 					.describe('Task priority'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('IDs of tasks this task depends on (must complete first)'),
+				task_type: z
+					.enum(['planning', 'coding', 'research', 'design', 'goal_review'])
+					.optional()
+					.describe('Task type - determines agent preset (default: coding)'),
+				assigned_agent: z
+					.enum(['coder', 'general'])
+					.optional()
+					.describe('Agent type to execute this task (default: coder)'),
 			},
 			(args) => handlers.create_task(args)
 		),
@@ -412,12 +445,16 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'update_task',
-			'Update an existing task (title, description, and/or priority). Only provided fields are changed; omitted fields keep their current values.',
+			'Update an existing task (title, description, priority, and/or dependencies). Only provided fields are changed; omitted fields keep their current values.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
 				title: z.string().trim().min(1).optional().describe('New title for the task'),
 				description: z.string().trim().min(1).optional().describe('New description for the task'),
 				priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('New priority'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('New list of task IDs this task depends on (replaces existing)'),
 			},
 			(args) => handlers.update_task(args)
 		),

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -536,7 +536,9 @@ describe('Leader Agent', () => {
 			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
 			const agent = agents['reviewer-opus'];
 			expect(agent.prompt).toContain('ME="$(gh api user --jq .login)"');
-			expect(agent.prompt).toContain('PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"');
+			expect(agent.prompt).toContain(
+				'PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"'
+			);
 			expect(agent.prompt).toContain('EVENT="COMMENT"');
 		});
 
@@ -544,7 +546,9 @@ describe('Leader Agent', () => {
 			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
 			const agent = agents['reviewer-custom-cli'];
 			expect(agent.prompt).toContain('ME="$(gh api user --jq .login)"');
-			expect(agent.prompt).toContain('PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"');
+			expect(agent.prompt).toContain(
+				'PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"'
+			);
 			expect(agent.prompt).toContain('EVENT="COMMENT"');
 		});
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -196,6 +196,97 @@ describe('Room Agent Tools', () => {
 			);
 			expect(updatedGoal!.linkedTaskIds.length).toBe(1);
 		});
+
+		it('should create a task with depends_on', async () => {
+			// Create prerequisite task first
+			const prerequisite = parseResult(
+				await handlers.create_task({
+					title: 'Prerequisite task',
+					description: 'This must complete first',
+				})
+			);
+			const prerequisiteId = prerequisite.taskId as string;
+
+			// Create dependent task
+			const result = parseResult(
+				await handlers.create_task({
+					title: 'Dependent task',
+					description: 'Depends on prerequisite',
+					depends_on: [prerequisiteId],
+				})
+			);
+			expect(result.success).toBe(true);
+			const task = result.task as { id: string; dependsOn: string[] };
+			expect(task.dependsOn).toEqual([prerequisiteId]);
+		});
+
+		it('should create a task with task_type', async () => {
+			const result = parseResult(
+				await handlers.create_task({
+					title: 'Research task',
+					description: 'Investigate options',
+					task_type: 'research',
+				})
+			);
+			expect(result.success).toBe(true);
+			const task = result.task as { id: string; taskType: string };
+			expect(task.taskType).toBe('research');
+		});
+
+		it('should create a task with assigned_agent', async () => {
+			const result = parseResult(
+				await handlers.create_task({
+					title: 'General task',
+					description: 'Any agent can do this',
+					assigned_agent: 'general',
+				})
+			);
+			expect(result.success).toBe(true);
+			const task = result.task as { id: string; assignedAgent: string };
+			expect(task.assignedAgent).toBe('general');
+		});
+
+		it('should create a task with all new fields', async () => {
+			const prerequisite = parseResult(
+				await handlers.create_task({
+					title: 'First task',
+					description: 'Start here',
+				})
+			);
+			const prerequisiteId = prerequisite.taskId as string;
+
+			const result = parseResult(
+				await handlers.create_task({
+					title: 'Full featured task',
+					description: 'All options',
+					depends_on: [prerequisiteId],
+					task_type: 'coding',
+					assigned_agent: 'coder',
+				})
+			);
+			expect(result.success).toBe(true);
+			const task = result.task as {
+				id: string;
+				dependsOn: string[];
+				taskType: string;
+				assignedAgent: string;
+			};
+			expect(task.dependsOn).toEqual([prerequisiteId]);
+			expect(task.taskType).toBe('coding');
+			expect(task.assignedAgent).toBe('coder');
+		});
+
+		it('should return error when depends_on references non-existent task', async () => {
+			const result = parseResult(
+				await handlers.create_task({
+					title: 'Task with bad dependency',
+					description: 'References non-existent task',
+					depends_on: ['non-existent-task-id'],
+				})
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Dependency task not found');
+		});
 	});
 
 	describe('list_tasks', () => {
@@ -351,6 +442,71 @@ describe('Room Agent Tools', () => {
 			const task = result.task as { id: string; title: string };
 			expect(task.id).toBe(taskId);
 			expect(task.title).toBe('Original');
+		});
+
+		it('should update task depends_on', async () => {
+			// Create two prerequisite tasks
+			const prereq1 = parseResult(
+				await handlers.create_task({ title: 'Prereq 1', description: 'First' })
+			);
+			const prereq1Id = prereq1.taskId as string;
+			const prereq2 = parseResult(
+				await handlers.create_task({ title: 'Prereq 2', description: 'Second' })
+			);
+			const prereq2Id = prereq2.taskId as string;
+
+			// Create dependent task
+			const created = parseResult(
+				await handlers.create_task({
+					title: 'Dependent',
+					description: 'Depends on others',
+					depends_on: [prereq1Id],
+				})
+			);
+			const taskId = created.taskId as string;
+
+			// Update to depend on both tasks
+			const result = parseResult(
+				await handlers.update_task({ task_id: taskId, depends_on: [prereq1Id, prereq2Id] })
+			);
+			expect(result.success).toBe(true);
+			const task = result.task as { dependsOn: string[] };
+			expect(task.dependsOn).toEqual([prereq1Id, prereq2Id]);
+		});
+
+		it('should clear depends_on when set to empty array', async () => {
+			// Create prerequisite task
+			const prereq = parseResult(
+				await handlers.create_task({ title: 'Prereq', description: 'First' })
+			);
+			const prereqId = prereq.taskId as string;
+
+			// Create dependent task
+			const created = parseResult(
+				await handlers.create_task({
+					title: 'Dependent',
+					description: 'Depends on other',
+					depends_on: [prereqId],
+				})
+			);
+			const taskId = created.taskId as string;
+
+			// Clear dependencies
+			const result = parseResult(await handlers.update_task({ task_id: taskId, depends_on: [] }));
+			expect(result.success).toBe(true);
+			const task = result.task as { dependsOn: string[] };
+			expect(task.dependsOn).toEqual([]);
+		});
+
+		it('should return error when updating depends_on with non-existent task', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'Task', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			const result = parseResult(
+				await handlers.update_task({ task_id: taskId, depends_on: ['non-existent-task-id'] })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Dependency task not found');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -150,13 +150,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker } = makeRuntime();
 			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
 
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskId,
-				message,
-				'worker'
-			);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'worker');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
@@ -166,13 +160,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToLeader } = makeRuntime();
 			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
 
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskId,
-				message,
-				'leader'
-			);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);


### PR DESCRIPTION
Update MCP room-agent-tools to support additional task fields:
- create_task now accepts depends_on, task_type, and assigned_agent
- update_task now accepts depends_on for modifying dependencies
- TaskManager.updateTaskFields extended to validate and accept dependsOn
- Add error handling to return validation errors as JSON responses
- Add comprehensive unit tests for all new fields

Closes: task/add-dependson-support-to-task-tools
