### PR TITLE
Room runtime refactor: remove group-state routing and align task flow

### DIFF
--- a/docs/design/pr-review-workflow.md
+++ b/docs/design/pr-review-workflow.md
@@ -17,16 +17,28 @@ stateDiagram-v2
     in_progress --> review : leader calls submit_for_review
     in_progress --> failed
     review --> completed : human approves
-    review --> pending : human rejects (with feedback)
+    review --> in_progress : human rejects (with feedback)
 
     note right of review
         Group slot freed.
         Room picks up next task.
-        PR awaits human merge.
+        Human decision resumes leader flow.
     end note
 ```
 
-## Worker → Leader → Reviewer Flow
+## Current Session Group State
+
+`session_groups.state` is compatibility metadata and currently uses:
+
+- `awaiting_worker`
+- `awaiting_leader`
+- `awaiting_human`
+- `completed`
+- `failed`
+
+`hibernated` is removed from the active model.
+
+## Worker → Leader → Human Flow
 
 ```mermaid
 flowchart TB
@@ -75,8 +87,20 @@ flowchart TB
     L3 -.->|"reads comments"| PR
 
     L4 -->|"No: send_to_worker"| W_feedback
-    L4 -->|"Yes: submit_for_review(pr_url)"| Review["Task → review status<br/>Group slot freed"]
-    Review --> Tick
+    L4 -->|"Yes: submit_for_review(pr_url)"| Review["Task → review status<br/>submittedForReview=true"]
+    Review --> Slot["Group slot freed<br/>task parked for human"]
+    Slot --> Tick
+
+    H["Human review"]
+    Review --> H
+    H -->|"task.approve"| ResumeA["runtime.resumeWorkerFromHuman(..., approved=true)<br/>resumeLeaderFromHuman()"]
+    H -->|"task.reject(feedback)"| ResumeR["runtime.resumeWorkerFromHuman(..., approved=false)<br/>resumeLeaderFromHuman()"]
+    H -->|"task.sendHumanMessage(target)"| HM["Direct inject to worker/leader"]
+
+    ResumeA --> L1
+    ResumeR --> L1
+    HM --> W_feedback
+    HM --> L1
 ```
 
 ## Reviewer Sub-agent Detail
@@ -116,107 +140,19 @@ sequenceDiagram
     RevCLI->>GH: Bash: gh pr comment --body "## Round 2 — approved"
     RevCLI-->>Leader: approved
 
-    Note over Leader: All approved → submit_for_review
+    Note over Leader: All approved → submit_for_review (task enters review)
 ```
 
 ---
+## Current Implementation Notes
 
