### PR TITLE
feat(room): add room-agent-tools MCP server to leader agent

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -25,6 +25,12 @@ import type {
 	McpServerConfig,
 	AgentDefinition,
 } from '@neokai/shared';
+import type { GoalManager } from '../managers/goal-manager';
+import type { TaskManager } from '../managers/task-manager';
+import type { SessionGroupRepository } from '../state/session-group-repository';
+import type { DaemonHub } from '../../daemon-hub';
+import type { RoomRuntime } from '../runtime/room-runtime';
+import { createRoomAgentMcpServer } from '../tools/room-agent-tools';
 
 const DEFAULT_LEADER_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -69,6 +75,16 @@ export interface LeaderAgentConfig {
 	model?: string;
 	/** What type of work is being reviewed */
 	reviewContext?: ReviewContext;
+	/** Dependencies for room-agent-tools MCP server (optional - only needed when creating MCP server) */
+	goalManager?: GoalManager;
+	taskManager?: TaskManager;
+	groupRepo?: SessionGroupRepository;
+	/** Optional: DaemonHub for emitting events (used for UI notifications) */
+	daemonHub?: DaemonHub;
+	/** Optional: Runtime service for runtime operations */
+	runtimeService?: {
+		getRuntime(roomId: string): RoomRuntime | null;
+	};
 }
 
 /**
@@ -959,6 +975,19 @@ export function createLeaderAgentInit(
 ): AgentSessionInit {
 	const mcpServer = createLeaderMcpServer(config.groupId, callbacks);
 
+	// Create room-agent-tools MCP server for task/goal management (if dependencies provided)
+	const roomAgentTools =
+		config.goalManager && config.taskManager && config.groupRepo
+			? (createRoomAgentMcpServer({
+					roomId: config.room.id,
+					goalManager: config.goalManager,
+					taskManager: config.taskManager,
+					groupRepo: config.groupRepo,
+					daemonHub: config.daemonHub,
+					runtimeService: config.runtimeService,
+				}) as unknown as McpServerConfig)
+			: undefined;
+
 	// Build reviewer agents from room config (if any)
 	const roomConfig = config.room.config ?? {};
 	const reviewerConfigs = getLeaderSubagents(roomConfig);
@@ -995,6 +1024,7 @@ export function createLeaderAgentInit(
 			},
 			mcpServers: {
 				'leader-agent-tools': mcpServer as unknown as McpServerConfig,
+				...(roomAgentTools ? { 'room-agent-tools': roomAgentTools } : {}),
 			},
 			features: LEADER_FEATURES,
 			context: { roomId: config.room.id },
@@ -1017,6 +1047,7 @@ export function createLeaderAgentInit(
 		},
 		mcpServers: {
 			'leader-agent-tools': mcpServer as unknown as McpServerConfig,
+			...(roomAgentTools ? { 'room-agent-tools': roomAgentTools } : {}),
 		},
 		features: LEADER_FEATURES,
 		context: { roomId: config.room.id },

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -219,6 +219,10 @@ export class RoomRuntime {
 			getRoom: config.getRoom,
 			getTask: config.getTask,
 			getGoal: config.getGoal,
+			daemonHub: config.daemonHub,
+			runtimeService: {
+				getRuntime: (roomId: string) => (roomId === this.room.id ? this : null),
+			},
 		});
 
 		// Keep test and direct-runtime usage predictable: when no explicit leader model

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -331,6 +331,9 @@ export class TaskGroupManager {
 				groupId: group.id,
 				model: this.model,
 				reviewContext: deferredLeader.reviewContext,
+				goalManager: this.goalManager,
+				taskManager: this.taskManager,
+				groupRepo: this.groupRepo,
 			};
 			const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
 

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -25,6 +25,8 @@ import type { GoalManager } from '../managers/goal-manager';
 import type { LeaderToolCallbacks } from '../agents/leader-agent';
 import { createLeaderAgentInit } from '../agents/leader-agent';
 import type { LeaderAgentConfig, ReviewContext } from '../agents/leader-agent';
+import type { DaemonHub } from '../../daemon-hub';
+import type { RoomRuntime } from './room-runtime';
 
 /**
  * Convert a task title to a git branch name slug.
@@ -135,6 +137,12 @@ export interface TaskGroupManagerConfig {
 	getTask: (taskId: string) => Promise<NeoTask | null>;
 	/** Fetch goal from DB by ID. Used to get CURRENT goal data at route time. */
 	getGoal: (goalId: string) => Promise<RoomGoal | null>;
