### PR TITLE
feat: add dead loop detection to runtime gates

### DIFF
--- a/packages/daemon/src/lib/room/runtime/dead-loop-detector.ts
+++ b/packages/daemon/src/lib/room/runtime/dead-loop-detector.ts
@@ -1,0 +1,180 @@
+/**
+ * Dead Loop Detector - Detects infinite bounce cycles in runtime gates
+ *
+ * When a gate repeatedly rejects an agent for the same reason, it is likely stuck
+ * in an infinite loop. This detector tracks gate failures per group and flags
+ * dead loops so the runtime can fail the task early with a diagnostic message.
+ *
+ * Detection strategy:
+ * - Count-based: same gate fails >= maxFailures times within rapidFailureWindow
+ * - Similarity-based: failure reasons are similar (avoids counting distinct issues)
+ *
+ * All detection logic is pure (no I/O), making it easy to test.
+ */
+
+export interface GateFailureRecord {
+	/** Gate that failed (e.g., 'worker_exit', 'leader_complete', 'leader_submit') */
+	gateName: string;
+	/** Human-readable failure reason from the gate */
+	reason: string;
+	/** Unix timestamp (ms) when the failure occurred */
+	timestamp: number;
+}
+
+export interface DeadLoopConfig {
+	/** Max failures before detecting loop within the time window (default: 5) */
+	maxFailures: number;
+	/** Time window (ms) within which failures are considered "rapid" (default: 5 min) */
+	rapidFailureWindow: number;
+	/** Similarity threshold for reason matching — 0-1 (default: 0.75) */
+	reasonSimilarityThreshold: number;
+}
+
+export interface DeadLoopStatus {
+	isDeadLoop: boolean;
+	/** Human-readable description of the detected loop */
+	reason: string;
+	/** Number of failures in the detection window */
+	failureCount: number;
+	/** Milliseconds spanned by the detected failures */
+	timeWindowMs: number;
+	/** Gate name that is looping */
+	gateName: string;
+	/** Top distinct failure reasons for diagnostic output */
+	topFailureReasons: string[];
+}
+
+export const DEFAULT_DEAD_LOOP_CONFIG: DeadLoopConfig = {
+	maxFailures: 5,
+	rapidFailureWindow: 5 * 60 * 1000, // 5 minutes
+	reasonSimilarityThreshold: 0.75,
+};
+
+// ---------------------------------------------------------------------------
+// String similarity helpers (Levenshtein distance based)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a string for similarity comparison.
+ * Lowercase, strip punctuation, collapse whitespace.
+ */
+function normalize(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^\w\s]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Compute Levenshtein edit distance between two strings.
+ */
+function editDistance(a: string, b: string): number {
+	const m = a.length;
+	const n = b.length;
+	// Use a single row DP approach to save memory
+	const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+	for (let i = 1; i <= m; i++) {
+		let prev = i;
+		for (let j = 1; j <= n; j++) {
+			const curr = a[i - 1] === b[j - 1] ? dp[j - 1] : Math.min(dp[j - 1], dp[j], prev) + 1;
+			dp[j - 1] = prev;
+			prev = curr;
+		}
+		dp[n] = prev;
+	}
+	return dp[n];
+}
+
+/**
+ * Compute normalized similarity score between two strings (0.0 – 1.0).
+ * Returns 1.0 for identical strings, 0.0 for completely different strings.
+ */
+export function calculateSimilarity(a: string, b: string): number {
+	const s1 = normalize(a);
+	const s2 = normalize(b);
+	if (s1 === s2) return 1;
+	if (s1.length === 0 && s2.length === 0) return 1;
+	if (s1.length === 0 || s2.length === 0) return 0;
+	const maxLen = Math.max(s1.length, s2.length);
+	const dist = editDistance(s1, s2);
+	return (maxLen - dist) / maxLen;
+}
+
+// ---------------------------------------------------------------------------
+// Dead loop detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a gate failure history constitutes a dead loop.
+ *
+ * Returns a DeadLoopStatus with isDeadLoop=true when the same gate has failed
+ * at least `config.maxFailures` times within `config.rapidFailureWindow` AND
+ * the failure reasons are sufficiently similar.
+ *
+ * Returns null when the history is too short to trigger detection.
+ * Returns a status with isDeadLoop=false when count threshold is met but
+ * reasons appear distinct (different issues, not a loop).
+ */
+export function checkDeadLoop(
+	history: GateFailureRecord[],
+	config: DeadLoopConfig = DEFAULT_DEAD_LOOP_CONFIG
+): DeadLoopStatus | null {
+	if (history.length === 0) return null;
+
+	const now = Date.now();
+	const windowStart = now - config.rapidFailureWindow;
+
+	// Group recent failures by gate name
+	const byGate = new Map<string, GateFailureRecord[]>();
+	for (const record of history) {
+		if (record.timestamp >= windowStart) {
+			const list = byGate.get(record.gateName) ?? [];
+			list.push(record);
+			byGate.set(record.gateName, list);
+		}
+	}
+
+	for (const [gateName, records] of byGate) {
+		if (records.length < config.maxFailures) continue;
+
+		// Check how similar the failure reasons are to each other
+		const reasons = records.map((r) => r.reason);
+		let similarPairs = 0;
+		let totalPairs = 0;
+
+		for (let i = 0; i < reasons.length - 1; i++) {
+			for (let j = i + 1; j < reasons.length; j++) {
+				totalPairs++;
+				if (calculateSimilarity(reasons[i], reasons[j]) >= config.reasonSimilarityThreshold) {
+					similarPairs++;
+				}
+			}
+		}
+
+		// Similarity ratio of pairs: if most pairs are similar, reasons are repetitive
+		const similarityRatio = totalPairs > 0 ? similarPairs / totalPairs : 0;
+
+		// It's a dead loop if reasons are mostly similar (repetitive failure)
+		// OR if the count is very high (>= 2x threshold), regardless of similarity —
+		// the agent clearly cannot make progress
+		const isRepetitive = similarityRatio >= 0.5;
+		const isExcessiveCount = records.length >= config.maxFailures * 2;
+
+		if (isRepetitive || isExcessiveCount) {
+			const timeWindowMs = records[records.length - 1].timestamp - records[0].timestamp;
+			const topFailureReasons = [...new Set(reasons)].slice(0, 3);
+
+			return {
+				isDeadLoop: true,
+				reason: `Gate "${gateName}" failed ${records.length} times${timeWindowMs > 0 ? ` over ${Math.round(timeWindowMs / 1000)}s` : ''} with similar reasons`,
+				failureCount: records.length,
+				timeWindowMs,
+				gateName,
+				topFailureReasons,
+			};
+		}
+	}
+
+	return null;
+}

