### PR TITLE
feat: Add setTaskStatus method with validation and clear error/result/progress on restart

### DIFF
--- a/docs/design/task-status-control-design.md
+++ b/docs/design/task-status-control-design.md
@@ -1,51 +1,188 @@
 # Task Status Control Design
 
-This document describes the design for human-in-the-loop task status control for for humans have full manual control over the task lifecycle when needed, bypassing the normal autonomous flow.
+This document describes the design for human-in-the-loop task status control, allowing humans to have full manual control over the task lifecycle when needed, bypassing the normal autonomous flow.
+
+## Status State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft: Create (planning)
+    [*] --> pending: Create (direct)
+
+    draft --> pending: Promote (planning complete)
+
+    pending --> in_progress: Worker starts
+    pending --> cancelled: Human cancels
+
+    in_progress --> review: Work done, awaiting review
+    in_progress --> completed: Human marks complete
+    in_progress --> failed: Worker fails / Human marks failed
+    in_progress --> cancelled: Human cancels
+
+    review --> completed: Human approves
+    review --> failed: Human rejects (fatal)
+    review --> in_progress: Human rejects (retry)
+
+    failed --> pending: Restart (human retry)
+    failed --> in_progress: Restart (human retry)
+
+    cancelled --> pending: Restart (human retry)
+    cancelled --> in_progress: Restart (human retry)
+
+    completed --> [*]
+    failed --> [*]
+    cancelled --> [*]
+```
 
 ## Valid Status Transitions
 
-Based on the code review, we room agent
- and room Agent (`set_task_status`) can change task status to Supports restart ( restart: failed/c cancelled tasks.
+| Current Status | Allowed Target Statuses | Notes |
+|----------------|------------------------|-------|
+| `draft` | `pending` | Planning-created tasks, promoted when plan approved |
+| `pending` | `in_progress`, `cancelled` | Worker not started yet |
+| `in_progress` | `review`, `completed`, `failed`, `cancelled` | Worker is actively working |
+| `review` | `completed`, `failed`, `in_progress` | Awaiting human approval |
+| `completed` | _(none)_ | Terminal state - no transitions allowed |
+| `failed` | `pending`, `in_progress` | Restart: human can retry failed task |
+| `cancelled` | `pending`, `in_progress` | Restart: human can retry cancelled task |
 
-### Valid Transitions
+## Transition Behavior
 
-| Current Status | Target Status | Notes |
-|---|---|----------|----------------|--------------------|----------|--------------|------|-------------|--------------|
-----------------|----------------|------------|-------------------|
-| pending | in_progress, cancelled | Worker not started | leader is actively working. Human can cancel without human review flow. |
-| in_progress | review, completed, failed, cancelled | Terminal state - no transitions allowed |
-| failed | pending, in_progress | Restart: human can retry failed task |
-| cancelled | pending, in_progress | Restart: human can retry cancelled task |
+### Validated via `setTaskStatus()`
 
-### Transitions with checked via `setTaskStatus`:
-- Validated via `VALIDStatusTransition()` before applying
-- Clears error/result/progress fields when restarting
-- Sets progress to 100% for- On terminal state,- Clears error/result when moving to terminal state
-- The **task.setStatus** RPC handler throws error if cancellation fails
-- Notifies UI of task.setStatus` event with- Returns updated task object
+All status transitions are validated against `VALID_STATUS_TRANSITIONS` before applying:
+
+- **Validation**: Throws error if transition is not allowed
+- **Restart clearing**: When moving from `failed`/`cancelled` to `pending`/`in_progress`:
+  - Clears `error` field (sets to `null`)
+  - Clears `result` field (sets to `null`)
+  - Clears `progress` field (sets to `null`)
+- **Completion**: When moving to `completed`:
+  - Sets `progress` to `100`
+  - Optionally sets `result` if provided
+- **Failure**: When moving to `failed`:
+  - Optionally sets `error` if provided
+
+### Active Group Cancellation
+
+When a task has an active session group (agents currently running) and transitions to a terminal state (`completed`, `failed`, `cancelled`), the system:
+
+1. Looks up the active group for the task
+2. Calls `taskGroupManager.cancel()` to stop running agents
+3. If cancellation fails (returns `null` due to version conflict or missing group), throws an error
+4. Only then applies the status change to the task
+
+This ensures agents are properly stopped before marking a task as complete/failed/cancelled.
 
 ## API