+	/** DaemonHub for emitting events (used for UI notifications) */
+	daemonHub?: DaemonHub;
+	/** Runtime service for runtime operations (task cancellation, etc.) */
+	runtimeService?: {
+		getRuntime(roomId: string): RoomRuntime | null;
+	};
 }
 
 export class TaskGroupManager {
@@ -149,6 +157,10 @@ export class TaskGroupManager {
 	readonly workspacePath: string;
 	private _model?: string;
 	readonly workerModel?: string;
+	private readonly daemonHub?: DaemonHub;
+	private readonly runtimeService?: {
+		getRuntime(roomId: string): RoomRuntime | null;
+	};
 
 	constructor(config: TaskGroupManagerConfig) {
 		this.groupRepo = config.groupRepo;
@@ -162,6 +174,8 @@ export class TaskGroupManager {
 		this.workspacePath = config.workspacePath;
 		this._model = config.model;
 		this.workerModel = config.workerModel;
+		this.daemonHub = config.daemonHub;
+		this.runtimeService = config.runtimeService;
 	}
 
 	/** Get the current model for leader sessions */
@@ -334,6 +348,8 @@ export class TaskGroupManager {
 				goalManager: this.goalManager,
 				taskManager: this.taskManager,
 				groupRepo: this.groupRepo,
+				daemonHub: this.daemonHub,
+				runtimeService: this.runtimeService,
 			};
 			const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -401,6 +401,61 @@ describe('Leader Agent', () => {
 			expect(init.mcpServers!['room-agent-tools']).toBeDefined();
 		});
 
+		it('should NOT include room-agent-tools when dependencies are missing', () => {
+			const callbacks = makeCallbacks();
+			// Create config without goalManager, taskManager, groupRepo
+			const init = createLeaderAgentInit(
+				{
+					task: makeTask(),
+					goal: makeGoal(),
+					room: makeRoom(),
+					sessionId: 'leader:room-1:task-1',
+					workspacePath: '/workspace',
+					groupId: 'group-1',
+				},
+				callbacks
+			);
+			expect(init.mcpServers).toBeDefined();
+			expect(init.mcpServers!['room-agent-tools']).toBeUndefined();
+		});
+
+		it('should NOT include room-agent-tools when only partial dependencies provided', () => {
+			const callbacks = makeCallbacks();
+			// Provide only goalManager, but not taskManager and groupRepo
+			const init = createLeaderAgentInit(
+				{
+					task: makeTask(),
+					goal: makeGoal(),
+					room: makeRoom(),
+					sessionId: 'leader:room-1:task-1',
+					workspacePath: '/workspace',
+					groupId: 'group-1',
+					goalManager: mockGoalManager,
+				},
+				callbacks
+			);
+			expect(init.mcpServers).toBeDefined();
+			expect(init.mcpServers!['room-agent-tools']).toBeUndefined();
+		});
+
+		it('should still include leader-agent-tools regardless of room-agent-tools availability', () => {
+			const callbacks = makeCallbacks();
+			// Config without room-agent-tools dependencies
+			const init = createLeaderAgentInit(
+				{
+					task: makeTask(),
+					goal: makeGoal(),
+					room: makeRoom(),
+					sessionId: 'leader:room-1:task-1',
+					workspacePath: '/workspace',
+					groupId: 'group-1',
+				},
+				callbacks
+			);
+			// leader-agent-tools should always be present
+			expect(init.mcpServers!['leader-agent-tools']).toBeDefined();
+		});
+
 		it('should use provided session ID and workspace path', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -56,6 +56,31 @@ function makeTask(overrides?: Partial<NeoTask>): NeoTask {
 	};
 }
 
+// Mock implementations for required dependencies
+const mockGoalManager = {
+	createGoal: async () => ({ id: 'goal-1' }) as RoomGoal,
+	listGoals: async () => [],
+	getGoal: async () => makeGoal(),
+	updateGoalStatus: async () => makeGoal(),
+	updateGoalPriority: async () => makeGoal(),
+	linkTaskToGoal: async () => {},
+} as unknown as import('../../../src/lib/room/managers/goal-manager').GoalManager;
+
+const mockTaskManager = {
+	createTask: async () => makeTask(),
+	listTasks: async () => [],
+	getTask: async () => makeTask(),
+	updateTaskFields: async () => makeTask(),
+	cancelTaskCascade: async () => [],
+	setTaskStatus: async () => makeTask(),
+} as unknown as import('../../../src/lib/room/managers/task-manager').TaskManager;
+
+const mockGroupRepo = {
+	getGroup: () => null,
+	getGroupsByRoom: () => [],
+	getActiveGroups: () => [],
+} as unknown as import('../../../src/lib/room/state/session-group-repository').SessionGroupRepository;
+
 function makeConfig(overrides?: Partial<LeaderAgentConfig>): LeaderAgentConfig {
 	return {
 		task: makeTask(),
@@ -64,6 +89,9 @@ function makeConfig(overrides?: Partial<LeaderAgentConfig>): LeaderAgentConfig {
 		sessionId: 'leader:room-1:task-1',
 		workspacePath: '/workspace',
 		groupId: 'group-1',
+		goalManager: mockGoalManager,
+		taskManager: mockTaskManager,
+		groupRepo: mockGroupRepo,
 		...overrides,
 	};
 }
@@ -364,6 +392,13 @@ describe('Leader Agent', () => {
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.mcpServers).toBeDefined();
 			expect(init.mcpServers!['leader-agent-tools']).toBeDefined();
+		});
+
+		it('should include room-agent-tools MCP server for task/goal management', () => {
+			const callbacks = makeCallbacks();
+			const init = createLeaderAgentInit(makeConfig(), callbacks);
+			expect(init.mcpServers).toBeDefined();
+			expect(init.mcpServers!['room-agent-tools']).toBeDefined();
 		});
 
 		it('should use provided session ID and workspace path', () => {


### PR DESCRIPTION
The leader agent now has access to task/goal management tools via the
room-agent-tools MCP server. This enables the leader to create new tasks
that result from replanning when it calls replan_goal.

Changes:
- Import createRoomAgentMcpServer from room-agent-tools
- Add optional goalManager, taskManager, groupRepo to LeaderAgentConfig
- Create room-agent-tools MCP server in createLeaderAgentInit (conditional)
- Add room-agent-tools to mcpServers in both paths (with/without reviewers)
- Update TaskGroupManager to pass required dependencies
- Add unit tests for room-agent-tools MCP server inclusion
