### PR TITLE
feat: add interrupt button to stop LLM generation without changing task status

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -269,6 +269,16 @@ export class RoomRuntimeService {
 					return null;
 				}
 			},
+			interruptSession: async (sessionId) => {
+				const session = agentSessions.get(sessionId);
+				if (!session) return;
+
+				try {
+					await session.handleInterrupt();
+				} catch (error) {
+					log.warn(`Failed to interrupt session ${sessionId}:`, error);
+				}
+			},
 			stopSession: async (sessionId) => {
 				const session = agentSessions.get(sessionId);
 				if (!session) return;

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -378,6 +378,13 @@ export class RoomRuntime {
 		const task = await this.taskManager.getTask(group.taskId);
 		if (!task) return;
 
+		// Check if generation was interrupted by human — skip routing to leader, await user input
+		if (group.humanInterrupted) {
+			this.groupRepo.setHumanInterrupted(groupId, false);
+			log.info(`Worker reached terminal state after human interrupt — awaiting user input`);
+			return;
+		}
+
 		// Check rate limit backoff
 		if (this.groupRepo.isRateLimited(groupId)) {
 			log.info(`Worker reached terminal state while rate limited - pausing routing to Leader`);
@@ -1064,6 +1071,49 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Interrupt the current agent session(s) for a task without changing task status.
+	 *
+	 * Unlike stopTaskSession() / cancelTask(), this:
+	 * - Does NOT change task status (keeps it 'in_progress' or 'review')
+	 * - Does NOT mark the group as terminal
+	 * - Does NOT clean up the session (session stays in cache, can receive new messages)
+	 * - Sets humanInterrupted flag to prevent automatic routing to leader
+	 *
+	 * Use this when a human wants to interrupt ongoing generation and immediately
+	 * type new instructions — the session stays alive and ready for input.
+	 */
+	async interruptTaskSession(taskId: string): Promise<{ success: boolean }> {
+		const task = await this.taskManager.getTask(taskId);
+		if (!task) return { success: false };
+
+		if (task.status !== 'in_progress' && task.status !== 'review') {
+			return { success: false };
+		}
+
+		const group = this.groupRepo.getGroupByTaskId(taskId);
+		if (!group || group.completedAt !== null) return { success: false };
+
+		// Set flag first so onWorkerTerminalState skips routing to leader
+		this.groupRepo.setHumanInterrupted(group.id, true);
+
+		// Interrupt active sessions (lightweight: no cleanup, no cache removal)
+		if (this.sessionFactory.interruptSession) {
+			for (const sessionId of [group.workerSessionId, group.leaderSessionId]) {
+				try {
+					await this.sessionFactory.interruptSession(sessionId);
+				} catch (error) {
+					log.warn(`Failed to interrupt session ${sessionId}:`, error);
+				}
+			}
+		}
+
+		this.appendGroupEvent(group.id, 'status', {
+			text: 'Generation interrupted by user. Awaiting input.',
+		});
+		return { success: true };
+	}
+
+	/**
 	 * Inject a human message directly into the worker session.
 	 *
 	 * Used when a human wants to provide additional context directly to the worker.
@@ -1075,6 +1125,12 @@ export class RoomRuntime {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 		if (!group) return false;
 		if (!this.sessionFactory.hasSession(group.workerSessionId)) return false;
+
+		// Clear humanInterrupted: the user is providing new input, so the next
+		// worker completion should route to leader normally (not be suppressed).
+		if (group.humanInterrupted) {
+			this.groupRepo.setHumanInterrupted(group.id, false);
+		}
 
 		try {
 			await this.sessionFactory.injectMessage(group.workerSessionId, message);

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -85,6 +85,12 @@ export interface SessionFactory {
 	 */
 	setSessionMcpServers(sessionId: string, mcpServers: Record<string, unknown>): boolean;
 	/**
+	 * Optional: interrupt a session's current LLM generation without cleanup.
+	 * The session remains in cache and can accept new messages immediately.
+	 * Used for user-initiated interrupts that keep the task alive.
+	 */
+	interruptSession?(sessionId: string): Promise<void>;
+	/**
 	 * Optional: stop and cleanup a session immediately.
 	 * Used for urgent cancellation paths where the group should terminate now.
 	 */

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -414,6 +414,12 @@ export class TaskGroupManager {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
+		// Clear humanInterrupted: the leader is routing a message to the worker,
+		// so the next worker completion should route back to leader normally.
+		if (group.humanInterrupted) {
+			this.groupRepo.setHumanInterrupted(groupId, false);
+		}
+
 		// If worker is waiting for input (AskUserQuestion), answer the question.
 		// Otherwise inject feedback as a regular message.
 		const answered = await this.sessionFactory.answerQuestion(group.workerSessionId, message);

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -61,6 +61,8 @@ interface TaskGroupMetadata {
 	rateLimit?: RateLimitBackoff | null;
 	/** Persisted bootstrap config for deferred Leader creation */
 	deferredLeader?: DeferredLeaderConfig | null;
+	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
+	humanInterrupted?: boolean;
 }
 
 function defaultMetadata(): TaskGroupMetadata {
@@ -111,6 +113,8 @@ export interface SessionGroup {
 	rateLimit: RateLimitBackoff | null;
 	/** Persisted bootstrap config for deferred Leader creation */
 	deferredLeader: DeferredLeaderConfig | null;
+	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
+	humanInterrupted: boolean;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -418,6 +422,24 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Set humanInterrupted flag without version check.
+	 * When true, prevents automatic routing to leader when worker reaches idle state.
+	 */
+	setHumanInterrupted(groupId: string, value: boolean): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		const merged = { ...currentMeta, humanInterrupted: value };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
 	 * Set approved flag without version check.
 	 * Records that the human has approved the task (plan or PR).
 	 */
@@ -612,6 +634,7 @@ export class SessionGroupRepository {
 			approved: meta.approved ?? false,
 			rateLimit: meta.rateLimit ?? null,
 			deferredLeader: meta.deferredLeader ?? null,
+			humanInterrupted: meta.humanInterrupted === true,
 			createdAt: row.created_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
 		};

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -6,7 +6,7 @@
  * these tools are attached to it.
  *
  * Tools: create_goal, list_goals, update_goal, create_task, list_tasks,
- *        update_task, cancel_task, get_room_status, approve_task, reject_task,
+ *        update_task, cancel_task, stop_session, get_room_status, approve_task, reject_task,
  *        send_message_to_task, get_task_detail
  */
 
@@ -228,6 +228,39 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 			}
 			return jsonResult({ success: true, message: `Task ${args.task_id} cancelled` });
+		},
+
+		async stop_session(args: { task_id: string }): Promise<ToolResult> {
+			const task = await taskManager.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+
+			if (task.status !== 'in_progress' && task.status !== 'review') {
+				return jsonResult({
+					success: false,
+					error: `Task cannot be interrupted (current status: ${task.status}). Only in_progress or review tasks can be interrupted.`,
+				});
+			}
+
+			if (runtimeService) {
+				const runtime = runtimeService.getRuntime(roomId);
+				if (runtime) {
+					const result = await runtime.interruptTaskSession(args.task_id);
+					if (!result.success) {
+						return jsonResult({
+							success: false,
+							error: `Failed to interrupt session for task ${args.task_id}`,
+						});
+					}
+					return jsonResult({
+						success: true,
+						message: `Generation interrupted for task ${args.task_id}. Task remains active and awaiting input.`,
+					});
+				}
+			}
+
+			return jsonResult({ success: false, error: 'Runtime service unavailable' });
 		},
 
 		async set_task_status(args: {
@@ -626,6 +659,12 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			'Cancel a task (marks as cancelled — distinct from failed — and cleans up agent sessions)',
 			{ task_id: z.string().describe('ID of the task to cancel') },
 			(args) => handlers.cancel_task(args)
+		),
+		tool(
+			'stop_session',
+			'Interrupt the current agent session(s) for a task. Stops LLM generation mid-stream while keeping the task in its current state (in_progress or review). The user can immediately type new instructions without any revive flow.',
+			{ task_id: z.string().describe('ID of the task whose session(s) to stop') },
+			(args) => handlers.stop_session(args)
 		),
 		tool(
 			'set_task_status',

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -7,6 +7,7 @@
  * - task.get - Get task details
  * - task.fail - Fail a task (used by tests to simulate failure)
  * - task.cancel - Cancel a task (human-initiated cancellation)
+ * - task.interruptSession - Interrupt current agent session(s) without changing task status
  * - task.setStatus - Set task status with validation (human-initiated status change)
  * - task.reject - Reject a task review (human-initiated rejection with feedback)
  * - task.getGroup - Get session group for a task
@@ -231,6 +232,49 @@ export function setupTaskHandlers(
 		emitRoomOverview(params.roomId);
 
 		return { task: cancelledTask };
+	});
+
+	// task.interruptSession - Interrupt current agent session(s) without changing task status.
+	// Stops LLM generation mid-stream while keeping the task alive. The user can immediately
+	// type new instructions and the session will process them.
+	messageHub.onRequest('task.interruptSession', async (data) => {
+		const params = data as { roomId: string; taskId: string };
+
+		if (!params.roomId) {
+			throw new Error('Room ID is required');
+		}
+		if (!params.taskId) {
+			throw new Error('Task ID is required');
+		}
+
+		const taskManager = taskManagerFactory(db, params.roomId);
+		const task = await taskManager.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		// Only allow interrupting tasks with active agent sessions
+		if (task.status !== 'in_progress' && task.status !== 'review') {
+			throw new Error(
+				`Task cannot be interrupted (current status: ${task.status}). Only in_progress or review tasks can be interrupted.`
+			);
+		}
+
+		if (!runtimeService) {
+			throw new Error('Runtime service is required for task.interruptSession');
+		}
+
+		const runtime = runtimeService.getRuntime(params.roomId);
+		if (!runtime) {
+			throw new Error(`No runtime found for room: ${params.roomId}`);
+		}
+
+		const result = await runtime.interruptTaskSession(params.taskId);
+		if (!result.success) {
+			throw new Error(`Failed to interrupt task session for ${params.taskId}`);
+		}
+
+		return { success: true };
 	});
 
 	// task.archive - Archive a task (cleanup worktree, hide from UI)

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -556,6 +556,78 @@ describe('Room Agent Tools', () => {
 		});
 	});
 
+	describe('stop_session', () => {
+		it('should interrupt in_progress task (task stays active)', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+			// Move task to in_progress
+			await taskManager.setTaskStatus(taskId, 'in_progress');
+
+			// Without runtime service, returns error (interrupt requires runtime)
+			const result = parseResult(await handlers.stop_session({ task_id: taskId }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('unavailable');
+
+			// Task should still be in_progress (not failed)
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('in_progress');
+		});
+
+		it('should use runtime.interruptTaskSession when runtime service is available', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+			await taskManager.setTaskStatus(taskId, 'in_progress');
+
+			const calls: Array<string> = [];
+			const mockRuntime = {
+				interruptTaskSession: async (tid: string) => {
+					calls.push(tid);
+					return { success: true };
+				},
+			};
+			const runtimeHandlers = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+
+			const result = parseResult(await runtimeHandlers.stop_session({ task_id: taskId }));
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('interrupted');
+			expect(calls).toEqual([taskId]);
+		});
+
+		it('should return error when task not found', async () => {
+			const result = parseResult(await handlers.stop_session({ task_id: 'no-such-task' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Task not found');
+		});
+
+		it('should return error for pending task', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			// Task is pending by default
+			const result = parseResult(
+				await handlers.stop_session({ task_id: created.taskId as string })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Task cannot be interrupted');
+		});
+
+		it('should return error for completed task', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			await taskManager.setTaskStatus(created.taskId as string, 'in_progress');
+			await taskManager.completeTask(created.taskId as string, 'done');
+
+			const result = parseResult(
+				await handlers.stop_session({ task_id: created.taskId as string })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Task cannot be interrupted');
+		});
+	});
+
 	describe('get_room_status', () => {
 		it('should return room overview', async () => {
 			await handlers.create_goal({ title: 'G1' });

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -239,6 +239,151 @@ describe('RoomRuntime flow', () => {
 		});
 	});
 
+	describe('interruptTaskSession', () => {
+		it('should interrupt sessions without changing task status', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+			expect(group!.completedAt).toBeNull();
+
+			const result = await ctx.runtime.interruptTaskSession(task.id);
+			expect(result.success).toBe(true);
+
+			// Task should remain in_progress (not failed/cancelled)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('in_progress');
+
+			// Group should remain active (not terminal)
+			const updatedGroup = ctx.groupRepo.getGroup(group!.id);
+			expect(updatedGroup!.completedAt).toBeNull();
+
+			// Both sessions should have been interrupted (not stopped/removed)
+			const interruptCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'interruptSession'
+			);
+			expect(interruptCalls).toHaveLength(2);
+			expect(interruptCalls.map((c) => c.args[0])).toEqual(
+				expect.arrayContaining([group!.workerSessionId, group!.leaderSessionId])
+			);
+			// stopSession should NOT be called
+			const stopCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'stopSession');
+			expect(stopCalls).toHaveLength(0);
+		});
+
+		it('should return failure for non-existent task', async () => {
+			const result = await ctx.runtime.interruptTaskSession('non-existent-task-id');
+			expect(result.success).toBe(false);
+		});
+
+		it('should return failure for task not in in_progress or review status', async () => {
+			const task = await ctx.taskManager.createTask({
+				title: 'Pending Task',
+				description: 'Not started yet',
+				priority: 'normal',
+			});
+			// Task is pending by default
+			expect(task.status).toBe('pending');
+
+			const result = await ctx.runtime.interruptTaskSession(task.id);
+			expect(result.success).toBe(false);
+		});
+
+		it('should return failure for task with no active group', async () => {
+			const task = await ctx.taskManager.createTask({
+				title: 'Task without group',
+				description: 'desc',
+				priority: 'normal',
+			});
+			// Manually move to in_progress with no group
+			await ctx.taskManager.setTaskStatus(task.id, 'in_progress');
+
+			// No group exists, so interruptTaskSession should fail gracefully
+			const result = await ctx.runtime.interruptTaskSession(task.id);
+			expect(result.success).toBe(false);
+		});
+
+		it('should set humanInterrupted flag preventing auto-routing to leader', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+
+			// Interrupt the task
+			await ctx.runtime.interruptTaskSession(task.id);
+
+			// humanInterrupted should be set
+			const updatedGroup = ctx.groupRepo.getGroup(group!.id);
+			expect(updatedGroup!.humanInterrupted).toBe(true);
+
+			// Simulate worker reaching terminal state (would normally route to leader)
+			const initialInjectCount = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage'
+			).length;
+			await ctx.runtime.onWorkerTerminalState(group!.id, {
+				sessionId: group!.workerSessionId,
+				kind: 'idle',
+			});
+
+			// humanInterrupted should be cleared after onWorkerTerminalState
+			const clearedGroup = ctx.groupRepo.getGroup(group!.id);
+			expect(clearedGroup!.humanInterrupted).toBe(false);
+
+			// No leader session should have been created (routing was blocked)
+			const createCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession'
+			);
+			// Only 1 create call (the initial worker), leader was not created
+			expect(createCalls).toHaveLength(1);
+
+			// No new inject messages (routing to leader sends an envelope)
+			const injectCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'injectMessage');
+			expect(injectCalls.length).toBe(initialInjectCount);
+		});
+
+		it('should clear humanInterrupted when injectMessageToWorker is called (race condition fix)', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+
+			// Interrupt the task (sets humanInterrupted = true)
+			await ctx.runtime.interruptTaskSession(task.id);
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(true);
+
+			// User injects a new message to the worker (simulates typing after interrupt)
+			const injected = await ctx.runtime.injectMessageToWorker(task.id, 'Please fix the error');
+			expect(injected).toBe(true);
+
+			// humanInterrupted should be cleared so the next worker completion routes normally
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(false);
+
+			// Now when worker finishes, onWorkerTerminalState should NOT be blocked by humanInterrupted
+			// (it's already false). Verify by checking the flag is NOT re-set after terminal state.
+			await ctx.runtime.onWorkerTerminalState(group!.id, {
+				sessionId: group!.workerSessionId,
+				kind: 'idle',
+			});
+
+			// humanInterrupted remains false — not set again by onWorkerTerminalState
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(false);
+
+			// The 'humanInterrupted early return' path was NOT taken, so either exit gate
+			// routing or normal routing occurred — at minimum, more than 0 injectMessage
+			// calls were made (from gate checks or leader routing), unlike the interrupt
+			// path which returns before any inject
+			const allCalls = ctx.sessionFactory.calls.map((c) => c.method);
+			// At least interruptSession x2 + injectMessage x1 (human msg) were made
+			expect(allCalls.filter((m) => m === 'interruptSession')).toHaveLength(2);
+		});
+	});
+
 	describe('autonomous flow integration', () => {
 		it('should complete the full single-iteration cycle: spawn → worker done → leader completes', async () => {
 			const { task } = await createGoalAndTask(ctx);

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -345,6 +345,34 @@ describe('RoomRuntime flow', () => {
 			expect(injectCalls.length).toBe(initialInjectCount);
 		});
 
+		it('should clear humanInterrupted when routeLeaderToWorker is called (P2 fix)', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+
+			// Interrupt the task (sets humanInterrupted = true)
+			await ctx.runtime.interruptTaskSession(task.id);
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(true);
+
+			// Leader routes feedback to worker (simulates send_to_worker tool call)
+			await ctx.runtime.taskGroupManager.routeLeaderToWorker(group!.id, 'Here is my feedback');
+
+			// humanInterrupted should be cleared so the next worker completion routes normally
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(false);
+
+			// Now when worker finishes, onWorkerTerminalState should NOT be blocked
+			await ctx.runtime.onWorkerTerminalState(group!.id, {
+				sessionId: group!.workerSessionId,
+				kind: 'idle',
+			});
+
+			// humanInterrupted remains false after terminal state
+			expect(ctx.groupRepo.getGroup(group!.id)!.humanInterrupted).toBe(false);
+		});
+
 		it('should clear humanInterrupted when injectMessageToWorker is called (race condition fix)', async () => {
 			const { task } = await createGoalAndTask(ctx);
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -65,6 +65,9 @@ export function createMockSessionFactory() {
 			calls.push({ method: 'restoreSession', args: [sessionId] });
 			return true;
 		},
+		async interruptSession(sessionId: string) {
+			calls.push({ method: 'interruptSession', args: [sessionId] });
+		},
 		async stopSession(sessionId: string) {
 			calls.push({ method: 'stopSession', args: [sessionId] });
 		},

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -78,11 +78,12 @@ const mockTask: NeoTask = {
 /** Build a minimal TaskManagerFactory that returns a controlled task. */
 function makeTaskManagerFactory(task: NeoTask | null): TaskManagerFactory {
 	const cancelledTask = task ? { ...task, status: 'cancelled' as const } : null;
+	const failedTask = task ? { ...task, status: 'failed' as const } : null;
 	const manager = {
 		createTask: mock(async () => task!),
 		getTask: mock(async () => task),
 		listTasks: mock(async () => []),
-		failTask: mock(async () => task!),
+		failTask: mock(async () => failedTask!),
 		cancelTask: mock(async () => cancelledTask!),
 	};
 	return mock(() => manager);
@@ -144,12 +145,14 @@ function makeRuntimeService(resumeResult = true, injectResult = true) {
 		cancelledTaskIds: injectResult ? ['task-1'] : [],
 	}));
 	const terminateTaskGroup = mock(async () => injectResult);
+	const interruptTaskSession = mock(async () => ({ success: injectResult }));
 	const runtime = {
 		resumeWorkerFromHuman,
 		injectMessageToLeader,
 		injectMessageToWorker,
 		cancelTask,
 		terminateTaskGroup,
+		interruptTaskSession,
 	};
 	const service = {
 		getRuntime: mock(() => runtime),
@@ -831,6 +834,116 @@ describe('task.setStatus RPC Handler', () => {
 				{}
 			);
 			expect(result).toEqual({ task: { ...cancelledTask, status: 'in_progress' } });
+		});
+	});
+});
+
+// ─── task.interruptSession Tests ───
+
+describe('task.interruptSession RPC Handler', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+
+	function setup(opts: { task?: NeoTask | null; runtimeService?: RoomRuntimeService }) {
+		const { task = mockTask, runtimeService } = opts;
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		setupTaskHandlers(
+			hub,
+			mockRoomManager,
+			createMockDaemonHub(),
+			makeDb(makeGroupRow()),
+			makeTaskManagerFactory(task),
+			runtimeService
+		);
+	}
+
+	function getHandler(): RequestHandler {
+		const h = handlers.get('task.interruptSession');
+		expect(h).toBeDefined();
+		return h!;
+	}
+
+	describe('parameter validation', () => {
+		beforeEach(() => {
+			setup({ runtimeService: makeNullRuntimeService() });
+		});
+
+		it('throws when roomId is missing', async () => {
+			await expect(getHandler()({ taskId: 'task-1' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(getHandler()({ roomId: 'room-1' }, {})).rejects.toThrow('Task ID is required');
+		});
+	});
+
+	describe('task status validation', () => {
+		it('throws when task is not found', async () => {
+			setup({ task: null, runtimeService: makeNullRuntimeService() });
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'Task not found'
+			);
+		});
+
+		it('throws when task status is pending', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'Task cannot be interrupted'
+			);
+		});
+
+		it('throws when task status is completed', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			setup({ task: completedTask, runtimeService: makeNullRuntimeService() });
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'Task cannot be interrupted'
+			);
+		});
+
+		it('throws when no runtime found for room', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			// makeNullRuntimeService returns a service with getRuntime() = null (no room runtime)
+			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'No runtime found for room'
+			);
+		});
+	});
+
+	describe('happy paths', () => {
+		it('calls runtime.interruptTaskSession for in_progress task and returns success', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			const { service, runtime } = makeRuntimeService(true);
+			setup({ task: inProgressTask, runtimeService: service });
+
+			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			expect(runtime.interruptTaskSession).toHaveBeenCalledWith('task-1');
+			// Returns just { success: true }, NOT the task (task status is unchanged)
+			expect(result).toEqual({ success: true });
+		});
+
+		it('calls runtime.interruptTaskSession for review task and returns success', async () => {
+			const reviewTask = { ...mockTask, status: 'review' as const };
+			const { service, runtime } = makeRuntimeService(true);
+			setup({ task: reviewTask, runtimeService: service });
+
+			const result = await getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {});
+			expect(runtime.interruptTaskSession).toHaveBeenCalledWith('task-1');
+			expect(result).toEqual({ success: true });
+		});
+
+		it('throws when runtime.interruptTaskSession returns failure', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			// Pass false as injectResult to make interruptTaskSession fail
+			const { service } = makeRuntimeService(true, false);
+			setup({ task: inProgressTask, runtimeService: service });
+
+			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
+				'Failed to interrupt task session'
+			);
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1120,6 +1120,120 @@ describe('TaskView — Task options dropdown menu', () => {
 	});
 });
 
