### PR TITLE
docs: add plan for pi-mono tool support

### DIFF
--- a/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
+++ b/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
@@ -1,0 +1,252 @@
+# Fix Pi-Mono Integration for Transparent Multi-Provider Support
+
+## Goal
+
+Make the pi-mono path fully transparent under our agent session layer so we can use any provider/model it supports (GitHub Copilot, OpenAI, Google, etc.) just like we use Anthropic models today.
+
+**Success Criteria:**
+- Tool use works correctly with pi-mono backed providers
+- Can seamlessly switch between Anthropic and pi-mono providers via config
+- All provider-specific features are abstracted at the agent session layer
+
+## Root Cause Analysis
+
+Investigation revealed three critical issues preventing pi-mono tool use:
+
+### Issue 1: Tools Not Passed to Custom Providers
+**Location:** `packages/daemon/src/lib/agent/query-runner.ts:228`
+
+```typescript
+const customQueryOptions: ProviderQueryOptions = {
+    // ...
+    tools: [], // Tools are handled by SDK in standard mode; custom providers handle their own tools
+};
+```
+
+The comment is misleading. Tools are hardcoded to an empty array, so pi-mono providers never receive tool definitions.
+
+### Issue 2: No Tool Executor Callback
+**Locations:**
+- `packages/daemon/src/lib/providers/openai-provider.ts:317` - passes `undefined`
+- `packages/daemon/src/lib/providers/github-copilot-provider.ts:265` - passes `undefined`
+
+Both providers pass `undefined` as the `toolExecutor` parameter to `piMonoQueryGenerator()`. When pi-agent-core's Agent calls tools, it receives "No tool executor available" error.
+
+### Issue 3: No Permission Handling Bridge
+There's no mechanism to route tool permission checks from pi-mono to the `canUseTool` callback used by the SDK path. The SDK handles permissions via `options.canUseTool`, but pi-mono has no equivalent.
+
+## Task Breakdown
+
+### Task 1: Pass Tool Definitions to Custom Query Providers
+**Agent:** coder
+
+**Description:**
+Extract tool definitions from SDK query options and pass them to custom query providers via `ProviderQueryOptions.tools`.
+
+Currently in `query-runner.ts`:
+```typescript
+tools: [], // hardcoded empty
+```
+
+Need to:
+1. Get available tools from the SDK options (via `optionsBuilder` or introspection)
+2. Convert SDK tool format to `ToolDefinition[]` format
+3. Populate `customQueryOptions.tools` with actual tool definitions
+
+**Files to modify:**
+- `packages/daemon/src/lib/agent/query-runner.ts`
+- `packages/shared/src/provider/query-types.ts` (if ToolDefinition needs enhancement)
+
+**Acceptance Criteria:**
+- Tool definitions are extracted from SDK options and passed to custom providers
+- `customQueryOptions.tools` contains actual tool definitions (not empty array)
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 2: Implement Tool Execution Bridge for Pi-Mono
+**Agent:** coder
+**Depends on:** Task 1
+
+**Description:**
+Create a tool executor callback that routes tool execution from pi-mono to NeoKai's existing tool handlers.
+
+The `piMonoQueryGenerator` function accepts a `ToolExecutionCallback` parameter:
+```typescript
+export type ToolExecutionCallback = (
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolUseId: string
+) => Promise<{ output: unknown; isError: boolean }>;
+```
+
+Need to:
+1. Create a tool executor in `QueryRunner` that can execute tools via NeoKai's existing infrastructure
+2. Pass this executor through the provider's `createQuery` method
+3. Update `Provider.createQuery` signature to accept the tool executor
+4. Update `piMonoQueryGenerator` calls in providers to use the provided executor
+
+**Files to modify:**
+- `packages/daemon/src/lib/agent/query-runner.ts`
+- `packages/shared/src/provider/types.ts` (add toolExecutor to createQuery context)
+- `packages/shared/src/provider/query-types.ts` (extend ProviderQueryContext)
+- `packages/daemon/src/lib/providers/pimono-adapter.ts`
+- `packages/daemon/src/lib/providers/openai-provider.ts`
+- `packages/daemon/src/lib/providers/github-copilot-provider.ts`
+
+**Acceptance Criteria:**
+- Tool executor callback is created and passed through the provider chain
+- When pi-agent-core Agent calls a tool, it executes via NeoKai's tool handlers
+- Tool results are properly returned to the pi-agent-core Agent
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 3: Implement Permission Handling for Pi-Mono Tools
+**Agent:** coder
+**Depends on:** Task 2
+
+**Description:**
+Integrate the `canUseTool` permission callback with the pi-mono tool execution flow.
+
+The SDK path uses `options.canUseTool` callback for permission prompts. The pi-mono path needs equivalent handling:
+1. Pass `canUseTool` callback to the tool executor
+2. Check permissions before executing tools
+3. Handle permission denials gracefully
+
+**Files to modify:**
+- `packages/daemon/src/lib/agent/query-runner.ts`
+- `packages/shared/src/provider/query-types.ts`
+- `packages/daemon/src/lib/providers/pimono-adapter.ts`
+
+**Acceptance Criteria:**
+- Tool permission checks work for pi-mono providers
+- Permission denials are communicated back to the agent
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 4: Fix Input Schema Conversion in convertToAgentTools
+**Agent:** coder
+**Depends on:** Task 1
+
+**Description:**
+The current schema conversion in `pimono-adapter.ts` uses a generic "any object" schema:
+```typescript
+parameters: Type.Record(Type.String(), Type.Any()) as unknown as TSchema,
+```
+
+This loses the actual input schema from `ToolDefinition.inputSchema`. Need to properly convert JSON Schema to pi-ai's `TSchema` format.
+
+**Files to modify:**
+- `packages/daemon/src/lib/providers/pimono-adapter.ts`
+
+**Acceptance Criteria:**
+- Tool input schemas are properly converted to pi-ai TSchema format
+- LLMs receive accurate parameter schemas for tools
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 5: Add Unit Tests for Pi-Mono Tool Execution
+**Agent:** coder
+**Depends on:** Task 2, Task 3, Task 4
+
+**Description:**
+Create comprehensive unit tests for the pi-mono tool execution path.
+
+**Test coverage:**
+- Tool definition extraction and passing
+- Tool executor callback invocation
+- Permission handling
+- Schema conversion
+- Error handling
+
+**Files to create/modify:**
+- `packages/daemon/tests/unit/providers/pimono-adapter.test.ts`
+- `packages/daemon/tests/unit/agent/query-runner-custom-provider.test.ts`
+
+**Acceptance Criteria:**
+- Unit tests cover all pi-mono tool execution paths
+- Tests pass with >80% coverage on modified code
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 6: Add Online Integration Tests for Pi-Mono Providers
+**Agent:** coder
+**Depends on:** Task 5
+
+**Description:**
+Create online integration tests that verify end-to-end tool execution with pi-mono providers (OpenAI, GitHub Copilot).
+
+These tests should:
+1. Use mock mode by default (NEOKAI_TEST_ONLINE=false)
+2. Support real API testing with NEOKAI_TEST_ONLINE=true
+3. Test actual tool calling and execution
+
+**Files to create/modify:**
+- `packages/daemon/tests/online/pimono-tool-execution.test.ts`
+
+**Acceptance Criteria:**
+- Integration tests verify tool execution works end-to-end
+- Mock mode tests run in CI
+- Real API tests can be run manually for verification
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (Tool Definitions)
+    ├── Task 2 (Tool Executor) ──┐
+    │       ├── Task 3 (Permissions)
+    │       └── Task 4 (Schema Conversion)
+    └── Task 5 (Unit Tests)
+            └── Task 6 (Integration Tests)
+```
+
+Tasks 2, 3, 4 can run in parallel after Task 1 completes.
+Task 5 depends on Tasks 2, 3, 4.
+Task 6 depends on Task 5.
+
+## Implementation Order
+
+1. **Task 1** - Foundation: Pass tool definitions to custom providers
+2. **Tasks 2, 3, 4** (parallel) - Core implementation
+3. **Task 5** - Unit tests for all core changes
+4. **Task 6** - Integration tests
+
+## Technical Notes
+
+### Provider Interface Changes
+
+The `Provider.createQuery` method may need to accept additional context:
+
+```typescript
+createQuery?(
+    prompt: AsyncGenerator<SDKUserMessage>,
+    options: ProviderQueryOptions,
+    context: ProviderQueryContext & {
+        toolExecutor?: ToolExecutionCallback;
+        canUseTool?: CanUseToolCallback;
+    }
+): Promise<AsyncGenerator<SDKMessage> | null>;
+```
+
+### Tool Definition Sources
+
+Tool definitions can be sourced from:
+1. SDK's built-in tools (from `options.tools` preset)
+2. MCP server tools
+3. Custom agent tools
+
+The `QueryOptionsBuilder` constructs the full tool set - we need to extract this for pi-mono.
+
+### Pi-AI Schema Conversion
+
+Pi-ai uses TypeBox for schemas (`Type.*` builders). We need to convert JSON Schema to TypeBox format. Options:
+1. Use `Type.Unsafe()` to wrap existing JSON Schema
+2. Implement a proper converter
+3. Use a library like `json-schema-to-typescript` concepts

--- a/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
+++ b/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
@@ -43,24 +43,41 @@ There's no mechanism to route tool permission checks from pi-mono to the `canUse
 **Description:**
 Extract tool definitions from SDK query options and pass them to custom query providers via `ProviderQueryOptions.tools`.
 
