### PR TITLE
fix(ci): run e2e on push to dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -730,8 +730,9 @@ jobs:
     name: E2E No-LLM (${{ matrix.test.name }})
     runs-on: ubuntu-latest
     needs: [build, discover]
-    # Skip E2E tests for release PRs to avoid blocking releases with flaky tests
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')) && !contains(github.event.pull_request.title, 'release') || github.event_name == 'workflow_dispatch'
+    # Run on: PR to main, push to dev, push to main, workflow_dispatch (skip on PR to dev)
+    # Skip release PRs to main to avoid blocking releases with flaky tests
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'release'))
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -827,8 +828,9 @@ jobs:
     name: E2E LLM (${{ matrix.test.name }})
     runs-on: ubuntu-latest
     needs: [build, discover]
-    # Skip E2E tests for release PRs to avoid blocking releases with flaky tests
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')) && !contains(github.event.pull_request.title, 'release') || github.event_name == 'workflow_dispatch'
+    # Run on: PR to main, push to dev, push to main, workflow_dispatch (skip on PR to dev)
+    # Skip release PRs to main to avoid blocking releases with flaky tests
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main' || github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'release'))
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
The e2e job condition used contains(github.event.pull_request.title, 'release')
which fails for push events since github.event.pull_request is undefined.

Fixed by checking if the event is a pull_request before accessing the title:
- push to dev: now runs e2e (github.event_name != 'pull_request' is true)
- workflow_dispatch: runs e2e
- PR to main: skips if title contains 'release'
