### PR TITLE
feat: enable sending messages to failed/cancelled tasks with auto-revive to review

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -29,8 +29,8 @@ export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	in_progress: ['review', 'completed', 'failed', 'cancelled'],
 	review: ['completed', 'failed', 'in_progress'],
 	completed: [], // Terminal state
-	failed: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review
-	cancelled: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review
+	failed: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review via message
+	cancelled: ['pending', 'in_progress'], // Restart only — worktree is cleaned up on cancel
 };
 
 /**
@@ -204,9 +204,9 @@ export class TaskManager {
 			}
 		}
 
-		// Clear error/result when restarting or reviving from failed/cancelled.
-		// Clearing on 'review' prevents the agent receiving the revive message from
-		// seeing a stale error field alongside a review-status task.
+		// Clear error/result when restarting from failed/cancelled, or when reviving
+		// a failed task to review. The 'review' case only applies to 'failed' since
+		// 'cancelled → review' is not a valid transition (worktree is cleaned up).
 		if (
 			(task.status === 'failed' || task.status === 'cancelled') &&
 			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -204,10 +204,12 @@ export class TaskManager {
 			}
 		}
 
-		// Clear error/result when restarting from failed/cancelled
+		// Clear error/result when restarting or reviving from failed/cancelled.
+		// Clearing on 'review' prevents the agent receiving the revive message from
+		// seeing a stale error field alongside a review-status task.
 		if (
 			(task.status === 'failed' || task.status === 'cancelled') &&
-			(newStatus === 'pending' || newStatus === 'in_progress')
+			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')
 		) {
 			// Use null to explicitly clear these fields in the database
 			updates.error = null;

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -29,8 +29,8 @@ export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	in_progress: ['review', 'completed', 'failed', 'cancelled'],
 	review: ['completed', 'failed', 'in_progress'],
 	completed: [], // Terminal state
-	failed: ['pending', 'in_progress'], // Restart allowed
-	cancelled: ['pending', 'in_progress'], // Restart allowed
+	failed: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review
+	cancelled: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review
 };
 
 /**

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -876,15 +876,18 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Revive a failed or cancelled task by injecting a human message, then
-	 * automatically transitioning the task to 'review' status.
+	 * Revive the session group for a failed/cancelled task and inject a human message.
 	 *
-	 * This is the implementation of "send message to failed task" UX:
+	 * The caller is responsible for transitioning the task status to 'review' before
+	 * calling this method. This method handles the group-level work:
 	 * - Clears the group's completedAt so it becomes active again
-	 * - Sets submittedForReview = true (group is awaiting human)
 	 * - Restores agent sessions (they were stopped when the task failed)
 	 * - Re-registers terminal-state observers so the runtime hears when agents finish
 	 * - Injects the human message (leader first, worker as fallback)
+	 *
+	 * On failure, undoes the group revive (re-sets completedAt) so the group is not
+	 * left in an orphaned active state without a running agent. The caller is
+	 * responsible for rolling back the task status on failure.
 	 *
 	 * Returns true on success, false if the group cannot be found or sessions
 	 * cannot be restored / injected.
@@ -893,10 +896,13 @@ export class RoomRuntime {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 		if (!group) return false;
 
-		// If the group is still marked as terminated, revive it
+		// If the group is still marked as terminated, revive it.
+		// Track whether we cleared completedAt so we can undo it on failure.
+		let didReviveGroup = false;
 		if (group.completedAt !== null) {
 			const revived = this.groupRepo.reviveGroup(group.id);
 			if (!revived) return false;
+			didReviveGroup = true;
 		}
 
 		// Mark as awaiting human so the runtime doesn't auto-inject a continuation
@@ -952,11 +958,16 @@ export class RoomRuntime {
 		}
 
 		if (!injected) {
-			// Neither session could accept the message — undo the revive so the
-			// group doesn't appear active without a running agent.
+			// Neither session could accept the message. Re-terminate the group so it
+			// doesn't appear active without a running agent.
+			if (didReviveGroup) {
+				const currentGroup = this.groupRepo.getGroup(group.id);
+				if (currentGroup) {
+					this.groupRepo.failGroup(currentGroup.id, currentGroup.version);
+				}
+			}
 			log.error(
-				`reviveTaskForMessage: no sessions available for task ${taskId}; ` +
-					'task reverted to failed group state'
+				`reviveTaskForMessage: no sessions available for task ${taskId}; group re-terminated`
 			);
 			return false;
 		}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -876,6 +876,101 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Revive a failed or cancelled task by injecting a human message, then
+	 * automatically transitioning the task to 'review' status.
+	 *
+	 * This is the implementation of "send message to failed task" UX:
+	 * - Clears the group's completedAt so it becomes active again
+	 * - Sets submittedForReview = true (group is awaiting human)
+	 * - Restores agent sessions (they were stopped when the task failed)
+	 * - Re-registers terminal-state observers so the runtime hears when agents finish
+	 * - Injects the human message (leader first, worker as fallback)
+	 *
+	 * Returns true on success, false if the group cannot be found or sessions
+	 * cannot be restored / injected.
+	 */
+	async reviveTaskForMessage(taskId: string, message: string): Promise<boolean> {
+		const group = this.groupRepo.getGroupByTaskId(taskId);
+		if (!group) return false;
+
+		// If the group is still marked as terminated, revive it
+		if (group.completedAt !== null) {
+			const revived = this.groupRepo.reviveGroup(group.id);
+			if (!revived) return false;
+		}
+
+		// Mark as awaiting human so the runtime doesn't auto-inject a continuation
+		// message if it happens to tick before we inject below.
+		this.groupRepo.setSubmittedForReview(group.id, true);
+
+		// Restore sessions that were stopped when the task failed.
+		// restoreSession() is idempotent — if a session is already in cache it
+		// returns true immediately without touching the running query.
+		let leaderAvailable = this.sessionFactory.hasSession(group.leaderSessionId);
+		if (!leaderAvailable) {
+			leaderAvailable = await this.sessionFactory.restoreSession(group.leaderSessionId);
+			if (leaderAvailable) {
+				this.observer.observe(group.leaderSessionId, (state) => {
+					void this.onLeaderTerminalState(group.id, state);
+				});
+			}
+		}
+
+		let workerAvailable = this.sessionFactory.hasSession(group.workerSessionId);
+		if (!workerAvailable) {
+			workerAvailable = await this.sessionFactory.restoreSession(group.workerSessionId);
+			if (workerAvailable) {
+				this.observer.observe(group.workerSessionId, (state) => {
+					void this.onWorkerTerminalState(group.id, state);
+				});
+			}
+		}
+
+		// Restore MCP servers (non-serialisable, lost when sessions were stopped)
+		if (leaderAvailable || workerAvailable) {
+			await this.restoreMcpServersForGroup(group);
+		}
+
+		// Inject into leader first (preferred — leader orchestrates the workflow).
+		// Fall back to worker if leader is unavailable.
+		let injected = false;
+		if (leaderAvailable) {
+			try {
+				await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+				injected = true;
+			} catch (error) {
+				log.warn(`reviveTaskForMessage: leader inject failed for ${taskId}:`, error);
+			}
+		}
+		if (!injected && workerAvailable) {
+			try {
+				await this.sessionFactory.injectMessage(group.workerSessionId, message);
+				injected = true;
+			} catch (error) {
+				log.warn(`reviveTaskForMessage: worker inject failed for ${taskId}:`, error);
+			}
+		}
+
+		if (!injected) {
+			// Neither session could accept the message — undo the revive so the
+			// group doesn't appear active without a running agent.
+			log.error(
+				`reviveTaskForMessage: no sessions available for task ${taskId}; ` +
+					'task reverted to failed group state'
+			);
+			return false;
+		}
+
+		// Message delivered — clear the review gate so agents can proceed
+		this.groupRepo.setSubmittedForReview(group.id, false);
+
+		await this.emitTaskUpdateById(group.taskId);
+		await this.emitGoalProgressForTask(group.taskId);
+		this.scheduleTick();
+		return true;
+	}
+
+	/**
 	 * Terminate the task's active group (if any) without changing task status.
 	 *
 	 * Used by task.setStatus paths that move tasks to terminal states other than

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -246,6 +246,29 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Revive a failed/cancelled group for human message injection.
+	 * Clears completed_at WITHOUT resetting metadata — preserves conversation
+	 * history, feedback iterations, and other state so the agent can continue
+	 * from where it left off after the human provides guidance.
+	 *
+	 * Unlike resetGroupForRestart() which does a full metadata wipe, this is a
+	 * lightweight revive intended for the "send message to failed task" flow.
+	 */
+	reviveGroup(groupId: string): SessionGroup | null {
+		const result = this.db
+			.prepare(
+				`UPDATE session_groups
+				 SET completed_at = NULL,
+				     version = version + 1
+				 WHERE id = ?`
+			)
+			.run(groupId);
+
+		if (result.changes === 0) return null;
+		return this.getGroup(groupId);
+	}
+
+	/**
 	 * Reset a failed/completed group for task restart.
 	 * Clears completed_at and resets metadata fields to allow the task to be
 	 * picked up fresh by the runtime.

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -391,6 +391,36 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			if (!runtime) {
 				return jsonResult({ success: false, error: 'Room runtime not found' });
 			}
+
+			// Auto-revive: if the task is failed or cancelled, transition it to
+			// 'review' status and restore the agent sessions so the message can
+			// be delivered. This lets users provide corrective feedback without
+			// manually calling set_task_status first.
+			if (task.status === 'failed' || task.status === 'cancelled') {
+				try {
+					await taskManager.setTaskStatus(args.task_id, 'review');
+				} catch (err) {
+					return jsonResult({
+						success: false,
+						error: `Failed to revive task ${args.task_id}: ${String(err)}`,
+					});
+				}
+
+				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
+				if (!revived) {
+					return jsonResult({
+						success: false,
+						error:
+							'Task revived to review status but agent sessions could not be restored. ' +
+							'The task is now in review — you can use approve_task or reject_task to proceed.',
+					});
+				}
+				return jsonResult({
+					success: true,
+					message: `Task ${args.task_id} revived from ${task.status} to review and message delivered to agent`,
+				});
+			}
+
 			const { success, error } = await routeHumanMessageToGroup(
 				runtime,
 				groupRepo,

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -289,11 +289,15 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 								error: `Failed to reset group for task ${args.task_id} — group may have been modified concurrently`,
 							});
 						}
-					} else if (args.status === 'review' && group.completedAt !== null) {
-						// Lightweight revive: clear completedAt without resetting metadata.
-						// Agent sessions are NOT restored here — the group becomes active
-						// but awaiting_human, so the tick loop and zombie-recovery will
-						// handle session restoration when needed.
+					} else if (
+						args.status === 'review' &&
+						task.status === 'failed' &&
+						group.completedAt !== null
+					) {
+						// Lightweight revive (failed → review only): clear completedAt without
+						// resetting metadata. Only supported for failed tasks — cancelled tasks
+						// have their worktree cleaned up so reviving the group would point
+						// sessions at a gone workspace.
 						const revived = groupRepo.reviveGroup(group.id);
 						if (!revived) {
 							return jsonResult({
@@ -405,12 +409,23 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: 'Room runtime not found' });
 			}
 
-			// Auto-revive: if the task is failed or cancelled, transition it to
-			// 'review' status and restore the agent sessions so the message can
-			// be delivered. This lets users provide corrective feedback without
-			// manually calling set_task_status first.
-			if (task.status === 'failed' || task.status === 'cancelled') {
-				const originalStatus = task.status;
+			// Cancelled tasks cannot be revived via message — the worktree is cleaned
+			// up on cancellation so restoring the session would point to a gone
+			// workspace. Direct the caller to restart the task from scratch instead.
+			if (task.status === 'cancelled') {
+				return jsonResult({
+					success: false,
+					error:
+						`Task ${args.task_id} is cancelled. Cancelled tasks cannot receive messages ` +
+						'because their workspace has been cleaned up. Use set_task_status to restart it ' +
+						'(e.g. status: "pending" or "in_progress").',
+				});
+			}
+
+			// Auto-revive: if the task has failed, transition it to 'review' and
+			// restore the agent sessions so the message can be delivered. Failed
+			// tasks preserve their worktree, so session restoration is safe.
+			if (task.status === 'failed') {
 				try {
 					await taskManager.setTaskStatus(args.task_id, 'review');
 				} catch (err) {
@@ -422,9 +437,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
 				if (!revived) {
-					// Roll back the task status: review → failed is always valid.
-					// Both 'failed' and 'cancelled' original statuses roll back to 'failed'
-					// because 'review → cancelled' is not a valid transition.
+					// Roll back the task status; review → failed is a valid transition.
 					try {
 						await taskManager.setTaskStatus(args.task_id, 'failed');
 					} catch {
@@ -433,13 +446,13 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					return jsonResult({
 						success: false,
 						error:
-							`Failed to revive task ${args.task_id} (originally ${originalStatus}): ` +
-							'agent sessions could not be restored. Task status has been reset to failed.',
+							`Failed to revive task ${args.task_id}: agent sessions could not be restored. ` +
+							'Task status has been reset to failed.',
 					});
 				}
 				return jsonResult({
 					success: true,
-					message: `Task ${args.task_id} revived from ${originalStatus} to review and message delivered to agent`,
+					message: `Task ${args.task_id} revived from failed to review and message delivered to agent`,
 				});
 			}
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -276,16 +276,29 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 			}
 
-			// Handle restart: reset failed/cancelled group so runtime picks it up fresh
+			// Handle restart/revive: update group state for failed/cancelled tasks
 			if (task.status === 'failed' || task.status === 'cancelled') {
-				if (args.status === 'pending' || args.status === 'in_progress') {
-					const group = groupRepo.getGroupByTaskId(args.task_id);
-					if (group) {
+				const group = groupRepo.getGroupByTaskId(args.task_id);
+				if (group) {
+					if (args.status === 'pending' || args.status === 'in_progress') {
+						// Full reset: wipe metadata so the runtime picks the task up fresh
 						const reset = groupRepo.resetGroupForRestart(group.id);
 						if (!reset) {
 							return jsonResult({
 								success: false,
 								error: `Failed to reset group for task ${args.task_id} — group may have been modified concurrently`,
+							});
+						}
+					} else if (args.status === 'review' && group.completedAt !== null) {
+						// Lightweight revive: clear completedAt without resetting metadata.
+						// Agent sessions are NOT restored here — the group becomes active
+						// but awaiting_human, so the tick loop and zombie-recovery will
+						// handle session restoration when needed.
+						const revived = groupRepo.reviveGroup(group.id);
+						if (!revived) {
+							return jsonResult({
+								success: false,
+								error: `Failed to revive group for task ${args.task_id} — group may have been modified concurrently`,
 							});
 						}
 					}
@@ -397,6 +410,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			// be delivered. This lets users provide corrective feedback without
 			// manually calling set_task_status first.
 			if (task.status === 'failed' || task.status === 'cancelled') {
+				const originalStatus = task.status;
 				try {
 					await taskManager.setTaskStatus(args.task_id, 'review');
 				} catch (err) {
@@ -408,16 +422,24 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
 				if (!revived) {
+					// Roll back the task status: review → failed is always valid.
+					// Both 'failed' and 'cancelled' original statuses roll back to 'failed'
+					// because 'review → cancelled' is not a valid transition.
+					try {
+						await taskManager.setTaskStatus(args.task_id, 'failed');
+					} catch {
+						// Rollback is best-effort; swallow to avoid masking the original error
+					}
 					return jsonResult({
 						success: false,
 						error:
-							'Task revived to review status but agent sessions could not be restored. ' +
-							'The task is now in review — you can use approve_task or reject_task to proceed.',
+							`Failed to revive task ${args.task_id} (originally ${originalStatus}): ` +
+							'agent sessions could not be restored. Task status has been reset to failed.',
 					});
 				}
 				return jsonResult({
 					success: true,
-					message: `Task ${args.task_id} revived from ${task.status} to review and message delivered to agent`,
+					message: `Task ${args.task_id} revived from ${originalStatus} to review and message delivered to agent`,
 				});
 			}
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -853,6 +853,110 @@ describe('Room Agent Tools', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('No active session group');
 		});
+
+		it('should auto-revive failed task and call reviveTaskForMessage', async () => {
+			let reviveCalledWith: unknown[] = [];
+			const mockRuntime = {
+				reviveTaskForMessage: async (...args: unknown[]) => {
+					reviveCalledWith = args;
+					return true;
+				},
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to failed state
+			await taskManager.startTask(taskId);
+			await taskManager.failTask(taskId, 'test failure');
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'please retry' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('revived');
+
+			// Task should be in review status after revive
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('review');
+
+			// reviveTaskForMessage should have been called with correct args
+			expect(reviveCalledWith[0]).toBe(taskId);
+			expect(reviveCalledWith[1]).toBe('please retry');
+		});
+
+		it('should auto-revive cancelled task and call reviveTaskForMessage', async () => {
+			let reviveCalledWith: unknown[] = [];
+			const mockRuntime = {
+				reviveTaskForMessage: async (...args: unknown[]) => {
+					reviveCalledWith = args;
+					return true;
+				},
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to cancelled state
+			await taskManager.startTask(taskId);
+			await taskManager.cancelTask(taskId);
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'resume please' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('revived');
+
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('review');
+			expect(reviveCalledWith[0]).toBe(taskId);
+		});
+
+		it('should return partial success when reviveTaskForMessage returns false', async () => {
+			const mockRuntime = {
+				reviveTaskForMessage: async () => false,
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			await taskManager.startTask(taskId);
+			await taskManager.failTask(taskId, 'test failure');
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'hello' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('review');
+
+			// Task status should still be review (already transitioned)
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('review');
+		});
 	});
 
 	describe('get_task_detail', () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -893,13 +893,9 @@ describe('Room Agent Tools', () => {
 			expect(reviveCalledWith[1]).toBe('please retry');
 		});
 
-		it('should auto-revive cancelled task and call reviveTaskForMessage', async () => {
-			let reviveCalledWith: unknown[] = [];
+		it('should return error for cancelled task (worktree is gone, restart required)', async () => {
 			const mockRuntime = {
-				reviveTaskForMessage: async (...args: unknown[]) => {
-					reviveCalledWith = args;
-					return true;
-				},
+				reviveTaskForMessage: async () => true,
 				injectMessageToWorker: async () => true,
 				injectMessageToLeader: async () => true,
 			};
@@ -920,12 +916,14 @@ describe('Room Agent Tools', () => {
 			const result = parseResult(
 				await h.send_message_to_task({ task_id: taskId, message: 'resume please' })
 			);
-			expect(result.success).toBe(true);
-			expect(result.message).toContain('revived');
+			// Cancelled tasks cannot receive messages — workspace is cleaned up
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('cancelled');
+			expect(result.error).toContain('set_task_status');
 
+			// Task should remain cancelled (no revive attempted)
 			const task = await taskManager.getTask(taskId);
-			expect(task!.status).toBe('review');
-			expect(reviveCalledWith[0]).toBe(taskId);
+			expect(task!.status).toBe('cancelled');
 		});
 
 		it('should roll back task to failed when reviveTaskForMessage returns false', async () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -928,7 +928,7 @@ describe('Room Agent Tools', () => {
 			expect(reviveCalledWith[0]).toBe(taskId);
 		});
 
-		it('should return partial success when reviveTaskForMessage returns false', async () => {
+		it('should roll back task to failed when reviveTaskForMessage returns false', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => false,
 				injectMessageToWorker: async () => true,
@@ -951,11 +951,11 @@ describe('Room Agent Tools', () => {
 				await h.send_message_to_task({ task_id: taskId, message: 'hello' })
 			);
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('review');
+			expect(result.error).toContain('failed');
 
-			// Task status should still be review (already transitioned)
+			// Task status should be rolled back to failed (not left in review)
 			const task = await taskManager.getTask(taskId);
-			expect(task!.status).toBe('review');
+			expect(task!.status).toBe('failed');
 		});
 	});
 
@@ -1226,6 +1226,79 @@ describe('Room Agent Tools', () => {
 			const groupAfter = groupRepo.getGroup(groupId);
 			expect(groupAfter).not.toBeNull();
 			expect(groupAfter!.submittedForReview).toBe(true);
+		});
+
+		it('should revive group (clear completedAt) when transitioning failed -> review', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress, create a group, then fail the task and the group
+			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_worker');
+			await taskManager.failTask(taskId, 'Something went wrong');
+			// Properly terminate the group (as failGroup would in production)
+			const groupBeforeFail = groupRepo.getGroup(groupId)!;
+			groupRepo.failGroup(groupId, groupBeforeFail.version);
+
+			// Verify the group is terminated
+			const groupTerminated = groupRepo.getGroup(groupId);
+			expect(groupTerminated!.completedAt).not.toBeNull();
+
+			// Revive to review via set_task_status
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'review' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('review');
+
+			// Group should be revived (completedAt cleared) and marked submittedForReview
+			const groupAfter = groupRepo.getGroup(groupId);
+			expect(groupAfter).not.toBeNull();
+			expect(groupAfter!.completedAt).toBeNull();
+			expect(groupAfter!.submittedForReview).toBe(true);
+		});
+
+		it('should clear error field when transitioning failed -> review', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			await taskManager.startTask(taskId);
+			await taskManager.failTask(taskId, 'Something went wrong');
+
+			// Revive to review — error field should be cleared (null→undefined via task repo)
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'review' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('review');
+			// The handler returns updatedTask which maps null→undefined for the error field
+			expect(result.task.error).toBeFalsy();
+		});
+
+		it('should not revive group when already active (failed -> review, group has completedAt null)', async () => {
+			// Edge case: group is not yet terminated (completedAt is null)
+			// This can happen if set_task_status is called before the runtime terminates the group.
+			// In this case, reviveGroup should be a no-op.
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			await taskManager.startTask(taskId);
+			// Create a group but don't terminate it (completedAt stays null)
+			const groupId = insertGroup(taskId, 'awaiting_worker');
+			await taskManager.failTask(taskId, 'Something went wrong');
+
+			// Group still has completedAt = null (insertGroup doesn't set it)
+			const groupBefore = groupRepo.getGroup(groupId)!;
+			expect(groupBefore.completedAt).toBeNull();
+
+			// Revive to review should still work
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'review' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('review');
+			// Group should still be active
+			expect(groupRepo.getGroup(groupId)!.completedAt).toBeNull();
 		});
 
 		it('should allow transition: in_progress -> completed with result', async () => {

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -324,6 +324,52 @@ describe('SessionGroupRepository', () => {
 		});
 	});
 
+	describe('reviveGroup', () => {
+		it('should clear completedAt on a failed group', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const failed = repo.failGroup(group.id, group.version);
+			expect(failed!.completedAt).not.toBeNull();
+
+			const revived = repo.reviveGroup(group.id);
+			expect(revived).not.toBeNull();
+			expect(revived!.completedAt).toBeNull();
+		});
+
+		it('should preserve existing metadata (unlike resetGroupForRestart)', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			// Simulate some accumulated metadata
+			const afterIter = repo.incrementFeedbackIteration(group.id, group.version)!;
+			repo.failGroup(afterIter.id, afterIter.version);
+
+			const revived = repo.reviveGroup(group.id);
+			// feedbackIteration should be preserved (not reset to 0)
+			expect(revived!.feedbackIteration).toBe(1);
+		});
+
+		it('should increment version', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.failGroup(group.id, group.version);
+
+			const revived = repo.reviveGroup(group.id);
+			expect(revived!.version).toBe(group.version + 2); // +1 failGroup, +1 revive
+		});
+
+		it('should return null for non-existent group', () => {
+			const result = repo.reviveGroup('non-existent');
+			expect(result).toBeNull();
+		});
+
+		it('should make the group appear in getActiveGroups after revive', () => {
+			// room and task already exist from beforeEach
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.failGroup(group.id, group.version);
+			expect(repo.getActiveGroups(roomId)).toHaveLength(0);
+
+			repo.reviveGroup(group.id);
+			expect(repo.getActiveGroups(roomId)).toHaveLength(1);
+		});
+	});
+
 	describe('updateLeaderContractViolations', () => {
 		it('should update violations and turn ID', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -783,6 +783,17 @@ describe('TaskManager', () => {
 			expect(revived.status).toBe('review');
 		});
 
+		it('should clear error field on failed → review transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.failTask(task.id, 'something broke');
+
+			const revived = await taskManager.setTaskStatus(task.id, 'review');
+			expect(revived.status).toBe('review');
+			// error is mapped null→undefined by the task repository
+			expect(revived.error).toBeUndefined();
+		});
+
 		it('should allow cancelled → review transition', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -772,4 +772,34 @@ describe('TaskManager', () => {
 			expect(final?.status).toBe('completed');
 		});
 	});
+
+	describe('setTaskStatus — revive to review', () => {
+		it('should allow failed → review transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.failTask(task.id, 'boom');
+
+			const revived = await taskManager.setTaskStatus(task.id, 'review');
+			expect(revived.status).toBe('review');
+		});
+
+		it('should allow cancelled → review transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.cancelTask(task.id);
+
+			const revived = await taskManager.setTaskStatus(task.id, 'review');
+			expect(revived.status).toBe('review');
+		});
+
+		it('should reject completed → review transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+
+			await expect(taskManager.setTaskStatus(task.id, 'review')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -794,13 +794,14 @@ describe('TaskManager', () => {
 			expect(revived.error).toBeUndefined();
 		});
 
-		it('should allow cancelled → review transition', async () => {
+		it('should reject cancelled → review transition (worktree is cleaned up on cancel)', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);
 			await taskManager.cancelTask(task.id);
 
-			const revived = await taskManager.setTaskStatus(task.id, 'review');
-			expect(revived.status).toBe('review');
+			await expect(taskManager.setTaskStatus(task.id, 'review')).rejects.toThrow(
+				'Invalid status transition'
+			);
 		});
 
 		it('should reject completed → review transition', async () => {


### PR DESCRIPTION
When a user sends a message to a task in `failed` or `cancelled` status,
automatically transition it to `review` and restore the agent sessions so
the message can be delivered without requiring a manual `set_task_status` call.

Changes:
- Add `failed → review` and `cancelled → review` to VALID_STATUS_TRANSITIONS
- Add `SessionGroupRepository.reviveGroup()` to clear completedAt without
  resetting metadata (preserves conversation history and iteration counts)
- Add `RoomRuntime.reviveTaskForMessage()` which revives the group, restores
  stopped agent sessions, re-registers terminal-state observers, restores MCP
  servers, and injects the human message (leader first, worker as fallback)
- Update `send_message_to_task` handler to detect failed/cancelled tasks and
  route through the revive path instead of the normal routing path
- Add unit tests for all three new/updated components