-Currently in `query-runner.ts`:
+**Implementation Approach:**
+
+The SDK's `queryOptions` object (built by `QueryOptionsBuilder`) contains:
+- `options.tools` - preset string like 'BashReadEditFiles' or array of tool names
+- `options.allowedTools` - tools to auto-approve
+- `options.disallowedTools` - tools to block
+
+However, the SDK doesn't expose the actual tool definitions with schemas - it handles tool registration internally. We have two options:
+
+**Option A (Recommended): Hardcode tool definitions from SDK's built-in presets**
+Create a `ToolDefinitions` module that maps tool names to their JSON Schema definitions, matching what the SDK uses internally. This is maintainable because the SDK's built-in tools are stable.
+
 ```typescript
-tools: [], // hardcoded empty
+// packages/shared/src/provider/builtin-tools.ts
+export const BUILTIN_TOOLS: Record<string, ToolDefinition> = {
+    Read: { name: 'Read', description: '...', inputSchema: { type: 'object', properties: {...} } },
+    Bash: { name: 'Bash', description: '...', inputSchema: { type: 'object', properties: {...} } },
+    // ...
+};
 ```
 
-Need to:
-1. Get available tools from the SDK options (via `optionsBuilder` or introspection)
-2. Convert SDK tool format to `ToolDefinition[]` format
-3. Populate `customQueryOptions.tools` with actual tool definitions
+**Option B: Fetch tools from SDK subprocess**
+Query the SDK for available tools at startup. This is more dynamic but adds complexity and startup latency.
+
+We'll use **Option A** - it's simpler, more reliable, and the SDK tools rarely change.
 
 **Files to modify:**
-- `packages/daemon/src/lib/agent/query-runner.ts`
-- `packages/shared/src/provider/query-types.ts` (if ToolDefinition needs enhancement)
+- `packages/daemon/src/lib/agent/query-runner.ts` - import tool definitions and pass to `customQueryOptions`
+- `packages/shared/src/provider/builtin-tools.ts` (NEW) - tool definitions with JSON Schemas
+- `packages/shared/src/provider/query-types.ts` - ensure `ToolDefinition` type is complete
 
 **Acceptance Criteria:**
-- Tool definitions are extracted from SDK options and passed to custom providers
+- Tool definitions are extracted from a lookup table matching SDK's built-in tools
 - `customQueryOptions.tools` contains actual tool definitions (not empty array)
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+- Only tools allowed by `allowedTools`/`disallowedTools` are included
 
 ---
 
@@ -69,36 +86,73 @@ Need to:
 **Depends on:** Task 1
 
 **Description:**
-Create a tool executor callback that routes tool execution from pi-mono to NeoKai's existing tool handlers.
+Create a tool executor callback that routes tool execution from pi-mono to the SDK's subprocess for actual execution.
 