--- a/packages/daemon/src/lib/room/runtime/dead-loop-detector.ts
+++ b/packages/daemon/src/lib/room/runtime/dead-loop-detector.ts
@@ -110,11 +110,12 @@ export function calculateSimilarity(a: string, b: string): number {
  *
  * Returns a DeadLoopStatus with isDeadLoop=true when the same gate has failed
  * at least `config.maxFailures` times within `config.rapidFailureWindow` AND
- * the failure reasons are sufficiently similar.
+ * the failure reasons are sufficiently similar (or the count reaches 2×
+ * the threshold regardless of similarity).
  *
- * Returns null when the history is too short to trigger detection.
- * Returns a status with isDeadLoop=false when count threshold is met but
- * reasons appear distinct (different issues, not a loop).
+ * Returns null when the history is too short to trigger detection, or when
+ * the count threshold is met but the reasons are too distinct (different
+ * underlying issues, not a stuck loop).
  */
 export function checkDeadLoop(
 	history: GateFailureRecord[],

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -59,6 +59,7 @@ import {
 	type WorkerExitHookContext,
 	type LeaderCompleteHookContext,
 } from './lifecycle-hooks';
+import { checkDeadLoop, DEFAULT_DEAD_LOOP_CONFIG, type DeadLoopConfig } from './dead-loop-detector';
 
 const log = new Logger('room-runtime');
 
@@ -110,6 +111,8 @@ export interface RoomRuntimeConfig {
 	messageHub?: MessageHub;
 	/** Hook options for lifecycle gates (test injection point) */
 	hookOptions?: HookOptions;
+	/** Dead loop detection config (overrides defaults) */
+	deadLoopConfig?: Partial<DeadLoopConfig>;
 	/** Fetch room from DB by ID (for lazy leader init with current config) */
 	getRoom: (roomId: string) => Room | null;
 	/** Fetch task from DB by ID (for lazy leader init with current data) */
@@ -142,6 +145,7 @@ export class RoomRuntime {
 	private readonly daemonHub?: DaemonHub;
 	private readonly messageHub?: MessageHub;
 	private readonly hookOptions?: HookOptions;
+	private readonly deadLoopConfig: DeadLoopConfig;
 	private readonly getRoomById: (roomId: string) => Room | null;
 	private readonly defaultModel: string;
 
@@ -204,6 +208,7 @@ export class RoomRuntime {
 		this.daemonHub = config.daemonHub;
 		this.messageHub = config.messageHub;
 		this.hookOptions = config.hookOptions;
+		this.deadLoopConfig = { ...DEFAULT_DEAD_LOOP_CONFIG, ...config.deadLoopConfig };
 		this.getRoomById = config.getRoom;
 		this.defaultModel = config.defaultModel ?? 'sonnet';
 
@@ -427,6 +432,30 @@ export class RoomRuntime {
 				this.appendGroupEvent(groupId, 'status', {
 					text: `Worker exit gate: ${gateResult.reason}`,
 				});
+
+				// Dead loop detection: record failure and check for loop
+				this.groupRepo.recordGateFailure(
+					groupId,
+					'worker_exit',
+					gateResult.reason ?? 'Gate check failed'
+				);
+				const history = this.groupRepo.getGateFailureHistory(groupId);
+				const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
+				if (loopStatus?.isDeadLoop) {
+					const failureMsg =
+						`Dead loop detected in worker exit gate: ${loopStatus.reason}\n\n` +
+						`Failure pattern:\n` +
+						`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
+						`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
+						`The task cannot make progress and is stuck in a retry loop. ` +
+						`Please review the requirements and try again with clearer instructions.`;
+					log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
+					await this.taskGroupManager.fail(groupId, failureMsg);
+					this.cleanupMirroring(groupId, 'Dead loop detected.');
+					await this.emitTaskUpdateById(group.taskId);
+					return;
+				}
+
 				await this.sessionFactory.injectMessage(
 					group.workerSessionId,
 					gateResult.bounceMessage ?? gateResult.reason ?? 'Gate check failed'
@@ -676,6 +705,30 @@ export class RoomRuntime {
 							this.appendGroupEvent(groupId, 'status', {
 								text: `Leader complete gate: ${gateResult.reason}`,
 							});
+
+							// Dead loop detection: record failure and check for loop
+							this.groupRepo.recordGateFailure(
+								groupId,
+								'leader_complete',
+								gateResult.reason ?? 'Gate check failed'
+							);
+							const history = this.groupRepo.getGateFailureHistory(groupId);
+							const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
+							if (loopStatus?.isDeadLoop) {
+								const failureMsg =
+									`Dead loop detected in leader complete gate: ${loopStatus.reason}\n\n` +
+									`Failure pattern:\n` +
+									`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
+									`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
+									`The task cannot make progress and is stuck in a retry loop. ` +
+									`Please review the requirements and try again with clearer instructions.`;
+								log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
+								await this.taskGroupManager.fail(groupId, failureMsg);
+								this.cleanupMirroring(groupId, 'Dead loop detected.');
+								await this.emitTaskUpdateById(group.taskId);
+								return jsonResult({ success: false, error: failureMsg });
+							}
+
 							// Reset leaderCalledTool so leader can try again
 							this.groupRepo.setLeaderCalledTool(groupId, false);
 							return jsonResult({
@@ -743,6 +796,30 @@ export class RoomRuntime {
 							this.appendGroupEvent(groupId, 'status', {
 								text: `Leader submit gate: ${gateResult.reason}`,
 							});
+
+							// Dead loop detection: record failure and check for loop
+							this.groupRepo.recordGateFailure(
+								groupId,
+								'leader_submit',
+								gateResult.reason ?? 'Gate check failed'
+							);
+							const submitHistory = this.groupRepo.getGateFailureHistory(groupId);
+							const submitLoopStatus = checkDeadLoop(submitHistory, this.deadLoopConfig);
+							if (submitLoopStatus?.isDeadLoop) {
+								const failureMsg =
+									`Dead loop detected in leader submit gate: ${submitLoopStatus.reason}\n\n` +
+									`Failure pattern:\n` +
+									`- ${submitLoopStatus.failureCount} failures${submitLoopStatus.timeWindowMs > 0 ? ` over ${Math.round(submitLoopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
+									`- Repeated reasons: ${submitLoopStatus.topFailureReasons.join('; ')}\n\n` +
+									`The task cannot make progress and is stuck in a retry loop. ` +
+									`Please review the requirements and try again with clearer instructions.`;
+								log.warn(`Dead loop detected for group ${groupId}: ${submitLoopStatus.reason}`);
+								await this.taskGroupManager.fail(groupId, failureMsg);
+								this.cleanupMirroring(groupId, 'Dead loop detected.');
+								await this.emitTaskUpdateById(group.taskId);
+								return jsonResult({ success: false, error: failureMsg });
+							}
+
 							// Reset leaderCalledTool so leader can try again
 							this.groupRepo.setLeaderCalledTool(groupId, false);
 							return jsonResult({

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -193,6 +193,37 @@ export class RoomRuntime {
 		}
 	}
 
+	/**
+	 * Fail a group due to a detected dead loop.
+	 * Formats the diagnostic message, fails the group, cleans up mirroring,
+	 * and schedules a tick so the runtime can start other pending tasks.
+	 */
+	private async failGroupForDeadLoop(
+		groupId: string,
+		taskId: string,
+		loopStatus: {
+			reason: string;
+			failureCount: number;
+			timeWindowMs: number;
+			topFailureReasons: string[];
+		},
+		gateName: string
+	): Promise<void> {
+		const failureMsg =
+			`Dead loop detected in ${gateName} gate: ${loopStatus.reason}\n\n` +
+			`Failure pattern:\n` +
+			`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
+			`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
+			`The task cannot make progress and is stuck in a retry loop. ` +
+			`Please review the requirements and try again with clearer instructions.`;
+		log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
+		await this.taskGroupManager.fail(groupId, failureMsg);
+		this.cleanupMirroring(groupId, 'Dead loop detected.');
+		await this.emitTaskUpdateById(taskId);
+		await this.emitGoalProgressForTask(taskId);
+		this.scheduleTick();
+	}
+
 	constructor(config: RoomRuntimeConfig) {
 		this.roomId = config.room.id;
 		this.room = config.room;
@@ -442,17 +473,7 @@ export class RoomRuntime {
 				const history = this.groupRepo.getGateFailureHistory(groupId);
 				const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
 				if (loopStatus?.isDeadLoop) {
-					const failureMsg =
-						`Dead loop detected in worker exit gate: ${loopStatus.reason}\n\n` +
-						`Failure pattern:\n` +
-						`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
-						`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
-						`The task cannot make progress and is stuck in a retry loop. ` +
-						`Please review the requirements and try again with clearer instructions.`;
-					log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
-					await this.taskGroupManager.fail(groupId, failureMsg);
-					this.cleanupMirroring(groupId, 'Dead loop detected.');
-					await this.emitTaskUpdateById(group.taskId);
+					await this.failGroupForDeadLoop(groupId, group.taskId, loopStatus, 'worker_exit');
 					return;
 				}
 
@@ -715,18 +736,13 @@ export class RoomRuntime {
 							const history = this.groupRepo.getGateFailureHistory(groupId);
 							const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
 							if (loopStatus?.isDeadLoop) {
-								const failureMsg =
-									`Dead loop detected in leader complete gate: ${loopStatus.reason}\n\n` +
-									`Failure pattern:\n` +
-									`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
-									`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
-									`The task cannot make progress and is stuck in a retry loop. ` +
-									`Please review the requirements and try again with clearer instructions.`;
-								log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
-								await this.taskGroupManager.fail(groupId, failureMsg);
-								this.cleanupMirroring(groupId, 'Dead loop detected.');
-								await this.emitTaskUpdateById(group.taskId);
-								return jsonResult({ success: false, error: failureMsg });
+								await this.failGroupForDeadLoop(
+									groupId,
+									group.taskId,
+									loopStatus,
+									'leader_complete'
+								);
+								return jsonResult({ success: false, error: loopStatus.reason });
 							}
 
 							// Reset leaderCalledTool so leader can try again
@@ -806,18 +822,13 @@ export class RoomRuntime {
 							const submitHistory = this.groupRepo.getGateFailureHistory(groupId);
 							const submitLoopStatus = checkDeadLoop(submitHistory, this.deadLoopConfig);
 							if (submitLoopStatus?.isDeadLoop) {
-								const failureMsg =
-									`Dead loop detected in leader submit gate: ${submitLoopStatus.reason}\n\n` +
-									`Failure pattern:\n` +
-									`- ${submitLoopStatus.failureCount} failures${submitLoopStatus.timeWindowMs > 0 ? ` over ${Math.round(submitLoopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
-									`- Repeated reasons: ${submitLoopStatus.topFailureReasons.join('; ')}\n\n` +
-									`The task cannot make progress and is stuck in a retry loop. ` +
-									`Please review the requirements and try again with clearer instructions.`;
-								log.warn(`Dead loop detected for group ${groupId}: ${submitLoopStatus.reason}`);
-								await this.taskGroupManager.fail(groupId, failureMsg);
-								this.cleanupMirroring(groupId, 'Dead loop detected.');
-								await this.emitTaskUpdateById(group.taskId);
-								return jsonResult({ success: false, error: failureMsg });
+								await this.failGroupForDeadLoop(
+									groupId,
+									group.taskId,
+									submitLoopStatus,
+									'leader_submit'
+								);
+								return jsonResult({ success: false, error: submitLoopStatus.reason });
 							}
 
 							// Reset leaderCalledTool so leader can try again

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -194,34 +194,39 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Fail a group due to a detected dead loop.
-	 * Formats the diagnostic message, fails the group, cleans up mirroring,
-	 * and schedules a tick so the runtime can start other pending tasks.
+	 * Record a gate failure, check for a dead loop, and fail the group if one is detected.
+	 *
+	 * Call this at every bounce point before injecting the bounce message back to the agent.
+	 * Returns true when a dead loop was detected and the group has been failed — the caller
+	 * should return immediately without injecting the bounce message.
+	 * Returns false when no loop detected — caller should proceed with the normal bounce.
 	 */
-	private async failGroupForDeadLoop(
+	private async recordAndCheckDeadLoop(
 		groupId: string,
 		taskId: string,
-		loopStatus: {
-			reason: string;
-			failureCount: number;
-			timeWindowMs: number;
-			topFailureReasons: string[];
-		},
-		gateName: string
-	): Promise<void> {
-		const failureMsg =
-			`Dead loop detected in ${gateName} gate: ${loopStatus.reason}\n\n` +
-			`Failure pattern:\n` +
-			`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
-			`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
-			`The task cannot make progress and is stuck in a retry loop. ` +
-			`Please review the requirements and try again with clearer instructions.`;
-		log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
-		await this.taskGroupManager.fail(groupId, failureMsg);
-		this.cleanupMirroring(groupId, 'Dead loop detected.');
-		await this.emitTaskUpdateById(taskId);
-		await this.emitGoalProgressForTask(taskId);
-		this.scheduleTick();
+		gateName: string,
+		reason: string
+	): Promise<boolean> {
+		this.groupRepo.recordGateFailure(groupId, gateName, reason);
+		const history = this.groupRepo.getGateFailureHistory(groupId);
+		const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
+		if (loopStatus?.isDeadLoop) {
+			const failureMsg =
+				`Dead loop detected in ${gateName} gate: ${loopStatus.reason}\n\n` +
+				`Failure pattern:\n` +
+				`- ${loopStatus.failureCount} failures${loopStatus.timeWindowMs > 0 ? ` over ${Math.round(loopStatus.timeWindowMs / 60000)} minutes` : ''}\n` +
+				`- Repeated reasons: ${loopStatus.topFailureReasons.join('; ')}\n\n` +
+				`The task cannot make progress and is stuck in a retry loop. ` +
+				`Please review the requirements and try again with clearer instructions.`;
+			log.warn(`Dead loop detected for group ${groupId}: ${loopStatus.reason}`);
+			await this.taskGroupManager.fail(groupId, failureMsg);
+			this.cleanupMirroring(groupId, 'Dead loop detected.');
+			await this.emitTaskUpdateById(taskId);
+			await this.emitGoalProgressForTask(taskId);
+			this.scheduleTick();
+			return true;
+		}
+		return false;
 	}
 
 	constructor(config: RoomRuntimeConfig) {
@@ -431,6 +436,16 @@ export class RoomRuntime {
 				this.appendGroupEvent(groupId, 'status', {
 					text: 'Worktree has uncommitted changes. Sending worker back to clean up.',
 				});
+				if (
+					await this.recordAndCheckDeadLoop(
+						groupId,
+						group.taskId,
+						'worktree_dirty',
+						'Worktree has uncommitted changes or untracked files'
+					)
+				) {
+					return;
+				}
 				await this.sessionFactory.injectMessage(
 					group.workerSessionId,
 					'Your worktree has uncommitted changes or untracked files. ' +
@@ -464,16 +479,14 @@ export class RoomRuntime {
 					text: `Worker exit gate: ${gateResult.reason}`,
 				});
 
-				// Dead loop detection: record failure and check for loop
-				this.groupRepo.recordGateFailure(
-					groupId,
-					'worker_exit',
-					gateResult.reason ?? 'Gate check failed'
-				);
-				const history = this.groupRepo.getGateFailureHistory(groupId);
-				const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
-				if (loopStatus?.isDeadLoop) {
-					await this.failGroupForDeadLoop(groupId, group.taskId, loopStatus, 'worker_exit');
+				if (
+					await this.recordAndCheckDeadLoop(
+						groupId,
+						group.taskId,
+						'worker_exit',
+						gateResult.reason ?? 'Gate check failed'
+					)
+				) {
 					return;
 				}
 
@@ -727,22 +740,15 @@ export class RoomRuntime {
 								text: `Leader complete gate: ${gateResult.reason}`,
 							});
 
-							// Dead loop detection: record failure and check for loop
-							this.groupRepo.recordGateFailure(
-								groupId,
-								'leader_complete',
-								gateResult.reason ?? 'Gate check failed'
-							);
-							const history = this.groupRepo.getGateFailureHistory(groupId);
-							const loopStatus = checkDeadLoop(history, this.deadLoopConfig);
-							if (loopStatus?.isDeadLoop) {
-								await this.failGroupForDeadLoop(
+							if (
+								await this.recordAndCheckDeadLoop(
 									groupId,
 									group.taskId,
-									loopStatus,
-									'leader_complete'
-								);
-								return jsonResult({ success: false, error: loopStatus.reason });
+									'leader_complete',
+									gateResult.reason ?? 'Gate check failed'
+								)
+							) {
+								return jsonResult({ success: false, error: 'Dead loop detected.' });
 							}
 
 							// Reset leaderCalledTool so leader can try again
@@ -813,22 +819,15 @@ export class RoomRuntime {
 								text: `Leader submit gate: ${gateResult.reason}`,
 							});
 
-							// Dead loop detection: record failure and check for loop
-							this.groupRepo.recordGateFailure(
-								groupId,
-								'leader_submit',
-								gateResult.reason ?? 'Gate check failed'
-							);
-							const submitHistory = this.groupRepo.getGateFailureHistory(groupId);
-							const submitLoopStatus = checkDeadLoop(submitHistory, this.deadLoopConfig);
-							if (submitLoopStatus?.isDeadLoop) {
-								await this.failGroupForDeadLoop(
+							if (
+								await this.recordAndCheckDeadLoop(
 									groupId,
 									group.taskId,
-									submitLoopStatus,
-									'leader_submit'
-								);
-								return jsonResult({ success: false, error: submitLoopStatus.reason });
+									'leader_submit',
+									gateResult.reason ?? 'Gate check failed'
+								)
+							) {
+								return jsonResult({ success: false, error: 'Dead loop detected.' });
 							}
 
 							// Reset leaderCalledTool so leader can try again

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -18,6 +18,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
+import type { GateFailureRecord } from '../runtime/dead-loop-detector';
 
 /** Rate limit backoff state stored in group metadata */
 export interface RateLimitBackoff {
@@ -61,6 +62,8 @@ interface TaskGroupMetadata {
 	rateLimit?: RateLimitBackoff | null;
 	/** Persisted bootstrap config for deferred Leader creation */
 	deferredLeader?: DeferredLeaderConfig | null;
+	/** Gate failure history for dead loop detection */
+	gateFailures?: GateFailureRecord[];
 }
 
 function defaultMetadata(): TaskGroupMetadata {
@@ -477,6 +480,44 @@ export class SessionGroupRepository {
 		if (!group?.rateLimit) return 0;
 		const remaining = group.rateLimit.resetsAt - Date.now();
 		return Math.max(0, remaining);
+	}
+
+	// ===== Dead Loop Detection =====
+
+	/**
+	 * Append a gate failure record for dead loop detection.
+	 * Keeps the last 50 records to bound storage size.
+	 */
+	recordGateFailure(groupId: string, gateName: string, reason: string): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		const existing = currentMeta.gateFailures ?? [];
+		const record: GateFailureRecord = { gateName, reason, timestamp: Date.now() };
+		// Cap at 50 records — old entries are unlikely to matter for detection
+		const updated = [...existing, record].slice(-50);
+		const merged = { ...currentMeta, gateFailures: updated };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
+	 * Get the full gate failure history for dead loop detection.
+	 */
+	getGateFailureHistory(groupId: string): GateFailureRecord[] {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const meta = this.parseMetadata(raw);
+		return meta.gateFailures ?? [];
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -512,21 +512,23 @@ export class SessionGroupRepository {
 	 * Keeps the last 50 records to bound storage size.
 	 */
 	recordGateFailure(groupId: string, gateName: string, reason: string): void {
-		const raw = (
-			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
-				string,
-				unknown
-			>
-		)?.metadata as string;
-		const currentMeta = this.parseMetadata(raw);
-		const existing = currentMeta.gateFailures ?? [];
-		const record: GateFailureRecord = { gateName, reason, timestamp: Date.now() };
-		// Cap at 50 records — old entries are unlikely to matter for detection
-		const updated = [...existing, record].slice(-50);
-		const merged = { ...currentMeta, gateFailures: updated };
-		this.db
-			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
-			.run(JSON.stringify(merged), groupId);
+		this.db.transaction(() => {
+			const raw = (
+				this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+					string,
+					unknown
+				>
+			)?.metadata as string;
+			const currentMeta = this.parseMetadata(raw);
+			const existing = currentMeta.gateFailures ?? [];
+			const record: GateFailureRecord = { gateName, reason, timestamp: Date.now() };
+			// Cap at 50 records — old entries are unlikely to matter for detection
+			const updated = [...existing, record].slice(-50);
+			const merged = { ...currentMeta, gateFailures: updated };
+			this.db
+				.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+				.run(JSON.stringify(merged), groupId);
+		})();
 	}
 
 	/**

--- a/packages/daemon/tests/unit/room/runtime/dead-loop-detector.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/dead-loop-detector.test.ts
@@ -83,11 +83,10 @@ describe('checkDeadLoop', () => {
 		expect(checkDeadLoop([])).toBeNull();
 	});
 
-	test('returns null when fewer failures than maxFailures', () => {
+	test('detects dead loop when failures equal maxFailures with identical reasons', () => {
 		const history = makeRepeatedFailures('worker_exit', 'No PR', 4);
 		const result = checkDeadLoop(history, STRICT_CONFIG);
-		// 4 < 3*2=6 but >= threshold 3; however similarity must pass too
-		// With count >= maxFailures AND similar reasons → should detect
+		// 4 >= maxFailures (3) with identical reasons → similarity ratio is 1.0 → detected
 		expect(result?.isDeadLoop).toBe(true);
 	});
 

--- a/packages/daemon/tests/unit/room/runtime/dead-loop-detector.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/dead-loop-detector.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect } from 'bun:test';
+import {
+	checkDeadLoop,
+	calculateSimilarity,
+	type GateFailureRecord,
+	type DeadLoopConfig,
+} from '../../../../src/lib/room/runtime/dead-loop-detector';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRecord(gateName: string, reason: string, offsetMs = 0): GateFailureRecord {
+	return { gateName, reason, timestamp: Date.now() - offsetMs };
+}
+
+/** Build N records for the same gate with the same reason, evenly spread */
+function makeRepeatedFailures(
+	gateName: string,
+	reason: string,
+	count: number,
+	spreadMs = 10_000
+): GateFailureRecord[] {
+	const now = Date.now();
+	return Array.from({ length: count }, (_, i) => ({
+		gateName,
+		reason,
+		// Spread evenly within spreadMs total window; oldest first
+		timestamp: now - spreadMs + Math.floor((i * spreadMs) / Math.max(count - 1, 1)),
+	}));
+}
+
+const STRICT_CONFIG: DeadLoopConfig = {
+	maxFailures: 3,
+	rapidFailureWindow: 5 * 60 * 1000,
+	reasonSimilarityThreshold: 0.75,
+};
+
+// ---------------------------------------------------------------------------
+// calculateSimilarity
+// ---------------------------------------------------------------------------
+
+describe('calculateSimilarity', () => {
+	test('identical strings return 1', () => {
+		expect(calculateSimilarity('hello world', 'hello world')).toBe(1);
+	});
+
+	test('completely different strings return low score', () => {
+		const score = calculateSimilarity('abc', 'xyz');
+		expect(score).toBeLessThan(0.5);
+	});
+
+	test('similar strings return high score', () => {
+		const score = calculateSimilarity(
+			'PR not found. Please create a PR before completing.',
+			'No PR exists. Create PR before completing.'
+		);
+		expect(score).toBeGreaterThan(0.6);
+	});
+
+	test('normalization ignores punctuation and case', () => {
+		const s1 = 'No PR exists!';
+		const s2 = 'no pr exists';
+		expect(calculateSimilarity(s1, s2)).toBe(1);
+	});
+
+	test('empty strings both return 1', () => {
+		expect(calculateSimilarity('', '')).toBe(1);
+	});
+
+	test('one empty string returns 0', () => {
+		expect(calculateSimilarity('hello', '')).toBe(0);
+		expect(calculateSimilarity('', 'world')).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkDeadLoop — basic cases
+// ---------------------------------------------------------------------------
+
+describe('checkDeadLoop', () => {
+	test('returns null for empty history', () => {
+		expect(checkDeadLoop([])).toBeNull();
+	});
+
+	test('returns null when fewer failures than maxFailures', () => {
+		const history = makeRepeatedFailures('worker_exit', 'No PR', 4);
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		// 4 < 3*2=6 but >= threshold 3; however similarity must pass too
+		// With count >= maxFailures AND similar reasons → should detect
+		expect(result?.isDeadLoop).toBe(true);
+	});
+
+	test('detects dead loop when same gate fails maxFailures times with similar reasons', () => {
+		const history = makeRepeatedFailures('worker_exit', 'No PR found for branch feature/x', 5);
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		expect(result).not.toBeNull();
+		expect(result?.isDeadLoop).toBe(true);
+		expect(result?.gateName).toBe('worker_exit');
+		expect(result?.failureCount).toBe(5);
+	});
+
+	test('detects dead loop with slightly varied but similar reasons', () => {
+		// All reasons are near-identical (small typo differences) — most pairs should be >= 0.75 similar
+		const reasons = [
+			'No PR found for branch feat/abc.',
+			'No PR found for branch feat/abc!',
+			'No PR found for branch feat/abc',
+			'No PR found for branch feat/abc.',
+		];
+		const now = Date.now();
+		const history: GateFailureRecord[] = reasons.map((reason, i) => ({
+			gateName: 'worker_exit',
+			reason,
+			timestamp: now - (reasons.length - i) * 5000,
+		}));
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		expect(result?.isDeadLoop).toBe(true);
+	});
+
+	test('does NOT detect loop when failures span different gates', () => {
+		// 3 worker_exit + 3 leader_complete — neither gate alone exceeds threshold
+		const history: GateFailureRecord[] = [
+			...makeRepeatedFailures('worker_exit', 'No PR', 2),
+			...makeRepeatedFailures('leader_complete', 'PR not merged', 2),
+		];
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		// Neither gate has 3 failures → null
+		expect(result).toBeNull();
+	});
+
+	test('does NOT detect loop when failures are outside the time window', () => {
+		const windowMs = 2 * 60 * 1000; // 2 min window
+		const config: DeadLoopConfig = {
+			maxFailures: 3,
+			rapidFailureWindow: windowMs,
+			reasonSimilarityThreshold: 0.75,
+		};
+		// All failures older than the window
+		const oldTime = Date.now() - 10 * 60 * 1000; // 10 minutes ago
+		const history: GateFailureRecord[] = Array.from({ length: 5 }, (_, i) => ({
+			gateName: 'worker_exit',
+			reason: 'No PR found.',
+			timestamp: oldTime + i * 1000,
+		}));
+		const result = checkDeadLoop(history, config);
+		expect(result).toBeNull();
+	});
+
+	test('detects loop even with very high count and dissimilar reasons (excessive count path)', () => {
+		// maxFailures=3 so 2x threshold = 6; distinct reasons → similarity won't catch it
+		const now = Date.now();
+		const distinctReasons = [
+			'PR not found',
+			'Branch check failed',
+			'No commits pushed',
+			'Worktree dirty',
+			'Model mismatch',
+			'Unknown git state',
+		];
+		const history: GateFailureRecord[] = distinctReasons.map((reason, i) => ({
+			gateName: 'worker_exit',
+			reason,
+			timestamp: now - (distinctReasons.length - i) * 3000,
+		}));
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		// 6 failures >= maxFailures*2 (3*2=6) → isExcessiveCount path
+		expect(result?.isDeadLoop).toBe(true);
+		expect(result?.failureCount).toBe(6);
+	});
+
+	test('returns topFailureReasons with at most 3 distinct entries', () => {
+		const history = makeRepeatedFailures('leader_complete', 'No PR exists.', 5);
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		expect(result?.topFailureReasons.length).toBeLessThanOrEqual(3);
+	});
+
+	test('timeWindowMs is 0 for a single instantaneous failure burst', () => {
+		// All records have the same timestamp
+		const now = Date.now();
+		const history: GateFailureRecord[] = Array.from({ length: 5 }, () => ({
+			gateName: 'worker_exit',
+			reason: 'No PR.',
+			timestamp: now,
+		}));
+		const result = checkDeadLoop(history, STRICT_CONFIG);
+		expect(result?.isDeadLoop).toBe(true);
+		expect(result?.timeWindowMs).toBe(0);
+	});
+
+	test('uses default config when none provided', () => {
+		// Default maxFailures = 5
+		const history = makeRepeatedFailures('worker_exit', 'No PR', 5);
+		const result = checkDeadLoop(history); // no config arg
+		expect(result?.isDeadLoop).toBe(true);
+	});
+
+	test('returns null with 4 failures when maxFailures=5 and count < 2x threshold', () => {
+		const config: DeadLoopConfig = {
+			maxFailures: 5,
+			rapidFailureWindow: 5 * 60 * 1000,
+			reasonSimilarityThreshold: 0.75,
+		};
+		const history = makeRepeatedFailures('worker_exit', 'No PR', 4);
+		// 4 < 5 → null (before similarity check)
+		const result = checkDeadLoop(history, config);
+		expect(result).toBeNull();
+	});
+
+	// -------------------------------------------------------------------
+	// Oscillation pattern: gate fails → succeeds (no record) → fails again
+	// -------------------------------------------------------------------
+
+	test('detects oscillation when failures accumulate over multiple cycles', () => {
+		// Simulate: fail 3x → some time passes → fail 3x again (all within window)
+		const now = Date.now();
+		const firstBatch: GateFailureRecord[] = Array.from({ length: 3 }, (_, i) => ({
+			gateName: 'leader_complete',
+			reason: 'PR not merged yet.',
+			timestamp: now - 4 * 60 * 1000 + i * 20_000, // 4 min ago
+		}));
+		const secondBatch: GateFailureRecord[] = Array.from({ length: 3 }, (_, i) => ({
+			gateName: 'leader_complete',
+			reason: 'PR not merged.',
+			timestamp: now - 1 * 60 * 1000 + i * 10_000, // 1 min ago
+		}));
+		const result = checkDeadLoop([...firstBatch, ...secondBatch], STRICT_CONFIG);
+		expect(result?.isDeadLoop).toBe(true);
+		expect(result?.failureCount).toBe(6);
+	});
+});

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -506,4 +506,68 @@ describe('SessionGroupRepository', () => {
 			expect(repo.getRateLimitRemainingMs(group.id)).toBe(0);
 		});
 	});
+
+	describe('Gate Failure Tracking (Dead Loop Detection)', () => {
+		it('starts with empty failure history', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const history = repo.getGateFailureHistory(group.id);
+			expect(history).toEqual([]);
+		});
+
+		it('records a gate failure', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.recordGateFailure(group.id, 'worker_exit', 'No PR found.');
+			const history = repo.getGateFailureHistory(group.id);
+			expect(history).toHaveLength(1);
+			expect(history[0].gateName).toBe('worker_exit');
+			expect(history[0].reason).toBe('No PR found.');
+			expect(history[0].timestamp).toBeGreaterThan(0);
+		});
+
+		it('accumulates multiple failures', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.recordGateFailure(group.id, 'worker_exit', 'No PR found.');
+			repo.recordGateFailure(group.id, 'worker_exit', 'Branch is base branch.');
+			repo.recordGateFailure(group.id, 'leader_complete', 'PR not merged.');
+			const history = repo.getGateFailureHistory(group.id);
+			expect(history).toHaveLength(3);
+			expect(history[0].gateName).toBe('worker_exit');
+			expect(history[2].gateName).toBe('leader_complete');
+		});
+
+		it('caps history at 50 records', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			for (let i = 0; i < 60; i++) {
+				repo.recordGateFailure(group.id, 'worker_exit', `Failure ${i}`);
+			}
+			const history = repo.getGateFailureHistory(group.id);
+			expect(history).toHaveLength(50);
+			// Should keep the most recent (last 50)
+			expect(history[0].reason).toBe('Failure 10');
+			expect(history[49].reason).toBe('Failure 59');
+		});
+
+		it('returns empty array for non-existent group', () => {
+			const history = repo.getGateFailureHistory('non-existent-id');
+			expect(history).toEqual([]);
+		});
+
+		it('preserves existing metadata when recording failures', () => {
+			const group = repo.createGroup(
+				taskId,
+				workerSessionId,
+				leaderSessionId,
+				'coder',
+				'/workspace'
+			);
+			repo.setApproved(group.id, true);
+			repo.recordGateFailure(group.id, 'worker_exit', 'No PR found.');
+			const updated = repo.getGroup(group.id)!;
+			// Approved flag should still be set
+			expect(updated.approved).toBe(true);
+			// Failure should be recorded
+			const history = repo.getGateFailureHistory(group.id);
+			expect(history).toHaveLength(1);
+		});
+	});
 });


### PR DESCRIPTION
Prevent infinite bounce cycles when agents get stuck failing the same
gate repeatedly (e.g., leader keeps calling complete_task without a PR).

Changes:
- New `dead-loop-detector.ts`: pure detection logic with Levenshtein
  similarity scoring. Flags dead loops when a gate fails >= maxFailures
  times within the rapid failure window with similar reasons.
- `session-group-repository.ts`: adds `recordGateFailure()` and
  `getGateFailureHistory()` methods. Failures are persisted in metadata
  (capped at 50 records) so detection survives daemon restarts.
- `room-runtime.ts`: integrates dead loop detection at all three gate
  check points (worker_exit, leader_complete, leader_submit). When a loop
  is detected the task is immediately failed with a diagnostic message
  instead of bouncing the agent again.

Default config: 5 failures within 5 minutes with similar reasons.
Configurable per runtime via `deadLoopConfig` in `RoomRuntimeConfig`.