-### Room Agent MCP Tool
-- `set_task_status` tool - validates and transitions, allows room agent to change task status
-## Types
 
-### UpdateTaskParams
-```ts
-export interface UpdateTaskParams {
-	title?: string;
-	description?: string;
-	status?: TaskStatus;
-	priority?: TaskPriority;
-	progress?: number | null;
-	currentStep?: string | null;
-	result?: string | null;
-	error?: string | null;
-	dependsOn?: string[];
+### Room Agent MCP Tool
+
+**`set_task_status`** - Validates and transitions task status
+
+```typescript
+// Tool definition
+{
+  name: 'set_task_status',
+  description: 'Change task status with validation. Allows room agent to complete, fail, restart, or change status of any task.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      task_id: { type: 'string', description: 'Task ID to update' },
+      status: {
+        type: 'string',
+        enum: ['draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled'],
+        description: 'New status to set'
+      },
+      result: { type: 'string', description: 'Optional result message (for completed status)' },
+      error: { type: 'string', description: 'Optional error message (for failed status)' }
+    },
+    required: ['task_id', 'status']
+  }
 }
 ```
 
-## Usage
+### RPC Handler
 
-```bash
-bun run format
-git commit -m "docs: add task status control design doc with task status transition diagram"
+**`task.setStatus`** - UI-initiated status change
+
+```typescript
+// Request
+{
+  roomId: string;
+  taskId: string;
+  status: TaskStatus;
+  result?: string;
+  error?: string;
+}
+
+// Response
+{ task: NeoTask }
+```
+
+### Events
+
+**`room.task.update`** - Emitted after status change
+
+```typescript
+{
+  sessionId: `room:${roomId}`,
+  roomId: string,
+  task: NeoTask
+}
+```
+
+## Types
+
+### UpdateTaskParams
+
+```typescript
+export interface UpdateTaskParams {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  progress?: number | null;  // null clears the field
+  currentStep?: string | null;
+  result?: string | null;
+  error?: string | null;
+  dependsOn?: string[];
+}
+```
+
+## Usage Examples
+
+### Restart a Failed Task
+
+```typescript
+// Via Room Agent MCP tool
+await set_task_status({
+  task_id: 'task-123',
+  status: 'pending'
+});
+// Result: error, result, progress fields cleared, task ready for worker pickup
+```
+
+### Complete a Task with Result
+
+```typescript
+// Via RPC handler
+await hub.request('task.setStatus', {
+  roomId: 'room-abc',
+  taskId: 'task-123',
+  status: 'completed',
+  result: 'Feature implemented and tested'
+});
+// Result: progress=100, result set, task marked complete
+```
+
+### Cancel an In-Progress Task
+
+```typescript
+// Via Room Agent MCP tool
+await set_task_status({
+  task_id: 'task-123',
+  status: 'cancelled'
+});
+// Result: active agents stopped, task marked cancelled
+```