-## Implementation Plan
-
-### Change 1: Add `review` task status, remove `escalated`
-
-Simplify task states to: `draft | pending | in_progress | review | completed | failed`.
-
-Remove `escalated` — it's a vague middle ground. If the leader can't resolve something,
-it fails the task. If work is done and needs human eyes, it goes to `review`.
-
-Also remove `awaiting_human` from `GroupState` and the escalation logic
-(nudge-then-escalate on leader contract violation → just fail instead).
-
-**Files:**
-- `packages/shared/src/types/neo.ts` — update `TaskStatus` union
-- `packages/daemon/src/storage/schema/index.ts` — update CHECK constraint
-- `packages/daemon/src/storage/schema/migrations.ts` — migration
-- `packages/daemon/src/lib/room/task-manager.ts` — add `reviewTask()`, remove
-  `escalateTask()` / `deescalateTask()`
-- `packages/daemon/src/lib/room/room-runtime.ts` — remove escalation logic, leader
-  contract violation → fail instead of escalate. `review` tasks don't trigger replanning.
-- `packages/daemon/src/lib/room/session-group-repository.ts` — remove `awaiting_human`
-  from `GroupState`
-- `packages/web/` — UI badge/color for review status, remove escalated references
-
-### Change 2: Worktree cleanliness gate
-
-Before routing worker output to leader, check `git status` in the worktree. If there are
-uncommitted changes or untracked files, auto-reply the worker instead of forwarding to leader:
-"Make logical commits for changes you want to keep and clean up unused files."
-
-This ensures the leader and reviewers always see a clean, committed state.
-
-**Files:**
-- `packages/daemon/src/lib/room/room-runtime.ts` — in `onWorkerTerminalState()`, before
-  `routeWorkerToLeader()`, run `git status --porcelain` in the worktree. If non-empty,
-  inject message back to worker and keep group in `awaiting_worker` state.
-
-### Change 3: Add `submit_for_review` leader tool
-
-New terminal tool for the leader. When called, it completes the group, transitions the task
-to `review` status, and records the PR URL on the task.
-
-**Files:**
-- `packages/daemon/src/lib/room/leader-agent.ts` — add tool definition + prompt section
-- `packages/daemon/src/lib/room/room-runtime.ts` — handle in `handleLeaderTool()`
-- `packages/daemon/src/lib/room/task-group-manager.ts` — add `submitForReview()` method
-
-### Change 4: Enable coordinator mode on leader
-
-The leader session gets coordinator mode with room-configured reviewer sub-agents.
-Each reviewer is an `AgentDefinition` with a model, restricted tools (Read, Grep, Glob,
-Bash for `gh`), and a reviewer prompt. For CLI-only models, the sub-agent uses sonnet
-and calls the CLI via Bash.
-
-**Files:**
-- `packages/daemon/src/lib/room/leader-agent.ts` — set `coordinatorMode: true`, build
-  reviewer `AgentDefinition` records from `Room.config.reviewers`
-- `packages/daemon/src/lib/agent/query-options-builder.ts` — ensure leader sessions
-  apply coordinator agents correctly
-
-### Change 5: Worktree per task group
-
-Worker session is created with `type: 'worker'` — `SessionLifecycle` detects the git repo
-and creates a worktree automatically. Leader session uses the worker's worktree path as its
-`workspacePath` (with `worktree: false` — it doesn't create its own). The leader init is
-already deferred in `pendingLeaderInits`, so by the time it's built the worker's worktree
-path is known and can be passed through.
-
-**Files:**
-- `packages/daemon/src/lib/room/coder-agent.ts` — set session features `worktree: true`
-- `packages/daemon/src/lib/room/task-group-manager.ts` — after worker session creation,
-  read its worktree path and pass to deferred leader init
-- `packages/daemon/src/lib/room/leader-agent.ts` — receives worker's worktree path,
-  keeps `worktree: false`
-
-### Change 6: Agents tab in room dashboard
-
-New tab between Context and Goals. Shows available providers/models from the registry
-and lets the user configure which reviewer agents this room uses. Writes to `Room.config`.
-
-**Files:**
-- `packages/web/src/islands/Room.tsx` — add `'agents'` to `RoomTab` union, render tab
-- `packages/web/src/components/room/RoomAgents.tsx` — new component
-- `packages/daemon/src/lib/rpc-handlers/room-handlers.ts` — RPC to read provider
-  registry (available models, auth status)
-
-### Change 7: Leader prompt for review orchestration
-
-Update the leader's system prompt (for `code_review` context) to describe the full
-review workflow: spawn reviewers, read verdicts, iterate or submit. Include instructions
-to use `Task(resume: agentId)` on subsequent rounds.
-
-**Files:**
-- `packages/daemon/src/lib/room/leader-agent.ts` — extend `buildLeaderSystemPrompt()`
-
----
+- Human approval and rejection use task-scoped RPCs:
+  - `task.approve` resumes review tasks with `approved=true`
+  - `task.reject` resumes review tasks with `approved=false`
+- `task.sendHumanMessage` is available at any time and routes directly to worker or leader.
+- Terminal status changes clean up runtime resources via runtime APIs:
+  - `task.cancel` and `task.setStatus(..., cancelled)` use runtime cancellation
+  - `task.setStatus(..., completed|failed)` uses runtime group termination
 
 ## Configuration (No New Tables)
 
@@ -235,27 +171,6 @@ Room agent configuration lives in the existing `Room.config` JSON field:
 
 The **Agents tab** reads available providers/models from the existing provider registry
 and writes selections to `Room.config`. No new database tables.
-
-## Schema Changes
-
-Update task status CHECK constraint — add `review`, remove `escalated`:
-
-```sql
--- Before
-status TEXT NOT NULL DEFAULT 'pending'
-  CHECK(status IN ('draft', 'pending', 'in_progress', 'escalated', 'completed', 'failed'))
-
--- After
-status TEXT NOT NULL DEFAULT 'pending'
-  CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'failed'))
-```
-
-Update `GroupState` — remove `hibernated` (vague, no clear trigger/resolution):
-
-```
-Before: awaiting_worker | awaiting_leader | awaiting_human | hibernated | completed | failed
-After:  awaiting_worker | awaiting_leader | awaiting_human | completed | failed
-```
 
 ## What We're NOT Building
 

--- a/docs/design/room-runtime-impl-plan.md
+++ b/docs/design/room-runtime-impl-plan.md
@@ -1,5 +1,13 @@
 # Room Runtime Implementation Plan
 
+> Historical note (outdated state model):
+> This implementation plan references older orchestration states (`awaiting_craft`, `awaiting_lead`, `hibernated`) and `escalated` task status, which are not current.
+> For current behavior, use:
+> - `docs/design/pr-review-workflow.md`
+> - `docs/design/task-status-control-design.md`
+> - `docs/design/room-runtime-spec.md`
+> Current compatibility `session_groups.state` values are: `awaiting_worker | awaiting_leader | awaiting_human | completed | failed` (`hibernated` removed).
+
 Status: Draft
 Date: 2026-02-24
 Related: [Room Runtime Spec v0.21](./room-runtime-spec.md)

--- a/docs/design/room-runtime-spec.md
+++ b/docs/design/room-runtime-spec.md
@@ -1,993 +1,206 @@
-# Room Autonomy Design Spec — Fresh Start
+# Room Runtime Spec (Current Model)
 
-Status: Draft v0.22
-Date: 2026-02-25
+Status: Active
+Date: 2026-03-09
 
-## Context
+## Purpose
 
-NeoKai has a solid human-AI app with multi-session/worktree support. We've been trying to add room autonomy (agents working toward room goals autonomously while allowing human intervention) but the current implementation doesn't work. The architecture drifted from the original "neo" design to a complex "room self agent" design with too many moving parts.
+This document defines the current room-runtime orchestration model implemented in daemon code.
+It is the source of truth for:
 
-**The core problem**: A room has goals. Work should happen on those goals continuously and autonomously. Humans should be able to intervene at any point.
+- task + session-group lifecycle
+- worker/leader feedback loop
+- human approval/rejection/messaging flow
+- runtime cleanup and recovery semantics
 
-## Why the Current Design Doesn't Work
+Related docs:
 
-The current `RoomSelfService` uses an **LLM as the orchestrator** — a persistent Claude session that receives injected messages and is expected to call tools (`room_create_task`, `room_spawn_worker`, etc.). This fails because:
+- `docs/design/pr-review-workflow.md`
+- `docs/design/task-status-control-design.md`
 
-1. **LLM orchestration is unreliable** — doesn't consistently call the right tools at the right time
-2. **Too many states** — 7 lifecycle states with complex transition rules
-3. **Double LLM cost** — orchestrator runs constantly alongside workers
-4. **Event soup** — complex event subscription/unsubscription patterns
-5. **Mixed responsibilities** — ~1300 lines handling everything
+## Core Model
 
-## The Fundamental Insight
-
-> A room is like a small organization. You need someone thinking about goals and strategy (high-level), and someone doing the detailed work (execution). No one can hold everything in their head. These two levels need a mechanism to work together.
-
----
-
-## The Core Abstraction: Craft → Lead Loop
-
-Everything in this system follows the same meta-process. **Planning, coding, researching, designing** — they're all just activities. The abstraction is always the same: one agent crafts, one agent leads and gives feedback.
-
-```mermaid
-graph LR
-    A[Something needs doing] --> B["Craft Agent works on it<br/>(any activity: planning, coding,<br/>research, design)"]
-    B --> C["Craft Agent reaches terminal state<br/>(result / error / question)"]
-    C --> D["Room Runtime observes terminal state,<br/>collects all assistant messages<br/>from Craft's last turn"]
-    D --> E["Lead Agent receives Craft output<br/>as user message, reviews"]
-    E -->|"send_to_craft(feedback)"| B
-    E -->|"complete_task(summary)"| F[Done]
-    E -->|"escalate(reason)"| G[Human intervenes]
-    G -->|guidance to Craft| B
-    G -->|decision to Lead| E
-```
-
-The **Craft → Lead loop** is universal:
-
-| Activity | Craft Agent does | Lead Agent does |
-|---|---|---|
-| **Planning** | Examines codebase, proposes task breakdown | Reviews plan quality, suggests adjustments |
-| **Coding** | Implements feature, writes tests | Reviews code, checks correctness, requests fixes |
-| **Research** | Investigates options, gathers findings | Evaluates findings, asks deeper questions |
-| **Design** | Drafts architecture, creates specs | Reviews design, identifies gaps, validates approach |
-| **PR Review** | Addresses review comments, pushes fixes | Reads diff, leaves feedback, approves/requests changes |
-
-The loop is always between two parties: a **Craft Agent** and a **Lead Agent**. The Lead can be an agent, a human, or both, or a process involving many parties (like a PR review).
-
-### The (Craft, Lead) Pair
-
-Every task in the system creates a **(Craft, Lead) pair** — two agent sessions that collaborate:
-
-```mermaid
-graph LR
-    subgraph TaskPair["Task: Implement auth endpoint"]
-        Craft["Craft Agent<br/>(AgentSession)"]
-        Lead["Lead Agent<br/>(AgentSession)"]
-    end
-
-    RT["Room Runtime"]
-
-    Craft -->|"reaches terminal state"| RT
-    RT -->|"sends all Craft messages<br/>from last turn"| Lead
-    Lead -->|"send_to_craft(feedback)<br/>routed through Runtime"| RT
-    RT -->|"injects as user message"| Craft
-    Lead -->|"complete_task() / fail_task()<br/>routed through Runtime"| RT
-    Human -->|joins conversation| Craft
-    Human -->|provides guidance| Lead
-```
-
-- **Craft Agent**: Full AgentSession with activity-appropriate tools. It does the work and naturally reaches a terminal state when done. Planning Craft Agents additionally get `create_task` tools for writing tasks to DB — this is an activity-specific tool, not a completion signal.
-- **Lead Agent**: Full AgentSession that reviews Craft Agent's output. Created once per task and **reused across all feedback iterations** (maintains full review context). Room Runtime sends all Craft Agent assistant messages from its last turn as a user message to Lead. Lead evaluates and uses tools to respond.
-- **Room Runtime**: All message routing between Craft and Lead goes through Runtime. Runtime observes session terminal states, collects messages, and routes them. Human messages to Craft are **queued** while Lead is actively reviewing (MVP).
-- **Human**: Can participate at any time — send messages to Craft Agent directly, or provide guidance to Lead Agent.
-
-### Message Routing Through Room Runtime
-
-All inter-agent communication is routed through the Room Runtime:
-
-```mermaid
-sequenceDiagram
-    participant C as Craft Agent
-    participant RT as Room Runtime
-    participant L as Lead Agent
-    participant H as Human
-
-    RT->>C: Create session, send task description
-    C->>C: Works on task...
-    C-->>RT: Session reaches terminal state (result)
-    Note over RT: Collects all Craft assistant<br/>messages from last turn
-    RT->>L: User message with Craft's output
-    L->>L: Evaluates against goal/task
-
-    alt Accepted
-        L->>L: Calls complete_task(summary) tool
-        Note over L,RT: Tool routes through Runtime
-        RT->>RT: Updates task status in DB
-    else Needs more work
-        L->>L: Calls send_to_craft(feedback) tool
-        Note over L,RT: Tool routes through Runtime
-        RT->>C: Injects feedback as user message
-        C->>C: Continues working...
-        C-->>RT: Reaches terminal state again
-        Note over RT: Collects latest messages
-        RT->>L: User message with Craft's update
-    else Needs human
-        L->>L: Calls escalate(reason) tool
-        Note over L,RT: Runtime notifies human
-        H->>C: Human sends message to Craft
-        C->>C: Incorporates guidance...
-        C-->>RT: Reaches terminal state
-        RT->>L: User message with Craft's update
-    end
-```
-
-**Why all routing goes through Runtime**:
-1. Runtime tracks state — knows when to re-observe Craft's next terminal state
-2. All inter-agent messages flow through one place — auditable
-3. Runtime can enforce guard rails (e.g., max feedback iterations)
-4. Consistent routing pattern in both directions
-
-### Lead Agent Tools
-
-Lead Agent has a focused tool set, all routed through Room Runtime:
-
-| Tool | Purpose | Runtime action |
-|---|---|---|
-| `send_to_craft(message)` | Send feedback/follow-up to Craft Agent | Injects as user message into Craft session |
-| `complete_task(summary)` | Accept the work, mark task done | Updates task status in DB |
-| `fail_task(reason)` | Task is not achievable | Updates task status, notifies Room Agent |
-| `escalate(reason)` | Flag for human attention | Notifies human via Room Agent / UI |
-| `read_craft_messages(limit, offset?)` | Read Craft messages from previous iterations | Returns messages from Craft session |
-| `run_verification(command)` | Run tests/linting independently of Craft | Executes command, returns output |
-
-### Task Chat View: Sub-Agent Blocks
-
-The (Craft, Lead) pair is rendered in the UI as a **single conversation** using **sub-agent blocks**, reading from the **session group messages** timeline. Each agent's complete turn (thinking + tool uses + result) is grouped into one collapsible block:
-
-```
-┌─────────────────────────────────────────────────┐
-│ Task: Implement auth endpoint                    │
-├─────────────────────────────────────────────────┤
-│                                                  │
-│ ┌─ 🔨 Craft Agent ────────────────────────────┐ │
-│ │ I'll start by examining the existing route   │ │
-│ │ structure...                                 │ │
-│ │ ▸ Read src/routes/index.ts                   │ │
-│ │ ▸ Read src/routes/auth.ts                    │ │
-│ │ ▸ Edit src/routes/auth.ts (+42 lines)        │ │
-│ │ ▸ Edit src/middleware/validate.ts (+18 lines) │ │
-│ │                                              │ │
-│ │ Created the POST /api/auth/login endpoint    │ │
-│ │ with JWT token generation.                   │ │
-│ └──────────────────────────────────────────────┘ │
-│                                                  │
-│ ┌─ 👁 Lead Agent ─────────────────────────────┐ │
-│ │ The endpoint looks good but you missed       │ │
-│ │ input validation. Add zod schema validation  │ │
-│ │ for the request body.                        │ │
-│ │ ▸ send_to_craft("Add zod schema...")         │ │
-│ └──────────────────────────────────────────────┘ │
-│                                                  │
-│ ┌─ 🔨 Craft Agent ────────────────────────────┐ │
-│ │ Good catch. Adding zod validation now...     │ │
-│ │ ▸ Edit src/routes/auth.ts (+12 lines)        │ │
-│ │                                              │ │
-│ │ Added zod schema for login request body.     │ │
-│ └──────────────────────────────────────────────┘ │
-│                                                  │
-│ 👤 Human: Also make sure to rate-limit the      │
-│    login endpoint                                │
-│                                                  │
-│ ┌─ 🔨 Craft Agent ────────────────────────────┐ │
-│ │ Adding rate limiting...                      │ │
-│ │ ▸ Edit src/middleware/rate.ts (+25 lines)     │ │
-│ │ ▸ Edit src/routes/auth.ts (+3 lines)         │ │
-│ │                                              │ │
-│ │ Added rate limiting middleware to the login   │ │
-│ │ endpoint (max 5 attempts per minute).        │ │
-│ └──────────────────────────────────────────────┘ │
-│                                                  │
-│ ┌─ 👁 Lead Agent ─────────────────────────────┐ │
-│ │ Looks complete. All requirements met.        │ │
-│ │ ▸ complete_task("Implemented auth endpoint   │ │
-│ │   with JWT, validation, and rate limiting")  │ │
-│ └──────────────────────────────────────────────┘ │
-│                                                  │
-│ ✅ Task completed                                │
-└─────────────────────────────────────────────────┘
-```
-
-**Data source**: The unified conversation is read from `session_group_messages` — every SDK message from Craft and Lead sessions is written here in real-time by the Room Runtime (via DaemonHub `sdk.message` subscription). Human messages and system status annotations are also stored. Content is self-contained (full JSON inline), so the timeline survives session deletion.
-
-**Rendering rules**:
-- **Craft Agent turns** (role='craft') → sub-agent block with 🔨 icon, blue color scheme. Consecutive messages from the same session form a turn. Each turn is one collapsible block.
-- **Lead Agent turns** (role='lead') → sub-agent block with 👁 icon, violet color scheme. Each complete turn is one block.
-- **Human messages** (role='human') → standard user message style (not in a sub-agent block)
-- **System status** (role='system') → small muted annotation line (centered, gray text). Shows turn transitions: "Lead reviewing — iteration 2", "Task completed", etc.
-- **Display-time filtering**: skip `user` messages (Runtime-injected routing), skip `system` init messages. All messages are saved; display decides what to show.
-- **Turn grouping**: Consecutive messages from the same `session_id` form a "turn". No `turn_id` needed in schema — turns are computed from the message sequence at display time.
-
-**Behind the scenes**:
-- Room Runtime subscribes to DaemonHub `sdk.message` events for each member session → writes every message to `session_group_messages` → broadcasts delta to UI
-- Craft Agent session: receives Lead feedback and Human messages as user messages
-- Lead Agent session: receives Craft output (all assistant messages from last turn) as user messages from Runtime
-- Human messages to Craft are real user messages in the Craft session
-- Lead's `send_to_craft()` tool calls route through Runtime → injected as user messages in Craft session
-- Runtime writes status annotations at orchestration boundaries (group spawned, turn transitions, completion)
-
----
-
-## Design: The Room Runtime
-
-### Architecture Overview
-
-```mermaid
-graph TB
-    subgraph Room["Room Runtime (deterministic scheduler)"]
-        direction TB
-        Tick[Tick Loop]
-        Rules[Scheduling Rules]
-        Router[Message Router]
-    end
-
-    subgraph Agents["Agent Sessions"]
-        RoomAgent["Room Agent<br/>(always-on, human-facing)<br/>The department head"]
-
-        subgraph Task1["Task 1: (Craft, Lead) pair"]
-            Craft1["Craft Agent"]
-            Lead1["Lead Agent"]
-        end
-
-        subgraph Task2["Task 2: (Craft, Lead) pair"]
-            Craft2["Craft Agent"]
-            Lead2["Lead Agent"]
-        end
-    end
-
-    Human["Human Operator"]
-
-    Human <-->|"chat, commands,<br/>goal/task management"| RoomAgent
-    RoomAgent -->|"creates goals/tasks<br/>via tools"| Room
-    Room -->|"spawns (Craft, Lead) pair"| Task1
-    Room -->|"spawns (Craft, Lead) pair"| Task2
-    Craft1 -->|"terminal state → Runtime collects messages"| Room
-    Room -->|"Craft output as user msg"| Lead1
-    Lead1 -->|"send_to_craft / complete_task<br/>routed through Runtime"| Room
-    Room -->|"feedback as user msg"| Craft1
-    Craft2 -->|terminal state| Room
-    Room -->|"Craft output"| Lead2
-    Lead2 -->|"tools route through Runtime"| Room
-    Human -->|"joins task conversation"| Craft1
-    Human -->|"joins task conversation"| Craft2
-```
-
-### The Actors
-
-#### 1. Room Runtime (deterministic code — no LLM)
-
-The Room Runtime is the **scheduler and router**. It's a simple loop driven by triggers (timer, events). It makes no decisions about WHAT work to do — it decides WHEN to create (Craft, Lead) pairs, routes messages between them, and executes Lead Agent tool calls.
-
-**Scheduling rules (hardcoded, not LLM-decided)**:
-- **Scheduler precedence**: Goal review takes precedence over re-planning. The tick loop evaluates goal review first, then planning. Predicates:
-  - **Goal review**: goal is `active` AND `task_count > 0` AND all tasks are terminal (`completed` or `failed`) AND at least one task is `completed`. The `task_count > 0` guard prevents brand-new goals with zero tasks from vacuously matching. Failed tasks do NOT block goal review — the goal review Craft Agent assesses whether the goal is met despite failures and either confirms completion or creates additional tasks
-  - **Planning**: goal is `active` AND has no tasks at all, OR all tasks are `failed` (none completed, no pending/in-progress/draft/escalated). Planning addresses the "fresh start" scenarios — brand-new goals or goals where every attempt failed
-- A goal needs planning when: it's active AND (has no tasks at all OR all tasks are `failed`) AND has no pending/in-progress/draft/escalated tasks AND `planning_attempts < max_planning_attempts` (default: 3)
-- A task is ready to execute when: status is `pending`. When multiple pending tasks exist, Runtime picks by: (1) `priority` descending (higher = more important, default 0), then (2) `created_at` ascending (oldest first), then (3) `id` ascending (deterministic tiebreaker for same-tick creation). For inter-goal ordering: same priority rules apply across goals
-- Planning is itself a task: "Plan goal X" → creates a (Craft, Lead) pair where Craft Agent plans
-- If all tasks for a goal have `failed` and `planning_attempts >= max_planning_attempts`, the goal enters `needs_human` status — Runtime stops auto-planning and notifies human via Room Agent
-- **`needs_human` recovery**: Human can mark a `needs_human` goal back to `active` via Room Agent's `update_goal` tool. This resets `planning_attempts` to 0, allowing Runtime to re-plan on the next tick
-
-**Counter semantics** (deterministic increment/reset rules):
-- `planning_attempts`: incremented when Runtime **spawns** a planning (Craft, Lead) pair (not on completion or failure). This counts attempts, not outcomes. Reset to 0 when human marks goal `active` via `needs_human` recovery
-- Goal review cycle count: tracked as `goal_review_attempts` on the goal (add to schema). Incremented when Runtime spawns a goal-review pair. Max 2 before `needs_human`. Reset to 0 when human marks goal `active`
-- `feedback_iteration` in session group metadata: incremented each time Lead calls `send_to_craft()`. Already tracked per-group
-
-**Routing rules**:
-- When Craft Agent reaches terminal state → collect all assistant messages from its last turn → send to Lead Agent as user message. **If a human sent messages to Craft during this iteration**, include them in the forwarding with a note: `[Human intervened: "{message}"]` so Lead understands why Craft may have changed direction
-- When Craft Agent emits `AskUserQuestion` → route question to Lead Agent first. Lead can answer via `send_to_craft()` or `escalate()` to human
-- When Lead Agent calls `send_to_craft()` → inject message into Craft Agent session as user message
-- When Lead Agent calls `complete_task()` / `fail_task()` → update task in DB → trigger next tick
-- When human sends message to Craft during Lead review → queue message until Lead's current review cycle completes. **Delivery rules per Lead terminal action**:
-  - `send_to_craft()` → deliver queued human messages to Craft after Lead's feedback
-  - `complete_task()` / `fail_task()` → surface queued messages to Room Agent as "FYI: human said X but task already completed/failed"
-  - `escalate()` → deliver to Lead along with escalation context (already specified)
-- **Human interrupt**: Human can flag a message as "interrupt" in the task chat UI. An interrupt message is **queued and delivered to Lead after its current turn completes**, transitioning the pair to `awaiting_lead` (not `awaiting_human`, because the interrupt IS the human's input — Lead must now act on it). This is a "pause and inject" — Lead retains its full session context and the interrupt is delivered as an additional user message. Lead must re-evaluate with the interrupt context before calling any terminal tool. This handles "Stop, use Preact not React" scenarios where the human wants to redirect, not cancel. **Interrupt precedence**: The Lead tool execution guard (see Lead tool contract) checks for queued interrupts before executing any Lead terminal tool. If an interrupt is queued when Lead calls `complete_task()`/`fail_task()`, the tool call is **rejected with reason** (tool result: "Tool rejected — human interrupt received. Please re-evaluate with the new context before calling a terminal tool."), then the interrupt is delivered to Lead as a follow-up user message, and Lead re-evaluates. Note: this is not pause-and-resume — the SDK has already emitted the tool call, so the implementation intercepts in the tool execution handler and returns a rejection result. This ensures interrupts take precedence over in-flight terminal actions — the human's redirect intent is respected before acceptance/rejection. Only if the task was already cancelled/completed via Room Agent's urgent controls (which bypass the queue entirely) does the interrupt fall through to FYI delivery.
-- **Urgent control actions** (`cancel_task`, `pause runtime`) bypass the message queue and execute immediately via Room Agent tools, even if Lead is mid-review
-
-**State**: `running` | `paused`. That's it.
-
-**Tick respects capacity**: Each tick checks `maxConcurrentPairs`. If at capacity, pending tasks wait — no wasted ticks.
-
-#### 2. Room Agent (persistent AgentSession — human-facing)
-
-The Room Agent is the **department head**. It's always available for human conversation. Note: "always available" means the session exists in DB and can be activated on demand — it is NOT a persistently-running LLM consuming tokens. It only costs tokens when the human actually sends a message.
-
-This is a full **AgentSession** with:
-- **Tools** for room management (see table below)
-- **Access to room context**: goals, tasks, active (Craft, Lead) pairs, room instructions
-- **Conversation persisted to DB** (like any other session)
-- **Human can chat naturally** — "what's the status?", "prioritize the auth work", "add a goal for..."
-
-**Room Agent Tools**:
-
-| Tool | Purpose |
-|---|---|
-| `create_goal(title, description)` | Create a new goal for the room |
-| `update_goal(goalId, updates)` | Update goal title/description/status |
-| `list_goals()` | List all goals with their status |
-| `create_task(goalId, title, description)` | Manually create a task for a goal |
-| `update_task(taskId, updates)` | Update task details or priority |
-| `cancel_task(taskId)` | **Full pair teardown**: (1) abort Craft session via SDK cancel, (2) abort Lead session, (3) transition pair to `failed`, (4) dead-letter all queued messages for this pair, (5) record last known state in task failure metadata (files modified, commands run — extracted from Craft's tool call history), (6) mark task `failed`, (7) surface to human: "Task X cancelled. Craft had modified: [file list]. These changes may be partial." |
-| `retry_task(taskId)` | **Full old-pair teardown + new pair creation**: (1) abort Craft session via SDK cancel, (2) abort Lead session, (3) transition old pair to `failed`, (4) dead-letter all queued messages for the old pair, (5) record last known state in task failure metadata, (6) create new (Craft, Lead) pair. New pair receives previous attempt context in system prompt: failure reason and summarized Lead feedback from prior pair. Prevents repeating the same mistakes. Same teardown guarantees as `cancel_task` for the old pair |
-| `get_task_status(taskId)` | Get task state including recent Craft/Lead messages |
-| `list_tasks(goalId?)` | List tasks, optionally filtered by goal |
-| `get_room_status()` | Overview: runtime state, active pairs, goal/task summary |
-
-The Room Agent is NOT the scheduler. It's the human interface. When the human creates a goal via conversation, the Room Agent calls its tools → data goes to DB → Room Runtime picks it up.
-
-**Context compaction**: Room Agent is a long-lived session that accumulates conversation over days/weeks. It uses the existing AgentSession compaction mechanism. Since Room Agent primarily does CRUD via tools (not deep reasoning), aggressive compaction of older conversations is safe — retain recent exchanges and a summary of older ones. **Important**: recent tool-call results (e.g., newly created goal/task IDs) must survive compaction so the human can reference them in follow-up messages.
-
-**Coordination with Runtime**: Room Agent tools that modify task state (`cancel_task`, `retry_task`, `update_task`) use **optimistic locking** — they check `task.version` before writing, and fail gracefully if Runtime has already transitioned the task. This prevents races where Room Agent cancels a task that Runtime just completed. On conflict, the tool returns the current state so Room Agent can inform the human. **Version protocol**: ALL writes to `tasks.version` and `session_groups.version` must increment the version column — both Runtime and Room Agent tools follow this protocol. Without this, optimistic locking is meaningless.
-
-#### 3. Craft Agent (on-demand AgentSession — per task)
-
-The Craft Agent works on a task. It's a standard AgentSession with tools appropriate for the activity:
-- **Coding task**: bash, edit, read, write, glob, grep (standard coding tools)
-- **Planning task**: read, glob, grep (codebase exploration) + `create_task(goalId, title, description)` for writing tasks to DB. **Tasks created by planning Craft are created with status `draft`** and tagged with `created_by_task_id` pointing to the planning task — Runtime does not schedule them until the planning task itself is `completed` (i.e., Lead has approved the plan), at which point only `draft` tasks matching that `created_by_task_id` are promoted to `pending` in a single DB transaction. If a planning task fails, Runtime cleans up its associated `draft` tasks (marks them `failed`) also in a single transaction.
-- **Research task**: read, web search, etc.
-- **Design task**: read, write (spec writing)
-
-**System prompt includes**:
-- The specific task description and acceptance criteria
-- The goal description this task belongs to (provides broader context)
-- Room-level instructions/guidelines (coding standards, conventions, tech stack)
-- **Previous task summaries** for completed tasks within the same goal (e.g., "Task 1: Added auth endpoint at src/routes/auth.ts. Task 2: Added input validation with zod schemas."). This gives Craft awareness of work already done, preventing conflicts and enabling building on prior results
-- Craft does **NOT** know about Lead Agent or the review process — it should focus on quality work and naturally reach a terminal state, not game its output for approval
-
-The Craft Agent has **no special completion-signaling tools**. It doesn't tell the system it's done — the system observes it. Activity-specific tools (like `create_task` for planning) are allowed. When the Craft Agent finishes, the SDK emits a terminal state:
-- **Result** (`type: "result"`, `subtype: "success"`) — normal turn completion → Runtime collects output, sends to Lead
-- **Error** (`type: "result"`, `subtype: "error"`) — turn failed → Runtime sends error context to Lead
-- **AskUserQuestion** (tool use detected via `canUseTool` callback) — session enters `waiting_for_input` → Runtime routes question to Lead first
-
-**Safety net**: A cron job (every 60s) queries DB for all in-progress sessions (stateless, no in-memory index — survives daemon restarts) to catch missed terminal states. Scenarios it guards against:
-- SDK event listener detached after hot module reload during development
-- Event callback threw an unhandled exception, preventing state transition
-- Race condition where session reached terminal state between observer setup and first check
-- Process recovered from an uncaught exception that disrupted the event loop
-
-Human can open this session and interact with it directly.
-
-#### 4. Lead Agent (on-demand AgentSession — per task)
-
-The Lead Agent reviews Craft Agent's work. It's a full AgentSession with tools routed through Room Runtime.
-
-**Lifecycle**: Created **once per task** and reused across all feedback iterations. This gives Lead full accumulated context of the entire review history. The Lead session lives for the duration of the task.
-
-**Tools** (all routed through Room Runtime):
-
-| Tool | Purpose |
-|---|---|
-| `send_to_craft(message)` | Send feedback/follow-up to Craft Agent |
-| `complete_task(summary)` | Accept the work, mark task done |
-| `fail_task(reason)` | Task is not achievable |
-| `escalate(reason)` | Flag for human attention (see Escalation Flow) |
-| `read_craft_messages(limit, offset?)` | Read Craft messages from previous iterations for deeper context (e.g., understanding decisions made in earlier turns). Reads Craft session directly (bypasses message queue — intentional, read-only) |
-| `run_verification(command)` | Run a verification command (e.g., `bun test`, `bun run check`) independently of Craft. Executes in the **Craft session's working directory/worktree**, not the base branch. Restricted to commands in the room's `allowed_verification_commands` list (default: `["bun test", "bun run check", "bun run typecheck"]`). Not arbitrary bash. Trust, but verify. |
-
-**System prompt includes**:
-- The goal description this task belongs to
-- The specific task description and acceptance criteria
-- Room-level instructions/guidelines (coding standards, review policy, etc.)
-- **Activity-specific review instructions** based on `task_type`:
-  - `planning`: Review task breakdown quality — are tasks well-scoped, ordered logically, covering the full goal?
-  - `coding`: Review code correctness, test coverage, style. Use `run_verification` to confirm tests/linting pass.
-  - `research`: Review findings completeness, source quality, actionability.
-  - `design`: Review architectural soundness, completeness, alignment with goals.
-  - `goal_review`: Verify all task summaries satisfy the original goal.
-- Available tools and when to use each
-- **Verification requirements**: Before calling `complete_task`, Lead must verify the work meets acceptance criteria. For coding tasks: use `run_verification` to confirm tests pass and linting is clean. Do not accept based solely on Craft's claim of completion. **If `run_verification` fails**, Lead must not attempt to debug or fix the issue — immediately call `send_to_craft()` with the verification output so Craft can address it. **If the same verification check fails 3 times consecutively**, Lead must call `escalate()` instead of continuing the feedback loop — the issue likely requires human diagnosis (flaky test, environment problem, broken fixture).
-- **AskUserQuestion answer policy**: Lead may answer Craft's questions about architectural choices, code patterns, and technical decisions based on goal/task context. Lead must **always escalate** questions about: secrets/API keys/credentials, subjective human preferences, access permissions, or anything outside the goal/task scope. When escalating a Craft question, Lead must call `escalate()` with the Craft's original question included verbatim in the reason, so the human has full context without needing to read the Craft session.
-
-**Context management**: Each message from Runtime to Lead includes a structured header:
-- **Immutable context** (in system prompt): goal, task description, room instructions
-- **Rolling context** (accumulated in session): all previous review exchanges
-- **Latest delta** (in user message): Craft's output from this iteration, in structured format:
-  ```
-  [CRAFT OUTPUT] Iteration: {n} / Task: {task_title}
-  Task description: {task_description}  ← included every time, survives compaction
-  Task type: {task_type}
-  Terminal state: {success|error|question}
-  Tool calls: ["Edit src/auth.ts (+42 lines)", "Bash: bun test (exit 0)"]
-  Human interventions: [{message}]  ← if any during this iteration
-  Draft tasks created: [{title}: {description}]  ← planning tasks only, so Lead reviews actual DB tasks not just narrative
-  ---
-  {craft_assistant_messages}
-  ```
-  Including `task_description` in every forwarded message ensures Lead can always compare "what was asked" vs "what was delivered," even after older context has been compacted. For planning tasks, including `Draft tasks created` ensures Lead reviews the actual tasks written to DB, not just Craft's narrative about what it planned.
-
-Lead session may need **context compaction** on long-running tasks. When Lead's conversation exceeds ~80% of the context window, Runtime summarizes older review exchanges before injecting the next Craft output. This uses the existing AgentSession compaction mechanism. **Compaction rules**:
-- Immutable context (goal description, task description, room instructions) is always retained verbatim
-- Only the rolling conversation history (previous review exchanges) is summarized
-- The latest Craft output delta is never summarized
-- Compaction preserves **structured feedback→resolution pairs** (e.g., "Lead requested input validation → Craft added zod schema → Lead accepted") rather than generic summaries. This prevents Lead from re-raising feedback that was already addressed.
-
-The Lead Agent is triggered when Room Runtime sends it a user message containing Craft Agent's output. It evaluates the output against the goal/task context and uses its tools to respond.
-
-**Lead tool contract**: Lead Agent must call **exactly one terminal tool** per turn: `complete_task`, `fail_task`, `escalate`, or `send_to_craft`. If Lead emits text with no tool call, or calls multiple conflicting tools, Runtime treats it as an error: it retries once with a system nudge ("You must call exactly one of: send_to_craft, complete_task, fail_task, or escalate"). If the second attempt also fails, Runtime escalates to human.
-
-**Lead tool execution guard**: Before executing ANY Lead tool call, Runtime validates: (1) group state == `awaiting_lead`, (2) task status and version match expected values, (3) no queued interrupts for this group. If validation fails (e.g., task was cancelled while Lead was generating), the tool call is rejected as stale and discarded. If a queued interrupt exists, Runtime defers the tool call, delivers the interrupt to Lead as a user message, and lets Lead re-evaluate before calling a terminal tool again. This prevents stale Lead actions from overriding urgent human controls.
-
-**Lead Agent question handling**: If Lead Agent itself triggers `AskUserQuestion`, Runtime transitions the group to `awaiting_human` and routes the question directly to the human (unlike Craft questions which route to Lead first). This is because Lead is already the review layer — there's no higher agent to route to. When the human responds, the group transitions back to `awaiting_lead` and the response is delivered to Lead. Lead's `AskUserQuestion` follows the same escalation SLA timeout as `escalate()` — if no human response within 2h, group hibernates.
-
-**Turn boundary tracking**: Session groups track `metadata.lastForwardedMessageId` — the ID of the last Craft message forwarded to Lead. When Craft reaches a terminal state, Runtime collects all assistant messages with ID > `lastForwardedMessageId`, forwards them, and updates the marker. This prevents duplicate or skipped reviews across restarts.
-
-**Loop termination guards**:
-- `max_feedback_iterations`: default 10 per task. After N `send_to_craft` cycles without `complete_task`/`fail_task`, Runtime auto-escalates to human
-- `task_timeout`: wall-clock timeout per task (default: 30 minutes), counting only **active work time** (`awaiting_craft` + `awaiting_lead` states). Clock is paused during `awaiting_human` and `hibernated` states to avoid conflicting with the escalation SLA (2h). Timeout is **soft** — if Craft is mid-tool-call when timeout fires, Runtime waits for the current turn to complete before pausing the pair and escalating. This prevents corrupted state from interrupted file edits or partial operations. **Prerequisite**: Craft's bash tool must have a per-command hard timeout (e.g., 5 minutes) to guarantee turns eventually end — otherwise a hanging command (e.g., `npm run dev` without background flag) would make the soft timeout wait forever
-- All thresholds configurable per room
-
-### Planning as a (Craft, Lead) Pair
-
-Planning is not a special actor — it's just another activity for a (Craft, Lead) pair:
-
-```mermaid
-graph TD
-    A["Goal created: 'Implement user auth'"] --> B["Runtime: no tasks for goal<br/>→ create planning task"]
-    B --> C["Spawn (Craft, Lead) pair<br/>Craft: plan the goal<br/>Lead: review the plan"]
-    C --> D["Craft Agent examines codebase,<br/>proposes task breakdown via tools"]
-    D --> E["Craft reaches terminal state →<br/>Runtime collects output → sends to Lead"]
-    E --> F["Lead reviews plan<br/>quality and completeness"]
-    F -->|"plan accepted → complete_task()"| G["Tasks saved to DB<br/>Planning task marked complete"]
-    F -->|"plan needs work → send_to_craft(feedback)"| H["Runtime routes feedback<br/>to Craft Agent"]
-    H --> D
-    G --> I["Runtime: pending tasks exist<br/>→ spawn coding (Craft, Lead) pairs"]
-```
-
-### Data Flow: A Complete Cycle
-
-```mermaid
-graph TD
-    A["Human → Room Agent:<br/>'Implement user authentication'"] --> B["Room Agent creates Goal in DB"]
-    B --> C["Runtime tick: active goal, no tasks<br/>→ create planning task"]
-    C --> D["Spawn planning (Craft, Lead) pair"]
-    D --> E["Craft Agent plans: examines code,<br/>creates 3 tasks in DB"]
-    E --> F["Runtime sends Craft output to Lead"]
-    F --> G["Lead reviews plan → complete_task()"]
-    G --> H["Runtime tick: pending task 1<br/>→ spawn coding (Craft, Lead) pair"]
-    H --> I["Craft Agent codes task 1...<br/>reaches terminal state"]
-    I --> J["Runtime sends Craft output to Lead"]
-    J --> K["Lead reviews code"]
-    K -->|"send_to_craft(feedback)"| L["Runtime routes to Craft"]
-    L --> I
-    K -->|"complete_task()"| M["Mark task 1 complete"]
-    M --> N["Runtime tick: pending task 2<br/>→ spawn (Craft, Lead) pair"]
-    N --> O["...repeat for remaining tasks"]
-    O --> P["All tasks done → goal completed"]
-```
-
-### Human Intervention
-
-Human intervention is NOT a special state. It works at multiple levels:
-
-**Level 1: Room Agent conversation (the department head)**
-- "What's the status of the auth feature?"
-- "Prioritize the testing tasks"
-- "Skip task 3, we don't need it"
-- "Add a goal to refactor the database layer"
-- "The worker seems stuck, tell it to use JWT instead of sessions"
-
-**Level 2: Direct task participation (join the group chat)**
-- Open a task view → see Craft and Lead conversation in sub-agent blocks
-- Send a message → goes to Craft Agent as user input
-- Human becomes a third participant in the (Craft, Lead) loop
-
-**Level 3: Traditional app controls**
-| Action | Effect |
-|---|---|
-| Pause/Resume runtime | Stops/starts scheduling |
-| Add/edit/delete goals | DB changes → Runtime picks up on next tick |
-| Add/edit/delete tasks | DB changes → Runtime picks up on next tick |
-| Reorder task priority | Affects which task Runtime picks next |
-
-### State Model
-
-**Room Runtime**: `running` | `paused`
-
-**Goals**: `active` | `needs_human` | `completed` | `archived` (human-initiated via Room Agent — hides goal from active views. Any goal can be archived. Active tasks are **hard cancelled** on archive — immediate abort, no soft wait, since this is an explicit human "stop everything" action. Archived goals can be restored to `active`)
-
-**Tasks**: `draft` | `pending` | `in_progress` | `escalated` | `completed` | `failed`
-
-**Session group lifecycle** (explicit state machine for deterministic recovery — stored in `session_groups.state`):
+### Task Status Lifecycle
 
 ```mermaid
 stateDiagram-v2
-    [*] --> awaiting_craft : pair created, Craft starts working
-    awaiting_craft --> awaiting_lead : Craft reaches terminal state
-    awaiting_lead --> awaiting_craft : Lead calls send_to_craft()
-    awaiting_lead --> awaiting_human : Lead calls escalate()
-    awaiting_lead --> awaiting_human : Lead triggers AskUserQuestion
-    awaiting_lead --> awaiting_lead : Human interrupt delivered to Lead
-    awaiting_human --> awaiting_lead : Human responds to Lead
-    awaiting_human --> hibernated : Escalation SLA timeout (2h)
-    hibernated --> awaiting_lead : Human responds, pair reactivated
-    awaiting_lead --> completed : Lead calls complete_task()
-    awaiting_lead --> failed : Lead calls fail_task()
-    awaiting_craft --> awaiting_lead : Craft errors (sent to Lead)
+    [*] --> draft
+    [*] --> pending
+
+    draft --> pending: plan promoted
+
+    pending --> in_progress: runtime spawn
+    pending --> cancelled: human cancel
+
+    in_progress --> review: leader submit_for_review
+    in_progress --> completed: leader complete_task or human setStatus
+    in_progress --> failed: leader fail_task or human setStatus
+    in_progress --> cancelled: human cancel/setStatus
+
+    review --> in_progress: task.reject or resume from human feedback
+    review --> completed: task.approve flow finishes
+    review --> failed: human setStatus
+
+    failed --> pending: restart
+    failed --> in_progress: restart
+
+    cancelled --> pending: restart
+    cancelled --> in_progress: restart
 ```
 
-| Group state | Meaning | Who acts next |
-|---|---|---|
-| `awaiting_craft` | Craft Agent is working or about to receive feedback | Craft |
-| `awaiting_lead` | Craft output collected, waiting for Lead review | Lead |
-| `awaiting_human` | Escalated or Lead asked question, group paused until human responds | Human |
-| `hibernated` | Escalation SLA expired, group preserved but not observed | Human (eventually) |
-| `completed` | Lead accepted, task done | — |
-| `failed` | Lead rejected or unrecoverable error | — |
+### Session Group Semantics
 
-No `planning`, `executing`, `reviewing`, `waiting`, `error` states for the room itself.
+Session groups are stored in `session_groups`, but orchestration no longer depends on a strict runtime state machine.
 
-### When Does the Runtime Tick?
+- `completedAt !== null` means terminal group.
+- `submittedForReview === true` means parked for human review (task is in `review`).
+- `approved === true` means human approval has been recorded (used by planning/coder completion gates).
+- DB `state` column is legacy and not authoritative for routing.
 
-Event-driven with a timer fallback:
+## Orchestration Loop
 
-1. **Timer**: Every 30 seconds (safety net for missed events)
-2. **Goal created/updated**: Immediate tick
-3. **Craft Agent session reaches terminal state**: Immediate tick
-4. **Lead Agent tool call executed**: Immediate tick (after `complete_task`, `fail_task`)
-5. **Task status changed**: Immediate tick
+### Tick Scheduling
 
-Each tick runs the same deterministic logic. No special handling per trigger type.
+Runtime runs a periodic/scheduled tick with a mutex:
 
-**Tick idempotency**: Runtime uses a single-flight mutex — only one tick executes at a time. If multiple events fire concurrently (timer + session terminal state), the first acquires the lock, subsequent triggers queue a single re-tick after the current one completes. This prevents double-spawning pairs, double-delivering feedback, or duplicate `complete_task` processing. Note: for parallel mode (`maxConcurrentPairs > 1`), this single-threaded tick architecture may need to evolve into a per-pair event loop.
+1. Recover zombie groups (missing in-memory sessions).
+2. Compute active capacity using groups where `completedAt === null` and `submittedForReview === false`.
+3. Planning has priority over execution.
+4. Spawn execution groups for ready pending tasks up to capacity.
 
-### Error Handling
+### Planning Priority
 
-- **Craft Agent session errors**: Runtime sends error context to Lead Agent as a structured user message:
-  ```
-  [CRAFT ERROR] Task: {task_title}
-  Error type: {sdk_error_subtype}
-  Last tool call: {tool_name}({args_summary})
-  Error message: {error_message}
-  Craft's last assistant message before error: {last_message_excerpt}
-  ```
-  Lead decides: `send_to_craft` (retry with guidance), `fail_task`, or `escalate`.
-- **Lead Agent session fails**: Recovery protocol: (1) Re-send the pending Craft output to the same Lead session on next tick. (2) If Lead fails 3 times consecutively, kill the Lead session and create a new one with a summary of prior review exchanges injected into the system prompt. When replacing a Lead session, retarget any `pending` messages in `task_messages` from the old Lead session ID to the new one (prevents queued interrupts from being dead-lettered due to session ID mismatch). (3) If the replacement Lead also fails, escalate to human.
-- **Too many consecutive errors**: Runtime pauses itself, notifies human via Room Agent.
+A goal is selected for planning when active and either:
 
-All errors are recoverable by re-running the tick. No stuck states.
+- no tasks exist, or
+- no active tasks remain and execution tasks are terminal (`failed`/`cancelled`).
 
-### Escalation Flow
+Planning attempts are bounded by `maxPlanningRetries` (room config). Exceeding attempts moves goal to `needs_human`.
 
-When Lead Agent calls `escalate(reason)`:
+## Worker <-> Leader Loop
 
 ```mermaid
 sequenceDiagram
-    participant L as Lead Agent
-    participant RT as Room Runtime
-    participant RA as Room Agent
-    participant H as Human
+    participant W as Worker
+    participant RT as RoomRuntime
+    participant L as Leader
 
-    L->>L: Calls escalate(reason)
-    Note over L,RT: Tool routes through Runtime
-    RT->>RT: Set task status to "escalated"
-    RT->>RT: Pause the (Craft, Lead) pair
-    RT->>RA: Notify Room Agent with reason
-    RA->>H: Surface notification (Room Agent message + UI badge/banner)
-    H->>L: Human responds to Lead with guidance
-    Note over RT: Lead reviews guidance
-    L->>L: Calls send_to_craft(revised_instruction)
-    RT->>RT: Resume pair, set task back to "in_progress"
-    RT-->>L: Route continues normally
+    W->>RT: terminal state
+    RT->>RT: cleanliness + lifecycle gates
+    RT->>L: envelope (worker output)
+    L->>RT: send_to_worker | submit_for_review | complete_task | fail_task | replan_goal
+    RT->>W: feedback (send_to_worker path)
 ```
 
-**Task state during escalation**: `escalated` (a sub-state of `in_progress`). The pair is paused — Lead waits for human input, Craft is idle. Human responds **directly to Lead** (since Lead has the review context), and Lead translates guidance into actionable feedback for Craft.
+### Worker Terminal Handling
 
-**Notification delivery** (applies to all Runtime→human notifications, not just escalation):
-- **Session injection**: Runtime injects a **notification message** (dedicated type — not user, assistant, or system) into Room Agent's conversation. Renders distinctly in UI (e.g., info banner style). Included in Room Agent's context as read-only information — Room Agent does NOT attempt to respond to it, avoiding unprompted token consumption
-- **UI push**: Runtime publishes an event via MessageHub — frontend shows a notification badge/toast immediately, regardless of whether Room Agent is active
-- Both mechanisms fire for: escalations, task failures, goal completion, `needs_human` transitions, session-lost errors
-- Push notifications (browser/OS) are out of scope for MVP
+On worker terminal state:
 
-**Queued messages on escalation**: When Lead calls `escalate()`, any human messages that were queued during Lead's review are **delivered to Lead** along with the escalation context. This way the human's earlier input isn't lost — Lead sees both the escalation reason and any human messages that arrived during review.
+1. enforce worktree cleanliness
+2. run worker exit gate
+3. build envelope + forward to leader
+4. increment review iteration
+5. update task progress (bounded review-progress model)
 
-**Escalation SLA**: If an escalated task receives no human response within a configurable timeout (default: 2 hours), Runtime transitions the pair to `hibernated` state — sessions are preserved in DB but not actively observed. This prevents blocking the task queue indefinitely. When the human eventually responds, the human message is stored in the message queue, triggering a tick. The tick loop checks for pending messages on hibernated pairs — if found, it reactivates the pair (transitions to `awaiting_lead`), delivers the message to Lead, and resumes normal flow. If the room has other pending tasks, Runtime can proceed with those while the escalated task hibernates.
+### Leader Tool Behavior
 
-### Goal Completion
+- `send_to_worker`
+  - forwards feedback to worker
+  - if `feedbackIteration >= maxReviewRounds`, runtime escalates to human review (`task.review`, `submittedForReview=true`)
+- `handoff_to_worker`
+  - compatibility no-op
+- `submit_for_review(pr_url)`
+  - sets `submittedForReview=true`
+  - transitions task to `review`
+  - keeps group alive but parked
+- `complete_task(summary)`
+  - allowed only after review submission or explicit human approval (`approved=true`) for planner/coder/general
+  - runs leader complete gate
+  - completes task + group cleanup
+- `fail_task(reason)`
+  - fails task + group cleanup
+- `replan_goal(reason)`
+  - fails current task, cancels pending siblings, spawns a replan planning task/group
 
-When all tasks for a goal are terminal (`completed` or `failed`) and at least one is `completed`, Runtime triggers a **goal review** (Craft, Lead) pair:
+## Human Collaboration APIs
 
-1. Runtime detects: all tasks for goal X are terminal (no pending/in_progress/draft/escalated) AND at least one task is `completed` AND `task_count > 0`
-2. Runtime creates a special task: "Review goal: X"
-3. Spawns a (Craft, Lead) pair where Craft Agent receives via system prompt:
-   - The original goal description
-   - All completed task summaries (from `complete_task(summary)` calls)
-   - All failed task summaries (reason, what was attempted) — so the reviewer can assess whether failures matter
-   - The Craft Agent then verifies the goal is satisfied (may use `read`, `glob`, `grep` tools to inspect actual results)
-   - Either confirms completion or creates additional tasks via `create_task` tool
-4. Lead Agent reviews the assessment
-5. If confirmed → Runtime marks goal as `completed`
-6. If gaps found → new tasks created → Runtime picks them up on next tick
+| API | Intent | Current Behavior |
+|---|---|---|
+| `task.approve` | Approve task in `review` | Validates task/runtime, calls `resumeWorkerFromHuman(..., { approved: true })` |
+| `task.reject` | Reject task in `review` with feedback | Calls `resumeWorkerFromHuman(..., { approved: false })` |
+| `task.sendHumanMessage` | Direct human message | Routes directly to `worker` (default) or `leader`; no group-state gate |
 
-**Goal review cycle cap**: Maximum 2 goal review cycles per goal. If the second review still finds gaps, Runtime marks the goal as `needs_human` and notifies via Room Agent rather than creating endless review loops.
+### Review Resume Flow
 
-### Daemon Restart / Recovery
-
-Runtime state is **reconstructed from DB on startup**. No in-memory-only state.
-
-**Recovery procedure**:
-1. On daemon start, Runtime queries DB for all non-terminal tasks (`in_progress`, `escalated`) with active session groups (group state NOT IN `completed`, `failed`)
-2. For each session group, check group state and session status:
-   - **Group `awaiting_craft`**: Check Craft session — re-observe if idle, attach observer if processing, re-route if waiting_for_input. Re-subscribe to DaemonHub `sdk.message` for message mirroring
-   - **Group `awaiting_lead`**: Check Lead session — re-observe if idle, attach observer if processing. Re-subscribe to DaemonHub `sdk.message` for message mirroring
-   - **Group `awaiting_human`**: No action needed — group is waiting for human input, just register for human message events
-   - **Group `hibernated`**: No action needed — group is preserved but not actively observed, just register for human reactivation
-   - **Session gone** (process crashed): Mark task as `failed` with reason `session_lost`
-3. **Active work time recovery**: For groups in `awaiting_craft`/`awaiting_lead`, `metadata.activeWorkStartedAt` was set before the crash but the elapsed time was never accumulated into `metadata.activeWorkElapsed` (no state transition occurred). Computing `now - activeWorkStartedAt` would count crash downtime as work time. **MVP approach**: reset `activeWorkStartedAt = now()` on recovery — crash time is not counted as active work. If precision matters later, Recovery can estimate crash duration from the daemon's last audit log entry
-4. **Message mirroring catch-up**: For each recovered group, compare last message timestamp in `session_group_messages` vs member sessions' `sdk_messages` → mirror any gap to ensure the conversation timeline is complete
-5. Runtime resumes `running` state and continues normal tick loop
-
-**Message queue recovery**: On restart, Runtime scans `task_messages` for entries with `status = 'pending'` and reprocesses them in `created_at` order. Since messages are scoped to `group_id` + `to_session_id`, only messages for still-active groups are delivered. Messages targeting sessions that no longer exist are marked `dead_letter`.
-
-**Delivery idempotency**: For Craft→Lead forwarding, `last_forwarded_message_id` serves as an idempotency guard — if a message ID is already ≤ the marker, it's skipped. For Lead→Craft messages via the queue, Runtime checks `task_messages.status` before injecting: only `pending` messages are delivered. After successful injection into the AgentSession, Runtime updates the message status to `delivered` with a `delivered_at` timestamp. On crash recovery, the restart scan re-processes `pending` messages — any that were actually delivered but not marked (crash window) result in a duplicate message to the agent. Sending to an AgentSession is an external side effect that cannot be atomically committed with SQLite, so true exactly-once delivery is not achievable; the design accepts at-most-once-duplicate as the failure mode. A `processing` intermediate state is deferred to parallel mode.
-
-**Planning duplicate risk**: For most task types, duplicate message delivery is benign (agent sees the same instruction twice). For **planning tasks**, duplicates could cause the Craft Agent to create duplicate draft tasks via `create_task`. Mitigations: (1) Runtime includes the `task_messages.id` as a header in each injected message — if the session already contains a message with that ID, the agent can recognize it as a duplicate. (2) Lead Agent reviews all draft tasks before promotion and would catch obvious duplicates. (3) Draft promotion is scoped to `created_by_task_id`, so duplicates are contained within one planning task's scope. These are soft guards — for stronger guarantees, the `processing` intermediate state (deferred to parallel mode) would close this window.
-
-**Non-idempotent task recovery**: When a Craft session is lost after it has already made changes (edited files, ran commands), blind retry is dangerous — it could duplicate side effects. For lost sessions, Runtime marks the task `failed` and **does not auto-retry**. The human must acknowledge and decide: retry (if workspace state is safe) or manually intervene. Room Agent surfaces these failures prominently.
-
-**Key invariant**: All state that matters (goals, tasks, session groups, session IDs) lives in the DB. Runtime is stateless and reconstructable.
-
-### Message Queue (Prerequisite)
-
-The message routing between agents requires a **DB-backed queue system** to ensure reliability:
-
-- Messages between Craft and Lead must survive daemon restarts
-- Human messages sent during Lead review must be queued and delivered in order
-- Messages are scoped to a specific `group_id` + `to_session_id` to prevent misdelivery on task retry
-- Urgent control actions (cancel, pause) bypass the queue entirely
-
-This is a **prerequisite component** that should be designed and implemented before the Craft→Lead loop.
-
-### Capacity Management
-
-- `maxConcurrentPairs`: configurable per room (default: 1 for MVP)
-- Runtime only spawns (Craft, Lead) pairs when below capacity
-- **`awaiting_human` and `hibernated` groups do NOT count** toward the concurrency limit — they're idle and blocking them would stall the queue for up to 2h. Only `awaiting_craft` and `awaiting_lead` groups count as active
-- Each tick checks capacity before spawning — pending tasks wait without wasted ticks
-- Tasks execute sequentially (MVP)
-
-### Database Schema
-
-```sql
--- Rooms: add config column (existing table)
--- Stores all room-level configuration as JSON
-ALTER TABLE rooms ADD COLUMN config TEXT;
-    -- JSON: { allowed_verification_commands: ["bun test", "bun run check", "bun run typecheck"],
-    --         max_feedback_iterations: 10, task_timeout: 1800000, max_planning_attempts: 3,
-    --         maxConcurrentPairs: 1, escalation_sla: 7200000 }
-
--- Tasks: add new columns (existing table)
--- task_type determines Craft tool set and Lead review prompt
--- depends_on is nullable, ignored in sequential MVP, required for parallel mode
--- version for optimistic locking (Room Agent tools check before writing)
-ALTER TABLE tasks ADD COLUMN task_type TEXT NOT NULL DEFAULT 'coding';
-    -- 'planning' | 'coding' | 'research' | 'design' | 'goal_review'
-ALTER TABLE tasks ADD COLUMN depends_on TEXT;
-    -- JSON array of task IDs, nullable
-ALTER TABLE tasks ADD COLUMN created_by_task_id TEXT;
-    -- References the planning task that created this task (for draft scoping)
-ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;
-    -- Higher = more important. Runtime picks highest priority first, then oldest
-ALTER TABLE tasks ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
-    -- Optimistic locking for Room Agent tools
-
--- Goals: add planning_attempts counter (existing table, new column)
-ALTER TABLE goals ADD COLUMN planning_attempts INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE goals ADD COLUMN goal_review_attempts INTEGER NOT NULL DEFAULT 0;
-
--- Session groups: generic multi-agent collaboration groups (replaces task_pairs)
--- A session group unifies multiple agent sessions into one conversation timeline.
--- For task pairs, group_type='task_pair' and ref_id=task_id.
--- The pattern is generic — adding a 3rd/4th agent = insert a member row.
-CREATE TABLE session_groups (
-    id TEXT PRIMARY KEY,
-    group_type TEXT NOT NULL,          -- 'task_pair', 'goal_review', 'planning', etc.
-    ref_id TEXT,                       -- owning entity (task_id, goal_id, etc.)
-    state TEXT NOT NULL DEFAULT 'active',
-        -- For task pairs: awaiting_craft | awaiting_lead | awaiting_human | hibernated | completed | failed
-    version INTEGER NOT NULL DEFAULT 0,  -- optimistic locking (both Runtime and Room Agent tools increment on write)
-    metadata TEXT,                     -- JSON: type-specific orchestration state
-        -- For task pairs: { feedbackIteration, leadContractViolations, lastForwardedMessageId,
-        --   activeWorkStartedAt, activeWorkElapsed, tokensUsed, hibernatedAt }
-    created_at INTEGER NOT NULL,
-    completed_at INTEGER
-);
-
-CREATE INDEX idx_session_groups_ref ON session_groups(ref_id);
-CREATE INDEX idx_session_groups_state ON session_groups(state);
-
--- Session group members: who's in the group
-CREATE TABLE session_group_members (
-    group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
-    session_id TEXT NOT NULL,
-    role TEXT NOT NULL,              -- 'craft', 'lead', 'tester', etc.
-    joined_at INTEGER NOT NULL,
-    PRIMARY KEY (group_id, session_id)
-);
-
-CREATE INDEX idx_sgm_session ON session_group_members(session_id);
-
--- Session group messages: the unified conversation timeline
--- Every SDK message from member sessions is written here in real-time.
--- Human messages and system status annotations are also stored.
--- Content is self-contained (full JSON inline, no FK to sdk_messages).
-CREATE TABLE session_group_messages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
-    session_id TEXT,                 -- NULL for human/system entries
-    role TEXT NOT NULL,              -- denormalized: 'craft', 'lead', 'human', 'system'
-    message_type TEXT NOT NULL,      -- SDK type ('assistant','result','user','system') or 'human','status'
-    content TEXT NOT NULL,           -- full SDK message JSON or plain text
-    created_at INTEGER NOT NULL
-);
-
-CREATE INDEX idx_sgmsg_group ON session_group_messages(group_id, id);
-CREATE INDEX idx_sgmsg_session ON session_group_messages(session_id);
-
--- Message queue: reliable inter-agent message delivery
-CREATE TABLE task_messages (
-    id TEXT PRIMARY KEY,
-    task_id TEXT NOT NULL REFERENCES tasks(id),
-    group_id TEXT NOT NULL REFERENCES session_groups(id),
-    from_role TEXT NOT NULL,       -- 'craft' | 'lead' | 'human'
-    to_role TEXT NOT NULL,         -- 'craft' | 'lead'
-    to_session_id TEXT NOT NULL,   -- target session (prevents misdelivery on retry)
-    message_type TEXT NOT NULL DEFAULT 'normal',  -- 'normal' | 'interrupt' | 'escalation_context'
-        -- Enables efficient queue scanning without JSON parsing:
-        -- 'interrupt' messages checked by Lead tool execution guard before terminal tools
-        -- 'escalation_context' bundled with escalation delivery to Lead
-    payload TEXT NOT NULL,         -- JSON message content
-    status TEXT NOT NULL DEFAULT 'pending',  -- pending | delivered | dead_letter
-    created_at INTEGER NOT NULL,
-    delivered_at INTEGER
-);
-
--- Task messages retention: messages are retained for the lifetime of the group.
--- When a group reaches terminal state (completed/failed), delivered and dead_letter
--- messages can be purged. Pending messages on terminal groups are dead-lettered first.
--- This is separate from audit log retention (7 days) — task messages have no
--- time-based TTL. Long-lived hibernated groups retain their pending messages
--- indefinitely until reactivation or manual cleanup.
-
--- Audit log: observability for debugging Runtime behavior
--- Retention: cleanup job deletes entries older than 7 days (audit log only, not task_messages)
-CREATE TABLE room_audit_log (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    room_id TEXT NOT NULL,
-    event_type TEXT NOT NULL,  -- 'tick' | 'group_state_change' | 'message_delivery' | 'notification'
-    detail TEXT NOT NULL,      -- JSON: what happened, trigger, outcome
-    created_at INTEGER NOT NULL
-);
+```mermaid
+flowchart TD
+    A["Task in review / submittedForReview=true"] --> B{"Human action"}
+    B -->|"task.approve"| C["resumeWorkerFromHuman approved=true"]
+    B -->|"task.reject"| D["resumeWorkerFromHuman approved=false"]
+    C --> E["task status set in_progress"]
+    D --> E
+    E --> F["resumeLeaderFromHuman"]
+    F --> G["leader merges/forwards + continues loop"]
 ```
 
-`tokens_used` is tracked in `session_groups.metadata` for cost tracking from day one (accumulated input + output tokens across all member sessions, updated after each agent turn).
+Important detail:
 
----
+- approvals and rejections are both routed to leader on resume.
+- resume path rolls back task status/approval flag if resume fails.
 
-## What We Reuse
+## Manual Status Control and Cleanup
 
-- **AgentSession infrastructure** — for ALL agents (Room Agent, Craft, Lead)
-- **Session persistence** — all conversations stored in DB automatically
-- **Sub-agent block UI components** — already exist, used for Task Chat View
-- **Database schema** — rooms, goals, tasks tables
-- **DaemonHub events** — for session state change observations
-- **MessageHub** — for UI communication
+Runtime-backed terminal transitions are mandatory when runtime exists.
 
-## What We Replace
+```mermaid
+flowchart LR
+    A["task.cancel"] --> B["runtime.cancelTask"]
+    C["task.setStatus(cancelled)"] --> B
+    D["task.setStatus(completed|failed)"] --> E["runtime.terminateTaskGroup"]
+    E --> F["persist requested terminal status"]
+```
 
-- **RoomSelfService** → new `RoomRuntime` (deterministic scheduler + router)
-- **Room agent tools MCP** → new Room Agent tools (goal/task CRUD, room state queries)
-- **RoomSelfLifecycleManager** → not needed (only 2 states)
-- **Worker tools (worker_complete_task etc.)** → Lead Agent tools instead
-- **WorkerManager** → replaced by session group manager
+Behavior:
 
-## New Components
+- `runtime.cancelTask(taskId)`
+  - cascade-cancels task + pending dependents
+  - terminates group sessions/mirroring
+- `runtime.terminateTaskGroup(taskId)`
+  - terminates group sessions/mirroring
+  - does not force task status to `cancelled`
 
-1. **RoomRuntime** — deterministic scheduler loop + message router
-2. **Room Agent tools** — MCP tools for goal/task CRUD, room state queries, task cancel/retry
-3. **Lead Agent tools** — MCP tools: `send_to_craft`, `complete_task`, `fail_task`, `escalate`, `read_craft_messages`
-4. **Session group manager** — creates and tracks session groups (Craft, Lead, etc.) for tasks. Generic pattern: `session_groups` + `session_group_members` replaces task-specific pair tracking
-5. **Session observer** — detects terminal states (Result/Error/AskQuestion) + cron safety net
-6. **DB-backed message queue** — reliable inter-agent message delivery with human message queueing
-7. **Session group messages** — unified conversation timeline. Every SDK message from member sessions is written in real-time via DaemonHub subscription. Self-contained content (full JSON inline). Display layer filters at read time
-8. **Task Chat View UI** — unified chat rendering with sub-agent blocks for (Craft, Lead, Human), reading from session group messages
+## Recovery Model
 
-## Design Decisions (Resolved)
+On startup and during ticks:
 
-*Grouped by category for navigability. Original decision numbers preserved for cross-references.*
+- runtime restores missing worker/leader sessions where possible
+- reattaches observers
+- fails groups whose worker session cannot be restored
+- skips continuation injection for parked review groups (`submittedForReview=true`)
 
-### Core Architecture & Agents
-4. **All agents are AgentSessions**: Room Agent, Craft, Lead all reuse existing session infrastructure. All conversations persisted.
-5. **Craft Agents have no completion-signaling tools**: They just work and reach terminal state. Activity-specific tools (e.g., `create_task` for planning) are allowed.
-11. **Naming**: Craft Agent (does the work) + Lead Agent (reviews and directs).
-18. **Model selection**: Use room default model for both Craft and Lead (configurable later).
-20. **Explicit group state machine**: Session groups have 6 states (`awaiting_craft`, `awaiting_lead`, `awaiting_human`, `hibernated`, `completed`, `failed`) for deterministic recovery.
-34. **Room Agent is on-demand**: "Always available" means session exists in DB, not persistently-running LLM. Only costs tokens when human chats.
-36. **Task type determines agent behavior**: `task_type` field on tasks determines Craft's tool set and Lead's activity-specific review prompt.
-58. **Craft Agent system prompt defined**: Includes task description, goal context, room instructions, and previous task summaries. Does NOT include Lead awareness — Craft focuses on quality, not gaming approval.
-59. **Cross-task context in Craft prompt**: Previous completed task summaries included in Craft's system prompt for tasks within same goal. Promoted from open question to MVP decision.
+Recovery is proactive and idempotent; runtime remains reconstructable from DB + session store.
 
-### Scheduling & Task Selection
-1. **Task execution**: Sequential only. One (Craft, Lead) pair at a time (MVP).
-19. **Tick idempotency**: Single-flight mutex prevents concurrent ticks from double-spawning or double-delivering.
-51. **`awaiting_human`/`hibernated` don't count toward concurrency**: Idle groups free the concurrency slot immediately, preventing 2h queue blocking on escalation.
-60. **Task selection ordering**: By `priority` descending (higher = more important), then `created_at` ascending (oldest first). Applies across goals.
-77. **Task selection deterministic tiebreaker**: priority DESC → created_at ASC → id ASC. Handles same-tick creation.
-81. **Counter increment on spawn**: `planning_attempts` and `goal_review_attempts` increment when group is spawned (counts attempts, not outcomes). `feedbackIteration` in group metadata increments on each `send_to_craft`.
-83. **Scheduler precedence: goal review before re-planning**: Tick evaluates goal review first. Goal review: `task_count > 0` AND all tasks terminal AND at least one `completed`. Planning: goal has zero tasks OR all tasks `failed`. No overlap possible.
+## Concurrency Rules
 
-### Craft→Lead Loop & Message Routing
-2. **Review policy**: Every Craft Agent terminal state triggers Lead Agent review via Runtime.
-7. **Runtime collects all messages from Craft's last turn**: When Craft reaches terminal state, Runtime collects all assistant messages since the last user message and sends to Lead.
-8. **Lead session created once, reused**: Lead Agent is created when the task starts and reused across all feedback iterations, maintaining full review context.
-12. **AskUserQuestion routes to Lead first**: When Craft asks a question, Runtime sends it to Lead. Lead can answer or escalate to human.
-13. **Human messages queued during Lead review**: Prevents race conditions. Messages delivered after Lead's current review cycle.
-22. **Turn boundary tracking**: `metadata.lastForwardedMessageId` on session groups prevents duplicate/skipped reviews.
-37. **Human interventions forwarded to Lead**: When human sends messages to Craft during an iteration, those messages are included in the Craft→Lead forwarding so Lead understands context changes.
-39. **Structured Craft→Lead message format**: Runtime sends structured envelope with iteration number, task description, tool call summary, terminal state, and human interventions.
-40. **Structured compaction**: Lead compaction preserves feedback→resolution pairs, not generic summaries.
-64. **Draft tasks in planning review**: Structured Craft→Lead message includes `Draft tasks created` list so Lead reviews actual DB tasks, not just narrative.
+Capacity uses `maxConcurrentGroups` with one critical exclusion:
 
-### Lead Agent Contract & Tools
-6. **Lead Agent tools route through Runtime**: `send_to_craft`, `complete_task`, etc. all go through Runtime for consistent routing, tracking, and guard rails.
-21. **Lead tool contract**: Exactly one terminal tool per turn. Invalid responses get one retry with system nudge, then escalate.
-30. **Lead verification tool**: Lead can independently run verification commands (`run_verification`) to confirm tests/linting pass before accepting.
-31. **Lead answer policy**: Lead may answer Craft's architectural/technical questions but must escalate secrets, credentials, permissions, and subjective preferences.
-49. **`run_verification` restricted to allowlist**: Commands scoped to room's `allowed_verification_commands` config (default: test/lint). Not arbitrary bash.
-69. **Verification consecutive failure escalation**: If same verification check fails 3 times consecutively, Lead must escalate instead of continuing feedback loop.
-78. **Lead tool execution guard**: Before executing any Lead tool, Runtime validates group state, task version, and checks for queued interrupts. Stale calls rejected, interrupts take precedence over terminal actions.
-87. **Interrupt tool rejection semantics**: "Deferred" means tool call is rejected with a reason result ("human interrupt received, re-evaluate"), then the interrupt is delivered as a follow-up user message. This is standard SDK tool rejection, not pause-and-resume.
+- parked review groups (`submittedForReview=true`) do **not** consume active slots.
 
-### Planning & Goal Lifecycle
-3. **Planning is a task**: Not a special actor. Planning creates a (Craft, Lead) pair like any other task.
-14. **Goal completion triggers review**: When all tasks done, Runtime spawns a goal-review (Craft, Lead) pair to verify the goal is truly met.
-26. **Goal review cap**: Max 2 goal review cycles, then `needs_human`.
-27. **Planning attempt cap**: Max 3 planning attempts per goal before `needs_human`.
-35. **Planning tasks created as `draft`**: Tasks created by planning Craft are `draft` until Lead approves the plan, then promoted to `pending`. Prevents unapproved tasks from executing.
-41. **Planning trigger includes all non-terminal states**: Re-planning only triggers when goal has no `pending`/`in_progress`/`draft`/`escalated` tasks. Prevents duplicate planning when tasks are escalated or drafts linger.
-42. **Draft tasks scoped to planning task**: `created_by_task_id` links drafts to the planning task that created them. Only matching drafts are promoted on approval. Failed planning cleans up its drafts.
-52. **Goal `needs_human` recovery**: Human marks goal `active` via Room Agent → resets `planning_attempts` to 0 → Runtime re-plans on next tick.
-53. **Draft promotion is atomic**: Single DB transaction for promoting drafts on approval or cleaning up drafts on failure.
-62. **Goal `archived` state**: Human-initiated, hides from active views. Active tasks cancelled on archive. Can be restored to `active`.
-76. **Goal archive is hard cancel**: Immediate abort of active tasks — no soft wait. Human-intentional action.
+This allows the room to continue autonomous execution while waiting for human review.
 
-### Human Intervention & Interrupts
-9. **Human interface**: Room Agent is always-on department head. Humans can also join any task's group chat.
-10. **Task Chat View**: (Craft, Lead) session group rendered as unified conversation with sub-agent blocks per turn, reading from `session_group_messages`.
-28. **Urgent controls bypass queue**: `cancel_task`, `pause runtime` execute immediately, not queued.
-29. **Lead questions route to human**: Lead Agent's `AskUserQuestion` goes directly to human (no higher review layer).
-32. **Human interrupt**: Human can interrupt Lead mid-review for redirect messages (not just cancel). Delivered after Lead's turn completes, pair stays in `awaiting_lead`. Interrupt takes precedence over in-flight terminal tools via the Lead tool execution guard.
-45. **Human interrupt goes to `awaiting_lead`**: Interrupt is delivered to Lead after its current turn, keeping pair in `awaiting_lead` (not `awaiting_human`) because the interrupt IS the human's input.
-46. **Lead `AskUserQuestion` transitions to `awaiting_human`**: Lead's questions route to human, pair pauses. Human responds → pair returns to `awaiting_lead`. Same SLA timeout as escalation.
-54. **Human interrupt is "pause and inject"**: Lead retains full session context. Interrupt delivered as additional user message after Lead's current turn.
-61. **`cancel_task` cleanup**: Abort Craft session, record modified files in failure metadata, surface partial changes to human.
-67. **Interrupt race with completion**: If Lead completes/fails task before interrupt is delivered, interrupt is surfaced to Room Agent as FYI. Room Agent can `retry_task` if rework is warranted.
-79. **`cancel_task` is full pair teardown**: Aborts both Craft and Lead sessions, transitions pair to `failed`, dead-letters queued messages, records partial changes.
-84. **`retry_task` full old-pair teardown**: Same teardown as `cancel_task` (abort both sessions, fail pair, dead-letter messages, record state) before creating new pair. No orphaned sessions or stale messages.
+## Legacy Compatibility Notes
 
-### Recovery & Resilience
-15. **Recovery from DB**: Runtime is stateless and reconstructable. All state lives in DB. On restart, Runtime queries all non-terminal tasks (`in_progress`, `escalated`) and re-attaches.
-16. **DB-backed message queue**: Prerequisite for reliable inter-agent message delivery.
-17. **Session idle detection**: SDK terminal states (Result/Error/AskQuestion) + cron job safety net every 60s.
-24. **Non-idempotent recovery**: Lost sessions mark task `failed` without auto-retry. Human must acknowledge.
-38. **Lead failure recovery**: Re-send pending output to same Lead. After 3 consecutive failures, replace Lead session with summary. After replacement also fails, escalate.
-43. **Recovery includes all non-terminal tasks**: Startup queries `in_progress` AND `escalated` tasks, handles all pair states including `awaiting_human` and `hibernated`.
-47. **Delivery idempotency via markers**: Craft→Lead uses `last_forwarded_message_id` as guard. Lead→Craft uses `task_messages.status` — only `pending` messages injected, then marked `delivered`. AgentSession injection is an external side effect (not atomically committed with SQLite), so crash-window duplicates are accepted as benign. `processing` queue state deferred to parallel mode.
-48. **Hibernation reactivation via message queue**: Human messages to hibernated pairs are stored in queue, tick detects pending messages and reactivates the pair.
-56. **Cron safety net is stateless**: Queries DB directly, no in-memory index. Survives daemon restarts.
-68. **`retry_task` injects previous attempt context**: New Craft and Lead receive failure reason and summarized prior feedback in system prompt. Prevents repeating mistakes.
-80. **Receiver-side delivery dedupe**: Each message has idempotency key (`task_messages.id`). Runtime checks before injecting into AgentSession. Handles crash window between send and mark-delivered.
-85. **Idempotency uses existing `task_messages.status`**: No separate `delivered_message_ids` tracking needed. Runtime checks `status == 'pending'` before injection, marks `delivered` after. Crash-window duplicates accepted as benign.
-88. **Active work time recovery on restart**: Reset `active_work_started_at = now()` on recovery — crash downtime not counted as active work. Avoids false timeout triggers.
+- Existing DB columns/strings like `state='awaiting_worker'` are retained for compatibility but are not the primary orchestration signal.
+- Tool names like `handoff_to_worker` remain for compatibility, even where behavior is now a no-op.
+- Historical design/plan docs may contain legacy state/status terms and are not authoritative for current behavior.
 
-### Timeouts & Loop Termination
-23. **Loop termination**: `max_feedback_iterations` (10), wall-clock timeout (30min). All configurable.
-33. **Escalation SLA**: Unresponded escalations hibernate after 2h (configurable). Pair preserved, not observed. Unblocks task queue.
-44. **Task timeout pauses during human waits**: `task_timeout` only counts active work time (`awaiting_craft` + `awaiting_lead`). Clock pauses during `awaiting_human`/`hibernated` to avoid conflicting with escalation SLA.
-50. **Soft task timeout**: Waits for current tool call to complete before pausing. Prevents corrupted state from interrupted operations.
-72. **Soft timeout requires per-command hard timeout**: Craft's bash tool must enforce a per-command timeout (e.g., 5 min) so hanging commands can't bypass the soft task timeout indefinitely.
+## Implementation Anchors
 
-### Room Agent & Notifications
-57. **Notification delivery: session injection + UI push**: All Runtime→human notifications use both: (1) inject into Room Agent conversation for persistence, (2) publish via MessageHub for immediate UI badge/toast. Push notifications out of scope for MVP.
-70. **Notification message type**: Dedicated type (not user/assistant/system). Renders distinctly in UI. Included in Room Agent context as read-only — no unprompted response.
+Primary implementation files:
 
-### Schema, Versioning & Data
-25. **Optimistic locking**: Room Agent tools check `task.version` to prevent races with Runtime state transitions.
-55. **Group state write ownership**: Runtime is the **primary** writer of group state for normal lifecycle transitions (`awaiting_craft` → `awaiting_lead` → `completed`/`failed`). Room Agent control-plane tools (`cancel_task`, `retry_task`) are **authorized writers** for urgent operations — they use optimistic locking (version check) to prevent races with Runtime. Both Runtime and Room Agent tools increment `session_groups.version` on every write. This is not "sole writer" — it's "primary writer with authorized control-plane overrides."
-63. **`version` on tasks table**: Optimistic locking for Room Agent tools modifying task state. Separate from `session_groups.version`.
-65. **Audit log**: `room_audit_log` table for tick decisions, group state changes, message delivery. Essential for debugging.
-66. **Token tracking**: `tokens_used` in session group metadata from day one for cost visibility.
-71. **Version bumping protocol**: ALL writes to `tasks.version` and `session_groups.version` must increment version. Both Runtime and Room Agent tools follow this.
-73. **Room config stored as JSON column**: `rooms.config` JSON column holds all room-level settings (verification commands, timeouts, caps, concurrency).
-74. **Audit log retention**: 7-day TTL, cleanup job deletes older entries.
-75. **Token tracking per-turn**: `metadata.tokensUsed` updated after each Craft/Lead turn for accuracy.
-86. **Task messages retention: group-scoped, not time-based**: Messages retained for group lifetime. Purged on terminal state. No time-based TTL — long-lived hibernated groups keep their pending messages. Separate from audit log 7-day retention.
-89. **`message_type` column on task_messages**: Explicit type (`normal`/`interrupt`/`escalation_context`) for efficient queue scanning. Enables Lead tool execution guard to check for interrupts without JSON parsing.
-90. **Goal review requires `task_count > 0`**: Prevents brand-new goals with zero tasks from vacuously matching "all tasks completed." Goal review predicate: `task_count > 0 AND all tasks terminal AND at least one completed`.
-91. **Failed tasks don't block goal review**: Goal review triggers when all tasks are terminal (`completed`/`failed`) with at least one `completed`. The goal review Craft assesses whether the goal is met despite failures. Re-planning only triggers when ALL tasks are `failed` (nothing succeeded).
-92. **Planning duplicate mitigation**: Runtime includes `task_messages.id` as header in injected messages. Lead reviews drafts before promotion. Draft promotion scoped to `created_by_task_id`. Soft guards; `processing` state (deferred) would close the window fully.
-93. **Group state write ownership clarified**: Runtime is **primary** writer for normal lifecycle. Room Agent tools are **authorized writers** for control-plane (`cancel_task`, `retry_task`). Both use optimistic locking. Replaces the overly-strong "sole writer" claim.
-94. **Lead session replacement retargets queued messages**: When Lead is replaced after 3 consecutive failures, pending messages in `task_messages` are retargeted from old to new Lead session ID. Prevents queued interrupts from being dead-lettered due to session ID mismatch.
-
-### Session Groups & Conversation Timeline
-95. **Session groups replace task_pairs**: Generic `session_groups` + `session_group_members` + `session_group_messages` tables replace the task-specific `task_pairs` table. A session group unifies multiple agent sessions into one conversation timeline. Adding a 3rd/4th agent = insert a member row. The pattern works for any multi-agent collaboration (task pairs, goal review, planning, etc.).
-96. **Save everything, filter at read time**: Every SDK message from member sessions is written to `session_group_messages` in real-time via DaemonHub `sdk.message` subscription. No write-time filtering. Display and routing layers filter independently at read time. This preserves full audit trail and allows different views of the same data.
-97. **Self-contained messages**: `session_group_messages.content` stores full SDK message JSON inline (no FK references to `sdk_messages`). The conversation timeline survives session deletion.
-98. **DaemonHub `sdk.message` emission**: `SDKMessageHandler` emits `sdk.message` on DaemonHub (internal) after saving to `sdk_messages` and broadcasting to WebSocket clients. Room Runtime subscribes to this for message mirroring into session group messages.
-99. **Turn grouping at display time**: Consecutive messages from the same `session_id` form a "turn". No `turn_id` or `seq` columns needed in schema — turns are computed from the message sequence at display time.
-100. **Type-specific metadata in JSON**: Session group orchestration state (feedbackIteration, leadContractViolations, lastForwardedMessageId, activeWorkStartedAt, activeWorkElapsed, tokensUsed, hibernatedAt) is stored as JSON in `session_groups.metadata`. Different group types can store different metadata without schema changes.
-
-### Meta
-82. **Resolved decisions kept in sync**: Decisions #15, #32, #55, #83 updated to match body changes.
-
-## Open Questions (For Future Iterations)
-
-1. **Parallel (Craft, Lead) pairs**: Multiple pairs for different tasks/goals. Requires: per-room scheduler lock, **worktree-per-pair isolation** (two Craft Agents editing the same files will corrupt each other), fair task selection, starvation prevention, and per-pair event loop. Not MVP.
-2. **Task dependency management**: Priority/dependency constraints across goals/tasks need first-class representation for parallel mode. Sequential MVP sidesteps this but it must be solved before `maxConcurrentPairs > 1`.
-3. **Multi-reviewer**: Multiple Lead Agents with different models reviewing the same work (consensus-based review). The Craft→Lead loop supports this naturally.
-4. **Room Agent as Lead**: Should the Room Agent serve as Lead for tasks, or should each task get its own dedicated Lead? Trade-off: shared context vs. isolation.
-5. **External review integration**: PR reviews, CI results as input to Lead Agent.
-6. **Budget limits**: Per-goal or per-room token budgets with auto-escalation on threshold. `tokens_used` tracking provides the data; policy enforcement is a future iteration.
-
----
-
-## Implementation Plan
-
-### Phase 0: Prerequisites
-- DB-backed message queue system (task_messages table + queue logic)
-- Database schema additions (session_groups, session_group_members, session_group_messages, task_messages tables)
-
-### Phase 1: Foundation
-- RoomRuntime scheduler loop (tick loop, event-driven + timer fallback)
-- Session observation (detect terminal states: Result/Error/AskQuestion + cron safety net)
-- Room Agent with goal/task management tools (full tool set)
-- Capacity management (maxConcurrentPairs check per tick)
-
-### Phase 2: Craft → Lead Loop
-- Task pair manager (create Craft + Lead sessions per task, Lead reused across iterations)
-- Lead Agent tools (`send_to_craft`, `complete_task`, `fail_task`, `escalate`, `read_craft_messages`)
-- Lead Agent system prompt with goal/task/room context
-- Runtime message collection (Craft terminal state → collect all messages from last turn → send to Lead)
-- Runtime message routing (Lead `send_to_craft()` → inject into Craft session via message queue)
-- AskUserQuestion routing (Craft question → Lead first → escalate if needed)
-- Human message queueing during Lead review
-- Integration test: task → Craft works → Lead reviews → feedback loop → accepted
-
-### Phase 3: Planning + Goal Completion
-- Planning (Craft, Lead) pair for goal decomposition (Craft gets `create_task` tool)
-- Goal completion review (Craft, Lead) pair
-- Full cycle test: goal → plan → tasks → execute → review → complete → goal review
-
-### Phase 4: Recovery + Resilience
-- Daemon restart recovery (reconstruct Runtime state from DB)
-- Escalation flow (pause pair, notify Room Agent, human responds to Lead)
-- Error recovery (Lead handles Craft errors, circuit breaker on repeated failures)
-
-### Phase 5: Human Intervention
-- Room Agent conversation flows
-- Human joins task group chat (message routing through queue)
-- Pause/resume, task editing, cancel/retry tasks
-
-### Phase 6: Task Chat View UI
-- Sub-agent blocks for Craft turns (🔨) and Lead turns (👁)
-- Human messages rendered inline
-- Chronological interleaving from both sessions
-- Task controls within the view
-
-### Verification (end-to-end acceptance criteria)
-- Create a room, chat with Room Agent: "Add a health check endpoint to the API"
-- Room Agent creates goal → Runtime creates planning task → plan reviewed → coding tasks created
-- Runtime spawns (Craft, Lead) pair → Craft codes → Lead reviews → iterates → accepts
-- Repeat for remaining tasks → goal marked complete
-- Human can: pause, chat with Room Agent, join task group chat, edit tasks
-- Add another goal and verify continuous operation
-- Restart daemon mid-execution and verify recovery (no stuck states)
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts`
+- `packages/daemon/src/lib/room/runtime/task-group-manager.ts`
+- `packages/daemon/src/lib/room/state/session-group-repository.ts`
+- `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`
+- `packages/daemon/src/lib/rpc-handlers/goal-handlers.ts`
+- `packages/daemon/src/lib/room/runtime/runtime-recovery.ts`

--- a/docs/design/task-status-control-design.md
+++ b/docs/design/task-status-control-design.md
@@ -20,8 +20,8 @@ stateDiagram-v2
     in_progress --> cancelled: Human cancels
 
     review --> completed: Human approves
-    review --> failed: Human rejects (fatal)
-    review --> in_progress: Human rejects (retry)
+    review --> failed: Human marks failed (manual terminal)
+    review --> in_progress: Human rejects (task.reject)
 
     failed --> pending: Restart (human retry)
     failed --> in_progress: Restart (human retry)
@@ -46,6 +46,18 @@ stateDiagram-v2
 | `failed` | `pending`, `in_progress` | Restart: human can retry failed task |
 | `cancelled` | `pending`, `in_progress` | Restart: human can retry cancelled task |
 
+## Session Group State (Current)
+
+`session_groups.state` is retained for compatibility and uses:
+
+- `awaiting_worker`
+- `awaiting_leader`
+- `awaiting_human`
+- `completed`
+- `failed`
+
+`hibernated` is not part of the current model.
+
 ## Transition Behavior
 
 ### Validated via `setTaskStatus()`
@@ -68,11 +80,26 @@ All status transitions are validated against `VALID_STATUS_TRANSITIONS` before a
 When a task has an active session group (agents currently running) and transitions to a terminal state (`completed`, `failed`, `cancelled`), the system:
 
 1. Looks up the active group for the task
-2. Calls `taskGroupManager.cancel()` to stop running agents
-3. If cancellation fails (returns `null` due to version conflict or missing group), throws an error
-4. Only then applies the status change to the task
+2. For `cancelled`, calls `runtime.cancelTask(taskId)` (task cancel + group/session cleanup)
+3. For `completed` or `failed`, calls `runtime.terminateTaskGroup(taskId)` (group/session cleanup only)
+4. If runtime cleanup fails, throws an error
+5. Only then applies (or returns) the final task status
 
-This ensures agents are properly stopped before marking a task as complete/failed/cancelled.
+For `task.cancel`, if runtime exists, the handler delegates directly to `runtime.cancelTask(taskId)`.
+
+```mermaid
+flowchart LR
+    A["task.cancel"] --> B["runtime.cancelTask(taskId)"]
+    C["task.setStatus(cancelled)"] --> B
+    D["task.setStatus(completed|failed)"] --> E["runtime.terminateTaskGroup(taskId)"]
+    E --> F["persist requested terminal status"]
+```
+
+### Human Review RPCs
+
+- **`task.approve`**: requires `review` status and resumes runtime with `approved=true`.
+- **`task.reject`**: requires `review` status and resumes runtime with `approved=false` plus feedback.
+- **`task.sendHumanMessage`**: direct human messaging to `worker` (default) or `leader` without state gating.
 
 ## API
 
@@ -118,6 +145,33 @@ This ensures agents are properly stopped before marking a task as complete/faile
 
 // Response
 { task: NeoTask }
+```
+
+**`task.approve`** - Human approval while task is in `review`
+
+```typescript
+// Request
+{
+  roomId: string;
+  taskId: string;
+}
+
+// Response
+{ success: boolean }
+```
+
+**`task.reject`** - Human rejection while task is in `review`
+
+```typescript
+// Request
+{
+  roomId: string;
+  taskId: string;
+  feedback: string;
+}
+
+// Response
+{ success: boolean }
 ```
 
 ### Events

--- a/docs/plans/complete-room-human-in-a-loop-features.md
+++ b/docs/plans/complete-room-human-in-a-loop-features.md
@@ -1,5 +1,13 @@
 # Plan: Complete Room Human-in-a-Loop Features
 
+> Historical plan note:
+> This plan captures an earlier design iteration and includes stale routing/group-state assumptions.
+> For current implementation behavior, use:
+> - `docs/design/pr-review-workflow.md`
+> - `docs/design/task-status-control-design.md`
+> - `docs/design/room-runtime-spec.md`
+> Current compatibility `session_groups.state` values are: `awaiting_worker | awaiting_leader | awaiting_human | completed | failed` (`hibernated` removed).
+
 ## Goal
 
 Allow humans to interact with room agents during autonomous task execution via two channels:
@@ -9,7 +17,7 @@ Allow humans to interact with room agents during autonomous task execution via t
 ## Current State
 
 - `awaiting_human` group state and `resumeWorkerFromHuman()` exist in `RoomRuntime`
-- `goal.approveTask` RPC exists but only handles approval (not rejection with feedback)
+- `task.approve` RPC exists but only handles approval (not rejection with feedback)
 - Room chat session (`room:chat:${roomId}`) exists with basic room-agent MCP tools (create_goal, list_goals, update_goal, create_task, list_tasks, update_task, cancel_task, get_room_status)
 - `TaskView` calls `request('task.get', ...)` but **no `task.get` RPC handler exists** — it must be added as a prerequisite
 - `TaskView` and `TaskConversationRenderer` display group conversation but have no human input
@@ -94,7 +102,7 @@ Add a message composition area at the bottom of `packages/web/src/components/roo
 
 **When `awaiting_human`:**
 - Prominent "Awaiting your review" banner
-- "Approve" button (calls existing `goal.approveTask` RPC) with green styling
+- "Approve" button (calls existing `task.approve` RPC) with green styling
 - Text input + "Send Feedback" button (calls `task.sendHumanMessage` RPC) that resumes worker with rejection feedback
 
 **When `awaiting_leader`:**
@@ -111,7 +119,7 @@ Human messages must render in `TaskConversationRenderer.tsx` with the existing `
 
 **Acceptance criteria:**
 - TaskView shows Approve + feedback input when `awaiting_human`
-- Approve button calls `goal.approveTask` successfully
+- Approve button calls `task.approve` successfully
 - Feedback input calls `task.sendHumanMessage` and the message appears in the conversation timeline
 - TaskView shows a generic "Send to Leader" input for `awaiting_leader` state
 - Input is disabled (with tooltip) for `awaiting_worker` state
@@ -206,7 +214,7 @@ In `packages/web/src/lib/room-store.ts`, when a `room.task.update` event arrives
 **2. Task list review actions in RoomDashboard**
 
 In `packages/web/src/components/room/RoomTasks.tsx`, for tasks in `review` status, show both:
-- "Approve" button (existing) — calls `goal.approveTask`
+- "Approve" button (existing) — calls `task.approve`
 - "View" button — navigates to TaskView so the human can read the conversation before deciding
 
 **3. Review count badge on room list**

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -1,19 +1,10 @@
 /**
  * Human Message Routing
  *
- * Shared helper that routes a human message to the correct agent(s) based on
- * the current state of the session group associated with a task.
- *
- * State routing (auto mode):
- * - awaiting_human  → inject into worker (resume from human approval/rejection)
- * - awaiting_leader → inject into leader + append to group timeline
- * - awaiting_worker → error (unless explicit target=worker)
- * - completed       → error: task is already completed
- * - failed          → error: task has already failed
- * - no group        → error: no active session group for the task
+ * Routes a human message to the worker or leader session.
+ * No state gates - messages can be sent to either agent at any time.
  */
 
-import type { MessageHub } from '@neokai/shared';
 import type { RoomRuntime } from './room-runtime';
 import type { SessionGroupRepository } from '../state/session-group-repository';
 
@@ -22,24 +13,23 @@ export interface HumanMessageResult {
 	error?: string;
 }
 
-export type HumanMessageTarget = 'auto' | 'worker' | 'leader';
+export type HumanMessageTarget = 'worker' | 'leader';
 
 /**
- * Route a human message to the correct agent based on the group's current state.
+ * Route a human message to the specified agent.
  *
  * @param runtime       The RoomRuntime instance for the room
  * @param groupRepo     The SessionGroupRepository for DB access
  * @param taskId        The task ID to route the message to
  * @param message       The human message content
- * @param target        Optional explicit target agent ('auto' | 'worker' | 'leader')
+ * @param target        Target agent ('worker' | 'leader'), defaults to 'worker'
  */
 export async function routeHumanMessageToGroup(
 	runtime: RoomRuntime,
 	groupRepo: SessionGroupRepository,
 	taskId: string,
 	message: string,
-	target: HumanMessageTarget = 'auto',
-	_messageHub?: MessageHub
+	target: HumanMessageTarget = 'worker'
 ): Promise<HumanMessageResult> {
 	const group = groupRepo.getGroupByTaskId(taskId);
 
@@ -47,63 +37,21 @@ export async function routeHumanMessageToGroup(
 		return { success: false, error: 'No active session group found for this task' };
 	}
 
-	if (group.state === 'completed') {
-		return { success: false, error: 'Task is already completed' };
-	}
-	if (group.state === 'failed') {
-		return { success: false, error: 'Task has already failed' };
+	// Check if group is terminated using completedAt timestamp
+	if (group.completedAt !== null) {
+		return { success: false, error: 'Task is already completed or failed' };
 	}
 
-	if (target === 'worker') {
-		if (group.state === 'awaiting_human') {
-			// Worker is paused waiting for human — resume by injecting into worker.
-			const resumed = await runtime.resumeWorkerFromHuman(taskId, message, { approved: false });
-			if (!resumed) {
-				return { success: false, error: 'Failed to resume worker from human message' };
-			}
-			return { success: true };
-		}
-
-		const injected = await runtime.injectMessageToWorker(taskId, message);
-		if (!injected) {
-			return { success: false, error: 'Failed to inject message into worker session' };
-		}
-		return { success: true };
-	}
-
+	// Simple routing - no state checks
 	if (target === 'leader') {
 		const injected = await runtime.injectMessageToLeader(taskId, message);
-		if (!injected) {
-			return { success: false, error: 'Failed to inject message into leader session' };
-		}
-		return { success: true };
-	}
-
-	// Auto mode (backward-compatible): route by state.
-	switch (group.state) {
-		case 'awaiting_human': {
-			const resumed = await runtime.resumeWorkerFromHuman(taskId, message, { approved: false });
-			if (!resumed) {
-				return { success: false, error: 'Failed to resume worker from human message' };
-			}
-			return { success: true };
-		}
-
-		case 'awaiting_leader': {
-			const injected = await runtime.injectMessageToLeader(taskId, message);
-			if (!injected) {
-				return { success: false, error: 'Failed to inject message into leader session' };
-			}
-			return { success: true };
-		}
-
-		case 'awaiting_worker':
-			return {
-				success: false,
-				error: 'Worker is running — wait for leader review before sending messages',
-			};
-
-		default:
-			return { success: false, error: `Unexpected group state: ${group.state}` };
+		return injected
+			? { success: true }
+			: { success: false, error: 'Failed to inject message into leader session' };
+	} else {
+		const injected = await runtime.injectMessageToWorker(taskId, message);
+		return injected
+			? { success: true }
+			: { success: false, error: 'Failed to inject message into worker session' };
 	}
 }

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -494,23 +494,15 @@ export class RoomRuntimeService {
 						await runtime.restoreMcpServersForGroup(group);
 
 						// Inject continuation message to resume work
-						if (group.state === 'awaiting_worker') {
+						// Groups awaiting human review don't need a message — human will provide one
+						if (!group.submittedForReview) {
 							await sessionFactory.injectMessage(
 								group.workerSessionId,
 								'The system was restarted. Continue working on the task.'
 							);
-						} else if (group.state === 'awaiting_leader') {
-							await sessionFactory.injectMessage(
-								group.leaderSessionId,
-								'The system was restarted. Continue reviewing from where you left off.'
-							);
 						}
-						// awaiting_human: no message needed — human will provide one
 					} catch (error) {
-						log.error(
-							`Failed to restore/inject continuation for group ${group.id} (${group.state}):`,
-							error
-						);
+						log.error(`Failed to restore/inject continuation for group ${group.id}:`, error);
 					}
 				}
 			}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -820,22 +820,45 @@ export class RoomRuntime {
 		// Determine if this is an approval
 		const isApproval =
 			opts?.approved === true || (group.workerRole === 'planner' && opts?.approved !== false);
+		const previousStatus = task.status;
+		const previousApproved = group.approved;
 
-		if (isApproval) {
+		if (isApproval && !previousApproved) {
 			this.groupRepo.setApproved(group.id, true);
 		}
 
 		// Move task back to in_progress
-		await this.taskManager.updateTaskStatus(group.taskId, 'in_progress');
+		try {
+			await this.taskManager.updateTaskStatus(group.taskId, 'in_progress');
+		} catch (error) {
+			if (isApproval && !previousApproved) {
+				this.groupRepo.setApproved(group.id, previousApproved);
+			}
+			log.error(`Failed to set task ${taskId} to in_progress before human resume:`, error);
+			return false;
+		}
 
 		// Route ALL messages (approval and rejection) to leader
 		// Leader handles: approval → merge + complete_task
 		// Leader handles: rejection → send_to_worker + handoff_to_worker
 		try {
 			const updated = await this.taskGroupManager.resumeLeaderFromHuman(group.id, message);
-			if (!updated) return false;
+			if (!updated) {
+				await this.taskManager.updateTaskStatus(group.taskId, previousStatus);
+				if (isApproval && !previousApproved) {
+					this.groupRepo.setApproved(group.id, previousApproved);
+				}
+				return false;
+			}
 		} catch (error) {
-			await this.taskManager.reviewTask(group.taskId);
+			try {
+				await this.taskManager.updateTaskStatus(group.taskId, previousStatus);
+			} catch (rollbackError) {
+				log.warn(`Failed to rollback task ${taskId} status after resume error:`, rollbackError);
+			}
+			if (isApproval && !previousApproved) {
+				this.groupRepo.setApproved(group.id, previousApproved);
+			}
 			log.error(`Failed to resume from human for task ${taskId}:`, error);
 			return false;
 		}
@@ -843,6 +866,31 @@ export class RoomRuntime {
 		await this.emitTaskUpdateById(group.taskId);
 		await this.emitGoalProgressForTask(group.taskId);
 		this.scheduleTick();
+		return true;
+	}
+
+	/**
+	 * Terminate the task's active group (if any) without changing task status.
+	 *
+	 * Used by task.setStatus paths that move tasks to terminal states other than
+	 * cancelled. This ensures agent sessions and mirroring are cleaned up while
+	 * preserving the caller's chosen task status transition.
+	 */
+	async terminateTaskGroup(taskId: string): Promise<boolean> {
+		const group = this.groupRepo.getGroupByTaskId(taskId);
+		if (!group) return true;
+
+		const isActiveGroup = group.completedAt === null;
+		if (isActiveGroup) {
+			const terminated = await this.taskGroupManager.terminateGroup(group.id);
+			if (!terminated) return false;
+		}
+
+		await this.terminateGroupSessions(group);
+		this.cleanupMirroring(
+			group.id,
+			isActiveGroup ? 'Task group terminated by user status change.' : undefined
+		);
 		return true;
 	}
 
@@ -876,7 +924,11 @@ export class RoomRuntime {
 		const isActiveGroup = !!group && group.completedAt === null;
 		if (group) {
 			if (isActiveGroup) {
-				await this.taskGroupManager.terminateGroup(group.id);
+				const terminated = await this.taskGroupManager.terminateGroup(group.id);
+				if (!terminated) {
+					log.warn(`Failed to terminate active group ${group.id} during cancelTask(${taskId})`);
+					return { success: false, cancelledTaskIds: [...cancelledTaskIds] };
+				}
 			}
 			await this.terminateGroupSessions(group);
 			this.cleanupMirroring(group.id, isActiveGroup ? 'Task cancelled by user.' : undefined);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -47,7 +47,6 @@ import {
 	formatWorkerToLeaderEnvelope,
 	formatPlanEnvelope,
 	formatLeaderToWorkerFeedback,
-	formatLeaderContractNudge,
 	sortTasksByPriority,
 } from './message-routing';
 import { isRateLimitError, createRateLimitBackoff } from './rate-limit-utils';
@@ -370,7 +369,7 @@ export class RoomRuntime {
 	 */
 	async onWorkerTerminalState(groupId: string, terminalState: TerminalState): Promise<void> {
 		const group = this.groupRepo.getGroup(groupId);
-		if (!group || group.state !== 'awaiting_worker') return;
+		if (!group) return;
 
 		const task = await this.taskManager.getTask(group.taskId);
 		if (!task) return;
@@ -525,48 +524,21 @@ export class RoomRuntime {
 
 	/**
 	 * Called when Leader reaches a terminal state.
-	 * Validates Leader tool contract (retry-then-fail).
+	 * No state checks - leader can finish without calling a tool.
 	 */
 	async onLeaderTerminalState(groupId: string, _terminalState: TerminalState): Promise<void> {
 		const group = this.groupRepo.getGroup(groupId);
-		if (!group || group.state !== 'awaiting_leader') return;
+		if (!group) return;
 
 		// Check rate limit backoff
 		if (this.groupRepo.isRateLimited(groupId)) {
-			log.info(`Leader reached terminal state while rate limited - pausing nudge`);
+			log.info(`Leader reached terminal state while rate limited - pausing`);
 			this.scheduleTickAfterRateLimitReset(groupId);
 			return;
 		}
 
-		// Check if Leader called a tool (persisted in DB metadata)
-		const calledTool = group.leaderCalledTool;
-
-		if (calledTool) {
-			// Leader called a tool → success, no action needed
-			// (The tool handler already processed the action)
-			return;
-		}
-
-		// Contract violation: Leader reached terminal without calling a tool
-		const violations = group.leaderContractViolations;
-
-		if (violations === 0) {
-			// First violation: nudge
-			const nudge = formatLeaderContractNudge();
-			await this.sessionFactory.injectMessage(group.leaderSessionId, nudge);
-			this.groupRepo.updateLeaderContractViolations(
-				groupId,
-				1,
-				'', // turn ID placeholder - MVP doesn't track turn IDs
-				group.version
-			);
-		} else {
-			// Second+ violation: fail the group
-			await this.taskGroupManager.fail(groupId, 'Leader failed to call required tool after nudge');
-			this.cleanupMirroring(groupId, 'Leader contract violation — task failed.');
-			await this.emitTaskUpdateById(group.taskId);
-			this.scheduleTick();
-		}
+		// Leader can finish without calling a tool - that's fine.
+		// No contract violation logic needed.
 	}
 
 	// =========================================================================
@@ -593,21 +565,11 @@ export class RoomRuntime {
 			return jsonResult({ success: false, error: `Group not found: ${groupId}` });
 		}
 
-		if (group.state !== 'awaiting_leader') {
-			return jsonResult({
-				success: false,
-				error: `Group not in awaiting_leader state (current: ${group.state})`,
-			});
-		}
-
-		// Mark that Leader called a tool (persisted immediately for restart safety)
-		this.groupRepo.setLeaderCalledTool(groupId, true);
+		// No state guard - tools always available
 
 		switch (toolName) {
 			case 'send_to_worker': {
 				// Enforce max feedback iterations — runtime escalates to human review.
-				// Like submit_for_review, this transitions to awaiting_human so we deliberately
-				// do NOT call cleanupMirroring (keeps mirroring running, consistent behaviour).
 				// The reason is persisted in the group timeline by escalateToHumanReview().
 				if (group.feedbackIteration >= this.maxFeedbackIterations) {
 					const reason = `Max feedback iterations (${this.maxFeedbackIterations}) reached`;
@@ -644,42 +606,18 @@ export class RoomRuntime {
 				});
 				return jsonResult({
 					success: true,
-					message:
-						mode === 'queue'
-							? 'Feedback queued for worker. Leader still owns the turn — call handoff_to_worker when ready.'
-							: 'Feedback steered to worker. Leader still owns the turn — call handoff_to_worker when ready.',
+					message: 'Feedback sent to worker.',
 				});
 			}
 
 			case 'handoff_to_worker': {
-				const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_worker', group.version);
-				if (!updated) {
-					return jsonResult({
-						success: false,
-						error: 'Failed to hand off to worker due to concurrent state update.',
-					});
-				}
-
+				// No-op: no state to transition. Kept for backward compatibility.
 				this.appendGroupEvent(groupId, 'status', {
-					text: 'Leader handed off control to Worker.',
+					text: 'Leader signaled handoff to Worker (no-op).',
 				});
-
-				const workerState = this.sessionFactory.getProcessingState?.(updated.workerSessionId);
-				if (workerState === 'idle' || workerState === 'interrupted') {
-					const unforwarded = this.getWorkerMessages
-						? this.getWorkerMessages(updated.workerSessionId, updated.lastForwardedMessageId)
-						: [];
-					if (unforwarded.length > 0) {
-						await this.onWorkerTerminalState(groupId, {
-							sessionId: updated.workerSessionId,
-							kind: 'idle',
-						});
-					}
-				}
-
 				return jsonResult({
 					success: true,
-					message: 'Ownership returned to Worker.',
+					message: 'Handoff acknowledged. Use send_to_worker to send messages.',
 				});
 			}
 
@@ -872,7 +810,8 @@ export class RoomRuntime {
 		opts?: { approved?: boolean }
 	): Promise<boolean> {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
-		if (!group || group.state !== 'awaiting_human') return false;
+		// Check group exists and is not completed/failed
+		if (!group || group.completedAt !== null) return false;
 
 		// Verify the task belongs to this runtime's room
 		const task = await this.taskManager.getTask(taskId);
@@ -931,10 +870,10 @@ export class RoomRuntime {
 		}
 
 		// 2) Clean up session group resources if a group exists.
-		// State transition (-> failed) is only needed for active groups, but session/
-		// mirroring cleanup is safe and idempotent for any group state.
+		// Terminate is only needed for active groups, but session/
+		// mirroring cleanup is safe and idempotent for any group.
 		const group = this.groupRepo.getGroupByTaskId(taskId);
-		const isActiveGroup = !!group && group.state !== 'completed' && group.state !== 'failed';
+		const isActiveGroup = !!group && group.completedAt === null;
 		if (group) {
 			if (isActiveGroup) {
 				await this.taskGroupManager.terminateGroup(group.id);
@@ -1274,8 +1213,7 @@ export class RoomRuntime {
 
 		for (const group of allActiveGroups) {
 			const workerMissing = !this.sessionFactory.hasSession(group.workerSessionId);
-			const leaderMissing =
-				group.state === 'awaiting_leader' && !this.sessionFactory.hasSession(group.leaderSessionId);
+			const leaderMissing = !this.sessionFactory.hasSession(group.leaderSessionId);
 
 			if (workerMissing || leaderMissing) {
 				zombies.push(group);
@@ -1295,7 +1233,7 @@ export class RoomRuntime {
 			let workerRestored = false;
 			if (!this.sessionFactory.hasSession(group.workerSessionId)) {
 				log.warn(
-					`Zombie detected: group ${group.id} (state=${group.state}) ` +
+					`Zombie detected: group ${group.id} ` +
 						`worker ${group.workerSessionId} not in cache. Attempting restore.`
 				);
 				const restored = await this.sessionFactory.restoreSession(group.workerSessionId);
@@ -1319,14 +1257,11 @@ export class RoomRuntime {
 				}
 			}
 
-			// Check leader session liveness (only when leader is the active actor)
+			// Check leader session liveness
 			let leaderRestored = false;
-			if (
-				group.state === 'awaiting_leader' &&
-				!this.sessionFactory.hasSession(group.leaderSessionId)
-			) {
+			if (!this.sessionFactory.hasSession(group.leaderSessionId)) {
 				log.warn(
-					`Zombie detected: group ${group.id} (state=awaiting_leader) ` +
+					`Zombie detected: group ${group.id} ` +
 						`leader ${group.leaderSessionId} not in cache. Attempting restore.`
 				);
 				const restored = await this.sessionFactory.restoreSession(group.leaderSessionId);
@@ -1337,29 +1272,28 @@ export class RoomRuntime {
 					});
 					leaderRestored = true;
 				} else {
-					log.error(
-						`Failed to restore leader ${group.leaderSessionId}. Failing group ${group.id}.`
+					// Leader restoration failure is not fatal - leader may be lazily created
+					log.warn(
+						`Could not restore leader ${group.leaderSessionId} for group ${group.id} - may be lazily created later.`
 					);
-					await this.taskGroupManager.fail(
-						group.id,
-						'Leader session lost and could not be restored'
-					);
-					this.cleanupMirroring(group.id, 'Leader session lost — could not be restored.');
-					await this.emitTaskUpdateById(group.taskId);
 				}
 			}
 
-			// Inject continuation message for restored sessions that need to resume work.
+			// Inject continuation message for restored sessions.
 			// The SDK query is started lazily by injectMessage → ensureQueryStarted().
-			// Sessions in awaiting_human don't need a message — human will provide one.
+			// Groups awaiting human review don't need a message — human will provide one.
+			if (group.submittedForReview) {
+				continue; // Awaiting human - no continuation message needed
+			}
+
 			try {
-				if (workerRestored && group.state === 'awaiting_worker') {
+				if (workerRestored) {
 					await this.sessionFactory.injectMessage(
 						group.workerSessionId,
 						'The system was restarted. Continue working on the task from where you left off.'
 					);
 				}
-				if (leaderRestored && group.state === 'awaiting_leader') {
+				if (leaderRestored) {
 					await this.sessionFactory.injectMessage(
 						group.leaderSessionId,
 						'The system was restarted. Continue reviewing from where you left off.'
@@ -1379,10 +1313,10 @@ export class RoomRuntime {
 			await this.recoverZombieGroups(zombies);
 		}
 
-		// Check capacity — awaiting_human groups are paused and don't consume slots
+		// Check capacity — groups awaiting human review don't consume slots
 		const activeGroups = this.groupRepo
 			.getActiveGroups(this.roomId)
-			.filter((g) => g.state !== 'awaiting_human');
+			.filter((g) => !g.submittedForReview);
 		const availableSlots = this.maxConcurrentGroups - activeGroups.length;
 
 		if (availableSlots <= 0) return;

--- a/packages/daemon/src/lib/room/runtime/runtime-recovery.ts
+++ b/packages/daemon/src/lib/room/runtime/runtime-recovery.ts
@@ -11,6 +11,10 @@
  * Key insight: Recovery is proactive - checks current state before subscribing
  * to future events, so groups that completed right before crash are processed
  * immediately rather than waiting for the safety net timer.
+ *
+ * Simplified model: No group state machine. Both worker and leader sessions
+ * are restored and observed. If submittedForReview is true, the group is
+ * awaiting human action.
  */
 
 import type { SessionGroupRepository, SessionGroup } from '../state/session-group-repository';
@@ -69,43 +73,7 @@ export async function recoverRuntime(
 	for (const group of activeGroups) {
 		result.recoveredGroups++;
 
-		switch (group.state) {
-			case 'awaiting_worker':
-				await recoverAwaitingWorker(
-					group,
-					groupRepo,
-					taskManager,
-					observer,
-					sessionChecker,
-					runtime,
-					result
-				);
-				break;
-
-			case 'awaiting_leader':
-				await recoverAwaitingLeader(
-					group,
-					groupRepo,
-					taskManager,
-					observer,
-					sessionChecker,
-					runtime,
-					result
-				);
-				break;
-
-			case 'awaiting_human':
-				await recoverAwaitingHuman(
-					group,
-					groupRepo,
-					taskManager,
-					observer,
-					sessionChecker,
-					runtime,
-					result
-				);
-				break;
-		}
+		await recoverGroup(group, groupRepo, taskManager, observer, sessionChecker, runtime, result);
 	}
 
 	return result;
@@ -130,7 +98,14 @@ async function ensureLive(
 	return restored;
 }
 
-async function recoverAwaitingWorker(
+/**
+ * Recover a group by restoring both worker and leader sessions.
+ *
+ * Simplified recovery: No state machine. Both sessions are restored if they exist.
+ * If submittedForReview is true, the group is awaiting human action but sessions
+ * are still kept live for message injection.
+ */
+async function recoverGroup(
 	group: SessionGroup,
 	groupRepo: SessionGroupRepository,
 	taskManager: TaskManager,
@@ -147,6 +122,7 @@ async function recoverAwaitingWorker(
 		return;
 	}
 
+	// Check if worker is already in terminal state
 	if (sessionChecker.isTerminalState(group.workerSessionId)) {
 		// Already terminal - process immediately
 		result.immediateTerminals++;
@@ -162,96 +138,26 @@ async function recoverAwaitingWorker(
 		result.reattachedObservers++;
 	}
 
-	// Also observe Leader for when it becomes active.
-	// IMPORTANT: observe even when the leader session row does not exist yet.
-	// Leader is lazily created after worker completion, so pre-observing here ensures
-	// post-restart leader terminal events are not missed.
+	// Restore and observe leader if it exists
+	// Leader may be lazily created, so session might not exist yet
 	if (sessionChecker.sessionExists(group.leaderSessionId)) {
-		await ensureLive(group.leaderSessionId, sessionChecker, result);
-	}
-	observer.observe(group.leaderSessionId, (state: TerminalState) => {
-		runtime.onLeaderTerminalState(group.id, state);
-	});
-}
-
-async function recoverAwaitingLeader(
-	group: SessionGroup,
-	groupRepo: SessionGroupRepository,
-	taskManager: TaskManager,
-	observer: SessionObserver,
-	sessionChecker: SessionStateChecker,
-	runtime: RoomRuntime,
-	result: RecoveryResult
-): Promise<void> {
-	// Restore leader into memory if not live
-	const leaderLive = await ensureLive(group.leaderSessionId, sessionChecker, result);
-	if (!leaderLive) {
-		await failGroupAndTask(group, groupRepo, taskManager, 'Leader session lost during restart');
-		result.failedGroups++;
-		return;
-	}
-
-	if (sessionChecker.isTerminalState(group.leaderSessionId)) {
-		// Already terminal - process immediately
-		result.immediateTerminals++;
-		await runtime.onLeaderTerminalState(group.id, {
-			sessionId: group.leaderSessionId,
-			kind: 'idle',
-		});
+		const leaderLive = await ensureLive(group.leaderSessionId, sessionChecker, result);
+		if (leaderLive) {
+			if (sessionChecker.isTerminalState(group.leaderSessionId)) {
+				result.immediateTerminals++;
+				await runtime.onLeaderTerminalState(group.id, {
+					sessionId: group.leaderSessionId,
+					kind: 'idle',
+				});
+			} else {
+				observer.observe(group.leaderSessionId, (state: TerminalState) => {
+					runtime.onLeaderTerminalState(group.id, state);
+				});
+				result.reattachedObservers++;
+			}
+		}
 	} else {
-		// Still active - observe for future terminal state
-		observer.observe(group.leaderSessionId, (state: TerminalState) => {
-			runtime.onLeaderTerminalState(group.id, state);
-		});
-		result.reattachedObservers++;
-	}
-
-	// Also restore and observe Worker for if it becomes active again
-	if (sessionChecker.sessionExists(group.workerSessionId)) {
-		await ensureLive(group.workerSessionId, sessionChecker, result);
-		observer.observe(group.workerSessionId, (state: TerminalState) => {
-			runtime.onWorkerTerminalState(group.id, state);
-		});
-	}
-}
-
-/**
- * Recover awaiting_human groups by restoring sessions into memory.
- *
- * The worker session must be live so that when the human approves,
- * injectMessage can deliver the approval to the worker.
- */
-async function recoverAwaitingHuman(
-	group: SessionGroup,
-	groupRepo: SessionGroupRepository,
-	taskManager: TaskManager,
-	observer: SessionObserver,
-	sessionChecker: SessionStateChecker,
-	runtime: RoomRuntime,
-	result: RecoveryResult
-): Promise<void> {
-	// Restore worker into memory so injectMessage works on human approval
-	const workerLive = await ensureLive(group.workerSessionId, sessionChecker, result);
-	if (!workerLive) {
-		await failGroupAndTask(
-			group,
-			groupRepo,
-			taskManager,
-			'Worker session lost during restart (awaiting human)'
-		);
-		result.failedGroups++;
-		return;
-	}
-
-	// Attach observer so worker terminal state fires after human approval
-	observer.observe(group.workerSessionId, (state: TerminalState) => {
-		runtime.onWorkerTerminalState(group.id, state);
-	});
-	result.reattachedObservers++;
-
-	// Also restore leader if it exists (best-effort)
-	if (sessionChecker.sessionExists(group.leaderSessionId)) {
-		await ensureLive(group.leaderSessionId, sessionChecker, result);
+		// Leader session doesn't exist yet - observe anyway for lazy creation
 		observer.observe(group.leaderSessionId, (state: TerminalState) => {
 			runtime.onLeaderTerminalState(group.id, state);
 		});

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -356,17 +356,12 @@ export class TaskGroupManager {
 			this.groupRepo.setDeferredLeader(groupId, null);
 		}
 
-		// Update group state to awaiting_leader
-		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_leader', group.version);
-
-		if (updated) {
-			// Increment feedback iteration (1-based: first review = iteration 1)
-			this.groupRepo.incrementFeedbackIteration(groupId, updated.version);
-			// Reset leader contract state for the new review round
-			const afterIncrement = this.groupRepo.getGroup(groupId);
-			if (afterIncrement) {
-				this.groupRepo.resetLeaderContractViolations(groupId, afterIncrement.version);
-			}
+		// Increment feedback iteration (1-based: first review = iteration 1)
+		this.groupRepo.incrementFeedbackIteration(groupId, group.version);
+		// Reset leader contract state for the new review round
+		const afterIncrement = this.groupRepo.getGroup(groupId);
+		if (afterIncrement) {
+			this.groupRepo.resetLeaderContractViolations(groupId, afterIncrement.version);
 		}
 
 		return this.groupRepo.getGroup(groupId);
@@ -399,10 +394,7 @@ export class TaskGroupManager {
 			});
 		}
 
-		// Optional transition: keep leader in control when using queue/steer forwarding.
-		if (opts?.transitionState !== false) {
-			this.groupRepo.updateGroupState(groupId, 'awaiting_worker', group.version);
-		}
+		// No state transition - simplified model allows messages anytime
 
 		return this.groupRepo.getGroup(groupId);
 	}
@@ -457,25 +449,21 @@ export class TaskGroupManager {
 	 * Submit a group for human review - work is done, PR awaits human approval.
 	 *
 	 * Called when Leader calls submit_for_review(pr_url).
-	 * Transitions the group to 'awaiting_human' (slot stays occupied but paused)
-	 * and moves the task to 'review' status.
+	 * Moves the task to 'review' status. The submittedForReview flag should be
+	 * set by the caller to indicate the group is awaiting human action.
 	 */
 	async submitForReview(groupId: string, prUrl: string): Promise<SessionGroup | null> {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
-		// Pause the group in awaiting_human (does NOT free the slot — slot exclusion is done in executeTick)
-		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_human', group.version);
-		if (!updated) return null;
-
 		// Move task to review status with PR URL
 		await this.taskManager.reviewTask(group.taskId, prUrl);
 
-		return updated;
+		return this.groupRepo.getGroup(groupId);
 	}
 
 	/**
-	 * Resume a group from awaiting_human by injecting a message into the existing worker.
+	 * Resume a group from human review by injecting a message into the existing worker.
 	 *
 	 * Used for:
 	 * - Rejection: worker addresses feedback
@@ -486,16 +474,12 @@ export class TaskGroupManager {
 	 */
 	async resumeWorkerFromHuman(groupId: string, message: string): Promise<boolean> {
 		const group = this.groupRepo.getGroup(groupId);
-		if (!group || group.state !== 'awaiting_human') return false;
-
-		// Transition: awaiting_human → awaiting_worker
-		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_worker', group.version);
-		if (!updated) return false;
+		if (!group || !group.submittedForReview) return false;
 
 		// Reset state for the new review round.
 		// feedbackIteration is reset to 0 so the resumed task gets a fresh iteration budget —
 		// without this the task would immediately re-escalate on the very next leader cycle.
-		this.groupRepo.resetLeaderContractViolations(groupId, updated.version);
+		this.groupRepo.resetLeaderContractViolations(groupId, group.version);
 		this.groupRepo.setSubmittedForReview(groupId, false);
 		const afterReset = this.groupRepo.getGroup(groupId);
 		if (afterReset) {
@@ -503,18 +487,7 @@ export class TaskGroupManager {
 		}
 
 		// Inject approval message into existing worker session.
-		// If injection fails (e.g., session not in cache after restart), rollback
-		// the group state so the task stays in review for retry.
-		try {
-			await this.sessionFactory.injectMessage(group.workerSessionId, message);
-		} catch (error) {
-			// Rollback: revert group back to awaiting_human
-			const current = this.groupRepo.getGroup(groupId);
-			if (current && current.state === 'awaiting_worker') {
-				this.groupRepo.updateGroupState(groupId, 'awaiting_human', current.version);
-			}
-			throw error;
-		}
+		await this.sessionFactory.injectMessage(group.workerSessionId, message);
 
 		return true;
 	}
@@ -531,41 +504,27 @@ export class TaskGroupManager {
 	 */
 	async resumeLeaderFromHuman(groupId: string, message: string): Promise<boolean> {
 		const group = this.groupRepo.getGroup(groupId);
-		if (!group || group.state !== 'awaiting_human') return false;
+		if (!group || !group.submittedForReview) return false;
 
 		// Ensure leader session exists
 		if (!this.sessionFactory.hasSession(group.leaderSessionId)) {
 			return false;
 		}
 
-		// Transition: awaiting_human → awaiting_leader
-		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_leader', group.version);
-		if (!updated) return false;
-
 		// Reset state for the new cycle (same as resumeWorkerFromHuman).
 		// feedbackIteration is reset to 0 so the worker gets a fresh iteration budget.
 		// submittedForReview is reset so the worker must re-submit for review after addressing feedback.
 		// For approval path, these resets are harmless since leader will complete the task.
 		// For rejection path, these resets are essential for the worker to have a fresh start.
-		this.groupRepo.resetLeaderContractViolations(groupId, updated.version);
+		this.groupRepo.resetLeaderContractViolations(groupId, group.version);
 		this.groupRepo.setSubmittedForReview(groupId, false);
 		const afterReset = this.groupRepo.getGroup(groupId);
 		if (afterReset) {
 			this.groupRepo.resetFeedbackIteration(groupId, afterReset.version);
 		}
 
-		// Inject approval message into existing leader session.
-		// If injection fails, rollback the group state so the task stays in review for retry.
-		try {
-			await this.sessionFactory.injectMessage(group.leaderSessionId, message);
-		} catch (error) {
-			// Rollback: revert group back to awaiting_human
-			const current = this.groupRepo.getGroup(groupId);
-			if (current && current.state === 'awaiting_leader') {
-				this.groupRepo.updateGroupState(groupId, 'awaiting_human', current.version);
-			}
-			throw error;
-		}
+		// Inject approval message into existing leader session
+		await this.sessionFactory.injectMessage(group.leaderSessionId, message);
 
 		return true;
 	}
@@ -574,7 +533,7 @@ export class TaskGroupManager {
 	 * Escalate a group to human review because max feedback iterations were reached.
 	 *
 	 * Called by the runtime (NOT the leader) when feedbackIteration >= maxFeedbackIterations.
-	 * Transitions the group to 'awaiting_human' and the task to 'review' so a human
+	 * Sets submittedForReview flag and moves task to 'review' status so a human
 	 * can inspect progress and decide whether to approve, reject, or provide guidance.
 	 *
 	 * Unlike submitForReview (triggered by leader's submit_for_review tool call),
@@ -584,14 +543,13 @@ export class TaskGroupManager {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
-		// Pause the group in awaiting_human (slot stays occupied but paused)
-		const updated = this.groupRepo.updateGroupState(groupId, 'awaiting_human', group.version);
-		if (!updated) return null;
+		// Set submittedForReview flag to indicate awaiting human action
+		this.groupRepo.setSubmittedForReview(groupId, true);
 
 		// Move task to review status (no PR URL — runtime-enforced escalation)
 		await this.taskManager.reviewTask(group.taskId);
 
-		return updated;
+		return this.groupRepo.getGroup(groupId);
 	}
 
 	/**
@@ -603,7 +561,7 @@ export class TaskGroupManager {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
-		if (group.state === 'completed' || group.state === 'failed') {
+		if (group.completedAt !== null) {
 			this.observer.unobserve(group.workerSessionId);
 			this.observer.unobserve(group.leaderSessionId);
 			return group;

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -363,6 +363,8 @@ export class TaskGroupManager {
 		if (afterIncrement) {
 			this.groupRepo.resetLeaderContractViolations(groupId, afterIncrement.version);
 		}
+		// Keep legacy state column in sync for compatibility.
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_leader');
 
 		return this.groupRepo.getGroup(groupId);
 	}
@@ -394,7 +396,8 @@ export class TaskGroupManager {
 			});
 		}
 
-		// No state transition - simplified model allows messages anytime
+		// Keep legacy state column in sync for compatibility.
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_worker');
 
 		return this.groupRepo.getGroup(groupId);
 	}
@@ -458,6 +461,7 @@ export class TaskGroupManager {
 
 		// Move task to review status with PR URL
 		await this.taskManager.reviewTask(group.taskId, prUrl);
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_human');
 
 		return this.groupRepo.getGroup(groupId);
 	}
@@ -488,6 +492,7 @@ export class TaskGroupManager {
 
 		// Inject approval message into existing worker session.
 		await this.sessionFactory.injectMessage(group.workerSessionId, message);
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_worker');
 
 		return true;
 	}
@@ -511,6 +516,10 @@ export class TaskGroupManager {
 			return false;
 		}
 
+		// Inject into leader first. If this fails, caller can safely rollback
+		// task status/approval without restoring group metadata.
+		await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+
 		// Reset state for the new cycle (same as resumeWorkerFromHuman).
 		// feedbackIteration is reset to 0 so the worker gets a fresh iteration budget.
 		// submittedForReview is reset so the worker must re-submit for review after addressing feedback.
@@ -522,9 +531,7 @@ export class TaskGroupManager {
 		if (afterReset) {
 			this.groupRepo.resetFeedbackIteration(groupId, afterReset.version);
 		}
-
-		// Inject approval message into existing leader session
-		await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_leader');
 
 		return true;
 	}
@@ -545,6 +552,7 @@ export class TaskGroupManager {
 
 		// Set submittedForReview flag to indicate awaiting human action
 		this.groupRepo.setSubmittedForReview(groupId, true);
+		this.groupRepo.setCompatibilityState(groupId, 'awaiting_human');
 
 		// Move task to review status (no PR URL — runtime-enforced escalation)
 		await this.taskManager.reviewTask(group.taskId);

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -38,6 +38,17 @@ export interface DeferredLeaderConfig {
 	leaderTaskContext?: string;
 }
 
+/**
+ * Compatibility state persisted in session_groups.state.
+ * Runtime routing should prefer submittedForReview/completedAt.
+ */
+export type GroupState =
+	| 'awaiting_worker'
+	| 'awaiting_leader'
+	| 'awaiting_human'
+	| 'completed'
+	| 'failed';
+
 /** Type-specific metadata for task groups */
 interface TaskGroupMetadata {
 	feedbackIteration: number;
@@ -88,6 +99,8 @@ export interface SessionGroup {
 	/** ref_id — the task_id for task groups */
 	taskId: string;
 	groupType: string;
+	/** Compatibility mirror only; not authoritative for routing. */
+	state: GroupState;
 	workerSessionId: string;
 	leaderSessionId: string;
 	/** The specific worker agent type: 'planner', 'coder', 'general' */
@@ -161,7 +174,7 @@ export class SessionGroupRepository {
 		const row = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -179,7 +192,7 @@ export class SessionGroupRepository {
 		const row = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -198,7 +211,7 @@ export class SessionGroupRepository {
 		const rows = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -266,7 +279,8 @@ export class SessionGroupRepository {
 		const result = this.db
 			.prepare(
 				`UPDATE session_groups
-				 SET completed_at = NULL,
+				 SET state = 'awaiting_worker',
+				     completed_at = NULL,
 				     metadata = ?,
 				     version = version + 1
 				 WHERE id = ?`
@@ -411,6 +425,14 @@ export class SessionGroupRepository {
 		this.db
 			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
 			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
+	 * Update legacy state column for compatibility/observability.
+	 * Runtime routing should not depend on this value.
+	 */
+	setCompatibilityState(groupId: string, state: GroupState): void {
+		this.db.prepare(`UPDATE session_groups SET state = ? WHERE id = ?`).run(state, groupId);
 	}
 
 	/**
@@ -568,10 +590,12 @@ export class SessionGroupRepository {
 
 	private rowToGroup(row: Record<string, unknown>): SessionGroup {
 		const meta = this.parseMetadata(row.metadata as string | null);
+		const state = ((row.state as string | null) ?? 'awaiting_worker') as GroupState;
 		return {
 			id: row.id as string,
 			taskId: row.ref_id as string,
 			groupType: row.group_type as string,
+			state,
 			workerSessionId: (row.worker_session_id as string) ?? '',
 			leaderSessionId: (row.leader_session_id as string) ?? '',
 			workerRole: meta.workerRole ?? 'coder',
@@ -586,7 +610,7 @@ export class SessionGroupRepository {
 			version: row.version as number,
 			tokensUsed: meta.tokensUsed,
 			workspacePath: meta.workspacePath,
-			submittedForReview: meta.submittedForReview ?? false,
+			submittedForReview: meta.submittedForReview === true || state === 'awaiting_human',
 			approved: meta.approved ?? false,
 			rateLimit: meta.rateLimit ?? null,
 			deferredLeader: meta.deferredLeader ?? null,

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -4,7 +4,6 @@
  * Generic multi-agent collaboration groups. For (Worker, Leader) task groups:
  *   group_type = 'task', ref_id = task_id
  *   members: role='worker' + role='leader'
- *   state: awaiting_worker | awaiting_leader | awaiting_human | hibernated | completed | failed
  *
  * The actual worker type (planner, coder, general) is stored in metadata.workerRole.
  *
@@ -12,17 +11,14 @@
  * as JSON in the metadata column — no schema change needed for new fields.
  *
  * All update methods use version-based optimistic locking.
+ *
+ * NOTE: The `state` DB column is legacy and no longer used for routing decisions.
+ * Use `completedAt` to check if a group is terminal, and `submittedForReview` to
+ * check if a group is awaiting human review.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
-
-export type GroupState =
-	| 'awaiting_worker'
-	| 'awaiting_leader'
-	| 'awaiting_human'
-	| 'completed'
-	| 'failed';
 
 /** Rate limit backoff state stored in group metadata */
 export interface RateLimitBackoff {
@@ -96,7 +92,6 @@ export interface SessionGroup {
 	leaderSessionId: string;
 	/** The specific worker agent type: 'planner', 'coder', 'general' */
 	workerRole: string;
-	state: GroupState;
 	feedbackIteration: number;
 	leaderContractViolations: number;
 	leaderCalledTool: boolean;
@@ -166,7 +161,7 @@ export class SessionGroupRepository {
 		const row = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -184,7 +179,7 @@ export class SessionGroupRepository {
 		const row = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -203,7 +198,7 @@ export class SessionGroupRepository {
 		const rows = this.db
 			.prepare(
 				`SELECT
-					sg.id, sg.group_type, sg.ref_id, sg.state, sg.version, sg.metadata,
+					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
 					sg.created_at, sg.completed_at,
 					worker.session_id AS worker_session_id,
 					leader.session_id AS leader_session_id
@@ -211,25 +206,10 @@ export class SessionGroupRepository {
 				JOIN tasks t ON sg.ref_id = t.id
 				LEFT JOIN session_group_members worker ON worker.group_id = sg.id AND worker.role = 'worker'
 				LEFT JOIN session_group_members leader ON leader.group_id = sg.id AND leader.role = 'leader'
-				WHERE t.room_id = ? AND sg.state NOT IN ('completed', 'failed')`
+				WHERE t.room_id = ? AND sg.completed_at IS NULL`
 			)
 			.all(roomId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToGroup(r));
-	}
-
-	updateGroupState(
-		groupId: string,
-		newState: GroupState,
-		expectedVersion: number
-	): SessionGroup | null {
-		const result = this.db
-			.prepare(
-				`UPDATE session_groups SET state = ?, version = version + 1
-			 WHERE id = ? AND version = ?`
-			)
-			.run(newState, groupId, expectedVersion);
-		if (result.changes === 0) return null;
-		return this.getGroup(groupId);
 	}
 
 	completeGroup(groupId: string, expectedVersion: number): SessionGroup | null {
@@ -268,8 +248,8 @@ export class SessionGroupRepository {
 
 	/**
 	 * Reset a failed/completed group for task restart.
-	 * Sets state back to 'awaiting_worker', clears completed_at, and resets
-	 * metadata fields to allow the task to be picked up fresh by the runtime.
+	 * Clears completed_at and resets metadata fields to allow the task to be
+	 * picked up fresh by the runtime.
 	 */
 	resetGroupForRestart(groupId: string): SessionGroup | null {
 		const current = this.getGroup(groupId);
@@ -286,8 +266,7 @@ export class SessionGroupRepository {
 		const result = this.db
 			.prepare(
 				`UPDATE session_groups
-				 SET state = 'awaiting_worker',
-				     completed_at = NULL,
+				 SET completed_at = NULL,
 				     metadata = ?,
 				     version = version + 1
 				 WHERE id = ?`
@@ -596,7 +575,6 @@ export class SessionGroupRepository {
 			workerSessionId: (row.worker_session_id as string) ?? '',
 			leaderSessionId: (row.leader_session_id as string) ?? '',
 			workerRole: meta.workerRole ?? 'coder',
-			state: row.state as GroupState,
 			feedbackIteration: meta.feedbackIteration,
 			leaderContractViolations: meta.leaderContractViolations,
 			leaderCalledTool: meta.leaderCalledTool ?? false,

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -256,7 +256,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					const runtime = runtimeService.getRuntime(roomId);
 					if (runtime) {
 						const group = groupRepo.getGroupByTaskId(args.task_id);
-						if (group && group.state !== 'completed' && group.state !== 'failed') {
+						if (group && group.completedAt === null) {
 							// There's an active group - cancel it first if moving to terminal state
 							if (
 								args.status === 'completed' ||
@@ -403,11 +403,11 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				group: group
 					? {
 							id: group.id,
-							state: group.state,
+							completedAt: group.completedAt,
 							workerSessionId: group.workerSessionId,
 							leaderSessionId: group.leaderSessionId,
 							feedbackIteration: group.feedbackIteration,
-							awaitingHumanReview: group.state === 'awaiting_human',
+							awaitingHumanReview: group.submittedForReview,
 						}
 					: null,
 			});
@@ -419,12 +419,10 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			const activeGroups = groupRepo.getActiveGroups(roomId);
 
 			// Collect task IDs that need human review:
-			// either the task is in 'review' status OR the group is in 'awaiting_human' state
+			// either the task is in 'review' status OR the group has submittedForReview flag
 			const needsReviewIds = new Set<string>();
 			tasks.filter((t) => t.status === 'review').forEach((t) => needsReviewIds.add(t.id));
-			activeGroups
-				.filter((g) => g.state === 'awaiting_human')
-				.forEach((g) => needsReviewIds.add(g.taskId));
+			activeGroups.filter((g) => g.submittedForReview).forEach((g) => needsReviewIds.add(g.taskId));
 
 			const tasksNeedingReview = [...needsReviewIds].map((taskId) => {
 				const task = tasks.find((t) => t.id === taskId);
@@ -453,7 +451,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					groups: activeGroups.map((g) => ({
 						id: g.id,
 						taskId: g.taskId,
-						state: g.state,
+						submittedForReview: g.submittedForReview,
 						iteration: g.feedbackIteration,
 					})),
 					tasksNeedingReview,

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -10,7 +10,7 @@
  * - goal.reactivate - Reactivate a goal (return to active)
  * - goal.linkTask - Link a task to a goal
  * - goal.delete - Delete a goal
- * - goal.approveTask - Human approves a task PR (resumes worker for phase 2)
+ * - task.approve - Human approves a task PR (resumes worker for phase 2)
  */
 
 import type { MessageHub, RoomGoal, GoalStatus, GoalPriority } from '@neokai/shared';
@@ -287,8 +287,8 @@ export function setupGoalHandlers(
 		return { success };
 	});
 
-	// goal.approveTask - Human approves the PR; resume leader to call complete_task
-	messageHub.onRequest('goal.approveTask', async (data) => {
+	// task.approve - Human approves the PR; resume leader to complete task flow
+	const approveTaskHandler = async (data: unknown) => {
 		const params = data as { roomId: string; taskId: string };
 
 		if (!params.roomId) {
@@ -298,7 +298,9 @@ export function setupGoalHandlers(
 			throw new Error('Task ID is required');
 		}
 		if (!taskManagerFactory || !runtimeService) {
-			throw new Error('Task manager factory and runtime service are required for goal.approveTask');
+			throw new Error(
+				'Task manager factory and runtime service are required for task approval handlers'
+			);
 		}
 
 		const taskManager = taskManagerFactory(params.roomId);
@@ -333,5 +335,8 @@ export function setupGoalHandlers(
 
 		log.info(`Task ${params.taskId} approved by human in room ${params.roomId}`);
 		return { success: true };
-	});
+	};
+
+	// task.approve - Task-scoped RPC name
+	messageHub.onRequest('task.approve', approveTaskHandler);
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -101,7 +101,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		deps.sessionManager
 	);
 
-	// Room Runtime Service (must be created before task/goal handlers — sendHumanMessage/approveTask need it)
+	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)
 	const roomRuntimeService = new RoomRuntimeService({
 		db: deps.db,
 		messageHub: deps.messageHub,
@@ -125,7 +125,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		roomRuntimeService
 	);
 
-	// Goal handlers (after runtime service — approveTask/rejectTask need runtimeService)
+	// Goal handlers (after runtime service — task.approve/task.reject need runtimeService)
 	setupGoalHandlers(
 		deps.messageHub,
 		deps.daemonHub,

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -204,24 +204,17 @@ export function setupTaskHandlers(
 		if (runtimeService) {
 			const runtime = runtimeService.getRuntime(params.roomId);
 			if (runtime) {
-				const groupRepo = new SessionGroupRepository(db.getDatabase());
-				const group = groupRepo.getGroupByTaskId(params.taskId);
-				if (group && group.completedAt === null) {
-					// Cancel the task group (stops agents and marks task as cancelled)
-					// cancel() returns null if the group doesn't exist or version conflict occurred
-					const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
-					if (!cancelledGroup) {
-						throw new Error(
-							`Failed to cancel task ${params.taskId} — group may have been modified concurrently`
-						);
-					}
-					// Reload task to get updated status
-					const updatedTask = await taskManager.getTask(params.taskId);
-					if (updatedTask) {
-						emitTaskUpdate(params.roomId, updatedTask);
-						emitRoomOverview(params.roomId);
-						return { task: updatedTask };
-					}
+				const result = await runtime.cancelTask(params.taskId);
+				if (!result.success) {
+					throw new Error(
+						`Failed to cancel task ${params.taskId} — runtime cancellation was unsuccessful`
+					);
+				}
+				const updatedTask = await taskManager.getTask(params.taskId);
+				if (updatedTask) {
+					emitTaskUpdate(params.roomId, updatedTask);
+					emitRoomOverview(params.roomId);
+					return { task: updatedTask };
 				}
 			}
 		}
@@ -269,25 +262,36 @@ export function setupTaskHandlers(
 			);
 		}
 
-		// If there's an active group with runtime, cancel it when moving to terminal state
+		// If there's an active group with runtime, terminate it on terminal transitions.
 		if (runtimeService) {
 			const runtime = runtimeService.getRuntime(params.roomId);
 			if (runtime) {
-				const groupRepo = new SessionGroupRepository(db.getDatabase());
-				const group = groupRepo.getGroupByTaskId(params.taskId);
-				if (group && group.completedAt === null) {
-					// Cancel active group if moving to terminal state
-					if (
-						params.status === 'completed' ||
-						params.status === 'failed' ||
-						params.status === 'cancelled'
-					) {
-						const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
-						if (!cancelledGroup) {
+				const isTerminalStatus =
+					params.status === 'completed' ||
+					params.status === 'failed' ||
+					params.status === 'cancelled';
+				if (isTerminalStatus) {
+					if (params.status === 'cancelled') {
+						const cancelResult = await runtime.cancelTask(params.taskId);
+						if (!cancelResult.success) {
 							throw new Error(
-								`Failed to cancel task group for task ${params.taskId} — group may have been modified concurrently`
+								`Failed to cancel task ${params.taskId} — runtime cancellation was unsuccessful`
 							);
 						}
+						const cancelledTask = await taskManager.getTask(params.taskId);
+						if (!cancelledTask) {
+							throw new Error(`Task not found: ${params.taskId}`);
+						}
+						emitTaskUpdate(params.roomId, cancelledTask);
+						emitRoomOverview(params.roomId);
+						return { task: cancelledTask };
+					}
+
+					const terminated = await runtime.terminateTaskGroup(params.taskId);
+					if (!terminated) {
+						throw new Error(
+							`Failed to terminate task group for task ${params.taskId} — group may have been modified concurrently`
+						);
 					}
 				}
 			}
@@ -361,11 +365,13 @@ export function setupTaskHandlers(
 			throw new Error('No active session group for this task');
 		}
 
-		// Send rejection feedback to leader - leader handles routing to worker
+		// Resume via runtime so review parking flags and task status are updated consistently.
 		const message = `[Human Rejection]\n\n${params.feedback.trim()}`;
-		const injected = await runtime.injectMessageToLeader(params.taskId, message);
-		if (!injected) {
-			throw new Error('Failed to inject rejection feedback into leader session');
+		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, message, {
+			approved: false,
+		});
+		if (!resumed) {
+			throw new Error('Failed to reject task — task may not be awaiting review');
 		}
 
 		log.info(`Task ${params.taskId} rejected by human in room ${params.roomId}`);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -206,7 +206,7 @@ export function setupTaskHandlers(
 			if (runtime) {
 				const groupRepo = new SessionGroupRepository(db.getDatabase());
 				const group = groupRepo.getGroupByTaskId(params.taskId);
-				if (group && group.state !== 'completed' && group.state !== 'failed') {
+				if (group && group.completedAt === null) {
 					// Cancel the task group (stops agents and marks task as cancelled)
 					// cancel() returns null if the group doesn't exist or version conflict occurred
 					const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
@@ -275,7 +275,7 @@ export function setupTaskHandlers(
 			if (runtime) {
 				const groupRepo = new SessionGroupRepository(db.getDatabase());
 				const group = groupRepo.getGroupByTaskId(params.taskId);
-				if (group && group.state !== 'completed' && group.state !== 'failed') {
+				if (group && group.completedAt === null) {
 					// Cancel active group if moving to terminal state
 					if (
 						params.status === 'completed' ||
@@ -357,16 +357,15 @@ export function setupTaskHandlers(
 
 		const groupRepo = new SessionGroupRepository(db.getDatabase());
 		const group = groupRepo.getGroupByTaskId(params.taskId);
-		if (!group || group.state !== 'awaiting_human') {
-			throw new Error('Task is not awaiting human review');
+		if (!group) {
+			throw new Error('No active session group for this task');
 		}
 
-		// Resume worker with rejection feedback
-		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, params.feedback.trim(), {
-			approved: false,
-		});
-		if (!resumed) {
-			throw new Error(`Failed to resume task ${params.taskId} — no awaiting_human group found`);
+		// Send rejection feedback to leader - leader handles routing to worker
+		const message = `[Human Rejection]\n\n${params.feedback.trim()}`;
+		const injected = await runtime.injectMessageToLeader(params.taskId, message);
+		if (!injected) {
+			throw new Error('Failed to inject rejection feedback into leader session');
 		}
 
 		log.info(`Task ${params.taskId} rejected by human in room ${params.roomId}`);
@@ -397,8 +396,9 @@ export function setupTaskHandlers(
 				taskId: group.taskId,
 				workerSessionId: group.workerSessionId,
 				leaderSessionId: group.leaderSessionId,
-				state: group.state,
+				workerRole: group.workerRole,
 				feedbackIteration: group.feedbackIteration,
+				submittedForReview: group.submittedForReview,
 				approved: group.approved,
 				createdAt: group.createdAt,
 				completedAt: group.completedAt,
@@ -615,13 +615,13 @@ export function setupTaskHandlers(
 		return { messages, hasMore: false, nextCursor, hasOlder, oldestCursor };
 	});
 
-	// task.sendHumanMessage - Send a human message to the active agent in a task group
+	// task.sendHumanMessage - Send a human message to the worker or leader in a task group
 	messageHub.onRequest('task.sendHumanMessage', async (data) => {
 		const params = data as {
 			roomId: string;
 			taskId: string;
 			message: string;
-			target?: 'auto' | 'worker' | 'leader';
+			target?: 'worker' | 'leader';
 		};
 
 		if (!params.roomId) {
@@ -639,8 +639,8 @@ export function setupTaskHandlers(
 		if (params.message.length > 10_000) {
 			throw new Error('Message is too long (max 10,000 characters)');
 		}
-		const target = params.target ?? 'auto';
-		if (target !== 'auto' && target !== 'worker' && target !== 'leader') {
+		const target = params.target ?? 'worker';
+		if (target !== 'worker' && target !== 'leader') {
 			throw new Error(`Invalid target: ${target}`);
 		}
 		if (!runtimeService) {
@@ -666,8 +666,7 @@ export function setupTaskHandlers(
 			groupRepo,
 			params.taskId,
 			params.message.trim(),
-			target,
-			messageHub
+			target
 		);
 
 		if (!result.success) {

--- a/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
+++ b/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
@@ -80,10 +80,10 @@ describe('Room Advanced Scenarios (API-dependent)', () => {
 					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
-			// If planning is in 'review', approve via goal.approveTask to trigger phase 2
+			// If planning is in 'review', approve via task.approve to trigger phase 2
 			// (worker resumes with approved=true, creates draft tasks, leader completes)
 			if (terminalPlanning.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalPlanning.id,
 				});
@@ -127,7 +127,7 @@ describe('Room Advanced Scenarios (API-dependent)', () => {
 				);
 			}
 			if (terminalCoding.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalCoding.id,
 				});

--- a/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
@@ -114,10 +114,10 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
-			// If planning is in 'review', approve via goal.approveTask to trigger phase 2
+			// If planning is in 'review', approve via task.approve to trigger phase 2
 			// (worker resumes with approved=true, creates draft tasks, leader completes)
 			if (terminalPlanning.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalPlanning.id,
 				});
@@ -155,9 +155,9 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 					`Coding task failed: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
-			// If coding is in 'review', approve via goal.approveTask to trigger PR merge
+			// If coding is in 'review', approve via task.approve to trigger PR merge
 			if (terminalCoding.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalCoding.id,
 				});

--- a/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
+++ b/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
@@ -8,7 +8,7 @@
  *          sub-agents to review the plan PR. After reviews pass, leader
  *          calls submit_for_review → task goes to 'review' / awaiting_human.
  *
- * Human approval: goal.approveTask routes planning tasks to WORKER (not leader).
+ * Human approval: task.approve resumes the planner flow through leader routing.
  *                 Sets approved=true, injects approval into existing worker session (phase 2).
  *
  * Phase 2: Planner merges plan PR, reads PLAN.md, creates tasks 1:1 from
@@ -223,7 +223,7 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 
 				// --- Stage 6: Human approves → triggers phase 2 planner ---
 				console.log('Approving planning task (human approval)...');
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: planningTask.id,
 				});

--- a/packages/daemon/tests/online/room/room-replan-recovery.test.ts
+++ b/packages/daemon/tests/online/room/room-replan-recovery.test.ts
@@ -82,10 +82,10 @@ describe('Room Replan Recovery (API-dependent)', () => {
 					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
-			// If planning is in 'review', approve via goal.approveTask to trigger phase 2
+			// If planning is in 'review', approve via task.approve to trigger phase 2
 			// (worker resumes with approved=true, creates draft tasks, leader completes)
 			if (terminalPlanning.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalPlanning.id,
 				});
@@ -108,7 +108,7 @@ describe('Room Replan Recovery (API-dependent)', () => {
 				);
 			}
 			if (terminalCoding.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalCoding.id,
 				});
@@ -168,7 +168,7 @@ describe('Room Replan Recovery (API-dependent)', () => {
 				120_000
 			);
 			if (newTerminalPlanning.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: newTerminalPlanning.id,
 				});

--- a/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
@@ -137,9 +137,9 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 				);
 			}
 
-			// If planning is in 'review', approve it via goal.approveTask to trigger phase 2
+			// If planning is in 'review', approve it via task.approve to trigger phase 2
 			if (terminalPlanning.status === 'review') {
-				await daemon.messageHub.request('goal.approveTask', {
+				await daemon.messageHub.request('task.approve', {
 					roomId,
 					taskId: terminalPlanning.id,
 				});
@@ -279,7 +279,7 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 			// This should route to the WORKER (not leader) with approved=true
 			// Worker merges the PR via `gh pr merge`, then exits
 			// Leader receives terminal state and calls complete_task (bypasses submittedForReview gate)
-			const result = await daemon.messageHub.request('goal.approveTask', {
+			const result = await daemon.messageHub.request('task.approve', {
 				roomId,
 				taskId: codingTaskId,
 			});

--- a/packages/daemon/tests/online/room/room-test-helpers.ts
+++ b/packages/daemon/tests/online/room/room-test-helpers.ts
@@ -219,15 +219,24 @@ export async function waitForGroupState(
 	taskId: string,
 	targetStates: string[],
 	timeout = 120_000
-): Promise<{ id: string; state: string; feedbackIteration: number }> {
+): Promise<{ id: string; submittedForReview: boolean; feedbackIteration: number }> {
 	const start = Date.now();
 
 	while (Date.now() - start < timeout) {
 		const result = (await daemon.messageHub.request('task.getGroup', { roomId, taskId })) as {
-			group: { id: string; state: string; feedbackIteration: number } | null;
+			group: { id: string; submittedForReview: boolean; feedbackIteration: number } | null;
 		};
-		if (result.group && targetStates.includes(result.group.state)) {
-			return result.group;
+		// Map old state names to new submittedForReview flag
+		if (result.group) {
+			const isAwaitingHuman = result.group.submittedForReview;
+			const matchesTarget =
+				(targetStates.includes('awaiting_human') && isAwaitingHuman) ||
+				(targetStates.includes('awaiting_worker') && !isAwaitingHuman) ||
+				(targetStates.includes('awaiting_leader') && !isAwaitingHuman);
+
+			if (matchesTarget) {
+				return result.group;
+			}
 		}
 		await new Promise((r) => setTimeout(r, 1000));
 	}

--- a/packages/daemon/tests/unit/core/daemon-app-cleanup.test.ts
+++ b/packages/daemon/tests/unit/core/daemon-app-cleanup.test.ts
@@ -8,7 +8,7 @@
  * OFFLINE TESTS - No API calls required
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { createDaemonApp } from '../../../src/app';
 import type { Config } from '../../../src/config';
 
@@ -20,6 +20,7 @@ describe('Daemon App Cleanup', () => {
 	let originalClaudeCodeOAuthToken: string | undefined;
 	let originalAnthropicAuthToken: string | undefined;
 	let originalGlmApiKey: string | undefined;
+	let bunServeSpy: ReturnType<typeof spyOn> | null = null;
 	const logs: string[] = [];
 
 	beforeEach(() => {
@@ -39,6 +40,14 @@ describe('Daemon App Cleanup', () => {
 		originalConsoleError = console.error;
 		console.log = (...args) => logs.push(args.join(' '));
 		console.error = (...args) => logs.push(args.join(' '));
+
+		// Avoid real socket binding in unit tests.
+		bunServeSpy = spyOn(Bun, 'serve').mockImplementation(
+			(_opts: Parameters<typeof Bun.serve>[0]) =>
+				({
+					stop() {},
+				}) as never
+		);
 
 		// Use in-memory database for tests
 		const tmpDir = process.env.TMPDIR || '/tmp';
@@ -82,6 +91,10 @@ describe('Daemon App Cleanup', () => {
 		// Restore console
 		console.log = originalConsoleLog;
 		console.error = originalConsoleError;
+		if (bunServeSpy) {
+			bunServeSpy.mockRestore();
+			bunServeSpy = null;
+		}
 		logs.length = 0;
 	});
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -109,7 +109,7 @@ describe('Room Agent Tools', () => {
 			hibernatedAt: null,
 			tokensUsed: 0,
 			workerRole: 'coder',
-			submittedForReview: false,
+			submittedForReview: state === 'awaiting_human',
 			approved: false,
 		});
 		db.run(
@@ -779,10 +779,11 @@ describe('Room Agent Tools', () => {
 		it('should route message to worker when group is in awaiting_human state', async () => {
 			let capturedArgs: unknown[] = [];
 			const mockRuntime = {
-				resumeWorkerFromHuman: async (...args: unknown[]) => {
+				injectMessageToWorker: async (...args: unknown[]) => {
 					capturedArgs = args;
 					return true;
 				},
+				resumeWorkerFromHuman: async () => true,
 				injectMessageToLeader: async () => true,
 			};
 			const h = createRoomAgentToolHandlers({
@@ -800,16 +801,16 @@ describe('Room Agent Tools', () => {
 				await h.send_message_to_task({ task_id: taskId, message: 'Looks good, proceed' })
 			);
 			expect(result.success).toBe(true);
-			// routeHumanMessageToGroup calls resumeWorkerFromHuman for awaiting_human state
 			expect(capturedArgs[0]).toBe(taskId);
 			expect(capturedArgs[1]).toBe('Looks good, proceed');
 		});
 
-		it('should route message to leader when group is in awaiting_leader state', async () => {
+		it('should route message to worker by default even when group is in awaiting_leader state', async () => {
 			let capturedArgs: unknown[] = [];
 			const mockRuntime = {
 				resumeWorkerFromHuman: async () => true,
-				injectMessageToLeader: async (...args: unknown[]) => {
+				injectMessageToLeader: async () => true,
+				injectMessageToWorker: async (...args: unknown[]) => {
 					capturedArgs = args;
 					return true;
 				},
@@ -906,7 +907,7 @@ describe('Room Agent Tools', () => {
 		it('should report awaitingHumanReview as false for non-awaiting_human groups', async () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
-			insertGroup(taskId, false /* submittedForReview */);
+			insertGroup(taskId, 'awaiting_worker');
 
 			const result = parseResult(await handlers.get_task_detail({ task_id: taskId }));
 			const group = result.group as { completedAt: number | null; awaitingHumanReview: boolean };

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -888,7 +888,7 @@ describe('Room Agent Tools', () => {
 
 			const group = result.group as {
 				id: string;
-				state: string;
+				completedAt: number | null;
 				workerSessionId: string;
 				leaderSessionId: string;
 				feedbackIteration: number;
@@ -896,21 +896,21 @@ describe('Room Agent Tools', () => {
 			};
 			expect(group).not.toBeNull();
 			expect(group.id).toBe(`group-${taskId}`);
-			expect(group.state).toBe('awaiting_human');
+			expect(group.completedAt).toBeNull();
 			expect(group.workerSessionId).toBe('worker-session-1');
 			expect(group.leaderSessionId).toBe('leader-session-1');
 			expect(group.feedbackIteration).toBe(0);
 			expect(group.awaitingHumanReview).toBe(true);
 		});
 
-		it('should report awaitingHumanReview as false for non-awaiting_human states', async () => {
+		it('should report awaitingHumanReview as false for non-awaiting_human groups', async () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
-			insertGroup(taskId, 'awaiting_leader');
+			insertGroup(taskId, false /* submittedForReview */);
 
 			const result = parseResult(await handlers.get_task_detail({ task_id: taskId }));
-			const group = result.group as { state: string; awaitingHumanReview: boolean };
-			expect(group.state).toBe('awaiting_leader');
+			const group = result.group as { completedAt: number | null; awaitingHumanReview: boolean };
+			expect(group.completedAt).toBeNull();
 			expect(group.awaitingHumanReview).toBe(false);
 		});
 	});

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -20,7 +20,7 @@ describe('RoomRuntime flow', () => {
 	});
 
 	describe('agent model resolution', () => {
-		it('should use planner and leader models from room.config.agentModels', async () => {
+		it('should use planner model from room.config.agentModels for planning task spawn', async () => {
 			ctx.runtime.stop();
 			ctx.db.close();
 			ctx = createRuntimeTestContext({
@@ -51,16 +51,7 @@ describe('RoomRuntime flow', () => {
 			expect((createCalls[0].args[0] as { model?: string }).model).toBe('planner-model');
 
 			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
-			await ctx.runtime.onWorkerTerminalState(group.id, {
-				sessionId: group.workerSessionId,
-				kind: 'idle',
-			});
-
-			const leaderCall = ctx.sessionFactory.calls
-				.filter((c) => c.method === 'createAndStartSession')
-				.find((c) => c.args[1] === 'leader');
-			expect(leaderCall).toBeDefined();
-			expect((leaderCall!.args[0] as { model?: string }).model).toBe('leader-model');
+			expect(group.workerRole).toBe('planner');
 		});
 
 		it('should use role-specific worker model for coder and general tasks', async () => {
@@ -87,6 +78,21 @@ describe('RoomRuntime flow', () => {
 			);
 			expect(createCalls[0].args[1]).toBe('coder');
 			expect((createCalls[0].args[0] as { model?: string }).model).toBe('coder-model');
+
+			// Force lazy leader creation path in test harness (mock hasSession() defaults to true).
+			(ctx.sessionFactory as unknown as { hasSession: (sessionId: string) => boolean }).hasSession =
+				(sessionId: string) => sessionId.includes('coder');
+
+			const coderGroup = ctx.groupRepo.getActiveGroups('room-1')[0];
+			await ctx.runtime.onWorkerTerminalState(coderGroup.id, {
+				sessionId: coderGroup.workerSessionId,
+				kind: 'idle',
+			});
+			const leaderCall = ctx.sessionFactory.calls
+				.filter((c) => c.method === 'createAndStartSession')
+				.find((c) => c.args[1] === 'leader');
+			expect(leaderCall).toBeDefined();
+			expect((leaderCall!.args[0] as { model?: string }).model).toBe('leader-model');
 
 			ctx.runtime.stop();
 			ctx.db.close();
@@ -462,9 +468,9 @@ describe('RoomRuntime flow', () => {
 			// Task back in in_progress
 			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('in_progress');
 
-			// Leader hands off to worker so the work cycle can continue
+			// handoff_to_worker is a no-op compatibility tool
 			await ctx.runtime.handleLeaderTool(group.id, 'handoff_to_worker', {});
-			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_worker');
+			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_leader');
 
 			// Worker finishes again → routeWorkerToLeader increments to 1 (not 6!)
 			await ctx.runtime.onWorkerTerminalState(group.id, {
@@ -515,13 +521,13 @@ describe('RoomRuntime flow', () => {
 			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(3);
 		});
 
-		it('should reset leader contract violations on each new worker→leader round', async () => {
+		it('should keep leader contract violations at 0 when leader reaches terminal without a tool', async () => {
 			await createGoalAndTask(ctx);
 			ctx.runtime.start();
 			await ctx.runtime.tick();
 			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
 
-			// Worker done → Leader violates contract once
+			// Worker done -> Leader reaches terminal without any tool call.
 			await ctx.runtime.onWorkerTerminalState(group.id, {
 				sessionId: group.workerSessionId,
 				kind: 'idle',
@@ -530,25 +536,10 @@ describe('RoomRuntime flow', () => {
 				sessionId: group.leaderSessionId,
 				kind: 'idle',
 			});
-			expect(ctx.groupRepo.getGroup(group.id)!.leaderContractViolations).toBe(1);
-
-			// Leader sends feedback, then explicitly hands off to worker
-			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
-				message: 'Redo this',
-				mode: 'queue',
-			});
-			await ctx.runtime.handleLeaderTool(group.id, 'handoff_to_worker', {});
-			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_worker');
-
-			// Iteration 2: Worker done → routeWorkerToLeader resets violations to 0
-			await ctx.runtime.onWorkerTerminalState(group.id, {
-				sessionId: group.workerSessionId,
-				kind: 'idle',
-			});
 			expect(ctx.groupRepo.getGroup(group.id)!.leaderContractViolations).toBe(0);
 			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('awaiting_leader');
 
-			// Leader finishes cleanly
+			// Leader can still complete after review submission.
 			ctx.groupRepo.setSubmittedForReview(group.id, true);
 			await ctx.runtime.handleLeaderTool(group.id, 'complete_task', { summary: 'Done' });
 			expect(ctx.groupRepo.getGroup(group.id)!.state).toBe('completed');
@@ -590,7 +581,7 @@ describe('RoomRuntime flow', () => {
 	});
 
 	describe('onLeaderTerminalState (contract validation)', () => {
-		it('should nudge on first contract violation', async () => {
+		it('should not inject nudge messages when leader reaches terminal without a tool', async () => {
 			const { group } = await spawnAndRouteToLeader(ctx);
 
 			// Leader reaches terminal without calling a tool
@@ -599,21 +590,21 @@ describe('RoomRuntime flow', () => {
 				kind: 'idle',
 			});
 
-			// Should inject nudge message
+			// No nudge is injected in the simplified model.
 			const nudgeCalls = ctx.sessionFactory.calls.filter(
 				(c) =>
 					c.method === 'injectMessage' &&
 					c.args[0] === group.leaderSessionId &&
 					(c.args[1] as string).includes('must call exactly one')
 			);
-			expect(nudgeCalls).toHaveLength(1);
+			expect(nudgeCalls).toHaveLength(0);
 
-			// Violations should be 1
+			// Violations stay at 0.
 			const updated = ctx.groupRepo.getGroup(group.id);
-			expect(updated!.leaderContractViolations).toBe(1);
+			expect(updated!.leaderContractViolations).toBe(0);
 		});
 
-		it('should fail group on second contract violation', async () => {
+		it('should keep group active even after repeated leader terminal states without tools', async () => {
 			const { group } = await spawnAndRouteToLeader(ctx);
 
 			// First violation
@@ -628,9 +619,9 @@ describe('RoomRuntime flow', () => {
 				kind: 'idle',
 			});
 
-			// Group should be failed after second contract violation
+			// Group remains active; no contract-failure transition.
 			const updated = ctx.groupRepo.getGroup(group.id);
-			expect(updated!.state).toBe('failed');
+			expect(updated!.state).toBe('awaiting_leader');
 		});
 
 		it('should not fire if Leader called a tool', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -49,7 +49,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(updatedTask!.status).toBe('failed');
 		});
 
-		it('should handle send_to_worker without changing group state', async () => {
+		it('should handle send_to_worker and route turn back to worker', async () => {
 			const { group } = await spawnAndRouteToLeader(ctx);
 
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
@@ -61,7 +61,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(parsed.success).toBe(true);
 
 			const updatedGroup = ctx.groupRepo.getGroup(group.id)!;
-			expect(updatedGroup.state).toBe('awaiting_leader');
+			expect(updatedGroup.state).toBe('awaiting_worker');
 
 			// Should inject feedback into worker session using queue mode
 			const injectCalls = ctx.sessionFactory.calls.filter(
@@ -71,7 +71,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(injectCalls[0].args[2]).toEqual({ deliveryMode: 'next_turn' });
 		});
 
-		it('should handoff_to_worker explicitly', async () => {
+		it('should handoff_to_worker explicitly (no-op compatibility tool)', async () => {
 			const { group } = await spawnAndRouteToLeader(ctx);
 
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'handoff_to_worker', {});
@@ -79,10 +79,10 @@ describe('RoomRuntime leader tools', () => {
 			expect(parsed.success).toBe(true);
 
 			const updatedGroup = ctx.groupRepo.getGroup(group.id)!;
-			expect(updatedGroup.state).toBe('awaiting_worker');
+			expect(updatedGroup.state).toBe('awaiting_leader');
 		});
 
-		it('should reject if group not in awaiting_leader state', async () => {
+		it('should reject complete_task until submit_for_review is called', async () => {
 			await createGoalAndTask(ctx);
 			ctx.runtime.start();
 			await ctx.runtime.tick();
@@ -90,14 +90,14 @@ describe('RoomRuntime leader tools', () => {
 			const groups = ctx.groupRepo.getActiveGroups('room-1');
 			const group = groups[0];
 
-			// Group is in awaiting_worker (haven't routed to leader yet)
+			// Group is active but has not called submit_for_review yet.
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'complete_task', {
 				summary: 'Done',
 			});
 
 			const parsed = JSON.parse(result.content[0].text);
 			expect(parsed.success).toBe(false);
-			expect(parsed.error).toContain('awaiting_leader');
+			expect(parsed.error).toContain('submit_for_review');
 		});
 
 		it('should reject for non-existent group', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -14,18 +14,24 @@ import {
 /**
  * Helper: create a task + session group directly in DB (bypassing tick).
  * Avoids race conditions from scheduleTick background ticks.
+ * @param submittedForReview - If true, sets the group as awaiting human review
  */
 async function createTaskWithGroup(
 	ctx: RuntimeTestContext,
-	groupState = 'awaiting_worker'
+	submittedForReview = false
 ): Promise<{ taskId: string; groupId: string; workerSessionId: string; leaderSessionId: string }> {
 	const { task } = await createGoalAndTask(ctx);
 	const group = ctx.groupRepo.createGroup(task.id, `worker:${task.id}`, `leader:${task.id}`);
 	await ctx.taskManager.updateTaskStatus(task.id, 'in_progress');
 
-	if (groupState !== 'awaiting_worker') {
-		ctx.groupRepo.updateGroupState(group.id, groupState as never, group.version);
+	if (submittedForReview) {
+		// Set submittedForReview flag and task status to review
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+		await ctx.taskManager.reviewTask(task.id);
 	}
+
+	// Reload group to get the updated values after setSubmittedForReview
+	const updatedGroup = ctx.groupRepo.getGroup(group.id);
 
 	return {
 		taskId: task.id,
@@ -72,7 +78,7 @@ describe('Zombie detection in tick', () => {
 
 		// Group should still be active (not failed)
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('awaiting_worker');
+		expect(updated!.completedAt).toBeNull();
 	});
 
 	it('should fail group when zombie worker cannot be restored', async () => {
@@ -90,7 +96,7 @@ describe('Zombie detection in tick', () => {
 
 		// Group should be failed
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('failed');
+		expect(updated!.completedAt).not.toBeNull();
 
 		// Task should be failed
 		const updatedTask = await ctx.taskManager.getTask(taskId);
@@ -98,7 +104,7 @@ describe('Zombie detection in tick', () => {
 	});
 
 	it('should restore a zombie leader session during tick', async () => {
-		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
 
 		// Leader is missing from cache — becomes live after first restore
 		const restoredSessions = new Set<string>();
@@ -122,11 +128,11 @@ describe('Zombie detection in tick', () => {
 
 		// Group should still be active
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('awaiting_leader');
+		expect(updated!.completedAt).toBeNull();
 	});
 
-	it('should fail group when zombie leader cannot be restored', async () => {
-		const { taskId, groupId, leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+	it('should continue when zombie leader cannot be restored (lazily created)', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
 
 		// Leader missing and unrestorable
 		ctx.sessionFactory.hasSession = (sessionId: string) => {
@@ -138,11 +144,9 @@ describe('Zombie detection in tick', () => {
 		ctx.runtime.start();
 		await ctx.runtime.tick();
 
+		// Group should NOT be failed - leader is created lazily later
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('failed');
-
-		const updatedTask = await ctx.taskManager.getTask(taskId);
-		expect(updatedTask!.status).toBe('failed');
+		expect(updated!.completedAt).toBeNull();
 	});
 
 	it('should not interfere with normal tick when no zombies exist', async () => {
@@ -202,12 +206,12 @@ describe('Zombie detection in tick', () => {
 		expect(restoredSessions.has('worker-2')).toBe(true);
 
 		// Both groups should remain active
-		expect(ctx.groupRepo.getGroup(group1.id)!.state).toBe('awaiting_worker');
-		expect(ctx.groupRepo.getGroup(group2.id)!.state).toBe('awaiting_worker');
+		expect(ctx.groupRepo.getGroup(group1.id)!.completedAt).toBeNull();
+		expect(ctx.groupRepo.getGroup(group2.id)!.completedAt).toBeNull();
 	});
 
-	it('should restore zombie worker in awaiting_human group during tick', async () => {
-		const { groupId, workerSessionId } = await createTaskWithGroup(ctx, 'awaiting_human');
+	it('should restore zombie worker in submitted_for_review group during tick', async () => {
+		const { groupId, workerSessionId } = await createTaskWithGroup(ctx, true);
 
 		// Worker is missing — becomes live after restore
 		const restoredSessions = new Set<string>();
@@ -229,13 +233,13 @@ describe('Zombie detection in tick', () => {
 		);
 		expect(restoreCalls).toHaveLength(1);
 
-		// Group should remain in awaiting_human (not failed)
+		// Group should remain active (not failed)
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('awaiting_human');
+		expect(updated!.completedAt).toBeNull();
 	});
 
-	it('should fail awaiting_human group when worker cannot be restored', async () => {
-		const { taskId, groupId, workerSessionId } = await createTaskWithGroup(ctx, 'awaiting_human');
+	it('should fail submitted_for_review group when worker cannot be restored', async () => {
+		const { taskId, groupId, workerSessionId } = await createTaskWithGroup(ctx, true);
 
 		ctx.sessionFactory.hasSession = (sessionId: string) => {
 			if (sessionId === workerSessionId) return false;
@@ -247,7 +251,7 @@ describe('Zombie detection in tick', () => {
 		await ctx.runtime.tick();
 
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('failed');
+		expect(updated!.completedAt).not.toBeNull();
 
 		const updatedTask = await ctx.taskManager.getTask(taskId);
 		expect(updatedTask!.status).toBe('failed');
@@ -274,7 +278,7 @@ describe('Zombie detection in tick', () => {
 	});
 
 	it('should reattach observer after restoring zombie leader', async () => {
-		const { leaderSessionId } = await createTaskWithGroup(ctx, 'awaiting_leader');
+		const { leaderSessionId } = await createTaskWithGroup(ctx);
 
 		const restoredSessions = new Set<string>();
 		ctx.sessionFactory.hasSession = (sessionId: string) => {
@@ -305,9 +309,9 @@ describe('resumeWorkerFromHuman rollback', () => {
 		ctx.db.close();
 	});
 
-	it('should rollback task and group state when injectMessage fails', async () => {
-		const { taskId, groupId } = await createTaskWithGroup(ctx, 'awaiting_human');
-		await ctx.taskManager.reviewTask(taskId);
+	it('should rollback task when injectMessage fails', async () => {
+		const { taskId } = await createTaskWithGroup(ctx, true);
+		// Task is already in review status from createTaskWithGroup
 
 		// Make injectMessage fail (simulates session not in cache after restart)
 		ctx.sessionFactory.injectMessage = async () => {
@@ -318,26 +322,22 @@ describe('resumeWorkerFromHuman rollback', () => {
 		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');
 		expect(result).toBe(false);
 
-		// Group should revert to awaiting_human (not stuck in awaiting_worker)
-		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('awaiting_human');
-
 		// Task should revert to review (not stuck in in_progress)
 		const updatedTask = await ctx.taskManager.getTask(taskId);
 		expect(updatedTask!.status).toBe('review');
 	});
 
 	it('should succeed normally when injectMessage works', async () => {
-		const { taskId, groupId } = await createTaskWithGroup(ctx, 'awaiting_human');
-		await ctx.taskManager.reviewTask(taskId);
+		const { taskId, groupId } = await createTaskWithGroup(ctx, true);
+		// Task is already in review status from createTaskWithGroup
 
 		ctx.runtime.start();
 		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');
 		expect(result).toBe(true);
 
-		// Group should be awaiting_worker
+		// Group should still be active (completedAt null)
 		const updated = ctx.groupRepo.getGroup(groupId);
-		expect(updated!.state).toBe('awaiting_worker');
+		expect(updated!.completedAt).toBeNull();
 
 		// Task should be in_progress
 		const updatedTask = await ctx.taskManager.getTask(taskId);
@@ -350,8 +350,8 @@ describe('resumeWorkerFromHuman rollback', () => {
 		expect(result).toBe(false);
 	});
 
-	it('should return false when group is not in awaiting_human', async () => {
-		const { taskId } = await createTaskWithGroup(ctx, 'awaiting_worker');
+	it('should return false when group is not in submitted_for_review', async () => {
+		const { taskId } = await createTaskWithGroup(ctx, false);
 
 		ctx.runtime.start();
 		const result = await ctx.runtime.resumeWorkerFromHuman(taskId, 'Approved');

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -178,7 +178,7 @@ describe('Runtime Recovery', () => {
 
 		const group = groupRepo.createGroup(taskId, `worker:${taskId}`, `leader:${taskId}`);
 		if (groupState !== 'awaiting_worker') {
-			groupRepo.updateGroupState(group.id, groupState as never, group.version);
+			groupRepo.setCompatibilityState(group.id, groupState as never);
 		}
 
 		return { taskId, group: groupRepo.getGroup(group.id) };
@@ -242,12 +242,12 @@ describe('Runtime Recovery', () => {
 			runtime
 		);
 
-		expect(result.failedGroups).toBe(1);
-		const updatedGroup = groupRepo.getGroup(group!.id);
-		expect(updatedGroup!.state).toBe('failed');
+		expect(result.failedGroups).toBe(0);
+		expect(observer.isObserving(group!.workerSessionId)).toBe(true);
+		expect(observer.isObserving(group!.leaderSessionId)).toBe(true);
 
 		const task = await taskManager.getTask(taskId);
-		expect(task!.status).toBe('failed');
+		expect(task!.status).toBe('in_progress');
 	});
 
 	it('should reattach observers for active worker sessions', async () => {
@@ -264,8 +264,9 @@ describe('Runtime Recovery', () => {
 			runtime
 		);
 
-		expect(result.reattachedObservers).toBe(1);
+		expect(result.reattachedObservers).toBe(2);
 		expect(observer.isObserving(group!.workerSessionId)).toBe(true);
+		expect(observer.isObserving(group!.leaderSessionId)).toBe(true);
 	});
 
 	it('should observe leader session id in awaiting_worker recovery even before leader exists', async () => {
@@ -304,7 +305,8 @@ describe('Runtime Recovery', () => {
 			runtime
 		);
 
-		expect(result.reattachedObservers).toBe(1);
+		expect(result.reattachedObservers).toBe(2);
+		expect(observer.isObserving(group!.workerSessionId)).toBe(true);
 		expect(observer.isObserving(group!.leaderSessionId)).toBe(true);
 	});
 
@@ -350,9 +352,10 @@ describe('Runtime Recovery', () => {
 		expect(result.recoveredGroups).toBe(1);
 		expect(result.failedGroups).toBe(0);
 		expect(result.restoredSessions).toBeGreaterThanOrEqual(1);
-		expect(result.reattachedObservers).toBe(1);
+		expect(result.reattachedObservers).toBe(2);
 		// Worker observer should be attached for future approval
 		expect(observer.isObserving(group!.workerSessionId)).toBe(true);
+		expect(observer.isObserving(group!.leaderSessionId)).toBe(true);
 	});
 
 	it('should fail awaiting_human group when worker cannot be restored', async () => {
@@ -403,7 +406,7 @@ describe('Runtime Recovery', () => {
 
 		expect(result.restoredSessions).toBeGreaterThanOrEqual(1);
 		expect(restoreCalls).toContain(group!.workerSessionId);
-		expect(result.reattachedObservers).toBe(1);
+		expect(result.reattachedObservers).toBe(2);
 	});
 
 	it('should handle multiple groups with mixed states', async () => {
@@ -423,7 +426,7 @@ describe('Runtime Recovery', () => {
 		);
 
 		expect(result.recoveredGroups).toBe(3);
-		// All 3 groups get observers (awaiting_human now restores and observes too)
-		expect(result.reattachedObservers).toBe(3);
+		// Each group observes both worker and leader sessions.
+		expect(result.reattachedObservers).toBe(6);
 	});
 });

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -1,13 +1,8 @@
 /**
  * Tests for routeHumanMessageToGroup
  *
- * Covers all session group state branches:
- * - awaiting_human  → calls resumeWorkerFromHuman
- * - awaiting_leader → calls injectMessageToLeader
- * - awaiting_worker → auto mode returns error; explicit target routes directly
- * - completed       → returns error
- * - failed          → returns error
- * - no group        → returns error
+ * Simplified routing: Messages can be sent to worker or leader at any time.
+ * Only fails if no group or group is completed (completedAt !== null).
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -16,10 +11,9 @@ import type { RoomRuntime } from '../../../../src/lib/room/runtime/room-runtime'
 import type {
 	SessionGroupRepository,
 	SessionGroup,
-	GroupState,
 } from '../../../../src/lib/room/state/session-group-repository';
 
-function makeGroup(state: GroupState): SessionGroup {
+function makeGroup(completedAt: number | null): SessionGroup {
 	return {
 		id: 'group-1',
 		taskId: 'task-1',
@@ -27,7 +21,6 @@ function makeGroup(state: GroupState): SessionGroup {
 		workerSessionId: 'worker-session',
 		leaderSessionId: 'leader-session',
 		workerRole: 'coder',
-		state,
 		feedbackIteration: 0,
 		approved: false,
 		leaderContractViolations: 0,
@@ -41,7 +34,7 @@ function makeGroup(state: GroupState): SessionGroup {
 		tokensUsed: 0,
 		submittedForReview: false,
 		createdAt: Date.now(),
-		completedAt: null,
+		completedAt,
 	};
 }
 
@@ -70,124 +63,73 @@ function makeRuntime(
 function makeGroupRepo(group: SessionGroup | null): {
 	groupRepo: SessionGroupRepository;
 	getGroupByTaskId: ReturnType<typeof mock>;
-	appendMessage: ReturnType<typeof mock>;
 } {
 	const getGroupByTaskId = mock(() => group);
-	const appendMessage = mock(() => 1);
 
 	const groupRepo = {
 		getGroupByTaskId,
-		appendMessage,
 	} as unknown as SessionGroupRepository;
 
-	return { groupRepo, getGroupByTaskId, appendMessage };
+	return { groupRepo, getGroupByTaskId };
 }
 
 describe('routeHumanMessageToGroup', () => {
 	const taskId = 'task-1';
 	const message = 'Hello from human';
 
-	describe('awaiting_human state', () => {
-		it('calls resumeWorkerFromHuman with approved=false and returns success', async () => {
-			const { runtime, resumeWorkerFromHuman } = makeRuntime(true);
-			const { groupRepo, appendMessage } = makeGroupRepo(makeGroup('awaiting_human'));
+	describe('target=worker (default)', () => {
+		it('injects to worker and returns success', async () => {
+			const { runtime, injectMessageToWorker } = makeRuntime(true, true);
+			const { groupRepo } = makeGroupRepo(makeGroup(null));
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(true);
-			expect(resumeWorkerFromHuman).toHaveBeenCalledWith(taskId, message, { approved: false });
-			// appendMessage must NOT be called — resumeWorkerFromHuman handles it internally
-			expect(appendMessage).not.toHaveBeenCalled();
-		});
-
-		it('returns error when resumeWorkerFromHuman returns false', async () => {
-			const { runtime } = makeRuntime(false);
-			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_human'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBeDefined();
-		});
-	});
-
-	describe('awaiting_leader state', () => {
-		it('calls injectMessageToLeader on success', async () => {
-			const { runtime, injectMessageToLeader } = makeRuntime(true, true);
-			const { groupRepo, appendMessage } = makeGroupRepo(makeGroup('awaiting_leader'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(true);
-			expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);
-			expect(appendMessage).not.toHaveBeenCalled();
-		});
-
-		it('returns error and does not append when injectMessageToLeader fails', async () => {
-			const { runtime } = makeRuntime(true, false);
-			const { groupRepo, appendMessage } = makeGroupRepo(makeGroup('awaiting_leader'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('Failed to inject message into leader session');
-			expect(appendMessage).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('awaiting_worker state', () => {
-		it('returns failure with descriptive error in auto mode', async () => {
-			const { runtime } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('Worker is running');
-		});
-
-		it('injects directly to worker when target=worker', async () => {
-			const { runtime, injectMessageToWorker } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'worker');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 		});
 
-		it('injects to leader when target=leader', async () => {
-			const { runtime, injectMessageToLeader } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup('awaiting_worker'));
+		it('returns error when injectMessageToWorker fails', async () => {
+			const { runtime } = makeRuntime(true, false);
+			const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to inject message into worker session');
+		});
+	});
+
+	describe('target=leader', () => {
+		it('injects to leader and returns success', async () => {
+			const { runtime, injectMessageToLeader } = makeRuntime(true, true);
+			const { groupRepo } = makeGroupRepo(makeGroup(null));
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
 
 			expect(result.success).toBe(true);
 			expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);
 		});
+
+		it('returns error when injectMessageToLeader fails', async () => {
+			const { runtime } = makeRuntime(true, false);
+			const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to inject message into leader session');
+		});
 	});
 
-	describe('completed state', () => {
-		it('returns failure with completed error', async () => {
+	describe('completed group', () => {
+		it('returns failure when group has completedAt set', async () => {
 			const { runtime } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup('completed'));
+			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()));
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('completed');
-		});
-	});
-
-	describe('failed state', () => {
-		it('returns failure with failed error', async () => {
-			const { runtime } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup('failed'));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('failed');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
-import type { GroupState } from '../../../src/lib/room/state/session-group-repository';
 
 describe('SessionGroupRepository', () => {
 	let db: Database;
@@ -80,7 +79,6 @@ describe('SessionGroupRepository', () => {
 			expect(group.workerSessionId).toBe(workerSessionId);
 			expect(group.leaderSessionId).toBe(leaderSessionId);
 			expect(group.workerRole).toBe('coder');
-			expect(group.state).toBe('awaiting_worker');
 			expect(group.feedbackIteration).toBe(0);
 			expect(group.leaderContractViolations).toBe(0);
 			expect(group.lastProcessedLeaderTurnId).toBeNull();
@@ -140,22 +138,6 @@ describe('SessionGroupRepository', () => {
 		});
 	});
 
-	describe('updateGroupState', () => {
-		it('should update state with correct version', () => {
-			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
-			const updated = repo.updateGroupState(group.id, 'awaiting_leader', group.version);
-			expect(updated).not.toBeNull();
-			expect(updated!.state).toBe('awaiting_leader');
-			expect(updated!.version).toBe(group.version + 1);
-		});
-
-		it('should return null on version mismatch', () => {
-			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
-			const result = repo.updateGroupState(group.id, 'awaiting_leader', group.version + 999);
-			expect(result).toBeNull();
-		});
-	});
-
 	describe('incrementFeedbackIteration', () => {
 		it('should increment feedback count', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
@@ -174,10 +156,9 @@ describe('SessionGroupRepository', () => {
 	});
 
 	describe('completeGroup', () => {
-		it('should set state to completed and set completedAt', () => {
+		it('should set completedAt timestamp', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
 			const completed = repo.completeGroup(group.id, group.version);
-			expect(completed!.state).toBe('completed');
 			expect(completed!.completedAt).toBeDefined();
 			expect(completed!.completedAt).toBeGreaterThan(0);
 			expect(completed!.version).toBe(group.version + 1);
@@ -185,10 +166,9 @@ describe('SessionGroupRepository', () => {
 	});
 
 	describe('failGroup', () => {
-		it('should set state to failed and set completedAt', () => {
+		it('should set completedAt timestamp', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
 			const failed = repo.failGroup(group.id, group.version);
-			expect(failed!.state).toBe('failed');
 			expect(failed!.completedAt).toBeDefined();
 			expect(failed!.completedAt).toBeGreaterThan(0);
 		});
@@ -252,7 +232,7 @@ describe('SessionGroupRepository', () => {
 	});
 
 	describe('resetGroupForRestart', () => {
-		it('should reset failed group to awaiting_worker state', () => {
+		it('should reset failed group (clear completedAt)', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
 			// Set to failed state
 			repo.failGroup(group.id, group.version);
@@ -260,11 +240,10 @@ describe('SessionGroupRepository', () => {
 			// Reset for restart
 			const reset = repo.resetGroupForRestart(group.id);
 			expect(reset).not.toBeNull();
-			expect(reset!.state).toBe('awaiting_worker');
 			expect(reset!.completedAt).toBeNull();
 		});
 
-		it('should reset completed group to awaiting_worker state', () => {
+		it('should reset completed group (clear completedAt)', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
 			// Set to completed state
 			repo.completeGroup(group.id, group.version);
@@ -272,7 +251,6 @@ describe('SessionGroupRepository', () => {
 			// Reset for restart
 			const reset = repo.resetGroupForRestart(group.id);
 			expect(reset).not.toBeNull();
-			expect(reset!.state).toBe('awaiting_worker');
 			expect(reset!.completedAt).toBeNull();
 		});
 
@@ -347,16 +325,16 @@ describe('SessionGroupRepository', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
 
 			// First update succeeds
-			const first = repo.updateGroupState(group.id, 'awaiting_leader', group.version);
+			const first = repo.incrementFeedbackIteration(group.id, group.version);
 			expect(first).not.toBeNull();
 
 			// Second update with stale version fails
-			const second = repo.updateGroupState(group.id, 'awaiting_human', group.version);
+			const second = repo.incrementFeedbackIteration(group.id, group.version);
 			expect(second).toBeNull();
 
 			// Verify first update stuck
 			const final = repo.getGroup(group.id);
-			expect(final!.state).toBe('awaiting_leader');
+			expect(final!.feedbackIteration).toBe(1);
 		});
 	});
 
@@ -394,26 +372,6 @@ describe('SessionGroupRepository', () => {
 			const page2 = repo.getEvents(group.id, { afterId: page1.events.at(-1)!.id });
 			expect(page2.events).toHaveLength(2);
 			expect(page2.hasMore).toBe(false);
-		});
-	});
-
-	describe('GroupState type coverage', () => {
-		it('should accept all valid states', () => {
-			const states: GroupState[] = [
-				'awaiting_worker',
-				'awaiting_leader',
-				'awaiting_human',
-				'completed',
-				'failed',
-			];
-			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
-			let currentVersion = group.version;
-
-			for (const state of states.slice(0, 3)) {
-				const updated = repo.updateGroupState(group.id, state, currentVersion);
-				expect(updated).not.toBeNull();
-				currentVersion = updated!.version;
-			}
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -15,12 +15,20 @@
  */
 
 import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
-import { MessageHub, type RoomGoal, type GoalStatus, type GoalPriority } from '@neokai/shared';
+import {
+	MessageHub,
+	type RoomGoal,
+	type GoalStatus,
+	type GoalPriority,
+	type NeoTask,
+} from '@neokai/shared';
 import {
 	setupGoalHandlers,
 	type GoalManagerLike,
+	type TaskManagerFactory,
 } from '../../../src/lib/rpc-handlers/goal-handlers';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
+import type { RoomRuntimeService } from '../../../src/lib/room/runtime/room-runtime-service';
 
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
@@ -701,6 +709,122 @@ describe('Goal RPC Handlers', () => {
 			};
 
 			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('task approval handlers', () => {
+		function setupApprovalHandlers(task: NeoTask | null, resumeResult = true) {
+			const taskManager = {
+				getTask: mock(async () => task),
+				reviewTask: mock(async () => task),
+				updateTaskStatus: mock(async () => task),
+			};
+			const taskManagerFactory: TaskManagerFactory = mock(() => taskManager);
+
+			const runtime = {
+				resumeWorkerFromHuman: mock(async () => resumeResult),
+			};
+			const runtimeService = {
+				getRuntime: mock(() => runtime),
+			} as unknown as RoomRuntimeService;
+
+			setupGoalHandlers(
+				messageHubData.hub,
+				daemonHubData.daemonHub,
+				createMockGoalManager,
+				taskManagerFactory,
+				runtimeService
+			);
+
+			return { taskManager, runtime, runtimeService };
+		}
+
+		it('registers task.approve handler', async () => {
+			setupApprovalHandlers(null, true);
+			expect(messageHubData.handlers.get('task.approve')).toBeDefined();
+		});
+
+		it('approves coding task via task.approve and resumes runtime', async () => {
+			const task = {
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Task',
+				description: '',
+				status: 'review',
+				priority: 'normal',
+				taskType: 'coding',
+				progress: 0,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as NeoTask;
+			const { runtime } = setupApprovalHandlers(task, true);
+			const handler = messageHubData.handlers.get('task.approve');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+				success: boolean;
+			};
+
+			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
+				'task-123',
+				expect.stringContaining('Human has approved the PR'),
+				{ approved: true }
+			);
+			expect(result.success).toBe(true);
+		});
+
+		it('approves planning task via task.approve and resumes runtime', async () => {
+			const task = {
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Task',
+				description: '',
+				status: 'review',
+				priority: 'normal',
+				taskType: 'planning',
+				progress: 0,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as NeoTask;
+			const { runtime } = setupApprovalHandlers(task, true);
+			const handler = messageHubData.handlers.get('task.approve');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ roomId: 'room-123', taskId: 'task-123' }, {})) as {
+				success: boolean;
+			};
+
+			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
+				'task-123',
+				expect.stringContaining('create tasks 1:1 from the approved plan'),
+				{ approved: true }
+			);
+			expect(result.success).toBe(true);
+		});
+
+		it('throws when task.approve resume fails', async () => {
+			const task = {
+				id: 'task-123',
+				roomId: 'room-123',
+				title: 'Task',
+				description: '',
+				status: 'review',
+				priority: 'normal',
+				taskType: 'coding',
+				progress: 0,
+				dependsOn: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as NeoTask;
+			setupApprovalHandlers(task, false);
+			const handler = messageHubData.handlers.get('task.approve');
+			expect(handler).toBeDefined();
+
+			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
+				'Failed to resume task task-123'
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -139,7 +139,18 @@ function makeRuntimeService(resumeResult = true, injectResult = true) {
 	const resumeWorkerFromHuman = mock(async () => resumeResult);
 	const injectMessageToLeader = mock(async () => injectResult);
 	const injectMessageToWorker = mock(async () => injectResult);
-	const runtime = { resumeWorkerFromHuman, injectMessageToLeader, injectMessageToWorker };
+	const cancelTask = mock(async () => ({
+		success: injectResult,
+		cancelledTaskIds: injectResult ? ['task-1'] : [],
+	}));
+	const terminateTaskGroup = mock(async () => injectResult);
+	const runtime = {
+		resumeWorkerFromHuman,
+		injectMessageToLeader,
+		injectMessageToWorker,
+		cancelTask,
+		terminateTaskGroup,
+	};
 	const service = {
 		getRuntime: mock(() => runtime),
 	} as unknown as RoomRuntimeService;
@@ -389,6 +400,16 @@ describe('task.cancel RPC Handler', () => {
 	});
 
 	describe('happy paths', () => {
+		it('uses runtime.cancelTask when runtime is available', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			const { service, runtime } = makeRuntimeService(true);
+			setup({ task: inProgressTask, submittedForReview: false, runtimeService: service });
+
+			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			expect(runtime.cancelTask).toHaveBeenCalledWith('task-1');
+			expect(result).toEqual({ task: inProgressTask });
+		});
+
 		it('cancels a pending task without active group', async () => {
 			const pendingTask = { ...mockTask, status: 'pending' as const };
 			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
@@ -546,14 +567,29 @@ describe('task.reject RPC Handler', () => {
 	describe('happy path', () => {
 		it('rejects a task in review with active group', async () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
-			const { service } = makeRuntimeService(true);
+			const { service, runtime } = makeRuntimeService(true);
 			setup({ task: reviewTask, submittedForReview: true, runtimeService: service });
 
 			const result = await getHandler()(
 				{ roomId: 'room-1', taskId: 'task-1', feedback: 'please fix the bug' },
 				{}
 			);
+			expect(runtime.resumeWorkerFromHuman).toHaveBeenCalledWith(
+				'task-1',
+				'[Human Rejection]\n\nplease fix the bug',
+				{ approved: false }
+			);
 			expect(result).toEqual({ success: true });
+		});
+
+		it('throws when runtime resume fails', async () => {
+			const reviewTask = { ...mockTask, status: 'review' as const };
+			const { service } = makeRuntimeService(false);
+			setup({ task: reviewTask, submittedForReview: true, runtimeService: service });
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'please fix' }, {})
+			).rejects.toThrow('Failed to reject task');
 		});
 	});
 });
@@ -582,20 +618,21 @@ describe('task.setStatus RPC Handler', () => {
 		return mock(() => manager);
 	}
 
-	/**
-	 * Create a runtime service with a taskGroupManager that can be controlled
-	 */
-	function makeRuntimeServiceWithGroupManager(
-		cancelResult: unknown = { id: 'group-1', state: 'cancelled' }
-	) {
-		const cancel = mock(async () => cancelResult);
-		const runtime = {
-			taskGroupManager: { cancel },
-		};
+	/** Create a runtime service with cancelTask/terminateTaskGroup controls. */
+	function makeRuntimeServiceWithRuntimeCleanup(options?: {
+		cancelSuccess?: boolean;
+		terminateSuccess?: boolean;
+	}) {
+		const cancelTask = mock(async () => ({
+			success: options?.cancelSuccess ?? true,
+			cancelledTaskIds: options?.cancelSuccess === false ? [] : ['task-1'],
+		}));
+		const terminateTaskGroup = mock(async () => options?.terminateSuccess ?? true);
+		const runtime = { cancelTask, terminateTaskGroup };
 		const service = {
 			getRuntime: mock(() => runtime),
 		} as unknown as RoomRuntimeService;
-		return { service, runtime, cancel };
+		return { service, runtime, cancelTask, terminateTaskGroup };
 	}
 
 	function setup(opts: {
@@ -684,8 +721,7 @@ describe('task.setStatus RPC Handler', () => {
 
 	describe('group cancellation', () => {
 		it('throws when group cancellation fails due to version conflict', async () => {
-			// Create runtime service where cancel returns null (simulating version conflict)
-			const { service } = makeRuntimeServiceWithGroupManager(null);
+			const { service } = makeRuntimeServiceWithRuntimeCleanup({ terminateSuccess: false });
 
 			setup({
 				task: mockTask, // in_progress status
@@ -695,15 +731,11 @@ describe('task.setStatus RPC Handler', () => {
 
 			await expect(
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
-			).rejects.toThrow('Failed to cancel task group');
+			).rejects.toThrow('Failed to terminate task group');
 		});
 
 		it('succeeds when group cancellation succeeds', async () => {
-			// Create runtime service where cancel returns a valid group
-			const { service, cancel } = makeRuntimeServiceWithGroupManager({
-				id: 'group-1',
-				completedAt: Date.now(),
-			});
+			const { service, terminateTaskGroup } = makeRuntimeServiceWithRuntimeCleanup();
 
 			setup({
 				task: mockTask, // in_progress status
@@ -715,12 +747,14 @@ describe('task.setStatus RPC Handler', () => {
 				{ roomId: 'room-1', taskId: 'task-1', status: 'completed' },
 				{}
 			);
-			expect(cancel).toHaveBeenCalledWith('group-1');
+			expect(terminateTaskGroup).toHaveBeenCalledWith('task-1');
 			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
 		});
 
-		it('does not cancel group when moving to non-terminal state', async () => {
-			const { service, cancel } = makeRuntimeServiceWithGroupManager();
+		it('uses runtime.cancelTask when moving to cancelled', async () => {
+			const { service, cancelTask, terminateTaskGroup } = makeRuntimeServiceWithRuntimeCleanup({
+				cancelSuccess: true,
+			});
 
 			setup({
 				task: mockTask, // in_progress status
@@ -728,9 +762,28 @@ describe('task.setStatus RPC Handler', () => {
 				runtimeService: service,
 			});
 
-			// Moving to 'review' is not a terminal state, so group shouldn't be cancelled
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'cancelled' },
+				{}
+			);
+			expect(cancelTask).toHaveBeenCalledWith('task-1');
+			expect(terminateTaskGroup).not.toHaveBeenCalled();
+			expect(result).toEqual({ task: mockTask });
+		});
+
+		it('does not terminate group when moving to non-terminal state', async () => {
+			const { service, cancelTask, terminateTaskGroup } = makeRuntimeServiceWithRuntimeCleanup();
+
+			setup({
+				task: mockTask, // in_progress status
+				submittedForReview: true,
+				runtimeService: service,
+			});
+
+			// Moving to 'review' is not a terminal state, so group shouldn't be terminated
 			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'review' }, {});
-			expect(cancel).not.toHaveBeenCalled();
+			expect(cancelTask).not.toHaveBeenCalled();
+			expect(terminateTaskGroup).not.toHaveBeenCalled();
 		});
 
 		it('does not cancel group when no runtime service', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -92,12 +92,12 @@ function makeTaskManagerFactory(task: NeoTask | null): TaskManagerFactory {
  * Build a mock SQLite row that SessionGroupRepository.rowToGroup() can parse.
  * All fields that rowToGroup() reads are included.
  */
-function makeGroupRow(state: string): Record<string, unknown> {
+function makeGroupRow(submittedForReview = false): Record<string, unknown> {
 	return {
 		id: 'group-1',
 		group_type: 'task',
 		ref_id: 'task-1',
-		state,
+		state: submittedForReview ? 'awaiting_human' : 'awaiting_worker', // DB column kept for compat
 		version: 1,
 		metadata: JSON.stringify({
 			workerRole: 'coder',
@@ -110,7 +110,7 @@ function makeGroupRow(state: string): Record<string, unknown> {
 			activeWorkElapsed: 0,
 			hibernatedAt: null,
 			tokensUsed: 0,
-			submittedForReview: false,
+			submittedForReview,
 			approved: false,
 		}),
 		created_at: Date.now(),
@@ -138,7 +138,8 @@ function makeDb(groupRow: Record<string, unknown> | null): Database {
 function makeRuntimeService(resumeResult = true, injectResult = true) {
 	const resumeWorkerFromHuman = mock(async () => resumeResult);
 	const injectMessageToLeader = mock(async () => injectResult);
-	const runtime = { resumeWorkerFromHuman, injectMessageToLeader };
+	const injectMessageToWorker = mock(async () => injectResult);
+	const runtime = { resumeWorkerFromHuman, injectMessageToLeader, injectMessageToWorker };
 	const service = {
 		getRuntime: mock(() => runtime),
 	} as unknown as RoomRuntimeService;
@@ -165,10 +166,10 @@ describe('task.sendHumanMessage RPC Handler', () => {
 	 */
 	function setup(opts: {
 		task?: NeoTask | null;
-		groupState?: string;
+		submittedForReview?: boolean;
 		runtimeService?: RoomRuntimeService;
 	}) {
-		const { task = mockTask, groupState = 'awaiting_human', runtimeService } = opts;
+		const { task = mockTask, submittedForReview = false, runtimeService } = opts;
 
 		const mh = createMockMessageHub();
 		hub = mh.hub;
@@ -178,7 +179,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			hub,
 			mockRoomManager,
 			createMockDaemonHub(),
-			makeDb(makeGroupRow(groupState)),
+			makeDb(makeGroupRow(submittedForReview)),
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -262,9 +263,9 @@ describe('task.sendHumanMessage RPC Handler', () => {
 	// ─── Routing behaviour ───
 
 	describe('routing', () => {
-		it('returns { success: true } when group is in awaiting_human state', async () => {
+		it('returns { success: true } when group is active (submittedForReview)', async () => {
 			const { service } = makeRuntimeService(true);
-			setup({ groupState: 'awaiting_human', runtimeService: service });
+			setup({ submittedForReview: true, runtimeService: service });
 
 			const result = await getHandler()(
 				{ roomId: 'room-1', taskId: 'task-1', message: 'please continue' },
@@ -273,13 +274,15 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('throws when group is in awaiting_worker state', async () => {
-			const { service } = makeRuntimeService();
-			setup({ groupState: 'awaiting_worker', runtimeService: service });
+		it('returns { success: true } when group is active (not submittedForReview)', async () => {
+			const { service } = makeRuntimeService(true);
+			setup({ submittedForReview: false, runtimeService: service });
 
-			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
-			).rejects.toThrow('Worker is running');
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'hello' },
+				{}
+			);
+			expect(result).toEqual({ success: true });
 		});
 
 		it('throws when no active group exists for the task', async () => {
@@ -313,10 +316,10 @@ describe('task.cancel RPC Handler', () => {
 
 	function setup(opts: {
 		task?: NeoTask | null;
-		groupState?: string;
+		submittedForReview?: boolean;
 		runtimeService?: RoomRuntimeService;
 	}) {
-		const { task = mockTask, groupState = 'awaiting_human', runtimeService } = opts;
+		const { task = mockTask, submittedForReview = false, runtimeService } = opts;
 
 		const mh = createMockMessageHub();
 		hub = mh.hub;
@@ -326,7 +329,7 @@ describe('task.cancel RPC Handler', () => {
 			hub,
 			mockRoomManager,
 			createMockDaemonHub(),
-			makeDb(makeGroupRow(groupState)),
+			makeDb(makeGroupRow(submittedForReview)),
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -417,10 +420,10 @@ describe('task.reject RPC Handler', () => {
 
 	function setup(opts: {
 		task?: NeoTask | null;
-		groupState?: string;
+		submittedForReview?: boolean;
 		runtimeService?: RoomRuntimeService;
 	}) {
-		const { task = mockTask, groupState = 'awaiting_human', runtimeService } = opts;
+		const { task = mockTask, submittedForReview = false, runtimeService } = opts;
 
 		const mh = createMockMessageHub();
 		hub = mh.hub;
@@ -430,7 +433,7 @@ describe('task.reject RPC Handler', () => {
 			hub,
 			mockRoomManager,
 			createMockDaemonHub(),
-			makeDb(makeGroupRow(groupState)),
+			makeDb(makeGroupRow(submittedForReview)),
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -515,16 +518,7 @@ describe('task.reject RPC Handler', () => {
 		});
 	});
 
-	describe('group state validation', () => {
-		it('throws when group is not in awaiting_human state', async () => {
-			const reviewTask = { ...mockTask, status: 'review' as const };
-			const { service } = makeRuntimeService();
-			setup({ task: reviewTask, groupState: 'awaiting_worker', runtimeService: service });
-			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
-			).rejects.toThrow('Task is not awaiting human review');
-		});
-
+	describe('group validation', () => {
 		it('throws when no active group exists', async () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
 			const { service } = makeRuntimeService();
@@ -545,15 +539,15 @@ describe('task.reject RPC Handler', () => {
 
 			await expect(
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', feedback: 'not good' }, {})
-			).rejects.toThrow('Task is not awaiting human review');
+			).rejects.toThrow('No active session group for this task');
 		});
 	});
 
 	describe('happy path', () => {
-		it('rejects a task in review with awaiting_human group state', async () => {
+		it('rejects a task in review with active group', async () => {
 			const reviewTask = { ...mockTask, status: 'review' as const };
 			const { service } = makeRuntimeService(true);
-			setup({ task: reviewTask, groupState: 'awaiting_human', runtimeService: service });
+			setup({ task: reviewTask, submittedForReview: true, runtimeService: service });
 
 			const result = await getHandler()(
 				{ roomId: 'room-1', taskId: 'task-1', feedback: 'please fix the bug' },
@@ -606,13 +600,13 @@ describe('task.setStatus RPC Handler', () => {
 
 	function setup(opts: {
 		task?: NeoTask | null;
-		groupState?: string;
+		submittedForReview?: boolean;
 		runtimeService?: RoomRuntimeService;
 		taskManagerFactory?: TaskManagerFactory;
 	}) {
 		const {
 			task = mockTask,
-			groupState = 'awaiting_human',
+			submittedForReview = false,
 			runtimeService,
 			taskManagerFactory,
 		} = opts;
@@ -625,7 +619,7 @@ describe('task.setStatus RPC Handler', () => {
 			hub,
 			mockRoomManager,
 			createMockDaemonHub(),
-			makeDb(makeGroupRow(groupState)),
+			makeDb(makeGroupRow(submittedForReview)),
 			taskManagerFactory ?? makeSetStatusTaskManagerFactory(task),
 			runtimeService
 		);
@@ -695,7 +689,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			setup({
 				task: mockTask, // in_progress status
-				groupState: 'awaiting_human',
+				submittedForReview: true,
 				runtimeService: service,
 			});
 
@@ -708,12 +702,12 @@ describe('task.setStatus RPC Handler', () => {
 			// Create runtime service where cancel returns a valid group
 			const { service, cancel } = makeRuntimeServiceWithGroupManager({
 				id: 'group-1',
-				state: 'cancelled',
+				completedAt: Date.now(),
 			});
 
 			setup({
 				task: mockTask, // in_progress status
-				groupState: 'awaiting_human',
+				submittedForReview: true,
 				runtimeService: service,
 			});
 
@@ -730,7 +724,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			setup({
 				task: mockTask, // in_progress status
-				groupState: 'awaiting_human',
+				submittedForReview: true,
 				runtimeService: service,
 			});
 
@@ -743,7 +737,7 @@ describe('task.setStatus RPC Handler', () => {
 			// Without runtime service, the group cancellation code path is not entered
 			setup({
 				task: mockTask,
-				groupState: 'awaiting_human',
+				submittedForReview: true,
 				runtimeService: undefined,
 			});
 

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -457,7 +457,7 @@ describe('task.sendHumanMessage handler', () => {
 	});
 
 	it('sends human message successfully when runtime is available', async () => {
-		const { runtimeService, injectMessageToLeader } = createMockRuntimeService(true);
+		const { runtimeService, injectMessageToWorker } = createMockRuntimeService(true);
 		const db = createMockDatabaseWithGroup('awaiting_leader');
 
 		setupTaskHandlers(
@@ -477,12 +477,12 @@ describe('task.sendHumanMessage handler', () => {
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToLeader).toHaveBeenCalledWith('task-123', 'Looks good!');
+		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'Looks good!');
 		expect(result.success).toBe(true);
 	});
 
 	it('trims whitespace from message before sending', async () => {
-		const { runtimeService, injectMessageToLeader } = createMockRuntimeService(true);
+		const { runtimeService, injectMessageToWorker } = createMockRuntimeService(true);
 		const db = createMockDatabaseWithGroup('awaiting_leader');
 
 		setupTaskHandlers(
@@ -497,7 +497,7 @@ describe('task.sendHumanMessage handler', () => {
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
 		await handler!({ roomId: 'room-123', taskId: 'task-123', message: '  please fix it  ' }, {});
 
-		expect(injectMessageToLeader).toHaveBeenCalledWith('task-123', 'please fix it');
+		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'please fix it');
 	});
 
 	it('throws error when roomId is missing', async () => {
@@ -614,8 +614,8 @@ describe('task.sendHumanMessage handler', () => {
 		).rejects.toThrow('No runtime found for room: room-999');
 	});
 
-	it('throws error when group is in awaiting_worker state in auto mode', async () => {
-		const { runtimeService } = createMockRuntimeService(true);
+	it('routes to worker when group is in awaiting_worker state', async () => {
+		const { runtimeService, injectMessageToWorker } = createMockRuntimeService(true);
 		const db = createMockDatabaseWithGroup('awaiting_worker');
 
 		setupTaskHandlers(
@@ -628,9 +628,13 @@ describe('task.sendHumanMessage handler', () => {
 		);
 
 		const handler = messageHubData.handlers.get('task.sendHumanMessage')!;
-		await expect(
-			handler!({ roomId: 'room-123', taskId: 'task-123', message: 'hello' }, {})
-		).rejects.toThrow('Worker is running');
+		const result = (await handler!(
+			{ roomId: 'room-123', taskId: 'task-123', message: 'hello' },
+			{}
+		)) as { success: boolean };
+
+		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', 'hello');
+		expect(result.success).toBe(true);
 	});
 
 	it('routes to worker when target=worker in awaiting_worker state', async () => {
@@ -677,7 +681,7 @@ describe('task.sendHumanMessage handler', () => {
 	});
 
 	it('accepts message at exactly 10,000 characters', async () => {
-		const { runtimeService, injectMessageToLeader } = createMockRuntimeService(true);
+		const { runtimeService, injectMessageToWorker } = createMockRuntimeService(true);
 		const db = createMockDatabaseWithGroup('awaiting_leader');
 
 		setupTaskHandlers(
@@ -696,7 +700,7 @@ describe('task.sendHumanMessage handler', () => {
 			{}
 		)) as { success: boolean };
 
-		expect(injectMessageToLeader).toHaveBeenCalledWith('task-123', maxMessage);
+		expect(injectMessageToWorker).toHaveBeenCalledWith('task-123', maxMessage);
 		expect(result.success).toBe(true);
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2,7 +2,7 @@
  * Tests for TaskView Component
  *
  * Tests the "Awaiting your review" pulsing badge in the header
- * when group.state === 'awaiting_human', and its absence otherwise.
+ * when group.submittedForReview is true, and its absence otherwise.
  *
  * Also covers the shared autoscroll/ScrollToBottomButton integration and
  * InputTextarea usage in HumanInputArea.
@@ -153,6 +153,8 @@ function makeGroup(state: string, feedbackIteration = 0) {
 		workerRole: 'worker',
 		state,
 		feedbackIteration,
+		submittedForReview: state === 'awaiting_human',
+		approved: false,
 		createdAt: Date.now(),
 		completedAt: null,
 	};
@@ -230,7 +232,7 @@ describe('TaskView — awaiting_human badge', () => {
 		expect(container.textContent).not.toContain('Awaiting your review');
 	});
 
-	it('shows group state label in header', async () => {
+	it('does not show review bar when group is not submitted for review', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_leader') };
@@ -240,8 +242,9 @@ describe('TaskView — awaiting_human badge', () => {
 		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
 
 		await waitFor(() => {
-			expect(container.textContent).toContain('Leader reviewing');
+			expect(container.textContent).not.toContain('Loading task');
 		});
+		expect(container.querySelector('.bg-amber-900\\/20')).toBeNull();
 	});
 });
 
@@ -401,11 +404,11 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		});
 	});
 
-	it('approves task via goal.approveTask in awaiting_human state', async () => {
+	it('approves task via task.approve in awaiting_human state', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
-			if (method === 'goal.approveTask') return {};
+			if (method === 'task.approve') return {};
 			return {};
 		});
 
@@ -425,7 +428,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		fireEvent.click(approveBtn);
 
 		await waitFor(() => {
-			expect(mockRequest).toHaveBeenCalledWith('goal.approveTask', {
+			expect(mockRequest).toHaveBeenCalledWith('task.approve', {
 				roomId: 'room-1',
 				taskId: 'task-1',
 			});
@@ -470,6 +473,9 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Please focus on auth first' } });
 
+		// Explicitly target leader in the dropdown.
+		fireEvent.click(getByTestId('task-target-button'));
+		fireEvent.click(getByTestId('task-target-option-leader'));
 		fireEvent.click(getByTestId('input-textarea-send'));
 
 		await waitFor(() => {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -122,7 +122,7 @@ function HeaderReviewBar({ roomId, taskId, onApproved, onRejected }: HeaderRevie
 		setApproving(true);
 		setError(null);
 		try {
-			await request('goal.approveTask', { roomId, taskId });
+			await request('task.approve', { roomId, taskId });
 			// Approval changes group state; re-fetch conversation to pick up the approval message
 			onApproved();
 		} catch (err) {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -80,8 +80,8 @@ interface TaskGroupInfo {
 	workerSessionId: string;
 	leaderSessionId: string;
 	workerRole: string;
-	state: string;
 	feedbackIteration: number;
+	submittedForReview: boolean;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -90,17 +90,6 @@ interface TaskViewProps {
 	roomId: string;
 	taskId: string;
 }
-
-const GROUP_STATE_LABELS: Record<string, string> = {
-	awaiting_worker: 'Worker active…',
-	awaiting_leader: 'Leader reviewing…',
-	awaiting_human: 'Needs human review',
-	completed: 'Completed',
-	failed: 'Failed',
-	// Backward compat
-	awaiting_craft: 'Worker active…',
-	awaiting_lead: 'Leader reviewing…',
-};
 
 const TASK_STATUS_COLORS: Record<string, string> = {
 	pending: 'text-gray-400',
@@ -244,7 +233,6 @@ function HeaderReviewBar({ roomId, taskId, onApproved, onRejected }: HeaderRevie
 type HumanMessageTarget = 'worker' | 'leader';
 
 interface HumanInputAreaProps {
-	groupState: string | null;
 	hasGroup: boolean;
 	roomId: string;
 	taskId: string;
@@ -257,12 +245,7 @@ const TARGET_LABELS: Record<HumanMessageTarget, string> = {
 	leader: 'Leader',
 };
 
-function defaultTargetForState(state: string | null): HumanMessageTarget {
-	return state === 'awaiting_leader' ? 'leader' : 'worker';
-}
-
 function HumanInputArea({
-	groupState,
 	hasGroup,
 	roomId,
 	taskId,
@@ -272,13 +255,9 @@ function HumanInputArea({
 	const [messageText, setMessageText] = useState('');
 	const [sending, setSending] = useState(false);
 	const [inputError, setInputError] = useState<string | null>(null);
-	const [target, setTarget] = useState<HumanMessageTarget>(() => defaultTargetForState(groupState));
+	const [target, setTarget] = useState<HumanMessageTarget>('worker');
 	const [menuOpen, setMenuOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		setTarget(defaultTargetForState(groupState));
-	}, [groupState]);
 
 	useEffect(() => {
 		if (!menuOpen) return;
@@ -306,10 +285,7 @@ function HumanInputArea({
 				target,
 			});
 			setMessageText('');
-			// Rejection feedback changes group state; re-fetch conversation to pick up the human message
-			if (groupState === 'awaiting_human' && target === 'worker') {
-				onMessageSentWithReload();
-			}
+			onMessageSentWithReload();
 		} catch (err) {
 			setInputError(err instanceof Error ? err.message : 'Failed to send message');
 		} finally {
@@ -617,10 +593,9 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 					{group && (
 						<div class="flex items-center gap-2 mt-0.5">
 							<p class="text-xs text-gray-500">
-								{GROUP_STATE_LABELS[group.state] ?? group.state}
-								{group.feedbackIteration > 0 && ` · iteration ${group.feedbackIteration}`}
+								{group.feedbackIteration > 0 && `iteration ${group.feedbackIteration}`}
 							</p>
-							{group.state === 'awaiting_human' && (
+							{group.submittedForReview && (
 								<span class="inline-flex items-center gap-1 text-xs font-medium text-amber-400 bg-amber-900/30 border border-amber-700/40 px-1.5 py-0.5 rounded-full animate-pulse">
 									Awaiting your review
 								</span>
@@ -679,7 +654,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			</div>
 
 			{/* Header Review Bar - shown when awaiting human approval */}
-			{group?.state === 'awaiting_human' && (
+			{group?.submittedForReview && (
 				<HeaderReviewBar
 					roomId={roomId}
 					taskId={taskId}
@@ -837,7 +812,6 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 
 			{/* Human input area (always visible) */}
 			<HumanInputArea
-				groupState={group?.state ?? null}
 				hasGroup={group !== null}
 				roomId={roomId}
 				taskId={taskId}

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -444,7 +444,7 @@ class RoomStore {
 			throw new Error('Not connected');
 		}
 
-		await hub.request<{ success: boolean }>('goal.approveTask', {
+		await hub.request<{ success: boolean }>('task.approve', {
 			roomId,
 			taskId,
 		});


### PR DESCRIPTION
## Summary
- remove authoritative runtime routing dependence on legacy `session_groups.state`
- simplify leader/worker/human flow and keep compatibility state updates for observability
- remove `goal.approveTask` handoff path and standardize on `task.approve`
- update room/runtime RPC handlers and web task view behavior to match current lifecycle gates
- refresh design docs and flow diagrams for the new collaboration model

## Validation
- `bun run typecheck`
- `cd packages/daemon && bun test --preload=./tests/unit/setup.ts ./tests/unit` (3619 pass, 0 fail, 8 skipped)
- targeted suites:
  - `packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts`
  - `packages/daemon/tests/unit/room/runtime-recovery.test.ts`
  - `packages/daemon/tests/unit/core/daemon-app-cleanup.test.ts`
  - `packages/web/src/components/room/TaskView.test.tsx`
