### PR TITLE
fix: update 7 failing no-LLM e2e tests

### DIFF
--- a/packages/e2e/tests/core/navigation-3-column.e2e.ts
+++ b/packages/e2e/tests/core/navigation-3-column.e2e.ts
@@ -35,8 +35,8 @@ test.describe('Desktop 3-Column Layout (>=768px)', () => {
 	});
 
 	test('should display NavRail with correct width and structure', async ({ page }) => {
-		// NavRail should be visible on desktop (uses slide-in animation: -translate-x-full md:translate-x-0)
-		const navRail = page.locator('.-translate-x-full.md\\:translate-x-0').first();
+		// NavRail should be visible on desktop (has w-16 class, 64px width)
+		const navRail = page.locator('.w-16').first();
 		await expect(navRail).toBeVisible();
 
 		// Verify NavRail has w-16 class (64px width)

--- a/packages/e2e/tests/features/thinking-level-selector.e2e.ts
+++ b/packages/e2e/tests/features/thinking-level-selector.e2e.ts
@@ -217,7 +217,7 @@ test.describe('Thinking Level Selector', () => {
 		await page.reload();
 
 		// Wait for daemon connection to be established
-		await expect(page.locator('[aria-label="Daemon: Connected"]')).toBeVisible({
+		await expect(page.locator('[aria-label="Daemon: Connected"]').first()).toBeVisible({
 			timeout: 15000,
 		});
 

--- a/packages/e2e/tests/read-only/home.e2e.ts
+++ b/packages/e2e/tests/read-only/home.e2e.ts
@@ -8,7 +8,7 @@ test.describe('Home Page', () => {
 		await expect(page.getByRole('heading', { name: 'Neo Lobby' }).first()).toBeVisible();
 
 		// Check for lobby subtitle (desktop only)
-		await expect(page.locator('text=Manage your AI-powered workspaces')).toBeVisible();
+		await expect(page.locator('text=Your agent command center')).toBeVisible();
 	});
 
 	test('should have a sidebar visible', async ({ page }) => {

--- a/packages/e2e/tests/read-only/ui-components.e2e.ts
+++ b/packages/e2e/tests/read-only/ui-components.e2e.ts
@@ -65,7 +65,7 @@ test.describe('UI Components', () => {
 
 			// All main elements should be visible
 			await expect(page.getByRole('heading', { name: 'Neo Lobby' }).first()).toBeVisible();
-			await expect(page.locator('text=Manage your AI-powered workspaces')).toBeVisible();
+			await expect(page.locator('text=Your agent command center')).toBeVisible();
 		});
 	});
 

--- a/packages/e2e/tests/serial/auth-error-scenarios.e2e.ts
+++ b/packages/e2e/tests/serial/auth-error-scenarios.e2e.ts
@@ -17,10 +17,12 @@ test.describe('Authentication Status', () => {
 	test('should show daemon connection status indicator', async ({ page }) => {
 		// The daemon status indicator shows connection state via aria-label
 		// Possible states: "Daemon: Connected", "Daemon: Connecting...", "Daemon: Offline", "Daemon: Error"
-		const daemonIndicator = page.locator('[aria-label^="Daemon:"]');
+		const daemonIndicator = page.locator('[aria-label^="Daemon:"]').first();
 		await expect(daemonIndicator).toBeVisible({ timeout: 5000 });
 
 		// Should show connected state (green indicator)
-		await expect(page.locator('[aria-label="Daemon: Connected"]')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('[aria-label="Daemon: Connected"]').first()).toBeVisible({
+			timeout: 10000,
+		});
 	});
 });

--- a/packages/e2e/tests/serial/error-scenarios.e2e.ts
+++ b/packages/e2e/tests/serial/error-scenarios.e2e.ts
@@ -132,8 +132,8 @@ test.describe('Error Scenarios', () => {
 		// Restore network connection
 		await restoreWebSocket(page);
 
-		// Wait for online indicator to return
-		await expect(page.locator('.text-green-400:has-text("Online")').first()).toBeVisible({
+		// Wait for connection to be restored - look for Daemon: Connected button
+		await expect(page.locator('button[aria-label="Daemon: Connected"]').first()).toBeVisible({
 			timeout: 10000,
 		});
 

--- a/packages/e2e/tests/settings/settings-modal.e2e.ts
+++ b/packages/e2e/tests/settings/settings-modal.e2e.ts
@@ -157,11 +157,11 @@ test.describe('Settings Modal - Global Settings', () => {
 	});
 
 	test('should show Thinking Level selection dropdown', async ({ page }) => {
-		// Thinking Level has been removed from the current settings UI.
+		// Thinking Level is present in the settings UI.
 		await openSettingsModal(page);
 
-		// Thinking Level is no longer present
-		await expect(page.locator('text=Thinking Level')).toBeHidden();
+		// Thinking Level is present
+		await expect(page.locator('text=Thinking Level')).toBeVisible();
 
 		// Permission Mode is the second dropdown in the General settings
 		await expect(page.locator('text=Permission Mode')).toBeVisible();
@@ -176,7 +176,7 @@ test.describe('Settings Modal - Global Settings', () => {
 		await expect(page.getByText('Auto-scroll', { exact: true })).toBeVisible();
 
 		// Should have a toggle switch (role="switch" button, not a checkbox)
-		await expect(page.locator('button[role="switch"]')).toBeVisible();
+		await expect(page.locator('button[role="switch"]').first()).toBeVisible();
 	});
 
 	test('should show Permission Mode selection', async ({ page }) => {
@@ -269,7 +269,7 @@ test.describe('Settings Modal - Global Tools Settings', () => {
 		// Verify the auto-scroll toggle has proper aria attributes.
 		await openSettingsModal(page);
 
-		const autoScrollToggle = page.locator('button[role="switch"]');
+		const autoScrollToggle = page.locator('button[role="switch"]').first();
 		await expect(autoScrollToggle).toBeVisible();
 
 		// Toggle should have aria-checked attribute (value is "true" or "false")
@@ -324,7 +324,7 @@ test.describe('Settings Modal - Settings Persistence', () => {
 		await openSettingsModal(page);
 
 		// Get the auto-scroll toggle switch
-		const autoScrollToggle = page.locator('button[role="switch"]');
+		const autoScrollToggle = page.locator('button[role="switch"]').first();
 		const initialChecked = await autoScrollToggle.getAttribute('aria-checked');
 
 		// Toggle the setting


### PR DESCRIPTION
Fix test failures due to UI changes:

1. core-navigation-3-column: Fixed selector to use `.w-16` instead of
   `.-translate-x-full.md:translate-x-0` to correctly select NavRail

2. read-only-home & read-only-ui-components: Updated expected text from
   "Manage your AI-powered workspaces" to "Your agent command center"

3. features-thinking-level-selector: Added `.first()` to handle multiple
   Daemon: Connected buttons in UI

4. serial-error-scenarios: Changed to look for "Daemon: Connected" button
   instead of "Online" text indicator

5. settings-settings-modal: Fixed multiple issues:
   - Changed to expect Thinking Level to be visible (not hidden)
   - Added `.first()` to button[role="switch"] selectors

6. serial-auth-error-scenarios: Added `.first()` to handle multiple
   Daemon status indicators
