### PR TITLE
feat: add SDK sub-agents for worker and leader to avoid context overflow

### DIFF
--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -11,7 +11,14 @@
  */
 
 import type { AgentSessionInit } from '../../agent/agent-session';
-import type { Room, RoomGoal, NeoTask, SessionFeatures, AgentDefinition } from '@neokai/shared';
+import type {
+	Room,
+	RoomGoal,
+	NeoTask,
+	SessionFeatures,
+	AgentDefinition,
+	SubagentConfig,
+} from '@neokai/shared';
 
 const DEFAULT_CODER_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -22,23 +29,6 @@ const CODER_FEATURES: SessionFeatures = {
 	archive: false,
 	sessionInfo: false,
 };
-
-/**
- * Sub-agent configuration for worker helper agents.
- * Matches the SubagentConfig shape used by the leader reviewer agents.
- */
-interface SubagentConfig {
-	/** Model ID (e.g., 'claude-haiku-4-5', 'claude-sonnet-4-6') */
-	model: string;
-	/** Provider name (e.g., 'anthropic', 'openai') */
-	provider?: string;
-	/** Full model ID when different from the short name in 'model' */
-	modelId?: string;
-	/** Optional display name override for this helper */
-	name?: string;
-	/** Optional description of what this helper specializes in */
-	description?: string;
-}
 
 export interface CoderAgentConfig {
 	task: NeoTask;

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -5,11 +5,13 @@
  * with context from the goal and room, then works using standard coding tools
  * (bash, edit, read, write, glob, grep) until it reaches a terminal state.
  *
- * No special MCP tools are needed - Coder just works until done.
+ * When worker sub-agents are configured via room.config.agentSubagents.worker,
+ * the Coder gets access to the Task/TaskOutput/TaskStop tools to spawn helper
+ * sub-agents for heavy tasks, keeping the main agent context clean.
  */
 
 import type { AgentSessionInit } from '../../agent/agent-session';
-import type { Room, RoomGoal, NeoTask, SessionFeatures } from '@neokai/shared';
+import type { Room, RoomGoal, NeoTask, SessionFeatures, AgentDefinition } from '@neokai/shared';
 
 const DEFAULT_CODER_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -20,6 +22,23 @@ const CODER_FEATURES: SessionFeatures = {
 	archive: false,
 	sessionInfo: false,
 };
+
+/**
+ * Sub-agent configuration for worker helper agents.
+ * Matches the SubagentConfig shape used by the leader reviewer agents.
+ */
+interface SubagentConfig {
+	/** Model ID (e.g., 'claude-haiku-4-5', 'claude-sonnet-4-6') */
+	model: string;
+	/** Provider name (e.g., 'anthropic', 'openai') */
+	provider?: string;
+	/** Full model ID when different from the short name in 'model' */
+	modelId?: string;
+	/** Optional display name override for this helper */
+	name?: string;
+	/** Optional description of what this helper specializes in */
+	description?: string;
+}
 
 export interface CoderAgentConfig {
 	task: NeoTask;
@@ -33,14 +52,134 @@ export interface CoderAgentConfig {
 }
 
 /**
+ * Read worker sub-agent configs from room config.
+ * Path: room.config.agentSubagents.worker
+ */
+export function getWorkerSubagents(
+	roomConfig: Record<string, unknown>
+): SubagentConfig[] | undefined {
+	const agentSubagents = roomConfig.agentSubagents as Record<string, SubagentConfig[]> | undefined;
+	if (agentSubagents?.worker && agentSubagents.worker.length > 0) {
+		return agentSubagents.worker;
+	}
+	return undefined;
+}
+
+/**
+ * Derive a short agent model tier from a model ID for the SDK.
+ * SDK accepts: 'sonnet' | 'opus' | 'haiku' | 'inherit'
+ */
+function toHelperAgentModel(modelId: string): AgentDefinition['model'] {
+	const lower = modelId.toLowerCase();
+	if (lower.includes('opus')) return 'opus';
+	if (lower.includes('haiku')) return 'haiku';
+	if (lower.includes('sonnet')) return 'sonnet';
+	return 'sonnet';
+}
+
+/**
+ * Resolve the full model ID from a sub-agent config.
+ */
+function resolveHelperModelId(config: SubagentConfig): string {
+	if (config.modelId) return config.modelId;
+	const m = config.model.toLowerCase();
+	if (m === 'opus') return 'claude-opus-4-6';
+	if (m === 'sonnet') return 'claude-sonnet-4-6';
+	if (m === 'haiku') return 'claude-haiku-4-5';
+	return config.model;
+}
+
+/**
+ * Build the system prompt for a worker helper sub-agent.
+ *
+ * Helper agents are spawned by the main Coder agent to handle heavy subtasks.
+ * They work autonomously and return a concise result summary. They do NOT
+ * create new PRs — they commit to the current branch and return a summary.
+ */
+export function buildCoderHelperAgentPrompt(): string {
+	return `You are a Worker Helper Agent spawned by the main Coder Agent to handle a specific subtask.
+
+Your job is to complete the delegated task and return a concise result summary.
+
+## Rules
+
+1. **Complete the task autonomously** — work thoroughly but focused
+2. **Commit any file changes** to the current branch (do NOT create new PRs or new branches)
+3. **Return a concise summary** — include: what you did, which files changed, and the outcome
+4. **Do not scope-creep** — only do what the task explicitly asks
+5. **No sub-agents** — you are a helper; do not spawn further sub-agents
+
+## Summary Format
+
+End your response with a structured summary:
+
+---SUBTASK_RESULT---
+status: success | partial | failed
+files_changed: <comma-separated list, or "none">
+summary: <1-3 sentence description of what was done and the result>
+---END_SUBTASK_RESULT---
+`;
+}
+
+/**
+ * Build the AgentDefinition map for worker helper sub-agents.
+ * Returns a map of helper name to AgentDefinition.
+ */
+export function buildWorkerHelperAgents(
+	helpers: SubagentConfig[]
+): Record<string, AgentDefinition> {
+	const agents: Record<string, AgentDefinition> = {};
+	const usedNames = new Set<string>();
+
+	for (const helper of helpers) {
+		// Build a short unique name
+		const baseName =
+			helper.name ??
+			helper.model
+				.toLowerCase()
+				.replace(/[^a-z0-9]/g, '-')
+				.replace(/-+/g, '-')
+				.replace(/^-|-$/g, '')
+				.slice(0, 20);
+		let name = `helper-${baseName}`;
+		let counter = 2;
+		while (usedNames.has(name)) {
+			name = `helper-${baseName}-${counter}`;
+			counter++;
+		}
+		usedNames.add(name);
+
+		const modelId = resolveHelperModelId(helper);
+		const provider = helper.provider ?? 'anthropic';
+		const description =
+			helper.description ??
+			`Worker helper agent using ${modelId} (${provider}). Handles delegated subtasks to keep the main agent context clean.`;
+
+		agents[name] = {
+			description,
+			// Helpers have full coding tools but NOT Task (no recursive sub-agents)
+			tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
+			model: toHelperAgentModel(modelId),
+			prompt: buildCoderHelperAgentPrompt(),
+		};
+	}
+
+	return agents;
+}
+
+/**
  * Build the behavioral system prompt for the Coder agent.
  *
  * Contains ONLY role definition, git workflow instructions, and behavioral rules.
  * Task-specific context (title, description, goal, room background) is delivered
  * via the initial user message built by buildCoderTaskMessage().
+ *
+ * @param helperAgentNames - Names of available helper sub-agents. When provided,
+ *   the prompt includes sub-agent usage instructions to help avoid context overflow.
  */
-export function buildCoderSystemPrompt(): string {
+export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 	const sections: string[] = [];
+	const hasHelpers = helperAgentNames && helperAgentNames.length > 0;
 
 	sections.push(`You are a Coder Agent working on a specific task within a larger goal.`);
 	sections.push(`Your job is to complete the task described below to the best of your ability.`);
@@ -95,6 +234,31 @@ export function buildCoderSystemPrompt(): string {
 	sections.push(
 		`7. Finish your response — the leader will re-dispatch reviewers for the next round`
 	);
+
+	// Sub-agent usage instructions (only when helpers are configured)
+	if (hasHelpers) {
+		sections.push(`\n## Sub-Agent Usage (Available)\n`);
+		sections.push(
+			`Helper sub-agents are available to delegate heavy subtasks and keep your context clean.`
+		);
+		sections.push(`Available helpers: ${helperAgentNames!.join(', ')}\n`);
+		sections.push(`**Spawn sub-agents for:**`);
+		sections.push(`- Analyzing large files (>500 lines) or many files at once`);
+		sections.push(
+			`- Implementing isolated components (e.g., a single module of a multi-file feature)`
+		);
+		sections.push(`- Running test suites and collecting detailed results`);
+		sections.push(`- Verbose git operations (e.g., comparing large diffs)`);
+		sections.push(`\n**Usage pattern:**`);
+		sections.push(
+			`\`\`\`\nTask(subagent_type: "<helper-name>", prompt: "Specific task with all necessary context")\n\`\`\``
+		);
+		sections.push(
+			`The helper commits changes to the current branch and returns a concise result summary.`
+		);
+		sections.push(`Store only the summary — do NOT re-read every file the helper touched.`);
+		sections.push(`**Limit:** max 3 concurrent sub-agents per turn.`);
+	}
 
 	return sections.join('\n');
 }
@@ -156,8 +320,63 @@ export function buildCoderTaskMessage(config: CoderAgentConfig): string {
  * The Coder agent uses the Claude Code preset (standard coding tools)
  * with a behavioral system prompt appended. Task-specific context is
  * delivered via the initial user message (buildCoderTaskMessage).
+ *
+ * When worker sub-agents are configured via room.config.agentSubagents.worker,
+ * the session uses the agent/agents pattern so the Coder has access to the
+ * Task/TaskOutput/TaskStop tools for spawning helper sub-agents.
  */
 export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit {
+	const roomConfig = config.room.config ?? {};
+	const workerSubagents = getWorkerSubagents(roomConfig);
+	const helperAgents = workerSubagents ? buildWorkerHelperAgents(workerSubagents) : undefined;
+	const helperNames = helperAgents ? Object.keys(helperAgents) : undefined;
+
+	// When helper sub-agents are configured, use the agent/agents pattern so
+	// the Coder has access to Task/TaskOutput/TaskStop tools. Otherwise use
+	// the simple preset path (no task-spawning capability).
+	if (helperAgents && helperNames && helperNames.length > 0) {
+		const coderAgentDef = {
+			description:
+				'Implementation agent that writes code, runs tests, and creates PRs. Can delegate heavy subtasks to helper sub-agents to avoid context overflow.',
+			prompt: buildCoderSystemPrompt(helperNames),
+			// Coder has all Claude Code tools plus Task for spawning helpers
+			tools: [
+				'Task',
+				'TaskOutput',
+				'TaskStop',
+				'Read',
+				'Write',
+				'Edit',
+				'Bash',
+				'Grep',
+				'Glob',
+				'WebFetch',
+				'WebSearch',
+			],
+			model: 'inherit' as const,
+		};
+
+		return {
+			sessionId: config.sessionId,
+			workspacePath: config.workspacePath,
+			systemPrompt: {
+				type: 'preset',
+				preset: 'claude_code',
+			},
+			features: CODER_FEATURES,
+			context: { roomId: config.room.id },
+			type: 'coder',
+			model: config.model ?? DEFAULT_CODER_MODEL,
+			agent: 'Coder',
+			agents: {
+				Coder: coderAgentDef,
+				...helperAgents,
+			},
+			contextAutoQueue: false,
+		};
+	}
+
+	// Simple path: no helper sub-agents
 	return {
 		sessionId: config.sessionId,
 		workspacePath: config.workspacePath,

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -122,6 +122,46 @@ summary: <1-3 sentence description of what was done and the result>
 }
 
 /**
+ * Build the AgentDefinition for the built-in Tester sub-agent.
+ *
+ * The Tester is automatically included whenever the Coder is in agent/agents mode.
+ * It writes and runs tests for the work just implemented, then commits test files.
+ */
+export function buildTesterAgentDef(): AgentDefinition {
+	return {
+		description:
+			'Test writer and runner. Spawned by the Coder after implementing changes to write and execute tests against the new code.',
+		tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+		model: 'inherit',
+		prompt: `You are a Tester Agent spawned by the main Coder Agent to write and run tests for recently implemented changes.
+
+Your job is to ensure the implementation is correctly tested and return a concise result summary.
+
+## Rules
+
+1. **Understand what was implemented** — read the prompt carefully; explore the changed files
+2. **Write tests** — create or update test files covering the new behavior and edge cases
+3. **Run the tests** — execute them and fix any failures you introduced
+4. **Commit test files** to the current branch (do NOT create new PRs or new branches)
+5. **Do not modify implementation files** — only write tests; if you find a bug, report it in your summary
+6. **No sub-agents** — do not spawn further sub-agents
+
+## Summary Format
+
+End your response with a structured summary:
+
+---TEST_RESULT---
+status: pass | fail | partial
+tests_written: <count or brief description>
+tests_run: <count>
+failures: <list of failing tests, or "none">
+summary: <1-3 sentence description of what was tested and the outcome>
+---END_TEST_RESULT---
+`,
+	};
+}
+
+/**
  * Build the AgentDefinition map for worker helper sub-agents.
  * Returns a map of helper name to AgentDefinition.
  */
@@ -235,28 +275,45 @@ export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 		`7. Finish your response — the leader will re-dispatch reviewers for the next round`
 	);
 
-	// Sub-agent usage instructions (only when helpers are configured)
+	// Sub-agent usage instructions (only when in agent/agents mode)
 	if (hasHelpers) {
 		sections.push(`\n## Sub-Agent Usage (Available)\n`);
 		sections.push(
-			`Helper sub-agents are available to delegate heavy subtasks and keep your context clean.`
+			`Sub-agents are available to delegate heavy subtasks and keep your context clean.`
 		);
-		sections.push(`Available helpers: ${helperAgentNames!.join(', ')}\n`);
-		sections.push(`**Spawn sub-agents for:**`);
+
+		// Tester is always available in agent mode
+		sections.push(`\n### Built-in: \`tester\``);
+		sections.push(`Writes and runs tests for changes you just implemented.`);
+		sections.push(
+			`**Spawn after implementation** — before committing, run the tester to cover new code:`
+		);
+		sections.push(
+			`\`\`\`\nTask(subagent_type: "tester", prompt: "Just implemented: <summary of changes>. Write and run tests for: <specific targets>.")\n\`\`\``
+		);
+		sections.push(
+			`The tester commits test files to the current branch and returns a \`---TEST_RESULT---\` block.`
+		);
+
+		// Custom helpers (if configured)
+		const helperList = helperAgentNames!.join(', ');
+		sections.push(`\n### Custom helpers: ${helperList}`);
+		sections.push(`**Spawn helpers for:**`);
 		sections.push(`- Analyzing large files (>500 lines) or many files at once`);
 		sections.push(
 			`- Implementing isolated components (e.g., a single module of a multi-file feature)`
 		);
-		sections.push(`- Running test suites and collecting detailed results`);
 		sections.push(`- Verbose git operations (e.g., comparing large diffs)`);
-		sections.push(`\n**Usage pattern:**`);
 		sections.push(
 			`\`\`\`\nTask(subagent_type: "<helper-name>", prompt: "Specific task with all necessary context")\n\`\`\``
 		);
 		sections.push(
-			`The helper commits changes to the current branch and returns a concise result summary.`
+			`The helper commits changes to the current branch and returns a \`---SUBTASK_RESULT---\` block.`
 		);
-		sections.push(`Store only the summary — do NOT re-read every file the helper touched.`);
+
+		sections.push(
+			`\nStore only the result summary — do NOT re-read every file the sub-agent touched.`
+		);
 		sections.push(`**Limit:** max 3 concurrent sub-agents per turn.`);
 	}
 
@@ -370,6 +427,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 			agent: 'Coder',
 			agents: {
 				Coder: coderAgentDef,
+				tester: buildTesterAgentDef(),
 				...helperAgents,
 			},
 			contextAutoQueue: false,

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -115,6 +115,13 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 		}
 	}
 
+	// Collect helper names from the built agent map — single source of truth (P2 fix).
+	// Names are derived once in buildLeaderHelperAgents and reused here via Object.keys().
+	const helperConfigs = getLeaderHelperSubagents(roomConfig);
+	const helperAgentsMap =
+		helperConfigs && helperConfigs.length > 0 ? buildLeaderHelperAgents(helperConfigs) : undefined;
+	const helperNames = helperAgentsMap ? Object.keys(helperAgentsMap) : [];
+
 	return [
 		leaderRoleIntro(isPlanReview),
 		leaderToolContractSection(),
@@ -122,8 +129,8 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 		leaderPostRejectionSection(),
 		leaderWorkerQuestionsSection(),
 		isPlanReview
-			? leaderPlanReviewGuidelinesSection(reviewerNames)
-			: leaderCodeReviewGuidelinesSection(reviewerNames),
+			? leaderPlanReviewGuidelinesSection(reviewerNames, helperNames)
+			: leaderCodeReviewGuidelinesSection(reviewerNames, helperNames),
 	].join('\n\n');
 }
 
@@ -223,14 +230,17 @@ If the worker output shows \`Terminal state: waiting_for_input\`, the worker is 
 - If the question requires human judgment or information you don't have, use \`fail_task\` with the reason (e.g., "Worker needs human input: <question>")`;
 }
 
