### PR TITLE
ci: configure devproxy for e2e-llm job in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -885,9 +885,6 @@ jobs:
           ANTHROPIC_API_KEY: "sk-devproxy-test-key"
           ANTHROPIC_AUTH_TOKEN: ""
           CLAUDE_CODE_OAUTH_TOKEN: ""
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
-          DEFAULT_PROVIDER: glm
-          DEFAULT_MODEL: glm-5
           CI: true
 
       - name: Stop Dev Proxy


### PR DESCRIPTION
Add Install Dev Proxy and Start Dev Proxy steps to the e2e-llm job.
Set devproxy environment variables for the test step:
- NEOKAI_USE_DEV_PROXY=1
- ANTHROPIC_BASE_URL=http://127.0.0.1:8000
- ANTHROPIC_API_KEY=sk-devproxy-test-key
- ANTHROPIC_AUTH_TOKEN=""
- CLAUDE_CODE_OAUTH_TOKEN=""

Add Stop Dev Proxy step with always() cleanup.