-The `piMonoQueryGenerator` function accepts a `ToolExecutionCallback` parameter:
-```typescript
-export type ToolExecutionCallback = (
-    toolName: string,
-    toolInput: Record<string, unknown>,
-    toolUseId: string
-) => Promise<{ output: unknown; isError: boolean }>;
+**Implementation Approach:**
+
+The SDK handles tool execution internally via a subprocess. For pi-mono providers, we need to execute tools ourselves since pi-agent-core's Agent only calls our callback. The key insight is:
+
+**NeoKai's "existing infrastructure" = the SDK subprocess itself**
+
+When using pi-mono, we still spawn an SDK subprocess (via `query()`) but use it ONLY for tool execution, not for LLM calls. The architecture becomes:
+
+```
+pi-mono (LLM) → toolExecutor callback → SDK subprocess (tool execution) → result → pi-mono
 ```
 
-Need to:
-1. Create a tool executor in `QueryRunner` that can execute tools via NeoKai's existing infrastructure
-2. Pass this executor through the provider's `createQuery` method
-3. Update `Provider.createQuery` signature to accept the tool executor
-4. Update `piMonoQueryGenerator` calls in providers to use the provided executor
+However, this approach is complex. A simpler approach:
+
+**Simpler Approach: Direct tool execution via SDK's tool implementations**
+
+The SDK exports tool implementations we can call directly. We'll:
+
+1. Import tool implementations from SDK (or recreate them in NeoKai)
+2. Create a `ToolExecutor` class that:
+   - Receives tool name, input, and toolUseId
+   - Validates against `allowedTools`/`disallowedTools`
+   - Calls `canUseTool` callback for permission
+   - Executes the tool
+   - Returns `{ output, isError }`
+
+**Implementation:**
+
+```typescript
+// packages/daemon/src/lib/agent/tool-executor.ts
+export class ToolExecutor {
+    constructor(
+        private ctx: {
+            canUseTool?: CanUseTool;
+            allowedTools?: string[];
+            disallowedTools?: string[];
+            cwd: string;
+        }
+    ) {}
+
+    async execute(toolName: string, input: Record<string, unknown>, toolUseId: string): Promise<{
+        output: unknown;
+        isError: boolean;
+    }> {
+        // 1. Check disallowed
+        // 2. Call canUseTool for permission
+        // 3. Execute tool
+        // 4. Return result
+    }
+}
+```
 
 **Files to modify:**
-- `packages/daemon/src/lib/agent/query-runner.ts`
-- `packages/shared/src/provider/types.ts` (add toolExecutor to createQuery context)
-- `packages/shared/src/provider/query-types.ts` (extend ProviderQueryContext)
-- `packages/daemon/src/lib/providers/pimono-adapter.ts`
-- `packages/daemon/src/lib/providers/openai-provider.ts`
-- `packages/daemon/src/lib/providers/github-copilot-provider.ts`
+- `packages/daemon/src/lib/agent/tool-executor.ts` (NEW) - ToolExecutor class
+- `packages/daemon/src/lib/agent/query-runner.ts` - create ToolExecutor, pass to provider
+- `packages/shared/src/provider/types.ts` - add `toolExecutor` to `createQuery` context
+- `packages/shared/src/provider/query-types.ts` - extend `ProviderQueryContext`
+- `packages/daemon/src/lib/providers/openai-provider.ts` - use passed toolExecutor
+- `packages/daemon/src/lib/providers/github-copilot-provider.ts` - use passed toolExecutor
 
 **Acceptance Criteria:**
-- Tool executor callback is created and passed through the provider chain
-- When pi-agent-core Agent calls a tool, it executes via NeoKai's tool handlers
-- Tool results are properly returned to the pi-agent-core Agent
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+- `ToolExecutor` class created with execute method
+- Tool executor is passed through `ProviderQueryContext` to providers
+- `piMonoQueryGenerator` receives and uses the tool executor
+- When pi-agent-core Agent calls a tool, it executes via ToolExecutor
 
 ---
 
@@ -109,20 +163,44 @@ Need to:
 **Description:**
 Integrate the `canUseTool` permission callback with the pi-mono tool execution flow.
 
-The SDK path uses `options.canUseTool` callback for permission prompts. The pi-mono path needs equivalent handling:
-1. Pass `canUseTool` callback to the tool executor
-2. Check permissions before executing tools
-3. Handle permission denials gracefully
+**Implementation Approach:**
+
+The permission check will happen **inside** the `ToolExecutor.execute()` method, **before** executing the tool:
+
+```typescript
+async execute(toolName: string, input: Record<string, unknown>, toolUseId: string) {
+    // 1. Check disallowed tools list (deny without asking)
+    if (this.ctx.disallowedTools?.some(d => matchesPattern(d, toolName))) {
+        return { output: `Tool ${toolName} is disallowed`, isError: true };
+    }
+
+    // 2. Check allowed tools list (auto-approve)
+    const isAllowed = this.ctx.allowedTools?.some(a => matchesPattern(a, toolName));
+
+    // 3. If not auto-approved, call canUseTool for user permission
+    if (!isAllowed && this.ctx.canUseTool) {
+        const permission = await this.ctx.canUseTool({ toolName, input, toolUseId });
+        if (!permission.allowed) {
+            return { output: `Tool ${toolName} permission denied`, isError: true };
+        }
+    }
+
+    // 4. Execute the tool
+    return this.executeToolInternal(toolName, input);
+}
+```
+
+The `canUseTool` callback is already created by `AskUserQuestionHandler.createCanUseToolCallback()` and passed to `QueryOptionsBuilder`. We'll pass it through to `ToolExecutor`.
 
 **Files to modify:**
-- `packages/daemon/src/lib/agent/query-runner.ts`
-- `packages/shared/src/provider/query-types.ts`
-- `packages/daemon/src/lib/providers/pimono-adapter.ts`
+- `packages/daemon/src/lib/agent/tool-executor.ts` - add permission logic
+- `packages/daemon/src/lib/agent/query-runner.ts` - pass canUseTool to ToolExecutor
 
 **Acceptance Criteria:**
-- Tool permission checks work for pi-mono providers
-- Permission denials are communicated back to the agent
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+- Tools in `disallowedTools` are blocked without user prompt
+- Tools in `allowedTools` are auto-approved
+- Other tools trigger `canUseTool` callback for user permission
+- Permission denials are returned as error results to pi-agent-core
 
 ---
 
@@ -138,13 +216,30 @@ parameters: Type.Record(Type.String(), Type.Any()) as unknown as TSchema,
 
 This loses the actual input schema from `ToolDefinition.inputSchema`. Need to properly convert JSON Schema to pi-ai's `TSchema` format.
 
+**Recommended Approach: Use `Type.Unsafe()`**
+
+TypeBox's `Type.Unsafe()` allows wrapping existing JSON Schema without conversion:
+
+```typescript
+import { Type } from '@mariozechner/pi-ai';
+
+export function jsonSchemaToTSchema(schema: Record<string, unknown>): TSchema {
+    // Type.Unsafe preserves the original JSON Schema
+    return Type.Unsafe(schema) as unknown as TSchema;
+}
+```
+
+This is the simplest approach and maintains full schema fidelity. The pi-ai library will pass the schema through to the LLM unchanged.
+
+**Alternative Considered: Full conversion to TypeBox**
+Converting JSON Schema to TypeBox's builder format (`Type.Object({ ... })`) is complex and error-prone for nested schemas. Not recommended.
+
 **Files to modify:**
-- `packages/daemon/src/lib/providers/pimono-adapter.ts`
+- `packages/daemon/src/lib/providers/pimono-adapter.ts` - update `convertToAgentTools`
 
 **Acceptance Criteria:**
-- Tool input schemas are properly converted to pi-ai TSchema format
-- LLMs receive accurate parameter schemas for tools
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+- `convertToAgentTools` uses `Type.Unsafe()` to wrap `inputSchema`
+- LLMs receive accurate parameter schemas with proper types, descriptions, and constraints
 
 ---
 
@@ -155,21 +250,54 @@ This loses the actual input schema from `ToolDefinition.inputSchema`. Need to pr
 **Description:**
 Create comprehensive unit tests for the pi-mono tool execution path.
 
-**Test coverage:**
-- Tool definition extraction and passing
-- Tool executor callback invocation
-- Permission handling
-- Schema conversion
-- Error handling
+**Mock Strategy:**
 
-**Files to create/modify:**
+Following the existing test patterns in `packages/daemon/tests/unit/`, we'll:
+
+1. **Mock pi-agent-core's Agent class** - Instead of using the real Agent, create a mock that:
+   - Accepts the same configuration
+   - Simulates tool calls by invoking the `execute` callback
+   - Returns predetermined responses
+
+```typescript
+// In test setup
+vi.mock('@mariozechner/pi-agent-core', () => ({
+    Agent: vi.fn().mockImplementation((config) => ({
+        subscribe: vi.fn((callback) => {
+            // Simulate tool call event
+            config.initialState.tools[0].execute('call-123', { path: '/test' });
+            callback({ type: 'tool_execution_start', toolName: 'Read', toolCallId: 'call-123' });
+            callback({ type: 'tool_execution_end', toolName: 'Read', toolCallId: 'call-123' });
+            return vi.fn(); // unsubscribe
+        }),
+        prompt: vi.fn(),
+        abort: vi.fn(),
+    })),
+}));
+```
+
+2. **Mock @mariozechner/pi-ai's getModel** - Return a minimal mock model:
+```typescript
+vi.mock('@mariozechner/pi-ai', () => ({
+    getModel: vi.fn(() => ({ id: 'test-model', contextWindow: 128000, maxTokens: 4096 })),
+    Type: { Unsafe: vi.fn((s) => s) },
+}));
+```
+
+**Test coverage:**
+- `convertToAgentTools` schema conversion
+- `sdkToAgentMessage` message translation
+- `ToolExecutor` permission checking and execution
+- `piMonoQueryGenerator` event handling and message yielding
+
+**Files to create:**
 - `packages/daemon/tests/unit/providers/pimono-adapter.test.ts`
-- `packages/daemon/tests/unit/agent/query-runner-custom-provider.test.ts`
+- `packages/daemon/tests/unit/agent/tool-executor.test.ts`
 
 **Acceptance Criteria:**
 - Unit tests cover all pi-mono tool execution paths
+- Tests mock pi-agent-core and pi-ai as described
 - Tests pass with >80% coverage on modified code
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 
 ---
 
@@ -178,21 +306,73 @@ Create comprehensive unit tests for the pi-mono tool execution path.
 **Depends on:** Task 5
 
 **Description:**
-Create online integration tests that verify end-to-end tool execution with pi-mono providers (OpenAI, GitHub Copilot).
+Create online integration tests that verify end-to-end tool execution with pi-mono providers.
 
-These tests should:
-1. Use mock mode by default (NEOKAI_TEST_ONLINE=false)
-2. Support real API testing with NEOKAI_TEST_ONLINE=true
-3. Test actual tool calling and execution
+**Test Strategy:**
 
-**Files to create/modify:**
+Follow the existing pattern in `packages/daemon/tests/online/`:
+- Mock mode by default (`NEOKAI_TEST_ONLINE=false` or unset)
+- Real API mode with `NEOKAI_TEST_ONLINE=true`
+
+**Mock Mode Implementation:**
+
+When not running online tests, mock the HTTP layer:
+```typescript
+// Mock fetch for OpenAI/GitHub Copilot API calls
+global.fetch = vi.fn().mockImplementation(async (url) => {
+    if (url.includes('api.openai.com')) {
+        return new Response(JSON.stringify({
+            choices: [{ message: { content: 'Mock response' } }]
+        }));
+    }
+    // ...
+});
+```
+
+**Test Scenarios:**
+1. Tool definition passing to provider
+2. Tool execution with permission approval
+3. Tool execution with permission denial
+4. Multi-turn tool calling
+5. Error handling (API errors, tool errors)
+
+**Files to create:**
 - `packages/daemon/tests/online/pimono-tool-execution.test.ts`
 
 **Acceptance Criteria:**
 - Integration tests verify tool execution works end-to-end
 - Mock mode tests run in CI
 - Real API tests can be run manually for verification
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+---
+
+### Task 7: Add E2E Tests for Pi-Mono Provider Tool Use
+**Agent:** coder
+**Depends on:** Task 6
+
+**Description:**
+Add Playwright E2E tests to verify the full user flow works with pi-mono providers.
+
+**Test Scenarios:**
+1. Create a session with GitHub Copilot provider
+2. Send a message that triggers tool use
+3. Verify tool execution appears in UI
+4. Verify agent response includes tool results
+
+**Mock Strategy for E2E:**
+
+Since E2E tests run against a real server, we'll:
+1. Use a mock provider configuration that simulates pi-mono behavior
+2. Or use a test API key stored securely in CI environment variables
+3. Focus on the UI flow rather than actual LLM responses
+
+**Files to create:**
+- `packages/e2e/tests/features/pimono-tool-use.e2e.ts`
+
+**Acceptance Criteria:**
+- E2E test covers session creation with pi-mono provider
+- E2E test verifies tool use UI flow works correctly
+- Test runs in CI with mocked provider or test credentials
 
 ---
 
@@ -200,16 +380,21 @@ These tests should:
 
 ```
 Task 1 (Tool Definitions)
-    ├── Task 2 (Tool Executor) ──┐
-    │       ├── Task 3 (Permissions)
-    │       └── Task 4 (Schema Conversion)
-    └── Task 5 (Unit Tests)
-            └── Task 6 (Integration Tests)
+    ├── Task 2 (Tool Executor) ──→ Task 3 (Permissions)
+    │              │
+    │              └──→ Task 4 (Schema Conversion)
+    │                        │
+    └────────────────────────┴──→ Task 5 (Unit Tests)
+                                          │
+                                          └──→ Task 6 (Integration Tests)
+                                                    │
+                                                    └──→ Task 7 (E2E Tests)
 ```
 
-Tasks 2, 3, 4 can run in parallel after Task 1 completes.
-Task 5 depends on Tasks 2, 3, 4.
-Task 6 depends on Task 5.
+- Tasks 2, 3, 4 can run in parallel after Task 1 completes
+- Task 5 requires Tasks 2, 3, 4 to be complete
+- Task 6 requires Task 5
+- Task 7 requires Task 6
 
 ## Implementation Order
 
@@ -217,36 +402,47 @@ Task 6 depends on Task 5.
 2. **Tasks 2, 3, 4** (parallel) - Core implementation
 3. **Task 5** - Unit tests for all core changes
 4. **Task 6** - Integration tests
+5. **Task 7** - E2E tests
 
 ## Technical Notes
 
 ### Provider Interface Changes
 
-The `Provider.createQuery` method may need to accept additional context:
+The `Provider.createQuery` method will accept additional context via `ProviderQueryContext`:
 
 ```typescript