--- a/docs/design/task-status-control-design.md
+++ b/docs/design/task-status-control-design.md
@@ -1,0 +1,51 @@
+# Task Status Control Design
+
+This document describes the design for human-in-the-loop task status control for for humans have full manual control over the task lifecycle when needed, bypassing the normal autonomous flow.
+
+## Valid Status Transitions
+
+Based on the code review, we room agent
+ and room Agent (`set_task_status`) can change task status to Supports restart ( restart: failed/c cancelled tasks.
+
+### Valid Transitions
+
+| Current Status | Target Status | Notes |
+|---|---|----------|----------------|--------------------|----------|--------------|------|-------------|--------------|
+----------------|----------------|------------|-------------------|
+| pending | in_progress, cancelled | Worker not started | leader is actively working. Human can cancel without human review flow. |
+| in_progress | review, completed, failed, cancelled | Terminal state - no transitions allowed |
+| failed | pending, in_progress | Restart: human can retry failed task |
+| cancelled | pending, in_progress | Restart: human can retry cancelled task |
+
+### Transitions with checked via `setTaskStatus`:
+- Validated via `VALIDStatusTransition()` before applying
+- Clears error/result/progress fields when restarting
+- Sets progress to 100% for- On terminal state,- Clears error/result when moving to terminal state
+- The **task.setStatus** RPC handler throws error if cancellation fails
+- Notifies UI of task.setStatus` event with- Returns updated task object
+
+## API
+### Room Agent MCP Tool
+- `set_task_status` tool - validates and transitions, allows room agent to change task status
+## Types
+
+### UpdateTaskParams
+```ts
+export interface UpdateTaskParams {
+	title?: string;
+	description?: string;
+	status?: TaskStatus;
+	priority?: TaskPriority;
+	progress?: number | null;
+	currentStep?: string | null;
+	result?: string | null;
+	error?: string | null;
+	dependsOn?: string[];
+}
+```
+
+## Usage
+
+```bash
+bun run format
+git commit -m "docs: add task status control design doc with task status transition diagram"

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -19,6 +19,27 @@ import type {
 	AgentType,
 } from '@neokai/shared';
 
+/**
+ * Valid task status transitions
+ * Maps current status -> allowed next statuses
+ */
+export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+	draft: ['pending'],
+	pending: ['in_progress', 'cancelled'],
+	in_progress: ['review', 'completed', 'failed', 'cancelled'],
+	review: ['completed', 'failed', 'in_progress'],
+	completed: [], // Terminal state
+	failed: ['pending', 'in_progress'], // Restart allowed
+	cancelled: ['pending', 'in_progress'], // Restart allowed
+};
+
+/**
+ * Check if a status transition is valid
+ */
+export function isValidStatusTransition(from: TaskStatus, to: TaskStatus): boolean {
+	return VALID_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
 export class TaskManager {
 	private taskRepo: TaskRepository;
 
@@ -141,6 +162,60 @@ export class TaskManager {
 			result,
 			progress: 100,
 		});
+	}
+
+	/**
+	 * Set task status with validation.
+	 * Validates that the transition is allowed before applying.
+	 * Optionally clears error/result fields when restarting from failed/cancelled.
+	 * Optionally sets result for completed status.
+	 */
+	async setTaskStatus(
+		taskId: string,
+		newStatus: TaskStatus,
+		options?: { result?: string; error?: string }
+	): Promise<NeoTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		// Validate transition
+		if (!isValidStatusTransition(task.status, newStatus)) {
+			throw new Error(
+				`Invalid status transition from '${task.status}' to '${newStatus}'. ` +
+					`Allowed transitions: ${VALID_STATUS_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
+		}
+
+		// Build updates based on new status
+		const updates: Partial<NeoTask> = {};
+
+		if (newStatus === 'completed') {
+			updates.progress = 100;
+			if (options?.result) {
+				updates.result = options.result;
+			}
+		}
+
+		if (newStatus === 'failed') {
+			if (options?.error) {
+				updates.error = options.error;
+			}
+		}
+
+		// Clear error/result when restarting from failed/cancelled
+		if (
+			(task.status === 'failed' || task.status === 'cancelled') &&
+			(newStatus === 'pending' || newStatus === 'in_progress')
+		) {
+			// Use null to explicitly clear these fields in the database
+			updates.error = null;
+			updates.result = null;
+			updates.progress = null;
+		}
+
+		return this.updateTaskStatus(taskId, newStatus, updates);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -13,6 +13,7 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { TaskStatus, TaskType, AgentType } from '@neokai/shared';
+import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
@@ -227,6 +228,74 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 			}
 			return jsonResult({ success: true, message: `Task ${args.task_id} cancelled` });
+		},
+
+		async set_task_status(args: {
+			task_id: string;
+			status: TaskStatus;
+			result?: string;
+			error?: string;
+		}): Promise<ToolResult> {
+			const task = await taskManager.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+
+			// Validate status transition
+			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
+			if (!allowedTransitions.includes(args.status)) {
+				return jsonResult({
+					success: false,
+					error: `Invalid status transition from '${task.status}' to '${args.status}'. Allowed: ${allowedTransitions.join(', ') || 'none'}`,
+				});
+			}
+
+			// Check for active group when transitioning from in_progress or review
+			if (task.status === 'in_progress' || task.status === 'review') {
+				if (runtimeService) {
+					const runtime = runtimeService.getRuntime(roomId);
+					if (runtime) {
+						const group = groupRepo.getGroupByTaskId(args.task_id);
+						if (group && group.state !== 'completed' && group.state !== 'failed') {
+							// There's an active group - cancel it first if moving to terminal state
+							if (
+								args.status === 'completed' ||
+								args.status === 'failed' ||
+								args.status === 'cancelled'
+							) {
+								await runtime.taskGroupManager.cancel(group.id);
+							}
+						}
+					}
+				}
+			}
+
+			// Apply status change
+			let updatedTask: typeof task;
+			try {
+				updatedTask = await taskManager.setTaskStatus(args.task_id, args.status, {
+					result: args.result,
+					error: args.error,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return jsonResult({ success: false, error: message });
+			}
+
+			// Notify UI of the status change
+			if (daemonHub) {
+				void daemonHub.emit('room.task.update', {
+					sessionId: `room:${roomId}`,
+					roomId,
+					task: updatedTask,
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				message: `Task ${args.task_id} status changed from '${task.status}' to '${args.status}'`,
+				task: updatedTask,
+			});
 		},
 
 		async approve_task(args: { task_id: string }): Promise<ToolResult> {
@@ -463,6 +532,19 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			'Cancel a task (marks as cancelled — distinct from failed — and cleans up agent sessions)',
 			{ task_id: z.string().describe('ID of the task to cancel') },
 			(args) => handlers.cancel_task(args)
+		),
+		tool(
+			'set_task_status',
+			'Set task status to any valid status. Use this to complete, fail, restart, or change status of any task. Validates that the status transition is allowed.',
+			{
+				task_id: z.string().describe('ID of the task to update'),
+				status: z
+					.enum(['draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled'])
+					.describe('New status for the task'),
+				result: z.string().optional().describe('Result description (for completed status)'),
+				error: z.string().optional().describe('Error message (for failed status)'),
+			},
+			(args) => handlers.set_task_status(args)
 		),
 		tool(
 			'approve_task',

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -263,7 +263,13 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 								args.status === 'failed' ||
 								args.status === 'cancelled'
 							) {
-								await runtime.taskGroupManager.cancel(group.id);
+								const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
+								if (!cancelledGroup) {
+									return jsonResult({
+										success: false,
+										error: `Failed to cancel active group for task ${args.task_id} — group may have been modified concurrently`,
+									});
+								}
 							}
 						}
 					}

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -7,6 +7,7 @@
  * - task.get - Get task details
  * - task.fail - Fail a task (used by tests to simulate failure)
  * - task.cancel - Cancel a task (human-initiated cancellation)
+ * - task.setStatus - Set task status with validation (human-initiated status change)
  * - task.reject - Reject a task review (human-initiated rejection with feedback)
  * - task.getGroup - Get session group for a task
  * - task.getGroupMessages - Get messages for a session group
@@ -18,7 +19,7 @@ import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
-import { TaskManager } from '../room/managers/task-manager';
+import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
 import { SessionGroupRepository } from '../room/state/session-group-repository';
 import { routeHumanMessageToGroup } from '../room/runtime/human-message-routing';
 import { SDKMessageRepository } from '../../storage/repositories/sdk-message-repository';
@@ -28,7 +29,7 @@ const log = new Logger('task-handlers');
 
 export type TaskManagerLike = Pick<
 	TaskManager,
-	'createTask' | 'getTask' | 'listTasks' | 'failTask' | 'cancelTask'
+	'createTask' | 'getTask' | 'listTasks' | 'failTask' | 'cancelTask' | 'setTaskStatus'
 >;
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;
@@ -231,6 +232,72 @@ export function setupTaskHandlers(
 		emitRoomOverview(params.roomId);
 
 		return { task: cancelledTask };
+	});
+
+	// task.setStatus - Set task status with validation (human-initiated)
+	messageHub.onRequest('task.setStatus', async (data) => {
+		const params = data as {
+			roomId: string;
+			taskId: string;
+			status: TaskStatus;
+			result?: string;
+			error?: string;
+		};
+
+		if (!params.roomId) {
+			throw new Error('Room ID is required');
+		}
+		if (!params.taskId) {
+			throw new Error('Task ID is required');
+		}
+		if (!params.status) {
+			throw new Error('Status is required');
+		}
+
+		const taskManager = taskManagerFactory(db, params.roomId);
+		const task = await taskManager.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		// Validate status transition
+		const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
+		if (!allowedTransitions.includes(params.status)) {
+			throw new Error(
+				`Invalid status transition from '${task.status}' to '${params.status}'. ` +
+					`Allowed: ${allowedTransitions.join(', ') || 'none'}`
+			);
+		}
+
+		// If there's an active group with runtime, cancel it when moving to terminal state
+		if (runtimeService) {
+			const runtime = runtimeService.getRuntime(params.roomId);
+			if (runtime) {
+				const groupRepo = new SessionGroupRepository(db.getDatabase());
+				const group = groupRepo.getGroupByTaskId(params.taskId);
+				if (group && group.state !== 'completed' && group.state !== 'failed') {
+					// Cancel active group if moving to terminal state
+					if (
+						params.status === 'completed' ||
+						params.status === 'failed' ||
+						params.status === 'cancelled'
+					) {
+						await runtime.taskGroupManager.cancel(group.id);
+					}
+				}
+			}
+		}
+
+		// Apply status change
+		const updatedTask = await taskManager.setTaskStatus(params.taskId, params.status, {
+			result: params.result,
+			error: params.error,
+		});
+
+		emitTaskUpdate(params.roomId, updatedTask);
+		emitRoomOverview(params.roomId);
+
+		return { task: updatedTask };
 	});
 
 	// task.reject - Reject a task review with feedback

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -282,7 +282,12 @@ export function setupTaskHandlers(
 						params.status === 'failed' ||
 						params.status === 'cancelled'
 					) {
-						await runtime.taskGroupManager.cancel(group.id);
+						const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
+						if (!cancelledGroup) {
+							throw new Error(
+								`Failed to cancel task group for task ${params.taskId} — group may have been modified concurrently`
+							);
+						}
 					}
 				}
 			}

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1063,5 +1063,88 @@ describe('Room Agent Tools', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Invalid status transition');
 		});
+
+		it('should return error when group cancellation fails due to version conflict', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress
+			await taskManager.startTask(taskId);
+
+			// Create an active group
+			insertGroup(taskId, 'awaiting_human');
+
+			// Create handler with mock runtime that returns null from cancel (simulating version conflict)
+			const mockRuntime = {
+				taskGroupManager: {
+					cancel: async () => null, // Returns null to simulate version conflict
+				},
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+
+			// Try to complete the task - should fail because group cancellation failed
+			const result = parseResult(await h.set_task_status({ task_id: taskId, status: 'completed' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to cancel active group');
+			expect(result.error).toContain('group may have been modified concurrently');
+		});
+
+		it('should succeed when group cancellation succeeds', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress
+			await taskManager.startTask(taskId);
+
+			// Create an active group
+			const groupId = insertGroup(taskId, 'awaiting_human');
+
+			// Create handler with mock runtime that successfully cancels
+			const mockRuntime = {
+				taskGroupManager: {
+					cancel: async (gId: string) => {
+						expect(gId).toBe(groupId);
+						return { id: gId, state: 'cancelled' };
+					},
+				},
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+
+			// Complete the task - should succeed because group cancellation succeeded
+			const result = parseResult(await h.set_task_status({ task_id: taskId, status: 'completed' }));
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('completed');
+		});
+
+		it('should allow status change without runtime even if group exists', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress
+			await taskManager.startTask(taskId);
+
+			// Create an active group
+			insertGroup(taskId, 'awaiting_human');
+
+			// Handler without runtime service - should still allow transition
+			// (for backwards compatibility or when runtime is not available)
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'completed' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('completed');
+		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -914,4 +914,154 @@ describe('Room Agent Tools', () => {
 			expect(group.awaitingHumanReview).toBe(false);
 		});
 	});
+
+	describe('set_task_status', () => {
+		it('should return error when task not found', async () => {
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: 'no-such-task', status: 'completed' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Task not found');
+		});
+
+		it('should return error for invalid status transition', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Try invalid transition: pending -> completed (not allowed)
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'completed' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid status transition');
+		});
+
+		it('should allow valid transition: pending -> in_progress', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'in_progress' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('in_progress');
+		});
+
+		it('should allow restart from failed to pending', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress first
+			await taskManager.startTask(taskId);
+			// Then fail it
+			await taskManager.failTask(taskId, 'Something went wrong');
+
+			// Now restart it
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'pending' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('pending');
+			// Error should be cleared
+			expect(result.task.error).toBeUndefined();
+		});
+
+		it('should allow restart from cancelled to in_progress', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Cancel the task
+			await taskManager.cancelTask(taskId);
+
+			// Now restart it
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'in_progress' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('in_progress');
+		});
+
+		it('should allow transition: in_progress -> review', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress first
+			await taskManager.startTask(taskId);
+
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'review' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('review');
+		});
+
+		it('should allow transition: in_progress -> completed with result', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress first
+			await taskManager.startTask(taskId);
+
+			const result = parseResult(
+				await handlers.set_task_status({
+					task_id: taskId,
+					status: 'completed',
+					result: 'Successfully implemented the feature',
+				})
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('completed');
+			expect(result.task.result).toBe('Successfully implemented the feature');
+			expect(result.task.progress).toBe(100);
+		});
+
+		it('should allow transition: in_progress -> failed with error', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress first
+			await taskManager.startTask(taskId);
+
+			const result = parseResult(
+				await handlers.set_task_status({
+					task_id: taskId,
+					status: 'failed',
+					error: 'Tests failed',
+				})
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('failed');
+			expect(result.task.error).toBe('Tests failed');
+		});
+
+		it('should allow transition: review -> in_progress', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress and then to review
+			await taskManager.startTask(taskId);
+			await taskManager.reviewTask(taskId);
+
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'in_progress' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('in_progress');
+		});
+
+		it('should deny transition: completed -> pending (terminal state)', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress and then to completed
+			await taskManager.startTask(taskId);
+			await taskManager.completeTask(taskId, 'Done');
+
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'pending' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid status transition');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -563,3 +563,227 @@ describe('task.reject RPC Handler', () => {
 		});
 	});
 });
+
+// ─── task.setStatus Tests ───
+
+describe('task.setStatus RPC Handler', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+
+	/**
+	 * Create a TaskManagerFactory that supports setTaskStatus
+	 */
+	function makeSetStatusTaskManagerFactory(task: NeoTask | null): TaskManagerFactory {
+		const manager = {
+			createTask: mock(async () => task!),
+			getTask: mock(async () => task),
+			listTasks: mock(async () => []),
+			failTask: mock(async () => task!),
+			cancelTask: mock(async () => ({ ...task!, status: 'cancelled' as const })),
+			setTaskStatus: mock(async (_id: string, status: string, _opts?: unknown) => ({
+				...task!,
+				status: status as NeoTask['status'],
+			})),
+		};
+		return mock(() => manager);
+	}
+
+	/**
+	 * Create a runtime service with a taskGroupManager that can be controlled
+	 */
+	function makeRuntimeServiceWithGroupManager(
+		cancelResult: unknown = { id: 'group-1', state: 'cancelled' }
+	) {
+		const cancel = mock(async () => cancelResult);
+		const runtime = {
+			taskGroupManager: { cancel },
+		};
+		const service = {
+			getRuntime: mock(() => runtime),
+		} as unknown as RoomRuntimeService;
+		return { service, runtime, cancel };
+	}
+
+	function setup(opts: {
+		task?: NeoTask | null;
+		groupState?: string;
+		runtimeService?: RoomRuntimeService;
+		taskManagerFactory?: TaskManagerFactory;
+	}) {
+		const {
+			task = mockTask,
+			groupState = 'awaiting_human',
+			runtimeService,
+			taskManagerFactory,
+		} = opts;
+
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+
+		setupTaskHandlers(
+			hub,
+			mockRoomManager,
+			createMockDaemonHub(),
+			makeDb(makeGroupRow(groupState)),
+			taskManagerFactory ?? makeSetStatusTaskManagerFactory(task),
+			runtimeService
+		);
+	}
+
+	function getHandler(): RequestHandler {
+		const h = handlers.get('task.setStatus');
+		expect(h).toBeDefined();
+		return h!;
+	}
+
+	describe('parameter validation', () => {
+		beforeEach(() => {
+			setup({ runtimeService: makeNullRuntimeService() });
+		});
+
+		it('throws when roomId is missing', async () => {
+			await expect(getHandler()({ taskId: 'task-1', status: 'completed' }, {})).rejects.toThrow(
+				'Room ID is required'
+			);
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(getHandler()({ roomId: 'room-1', status: 'completed' }, {})).rejects.toThrow(
+				'Task ID is required'
+			);
+		});
+
+		it('throws when status is missing', async () => {
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'Status is required'
+			);
+		});
+	});
+
+	describe('task validation', () => {
+		it('throws when task is not found', async () => {
+			setup({ task: null, runtimeService: makeNullRuntimeService() });
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+			).rejects.toThrow('Task not found');
+		});
+	});
+
+	describe('status transition validation', () => {
+		it('throws for invalid transition from pending to completed', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+			).rejects.toThrow('Invalid status transition');
+		});
+
+		it('throws for invalid transition from completed to pending', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'pending' }, {})
+			).rejects.toThrow('Invalid status transition');
+		});
+	});
+
+	describe('group cancellation', () => {
+		it('throws when group cancellation fails due to version conflict', async () => {
+			// Create runtime service where cancel returns null (simulating version conflict)
+			const { service } = makeRuntimeServiceWithGroupManager(null);
+
+			setup({
+				task: mockTask, // in_progress status
+				groupState: 'awaiting_human',
+				runtimeService: service,
+			});
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+			).rejects.toThrow('Failed to cancel task group');
+		});
+
+		it('succeeds when group cancellation succeeds', async () => {
+			// Create runtime service where cancel returns a valid group
+			const { service, cancel } = makeRuntimeServiceWithGroupManager({
+				id: 'group-1',
+				state: 'cancelled',
+			});
+
+			setup({
+				task: mockTask, // in_progress status
+				groupState: 'awaiting_human',
+				runtimeService: service,
+			});
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'completed' },
+				{}
+			);
+			expect(cancel).toHaveBeenCalledWith('group-1');
+			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
+		});
+
+		it('does not cancel group when moving to non-terminal state', async () => {
+			const { service, cancel } = makeRuntimeServiceWithGroupManager();
+
+			setup({
+				task: mockTask, // in_progress status
+				groupState: 'awaiting_human',
+				runtimeService: service,
+			});
+
+			// Moving to 'review' is not a terminal state, so group shouldn't be cancelled
+			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'review' }, {});
+			expect(cancel).not.toHaveBeenCalled();
+		});
+
+		it('does not cancel group when no runtime service', async () => {
+			// Without runtime service, the group cancellation code path is not entered
+			setup({
+				task: mockTask,
+				groupState: 'awaiting_human',
+				runtimeService: undefined,
+			});
+
+			// This should succeed without attempting to cancel any group
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'completed' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
+		});
+	});
+
+	describe('happy paths', () => {
+		it('allows valid transition from in_progress to completed', async () => {
+			setup({ task: mockTask, runtimeService: makeNullRuntimeService() });
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', result: 'Done' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
+		});
+
+		it('allows valid transition from failed to pending (restart)', async () => {
+			const failedTask = { ...mockTask, status: 'failed' as const };
+			setup({ task: failedTask, runtimeService: makeNullRuntimeService() });
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'pending' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...failedTask, status: 'pending' } });
+		});
+
+		it('allows valid transition from cancelled to in_progress (restart)', async () => {
+			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
+			setup({ task: cancelledTask, runtimeService: makeNullRuntimeService() });
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'in_progress' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...cancelledTask, status: 'in_progress' } });
+		});
+	});
+});

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -196,13 +196,13 @@ export interface NeoTask {
 	/** ID of the planning task that created this task (for draft→pending promotion) */
 	createdByTaskId?: string;
 	/** Progress percentage (0-100) */
-	progress?: number;
+	progress?: number | null;
 	/** Description of current step */
-	currentStep?: string;
+	currentStep?: string | null;
 	/** Result of completed task */
-	result?: string;
+	result?: string | null;
 	/** Error message for failed task */
-	error?: string;
+	error?: string | null;
 	/** IDs of tasks this task depends on */
 	dependsOn: string[];
 	/** Creation timestamp (milliseconds since epoch) */
@@ -248,10 +248,10 @@ export interface UpdateTaskParams {
 	description?: string;
 	status?: TaskStatus;
 	priority?: TaskPriority;
-	progress?: number;
-	currentStep?: string;
-	result?: string;
-	error?: string;
+	progress?: number | null;
+	currentStep?: string | null;
+	result?: string | null;
+	error?: string | null;
 	dependsOn?: string[];
 }
 
@@ -286,11 +286,11 @@ export interface TaskSummary {
 	title: string;
 	status: TaskStatus;
 	priority: TaskPriority;
-	progress?: number;
+	progress?: number | null;
 	/** IDs of tasks this task depends on */
 	dependsOn: string[];
 	/** Error message for failed tasks */
-	error?: string;
+	error?: string | null;
 }
 
 /**


### PR DESCRIPTION
This allows:
1. Room Agent to use `set_task_status` tool to change task status
2. UI to use `task.setStatus` RPC to change task status
