### PR TITLE
fix(tests): use Dev Proxy for remaining online tests

### DIFF
--- a/.devproxy/devproxyrc.json
+++ b/.devproxy/devproxyrc.json
@@ -11,7 +11,7 @@
 	"urlsToWatch": ["https://api.anthropic.com/*"],
 	"mockResponsePlugin": {
 		"$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v2.2.0/mockresponseplugin.schema.json",
-		"mocksFile": "mocks.json"
+		"mocksFile": "mocks-basic.json"
 	},
 	"logLevel": "information",
 	"port": 8000,

--- a/.devproxy/mocks-basic.json
+++ b/.devproxy/mocks-basic.json
@@ -330,6 +330,946 @@
 					}
 				}
 			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Reply with exactly: room ok"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json (room)"
+					}
+				],
+				"body": {
+					"id": "msg_room_ok",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "room ok"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 5,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 5 + 7? Just reply with the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_math_57",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "12"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 20,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Now add 3 to that result. Just reply with the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_math_add3",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "15"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 25,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "First message: Say \"One\"."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_one",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "One"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Second message: Say \"Two\"."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_two",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Two"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Third message: Say \"Three\"."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_three",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Three"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Say \"Done\". Just that word."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_done",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Done"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 2+2? Reply with just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_22a",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "4"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 20,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 3+3? Reply with just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_33a",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "6"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 20,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 1+1?"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_11",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "2"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 2+2?"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_22b",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "4"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 3+3?"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_33b",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "6"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 4+4?"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_44",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "8"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 15,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "What is 5+5? Just the number."
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_basic_55",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "10"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 18,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Count to 1"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_count_1",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "1"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 2,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Count to 2"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_count_2",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "1, 2"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 4,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Hello"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_hello",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "Hello! How can I help you?"
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 5,
+						"output_tokens": 10,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "First message"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_first",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I received your first message."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 10,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Second message"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_second",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I received your second message."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 10,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
+		},
+		{
+			"request": {
+				"url": "https://api.anthropic.com/v1/messages",
+				"method": "POST",
+				"bodyFragment": {
+					"messages": [
+						{
+							"content": "Third message"
+						}
+					]
+				}
+			},
+			"response": {
+				"statusCode": 200,
+				"headers": [
+					{
+						"name": "content-type",
+						"value": "application/json"
+					},
+					{
+						"name": "x-mocked-by",
+						"value": "Dev Proxy MockResponsePlugin - mocks-basic.json"
+					}
+				],
+				"body": {
+					"id": "msg_third",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{
+							"type": "text",
+							"text": "I received your third message."
+						}
+					],
+					"model": "claude-sonnet-4-20250514",
+					"stop_reason": "end_turn",
+					"stop_sequence": null,
+					"usage": {
+						"input_tokens": 10,
+						"output_tokens": 10,
+						"cache_creation_input_tokens": 0,
+						"cache_read_input_tokens": 0,
+						"service_tier": "standard"
+					}
+				}
+			}
 		}
 	]
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,7 @@ jobs:
           # Run `bash scripts/validate-online-test-matrix.sh` to verify all files are covered.
           - module: agent
             test_path: tests/online/agent
+            mock_sdk: true
           - module: components
             test_path: tests/online/components
             mock_sdk: true
@@ -158,6 +159,7 @@ jobs:
           #   test_path: tests/online/glm
           - module: convo
             test_path: tests/online/convo
+            mock_sdk: true
           - module: coordinator
             test_path: tests/online/coordinator
             timeout: 10
@@ -190,12 +192,15 @@ jobs:
             test_path: tests/online/providers/github-copilot-provider.test.ts
           - module: rewind
             test_path: tests/online/rewind
+            mock_sdk: true
           - module: room-1
             test_path: >-
               tests/online/room/room-advanced-scenarios.test.ts
               tests/online/room/room-chat-agent-tools.test.ts
-              tests/online/room/room-chat-constraints.test.ts
             timeout: 10
+          - module: room-chat-constraints
+            test_path: tests/online/room/room-chat-constraints.test.ts
+            mock_sdk: true
           - module: room-multi-agent
             test_path: tests/online/room/room-multi-agent-flow.test.ts
             timeout: 10


### PR DESCRIPTION
- Update devproxyrc.json to use mocks-basic.json with more specific mock responses
- Add mock responses for test messages (math, room constraints, etc.)
- Update CI matrix to enable Dev Proxy for agent, convo, rewind, and room-chat-constraints modules
- Split room-chat-constraints into its separate module with mock_sdk: true

This completes the migration of online tests to Dev Proxy for both local and CI environments.

Note: room-advanced-scenarios and room-chat-agent-tools tests remain with real API
calls as they explicitly require multi-agent flow testing that cannot be mocked.
