### PR TITLE
ci: add devproxy to agent-context, features-2, git, and websocket modules

### DIFF
--- a/packages/daemon/tests/online/features/message-persistence.test.ts
+++ b/packages/daemon/tests/online/features/message-persistence.test.ts
@@ -146,8 +146,8 @@ describe('Message Persistence', () => {
 				// Interrupt the stream
 				await interrupt(daemon, sessionId);
 
-				// Wait for interrupt to complete
-				await new Promise((resolve) => setTimeout(resolve, interruptDelay / 2));
+				// Wait for session to settle after interrupt before sending next message
+				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
 				// Session should still be functional after interrupt
 				const state = await getProcessingState(daemon, sessionId);


### PR DESCRIPTION
## Summary
- Add `mock_sdk: true` to agent-context, git, and websocket modules in CI workflow
- features-2 already has `mock_sdk: true` from PR #291
- Fixed test timing bug in message-persistence.test.ts (wait for idle after interrupt)

## Test Results (CI run #22883559998)
- features-2: **pass**
- agent-context: **pass**
- git: **pass**
- websocket: **pass**

## Test plan
- [x] CI runs with devproxy enabled
- [x] All tests pass