-createQuery?(
-    prompt: AsyncGenerator<SDKUserMessage>,
-    options: ProviderQueryOptions,
-    context: ProviderQueryContext & {
-        toolExecutor?: ToolExecutionCallback;
-        canUseTool?: CanUseToolCallback;
-    }
-): Promise<AsyncGenerator<SDKMessage> | null>;
+interface ProviderQueryContext {
+    signal: AbortSignal;
+    sessionId: string;
+    // NEW additions:
+    toolExecutor?: ToolExecutionCallback;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+}
 ```
 
 ### Tool Definition Sources
 
-Tool definitions can be sourced from:
-1. SDK's built-in tools (from `options.tools` preset)
-2. MCP server tools
-3. Custom agent tools
+Tool definitions will be sourced from a new `builtin-tools.ts` module that maps tool names to their JSON Schema definitions, matching what the SDK uses internally.
 
-The `QueryOptionsBuilder` constructs the full tool set - we need to extract this for pi-mono.
+### Permission Flow
 
-### Pi-AI Schema Conversion
+```
+pi-agent-core calls tool
+    ↓
+ToolExecutor.execute(toolName, input, toolUseId)
+    ↓
+Check disallowedTools → deny if matches
+    ↓
+Check allowedTools → approve if matches
+    ↓
+Call canUseTool({ toolName, input }) → user decision
+    ↓
+Execute tool → return result
+    ↓
+Result passed back to pi-agent-core
+```
 
-Pi-ai uses TypeBox for schemas (`Type.*` builders). We need to convert JSON Schema to TypeBox format. Options:
-1. Use `Type.Unsafe()` to wrap existing JSON Schema
-2. Implement a proper converter
-3. Use a library like `json-schema-to-typescript` concepts
+### Schema Conversion
+
+Using `Type.Unsafe()` from TypeBox to wrap existing JSON Schema without conversion - maintains full schema fidelity with minimal code.

--- a/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
+++ b/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
@@ -49,29 +49,71 @@ We were trying to build tool execution infrastructure, but `pi-coding-agent` alr
 
 ## Task Breakdown
 
-### Task 1: Add pi-coding-agent Dependency and Research API
+### Task 1: Add pi-coding-agent Dependency and Research API with Proof-of-Concept
 **Agent:** coder
 
 **Description:**
-Add `@mariozechner/pi-coding-agent` to dependencies and research its API to understand the integration points.
+Add `@mariozechner/pi-coding-agent` to dependencies, research its API, and create a proof-of-concept to verify the integration works before full migration.
 
 **Implementation Steps:**
-1. Add dependency: `bun add @mariozechner/pi-coding-agent` in `packages/daemon/`
-2. Explore the package exports:
-   - `createAgentSession` - main entry point
-   - `SessionManager` - session lifecycle
-   - `AuthStorage` - credential management
-   - `ModelRegistry` - model configuration
-   - Built-in tools availability
-3. Document the API patterns and how they map to NeoKai's architecture
+
+**Step 1: Add Dependency**
+```bash
+cd packages/daemon && bun add @mariozechner/pi-coding-agent
+```
+
+**Step 2: Create Proof-of-Concept**
+Create a minimal test file that verifies:
+- `createAgentSession` can be called successfully
+- Messages can be iterated via async generator
+- Built-in tools are available and work
+- Message format can be translated to `SDKMessage`
+
+```typescript
+// packages/daemon/tests/unit/providers/pi-coding-agent-poc.test.ts
+import { createAgentSession } from '@mariozechner/pi-coding-agent';
+
+describe('pi-coding-agent PoC', () => {
+    it('should create session and iterate messages', async () => {
+        // Mock the HTTP layer to avoid real API calls
+        const session = await createAgentSession({
+            provider: 'github-copilot',
+            model: 'gpt-4',
+            cwd: '/tmp/test',
+            systemPrompt: 'You are a helpful assistant.',
+            // Verify correct config option name for tools
+        });
+
+        const messages = [];
+        for await (const msg of session.messages()) {
+            messages.push(msg);
+            if (messages.length >= 3) break; // Just verify first few
+        }
+
+        expect(messages.length).toBeGreaterThan(0);
+    });
+});
+```
+
+**Step 3: Document API Findings**
+Update this plan or add code comments with answers to:
+1. Does `pi-coding-agent` export an async generator or event emitter for messages?
+2. What is the exact message format from `pi-coding-agent`?
+3. How does `pi-coding-agent` handle streaming text deltas?
+4. What configuration options does `createAgentSession` accept? (Verify if `tools: 'builtin'` is correct)
+5. How do we map NeoKai's session ID to `pi-coding-agent`'s session system?
+6. How does `pi-coding-agent` handle MCP server tools? (Can they be passed through?)
+7. Does `pi-coding-agent` have its own permission system, or can we integrate ours?
 
 **Files to modify:**
 - `packages/daemon/package.json` - add dependency
+- `packages/daemon/tests/unit/providers/pi-coding-agent-poc.test.ts` (NEW) - proof-of-concept
 
 **Acceptance Criteria:**
 - `@mariozechner/pi-coding-agent` added to dependencies
-- API exploration documented in code comments or this plan
-- Understand how `createAgentSession` yields messages compatible with NeoKai's `SDKMessage` format
+- Proof-of-concept test passes (with mocked HTTP)
+- API exploration documented
+- All 7 open questions answered
 
 ---
 
@@ -81,6 +123,19 @@ Add `@mariozechner/pi-coding-agent` to dependencies and research its API to unde
 
 **Description:**
 Replace the low-level `pi-agent-core` Agent with `pi-coding-agent`'s `createAgentSession`.
+
+**Migration Strategy: Complete Rewrite**
+
+The existing `pimono-adapter.ts` is ~800 lines with significant complexity. Given the architectural change, we will:
+
+1. **Create a new adapter file** (`pimono-adapter-v2.ts`) using `pi-coding-agent`
+2. **Keep the old file** temporarily for reference (rename to `pimono-adapter.deprecated.ts`)
+3. **Delete old file** after Task 3 proves the new adapter works
+
+This approach:
+- Allows easy rollback if issues arise
+- Provides reference during migration
+- Results in cleaner code (not a gradual refactor of fundamentally wrong architecture)
 
 **Implementation Approach:**
 
@@ -96,22 +151,24 @@ const agent = new Agent({
 await agent.prompt(messages);
 ```
 
-New code (conceptual):
+New code (exact config TBD in Task 1):
 ```typescript
 import { createAgentSession } from '@mariozechner/pi-coding-agent';
 
 const session = await createAgentSession({
-    provider: 'github-copilot',  // or 'openai'
+    provider: provider,  // 'github-copilot' or 'openai'
     model: modelId,
     cwd: options.cwd,
     systemPrompt: options.systemPrompt,
-    tools: 'builtin',  // Use built-in coding tools
-    // ... other config
+    // tools config TBD based on Task 1 findings
+    // (may be 'builtin', or an array, or a different option)
+    sessionId: context.sessionId,  // Map NeoKai session ID
 });
 
 // Iterate over session messages
 for await (const message of session.messages()) {
-    // Convert to SDKMessage format and yield
+    const sdkMessage = translateToSDKMessage(message, context.sessionId);
+    yield sdkMessage;
 }
 ```
 
