### PR TITLE
feat: fail tasks immediately on terminal API errors instead of bouncing

### DIFF
--- a/packages/daemon/src/lib/room/runtime/error-classifier.ts
+++ b/packages/daemon/src/lib/room/runtime/error-classifier.ts
@@ -1,23 +1,36 @@
 /**
- * Error Classifier - Classifies errors as terminal or recoverable
+ * Error Classifier - Unified API error classification
  *
- * Terminal errors indicate unrecoverable failures that should immediately fail a task.
- * Recoverable errors may succeed on retry (network issues, 5xx, temporary limits).
+ * Single point of truth for classifying API errors from agent output:
+ * - terminal:    unrecoverable errors (4xx, invalid model, etc.) → fail task immediately
+ * - rate_limit:  429 rate limits with parseable retry-after → pause with backoff
+ * - recoverable: transient errors (5xx, network) → bounce/retry
+ *
+ * Consolidates the previously separate rate-limit-utils detection into one place.
+ * rate-limit-utils.ts remains for its parsing logic but is no longer imported
+ * directly in room-runtime.ts.
  */
 
-export type ErrorClass = 'recoverable' | 'terminal';
+import { parseRateLimitReset } from './rate-limit-utils';
+
+export type ErrorClass = 'terminal' | 'rate_limit' | 'recoverable';
 
 export interface ErrorClassification {
 	class: ErrorClass;
 	reason: string;
 	/** HTTP status code if extracted from the error message, undefined otherwise */
 	statusCode?: number;
+	/**
+	 * For rate_limit: Unix timestamp (ms) when the limit resets.
+	 * Consumers should set a backoff until this time.
+	 */
+	resetsAt?: number;
 }
 
 /**
  * HTTP status codes that are terminal (unrecoverable client errors).
- * Note: 429 (rate limit) is intentionally excluded — it is handled separately
- * by rate-limit-utils.ts which parses retry-after timing.
+ * 429 is handled separately as rate_limit (not terminal) because it has
+ * a parseable retry-after time and the underlying credentials are valid.
  */
 const TERMINAL_HTTP_CODES = new Set([400, 401, 403, 404, 422]);
 
