### PR TITLE
fix(tests): use proxy env vars for Dev Proxy integration

### DIFF
--- a/.devproxy/mocks-basic.json
+++ b/.devproxy/mocks-basic.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.mocksfile.schema.json",
 	"mocks": [
 		{
 			"request": {

--- a/.devproxy/mocks-errors.json
+++ b/.devproxy/mocks-errors.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.mocksfile.schema.json",
 	"mocks": [
 		{
 			"request": {

--- a/.devproxy/mocks-room.json
+++ b/.devproxy/mocks-room.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.mocksfile.schema.json",
 	"mocks": [
 		{
 			"comment": "Room chat agent - simple text response",

--- a/.devproxy/mocks-tool-use.json
+++ b/.devproxy/mocks-tool-use.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.mocksfile.schema.json",
 	"mocks": [
 		{
 			"request": {

--- a/.devproxy/mocks.json
+++ b/.devproxy/mocks.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.1.0/mockresponseplugin.mocksfile.schema.json",
+	"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.mocksfile.schema.json",
 	"mocks": [
 		{
 			"request": {

--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -112,17 +112,18 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 	} = options;
 
 	// Start Dev Proxy if requested
-	// Use ANTHROPIC_BASE_URL to redirect SDK to Dev Proxy instead of proxy env vars
+	// Use proxy env vars (HTTPS_PROXY, HTTP_PROXY, NODE_USE_ENV_PROXY) for SDK to route through Dev Proxy
 	let devProxy: DevProxyController | null = null;
 	const shouldUseDevProxy = useDevProxy || process.env.NEOKAI_USE_DEV_PROXY === '1';
 
 	if (shouldUseDevProxy) {
 		devProxy = createDevProxyController({
-			setEnvVars: false, // Don't set proxy env vars - use ANTHROPIC_BASE_URL instead
+			setEnvVars: true, // Set proxy env vars (HTTPS_PROXY, HTTP_PROXY, NODE_USE_ENV_PROXY)
 			...devProxyOptions,
 		});
 		try {
 			await devProxy.start();
+			// Proxy env vars are set by DevProxyController when setEnvVars: true
 		} catch (error) {
 			// If Dev Proxy can't start (not installed, etc.), skip it and continue without mocking
 			// Tests will use real API calls if credentials are available
@@ -146,11 +147,8 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 		...customEnv,
 	};
 
-	// Set ANTHROPIC_BASE_URL to point to Dev Proxy if it's running
-	// This is more reliable than proxy env vars for subprocess inheritance
-	if (devProxy?.isRunning()) {
-		daemonEnv.ANTHROPIC_BASE_URL = devProxy.proxyUrl;
-	}
+	// Note: Proxy env vars are inherited from parent process via ...process.env
+	// Dev Proxy will intercept requests to api.anthropic.com
 
 	// Spawn the daemon server
 	const daemonProcess = spawn('bun', ['run', serverPath], {
@@ -277,25 +275,19 @@ async function createInProcessDaemonServer(
 		useDevProxy = false,
 	} = options;
 
-	// Track original ANTHROPIC_BASE_URL for restoration
-	let originalAnthropicBaseUrl: string | undefined;
-
 	// Start Dev Proxy if requested
-	// Use ANTHROPIC_BASE_URL to redirect SDK to Dev Proxy instead of proxy env vars
+	// Use proxy env vars (HTTPS_PROXY, HTTP_PROXY, NODE_USE_ENV_PROXY) for SDK to route through Dev Proxy
 	let devProxy: DevProxyController | null = null;
 	const shouldUseDevProxy = useDevProxy || process.env.NEOKAI_USE_DEV_PROXY === '1';
 
 	if (shouldUseDevProxy) {
 		devProxy = createDevProxyController({
-			setEnvVars: false, // Don't set proxy env vars - use ANTHROPIC_BASE_URL instead
+			setEnvVars: true, // Set proxy env vars (HTTPS_PROXY, HTTP_PROXY, NODE_USE_ENV_PROXY)
 			...devProxyOptions,
 		});
 		try {
 			await devProxy.start();
-			// Set ANTHROPIC_BASE_URL to point to Dev Proxy
-			// This is more reliable than proxy env vars since SDK subprocess inherits it
-			originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
-			process.env.ANTHROPIC_BASE_URL = devProxy.proxyUrl;
+			// Proxy env vars are set by DevProxyController when setEnvVars: true
 		} catch (error) {
 			// If Dev Proxy can't start (not installed, etc.), skip it and continue without mocking
 			// Tests will use real API calls if credentials are available
@@ -414,15 +406,10 @@ async function createInProcessDaemonServer(
 				await Bun.$`rm -rf ${workspace}`.quiet();
 			}
 
-			// Stop Dev Proxy and restore ANTHROPIC_BASE_URL if Dev Proxy was started
+			// Stop Dev Proxy and restore environment variables if Dev Proxy was started
 			if (devProxy) {
 				await devProxy.stop();
-				// Restore original ANTHROPIC_BASE_URL
-				if (originalAnthropicBaseUrl !== undefined) {
-					process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
-				} else {
-					delete process.env.ANTHROPIC_BASE_URL;
-				}
+				devProxy.restoreEnv();
 			}
 		},
 		trackSession: (sessionId: string) => {

--- a/packages/daemon/tests/helpers/dev-proxy.ts
+++ b/packages/daemon/tests/helpers/dev-proxy.ts
@@ -351,19 +351,19 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 		saveEnvVar('HTTP_PROXY');
 		saveEnvVar('NODE_USE_ENV_PROXY');
 		saveEnvVar('NODE_EXTRA_CA_CERTS');
+		saveEnvVar('NODE_TLS_REJECT_UNAUTHORIZED');
 		saveEnvVar('NO_PROXY');
 
 		globalThis.process.env.HTTPS_PROXY = proxyUrl;
 		globalThis.process.env.HTTP_PROXY = proxyUrl;
 		globalThis.process.env.NODE_USE_ENV_PROXY = '1';
+		globalThis.process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // Required for Dev Proxy HTTPS interception
+		globalThis.process.env.NO_PROXY = 'localhost,127.0.0.1';
 
-		// Set CA cert path if it exists
+		// Set CA cert path if it exists (optional, fallback to TLS reject disabled)
 		if (fs.existsSync(caCertPath)) {
 			globalThis.process.env.NODE_EXTRA_CA_CERTS = caCertPath;
 		}
-
-		// Don't proxy localhost
-		globalThis.process.env.NO_PROXY = 'localhost,127.0.0.1';
 	};
 
 	const controller: DevProxyController = {


### PR DESCRIPTION
- Updated daemon-server.ts to use setEnvVars: true
- Updated dev-proxy.ts to set NODE_TLS_REJECT_UNAUTHORIZED=0
- Updated all mock files to use v2.2.0 schema