@@ -122,13 +179,14 @@ for await (const message of session.messages()) {
 4. Error handling: Map errors to NeoKai's error system
 
 **Files to modify:**
-- `packages/daemon/src/lib/providers/pimono-adapter.ts` - major refactor
-- Possibly delete or simplify significantly
+- `packages/daemon/src/lib/providers/pimono-adapter.ts` → rename to `pimono-adapter.deprecated.ts`
+- `packages/daemon/src/lib/providers/pimono-adapter.ts` (NEW) - fresh implementation
 
 **Acceptance Criteria:**
 - `pi-coding-agent`'s `createAgentSession` is used instead of `pi-agent-core`'s `Agent`
 - Built-in tools work automatically (no manual tool executor needed)
 - Message format is correctly translated to `SDKMessage`
+- Old adapter preserved as `.deprecated.ts` for reference
 
 ---
 
@@ -141,17 +199,51 @@ Update the provider implementations to use the refactored `pimono-adapter`.
 
 Since the adapter will now use `pi-coding-agent`, the provider code should be simpler:
 - Remove `undefined` tool executor parameter
-- Let `pi-coding-agent` handle authentication via its `AuthStorage`
+- Let `pi-coding-agent` handle authentication via its `AuthStorage` OR keep NeoKai's auth (see below)
 - Simplify the call signature
+
+**NeoKai Tool Integration Questions (Answered in Task 1, Implemented Here):**
+
+**MCP Server Tools:**
+- If `pi-coding-agent` supports custom tools: Pass MCP tools through
+- If not: MCP tools will only work with Anthropic SDK path (document this limitation)
+
+**Permission System (`canUseTool`):**
+- If `pi-coding-agent` has its own permission callback: Use it
+- If not: We'll need to wrap the tool execution to add our permission layer
+
+**Current assessment (to verify in Task 1):**
+Most likely, `pi-coding-agent` handles tool execution internally without exposing a permission hook. In that case, we have two options:
+1. **Accept pi-coding-agent's built-in behavior** - simpler, but loses NeoKai's permission UI
+2. **Configure pi-coding-agent with `autoApprove: false`** (if supported) and handle permissions
+
+**Session Management:**
+NeoKai's session management (`AgentSession`, `SessionManager`) wraps the provider layer. We will:
+- Keep NeoKai's session management as the outer layer
+- Pass NeoKai's `sessionId` to `pi-coding-agent` for correlation
+- `pi-coding-agent`'s internal session management is an implementation detail
+
+Architecture:
+```
+NeoKai Session (outer layer - our management)
+    ↓
+pi-coding-agent session (inner layer - for tool execution)
+```
+
+We do NOT need to use `pi-coding-agent`'s `SessionManager` - NeoKai already has one.
 
 **Files to modify:**
 - `packages/daemon/src/lib/providers/openai-provider.ts`
 - `packages/daemon/src/lib/providers/github-copilot-provider.ts`
+- `packages/daemon/src/lib/providers/pimono-adapter.deprecated.ts` - DELETE after providers work
 
 **Acceptance Criteria:**
 - Providers use the refactored `pimono-adapter`
 - No more `undefined` tool executor passed
 - Authentication flows still work correctly
+- MCP tools work OR limitation is documented
+- Permission system works OR acceptable alternative documented
+- Old deprecated adapter deleted
 
 ---
 
@@ -183,6 +275,7 @@ vi.mock('@mariozechner/pi-coding-agent', () => ({
 - Message format translation to SDKMessage
 - Tool execution (verify it's handled by pi-coding-agent)
 - Error handling
+- Abort signal handling
 
 **Files to create:**
 - `packages/daemon/tests/unit/providers/pimono-adapter.test.ts`
@@ -211,6 +304,7 @@ Create integration tests that verify end-to-end tool execution with pi-mono prov
 2. Send message that triggers tool use
 3. Verify tool is executed and results returned
 4. Verify multi-turn conversation works
+5. Verify permission system works (if applicable)
 
 **Files to create:**
 - `packages/daemon/tests/online/pimono-tool-execution.test.ts`
@@ -248,11 +342,11 @@ Add Playwright E2E tests to verify the full user flow works with pi-mono provide
 ## Dependency Graph
 
 ```
-Task 1 (Add Dependency & Research)
+Task 1 (Add Dependency & PoC)
     │
-    └──→ Task 2 (Refactor Adapter)
+    └──→ Task 2 (Refactor Adapter - Complete Rewrite)
               │
-              └──→ Task 3 (Update Providers)
+              └──→ Task 3 (Update Providers + Delete Old Code)
                         │
                         └──→ Task 4 (Unit Tests)
                                   │
@@ -265,9 +359,9 @@ Tasks are sequential because each depends on the previous one being complete.
 
 ## Implementation Order
 
-1. **Task 1** - Add dependency and research API
-2. **Task 2** - Core refactor to use `pi-coding-agent`
-3. **Task 3** - Update provider implementations
+1. **Task 1** - Add dependency, create PoC, document API findings
+2. **Task 2** - Core refactor to use `pi-coding-agent` (complete rewrite, keep old as `.deprecated.ts`)
+3. **Task 3** - Update providers, verify MCP tools and permissions, delete deprecated code
 4. **Task 4** - Unit tests
 5. **Task 5** - Integration tests
 6. **Task 6** - E2E tests
@@ -293,6 +387,8 @@ ToolExecutionCallback → undefined (BROKEN!)
 ### Architecture After (Correct)
 
 ```
+NeoKai Session (NeoKai's session management - OUTER LAYER)
+    ↓
 NeoKai AgentSession
     ↓
 QueryRunner
@@ -301,10 +397,14 @@ Provider.createQuery (OpenAI/Copilot)
     ↓
 piMonoQueryGenerator (refactored)
     ↓
-pi-coding-agent createAgentSession (high-level)
+pi-coding-agent createAgentSession (INNER session for tools)
     ↓
 Built-in tools work automatically!
 ```
+
+**Session Layers:**
+- NeoKai's session management is the outer layer (we keep this)
+- pi-coding-agent's session is an implementation detail (inner layer)
 
 ### Key Differences
 
@@ -312,31 +412,27 @@ Built-in tools work automatically!
 |--------|-------------------------|--------------------------|
 | Level | Low-level framework | High-level coding SDK |
 | Tools | Manual via callback | Built-in (read, bash, edit, etc.) |
-| Session | Manual state management | SessionManager built-in |
-| Auth | Manual | AuthStorage built-in |
+| Session | Manual state management | SessionManager built-in (but we use our own) |
+| Auth | Manual | AuthStorage built-in (we may use ours instead) |
 | Complexity | High (we build everything) | Low (SDK handles it) |
+| MCP Tools | Would need manual integration | TBD (verify in Task 1) |
+| Permissions | Would need manual callback | TBD (verify in Task 1) |
 
-### Message Format Translation
+### Migration Strategy
 
-The `pi-coding-agent` likely has its own message format. We need to translate to NeoKai's `SDKMessage`:
+| Phase | Action |
+|-------|--------|
+| Task 1 | Add new dependency, create PoC, answer questions |
+| Task 2 | Create new adapter (keep old as `.deprecated.ts`) |
+| Task 3 | Update providers, verify everything works, delete deprecated |
+| Task 4-6 | Testing |
 
-```typescript
-// Conceptual translation
-function piCodingMessageToSdk(msg: PiCodingMessage): SDKMessage {
-    switch (msg.type) {
-        case 'text':
-            return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: msg.content }] }, ... };
-        case 'tool_use':
-            return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: msg.id, name: msg.name, input: msg.input }] }, ... };
-        // ... etc
-    }
-}
-```
-
-### Open Questions for Task 1
+### Open Questions (Answered in Task 1)
 
 1. Does `pi-coding-agent` export an async generator or event emitter for messages?
 2. What is the exact message format from `pi-coding-agent`?
 3. How does `pi-coding-agent` handle streaming text deltas?
-4. What configuration options does `createAgentSession` accept?
+4. What configuration options does `createAgentSession` accept? **(Verify if `tools: 'builtin'` is correct or if it's an array/object)**
 5. How do we map NeoKai's session ID to `pi-coding-agent`'s session system?
+6. **How does `pi-coding-agent` handle MCP server tools? Can they be passed through?**
+7. **Does `pi-coding-agent` have its own permission system, or can we integrate our `canUseTool` callback?**

--- a/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
+++ b/docs/plans/fix-pi-mono-integration-for-transparent-multi-provider-suppo.md
@@ -11,330 +11,206 @@ Make the pi-mono path fully transparent under our agent session layer so we can 
 
 ## Root Cause Analysis
 
-Investigation revealed three critical issues preventing pi-mono tool use:
+### The Real Problem: Using the Wrong Layer
 
-### Issue 1: Tools Not Passed to Custom Providers
-**Location:** `packages/daemon/src/lib/agent/query-runner.ts:228`
+**Current (Wrong) Approach:**
+- Uses `@mariozechner/pi-agent-core` - the **low-level** agent framework
+- Imports `Agent` class and manually handles tool execution via `ToolExecutionCallback`
+- We're building custom tool execution infrastructure from scratch
+- Located in: `/packages/daemon/src/lib/providers/pimono-adapter.ts`
 
-```typescript
-const customQueryOptions: ProviderQueryOptions = {
-    // ...
-    tools: [], // Tools are handled by SDK in standard mode; custom providers handle their own tools
-};
+**Correct Approach:**
+- Should use `@mariozechner/pi-coding-agent` - the **high-level** coding agent SDK
+- Provides `createAgentSession` with built-in tool handling
+- Has SessionManager, AuthStorage, ModelRegistry
+- Built-in tools: read, bash, edit, write, grep, find, ls
+- **Tools are already implemented and working!**
+
+### Current Dependencies (package.json)
+```json
+"@mariozechner/pi-ai": "^0.57.1",
+"@mariozechner/pi-agent-core": "^0.57.1"
+// MISSING: "@mariozechner/pi-coding-agent"
 ```
 
-The comment is misleading. Tools are hardcoded to an empty array, so pi-mono providers never receive tool definitions.
+### Why Tools Don't Work Now
 
-### Issue 2: No Tool Executor Callback
-**Locations:**
-- `packages/daemon/src/lib/providers/openai-provider.ts:317` - passes `undefined`
-- `packages/daemon/src/lib/providers/github-copilot-provider.ts:265` - passes `undefined`
+The `pimono-adapter.ts` creates an `Agent` from `pi-agent-core` but passes `undefined` for the tool executor:
 