-function leaderPlanReviewGuidelinesSection(reviewerNames: string[]): string {
+function leaderPlanReviewGuidelinesSection(reviewerNames: string[], helperNames: string[]): string {
 	if (reviewerNames.length > 0) {
-		return leaderPlanReviewOrchestrationSection(reviewerNames);
+		return leaderPlanReviewOrchestrationSection(reviewerNames, helperNames);
 	}
-	return leaderPlanReviewSimpleSection();
+	return leaderPlanReviewSimpleSection(helperNames);
 }
 
-function leaderPlanReviewOrchestrationSection(reviewerNames: string[]): string {
+function leaderPlanReviewOrchestrationSection(
+	reviewerNames: string[],
+	helperNames: string[]
+): string {
 	const dispatchCalls = reviewerNames
 		.map(
 			(name) =>
@@ -238,10 +248,15 @@ function leaderPlanReviewOrchestrationSection(reviewerNames: string[]): string {
 		)
 		.join('\n');
 
+	const allSpecialists =
+		helperNames.length > 0
+			? `${reviewerNames.join(', ')}, ${helperNames.join(', ')}`
+			: reviewerNames.join(', ');
+
 	return `\
 ## Available Specialists (via Task subagent_type)
 
-Custom: ${reviewerNames.join(', ')}
+Custom: ${allSpecialists}
 
 ## Plan Review Orchestration Workflow
 
@@ -273,9 +288,13 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 Do NOT call \`complete_task\` after Phase 1 — the plan must be reviewed by a human first. After the planner runs Phase 2 and you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\`, call \`complete_task\`.`;
 }
 
-function leaderPlanReviewSimpleSection(): string {
+function leaderPlanReviewSimpleSection(helperNames: string[]): string {
+	const helperSection =
+		helperNames.length > 0
+			? `\n## Available Helpers (via Task subagent_type)\n\n${helperNames.join(', ')}\n\nHelpers perform read-only analysis tasks. Use them to delegate heavy analysis and keep your context clean.\n`
+			: '';
 	return `\
-## Plan Review Guidelines
+${helperSection}## Plan Review Guidelines
 
 **Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:
 1. Read the planner output and extract the PR number/URL.
@@ -291,14 +310,17 @@ function leaderPlanReviewSimpleSection(): string {
 **Phase 2 (task creation)**: When you receive \`[PLANNER OUTPUT] — Phase 2 (task creation)\` showing "Tasks created: N", call \`complete_task\` with a summary of the tasks created.`;
 }
 
-function leaderCodeReviewGuidelinesSection(reviewerNames: string[]): string {
+function leaderCodeReviewGuidelinesSection(reviewerNames: string[], helperNames: string[]): string {
 	if (reviewerNames.length > 0) {
-		return leaderCodeReviewOrchestrationSection(reviewerNames);
+		return leaderCodeReviewOrchestrationSection(reviewerNames, helperNames);
 	}
-	return leaderCodeReviewSimpleSection();
+	return leaderCodeReviewSimpleSection(helperNames);
 }
 
-function leaderCodeReviewOrchestrationSection(reviewerNames: string[]): string {
+function leaderCodeReviewOrchestrationSection(
+	reviewerNames: string[],
+	helperNames: string[]
+): string {
 	const dispatchCalls = reviewerNames
 		.map(
 			(name) =>
@@ -306,10 +328,15 @@ function leaderCodeReviewOrchestrationSection(reviewerNames: string[]): string {
 		)
 		.join('\n');
 
+	const allSpecialists =
+		helperNames.length > 0
+			? `${reviewerNames.join(', ')}, ${helperNames.join(', ')}`
+			: reviewerNames.join(', ');
+
 	return `\
 ## Available Specialists (via Task subagent_type)
 
-Custom: ${reviewerNames.join(', ')}
+Custom: ${allSpecialists}
 
 ## Review Orchestration Workflow
 
@@ -339,9 +366,13 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 - **Fundamentally broken** → \`fail_task\` or \`replan_goal\``;
 }
 
-function leaderCodeReviewSimpleSection(): string {
+function leaderCodeReviewSimpleSection(helperNames: string[]): string {
+	const helperSection =
+		helperNames.length > 0
+			? `\n## Available Helpers (via Task subagent_type)\n\n${helperNames.join(', ')}\n\nHelpers perform read-only analysis tasks (e.g., "summarize changes in these files"). Use them to delegate heavy analysis and keep your context clean.\n`
+			: '';
 	return `\
-## Code Review Guidelines
+${helperSection}## Code Review Guidelines
 
 **Every iteration follows the same workflow** — including after the worker addresses feedback.
 1. Read the worker output and extract the PR number/URL.
@@ -514,6 +545,78 @@ function getLeaderSubagents(roomConfig: Record<string, unknown>): SubagentConfig
 		return agentSubagents.leader;
 	}
 	return undefined;
+}
+
+/**
+ * Read leader helper sub-agents from room config.
+ * Path: room.config.agentSubagents.leaderHelpers
+ *
+ * Leader helpers are read-only analysis agents (no Write/Edit) used to delegate
+ * heavy analysis tasks. Unlike reviewers, they do not post GitHub reviews.
+ */
+export function getLeaderHelperSubagents(
+	roomConfig: Record<string, unknown>
+): SubagentConfig[] | undefined {
+	const agentSubagents = roomConfig.agentSubagents as Record<string, SubagentConfig[]> | undefined;
+	if (agentSubagents?.leaderHelpers && agentSubagents.leaderHelpers.length > 0) {
+		return agentSubagents.leaderHelpers;
+	}
+	return undefined;
+}
+
+/**
+ * Build AgentDefinition map for leader helper sub-agents.
+ *
+ * Helper names follow the pattern `leader-helper-{shortModelName}` with a counter
+ * suffix to avoid collisions. The names returned by Object.keys() of this map are
+ * the canonical names used in prompts — ensuring prompt and agent map stay in sync.
+ */
+export function buildLeaderHelperAgents(
+	helpers: SubagentConfig[]
+): Record<string, AgentDefinition> {
+	const agents: Record<string, AgentDefinition> = {};
+	const usedNames = new Set<string>();
+
+	for (const helper of helpers) {
+		const shortName = toShortModelName(helper.model);
+		let name = `leader-helper-${shortName}`;
+		let counter = 2;
+		while (usedNames.has(name)) {
+			name = `leader-helper-${shortName}-${counter}`;
+			counter++;
+		}
+		usedNames.add(name);
+
+		const modelId = helper.modelId ?? helper.model;
+		const provider = helper.provider ?? 'anthropic';
+		const description = `Leader analysis helper using ${modelId} (${provider}). Performs read-only analysis to keep the main leader context clean.`;
+
+		agents[name] = {
+			description,
+			// Read-only tools — helpers analyze but do not modify files
+			tools: ['Read', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch'],
+			model: toAgentModel(modelId),
+			prompt: `You are a Leader Analysis Helper Agent. Your job is to perform read-only analysis tasks delegated by the main Leader Agent.
+
+## Rules
+
+1. **Read-only** — do NOT modify, create, or delete files
+2. **Return a concise summary** — include what you found and the key insights
+3. **No sub-agents** — do not spawn further sub-agents
+
+## Summary Format
+
+End your response with a structured summary:
+
+---ANALYSIS_RESULT---
+status: success | partial | failed
+summary: <1-3 sentence description of findings>
+---END_ANALYSIS_RESULT---
+`,
+		};
+	}
+
+	return agents;
 }
 
 /**
@@ -979,14 +1082,24 @@ export function createLeaderAgentInit(
 			? buildReviewerAgents(reviewerConfigs, leaderModel)
 			: undefined;
 
-	// Only define the Leader agent definition and use agent/agents pattern
-	// when there are reviewer sub-agents to dispatch. Otherwise, use the simple
-	// preset path to avoid unnecessary complexity.
-	if (reviewerAgents) {
+	// Build helper agents from room config (if any)
+	const helperConfigs = getLeaderHelperSubagents(roomConfig);
+	const helperAgents =
+		helperConfigs && helperConfigs.length > 0 ? buildLeaderHelperAgents(helperConfigs) : undefined;
+
+	// Merge reviewers and helpers into a single sub-agents map.
+	// Use the agent/agents pattern when ANY sub-agents are configured.
+	const allSubAgents: Record<string, AgentDefinition> = {
+		...reviewerAgents,
+		...helperAgents,
+	};
+	const hasSubAgents = Object.keys(allSubAgents).length > 0;
+
+	if (hasSubAgents) {
 		// Leader agent definition — orchestrates reviews via MCP tools + Task for sub-agents
 		const leaderAgentDef: AgentDefinition = {
 			description:
-				'Coordinator that orchestrates code review. Dispatches reviewer sub-agents, collects their review links, and routes decisions using MCP tools.',
+				'Coordinator that orchestrates code review. Dispatches reviewer and helper sub-agents, collects their results, and routes decisions using MCP tools.',
 			prompt: buildLeaderSystemPrompt(config),
 			tools: ['Task', 'TaskOutput', 'TaskStop', 'Read', 'Grep', 'Glob'],
 			model: toAgentModel(config.model ?? DEFAULT_LEADER_MODEL),
@@ -994,7 +1107,7 @@ export function createLeaderAgentInit(
 
 		const allAgents: Record<string, AgentDefinition> = {
 			Leader: leaderAgentDef,
-			...reviewerAgents,
+			...allSubAgents,
 		};
 
 		return {

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -23,6 +23,7 @@ import type {
 	SessionFeatures,
 	McpServerConfig,
 	AgentDefinition,
+	SubagentConfig,
 } from '@neokai/shared';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
@@ -503,22 +504,6 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 	];
 
 	return createSdkMcpServer({ name: 'leader-agent-tools', tools });
-}
-
-/**
- * Sub-agent configuration (used in room.config.agentSubagents.{role})
- */
-interface SubagentConfig {
-	/** Model ID (e.g., 'claude-opus-4-6', 'gpt-5.3-codex') or CLI agent short name */
-	model: string;
-	/** Provider name (e.g., 'anthropic', 'openai', 'google') */
-	provider?: string;
-	/** Marks this reviewer as CLI-based (external tool orchestrated via Bash) */
-	type?: 'cli';
-	/** Full model ID when different from the short name in 'model' */
-	modelId?: string;
-	/** Model the CLI tool should use internally (e.g., copilot --model gpt-5.3-codex) */
-	cliModel?: string;
 }
 
 /**

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -3,12 +3,18 @@
  *
  * Creates AgentSessionInit for Planner sessions that break goals into tasks.
  *
- * The Planner agent:
- * - Examines the codebase to understand scope
- * - Creates concrete, well-scoped tasks via the create_task MCP tool
- * - Can update or remove draft tasks during plan polishing with Leader feedback
- * - Tasks are created as 'draft' and tagged with createdByTaskId
- * - Leader reviews the plan; on complete_task() the runtime promotes drafts to pending
+ * The Planner agent orchestrates two phases:
+ * 1. Plan phase: Spawns the plan-writer sub-agent to explore the codebase and produce
+ *    plan document(s) on a feature branch/PR.
+ * 2. Task creation phase: After human approval, merges the PR and creates tasks.
+ *
+ * The plan-writer sub-agent handles scope assessment and file structure:
+ * - Small goals (≤ 5 milestones): single docs/plans/<slug>.md
+ * - Large goals (> 5 milestones): multi-file docs/plans/<slug>/ with numbered overview
+ *   and per-milestone detail files, produced via an iterative two-pass approach.
+ *
+ * The create_task/update_task/remove_task tools are gated by a dynamic isPlanApproved
+ * check — they become available only after the human approves the plan.
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
@@ -96,32 +102,157 @@ export function toPlanSlug(goalTitle: string): string {
 }
 
 /**
+ * Build the system prompt for the Plan Writer sub-agent.
+ *
+ * The plan-writer handles all Phase 1 work: codebase exploration, scope assessment,
+ * plan document creation (single file or multi-file), branch/commit/PR.
+ *
+ * For large-scope goals it uses an iterative two-pass approach:
+ * - Pass 1: Create 00-overview.md with milestones list
+ * - Pass 2: Create per-milestone files (NN-<slug>.md) with detailed tasks and subtasks
+ *
+ * Placeholders (substituted at creation time via buildPlanWriterAgentDef):
+ *   <single_plan_path> — e.g., docs/plans/build-stock-app.md
+ *   <plan_dir>         — e.g., docs/plans/build-stock-app
+ *   <plan_slug>        — e.g., build-stock-app
+ */
+export function buildPlanWriterPrompt(): string {
+	return `You are a Plan Writer Agent spawned by the Planner to produce a structured plan for a goal.
+
+## Pre-Work: Git Sync (MANDATORY)
+
+Before exploring, sync with the default branch — run all three lines as a **single bash invocation**:
+\`\`\`bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+git fetch origin && git rebase origin/$DEFAULT_BRANCH
+\`\`\`
+**If the rebase fails with conflicts, stop immediately and report the error** — do NOT plan against a stale codebase.
+
+## Step 1: Codebase Exploration
+
+Explore the codebase using Explore sub-agents (each has its own context window):
+\`\`\`
+Task(subagent_type: "Explore", prompt: "Explore [area]. I need: [questions]. Return key findings, file paths, patterns.")
+\`\`\`
+Spawn multiple Explore agents **in parallel** to cover different areas. Gather enough context to understand existing patterns, affected areas, dependencies, and overall complexity.
+
+## Step 2: Scope Assessment
+
+Based on your exploration, determine the plan structure:
+- **Small scope** (≤ 5 milestones, ≤ 15 total tasks) → Single file: \`<single_plan_path>\`
+- **Large scope** (> 5 milestones OR > 15 total tasks) → Multi-file folder: \`<plan_dir>/\`
+
+## Step 3: Writing the Plan
+
+### Small Scope — Single File
+
+Write \`<single_plan_path>\` with:
+- Goal summary and approach
+- Ordered tasks with: title, description, subtasks (ordered implementation steps), acceptance criteria, dependencies on other tasks, agent type (coder/general)
+- For coding tasks always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
+
+### Large Scope — Multi-File (Two-Pass Iterative Approach)
+
+**Pass 1 — Create the overview first:**
+Write \`<plan_dir>/00-overview.md\`:
+- Goal summary and high-level approach
+- Numbered milestones list (one line each with brief description)
+- Cross-milestone dependencies and key sequencing decisions
+- Total estimated task count
+
+**Pass 2 — Create per-milestone detail files:**
+For each milestone \`N\`, write \`<plan_dir>/NN-<milestone-slug>.md\` (zero-padded: 01, 02, …):
+- Milestone goal and scope
+- Ordered tasks — each task maps to ONE coder agent session (keep focused, not too broad)
+- Per task: title, description, subtasks (ordered implementation steps within the session), acceptance criteria, depends_on (list of task titles from this or earlier milestones), agent type
+- For coding tasks always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
+
+**File naming rules:**
+- Overview: \`<plan_dir>/00-overview.md\`
+- Milestones: \`<plan_dir>/01-<milestone-slug>.md\`, \`<plan_dir>/02-<milestone-slug>.md\`, …
+- Milestone slug = lowercase, hyphens only (e.g., "User Authentication" → \`user-authentication\`)
+
+## Step 4: Branch, Commit, PR
+
+1. Create a feature branch: \`git checkout -b plan/<plan_slug>\`
+2. Commit all plan files with a clear message
+3. Push and create a PR (detect base branch in subshell):
+   \`\`\`bash
+   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")
+   \`\`\`
+
+## Step 5: Return Result
+
+End your response with:
+\`\`\`
+---PLAN_RESULT---
+pr_number: <number>
+branch: <branch-name>
+plan_files: <comma-separated relative file paths>
+structure: single | multi
+---END_PLAN_RESULT---
+\`\`\``;
+}
+
+/**
+ * Build the AgentDefinition for the plan-writer sub-agent.
+ * The plan slug is embedded into the prompt at creation time so file paths are concrete.
+ */
+export function buildPlanWriterAgentDef(planSlug: string): AgentDefinition {
+	const singlePlanPath = `docs/plans/${planSlug}.md`;
+	const planDir = `docs/plans/${planSlug}`;
+	const prompt = buildPlanWriterPrompt()
+		.replace(/<single_plan_path>/g, singlePlanPath)
+		.replace(/<plan_dir>/g, planDir)
+		.replace(/<plan_slug>/g, planSlug);
+
+	return {
+		description:
+			'Plan writer that explores the codebase and produces structured plan documents. ' +
+			'Supports single-file plans for small goals and multi-file iterative plans for large-scope goals.',
+		tools: [
+			'Task',
+			'TaskOutput',
+			'TaskStop',
+			'Read',
+			'Write',
+			'Edit',
+			'Bash',
+			'Grep',
+			'Glob',
+			'WebFetch',
+			'WebSearch',
+		],
+		model: 'inherit',
+		prompt,
+	};
+}
+
+/**
  * Build the behavioral system prompt for the Planner agent.
  *
- * Single-session lifecycle:
- * 1. Examine codebase, write plan as docs/plans/<slug>.md, commit, create PR
- * 2. (Worker exits → Leader reviews → submit_for_review → Human approves)
- * 3. When resumed with approval message: merge PR, create tasks using create_task tool
- *
- * The create_task/update_task/remove_task tools are gated by a dynamic isPlanApproved
- * check — they become available only after the human approves the plan.
+ * The Planner orchestrates two phases:
+ * 1. Plan phase: Spawns the plan-writer sub-agent to explore and create a plan PR.
+ * 2. Task creation phase: After human approval, merges the PR and creates tasks.
  *
  * Goal-specific context is delivered via the initial user message.
  */
 export function buildPlannerSystemPrompt(goalTitle?: string): string {
 	const planSlug = goalTitle ? toPlanSlug(goalTitle) : 'plan';
+	const planDir = `docs/plans/${planSlug}`;
 	const planPath = `docs/plans/${planSlug}.md`;
 
 	return `\
 You are a Planner Agent responsible for breaking down a goal into a concrete plan.
 
 Your job has two phases within a single session:
-1. **Plan phase**: Examine the codebase, write a plan document, and create a PR
+1. **Plan phase**: Spawn the \`plan-writer\` sub-agent to explore the codebase and create a plan PR
 2. **Task creation phase**: After the plan is approved, merge the PR and create tasks
 
 ## Pre-Planning Setup (MANDATORY)
 
-Before reading any files or writing the plan, sync with the default branch.
+Before starting, sync with the default branch.
 Run all three lines as a **single bash invocation** (variables persist within one call):
 \`\`\`bash
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
@@ -132,50 +263,39 @@ git fetch origin && git rebase origin/$DEFAULT_BRANCH
 
 ## Phase 1: Planning
 
-### Codebase Exploration
-
-Before writing the plan, explore the codebase thoroughly. Use the built-in **Explore** sub-agent for deep analysis — it has its own context window and won't pollute yours:
+Spawn the \`plan-writer\` sub-agent to handle all exploration and plan creation work.
+Pass the full goal context (title, description, room background, instructions) as the Task prompt:
 
 \`\`\`
-Task(subagent_type: "Explore", prompt: "Explore [specific area]. I need to understand: [questions]. Return key findings, file paths, and relevant code patterns.")
+Task(subagent_type: "plan-writer", prompt: "Goal: <title>\\n\\nDescription: <description>\\n\\n<room context>")
 \`\`\`
 
-Use Explore for:
-- Understanding large unfamiliar codebases before planning
-- Mapping out architectural patterns and conventions
-- Finding all files affected by a proposed change
-- Answering "how does X work?" without reading dozens of files yourself
+The plan-writer will:
+- Explore the codebase and assess scope
+- For small goals (≤ 5 milestones): write a single plan file at \`${planPath}\`
+- For large goals (> 5 milestones): write multi-file plans in \`${planDir}/\` with a numbered overview (\`00-overview.md\`) and per-milestone files (\`01-<milestone>.md\`, \`02-<milestone>.md\`, …)
+- Use an iterative two-pass approach for large goals: first create the overview, then expand each milestone into detailed tasks and subtasks
+- Create a feature branch, commit, push, and open a PR
 
-Spawn multiple Explore agents in parallel if you need to investigate different areas.
+Parse the \`---PLAN_RESULT---\` block in the plan-writer's response to capture:
+- \`pr_number\` — needed for Phase 2 merge
+- \`plan_files\` — file paths to read in Phase 2
+- \`structure\` — \`single\` or \`multi\`
 
-### Plan Creation
+**If the Leader sends feedback on the plan:** Edit the plan files directly (you have Write/Edit/Bash tools), push to the existing branch, and finish your response.
 
-1. Break the goal into as many concrete, independently executable tasks as needed — be as granular as the goal requires. Simple goals may need just a few tasks; complex goals may need many more.
-2. Order tasks by dependency (later tasks build on earlier ones). Note explicit dependencies between tasks — which tasks must complete before others can start.
-3. Each task description must include clear acceptance criteria. For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
-4. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
 5. Do NOT call \`create_task\` — that tool is disabled until the plan is approved
 6. Do NOT implement any code — only plan
-7. If the Leader sends feedback, update the plan document accordingly
 
-### Plan Deliverable (REQUIRED)
-
-You MUST produce a plan file and create a PR for review:
-1. Create the \`docs/plans/\` directory if it doesn't exist, then write the plan file at \`${planPath}\` with: goal, ordered task list with descriptions, dependencies between tasks, acceptance criteria, and agent type assignments
-2. Create a feature branch, commit the plan file, and push it
-3. Create a GitHub PR — detect the default branch inside the subshell with the plan summary as the PR description:
-   \`\`\`bash
-   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")
-   \`\`\`
-4. Finish your response — the Leader will dispatch reviewers, then submit for human approval
+Finish your response after the plan-writer completes — the Leader will dispatch reviewers, then submit for human approval.
 
 ## Phase 2: Task Creation (after plan approval)
 
 When the Leader sends you an approval message, you are in Phase 2.
-**IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first. Creating tasks without merging the plan PR is incorrect and will leave the plan file out of the main codebase.
+**IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first.
 
-1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --merge\`
-2. Read the plan file (look for \`${planPath}\` or any \`.md\` file under \`docs/plans/\`) to get the approved plan
+1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --merge\` (use the pr_number from the Phase 1 plan-writer result)
+2. Read the plan files (use the \`plan_files\` list from Phase 1, or find them under \`${planDir}/\` or at \`${planPath}\`)
 3. Create tasks 1:1 from the plan sections using the \`create_task\` tool
 4. Each task title and description should match the plan exactly
 5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
@@ -251,7 +371,7 @@ export function createPlannerMcpServer(config: PlannerAgentConfig) {
 					success: false,
 					error:
 						'This tool is not available during the planning phase. ' +
-						'Write your plan file under docs/plans/, commit it, and create a PR instead. ' +
+						'The plan-writer sub-agent will create plan files under docs/plans/, commit them, and create a PR. ' +
 						'Tasks will be created after the plan is approved.',
 				}),
 			},
@@ -400,22 +520,24 @@ export function createPlannerMcpServer(config: PlannerAgentConfig) {
 /**
  * Create an AgentSessionInit for a Planner agent.
  *
- * Always uses the agent/agents pattern so the Planner has access to the Task/
- * TaskOutput/TaskStop tools. This enables spawning the built-in Explore sub-agent
- * for deep codebase analysis without consuming the Planner's own context window.
+ * Uses the agent/agents pattern so the Planner has access to the Task/TaskOutput/TaskStop
+ * tools for spawning the plan-writer sub-agent. The plan-writer handles all Phase 1 work
+ * (exploration, scope assessment, plan creation, branch/PR).
  *
- * MCP planning tools (create_task, update_task, remove_task) are provided via
- * mcpServers and are available to the main Planner agent thread regardless.
+ * MCP planning tools (create_task, update_task, remove_task) are provided via mcpServers
+ * and are available to the main Planner agent thread regardless.
  */
 export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSessionInit {
 	const mcpServer = createPlannerMcpServer(config);
+	const planSlug = toPlanSlug(config.goal.title);
 
 	const plannerAgentDef: AgentDefinition = {
 		description:
-			'Planning agent that breaks goals into concrete tasks. Uses Explore sub-agents for deep codebase analysis.',
+			'Planning agent that orchestrates plan creation by spawning a plan-writer sub-agent, ' +
+			'then creates tasks from the approved plan.',
 		prompt: buildPlannerSystemPrompt(config.goal.title),
-		// Planner needs Task/TaskOutput/TaskStop to spawn Explore sub-agents,
-		// plus standard codebase tools for direct file reading.
+		// Planner needs Task/TaskOutput/TaskStop to spawn plan-writer,
+		// plus standard tools for direct file editing during feedback rounds.
 		tools: [
 			'Task',
 			'TaskOutput',
@@ -449,6 +571,7 @@ export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSession
 		agent: 'Planner',
 		agents: {
 			Planner: plannerAgentDef,
+			'plan-writer': buildPlanWriterAgentDef(planSlug),
 		},
 		contextAutoQueue: false,
 	};

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -22,6 +22,7 @@ import type {
 	McpServerConfig,
 	TaskPriority,
 	AgentType,
+	AgentDefinition,
 } from '@neokai/shared';
 
 const DEFAULT_PLANNER_MODEL = 'claude-sonnet-4-5-20250929';
@@ -131,14 +132,31 @@ git fetch origin && git rebase origin/$DEFAULT_BRANCH
 
 ## Phase 1: Planning
 
-1. Read relevant files to understand the current codebase state
-2. Break the goal into 3-8 concrete, independently executable tasks
-3. Order tasks by dependency (later tasks build on earlier ones). Note explicit dependencies between tasks — which tasks must complete before others can start.
-4. Each task description must include clear acceptance criteria. For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
-5. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
-6. Do NOT call \`create_task\` — that tool is disabled until the plan is approved
-7. Do NOT implement any code — only plan
-8. If the Leader sends feedback, update the plan document accordingly
+### Codebase Exploration
+
+Before writing the plan, explore the codebase thoroughly. Use the built-in **Explore** sub-agent for deep analysis — it has its own context window and won't pollute yours:
+
+\`\`\`
+Task(subagent_type: "Explore", prompt: "Explore [specific area]. I need to understand: [questions]. Return key findings, file paths, and relevant code patterns.")
+\`\`\`
+
+Use Explore for:
+- Understanding large unfamiliar codebases before planning
+- Mapping out architectural patterns and conventions
+- Finding all files affected by a proposed change
+- Answering "how does X work?" without reading dozens of files yourself
+
+Spawn multiple Explore agents in parallel if you need to investigate different areas.
+
+### Plan Creation
+
+1. Break the goal into as many concrete, independently executable tasks as needed — be as granular as the goal requires. Simple goals may need just a few tasks; complex goals may need many more.
+2. Order tasks by dependency (later tasks build on earlier ones). Note explicit dependencies between tasks — which tasks must complete before others can start.
+3. Each task description must include clear acceptance criteria. For coding tasks, always include: "Changes must be on a feature branch with a GitHub PR created via \`gh pr create\`"
+4. For each task, assign the appropriate agent type: "coder" for implementation tasks, "general" for non-coding tasks
+5. Do NOT call \`create_task\` — that tool is disabled until the plan is approved
+6. Do NOT implement any code — only plan
+7. If the Leader sends feedback, update the plan document accordingly
 
 ### Plan Deliverable (REQUIRED)
 
@@ -382,11 +400,37 @@ export function createPlannerMcpServer(config: PlannerAgentConfig) {
 /**
  * Create an AgentSessionInit for a Planner agent.
  *
- * Uses the Claude Code preset (for read/glob/grep codebase access) plus planning
- * MCP tools. The system prompt instructs the agent to plan only, not implement.
+ * Always uses the agent/agents pattern so the Planner has access to the Task/
+ * TaskOutput/TaskStop tools. This enables spawning the built-in Explore sub-agent
+ * for deep codebase analysis without consuming the Planner's own context window.
+ *
+ * MCP planning tools (create_task, update_task, remove_task) are provided via
+ * mcpServers and are available to the main Planner agent thread regardless.
  */
 export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSessionInit {
 	const mcpServer = createPlannerMcpServer(config);
+
+	const plannerAgentDef: AgentDefinition = {
+		description:
+			'Planning agent that breaks goals into concrete tasks. Uses Explore sub-agents for deep codebase analysis.',
+		prompt: buildPlannerSystemPrompt(config.goal.title),
+		// Planner needs Task/TaskOutput/TaskStop to spawn Explore sub-agents,
+		// plus standard codebase tools for direct file reading.
+		tools: [
+			'Task',
+			'TaskOutput',
+			'TaskStop',
+			'Read',
+			'Write',
+			'Edit',
+			'Bash',
+			'Grep',
+			'Glob',
+			'WebFetch',
+			'WebSearch',
+		],
+		model: 'inherit',
+	};
 
 	return {
 		sessionId: config.sessionId,
@@ -394,7 +438,6 @@ export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSession
 		systemPrompt: {
 			type: 'preset',
 			preset: 'claude_code',
-			append: buildPlannerSystemPrompt(config.goal.title),
 		},
 		mcpServers: {
 			'planner-tools': mcpServer as unknown as McpServerConfig,
@@ -403,6 +446,10 @@ export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSession
 		context: { roomId: config.room.id },
 		type: 'planner',
 		model: config.model ?? DEFAULT_PLANNER_MODEL,
+		agent: 'Planner',
+		agents: {
+			Planner: plannerAgentDef,
+		},
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
+	buildCoderHelperAgentPrompt,
 	buildCoderSystemPrompt,
 	buildCoderTaskMessage,
+	buildWorkerHelperAgents,
 	createCoderAgentInit,
+	getWorkerSubagents,
 	type CoderAgentConfig,
 } from '../../../src/lib/room/agents/coder-agent';
 import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
@@ -251,6 +254,168 @@ describe('Coder Agent', () => {
 		it('should include room ID in context', () => {
 			const init = createCoderAgentInit(makeConfig());
 			expect(init.context).toEqual({ roomId: 'room-1' });
+		});
+
+		describe('with worker sub-agents configured', () => {
+			function makeConfigWithWorkers(workerConfigs = [{ model: 'haiku' }]): CoderAgentConfig {
+				return makeConfig({
+					room: makeRoom({
+						config: {
+							agentSubagents: { worker: workerConfigs },
+						},
+					}),
+				});
+			}
+
+			it('uses agent/agents pattern when worker sub-agents are configured', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agent).toBe('Coder');
+				expect(init.agents).toBeDefined();
+			});
+
+			it('includes Coder in agents map', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agents).toHaveProperty('Coder');
+			});
+
+			it('includes helper agents in agents map', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers([{ model: 'haiku' }]));
+				const agentKeys = Object.keys(init.agents ?? {});
+				expect(agentKeys.some((k) => k.startsWith('helper-'))).toBe(true);
+			});
+
+			it('Coder agent def includes Task tool', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const coderDef = init.agents?.['Coder'];
+				expect(coderDef?.tools).toContain('Task');
+			});
+
+			it('Coder agent def includes standard coding tools', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const coderDef = init.agents?.['Coder'];
+				expect(coderDef?.tools).toContain('Read');
+				expect(coderDef?.tools).toContain('Bash');
+				expect(coderDef?.tools).toContain('Edit');
+			});
+
+			it('Coder system prompt includes sub-agent usage section when helpers configured', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const coderPrompt = init.agents?.['Coder']?.prompt ?? '';
+				expect(coderPrompt).toContain('Sub-Agent Usage');
+				expect(coderPrompt).toContain('helper-');
+			});
+
+			it('uses simple preset path when no worker sub-agents configured', () => {
+				const init = createCoderAgentInit(makeConfig());
+				expect(init.agent).toBeUndefined();
+				expect(init.agents).toBeUndefined();
+				expect((init.systemPrompt as { append?: string }).append).toBeDefined();
+			});
+
+			it('handles multiple worker configs with deduplication', () => {
+				const init = createCoderAgentInit(
+					makeConfigWithWorkers([{ model: 'haiku' }, { model: 'haiku' }])
+				);
+				const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Coder');
+				// Two haiku configs should produce unique names
+				expect(keys.length).toBe(2);
+				expect(new Set(keys).size).toBe(2);
+			});
+		});
+	});
+
+	describe('getWorkerSubagents', () => {
+		it('returns undefined when agentSubagents not set', () => {
+			expect(getWorkerSubagents({})).toBeUndefined();
+		});
+
+		it('returns undefined when worker array is empty', () => {
+			expect(getWorkerSubagents({ agentSubagents: { worker: [] } })).toBeUndefined();
+		});
+
+		it('returns configs when worker sub-agents are configured', () => {
+			const configs = [{ model: 'haiku' }, { model: 'sonnet' }];
+			expect(getWorkerSubagents({ agentSubagents: { worker: configs } })).toEqual(configs);
+		});
+
+		it('returns undefined when only non-worker keys are set', () => {
+			expect(
+				getWorkerSubagents({ agentSubagents: { leader: [{ model: 'sonnet' }] } })
+			).toBeUndefined();
+		});
+	});
+
+	describe('buildWorkerHelperAgents', () => {
+		it('returns empty map for empty input', () => {
+			expect(buildWorkerHelperAgents([])).toEqual({});
+		});
+
+		it('creates helper with correct name prefix', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }]);
+			const keys = Object.keys(agents);
+			expect(keys.length).toBe(1);
+			expect(keys[0]).toMatch(/^helper-/);
+		});
+
+		it('creates multiple helpers for multiple configs', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }, { model: 'sonnet' }]);
+			expect(Object.keys(agents).length).toBe(2);
+		});
+
+		it('deduplicates names when same model used twice', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }, { model: 'haiku' }]);
+			const keys = Object.keys(agents);
+			expect(keys.length).toBe(2);
+			expect(new Set(keys).size).toBe(2);
+		});
+
+		it('uses custom name from config when provided', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku', name: 'analyzer' }]);
+			expect(Object.keys(agents)[0]).toBe('helper-analyzer');
+		});
+
+		it('helpers do NOT have Task tool (no recursive sub-agents)', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).not.toContain('Task');
+		});
+
+		it('helpers have standard coding tools', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).toContain('Read');
+			expect(helper.tools).toContain('Write');
+			expect(helper.tools).toContain('Edit');
+			expect(helper.tools).toContain('Bash');
+		});
+
+		it('maps opus model to opus tier', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'claude-opus-4-6' }]);
+			expect(Object.values(agents)[0].model).toBe('opus');
+		});
+
+		it('maps haiku model to haiku tier', () => {
+			const agents = buildWorkerHelperAgents([{ model: 'haiku' }]);
+			expect(Object.values(agents)[0].model).toBe('haiku');
+		});
+	});
+
+	describe('buildCoderHelperAgentPrompt', () => {
+		it('instructs helper to commit but NOT create new PRs', () => {
+			const prompt = buildCoderHelperAgentPrompt();
+			expect(prompt).toContain('current branch');
+			expect(prompt).toContain('do NOT create new PRs');
+		});
+
+		it('requires SUBTASK_RESULT structured output block', () => {
+			const prompt = buildCoderHelperAgentPrompt();
+			expect(prompt).toContain('---SUBTASK_RESULT---');
+			expect(prompt).toContain('---END_SUBTASK_RESULT---');
+		});
+
+		it('forbids recursive sub-agent spawning', () => {
+			const prompt = buildCoderHelperAgentPrompt();
+			expect(prompt).toContain('No sub-agents');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -3,6 +3,7 @@ import {
 	buildCoderHelperAgentPrompt,
 	buildCoderSystemPrompt,
 	buildCoderTaskMessage,
+	buildTesterAgentDef,
 	buildWorkerHelperAgents,
 	createCoderAgentInit,
 	getWorkerSubagents,
@@ -305,6 +306,36 @@ describe('Coder Agent', () => {
 				expect(coderPrompt).toContain('helper-');
 			});
 
+			it('includes built-in tester agent in agents map', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agents).toHaveProperty('tester');
+			});
+
+			it('tester agent has Write and Edit tools', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const tester = init.agents?.['tester'];
+				expect(tester?.tools).toContain('Write');
+				expect(tester?.tools).toContain('Edit');
+			});
+
+			it('tester agent does NOT have Task tool', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const tester = init.agents?.['tester'];
+				expect(tester?.tools).not.toContain('Task');
+			});
+
+			it('tester agent uses inherit model', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				expect(init.agents?.['tester']?.model).toBe('inherit');
+			});
+
+			it('Coder system prompt includes tester sub-agent instructions', () => {
+				const init = createCoderAgentInit(makeConfigWithWorkers());
+				const prompt = init.agents?.['Coder']?.prompt ?? '';
+				expect(prompt).toContain('tester');
+				expect(prompt).toContain('---TEST_RESULT---');
+			});
+
 			it('uses simple preset path when no worker sub-agents configured', () => {
 				const init = createCoderAgentInit(makeConfig());
 				expect(init.agent).toBeUndefined();
@@ -316,7 +347,8 @@ describe('Coder Agent', () => {
 				const init = createCoderAgentInit(
 					makeConfigWithWorkers([{ model: 'haiku' }, { model: 'haiku' }])
 				);
-				const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Coder');
+				// Filter out built-in Coder and tester; count only the helper sub-agents
+				const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Coder' && k !== 'tester');
 				// Two haiku configs should produce unique names
 				expect(keys.length).toBe(2);
 				expect(new Set(keys).size).toBe(2);
@@ -397,6 +429,50 @@ describe('Coder Agent', () => {
 		it('maps haiku model to haiku tier', () => {
 			const agents = buildWorkerHelperAgents([{ model: 'haiku' }]);
 			expect(Object.values(agents)[0].model).toBe('haiku');
+		});
+	});
+
+	describe('buildTesterAgentDef', () => {
+		it('has Read, Write, Edit, Bash, Grep, Glob tools', () => {
+			const def = buildTesterAgentDef();
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Write');
+			expect(def.tools).toContain('Edit');
+			expect(def.tools).toContain('Bash');
+			expect(def.tools).toContain('Grep');
+			expect(def.tools).toContain('Glob');
+		});
+
+		it('does NOT have Task tool (no recursive sub-agents)', () => {
+			const def = buildTesterAgentDef();
+			expect(def.tools).not.toContain('Task');
+		});
+
+		it('uses inherit model', () => {
+			const def = buildTesterAgentDef();
+			expect(def.model).toBe('inherit');
+		});
+
+		it('prompt requires ---TEST_RESULT--- structured output block', () => {
+			const def = buildTesterAgentDef();
+			expect(def.prompt).toContain('---TEST_RESULT---');
+			expect(def.prompt).toContain('---END_TEST_RESULT---');
+		});
+
+		it('prompt forbids modifying implementation files', () => {
+			const def = buildTesterAgentDef();
+			expect(def.prompt).toContain('Do not modify implementation files');
+		});
+
+		it('prompt forbids recursive sub-agent spawning', () => {
+			const def = buildTesterAgentDef();
+			expect(def.prompt).toContain('No sub-agents');
+		});
+
+		it('prompt instructs to commit test files to current branch', () => {
+			const def = buildTesterAgentDef();
+			expect(def.prompt).toContain('current branch');
+			expect(def.prompt).toContain('do NOT create new PRs');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import {
+	buildLeaderHelperAgents,
 	buildLeaderSystemPrompt,
 	buildLeaderTaskContext,
 	buildReviewerAgents,
-	createLeaderToolHandlers,
 	createLeaderAgentInit,
+	createLeaderToolHandlers,
+	getLeaderHelperSubagents,
 	toAgentModel,
 	toShortModelName,
 	type LeaderAgentConfig,
@@ -948,6 +950,270 @@ describe('Leader Agent', () => {
 			);
 			const reviewerAgent = init.agents!['reviewer-copilot'];
 			expect(reviewerAgent.model).toBe('inherit');
+		});
+	});
+});
+
+describe('Leader Helper Sub-Agents', () => {
+	function makeRoom(overrides?: Partial<Room>): Room {
+		return {
+			id: 'room-1',
+			name: 'Test Room',
+			allowedPaths: [{ path: '/workspace', label: 'ws' }],
+			defaultPath: '/workspace',
+			sessionIds: [],
+			status: 'active',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			...overrides,
+		};
+	}
+
+	function makeGoal(overrides?: Partial<RoomGoal>): RoomGoal {
+		return {
+			id: 'goal-1',
+			roomId: 'room-1',
+			title: 'Test goal',
+			status: 'active',
+			priority: 'normal',
+			progress: 0,
+			linkedTaskIds: [],
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			...overrides,
+		};
+	}
+
+	function makeTask(overrides?: Partial<NeoTask>): NeoTask {
+		return {
+			id: 'task-1',
+			roomId: 'room-1',
+			goalId: 'goal-1',
+			title: 'Test task',
+			description: 'Test description',
+			status: 'pending',
+			priority: 'normal',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			...overrides,
+		};
+	}
+
+	function makeCallbacks(): LeaderToolCallbacks {
+		const stub = async () => ({ content: [{ type: 'text' as const, text: 'ok' }] });
+		return {
+			sendToWorker: stub,
+			handoffToWorker: stub,
+			completeTask: stub,
+			failTask: stub,
+			replanGoal: stub,
+			submitForReview: stub,
+		};
+	}
+
+	function makeConfig(overrides?: Partial<LeaderAgentConfig>): LeaderAgentConfig {
+		return {
+			task: makeTask(),
+			goal: makeGoal(),
+			room: makeRoom(),
+			sessionId: 'sess-1',
+			workspacePath: '/workspace',
+			groupId: 'group-1',
+			...overrides,
+		};
+	}
+
+	describe('getLeaderHelperSubagents', () => {
+		it('returns undefined when agentSubagents not set', () => {
+			expect(getLeaderHelperSubagents({})).toBeUndefined();
+		});
+
+		it('returns undefined when leaderHelpers is empty', () => {
+			expect(getLeaderHelperSubagents({ agentSubagents: { leaderHelpers: [] } })).toBeUndefined();
+		});
+
+		it('returns configs when leaderHelpers are configured', () => {
+			const configs = [{ model: 'haiku' }, { model: 'sonnet' }];
+			expect(getLeaderHelperSubagents({ agentSubagents: { leaderHelpers: configs } })).toEqual(
+				configs
+			);
+		});
+
+		it('returns undefined when only non-leaderHelpers keys are set', () => {
+			expect(
+				getLeaderHelperSubagents({ agentSubagents: { leader: [{ model: 'sonnet' }] } })
+			).toBeUndefined();
+		});
+	});
+
+	describe('buildLeaderHelperAgents', () => {
+		it('returns empty map for empty input', () => {
+			expect(buildLeaderHelperAgents([])).toEqual({});
+		});
+
+		it('creates helper with correct name prefix', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }]);
+			const keys = Object.keys(agents);
+			expect(keys.length).toBe(1);
+			expect(keys[0]).toMatch(/^leader-helper-/);
+		});
+
+		it('creates multiple helpers for multiple configs', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }, { model: 'sonnet' }]);
+			expect(Object.keys(agents).length).toBe(2);
+		});
+
+		it('deduplicates names when same model used twice', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }, { model: 'haiku' }]);
+			const keys = Object.keys(agents);
+			expect(keys.length).toBe(2);
+			expect(new Set(keys).size).toBe(2);
+		});
+
+		it('helpers do NOT have Task tool (no recursive sub-agents)', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).not.toContain('Task');
+		});
+
+		it('helpers do NOT have Write tool (read-only analysis)', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).not.toContain('Write');
+		});
+
+		it('helpers do NOT have Edit tool (read-only analysis)', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).not.toContain('Edit');
+		});
+
+		it('helpers have read tools', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'haiku' }]);
+			const helper = Object.values(agents)[0];
+			expect(helper.tools).toContain('Read');
+			expect(helper.tools).toContain('Grep');
+			expect(helper.tools).toContain('Glob');
+			expect(helper.tools).toContain('Bash');
+		});
+
+		it('maps opus model to opus tier', () => {
+			const agents = buildLeaderHelperAgents([{ model: 'claude-opus-4-6' }]);
+			expect(Object.values(agents)[0].model).toBe('opus');
+		});
+	});
+
+	describe('createLeaderAgentInit with leaderHelpers', () => {
+		function makeConfigWithHelpers(helperConfigs = [{ model: 'haiku' }]): LeaderAgentConfig {
+			return makeConfig({
+				room: makeRoom({
+					config: {
+						agentSubagents: { leaderHelpers: helperConfigs },
+					},
+				}),
+			});
+		}
+
+		it('uses agent/agents pattern when only leaderHelpers are configured', () => {
+			const init = createLeaderAgentInit(makeConfigWithHelpers(), makeCallbacks());
+			expect(init.agent).toBe('Leader');
+			expect(init.agents).toBeDefined();
+		});
+
+		it('includes leader helper agents in agents map', () => {
+			const init = createLeaderAgentInit(makeConfigWithHelpers(), makeCallbacks());
+			const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Leader');
+			expect(keys.some((k) => k.startsWith('leader-helper-'))).toBe(true);
+		});
+
+		it('includes both reviewers and helpers when both configured', () => {
+			const config = makeConfig({
+				room: makeRoom({
+					config: {
+						agentSubagents: {
+							leader: [{ model: 'haiku' }],
+							leaderHelpers: [{ model: 'sonnet' }],
+						},
+					},
+				}),
+			});
+			const init = createLeaderAgentInit(config, makeCallbacks());
+			const keys = Object.keys(init.agents ?? {}).filter((k) => k !== 'Leader');
+			expect(keys.some((k) => k.startsWith('reviewer-'))).toBe(true);
+			expect(keys.some((k) => k.startsWith('leader-helper-'))).toBe(true);
+		});
+
+		it('uses simple path when neither reviewers nor helpers are configured', () => {
+			const init = createLeaderAgentInit(makeConfig(), makeCallbacks());
+			expect(init.agent).toBeUndefined();
+			expect(init.agents).toBeUndefined();
+		});
+
+		it('Leader agent def includes Task tool when helpers configured', () => {
+			const init = createLeaderAgentInit(makeConfigWithHelpers(), makeCallbacks());
+			const leaderDef = init.agents?.['Leader'];
+			expect(leaderDef?.tools).toContain('Task');
+		});
+	});
+
+	describe('buildLeaderSystemPrompt with leaderHelpers (no reviewers)', () => {
+		function makeConfigWithHelpers(helperConfigs = [{ model: 'haiku' }]): LeaderAgentConfig {
+			return makeConfig({
+				room: makeRoom({
+					config: {
+						agentSubagents: { leaderHelpers: helperConfigs },
+					},
+				}),
+			});
+		}
+
+		it('includes Available Helpers section in code review mode', () => {
+			const config = makeConfigWithHelpers();
+			const prompt = buildLeaderSystemPrompt(config);
+			expect(prompt).toContain('Available Helpers');
+			expect(prompt).toContain('leader-helper-');
+		});
+
+		it('includes Available Helpers section in plan review mode', () => {
+			const config = makeConfigWithHelpers();
+			config.reviewContext = 'plan_review';
+			const prompt = buildLeaderSystemPrompt(config);
+			expect(prompt).toContain('Available Helpers');
+			expect(prompt).toContain('leader-helper-');
+		});
+
+		it('helper names in prompt match keys from buildLeaderHelperAgents (P2: single source of truth)', () => {
+			const helperConfigs = [{ model: 'haiku' }, { model: 'sonnet' }, { model: 'haiku' }];
+			const config = makeConfig({
+				room: makeRoom({
+					config: { agentSubagents: { leaderHelpers: helperConfigs } },
+				}),
+			});
+			// Build agents to get canonical names
+			const agentMap = buildLeaderHelperAgents(helperConfigs);
+			const expectedNames = Object.keys(agentMap);
+			// Check prompt references same names
+			const prompt = buildLeaderSystemPrompt(config);
+			for (const name of expectedNames) {
+				expect(prompt).toContain(name);
+			}
+		});
+
+		it('includes helpers alongside reviewers in Available Specialists section', () => {
+			const config = makeConfig({
+				room: makeRoom({
+					config: {
+						agentSubagents: {
+							leader: [{ model: 'haiku' }],
+							leaderHelpers: [{ model: 'sonnet' }],
+						},
+					},
+				}),
+			});
+			const prompt = buildLeaderSystemPrompt(config);
+			expect(prompt).toContain('Available Specialists');
+			expect(prompt).toContain('reviewer-haiku');
+			expect(prompt).toContain('leader-helper-sonnet');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -2,9 +2,49 @@ import { describe, expect, it } from 'bun:test';
 import {
 	buildPlannerSystemPrompt,
 	buildPlannerTaskMessage,
+	createPlannerAgentInit,
 	toPlanSlug,
 	type PlannerAgentConfig,
 } from '../../../src/lib/room/agents/planner-agent';
+
+const sharedBaseConfig: PlannerAgentConfig = {
+	task: {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Plan: Build stock app',
+		description: 'Break down the goal',
+		status: 'in_progress',
+		priority: 'normal',
+		createdAt: Date.now(),
+		taskType: 'planning',
+	},
+	goal: {
+		id: 'goal-1',
+		roomId: 'room-1',
+		title: 'Build stock app',
+		description: 'A stock tracking web app',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	},
+	room: {
+		id: 'room-1',
+		name: 'Test Room',
+		allowedPaths: [{ path: '/workspace', label: 'ws' }],
+		defaultPath: '/workspace',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	},
+	sessionId: 'session-1',
+	workspacePath: '/workspace',
+	createDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+	updateDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+	removeDraftTask: async () => true,
+};
 
 describe('planner-agent', () => {
 	describe('toPlanSlug', () => {
@@ -113,6 +153,37 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('Do NOT call');
 			expect(prompt).toContain('disabled');
 		});
+
+		it('should NOT impose a fixed task count limit', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).not.toContain('3-8');
+			expect(prompt).not.toContain('3 to 8');
+		});
+
+		it('should encourage granular tasks for complex goals', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('granular');
+		});
+
+		it('should include Explore sub-agent guidance for codebase exploration', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('Explore');
+			expect(prompt).toContain('subagent_type');
+		});
+
+		it('should recommend spawning multiple Explore agents in parallel', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('parallel');
+		});
+
+		it('should include Codebase Exploration section before Plan Creation', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			const exploreIdx = prompt.indexOf('Codebase Exploration');
+			const planCreationIdx = prompt.indexOf('Plan Creation');
+			expect(exploreIdx).toBeGreaterThanOrEqual(0);
+			expect(planCreationIdx).toBeGreaterThanOrEqual(0);
+			expect(exploreIdx).toBeLessThan(planCreationIdx);
+		});
 	});
 
 	describe('buildPlannerTaskMessage', () => {
@@ -196,6 +267,56 @@ describe('planner-agent', () => {
 			expect(msg).toContain('Add signup');
 			expect(msg).toContain('OAuth not configured');
 			expect(msg).toContain('DO NOT redo');
+		});
+	});
+
+	describe('createPlannerAgentInit', () => {
+		it('should always use agent/agents pattern', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.agent).toBe('Planner');
+			expect(init.agents).toBeDefined();
+			expect(init.agents).toHaveProperty('Planner');
+		});
+
+		it('Planner agent def includes Task tool for spawning Explore sub-agents', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.agents?.['Planner']?.tools).toContain('Task');
+		});
+
+		it('Planner agent def includes TaskOutput and TaskStop tools', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			const tools = init.agents?.['Planner']?.tools ?? [];
+			expect(tools).toContain('TaskOutput');
+			expect(tools).toContain('TaskStop');
+		});
+
+		it('Planner agent def includes standard codebase tools', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			const tools = init.agents?.['Planner']?.tools ?? [];
+			expect(tools).toContain('Read');
+			expect(tools).toContain('Write');
+			expect(tools).toContain('Bash');
+			expect(tools).toContain('Grep');
+		});
+
+		it('Planner agent def uses inherit model', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.agents?.['Planner']?.model).toBe('inherit');
+		});
+
+		it('should use claude_code preset', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.systemPrompt).toEqual({ type: 'preset', preset: 'claude_code' });
+		});
+
+		it('should include planner-tools MCP server', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.mcpServers).toHaveProperty('planner-tools');
+		});
+
+		it('should set session type to planner', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.type).toBe('planner');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/planner-agent.test.ts
+++ b/packages/daemon/tests/unit/room/planner-agent.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import {
 	buildPlannerSystemPrompt,
 	buildPlannerTaskMessage,
+	buildPlanWriterAgentDef,
+	buildPlanWriterPrompt,
 	createPlannerAgentInit,
 	toPlanSlug,
 	type PlannerAgentConfig,
@@ -77,12 +79,24 @@ describe('planner-agent', () => {
 			// Phase 1: Planning
 			expect(prompt).toContain('Phase 1: Planning');
 			expect(prompt).toContain('docs/plans/');
-			expect(prompt).toContain('gh pr create');
 
 			// Phase 2: Task Creation
 			expect(prompt).toContain('Phase 2: Task Creation');
 			expect(prompt).toContain('create_task');
 			expect(prompt).toContain('depends_on');
+		});
+
+		it('should instruct to spawn the plan-writer sub-agent in Phase 1', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('plan-writer');
+			expect(prompt).toContain('plan-writer');
+		});
+
+		it('should instruct to parse ---PLAN_RESULT--- from plan-writer response', () => {
+			const prompt = buildPlannerSystemPrompt('Build stock app');
+			expect(prompt).toContain('---PLAN_RESULT---');
+			expect(prompt).toContain('pr_number');
+			expect(prompt).toContain('plan_files');
 		});
 
 		it('should include pre-planning git sync setup', () => {
@@ -111,19 +125,6 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('git fetch origin && git rebase origin/$DEFAULT_BRANCH');
 		});
 
-		it('should use subshell with empty-check fallback for gh pr create --base', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
-			expect(prompt).toContain(
-				`gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")`
-			);
-		});
-
-		it('should include fallback for repos where origin/HEAD is not configured', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
-			expect(prompt).toContain('git remote show origin');
-			expect(prompt).toContain("sed -n '/HEAD branch/s/.*: //p'");
-		});
-
 		it('should suppress git symbolic-ref stderr with 2>/dev/null', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
 			expect(prompt).toContain('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
@@ -138,14 +139,14 @@ describe('planner-agent', () => {
 			expect(syncIdx).toBeLessThan(phase1Idx);
 		});
 
-		it('should use goal title for plan path', () => {
+		it('should reference goal title for plan path', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
-			expect(prompt).toContain('docs/plans/build-stock-app.md');
+			expect(prompt).toContain('docs/plans/build-stock-app');
 		});
 
 		it('should use default plan name when no goal title', () => {
 			const prompt = buildPlannerSystemPrompt();
-			expect(prompt).toContain('docs/plans/plan.md');
+			expect(prompt).toContain('docs/plans/plan');
 		});
 
 		it('should mention tools are disabled during planning phase', () => {
@@ -154,35 +155,135 @@ describe('planner-agent', () => {
 			expect(prompt).toContain('disabled');
 		});
 
-		it('should NOT impose a fixed task count limit', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
-			expect(prompt).not.toContain('3-8');
-			expect(prompt).not.toContain('3 to 8');
+		it('should instruct to merge PR before creating tasks in Phase 2', () => {
+			const prompt = buildPlannerSystemPrompt('Test');
+			expect(prompt).toContain('gh pr merge');
+			expect(prompt).toContain('pr_number');
 		});
 
-		it('should encourage granular tasks for complex goals', () => {
+		it('should describe multi-file plan structure for large goals', () => {
 			const prompt = buildPlannerSystemPrompt('Build stock app');
-			expect(prompt).toContain('granular');
+			expect(prompt).toContain('00-overview.md');
+			expect(prompt).toContain('multi');
+		});
+	});
+
+	describe('buildPlanWriterPrompt', () => {
+		it('should include git sync pre-work', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('git fetch origin && git rebase origin/$DEFAULT_BRANCH');
+			expect(prompt).toContain('git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
+		});
+
+		it('should instruct to stop on rebase conflict', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('rebase fails with conflicts, stop immediately');
 		});
 
 		it('should include Explore sub-agent guidance for codebase exploration', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
+			const prompt = buildPlanWriterPrompt();
 			expect(prompt).toContain('Explore');
 			expect(prompt).toContain('subagent_type');
 		});
 
 		it('should recommend spawning multiple Explore agents in parallel', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
+			const prompt = buildPlanWriterPrompt();
 			expect(prompt).toContain('parallel');
 		});
 
-		it('should include Codebase Exploration section before Plan Creation', () => {
-			const prompt = buildPlannerSystemPrompt('Build stock app');
-			const exploreIdx = prompt.indexOf('Codebase Exploration');
-			const planCreationIdx = prompt.indexOf('Plan Creation');
-			expect(exploreIdx).toBeGreaterThanOrEqual(0);
-			expect(planCreationIdx).toBeGreaterThanOrEqual(0);
-			expect(exploreIdx).toBeLessThan(planCreationIdx);
+		it('should define small vs large scope thresholds', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('Small scope');
+			expect(prompt).toContain('Large scope');
+			expect(prompt).toContain('5 milestones');
+		});
+
+		it('should describe single-file path for small scope using placeholder', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('<single_plan_path>');
+		});
+
+		it('should describe multi-file folder structure for large scope', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('<plan_dir>');
+			expect(prompt).toContain('00-overview.md');
+		});
+
+		it('should describe iterative two-pass approach for large scope', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('Two-Pass');
+			expect(prompt).toContain('Pass 1');
+			expect(prompt).toContain('Pass 2');
+		});
+
+		it('should describe numbered file naming convention', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('NN-<milestone-slug>.md');
+			expect(prompt).toContain('01-');
+			expect(prompt).toContain('02-');
+		});
+
+		it('should use subshell with empty-check fallback for gh pr create --base', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain(
+				`gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")`
+			);
+		});
+
+		it('should require ---PLAN_RESULT--- structured output block', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('---PLAN_RESULT---');
+			expect(prompt).toContain('---END_PLAN_RESULT---');
+			expect(prompt).toContain('pr_number');
+			expect(prompt).toContain('plan_files');
+			expect(prompt).toContain('structure: single | multi');
+		});
+
+		it('should instruct to create a feature branch with plan slug', () => {
+			const prompt = buildPlanWriterPrompt();
+			expect(prompt).toContain('git checkout -b plan/<plan_slug>');
+		});
+	});
+
+	describe('buildPlanWriterAgentDef', () => {
+		it('substitutes plan slug placeholders in prompt', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.prompt).toContain('docs/plans/my-goal.md');
+			expect(def.prompt).toContain('docs/plans/my-goal/');
+			expect(def.prompt).toContain('plan/my-goal');
+		});
+
+		it('does NOT contain raw placeholders after substitution', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.prompt).not.toContain('<single_plan_path>');
+			expect(def.prompt).not.toContain('<plan_dir>');
+			expect(def.prompt).not.toContain('<plan_slug>');
+		});
+
+		it('has Task tool for spawning Explore sub-agents', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.tools).toContain('Task');
+			expect(def.tools).toContain('TaskOutput');
+			expect(def.tools).toContain('TaskStop');
+		});
+
+		it('has standard codebase tools', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.tools).toContain('Read');
+			expect(def.tools).toContain('Write');
+			expect(def.tools).toContain('Edit');
+			expect(def.tools).toContain('Bash');
+		});
+
+		it('uses inherit model', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.model).toBe('inherit');
+		});
+
+		it('prompt includes iterative multi-file instructions', () => {
+			const def = buildPlanWriterAgentDef('my-goal');
+			expect(def.prompt).toContain('00-overview.md');
+			expect(def.prompt).toContain('Two-Pass');
 		});
 	});
 