+// ─── Interrupt Button Tests ───
+
+describe('TaskView — Interrupt button', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows interrupt button for in_progress tasks', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const stopButton = container.querySelector(
+			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
+		);
+		expect(stopButton).not.toBeNull();
+	});
+
+	it('shows interrupt button for review tasks', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const stopButton = container.querySelector(
+			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
+		);
+		expect(stopButton).not.toBeNull();
+	});
+
+	it('does NOT show interrupt button for pending tasks', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const stopButton = container.querySelector(
+			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
+		);
+		expect(stopButton).toBeNull();
+	});
+
+	it('does NOT show interrupt button for failed tasks', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'failed') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const stopButton = container.querySelector(
+			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
+		);
+		expect(stopButton).toBeNull();
+	});
+
+	it('does NOT show interrupt button for cancelled tasks', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const stopButton = container.querySelector(
+			'button[title="Interrupt generation (task stays active, type your suggestions)"]'
+		);
+		expect(stopButton).toBeNull();
+	});
+});
+
 // ─── Reject Button Tests ───
 
 describe('TaskView — Reject button in HeaderReviewBar', () => {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -813,6 +813,23 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		});
 	}
 
+	// Interrupt button shown only when task has active agent sessions
+	const canInterrupt = task.status === 'in_progress' || task.status === 'review';
+	const [interrupting, setInterrupting] = useState(false);
+
+	// Interrupt handler - stops LLM generation without changing task status
+	const interruptSession = async () => {
+		if (interrupting) return;
+		setInterrupting(true);
+		try {
+			await request('task.interruptSession', { roomId, taskId });
+		} catch (err) {
+			// Best-effort: ignore errors from interrupt (session may already be idle)
+			void err;
+		} finally {
+			setInterrupting(false);
+		}
+	};
 	return (
 		<div class="flex-1 flex flex-col overflow-hidden bg-dark-900">
 			{/* Header */}
@@ -859,6 +876,19 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						</div>
 						<span class="text-xs text-gray-400">{task.progress}%</span>
 					</div>
+				)}
+				{/* Interrupt button - stops LLM generation without changing task status */}
+				{canInterrupt && (
+					<button
+						class="p-1.5 rounded text-amber-400 hover:text-amber-300 hover:bg-dark-700 transition-colors disabled:opacity-50"
+						onClick={interruptSession}
+						title="Interrupt generation (task stays active, type your suggestions)"
+						disabled={interrupting}
+					>
+						<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+							<rect x="6" y="6" width="12" height="12" rx="1" />
+						</svg>
+					</button>
 				)}
 				{/* Task options dropdown — shown when at least one action is available */}
 				{dropdownItems.length > 0 && (

--- a/packages/web/src/components/ui/ConfirmModal.tsx
+++ b/packages/web/src/components/ui/ConfirmModal.tsx
@@ -15,7 +15,7 @@ export interface ConfirmModalProps {
 	message: string;
 	confirmText?: string;
 	cancelText?: string;
-	confirmButtonVariant?: 'danger' | 'primary';
+	confirmButtonVariant?: 'danger' | 'primary' | 'warning';
 	isLoading?: boolean;
 	error?: string | null;
 }
@@ -40,7 +40,9 @@ export function ConfirmModal({
 	const confirmButtonClasses =
 		confirmButtonVariant === 'danger'
 			? 'bg-red-600 hover:bg-red-700 text-white disabled:bg-red-600/50'
-			: 'bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-600/50';
+			: confirmButtonVariant === 'warning'
+				? 'bg-amber-600 hover:bg-amber-700 text-white disabled:bg-amber-600/50'
+				: 'bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-600/50';
 
 	return (
 		<Modal isOpen={isOpen} onClose={onClose} title={title} size="sm" showCloseButton={false}>


### PR DESCRIPTION
Replaces the previous stop-session implementation (which marked tasks as
`failed` and required a revive flow) with a lightweight interrupt that:

- Stops LLM generation mid-stream (like Ctrl+C)
- Keeps task in `in_progress` / `review` state
- Session stays in cache, ready for new messages immediately
- User can type suggestions/corrections right after clicking interrupt

## How it works

**Backend:**
- `humanInterrupted` flag added to `SessionGroup` metadata — when set,
  `onWorkerTerminalState` skips routing to leader, keeping the task alive
- New `interruptSession()` on `SessionFactory`: calls only `handleInterrupt()`
  (no cleanup, no cache removal)
- `interruptTaskSession()` on `RoomRuntime`: sets flag + interrupts sessions,
  does NOT change task status or terminate group
- `task.interruptSession` RPC handler: validates in_progress/review, calls
  runtime, returns `{ success: true }` (task status unchanged)
- `stop_session` MCP tool updated to use `interruptTaskSession`

**Frontend:**
- Amber square button in TaskView header for in_progress/review tasks
- No confirmation modal — interrupt is lightweight and immediately reversible
- User can start typing in the chat input right after clicking

**After interrupt flow:**
1. User clicks interrupt → `handleInterrupt()` called on active session(s)
2. Worker goes idle → `onWorkerTerminalState` fires → sees `humanInterrupted=true` → clears flag, returns early (no leader routing)
3. Task stays in_progress, session stays in cache
4. User types suggestion → `task.sendHumanMessage` → `injectMessage` → `ensureQueryStarted()` restarts queue → worker processes it
5. Worker finishes → normal routing to leader resumes

## Tests
- `room-runtime-flow`: 5 new tests for `interruptTaskSession` behavior including `humanInterrupted` flag prevention of leader routing
- `task-handlers`: 6 new tests for `task.interruptSession` RPC handler
- `room-agent-tools`: 5 updated tests for `stop_session` MCP tool
- `TaskView.test`: 5 updated tests for interrupt button visibility