-Both providers pass `undefined` as the `toolExecutor` parameter to `piMonoQueryGenerator()`. When pi-agent-core's Agent calls tools, it receives "No tool executor available" error.
+```typescript
+// openai-provider.ts:317 and github-copilot-provider.ts:265
+return piMonoQueryGenerator(
+    prompt, options, context, 'openai', modelId,
+    undefined  // <-- No tool executor!
+);
+```
 
-### Issue 3: No Permission Handling Bridge
-There's no mechanism to route tool permission checks from pi-mono to the `canUseTool` callback used by the SDK path. The SDK handles permissions via `options.canUseTool`, but pi-mono has no equivalent.
+We were trying to build tool execution infrastructure, but `pi-coding-agent` already has this built-in.
 
 ## Task Breakdown
 
-### Task 1: Pass Tool Definitions to Custom Query Providers
+### Task 1: Add pi-coding-agent Dependency and Research API
 **Agent:** coder
 
 **Description:**
-Extract tool definitions from SDK query options and pass them to custom query providers via `ProviderQueryOptions.tools`.
+Add `@mariozechner/pi-coding-agent` to dependencies and research its API to understand the integration points.
 
-**Implementation Approach:**
-
-The SDK's `queryOptions` object (built by `QueryOptionsBuilder`) contains:
-- `options.tools` - preset string like 'BashReadEditFiles' or array of tool names
-- `options.allowedTools` - tools to auto-approve
-- `options.disallowedTools` - tools to block
-
-However, the SDK doesn't expose the actual tool definitions with schemas - it handles tool registration internally. We have two options:
-
-**Option A (Recommended): Hardcode tool definitions from SDK's built-in presets**
-Create a `ToolDefinitions` module that maps tool names to their JSON Schema definitions, matching what the SDK uses internally. This is maintainable because the SDK's built-in tools are stable.
-
-```typescript
-// packages/shared/src/provider/builtin-tools.ts
-export const BUILTIN_TOOLS: Record<string, ToolDefinition> = {
-    Read: { name: 'Read', description: '...', inputSchema: { type: 'object', properties: {...} } },
-    Bash: { name: 'Bash', description: '...', inputSchema: { type: 'object', properties: {...} } },
-    // ...
-};
-```
-
-**Option B: Fetch tools from SDK subprocess**
-Query the SDK for available tools at startup. This is more dynamic but adds complexity and startup latency.
-
-We'll use **Option A** - it's simpler, more reliable, and the SDK tools rarely change.
+**Implementation Steps:**
+1. Add dependency: `bun add @mariozechner/pi-coding-agent` in `packages/daemon/`
+2. Explore the package exports:
+   - `createAgentSession` - main entry point
+   - `SessionManager` - session lifecycle
+   - `AuthStorage` - credential management
+   - `ModelRegistry` - model configuration
+   - Built-in tools availability
+3. Document the API patterns and how they map to NeoKai's architecture
 
 **Files to modify:**
-- `packages/daemon/src/lib/agent/query-runner.ts` - import tool definitions and pass to `customQueryOptions`
-- `packages/shared/src/provider/builtin-tools.ts` (NEW) - tool definitions with JSON Schemas
-- `packages/shared/src/provider/query-types.ts` - ensure `ToolDefinition` type is complete
+- `packages/daemon/package.json` - add dependency
 
 **Acceptance Criteria:**
-- Tool definitions are extracted from a lookup table matching SDK's built-in tools
-- `customQueryOptions.tools` contains actual tool definitions (not empty array)
-- Only tools allowed by `allowedTools`/`disallowedTools` are included
+- `@mariozechner/pi-coding-agent` added to dependencies
+- API exploration documented in code comments or this plan
+- Understand how `createAgentSession` yields messages compatible with NeoKai's `SDKMessage` format
 
 ---
 
-### Task 2: Implement Tool Execution Bridge for Pi-Mono
+### Task 2: Refactor pimono-adapter to Use pi-coding-agent
 **Agent:** coder
 **Depends on:** Task 1
 
 **Description:**
-Create a tool executor callback that routes tool execution from pi-mono to the SDK's subprocess for actual execution.
+Replace the low-level `pi-agent-core` Agent with `pi-coding-agent`'s `createAgentSession`.
 
 **Implementation Approach:**
 
-The SDK handles tool execution internally via a subprocess. For pi-mono providers, we need to execute tools ourselves since pi-agent-core's Agent only calls our callback. The key insight is:
-
-**NeoKai's "existing infrastructure" = the SDK subprocess itself**
-
-When using pi-mono, we still spawn an SDK subprocess (via `query()`) but use it ONLY for tool execution, not for LLM calls. The architecture becomes:
-
-```
-pi-mono (LLM) → toolExecutor callback → SDK subprocess (tool execution) → result → pi-mono
-```
-
-However, this approach is complex. A simpler approach:
-
-**Simpler Approach: Direct tool execution via SDK's tool implementations**
-
-The SDK exports tool implementations we can call directly. We'll:
-
-1. Import tool implementations from SDK (or recreate them in NeoKai)
-2. Create a `ToolExecutor` class that:
-   - Receives tool name, input, and toolUseId
-   - Validates against `allowedTools`/`disallowedTools`
-   - Calls `canUseTool` callback for permission
-   - Executes the tool
-   - Returns `{ output, isError }`
-
-**Implementation:**
-
+Current code:
 ```typescript
-// packages/daemon/src/lib/agent/tool-executor.ts
-export class ToolExecutor {
-    constructor(
-        private ctx: {
-            canUseTool?: CanUseTool;
-            allowedTools?: string[];
-            disallowedTools?: string[];
-            cwd: string;
-        }
-    ) {}
+import { Agent } from '@mariozechner/pi-agent-core';
 
-    async execute(toolName: string, input: Record<string, unknown>, toolUseId: string): Promise<{
-        output: unknown;
-        isError: boolean;
-    }> {
-        // 1. Check disallowed
-        // 2. Call canUseTool for permission
-        // 3. Execute tool
-        // 4. Return result
-    }
+const agent = new Agent({
+    initialState: { model, tools, messages, ... },
+    sessionId,
+    getApiKey,
+});
+await agent.prompt(messages);
+```
+
+New code (conceptual):
+```typescript
+import { createAgentSession } from '@mariozechner/pi-coding-agent';
+
+const session = await createAgentSession({
+    provider: 'github-copilot',  // or 'openai'
+    model: modelId,
+    cwd: options.cwd,
+    systemPrompt: options.systemPrompt,
+    tools: 'builtin',  // Use built-in coding tools
+    // ... other config
+});
+
+// Iterate over session messages
+for await (const message of session.messages()) {
+    // Convert to SDKMessage format and yield
 }
 ```
 
+**Key Integration Points:**
+1. Message format translation: `pi-coding-agent` messages → NeoKai `SDKMessage`
+2. Streaming: Ensure text deltas stream correctly
+3. Tool execution: Let `pi-coding-agent` handle it internally
+4. Error handling: Map errors to NeoKai's error system
+
 **Files to modify:**
-- `packages/daemon/src/lib/agent/tool-executor.ts` (NEW) - ToolExecutor class
-- `packages/daemon/src/lib/agent/query-runner.ts` - create ToolExecutor, pass to provider
-- `packages/shared/src/provider/types.ts` - add `toolExecutor` to `createQuery` context
-- `packages/shared/src/provider/query-types.ts` - extend `ProviderQueryContext`
-- `packages/daemon/src/lib/providers/openai-provider.ts` - use passed toolExecutor
-- `packages/daemon/src/lib/providers/github-copilot-provider.ts` - use passed toolExecutor
+- `packages/daemon/src/lib/providers/pimono-adapter.ts` - major refactor
+- Possibly delete or simplify significantly
 
 **Acceptance Criteria:**
-- `ToolExecutor` class created with execute method
-- Tool executor is passed through `ProviderQueryContext` to providers
-- `piMonoQueryGenerator` receives and uses the tool executor
-- When pi-agent-core Agent calls a tool, it executes via ToolExecutor
+- `pi-coding-agent`'s `createAgentSession` is used instead of `pi-agent-core`'s `Agent`
+- Built-in tools work automatically (no manual tool executor needed)
+- Message format is correctly translated to `SDKMessage`
 
 ---
 
-### Task 3: Implement Permission Handling for Pi-Mono Tools
+### Task 3: Update OpenAI and GitHub Copilot Providers
 **Agent:** coder
 **Depends on:** Task 2
 
 **Description:**
-Integrate the `canUseTool` permission callback with the pi-mono tool execution flow.
+Update the provider implementations to use the refactored `pimono-adapter`.
 