@@ -50,17 +63,24 @@ function extractHttpStatus(message: string): number | undefined {
 }
 
 /**
- * Classify an error message as terminal or recoverable.
+ * Classify an API error message.
  *
- * HTTP status codes are checked first (they carry the most reliable signal).
- * Text patterns are a fallback for messages that lack an explicit HTTP code.
+ * Evaluation order (first match wins):
+ * 1. HTTP status code — most authoritative signal
+ *    - 400/401/403/404/422 → terminal
+ *    - 429 → rate_limit (with resetsAt if parseable)
+ *    - 5xx → recoverable
+ * 2. Text patterns — fallback for messages without an HTTP code
+ *    - "invalid model", "invalid api key", etc. → terminal
  *
- * Returns an ErrorClassification if the message matches a known error pattern,
- * or null if it is not recognized as an API error.
+ * Returns null when the message is not recognised as an API error.
  *
  * @example
  * classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}')
  * // → { class: 'terminal', reason: '...', statusCode: 400 }
+ *
+ * classifyError("You've hit your limit · resets 1pm (America/New_York)")
+ * // → { class: 'rate_limit', reason: '...', statusCode: 429, resetsAt: <timestamp> }
  *
  * classifyError('API Error: 500 Internal Server Error')
  * // → { class: 'recoverable', reason: '...', statusCode: 500 }
@@ -72,10 +92,11 @@ function extractHttpStatus(message: string): number | undefined {
  * // → null
  */
 export function classifyError(message: string): ErrorClassification | null {
-	// Check HTTP status code first — it is the most authoritative signal.
+	// ── 1. HTTP status code ──────────────────────────────────────────────────
 	const statusCode = extractHttpStatus(message);
 	if (statusCode !== undefined) {
 		const excerpt = message.slice(0, 300);
+
 		if (TERMINAL_HTTP_CODES.has(statusCode)) {
 			return {
 				class: 'terminal',
@@ -83,6 +104,17 @@ export function classifyError(message: string): ErrorClassification | null {
 				statusCode,
 			};
 		}
+
+		if (statusCode === 429) {
+			const resetsAt = parseRateLimitReset(message) ?? undefined;
+			return {
+				class: 'rate_limit',
+				reason: `Rate limit reached (HTTP 429)${resetsAt ? ` — resets at ${new Date(resetsAt).toLocaleTimeString()}` : ''}`,
+				statusCode: 429,
+				resetsAt,
+			};
+		}
+
 		if (statusCode >= 500 && statusCode < 600) {
 			return {
 				class: 'recoverable',
@@ -92,8 +124,17 @@ export function classifyError(message: string): ErrorClassification | null {
 		}
 	}
 
-	// Fall back to text patterns — these catch misconfigurations that may not
-	// include an explicit HTTP status code in the message.
+	// ── 2. Text patterns (no explicit HTTP code) ─────────────────────────────
+	// Also catches the Anthropic usage-limit message ("You've hit your limit…")
+	const resetsAt = parseRateLimitReset(message);
+	if (resetsAt !== null) {
+		return {
+			class: 'rate_limit',
+			reason: `Rate limit reached — resets at ${new Date(resetsAt).toLocaleTimeString()}`,
+			resetsAt,
+		};
+	}
+
 	for (const pattern of TERMINAL_TEXT_PATTERNS) {
 		if (pattern.test(message)) {
 			const excerpt = message.slice(0, 300);
@@ -109,11 +150,9 @@ export function classifyError(message: string): ErrorClassification | null {
 
 /**
  * Check whether a message contains a terminal error that should fail a task immediately.
- *
- * Returns the classification when the error is terminal, null otherwise.
- * Callers should still invoke isRateLimitError() separately for 429 rate-limit handling.
+ * Returns the classification when terminal, null otherwise.
  */
 export function detectTerminalError(message: string): ErrorClassification | null {
-	const classification = classifyError(message);
-	return classification?.class === 'terminal' ? classification : null;
+	const c = classifyError(message);
+	return c?.class === 'terminal' ? c : null;
 }

--- a/packages/daemon/src/lib/room/runtime/error-classifier.ts
+++ b/packages/daemon/src/lib/room/runtime/error-classifier.ts
@@ -2,13 +2,18 @@
  * Error Classifier - Unified API error classification
  *
  * Single point of truth for classifying API errors from agent output:
- * - terminal:    unrecoverable errors (4xx, invalid model, etc.) → fail task immediately
+ * - terminal:    unrecoverable errors (4xx) → fail task immediately
  * - rate_limit:  429 rate limits with parseable retry-after → pause with backoff
- * - recoverable: transient errors (5xx, network) → bounce/retry
+ * - recoverable: transient errors (5xx) → bounce/retry
  *
- * Consolidates the previously separate rate-limit-utils detection into one place.
- * rate-limit-utils.ts remains for its parsing logic but is no longer imported
- * directly in room-runtime.ts.
+ * Detection strategy: match only structured "API Error: NNN" messages from the
+ * Claude Agent SDK. Free-form text patterns are intentionally avoided because
+ * they cause false positives when workers discuss error handling in prose
+ * (e.g. "implemented handling for invalid model errors").
+ *
+ * The Anthropic usage-limit text pattern ("You've hit your limit · resets …")
+ * is kept as a rate_limit fallback because it is highly specific and not
+ * something a worker would write as normal explanatory output.
  */
 
 import { parseRateLimitReset } from './rate-limit-utils';
@@ -18,7 +23,7 @@ export type ErrorClass = 'terminal' | 'rate_limit' | 'recoverable';
 export interface ErrorClassification {
 	class: ErrorClass;
 	reason: string;
-	/** HTTP status code if extracted from the error message, undefined otherwise */
+	/** HTTP status code extracted from the error message, if present */
 	statusCode?: number;
 	/**
 	 * For rate_limit: Unix timestamp (ms) when the limit resets.
@@ -29,32 +34,17 @@ export interface ErrorClassification {
 
 /**
  * HTTP status codes that are terminal (unrecoverable client errors).
- * 429 is handled separately as rate_limit (not terminal) because it has
- * a parseable retry-after time and the underlying credentials are valid.
+ * 429 is handled separately as rate_limit because the underlying credentials
+ * are valid and the limit resets after a known period.
  */
 const TERMINAL_HTTP_CODES = new Set([400, 401, 403, 404, 422]);
-
-/**
- * Text patterns that indicate terminal errors regardless of HTTP status code.
- * Applied case-insensitively against the full error message.
- */
-const TERMINAL_TEXT_PATTERNS: readonly RegExp[] = [
-	/invalid model/i,
-	/invalid api key/i,
-	/authentication failed/i,
-	/quota exceeded/i,
-	/account suspended/i,
-	/model does not exist/i,
-	/model not found/i,
-	/no such model/i,
-];
 
 /** Pattern to extract HTTP status code from SDK error messages like "API Error: 400 ..." */
 const API_ERROR_PATTERN = /API Error:\s*(\d{3})/;
 
 /**
- * Extract the HTTP status code from an error message.
- * Returns undefined if no recognizable HTTP error code is found.
+ * Extract the HTTP status code from a message.
+ * Returns undefined if no recognisable "API Error: NNN" prefix is found.
  */
 function extractHttpStatus(message: string): number | undefined {
 	const match = message.match(API_ERROR_PATTERN);
@@ -63,36 +53,36 @@ function extractHttpStatus(message: string): number | undefined {
 }
 
 /**
- * Classify an API error message.
+ * Classify an error message from agent output.
+ *
+ * Only matches structured "API Error: NNN" messages produced by the Claude
+ * Agent SDK, plus the Anthropic usage-limit text for rate_limit detection.
+ * Free-form prose does NOT trigger classification.
  *
  * Evaluation order (first match wins):
- * 1. HTTP status code — most authoritative signal
+ * 1. "API Error: NNN" — HTTP status code determines class
  *    - 400/401/403/404/422 → terminal
- *    - 429 → rate_limit (with resetsAt if parseable)
- *    - 5xx → recoverable
- * 2. Text patterns — fallback for messages without an HTTP code
- *    - "invalid model", "invalid api key", etc. → terminal
+ *    - 429               → rate_limit (with resetsAt if parseable)
+ *    - 5xx              → recoverable
+ * 2. Anthropic usage-limit text → rate_limit (specific, not prose-writable)
  *
- * Returns null when the message is not recognised as an API error.
+ * Returns null when the message is not an API error.
  *
  * @example
  * classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}')
  * // → { class: 'terminal', reason: '...', statusCode: 400 }
  *
  * classifyError("You've hit your limit · resets 1pm (America/New_York)")
- * // → { class: 'rate_limit', reason: '...', statusCode: 429, resetsAt: <timestamp> }
+ * // → { class: 'rate_limit', reason: '...', resetsAt: <timestamp> }
  *
  * classifyError('API Error: 500 Internal Server Error')
  * // → { class: 'recoverable', reason: '...', statusCode: 500 }
  *
- * classifyError('Invalid model: claude-bad-v0')
- * // → { class: 'terminal', reason: '...' }
- *
- * classifyError('some unrelated text')
- * // → null
+ * classifyError('implemented handling for invalid model errors')
+ * // → null  (prose — no false positive)
  */
 export function classifyError(message: string): ErrorClassification | null {
-	// ── 1. HTTP status code ──────────────────────────────────────────────────
+	// ── 1. Structured "API Error: NNN" from the SDK ──────────────────────────
 	const statusCode = extractHttpStatus(message);
 	if (statusCode !== undefined) {
 		const excerpt = message.slice(0, 300);
@@ -124,8 +114,7 @@ export function classifyError(message: string): ErrorClassification | null {
 		}
 	}
 
-	// ── 2. Text patterns (no explicit HTTP code) ─────────────────────────────
-	// Also catches the Anthropic usage-limit message ("You've hit your limit…")
+	// ── 2. Anthropic usage-limit text (specific, cannot appear in normal prose)
 	const resetsAt = parseRateLimitReset(message);
 	if (resetsAt !== null) {
 		return {
@@ -133,16 +122,6 @@ export function classifyError(message: string): ErrorClassification | null {
 			reason: `Rate limit reached — resets at ${new Date(resetsAt).toLocaleTimeString()}`,
 			resetsAt,
 		};
-	}
-
-	for (const pattern of TERMINAL_TEXT_PATTERNS) {
-		if (pattern.test(message)) {
-			const excerpt = message.slice(0, 300);
-			return {
-				class: 'terminal',
-				reason: `Terminal error detected: ${excerpt}`,
-			};
-		}
 	}
 
 	return null;

--- a/packages/daemon/src/lib/room/runtime/error-classifier.ts
+++ b/packages/daemon/src/lib/room/runtime/error-classifier.ts
@@ -1,0 +1,119 @@
+/**
+ * Error Classifier - Classifies errors as terminal or recoverable
+ *
+ * Terminal errors indicate unrecoverable failures that should immediately fail a task.
+ * Recoverable errors may succeed on retry (network issues, 5xx, temporary limits).
+ */
+
+export type ErrorClass = 'recoverable' | 'terminal';
+
+export interface ErrorClassification {
+	class: ErrorClass;
+	reason: string;
+	/** HTTP status code if extracted from the error message, undefined otherwise */
+	statusCode?: number;
+}
+
+/**
+ * HTTP status codes that are terminal (unrecoverable client errors).
+ * Note: 429 (rate limit) is intentionally excluded — it is handled separately
+ * by rate-limit-utils.ts which parses retry-after timing.
+ */
+const TERMINAL_HTTP_CODES = new Set([400, 401, 403, 404, 422]);
+
+/**
+ * Text patterns that indicate terminal errors regardless of HTTP status code.
+ * Applied case-insensitively against the full error message.
+ */
+const TERMINAL_TEXT_PATTERNS: readonly RegExp[] = [
+	/invalid model/i,
+	/invalid api key/i,
+	/authentication failed/i,
+	/quota exceeded/i,
+	/account suspended/i,
+	/model does not exist/i,
+	/model not found/i,
+	/no such model/i,
+];
+
+/** Pattern to extract HTTP status code from SDK error messages like "API Error: 400 ..." */
+const API_ERROR_PATTERN = /API Error:\s*(\d{3})/;
+
+/**
+ * Extract the HTTP status code from an error message.
+ * Returns undefined if no recognizable HTTP error code is found.
+ */
+function extractHttpStatus(message: string): number | undefined {
+	const match = message.match(API_ERROR_PATTERN);
+	if (!match) return undefined;
+	return parseInt(match[1], 10);
+}
+
+/**
+ * Classify an error message as terminal or recoverable.
+ *
+ * HTTP status codes are checked first (they carry the most reliable signal).
+ * Text patterns are a fallback for messages that lack an explicit HTTP code.
+ *
+ * Returns an ErrorClassification if the message matches a known error pattern,
+ * or null if it is not recognized as an API error.
+ *
+ * @example
+ * classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}')
+ * // → { class: 'terminal', reason: '...', statusCode: 400 }
+ *
+ * classifyError('API Error: 500 Internal Server Error')
+ * // → { class: 'recoverable', reason: '...', statusCode: 500 }
+ *
+ * classifyError('Invalid model: claude-bad-v0')
+ * // → { class: 'terminal', reason: '...' }
+ *
+ * classifyError('some unrelated text')
+ * // → null
+ */
+export function classifyError(message: string): ErrorClassification | null {
+	// Check HTTP status code first — it is the most authoritative signal.
+	const statusCode = extractHttpStatus(message);
+	if (statusCode !== undefined) {
+		const excerpt = message.slice(0, 300);
+		if (TERMINAL_HTTP_CODES.has(statusCode)) {
+			return {
+				class: 'terminal',
+				reason: `Unrecoverable API error (HTTP ${statusCode}): ${excerpt}`,
+				statusCode,
+			};
+		}
+		if (statusCode >= 500 && statusCode < 600) {
+			return {
+				class: 'recoverable',
+				reason: `Transient server error (HTTP ${statusCode}) — will retry`,
+				statusCode,
+			};
+		}
+	}
+
+	// Fall back to text patterns — these catch misconfigurations that may not
+	// include an explicit HTTP status code in the message.
+	for (const pattern of TERMINAL_TEXT_PATTERNS) {
+		if (pattern.test(message)) {
+			const excerpt = message.slice(0, 300);
+			return {
+				class: 'terminal',
+				reason: `Terminal error detected: ${excerpt}`,
+			};
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Check whether a message contains a terminal error that should fail a task immediately.
+ *
+ * Returns the classification when the error is terminal, null otherwise.
+ * Callers should still invoke isRateLimitError() separately for 429 rate-limit handling.
+ */
+export function detectTerminalError(message: string): ErrorClassification | null {
+	const classification = classifyError(message);
+	return classification?.class === 'terminal' ? classification : null;
+}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -601,7 +601,6 @@ export class RoomRuntime {
 			}
 		}
 
-
 		// Classify any API errors in worker output.
 		// terminal   → fail task immediately (4xx, invalid model, etc. — won't fix on retry)
 		// rate_limit → pause with timed backoff (429 / usage limit)

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -50,6 +50,7 @@ import {
 	sortTasksByPriority,
 } from './message-routing';
 import { isRateLimitError, createRateLimitBackoff } from './rate-limit-utils';
+import { detectTerminalError } from './error-classifier';
 import { Logger } from '../../logger';
 import {
 	runWorkerExitGate,
@@ -597,6 +598,27 @@ export class RoomRuntime {
 						`Bypass detected for ${group.workerRole} group ${groupId} — pre-authorizing leader complete`
 					);
 				}
+			}
+		}
+
+
+		// Check for terminal API errors in worker output (e.g. HTTP 400/401/403/404/422).
+		// These are unrecoverable — bouncing back to the agent will never fix them.
+		{
+			const terminalError = detectTerminalError(workerOutputText);
+			if (terminalError) {
+				log.info(
+					`Terminal API error in worker output for group ${groupId}: ${terminalError.reason}`
+				);
+				this.appendGroupEvent(groupId, 'status', {
+					text: `Terminal error: ${terminalError.reason}`,
+				});
+				await this.taskGroupManager.fail(groupId, terminalError.reason);
+				this.cleanupMirroring(groupId, `Terminal API error: ${terminalError.reason}`);
+				await this.emitTaskUpdateById(group.taskId);
+				await this.emitGoalProgressForTask(group.taskId);
+				this.scheduleTick();
+				return;
 			}
 		}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -49,8 +49,8 @@ import {
 	formatLeaderToWorkerFeedback,
 	sortTasksByPriority,
 } from './message-routing';
-import { isRateLimitError, createRateLimitBackoff } from './rate-limit-utils';
-import { detectTerminalError } from './error-classifier';
+import { createRateLimitBackoff } from './rate-limit-utils';
+import { classifyError } from './error-classifier';
 import { Logger } from '../../logger';
 import {
 	runWorkerExitGate,
@@ -602,42 +602,42 @@ export class RoomRuntime {
 		}
 
 
-		// Check for terminal API errors in worker output (e.g. HTTP 400/401/403/404/422).
-		// These are unrecoverable — bouncing back to the agent will never fix them.
+		// Classify any API errors in worker output.
+		// terminal   → fail task immediately (4xx, invalid model, etc. — won't fix on retry)
+		// rate_limit → pause with timed backoff (429 / usage limit)
+		// recoverable / null → fall through to normal leader routing
 		{
-			const terminalError = detectTerminalError(workerOutputText);
-			if (terminalError) {
-				log.info(
-					`Terminal API error in worker output for group ${groupId}: ${terminalError.reason}`
-				);
+			const errorClass = classifyError(workerOutputText);
+			if (errorClass?.class === 'terminal') {
+				log.info(`Terminal API error in worker output for group ${groupId}: ${errorClass.reason}`);
 				this.appendGroupEvent(groupId, 'status', {
-					text: `Terminal error: ${terminalError.reason}`,
+					text: `Terminal error: ${errorClass.reason}`,
 				});
-				await this.taskGroupManager.fail(groupId, terminalError.reason);
-				this.cleanupMirroring(groupId, `Terminal API error: ${terminalError.reason}`);
+				await this.taskGroupManager.fail(groupId, errorClass.reason);
+				this.cleanupMirroring(groupId, `Terminal API error: ${errorClass.reason}`);
 				await this.emitTaskUpdateById(group.taskId);
 				await this.emitGoalProgressForTask(group.taskId);
 				this.scheduleTick();
 				return;
 			}
-		}
-
-		// Check for rate limit errors in worker output
-		if (isRateLimitError(workerOutputText)) {
-			const rateLimitBackoff = createRateLimitBackoff(workerOutputText, 'worker');
-			if (rateLimitBackoff) {
-				this.groupRepo.setRateLimit(groupId, rateLimitBackoff);
-				log.info(
-					`Rate limit detected in worker output for group ${groupId}. ` +
-						`Backoff until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`
-				);
-				this.appendGroupEvent(groupId, 'rate_limited', {
-					text: `Rate limit detected. Pausing until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`,
-					resetsAt: rateLimitBackoff.resetsAt,
-					sessionRole: 'worker',
-				});
-				this.scheduleTickAfterRateLimitReset(groupId);
-				return;
+			if (errorClass?.class === 'rate_limit') {
+				const rateLimitBackoff = errorClass.resetsAt
+					? createRateLimitBackoff(workerOutputText, 'worker')
+					: null;
+				if (rateLimitBackoff) {
+					this.groupRepo.setRateLimit(groupId, rateLimitBackoff);
+					log.info(
+						`Rate limit detected in worker output for group ${groupId}. ` +
+							`Backoff until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`
+					);
+					this.appendGroupEvent(groupId, 'rate_limited', {
+						text: `Rate limit detected. Pausing until ${new Date(rateLimitBackoff.resetsAt).toLocaleTimeString()}.`,
+						resetsAt: rateLimitBackoff.resetsAt,
+						sessionRole: 'worker',
+					});
+					this.scheduleTickAfterRateLimitReset(groupId);
+					return;
+				}
 			}
 		}
 
@@ -1571,10 +1571,10 @@ export class RoomRuntime {
 					if (uuid && mirroredUuids.has(uuid)) return;
 					if (uuid) mirroredUuids.add(uuid);
 
-					// Check for rate limit errors in the message content
-					// This detects rate limits in real-time for both Worker and Leader sessions
+					// Check for rate limit errors in real-time for both Worker and Leader sessions
 					const messageContent = JSON.stringify(event.message);
-					if (isRateLimitError(messageContent)) {
+					const msgErrorClass = classifyError(messageContent);
+					if (msgErrorClass?.class === 'rate_limit') {
 						const sessionRole = sessionId === group.workerSessionId ? 'worker' : 'leader';
 						const rateLimitBackoff = createRateLimitBackoff(messageContent, sessionRole);
 						if (rateLimitBackoff) {

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -57,7 +57,7 @@ describe('RoomRuntime - terminal error detection', () => {
 
 			// Task should be failed, NOT routed to leader
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 
 			// Group should be completed (terminated)
 			const updatedGroup = ctx.groupRepo.getGroup(group.id);
@@ -78,7 +78,7 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 
 		it('fails task immediately on HTTP 403 error in worker output', async () => {
@@ -89,7 +89,7 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 
 		it('fails task immediately on HTTP 404 error in worker output', async () => {
@@ -100,7 +100,7 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 
 		it('fails task immediately on HTTP 422 error in worker output', async () => {
@@ -111,7 +111,7 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 
 		it('fails task on terminal error embedded in multi-line worker output', async () => {
@@ -129,7 +129,7 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 	});
 
@@ -191,7 +191,7 @@ describe('RoomRuntime - terminal error detection', () => {
 
 			// 429 is rate_limit, not terminal — task is NOT failed immediately
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).not.toBe('failed');
+			expect(updatedTask!.status).not.toBe('needs_attention');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for terminal API error detection in RoomRuntime.
+ *
+ * Verifies that when a worker session outputs a terminal API error
+ * (HTTP 400, 401, 403, 404, 422, invalid model, etc.) the runtime
+ * fails the task immediately instead of routing to the leader.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import {
+	createRuntimeTestContext,
+	createGoalAndTask,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+
+describe('RoomRuntime - terminal error detection', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	function makeWorkerMessage(text: string) {
+		return { id: 'msg-1', text, toolCallNames: [] };
+	}
+
+	/**
+	 * Spawn a group and simulate worker terminal state with the given output text.
+	 * Returns the group that was spawned.
+	 */
+	async function spawnAndSimulateWorkerOutput(workerOutput: string) {
+		const { task } = await createGoalAndTask(ctx);
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		return { group, task };
+	}
+
+	describe('terminal errors cause immediate task failure', () => {
+		it('fails task immediately on HTTP 400 error in worker output', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage('API Error: 400 {"error":{"message":"Invalid model: claude-bad-v0"}}'),
+				],
+			});
+
+			const { group, task } = await spawnAndSimulateWorkerOutput('');
+
+			// Task should be failed, NOT routed to leader
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+
+			// Group should be completed (terminated)
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.completedAt).not.toBeNull();
+
+			// No leader session should have been created
+			const leaderCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			);
+			expect(leaderCalls).toHaveLength(0);
+		});
+
+		it('fails task immediately on HTTP 401 error in worker output', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 401 Unauthorized')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+
+		it('fails task immediately on HTTP 403 error in worker output', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 403 Forbidden')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+
+		it('fails task immediately on HTTP 404 error in worker output', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 404 Not Found')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+
+		it('fails task immediately on HTTP 422 error in worker output', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 422 Unprocessable Entity')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+
+		it('fails task immediately on "Invalid model" text pattern', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage('Invalid model: claude-unknown-v99. Please check your configuration.'),
+				],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+
+		it('fails task on terminal error embedded in multi-line worker output', async () => {
+			const multilineOutput = [
+				'Starting task execution...',
+				'Running some analysis...',
+				'API Error: 400 {"error":{"message":"Invalid model: xyz","type":"invalid_request_error"}}',
+				'Session ended.',
+			].join('\n');
+
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage(multilineOutput)],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('failed');
+		});
+	});
+
+	describe('recoverable errors are still routed to leader', () => {
+		it('routes worker to leader on HTTP 500 error (server error - recoverable)', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 500 Internal Server Error')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// Task should remain in_progress (routed to leader, not failed)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+
+		it('routes worker to leader when no API error in output (normal flow)', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage('Completed the implementation. All tests pass.'),
+				],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// Task should remain in_progress (awaiting leader review)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+
+		it('does NOT fail task on HTTP 429 rate limit (handled by rate-limit-utils)', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage('API Error: 429 Too Many Requests')],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// 429 without a parseable retry-after falls through to normal leader routing
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			// Should NOT be failed — 429 handling is separate
+			expect(updatedTask!.status).not.toBe('failed');
+		});
+	});
+
+	describe('empty / no worker messages use terminal state placeholder', () => {
+		it('does not fail task when worker has no messages (idle exit - normal)', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [], // empty — triggers placeholder text
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// Placeholder text does not match terminal error patterns
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -114,19 +114,6 @@ describe('RoomRuntime - terminal error detection', () => {
 			expect(updatedTask!.status).toBe('failed');
 		});
 
-		it('fails task immediately on "Invalid model" text pattern', async () => {
-			ctx = createRuntimeTestContext({
-				getWorkerMessages: () => [
-					makeWorkerMessage('Invalid model: claude-unknown-v99. Please check your configuration.'),
-				],
-			});
-
-			const { task } = await spawnAndSimulateWorkerOutput('');
-
-			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
-		});
-
 		it('fails task on terminal error embedded in multi-line worker output', async () => {
 			const multilineOutput = [
 				'Starting task execution...',
@@ -169,6 +156,28 @@ describe('RoomRuntime - terminal error detection', () => {
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
 			// Task should remain in_progress (awaiting leader review)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+		});
+
+		it('does NOT fail task when worker discusses error handling in prose (regression)', async () => {
+			// Regression: broad text patterns previously caused false positives
+			// when the worker wrote explanatory text containing phrases like
+			// "invalid model", "authentication failed", etc.
+			const proseOutput = [
+				'I have implemented handling for invalid model errors in the provider adapter.',
+				'The fix ensures authentication failed scenarios are retried correctly.',
+				'I also added quota exceeded detection so users get clear messages.',
+				'All tests pass. Creating PR now.',
+			].join('\n');
+
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [makeWorkerMessage(proseOutput)],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// Prose should NOT fail the task — it should route to leader normally
 			const updatedTask = await ctx.taskManager.getTask(task.id);
 			expect(updatedTask!.status).toBe('in_progress');
 		});

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -173,16 +173,15 @@ describe('RoomRuntime - terminal error detection', () => {
 			expect(updatedTask!.status).toBe('in_progress');
 		});
 
-		it('does NOT fail task on HTTP 429 rate limit (handled by rate-limit-utils)', async () => {
+		it('does NOT fail task on HTTP 429 rate limit (classified as rate_limit, not terminal)', async () => {
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => [makeWorkerMessage('API Error: 429 Too Many Requests')],
 			});
 
 			const { task } = await spawnAndSimulateWorkerOutput('');
 
-			// 429 without a parseable retry-after falls through to normal leader routing
+			// 429 is rate_limit, not terminal — task is NOT failed immediately
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			// Should NOT be failed — 429 handling is separate
 			expect(updatedTask!.status).not.toBe('failed');
 		});
 	});

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -174,7 +174,7 @@ export interface RuntimeTestContextOptions {
 	room?: Partial<Room>;
 	maxConcurrentGroups?: number;
 	maxFeedbackIterations?: number;
-	/** Optional worker message provider for testing bypass markers and envelope content */
+	/** Worker message provider for testing (bypass markers, envelope content, terminal errors) */
 	getWorkerMessages?: (
 		sessionId: string,
 		afterMessageId: string | null

--- a/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	classifyError,
+	detectTerminalError,
+} from '../../../../src/lib/room/runtime/error-classifier';
+
+describe('error-classifier', () => {
+	describe('classifyError', () => {
+		describe('terminal HTTP status codes', () => {
+			it('classifies HTTP 400 as terminal', () => {
+				const result = classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(400);
+			});
+
+			it('classifies HTTP 401 as terminal', () => {
+				const result = classifyError('API Error: 401 Unauthorized');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(401);
+			});
+
+			it('classifies HTTP 403 as terminal', () => {
+				const result = classifyError('API Error: 403 Forbidden');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(403);
+			});
+
+			it('classifies HTTP 404 as terminal', () => {
+				const result = classifyError('API Error: 404 Not Found');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(404);
+			});
+
+			it('classifies HTTP 422 as terminal', () => {
+				const result = classifyError('API Error: 422 Unprocessable Entity');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(422);
+			});
+		});
+
+		describe('recoverable HTTP status codes', () => {
+			it('classifies HTTP 500 as recoverable', () => {
+				const result = classifyError('API Error: 500 Internal Server Error');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('recoverable');
+				expect(result!.statusCode).toBe(500);
+			});
+
+			it('classifies HTTP 502 as recoverable', () => {
+				const result = classifyError('API Error: 502 Bad Gateway');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('recoverable');
+				expect(result!.statusCode).toBe(502);
+			});
+
+			it('classifies HTTP 503 as recoverable', () => {
+				const result = classifyError('API Error: 503 Service Unavailable');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('recoverable');
+				expect(result!.statusCode).toBe(503);
+			});
+		});
+
+		describe('429 rate limit exclusion', () => {
+			it('does NOT classify HTTP 429 as terminal (rate limits handled separately)', () => {
+				const result = classifyError('API Error: 429 Too Many Requests');
+				// 429 is excluded from TERMINAL_HTTP_CODES, so it falls through to null
+				expect(result).toBeNull();
+			});
+		});
+
+		describe('terminal text patterns', () => {
+			it('classifies "Invalid model" as terminal', () => {
+				const result = classifyError('Invalid model: claude-fake-model');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBeUndefined();
+			});
+
+			it('classifies "invalid api key" as terminal (case-insensitive)', () => {
+				const result = classifyError('Invalid API Key provided');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "authentication failed" as terminal', () => {
+				const result = classifyError('Authentication failed: bad credentials');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "quota exceeded" as terminal', () => {
+				const result = classifyError('quota exceeded for this account');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "account suspended" as terminal', () => {
+				const result = classifyError('Account suspended due to policy violation');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "model does not exist" as terminal', () => {
+				const result = classifyError('The model does not exist: gpt-99');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "model not found" as terminal', () => {
+				const result = classifyError('model not found in registry');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('classifies "no such model" as terminal', () => {
+				const result = classifyError('No such model: my-custom-model');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+			});
+
+			it('is case-insensitive for text patterns', () => {
+				expect(classifyError('INVALID MODEL')!.class).toBe('terminal');
+				expect(classifyError('Quota Exceeded')!.class).toBe('terminal');
+			});
+		});
+
+		describe('realistic combined messages', () => {
+			it('classifies full invalid-model API error as terminal with statusCode', () => {
+				const msg =
+					'API Error: 400 {"error":{"message":"Invalid model: claude-invalid-v99","type":"invalid_request_error"}}';
+				const result = classifyError(msg);
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				// HTTP status check fires first, so statusCode is set
+				expect(result!.statusCode).toBe(400);
+			});
+
+			it('classifies bare HTTP 400 with no text pattern as terminal', () => {
+				const result = classifyError('API Error: 400 Bad Request');
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('terminal');
+				expect(result!.statusCode).toBe(400);
+			});
+		});
+
+		describe('unrecognized messages return null', () => {
+			it('returns null for generic text', () => {
+				expect(classifyError('Some unrelated error')).toBeNull();
+			});
+
+			it('returns null for empty string', () => {
+				expect(classifyError('')).toBeNull();
+			});
+
+			it('returns null for network errors (not API errors)', () => {
+				expect(classifyError('Network timeout')).toBeNull();
+				expect(classifyError('Connection refused')).toBeNull();
+			});
+
+			it('returns null for file-system errors', () => {
+				expect(classifyError('Error: ENOENT: no such file or directory')).toBeNull();
+			});
+		});
+
+		describe('reason field', () => {
+			it('includes a non-empty reason for terminal errors', () => {
+				const result = classifyError('API Error: 401 Unauthorized');
+				expect(result!.reason.length).toBeGreaterThan(0);
+			});
+
+			it('truncates very long messages in reason', () => {
+				const longMsg = 'API Error: 400 ' + 'x'.repeat(1000);
+				const result = classifyError(longMsg);
+				expect(result!.reason.length).toBeLessThan(500);
+			});
+		});
+	});
+
+	describe('detectTerminalError', () => {
+		it('returns classification for terminal errors', () => {
+			const result = detectTerminalError('API Error: 401 Unauthorized');
+			expect(result).not.toBeNull();
+			expect(result!.class).toBe('terminal');
+		});
+
+		it('returns null for recoverable errors', () => {
+			const result = detectTerminalError('API Error: 500 Internal Server Error');
+			expect(result).toBeNull();
+		});
+
+		it('returns null for unrecognized text', () => {
+			const result = detectTerminalError('Some other output');
+			expect(result).toBeNull();
+		});
+
+		it('returns null for rate limit messages (handled separately)', () => {
+			const result = detectTerminalError('API Error: 429 Too Many Requests');
+			expect(result).toBeNull();
+		});
+
+		it('detects terminal error embedded in multi-line worker output', () => {
+			const output = [
+				'Attempting to solve the task...',
+				'Running tests...',
+				'API Error: 400 {"error":{"message":"Invalid model: bad-model"}}',
+				'Exiting.',
+			].join('\n');
+			const result = detectTerminalError(output);
+			expect(result).not.toBeNull();
+			expect(result!.class).toBe('terminal');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('error-classifier', () => {
 	describe('classifyError', () => {
-		describe('terminal HTTP status codes', () => {
+		describe('terminal HTTP status codes (via "API Error: NNN")', () => {
 			it('classifies HTTP 400 as terminal', () => {
 				const result = classifyError('API Error: 400 {"error":{"message":"Invalid model: xyz"}}');
 				expect(result).not.toBeNull();
@@ -89,62 +89,6 @@ describe('error-classifier', () => {
 			});
 		});
 
-		describe('terminal text patterns', () => {
-			it('classifies "Invalid model" as terminal', () => {
-				const result = classifyError('Invalid model: claude-fake-model');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-				expect(result!.statusCode).toBeUndefined();
-			});
-
-			it('classifies "invalid api key" as terminal (case-insensitive)', () => {
-				const result = classifyError('Invalid API Key provided');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "authentication failed" as terminal', () => {
-				const result = classifyError('Authentication failed: bad credentials');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "quota exceeded" as terminal', () => {
-				const result = classifyError('quota exceeded for this account');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "account suspended" as terminal', () => {
-				const result = classifyError('Account suspended due to policy violation');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "model does not exist" as terminal', () => {
-				const result = classifyError('The model does not exist: gpt-99');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "model not found" as terminal', () => {
-				const result = classifyError('model not found in registry');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('classifies "no such model" as terminal', () => {
-				const result = classifyError('No such model: my-custom-model');
-				expect(result).not.toBeNull();
-				expect(result!.class).toBe('terminal');
-			});
-
-			it('is case-insensitive for text patterns', () => {
-				expect(classifyError('INVALID MODEL')!.class).toBe('terminal');
-				expect(classifyError('Quota Exceeded')!.class).toBe('terminal');
-			});
-		});
-
 		describe('realistic combined messages', () => {
 			it('classifies full invalid-model API error as terminal with statusCode', () => {
 				const msg =
@@ -152,11 +96,10 @@ describe('error-classifier', () => {
 				const result = classifyError(msg);
 				expect(result).not.toBeNull();
 				expect(result!.class).toBe('terminal');
-				// HTTP status check fires first, so statusCode is set
 				expect(result!.statusCode).toBe(400);
 			});
 
-			it('classifies bare HTTP 400 with no text pattern as terminal', () => {
+			it('classifies bare HTTP 400 as terminal', () => {
 				const result = classifyError('API Error: 400 Bad Request');
 				expect(result).not.toBeNull();
 				expect(result!.class).toBe('terminal');
@@ -164,7 +107,29 @@ describe('error-classifier', () => {
 			});
 		});
 
-		describe('unrecognized messages return null', () => {
+		describe('prose / explanatory text does NOT trigger false positives', () => {
+			it('returns null for "implemented handling for invalid model errors"', () => {
+				expect(
+					classifyError('implemented handling for invalid model errors in provider adapter')
+				).toBeNull();
+			});
+
+			it('returns null for "added support for invalid api key detection"', () => {
+				expect(classifyError('added support for invalid api key detection')).toBeNull();
+			});
+
+			it('returns null for "fixed authentication failed edge case"', () => {
+				expect(classifyError('fixed authentication failed edge case in login flow')).toBeNull();
+			});
+
+			it('returns null for "handle quota exceeded scenario in tests"', () => {
+				expect(classifyError('handle quota exceeded scenario in tests')).toBeNull();
+			});
+
+			it('returns null for "model not found error is now logged properly"', () => {
+				expect(classifyError('model not found error is now logged properly')).toBeNull();
+			});
+
 			it('returns null for generic text', () => {
 				expect(classifyError('Some unrelated error')).toBeNull();
 			});
@@ -173,7 +138,7 @@ describe('error-classifier', () => {
 				expect(classifyError('')).toBeNull();
 			});
 
-			it('returns null for network errors (not API errors)', () => {
+			it('returns null for network errors (not "API Error: NNN" shaped)', () => {
 				expect(classifyError('Network timeout')).toBeNull();
 				expect(classifyError('Connection refused')).toBeNull();
 			});
@@ -229,6 +194,15 @@ describe('error-classifier', () => {
 			const result = detectTerminalError(output);
 			expect(result).not.toBeNull();
 			expect(result!.class).toBe('terminal');
+		});
+
+		it('does NOT trigger on explanatory prose about error handling', () => {
+			const proseOutput = [
+				'I have implemented handling for invalid model errors in the provider adapter.',
+				'The fix ensures authentication failed scenarios are retried correctly.',
+				'All tests pass.',
+			].join('\n');
+			expect(detectTerminalError(proseOutput)).toBeNull();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
@@ -66,11 +66,26 @@ describe('error-classifier', () => {
 			});
 		});
 
-		describe('429 rate limit exclusion', () => {
-			it('does NOT classify HTTP 429 as terminal (rate limits handled separately)', () => {
+		describe('429 rate limit handling', () => {
+			it('classifies HTTP 429 as rate_limit (not terminal)', () => {
 				const result = classifyError('API Error: 429 Too Many Requests');
-				// 429 is excluded from TERMINAL_HTTP_CODES, so it falls through to null
-				expect(result).toBeNull();
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('rate_limit');
+				expect(result!.statusCode).toBe(429);
+			});
+
+			it('classifies Anthropic usage-limit message as rate_limit with resetsAt', () => {
+				const result = classifyError("You've hit your limit · resets 1pm (America/New_York)");
+				expect(result).not.toBeNull();
+				expect(result!.class).toBe('rate_limit');
+				expect(result!.resetsAt).toBeGreaterThan(Date.now() - 1000);
+			});
+
+			it('classifies HTTP 429 without retry-after as rate_limit (resetsAt undefined)', () => {
+				const result = classifyError('API Error: 429 Too Many Requests');
+				expect(result!.class).toBe('rate_limit');
+				// No parseable retry-after time in this message
+				expect(result!.resetsAt).toBeUndefined();
 			});
 		});
 
@@ -199,7 +214,7 @@ describe('error-classifier', () => {
 			expect(result).toBeNull();
 		});
 
-		it('returns null for rate limit messages (handled separately)', () => {
+		it('returns null for rate limit messages (classified as rate_limit, not terminal)', () => {
 			const result = detectTerminalError('API Error: 429 Too Many Requests');
 			expect(result).toBeNull();
 		});


### PR DESCRIPTION
When a worker session outputs a terminal API error (HTTP 400/401/403/404/422,
invalid model, invalid API key, quota exceeded, etc.) the runtime now fails
the task immediately instead of routing to the leader for review.

Previously, these unrecoverable errors triggered the normal leader review
flow, which would bounce feedback back to the worker with "retry with the
correct model", creating an infinite loop that wasted API calls and time.

Changes:
- Add error-classifier.ts: classifyError() and detectTerminalError() that
  identify terminal vs recoverable errors from worker output text
- room-runtime.ts: detect terminal errors in worker output before routing
  to leader; fail task immediately when detected
- room-runtime-test-helpers.ts: expose getWorkerMessages option for testing
- Add unit tests for error-classifier (31 tests)
- Add integration tests for terminal error detection in room-runtime (11 tests)

Terminal errors: HTTP 400/401/403/404/422, invalid model, invalid API key,
authentication failed, quota exceeded, account suspended
Recoverable errors: HTTP 5xx, timeout, connection issues
Excluded: HTTP 429 rate limits (handled separately by rate-limit-utils.ts)