@@ -278,7 +379,29 @@ describe('planner-agent', () => {
 			expect(init.agents).toHaveProperty('Planner');
 		});
 
-		it('Planner agent def includes Task tool for spawning Explore sub-agents', () => {
+		it('agents map includes plan-writer sub-agent', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.agents).toHaveProperty('plan-writer');
+		});
+
+		it('plan-writer agent has Task tool for spawning Explore sub-agents', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			const planWriter = init.agents?.['plan-writer'];
+			expect(planWriter?.tools).toContain('Task');
+		});
+
+		it('plan-writer agent uses inherit model', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			expect(init.agents?.['plan-writer']?.model).toBe('inherit');
+		});
+
+		it('plan-writer prompt has concrete file paths derived from goal title', () => {
+			const init = createPlannerAgentInit(sharedBaseConfig);
+			const planWriterPrompt = init.agents?.['plan-writer']?.prompt ?? '';
+			expect(planWriterPrompt).toContain('docs/plans/build-stock-app');
+		});
+
+		it('Planner agent def includes Task tool for spawning plan-writer', () => {
 			const init = createPlannerAgentInit(sharedBaseConfig);
 			expect(init.agents?.['Planner']?.tools).toContain('Task');
 		});

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -260,6 +260,34 @@ export interface UpdateTaskParams {
 }
 
 // ============================================================================