-**Implementation Approach:**
-
-The permission check will happen **inside** the `ToolExecutor.execute()` method, **before** executing the tool:
-
-```typescript
-async execute(toolName: string, input: Record<string, unknown>, toolUseId: string) {
-    // 1. Check disallowed tools list (deny without asking)
-    if (this.ctx.disallowedTools?.some(d => matchesPattern(d, toolName))) {
-        return { output: `Tool ${toolName} is disallowed`, isError: true };
-    }
-
-    // 2. Check allowed tools list (auto-approve)
-    const isAllowed = this.ctx.allowedTools?.some(a => matchesPattern(a, toolName));
-
-    // 3. If not auto-approved, call canUseTool for user permission
-    if (!isAllowed && this.ctx.canUseTool) {
-        const permission = await this.ctx.canUseTool({ toolName, input, toolUseId });
-        if (!permission.allowed) {
-            return { output: `Tool ${toolName} permission denied`, isError: true };
-        }
-    }
-
-    // 4. Execute the tool
-    return this.executeToolInternal(toolName, input);
-}
-```
-
-The `canUseTool` callback is already created by `AskUserQuestionHandler.createCanUseToolCallback()` and passed to `QueryOptionsBuilder`. We'll pass it through to `ToolExecutor`.
+Since the adapter will now use `pi-coding-agent`, the provider code should be simpler:
+- Remove `undefined` tool executor parameter
+- Let `pi-coding-agent` handle authentication via its `AuthStorage`
+- Simplify the call signature
 
 **Files to modify:**
-- `packages/daemon/src/lib/agent/tool-executor.ts` - add permission logic
-- `packages/daemon/src/lib/agent/query-runner.ts` - pass canUseTool to ToolExecutor
+- `packages/daemon/src/lib/providers/openai-provider.ts`
+- `packages/daemon/src/lib/providers/github-copilot-provider.ts`
 
 **Acceptance Criteria:**
-- Tools in `disallowedTools` are blocked without user prompt
-- Tools in `allowedTools` are auto-approved
-- Other tools trigger `canUseTool` callback for user permission
-- Permission denials are returned as error results to pi-agent-core
+- Providers use the refactored `pimono-adapter`
+- No more `undefined` tool executor passed
+- Authentication flows still work correctly
 
 ---
 
-### Task 4: Fix Input Schema Conversion in convertToAgentTools
+### Task 4: Add Unit Tests for Refactored Pi-Mono Adapter
 **Agent:** coder
-**Depends on:** Task 1
+**Depends on:** Task 2, Task 3
 
 **Description:**
-The current schema conversion in `pimono-adapter.ts` uses a generic "any object" schema:
-```typescript
-parameters: Type.Record(Type.String(), Type.Any()) as unknown as TSchema,
-```
-
-This loses the actual input schema from `ToolDefinition.inputSchema`. Need to properly convert JSON Schema to pi-ai's `TSchema` format.
-
-**Recommended Approach: Use `Type.Unsafe()`**
-
-TypeBox's `Type.Unsafe()` allows wrapping existing JSON Schema without conversion:
-
-```typescript
-import { Type } from '@mariozechner/pi-ai';
-
-export function jsonSchemaToTSchema(schema: Record<string, unknown>): TSchema {
-    // Type.Unsafe preserves the original JSON Schema
-    return Type.Unsafe(schema) as unknown as TSchema;
-}
-```
-
-This is the simplest approach and maintains full schema fidelity. The pi-ai library will pass the schema through to the LLM unchanged.
-
-**Alternative Considered: Full conversion to TypeBox**
-Converting JSON Schema to TypeBox's builder format (`Type.Object({ ... })`) is complex and error-prone for nested schemas. Not recommended.
-
-**Files to modify:**
-- `packages/daemon/src/lib/providers/pimono-adapter.ts` - update `convertToAgentTools`
-
-**Acceptance Criteria:**
-- `convertToAgentTools` uses `Type.Unsafe()` to wrap `inputSchema`
-- LLMs receive accurate parameter schemas with proper types, descriptions, and constraints
-
----
-
-### Task 5: Add Unit Tests for Pi-Mono Tool Execution
-**Agent:** coder
-**Depends on:** Task 2, Task 3, Task 4
-
-**Description:**
-Create comprehensive unit tests for the pi-mono tool execution path.
+Create unit tests for the refactored `pimono-adapter` using `pi-coding-agent`.
 
 **Mock Strategy:**
 
-Following the existing test patterns in `packages/daemon/tests/unit/`, we'll:
-
-1. **Mock pi-agent-core's Agent class** - Instead of using the real Agent, create a mock that:
-   - Accepts the same configuration
-   - Simulates tool calls by invoking the `execute` callback
-   - Returns predetermined responses
-
+Mock `pi-coding-agent` at the module level:
 ```typescript
-// In test setup
-vi.mock('@mariozechner/pi-agent-core', () => ({
-    Agent: vi.fn().mockImplementation((config) => ({
-        subscribe: vi.fn((callback) => {
-            // Simulate tool call event
-            config.initialState.tools[0].execute('call-123', { path: '/test' });
-            callback({ type: 'tool_execution_start', toolName: 'Read', toolCallId: 'call-123' });
-            callback({ type: 'tool_execution_end', toolName: 'Read', toolCallId: 'call-123' });
-            return vi.fn(); // unsubscribe
+vi.mock('@mariozechner/pi-coding-agent', () => ({
+    createAgentSession: vi.fn(async (config) => ({
+        messages: vi.fn(async function* () {
+            yield { type: 'text', content: 'Hello' };
+            yield { type: 'tool_use', name: 'Read', input: { path: '/test' } };
+            yield { type: 'tool_result', output: 'file contents' };
         }),
-        prompt: vi.fn(),
         abort: vi.fn(),
     })),
 }));
 ```
 
