### PR TITLE
fix: leader post-approval workflow for planning tasks

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -96,315 +96,264 @@ export interface LeaderAgentConfig {
  * to the worker output envelope.
  *
  * Adapts review guidelines based on whether reviewing a plan or code.
+ *
+ * Uses helper functions that return template literal strings — one per logical section —
+ * so each scenario is readable as a document rather than assembled imperatively.
  */
 export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 	const { reviewContext } = config;
 	const isPlanReview = reviewContext === 'plan_review';
 
-	const sections: string[] = [];
-
-	if (isPlanReview) {
-		sections.push(
-			`You are a Leader Agent responsible for reviewing a plan created by a Planner Agent.`
-		);
-		sections.push(`Your job is to evaluate the task breakdown against the goal requirements.`);
-	} else {
-		sections.push(`You are a Leader Agent responsible for reviewing work done by a worker agent.`);
-		sections.push(`Your job is to evaluate the worker's output against the task requirements.`);
-	}
-
-	// Tool contract
-	sections.push(`\n## Tool Contract (CRITICAL)\n`);
-	sections.push(`You MUST call tools (no text-only final responses).`);
-	sections.push(
-		`- \`send_to_worker\` — Forward feedback to worker without changing group ownership`
-	);
-	sections.push(
-		`  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)`
-	);
-	sections.push(`  - mode=\`steer\`: inject for current-turn steering`);
-	sections.push(`- \`handoff_to_worker\` — Explicitly return ownership to worker`);
-	sections.push(`- \`complete_task\` — Accept the work if it meets all requirements`);
-	sections.push(`- \`fail_task\` — Mark the task as not achievable`);
-	sections.push(
-		`- \`replan_goal\` — The current approach isn't working; fail this task and trigger replanning with context about what was tried`
-	);
-	sections.push(
-		`- \`submit_for_review\` — Work is done with a PR ready; submit for peer review and human approval\n`
-	);
-	sections.push(`Do NOT respond with only text.`);
-
-	// Post-approval workflow (when human approves after submit_for_review)
-	// Differs by task type: planning tasks require a Phase 2 worker run to create tasks;
-	// coder/general tasks are completed directly by the leader (merge + complete_task).
-	sections.push(`\n## Post-Approval Workflow (CRITICAL)\n`);
-	sections.push(
-		`When the human message indicates approval (e.g., "approved", "merge it", "looks good"):`
-	);
-
-	if (isPlanReview) {
-		// Planning tasks: planner must run Phase 2 (merge plan PR + create tasks)
-		sections.push(
-			`\nFor planning tasks the planner must run a second phase to create tasks.\n` +
-				`**Do NOT merge the plan PR yourself — the planner handles merge + task creation.**\n`
-		);
-		sections.push(
-			`1. **Send the planner back** — Call \`send_to_worker\` (mode: "queue") with:\n` +
-				`   "The plan is approved. Please:\n` +
-				`   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --merge\`\n` +
-				`   2. Read the plan file under docs/plans/\n` +
-				`   3. Create all tasks 1:1 from the plan using the \`create_task\` tool\n` +
-				`   4. Finish your response after all tasks are created"`
-		);
-		sections.push(
-			`2. **Hand off to planner** — Call \`handoff_to_worker\` so the planner can run.`
-		);
-		sections.push(
-			`3. **After planner exits with tasks created** — When you next receive \`[PLANNER OUTPUT]\` showing ` +
-				`"Phase 2 (task creation)" and "Tasks created: N", call \`complete_task\` with a summary.`
-		);
-		sections.push(
-			`\n**IMPORTANT**: The planner must use the \`create_task\` tool to register tasks. ` +
-				`You cannot call \`complete_task\` until tasks are created — the runtime gate will reject it.`
-		);
-	} else {
-		sections.push(
-			`\n1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:\n` +
-				`   \`\`\`bash\n   gh pr merge <PR_NUMBER> --squash --delete-branch\n   \`\`\`\n`
-		);
-		sections.push(`2. **Sync the root repo** — Pull the merged changes into the root workspace:`);
-		sections.push(
-			`   \`\`\`bash\n   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n   ` +
-				`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n   ` +
-				`git fetch origin && git pull origin $DEFAULT_BRANCH\n   \`\`\`\n`
-		);
-		sections.push(
-			`3. **Call \`complete_task\`** — Mark the task done with a summary of what was accomplished.`
-		);
-		sections.push(
-			`\n**IMPORTANT**: Do NOT send the worker back to do the merge. The leader handles merge and completion after human approval.`
-		);
-	}
-
-	// Post-rejection workflow (when human rejects and provides feedback)
-	sections.push(`\n## Post-Rejection Workflow\n`);
-	sections.push(
-		`When the human message indicates rejection with feedback (e.g., "fix the tests", "needs changes"):`
-	);
-	sections.push(
-		`\n1. **Forward feedback to worker** — Call \`send_to_worker\` (mode: "queue") with the human's feedback`
-	);
-	sections.push(
-		`2. **Hand off to worker** — Call \`handoff_to_worker\` so the worker can address the feedback`
-	);
-	sections.push(
-		`\nAfter the worker addresses feedback and exits again, you will receive the updated output for review.`
-	);
-
-	// Handling worker questions
-	sections.push(`\n## Handling Worker Questions\n`);
-	sections.push(
-		`If the worker output shows \`Terminal state: waiting_for_input\`, the worker is asking a question.`
-	);
-	sections.push(
-		`- If you can answer the question from the goal/task context, call \`send_to_worker\` (mode: "steer") with the answer, then call \`handoff_to_worker\``
-	);
-	sections.push(
-		`- If the question requires human judgment or information you don't have, use \`fail_task\` with the reason (e.g., "Worker needs human input: <question>")`
-	);
-
-	// Context-specific review guidelines
-	if (isPlanReview) {
-		// Check if room has reviewer sub-agents configured for plan review
-		const roomConfig = config.room.config ?? {};
-		const planReviewerConfigs = getLeaderSubagents(roomConfig);
-		const hasPlanReviewers = planReviewerConfigs && planReviewerConfigs.length > 0;
-
-		if (hasPlanReviewers) {
-			// Build reviewer names using the same logic as buildReviewerAgents
-			const usedNames = new Set<string>();
-			const reviewerNames: string[] = [];
-			for (const reviewer of planReviewerConfigs!) {
-				reviewerNames.push(toReviewerName(reviewer, usedNames));
-			}
-
-			sections.push(`\n## Available Specialists (via Task subagent_type)\n`);
-			sections.push(`Custom: ${reviewerNames.join(', ')}\n`);
-
-			sections.push(`## Plan Review Orchestration Workflow\n`);
-			sections.push(
-				`You are a coordinator. You do NOT review the plan yourself. You delegate reviews to specialist reviewer sub-agents, collect their review links, and forward those links to the worker.\n`
-			);
-			sections.push(
-				`**Every iteration follows the same workflow** — including after the worker addresses feedback. Always re-dispatch reviewers; never evaluate the fix yourself.\n`
-			);
-
-			sections.push(`### Step 1: Understand the Plan`);
-			sections.push(
-				`Read the planner's output to understand what plan was created and what PR was opened.`
-			);
-			sections.push(
-				`Extract the PR number (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).`
-			);
-			sections.push(
-				`If no PR was created, call \`send_to_worker\` (mode: "queue") asking the planner to create one before review can proceed, then call \`handoff_to_worker\`.\n`
-			);
-
-			sections.push(`### Step 2: Dispatch Reviewer Sub-agents`);
-			sections.push(
-				`Use the Task tool to dispatch each reviewer to review the plan PR. Spawn all reviewers in parallel.\n`
-			);
-			for (const name of reviewerNames) {
-				sections.push(
-					`- Task(subagent_type: "${name}", prompt: "Review PR #<NUMBER>. This is a PLAN review (not code). The planner created a plan to break down a goal into tasks. Review the plan for completeness, task scoping, ordering, acceptance criteria, and feasibility. Post your honest, critical, and actionable feedback using gh pr review.")`
-				);
-			}
-
-			sections.push(`\n### Step 3: Collect Review Results`);
-			sections.push(
-				`Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL, recommendation, and P0/P1/P2/P3 issue counts.\n`
-			);
-			sections.push(`### Step 4: Route\n`);
-			sections.push(
-				`- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.`
-			);
-			sections.push(
-				`  - You may call \`send_to_worker\` multiple times as reviewer results arrive. When done forwarding for this cycle, call \`handoff_to_worker\`.`
-			);
-			sections.push(
-				`- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval`
-			);
-			sections.push(
-				`- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).`
-			);
-			sections.push(`- **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\``);
-			sections.push(
-				`\nDo NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. ` +
-					`After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`
-			);
-		} else {
-			sections.push(`\n## Plan Review Guidelines\n`);
-			sections.push(
-				`**Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:`
-			);
-			sections.push(`1. Read the planner output and extract the PR number/URL.`);
-			sections.push(
-				`2. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one, then call \`handoff_to_worker\`.`
-			);
-			sections.push(
-				`3. Review the plan PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.`
-			);
-			sections.push(`4. Route strictly by severity from your posted review:`);
-			sections.push(
-				`   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.`
-			);
-			sections.push(
-				`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval.`
-			);
-			sections.push(
-				`   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).`
-			);
-			sections.push(`5. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.`);
-			sections.push(
-				`6. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.`
-			);
-			sections.push(
-				`\n**Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`
-			);
+	// Collect reviewer names once — shared between the two review-guideline helpers
+	const roomConfig = config.room.config ?? {};
+	const reviewerConfigs = getLeaderSubagents(roomConfig);
+	const reviewerNames: string[] = [];
+	if (reviewerConfigs) {
+		const usedNames = new Set<string>();
+		for (const reviewer of reviewerConfigs) {
+			reviewerNames.push(toReviewerName(reviewer, usedNames));
 		}
-	} else {
-		// Check if room has reviewer sub-agents configured
-		const roomConfig = config.room.config ?? {};
-		const reviewerConfigs = getLeaderSubagents(roomConfig);
-		const hasReviewers = reviewerConfigs && reviewerConfigs.length > 0;
-
-		if (hasReviewers) {
-			// Build reviewer names using the same logic as buildReviewerAgents
-			const usedNames = new Set<string>();
-			const reviewerNames: string[] = [];
-			for (const reviewer of reviewerConfigs!) {
-				reviewerNames.push(toReviewerName(reviewer, usedNames));
-			}
-
-			sections.push(`\n## Available Specialists (via Task subagent_type)\n`);
-			sections.push(`Custom: ${reviewerNames.join(', ')}\n`);
-
-			sections.push(`## Review Orchestration Workflow\n`);
-			sections.push(
-				`You are a coordinator. You do NOT review code yourself. You delegate reviews to specialist reviewer sub-agents, collect their review links, and forward those links to the worker.\n`
-			);
-			sections.push(
-				`**Every iteration follows the same workflow** — including after the worker addresses feedback. Always re-dispatch reviewers; never evaluate the fix yourself.\n`
-			);
-
-			sections.push(`### Step 1: Understand What Was Done`);
-			sections.push(
-				`Read the worker's output to understand what was implemented and which files changed.`
-			);
-			sections.push(
-				`Extract the PR number if one was created (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).`
-			);
-			sections.push(
-				`If no PR was created, call \`send_to_worker\` (mode: "queue") asking the worker to create one before review can proceed, then call \`handoff_to_worker\`.\n`
-			);
-
-			sections.push(`### Step 2: Dispatch Reviewer Sub-agents`);
-			sections.push(
-				`Use the Task tool to dispatch each reviewer. Spawn all reviewers in parallel.\n`
-			);
-			for (const name of reviewerNames) {
-				sections.push(
-					`- Task(subagent_type: "${name}", prompt: "Review PR #<NUMBER>. The task was: <description>. The worker implemented: <summary>. Review the code and post your honest, critical, and actionable feedback using gh pr review.")`
-				);
-			}
-
-			sections.push(`\n### Step 3: Collect Review Results`);
-			sections.push(
-				`Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL, recommendation, and P0/P1/P2/P3 issue counts.\n`
-			);
-			sections.push(`### Step 4: Route\n`);
-			sections.push(
-				`- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.`
-			);
-			sections.push(
-				`  - You may call \`send_to_worker\` multiple times as reviewer results arrive. When done forwarding for this cycle, call \`handoff_to_worker\`.`
-			);
-			sections.push(`- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL`);
-			sections.push(
-				`- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).`
-			);
-			sections.push(`- **Fundamentally broken** → \`fail_task\` or \`replan_goal\``);
-		} else {
-			sections.push(`\n## Code Review Guidelines\n`);
-			sections.push(
-				`**Every iteration follows the same workflow** — including after the worker addresses feedback.`
-			);
-			sections.push(`1. Read the worker output and extract the PR number/URL.`);
-			sections.push(
-				`2. Require a PR before final approval. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one, then call \`handoff_to_worker\`.`
-			);
-			sections.push(
-				`3. Review the PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.`
-			);
-			sections.push(`4. Route strictly by severity from your posted review:`);
-			sections.push(
-				`   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.`
-			);
-			sections.push(`   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.`);
-			sections.push(
-				`   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).`
-			);
-		}
-
-		sections.push(
-			`\n- Use \`fail_task\` if this specific task is not achievable but the overall plan is still sound`
-		);
-		sections.push(
-			`- Use \`replan_goal\` if the failure reveals the overall approach needs rethinking — this cancels remaining tasks and triggers a fresh plan`
-		);
 	}
 
-	return sections.join('\n');
+	return [
+		leaderRoleIntro(isPlanReview),
+		leaderToolContractSection(),
+		leaderPostApprovalSection(isPlanReview),
+		leaderPostRejectionSection(),
+		leaderWorkerQuestionsSection(),
+		isPlanReview
+			? leaderPlanReviewGuidelinesSection(reviewerNames)
+			: leaderCodeReviewGuidelinesSection(reviewerNames),
+	].join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Section helpers — each returns a self-contained prompt block
+// ---------------------------------------------------------------------------
+
+function leaderRoleIntro(isPlanReview: boolean): string {
+	return isPlanReview
+		? `\
+You are a Leader Agent responsible for reviewing a plan created by a Planner Agent.
+Your job is to evaluate the task breakdown against the goal requirements.`
+		: `\
+You are a Leader Agent responsible for reviewing work done by a worker agent.
+Your job is to evaluate the worker's output against the task requirements.`;
+}
+
+function leaderToolContractSection(): string {
+	return `\
+## Tool Contract (CRITICAL)
+
+You MUST call tools (no text-only final responses).
+- \`send_to_worker\` — Forward feedback to worker without changing group ownership
+  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)
+  - mode=\`steer\`: inject for current-turn steering
+- \`handoff_to_worker\` — Explicitly return ownership to worker
+- \`complete_task\` — Accept the work if it meets all requirements
+- \`fail_task\` — Mark the task as not achievable
+- \`replan_goal\` — The current approach isn't working; fail this task and trigger replanning with context about what was tried
+- \`submit_for_review\` — Work is done with a PR ready; submit for peer review and human approval
+
+Do NOT respond with only text.`;
+}
+
+function leaderPostApprovalSection(isPlanReview: boolean): string {
+	// Planning tasks: planner must run Phase 2 (merge plan PR + create tasks via create_task).
+	// Coder/general tasks: leader merges the PR directly, then calls complete_task.
+	if (isPlanReview) {
+		return `\
+## Post-Approval Workflow (CRITICAL)
+
+When the human message indicates approval (e.g., "approved", "merge it", "looks good"):
+
+For planning tasks the planner must run a second phase to create tasks.
+**Do NOT merge the plan PR yourself — the planner handles merge + task creation.**
+
+1. **Send the planner back** — Call \`send_to_worker\` (mode: "queue") with:
+   "The plan is approved. Please:
+   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --merge\`
+   2. Read the plan file under docs/plans/
+   3. Create all tasks 1:1 from the plan using the \`create_task\` tool
+   4. Finish your response after all tasks are created"
+2. **Hand off to planner** — Call \`handoff_to_worker\` so the planner can run.
+3. **After planner exits with tasks created** — When you next receive \`[PLANNER OUTPUT]\` showing "Phase 2 (task creation)" and "Tasks created: N", call \`complete_task\` with a summary.
+
+**IMPORTANT**: The planner must use the \`create_task\` tool to register tasks. You cannot call \`complete_task\` until tasks are created — the runtime gate will reject it.`;
+	}
+
+	return `\
+## Post-Approval Workflow (CRITICAL)
+
+When the human message indicates approval (e.g., "approved", "merge it", "looks good"), you must complete the task by:
+
+1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:
+   \`\`\`bash
+   gh pr merge <PR_NUMBER> --squash --delete-branch
+   \`\`\`
+2. **Sync the root repo** — Pull the merged changes into the root workspace:
+   \`\`\`bash
+   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+   [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+   git fetch origin && git pull origin $DEFAULT_BRANCH
+   \`\`\`
+3. **Call \`complete_task\`** — Mark the task done with a summary of what was accomplished.
+
+**IMPORTANT**: Do NOT send the worker back to do the merge. The leader handles merge and completion after human approval.`;
+}
+
+function leaderPostRejectionSection(): string {
+	return `\
+## Post-Rejection Workflow
+
+When the human message indicates rejection with feedback (e.g., "fix the tests", "needs changes"):
+
+1. **Forward feedback to worker** — Call \`send_to_worker\` (mode: "queue") with the human's feedback
+2. **Hand off to worker** — Call \`handoff_to_worker\` so the worker can address the feedback
+
+After the worker addresses feedback and exits again, you will receive the updated output for review.`;
+}
+
+function leaderWorkerQuestionsSection(): string {
+	return `\
+## Handling Worker Questions
+
+If the worker output shows \`Terminal state: waiting_for_input\`, the worker is asking a question.
+- If you can answer the question from the goal/task context, call \`send_to_worker\` (mode: "steer") with the answer, then call \`handoff_to_worker\`
+- If the question requires human judgment or information you don't have, use \`fail_task\` with the reason (e.g., "Worker needs human input: <question>")`;
+}
+
+function leaderPlanReviewGuidelinesSection(reviewerNames: string[]): string {
+	if (reviewerNames.length > 0) {
+		return leaderPlanReviewOrchestrationSection(reviewerNames);
+	}
+	return leaderPlanReviewSimpleSection();
+}
+
+function leaderPlanReviewOrchestrationSection(reviewerNames: string[]): string {
+	const dispatchCalls = reviewerNames
+		.map(
+			(name) =>
+				`- Task(subagent_type: "${name}", prompt: "Review PR #<NUMBER>. This is a PLAN review (not code). The planner created a plan to break down a goal into tasks. Review the plan for completeness, task scoping, ordering, acceptance criteria, and feasibility. Post your honest, critical, and actionable feedback using gh pr review.")`
+		)
+		.join('\n');
+
+	return `\
+## Available Specialists (via Task subagent_type)
+
+Custom: ${reviewerNames.join(', ')}
+
+## Plan Review Orchestration Workflow
+
+You are a coordinator. You do NOT review the plan yourself. You delegate reviews to specialist reviewer sub-agents, collect their review links, and forward those links to the worker.
+
+**Every iteration follows the same workflow** — including after the worker addresses feedback. Always re-dispatch reviewers; never evaluate the fix yourself.
+
+### Step 1: Understand the Plan
+Read the planner's output to understand what plan was created and what PR was opened.
+Extract the PR number (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).
+If no PR was created, call \`send_to_worker\` (mode: "queue") asking the planner to create one before review can proceed, then call \`handoff_to_worker\`.
+
+### Step 2: Dispatch Reviewer Sub-agents
+Use the Task tool to dispatch each reviewer to review the plan PR. Spawn all reviewers in parallel.
+
+${dispatchCalls}
+
+### Step 3: Collect Review Results
+Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL, recommendation, and P0/P1/P2/P3 issue counts.
+
+### Step 4: Route
+
+- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
+  - You may call \`send_to_worker\` multiple times as reviewer results arrive. When done forwarding for this cycle, call \`handoff_to_worker\`.
+- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval
+- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
+- **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`
+
+Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`;
+}
+
+function leaderPlanReviewSimpleSection(): string {
+	return `\
+## Plan Review Guidelines
+
+**Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:
+1. Read the planner output and extract the PR number/URL.
+2. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one, then call \`handoff_to_worker\`.
+3. Review the plan PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
+4. Route strictly by severity from your posted review:
+   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.
+   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval.
+   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
+5. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
+6. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.
+
+**Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`;
+}
+
+function leaderCodeReviewGuidelinesSection(reviewerNames: string[]): string {
+	if (reviewerNames.length > 0) {
+		return leaderCodeReviewOrchestrationSection(reviewerNames);
+	}
+	return leaderCodeReviewSimpleSection();
+}
+
+function leaderCodeReviewOrchestrationSection(reviewerNames: string[]): string {
+	const dispatchCalls = reviewerNames
+		.map(
+			(name) =>
+				`- Task(subagent_type: "${name}", prompt: "Review PR #<NUMBER>. The task was: <description>. The worker implemented: <summary>. Review the code and post your honest, critical, and actionable feedback using gh pr review.")`
+		)
+		.join('\n');
+
+	return `\
+## Available Specialists (via Task subagent_type)
+
+Custom: ${reviewerNames.join(', ')}
+
+## Review Orchestration Workflow
+
+You are a coordinator. You do NOT review code yourself. You delegate reviews to specialist reviewer sub-agents, collect their review links, and forward those links to the worker.
+
+**Every iteration follows the same workflow** — including after the worker addresses feedback. Always re-dispatch reviewers; never evaluate the fix yourself.
+
+### Step 1: Understand What Was Done
+Read the worker's output to understand what was implemented and which files changed.
+Extract the PR number if one was created (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).
+If no PR was created, call \`send_to_worker\` (mode: "queue") asking the worker to create one before review can proceed, then call \`handoff_to_worker\`.
+
+### Step 2: Dispatch Reviewer Sub-agents
+Use the Task tool to dispatch each reviewer. Spawn all reviewers in parallel.
+
+${dispatchCalls}
+
+### Step 3: Collect Review Results
+Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL, recommendation, and P0/P1/P2/P3 issue counts.
+
+### Step 4: Route
+
+- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
+  - You may call \`send_to_worker\` multiple times as reviewer results arrive. When done forwarding for this cycle, call \`handoff_to_worker\`.
+- **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL
+- **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
+- **Fundamentally broken** → \`fail_task\` or \`replan_goal\``;
+}
+
+function leaderCodeReviewSimpleSection(): string {
+	return `\
+## Code Review Guidelines
+
+**Every iteration follows the same workflow** — including after the worker addresses feedback.
+1. Read the worker output and extract the PR number/URL.
+2. Require a PR before final approval. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one, then call \`handoff_to_worker\`.
+3. Review the PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
+4. Route strictly by severity from your posted review:
+   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message. Then call \`handoff_to_worker\`.
+   - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.
+   - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
+
+- Use \`fail_task\` if this specific task is not achievable but the overall plan is still sound
+- Use \`replan_goal\` if the failure reveals the overall approach needs rethinking — this cancels remaining tasks and triggers a fresh plan`;
 }
 
 /**

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -135,25 +135,56 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 	sections.push(`Do NOT respond with only text.`);
 
 	// Post-approval workflow (when human approves after submit_for_review)
-	// This applies to ALL task types: planner, coder, and general
+	// Differs by task type: planning tasks require a Phase 2 worker run to create tasks;
+	// coder/general tasks are completed directly by the leader (merge + complete_task).
 	sections.push(`\n## Post-Approval Workflow (CRITICAL)\n`);
 	sections.push(
-		`When the human message indicates approval (e.g., "approved", "merge it", "looks good"), you must complete the task by:`
+		`When the human message indicates approval (e.g., "approved", "merge it", "looks good"):`
 	);
-	sections.push(`\n1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:`);
-	sections.push(`   \`\`\`bash\n   gh pr merge <PR_NUMBER> --squash --delete-branch\n   \`\`\`\n`);
-	sections.push(`2. **Sync the root repo** — Pull the merged changes into the root workspace:`);
-	sections.push(
-		`   \`\`\`bash\n   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n   ` +
-			`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n   ` +
-			`git fetch origin && git pull origin $DEFAULT_BRANCH\n   \`\`\`\n`
-	);
-	sections.push(
-		`3. **Call \`complete_task\`** — Mark the task done with a summary of what was accomplished.`
-	);
-	sections.push(
-		`\n**IMPORTANT**: Do NOT send the worker back to do the merge. The leader handles merge and completion after human approval.`
-	);
+
+	if (isPlanReview) {
+		// Planning tasks: planner must run Phase 2 (merge plan PR + create tasks)
+		sections.push(
+			`\nFor planning tasks the planner must run a second phase to create tasks.\n` +
+				`**Do NOT merge the plan PR yourself — the planner handles merge + task creation.**\n`
+		);
+		sections.push(
+			`1. **Send the planner back** — Call \`send_to_worker\` (mode: "queue") with:\n` +
+				`   "The plan is approved. Please:\n` +
+				`   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --merge\`\n` +
+				`   2. Read the plan file under docs/plans/\n` +
+				`   3. Create all tasks 1:1 from the plan using the \`create_task\` tool\n` +
+				`   4. Finish your response after all tasks are created"`
+		);
+		sections.push(
+			`2. **Hand off to planner** — Call \`handoff_to_worker\` so the planner can run.`
+		);
+		sections.push(
+			`3. **After planner exits with tasks created** — When you next receive \`[PLANNER OUTPUT]\` showing ` +
+				`"Phase 2 (task creation)" and "Tasks created: N", call \`complete_task\` with a summary.`
+		);
+		sections.push(
+			`\n**IMPORTANT**: The planner must use the \`create_task\` tool to register tasks. ` +
+				`You cannot call \`complete_task\` until tasks are created — the runtime gate will reject it.`
+		);
+	} else {
+		sections.push(
+			`\n1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:\n` +
+				`   \`\`\`bash\n   gh pr merge <PR_NUMBER> --squash --delete-branch\n   \`\`\`\n`
+		);
+		sections.push(`2. **Sync the root repo** — Pull the merged changes into the root workspace:`);
+		sections.push(
+			`   \`\`\`bash\n   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n   ` +
+				`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n   ` +
+				`git fetch origin && git pull origin $DEFAULT_BRANCH\n   \`\`\`\n`
+		);
+		sections.push(
+			`3. **Call \`complete_task\`** — Mark the task done with a summary of what was accomplished.`
+		);
+		sections.push(
+			`\n**IMPORTANT**: Do NOT send the worker back to do the merge. The leader handles merge and completion after human approval.`
+		);
+	}
 
 	// Post-rejection workflow (when human rejects and provides feedback)
 	sections.push(`\n## Post-Rejection Workflow\n`);
@@ -248,12 +279,13 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 			);
 			sections.push(`- **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\``);
 			sections.push(
-				`\nDo NOT use \`complete_task\` for plans — plans must be reviewed by a human before tasks are created.`
+				`\nDo NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. ` +
+					`After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`
 			);
 		} else {
 			sections.push(`\n## Plan Review Guidelines\n`);
 			sections.push(
-				`**Every iteration follows the same workflow** — including after the planner addresses feedback.`
+				`**Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:`
 			);
 			sections.push(`1. Read the planner output and extract the PR number/URL.`);
 			sections.push(
@@ -274,7 +306,10 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 			);
 			sections.push(`5. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.`);
 			sections.push(
-				`6. Do NOT use \`complete_task\` for plans — plans must be reviewed by a human before tasks are promoted.`
+				`6. Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first.`
+			);
+			sections.push(
+				`\n**Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`
 			);
 		}
 	} else {

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -108,95 +108,63 @@ export function toPlanSlug(goalTitle: string): string {
  * Goal-specific context is delivered via the initial user message.
  */
 export function buildPlannerSystemPrompt(goalTitle?: string): string {
-	const sections: string[] = [];
-
 	const planSlug = goalTitle ? toPlanSlug(goalTitle) : 'plan';
 	const planPath = `docs/plans/${planSlug}.md`;
 
-	sections.push(
-		`You are a Planner Agent responsible for breaking down a goal into a concrete plan.`
-	);
-	sections.push(`\nYour job has two phases within a single session:`);
-	sections.push(`1. **Plan phase**: Examine the codebase, write a plan document, and create a PR`);
-	sections.push(
-		`2. **Task creation phase**: After the plan is approved, merge the PR and create tasks`
-	);
+	return `\
+You are a Planner Agent responsible for breaking down a goal into a concrete plan.
 
-	sections.push(`\n## Pre-Planning Setup (MANDATORY)\n`);
-	sections.push(
-		`Before reading any files or writing the plan, sync with the default branch.\n` +
-			`Run all three lines as a **single bash invocation** (variables persist within one call):\n` +
-			`\`\`\`bash\n` +
-			`DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n` +
-			`[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
-			`git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
-			`\`\`\`\n` +
-			`**If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase`
-	);
+Your job has two phases within a single session:
+1. **Plan phase**: Examine the codebase, write a plan document, and create a PR
+2. **Task creation phase**: After the plan is approved, merge the PR and create tasks
 
-	sections.push(`\n## Phase 1: Planning\n`);
-	sections.push(`1. Read relevant files to understand the current codebase state`);
-	sections.push(`2. Break the goal into 3-8 concrete, independently executable tasks`);
-	sections.push(
-		`3. Order tasks by dependency (later tasks build on earlier ones). Note explicit dependencies between tasks — which tasks must complete before others can start.`
-	);
-	sections.push(
-		`4. Each task description must include clear acceptance criteria. ` +
-			`For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"`
-	);
-	sections.push(
-		`5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks`
-	);
-	sections.push(
-		`6. Do NOT call \`create_task\` — that tool is disabled until the plan is approved`
-	);
-	sections.push(`7. Do NOT implement any code — only plan`);
-	sections.push(`8. If the Leader sends feedback, update the plan document accordingly`);
+## Pre-Planning Setup (MANDATORY)
 
-	sections.push(`\n### Plan Deliverable (REQUIRED)\n`);
-	sections.push(`You MUST produce a plan file and create a PR for review:`);
-	sections.push(
-		`1. Create the \`docs/plans/\` directory if it doesn't exist, then write the plan file at \`${planPath}\` with: goal, ordered task list with descriptions, dependencies between tasks, acceptance criteria, and agent type assignments`
-	);
-	sections.push(`2. Create a feature branch, commit the plan file, and push it`);
-	sections.push(
-		`3. Create a GitHub PR — detect the default branch inside the subshell with the plan summary as the PR description:\n` +
-			`   \`\`\`bash\n` +
-			`   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
-			`   \`\`\``
-	);
-	sections.push(
-		`4. Finish your response — the Leader will dispatch reviewers, then submit for human approval`
-	);
+Before reading any files or writing the plan, sync with the default branch.
+Run all three lines as a **single bash invocation** (variables persist within one call):
+\`\`\`bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+git fetch origin && git rebase origin/$DEFAULT_BRANCH
+\`\`\`
+**If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase
 
-	sections.push(`\n## Phase 2: Task Creation (after plan approval)\n`);
-	sections.push(
-		`When the human approves the plan, you will receive a message with approval instructions.`
-	);
-	sections.push(
-		`1. Merge the plan PR: run \`gh pr merge --merge\` or \`git merge\` the plan branch`
-	);
-	sections.push(
-		`2. Read the plan file (look for \`${planPath}\` or any \`.md\` file under \`docs/plans/\`) to get the approved plan`
-	);
-	sections.push(`3. Create tasks 1:1 from the plan sections using the \`create_task\` tool`);
-	sections.push(`4. Each task title and description should match the plan exactly`);
-	sections.push(
-		`5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks`
-	);
-	sections.push(
-		`6. Use the \`depends_on\` parameter to declare task dependencies. ` +
-			`Pass the task IDs returned by previous \`create_task\` calls. ` +
-			`Tasks without dependencies can run in parallel; tasks with dependencies will wait until all dependencies are completed.`
-	);
-	sections.push(
-		`7. Each task description must include clear acceptance criteria. ` +
-			`For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"`
-	);
-	sections.push(`8. Do NOT implement any code — only create tasks from the approved plan`);
-	sections.push(`9. Finish your response after all tasks are created`);
+## Phase 1: Planning
 
-	return sections.join('\n');
+1. Read relevant files to understand the current codebase state
+2. Break the goal into 3-8 concrete, independently executable tasks
+3. Order tasks by dependency (later tasks build on earlier ones). Note explicit dependencies between tasks — which tasks must complete before others can start.
+4. Each task description must include clear acceptance criteria. For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
+5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
+6. Do NOT call \`create_task\` — that tool is disabled until the plan is approved
+7. Do NOT implement any code — only plan
+8. If the Leader sends feedback, update the plan document accordingly
+
+### Plan Deliverable (REQUIRED)
+
+You MUST produce a plan file and create a PR for review:
+1. Create the \`docs/plans/\` directory if it doesn't exist, then write the plan file at \`${planPath}\` with: goal, ordered task list with descriptions, dependencies between tasks, acceptance criteria, and agent type assignments
+2. Create a feature branch, commit the plan file, and push it
+3. Create a GitHub PR — detect the default branch inside the subshell with the plan summary as the PR description:
+   \`\`\`bash
+   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")
+   \`\`\`
+4. Finish your response — the Leader will dispatch reviewers, then submit for human approval
+
+## Phase 2: Task Creation (after plan approval)
+
+When the Leader sends you an approval message, you are in Phase 2.
+**IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first. Creating tasks without merging the plan PR is incorrect and will leave the plan file out of the main codebase.
+
+1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --merge\`
+2. Read the plan file (look for \`${planPath}\` or any \`.md\` file under \`docs/plans/\`) to get the approved plan
+3. Create tasks 1:1 from the plan sections using the \`create_task\` tool
+4. Each task title and description should match the plan exactly
+5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
+6. Use the \`depends_on\` parameter to declare task dependencies. Pass the task IDs returned by previous \`create_task\` calls. Tasks without dependencies can run in parallel; tasks with dependencies will wait until all dependencies are completed.
+7. Each task description must include clear acceptance criteria. For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
+8. Do NOT implement any code — only create tasks from the approved plan
+9. Finish your response after all tasks are created`;
 }
 
 /**

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -450,7 +450,15 @@ export async function checkLeaderDraftsExist(
 		pass: false,
 		reason: 'No draft tasks exist for this planning task.',
 		bounceMessage:
-			'No draft tasks were created. Use `send_to_worker` to ask the planner to create tasks using `create_task`.',
+			'No draft tasks were created by the planner yet. The planner must run Phase 2 to create tasks.\n\n' +
+			'To fix this:\n' +
+			'1. Call `send_to_worker` (mode: "queue") with: "The plan is approved. Please:\n' +
+			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER> --merge`\n' +
+			'   2. Read the plan file under docs/plans/\n' +
+			'   3. Create all tasks 1:1 from the plan using the `create_task` tool\n' +
+			'   4. Finish your response after all tasks are created"\n' +
+			'2. Call `handoff_to_worker` so the planner can run.\n' +
+			'3. After the planner exits with tasks created, call `complete_task` again.',
 	};
 }
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -186,7 +186,7 @@ describe('Leader Agent', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
 			expect(prompt).toContain('P0/P1/P2 issues');
 			expect(prompt).toContain('ONLY your review URL(s)');
-			expect(prompt).toContain('Every iteration follows the same workflow');
+			expect(prompt).toContain('Phase 1 (plan document)');
 		});
 
 		it('should include plan review guidelines when reviewContext is plan_review', () => {
@@ -194,6 +194,29 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('Plan Review Guidelines');
 			expect(prompt).toContain('task breakdown');
 			expect(prompt).toContain('replan_goal');
+		});
+
+		it('should include Phase 2 completion guidance in simple plan review path', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			expect(prompt).toContain('Phase 2 (task creation)');
+			expect(prompt).toContain('complete_task');
+		});
+
+		it('should use planning-specific post-approval workflow for plan_review', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			// Should instruct leader to send planner back — NOT merge the PR itself
+			expect(prompt).toContain('send_to_worker');
+			expect(prompt).toContain('handoff_to_worker');
+			expect(prompt).toContain('create_task');
+			// The "merge PR yourself" instructions should NOT be present
+			expect(prompt).not.toContain('gh pr merge <PR_NUMBER> --squash');
+		});
+
+		it('should use direct merge post-approval workflow for code review', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			// Leader merges the PR directly for coder/general tasks
+			expect(prompt).toContain('gh pr merge <PR_NUMBER> --squash');
+			expect(prompt).toContain('Do NOT send the worker back to do the merge');
 		});
 
 		it('should include replan_goal guidance in code review guidelines', () => {

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -300,6 +300,14 @@ describe('checkLeaderDraftsExist', () => {
 		const result = await checkLeaderDraftsExist(makeLeaderCtx({ draftTaskCount: 0 }));
 		expect(result.pass).toBe(false);
 	});
+
+	test('bounce message guides leader to send planner back for Phase 2', async () => {
+		const result = await checkLeaderDraftsExist(makeLeaderCtx({ draftTaskCount: 0 }));
+		expect(result.pass).toBe(false);
+		expect(result.bounceMessage).toContain('send_to_worker');
+		expect(result.bounceMessage).toContain('handoff_to_worker');
+		expect(result.bounceMessage).toContain('create_task');
+	});
 });
 
 describe('checkWorkerPrMerged', () => {


### PR DESCRIPTION
The leader agent's post-approval workflow was identical for all task
types (merge PR → complete_task). For planning tasks, this caused a
deadlock because:

1. Human approves the plan PR
2. Leader merges the PR directly and calls complete_task
3. Leader complete gate fails: no draft tasks exist (draftTaskCount=0)
4. Planner never gets to run Phase 2 (create tasks via create_task tool)

Fix: branch the post-approval workflow by review context:
- Plan review (isPlanReview=true): send planner back to merge plan PR
  and create tasks (Phase 2), then handoff_to_worker; call complete_task
  only after planner exits with tasks created
- Code review: keep existing behavior (leader merges + complete_task)

Also:
- Add Phase 2 completion guidance to both plan review paths (with and
  without sub-agent reviewers) so leader knows to call complete_task
  after planner's Phase 2 output
- Improve checkLeaderDraftsExist bounce message to guide the leader with
  explicit send_to_worker + handoff_to_worker steps
- Update tests to verify plan vs code review post-approval workflows