+// Sub-Agent Configuration Types
+// ============================================================================
+
+/**
+ * Configuration for a sub-agent entry in room.config.agentSubagents.
+ *
+ * Used for leader reviewers (.leader[]), leader analysis helpers (.leaderHelpers[]),
+ * and coder worker helpers (.worker[]). The runtime builder functions convert these
+ * configs into AgentDefinition objects for the SDK.
+ */
+export interface SubagentConfig {
+	/** Model ID (e.g., 'claude-haiku-4-5', 'claude-sonnet-4-6') or CLI agent short name */
+	model: string;
+	/** Provider name (e.g., 'anthropic', 'openai', 'google') */
+	provider?: string;
+	/** Marks this as CLI-based (external tool orchestrated via Bash) */
+	type?: 'cli';
+	/** Full model ID when different from the short name in 'model' */
+	modelId?: string;
+	/** Model the CLI tool should use internally (e.g., copilot --model gpt-5.3-codex) */
+	cliModel?: string;
+	/** Optional display name override for this sub-agent */
+	name?: string;
+	/** Optional description of what this sub-agent specializes in */
+	description?: string;
+}
+
+// ============================================================================
 // Runtime Types
 // ============================================================================
 


### PR DESCRIPTION
- Add worker helper sub-agents for coder agent via room.config.agentSubagents.worker
  - Helper agents handle heavy subtasks (large file analysis, isolated component impl)
  - Uses AgentDefinition + Task/TaskOutput/TaskStop tool pattern (matches existing leader reviewers)
  - Helper agents have full coding tools but no Task (no recursive sub-agents)
  - buildCoderHelperAgentPrompt() returns SUBTASK_RESULT structured output
  - getWorkerSubagents(), buildWorkerHelperAgents() helper functions
  - createCoderAgentInit() uses agent/agents pattern when helpers configured

- Add leader analysis helper sub-agents via room.config.agentSubagents.leaderHelpers
  - Leader helpers are read-only (no Write/Edit) for analysis tasks
  - getLeaderHelperSubagents(), buildLeaderHelperAgents() helper functions
  - createLeaderAgentInit() merges reviewerAgents + helperAgents into allSubAgents
  - buildLeaderSystemPrompt() includes helpers in Available Specialists section

- Add comprehensive unit tests for all new functionality (50 coder, 110 leader total)