-2. **Mock @mariozechner/pi-ai's getModel** - Return a minimal mock model:
-```typescript
-vi.mock('@mariozechner/pi-ai', () => ({
-    getModel: vi.fn(() => ({ id: 'test-model', contextWindow: 128000, maxTokens: 4096 })),
-    Type: { Unsafe: vi.fn((s) => s) },
-}));
-```
-
-**Test coverage:**
-- `convertToAgentTools` schema conversion
-- `sdkToAgentMessage` message translation
-- `ToolExecutor` permission checking and execution
-- `piMonoQueryGenerator` event handling and message yielding
+**Test Coverage:**
+- Session creation with correct config
+- Message format translation to SDKMessage
+- Tool execution (verify it's handled by pi-coding-agent)
+- Error handling
 
 **Files to create:**
 - `packages/daemon/tests/unit/providers/pimono-adapter.test.ts`
-- `packages/daemon/tests/unit/agent/tool-executor.test.ts`
 
 **Acceptance Criteria:**
-- Unit tests cover all pi-mono tool execution paths
-- Tests mock pi-agent-core and pi-ai as described
+- Unit tests cover main code paths
+- Tests mock `pi-coding-agent` appropriately
 - Tests pass with >80% coverage on modified code
 
 ---
 
-### Task 6: Add Online Integration Tests for Pi-Mono Providers
+### Task 5: Add Online Integration Tests
 **Agent:** coder
-**Depends on:** Task 5
+**Depends on:** Task 4
 
 **Description:**
-Create online integration tests that verify end-to-end tool execution with pi-mono providers.
+Create integration tests that verify end-to-end tool execution with pi-mono providers.
 
 **Test Strategy:**
-
-Follow the existing pattern in `packages/daemon/tests/online/`:
-- Mock mode by default (`NEOKAI_TEST_ONLINE=false` or unset)
+- Mock mode by default (mock HTTP requests)
 - Real API mode with `NEOKAI_TEST_ONLINE=true`
-
-**Mock Mode Implementation:**
-
-When not running online tests, mock the HTTP layer:
-```typescript
-// Mock fetch for OpenAI/GitHub Copilot API calls
-global.fetch = vi.fn().mockImplementation(async (url) => {
-    if (url.includes('api.openai.com')) {
-        return new Response(JSON.stringify({
-            choices: [{ message: { content: 'Mock response' } }]
-        }));
-    }
-    // ...
-});
-```
+- Test actual tool calling and execution flow
 
 **Test Scenarios:**
-1. Tool definition passing to provider
-2. Tool execution with permission approval
-3. Tool execution with permission denial
-4. Multi-turn tool calling
-5. Error handling (API errors, tool errors)
+1. Create session with pi-mono provider
+2. Send message that triggers tool use
+3. Verify tool is executed and results returned
+4. Verify multi-turn conversation works
 
 **Files to create:**
 - `packages/daemon/tests/online/pimono-tool-execution.test.ts`
@@ -342,29 +218,22 @@ global.fetch = vi.fn().mockImplementation(async (url) => {
 **Acceptance Criteria:**
 - Integration tests verify tool execution works end-to-end
 - Mock mode tests run in CI
-- Real API tests can be run manually for verification
+- Real API tests can be run manually
 
 ---
 
-### Task 7: Add E2E Tests for Pi-Mono Provider Tool Use
+### Task 6: Add E2E Tests for Pi-Mono Provider Tool Use
 **Agent:** coder
-**Depends on:** Task 6
+**Depends on:** Task 5
 
 **Description:**
 Add Playwright E2E tests to verify the full user flow works with pi-mono providers.
 
 **Test Scenarios:**
-1. Create a session with GitHub Copilot provider
-2. Send a message that triggers tool use
+1. Create session with GitHub Copilot/OpenAI provider
+2. Send message that triggers tool use (e.g., "read package.json")
 3. Verify tool execution appears in UI
 4. Verify agent response includes tool results
-
-**Mock Strategy for E2E:**
-
-Since E2E tests run against a real server, we'll:
-1. Use a mock provider configuration that simulates pi-mono behavior
-2. Or use a test API key stored securely in CI environment variables
-3. Focus on the UI flow rather than actual LLM responses
 
 **Files to create:**
 - `packages/e2e/tests/features/pimono-tool-use.e2e.ts`
@@ -372,77 +241,102 @@ Since E2E tests run against a real server, we'll:
 **Acceptance Criteria:**
 - E2E test covers session creation with pi-mono provider
 - E2E test verifies tool use UI flow works correctly
-- Test runs in CI with mocked provider or test credentials
+- Test runs in CI (with mocked provider or test credentials)
 
 ---
 
 ## Dependency Graph
 
 ```
-Task 1 (Tool Definitions)
-    ├── Task 2 (Tool Executor) ──→ Task 3 (Permissions)
-    │              │
-    │              └──→ Task 4 (Schema Conversion)
-    │                        │
-    └────────────────────────┴──→ Task 5 (Unit Tests)
-                                          │
-                                          └──→ Task 6 (Integration Tests)
-                                                    │
-                                                    └──→ Task 7 (E2E Tests)
+Task 1 (Add Dependency & Research)
+    │
+    └──→ Task 2 (Refactor Adapter)
+              │
+              └──→ Task 3 (Update Providers)
+                        │
+                        └──→ Task 4 (Unit Tests)
+                                  │
+                                  └──→ Task 5 (Integration Tests)
+                                            │
+                                            └──→ Task 6 (E2E Tests)
 ```
 
-- Tasks 2, 3, 4 can run in parallel after Task 1 completes
-- Task 5 requires Tasks 2, 3, 4 to be complete
-- Task 6 requires Task 5
-- Task 7 requires Task 6
+Tasks are sequential because each depends on the previous one being complete.
 
 ## Implementation Order
 
-1. **Task 1** - Foundation: Pass tool definitions to custom providers
-2. **Tasks 2, 3, 4** (parallel) - Core implementation
-3. **Task 5** - Unit tests for all core changes
-4. **Task 6** - Integration tests
-5. **Task 7** - E2E tests
+1. **Task 1** - Add dependency and research API
+2. **Task 2** - Core refactor to use `pi-coding-agent`
+3. **Task 3** - Update provider implementations
+4. **Task 4** - Unit tests
+5. **Task 5** - Integration tests
+6. **Task 6** - E2E tests
 
 ## Technical Notes
 
-### Provider Interface Changes
+### Architecture Before (Wrong)
 
-The `Provider.createQuery` method will accept additional context via `ProviderQueryContext`:
+```
+NeoKai AgentSession
+    ↓
+QueryRunner
+    ↓
+Provider.createQuery (OpenAI/Copilot)
+    ↓
+piMonoQueryGenerator
+    ↓
+pi-agent-core Agent (low-level)
+    ↓
+ToolExecutionCallback → undefined (BROKEN!)
+```
+
+### Architecture After (Correct)
+
+```
+NeoKai AgentSession
+    ↓
+QueryRunner
+    ↓
+Provider.createQuery (OpenAI/Copilot)
+    ↓
+piMonoQueryGenerator (refactored)
+    ↓
+pi-coding-agent createAgentSession (high-level)
+    ↓
+Built-in tools work automatically!
+```
+
+### Key Differences
+
+| Aspect | pi-agent-core (Current) | pi-coding-agent (Target) |
+|--------|-------------------------|--------------------------|
+| Level | Low-level framework | High-level coding SDK |
+| Tools | Manual via callback | Built-in (read, bash, edit, etc.) |
+| Session | Manual state management | SessionManager built-in |
+| Auth | Manual | AuthStorage built-in |
+| Complexity | High (we build everything) | Low (SDK handles it) |
+
+### Message Format Translation
+
+The `pi-coding-agent` likely has its own message format. We need to translate to NeoKai's `SDKMessage`:
 
 ```typescript
-interface ProviderQueryContext {
-    signal: AbortSignal;
-    sessionId: string;
-    // NEW additions:
-    toolExecutor?: ToolExecutionCallback;
-    allowedTools?: string[];
-    disallowedTools?: string[];
+// Conceptual translation
+function piCodingMessageToSdk(msg: PiCodingMessage): SDKMessage {
+    switch (msg.type) {
+        case 'text':
+            return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: msg.content }] }, ... };
+        case 'tool_use':
+            return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: msg.id, name: msg.name, input: msg.input }] }, ... };
+        // ... etc
+    }
 }
 ```
 
-### Tool Definition Sources
+### Open Questions for Task 1
 
-Tool definitions will be sourced from a new `builtin-tools.ts` module that maps tool names to their JSON Schema definitions, matching what the SDK uses internally.
-
-### Permission Flow
-
-```
-pi-agent-core calls tool
-    ↓
-ToolExecutor.execute(toolName, input, toolUseId)
-    ↓
-Check disallowedTools → deny if matches
-    ↓
-Check allowedTools → approve if matches
-    ↓
-Call canUseTool({ toolName, input }) → user decision
-    ↓
-Execute tool → return result
-    ↓
-Result passed back to pi-agent-core
-```
-
-### Schema Conversion
-
-Using `Type.Unsafe()` from TypeBox to wrap existing JSON Schema without conversion - maintains full schema fidelity with minimal code.
+1. Does `pi-coding-agent` export an async generator or event emitter for messages?
+2. What is the exact message format from `pi-coding-agent`?
+3. How does `pi-coding-agent` handle streaming text deltas?
+4. What configuration options does `createAgentSession` accept?
+5. How do we map NeoKai's session ID to `pi-coding-agent`'s session system?

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -100,10 +100,16 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 	// Tool contract
 	sections.push(`\n## Tool Contract (CRITICAL)\n`);
 	sections.push(`You MUST call tools (no text-only final responses).`);
-	sections.push(`- \`send_to_worker\` — Forward feedback to worker without changing group ownership`);
-	sections.push(`  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)`);
+	sections.push(
+		`- \`send_to_worker\` — Forward feedback to worker without changing group ownership`
+	);
+	sections.push(
+		`  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)`
+	);
 	sections.push(`  - mode=\`steer\`: inject for current-turn steering`);
-	sections.push(`- \`handoff_to_worker\` — Explicitly return ownership to worker (awaiting_worker)`);
+	sections.push(
+		`- \`handoff_to_worker\` — Explicitly return ownership to worker (awaiting_worker)`
+	);
 	sections.push(`- \`complete_task\` — Accept the work if it meets all requirements`);
 	sections.push(`- \`fail_task\` — Mark the task as not achievable`);
 	sections.push(
@@ -299,9 +305,7 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 			sections.push(
 				`   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.`
 			);
-			sections.push(
-				`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.`
-			);
+			sections.push(`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.`);
 			sections.push(
 				`   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).`
 			);

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -536,7 +536,9 @@ describe('Leader Agent', () => {
 			const agents = buildReviewerAgents([{ model: 'claude-opus-4-6' }]);
 			const agent = agents['reviewer-opus'];
 			expect(agent.prompt).toContain('ME="$(gh api user --jq .login)"');
-			expect(agent.prompt).toContain('PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"');
+			expect(agent.prompt).toContain(
+				'PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"'
+			);
 			expect(agent.prompt).toContain('EVENT="COMMENT"');
 		});
 
@@ -544,7 +546,9 @@ describe('Leader Agent', () => {
 			const agents = buildReviewerAgents([{ model: 'custom-cli', type: 'cli' }]);
 			const agent = agents['reviewer-custom-cli'];
 			expect(agent.prompt).toContain('ME="$(gh api user --jq .login)"');
-			expect(agent.prompt).toContain('PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"');
+			expect(agent.prompt).toContain(
+				'PR_AUTHOR="$(gh pr view {pr} --json author --jq .author.login)"'
+			);
 			expect(agent.prompt).toContain('EVENT="COMMENT"');
 		});
 

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -150,13 +150,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker } = makeRuntime();
 			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
 
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskId,
-				message,
-				'worker'
-			);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'worker');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
@@ -166,13 +160,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToLeader } = makeRuntime();
 			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
 
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskId,
-				message,
-				'leader'
-			);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);


### PR DESCRIPTION
Plan to fix pi-mono integration for transparent multi-provider support.
Root causes identified:
- Tools not passed to custom providers (hardcoded empty array)
- No tool executor callback passed to piMonoQueryGenerator
- No permission handling bridge

Six tasks covering:
1. Pass tool definitions to custom providers
2. Implement tool execution bridge
3. Add permission handling
4. Fix schema conversion
5. Add unit tests
6. Add integration tests
