### PR TITLE
ci: add devproxy to agent-context, features-2, git, and websocket modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
           # Run `bash scripts/validate-online-test-matrix.sh` to verify all files are covered.
           - module: agent-context
             test_path: tests/online/agent/context-command.test.ts
+            mock_sdk: true
           - module: agent-sdk
             test_path: tests/online/agent/agent-session-sdk.test.ts
             mock_sdk: true
@@ -175,9 +176,11 @@ jobs:
             mock_sdk: true
           - module: features-2
             test_path: tests/online/features/message-persistence.test.ts
+            mock_sdk: true
           - module: git
             test_path: tests/online/git
             timeout: 10
+            mock_sdk: true
           - module: lifecycle
             test_path: tests/online/lifecycle
             mock_sdk: true
@@ -245,6 +248,7 @@ jobs:
             mock_sdk: true
           - module: websocket
             test_path: tests/online/websocket
+            mock_sdk: true
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/daemon/tests/online/websocket/websocket-protocol.test.ts
+++ b/packages/daemon/tests/online/websocket/websocket-protocol.test.ts
@@ -7,9 +7,20 @@
  * - RPC call/response correlation
  * - Error handling (invalid JSON, non-existent method, session validation)
  * - Large message handling
+ *
+ * MODES:
+ * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
+ * - Dev Proxy: Set NEOKAI_USE_DEV_PROXY=1 for offline testing with mocked responses
+ *
+ * Run with Dev Proxy:
+ *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/websocket/websocket-protocol.test.ts
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// Detect mock mode for Dev Proxy
+const IS_MOCK = !!process.env.NEOKAI_USE_DEV_PROXY;
+const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
 import { createDaemonServer, type DaemonServerContext } from '../../helpers/daemon-server';
 import {
 	createWebSocket,
@@ -24,13 +35,13 @@ describe('WebSocket Protocol', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
 		if (daemon) {
 			await daemon.waitForExit();
 		}
-	});
+	}, SETUP_TIMEOUT);
 
 	describe('Connection Lifecycle', () => {
 		test('should establish WebSocket connection', async () => {


### PR DESCRIPTION
- Add mock_sdk: true to agent-context, features-2, git, and websocket
- Add IS_MOCK support to websocket-protocol.test.ts

All identified tests now use devproxy in CI for stability and cost reduction.
