### PR TITLE
feat: replace cancel button with dropdown menu for task completion/cancellation UX

### DIFF
--- a/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
+++ b/packages/e2e/tests/features/task-actions-dropdown.e2e.ts
@@ -1,0 +1,263 @@
+/**
+ * Task Actions Dropdown E2E Tests
+ *
+ * Tests the task completion/cancellation UX redesign:
+ * - Three-dot dropdown menu replaces the old cancel button
+ * - "Mark as Complete" option for in_progress/review tasks
+ * - "Cancel Task" option for pending/in_progress/review tasks
+ * - Confirmation dialogs for both operations
+ *
+ * Setup: creates a real room+task via RPC (infrastructure), then tests UI.
+ * Cleanup: deletes the room via RPC in afterEach.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function createRoomAndTask(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	taskStatus: 'pending' | 'in_progress' | 'review' = 'pending'
+): Promise<{ roomId: string; taskId: string }> {
+	await waitForWebSocketConnected(page);
+
+	return page.evaluate(async (status) => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+
+		// Create room
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Test Room — Task Actions',
+		});
+		const roomId = (roomRes as { room: { id: string } }).room.id;
+
+		// Create task in pending state
+		const taskRes = await hub.request('task.create', {
+			roomId,
+			title: 'E2E Test Task',
+			description: 'Task for testing the actions dropdown',
+		});
+		const taskId = (taskRes as { task: { id: string } }).task.id;
+
+		// Transition to requested status if not pending
+		if (status !== 'pending') {
+			await hub.request('task.setStatus', {
+				roomId,
+				taskId,
+				status: 'in_progress',
+				result: undefined,
+				error: undefined,
+			});
+			if (status === 'review') {
+				await hub.request('task.setStatus', {
+					roomId,
+					taskId,
+					status: 'review',
+					result: undefined,
+					error: undefined,
+				});
+			}
+		}
+
+		return { roomId, taskId };
+	}, taskStatus);
+}
+
+async function deleteRoom(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string
+): Promise<void> {
+	if (!roomId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('room.delete', { roomId: id });
+		}, roomId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Task Actions Dropdown', () => {
+	let roomId = '';
+	let taskId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+		taskId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('shows task options menu for pending task (cancel only)', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'pending'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Dropdown trigger should be visible for pending task (cancel is available)
+		const menuButton = page.locator('[data-testid="task-options-menu"]');
+		await expect(menuButton).toBeVisible({ timeout: 5000 });
+	});
+
+	test('shows task options menu for in_progress task (complete + cancel)', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'in_progress'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		const menuButton = page.locator('[data-testid="task-options-menu"]');
+		await expect(menuButton).toBeVisible({ timeout: 5000 });
+	});
+
+	test('does NOT show task options menu for completed task', async ({ page }) => {
+		// Create a pending task then transition to completed via in_progress
+		({ roomId, taskId } = await createRoomAndTask(page, 'in_progress'));
+
+		// Complete the task via RPC (infrastructure)
+		await page.evaluate(
+			async ({ rId, tId }) => {
+				const hub = window.__messageHub || window.appState?.messageHub;
+				if (!hub?.request) throw new Error('MessageHub not available');
+				await hub.request('task.setStatus', { roomId: rId, taskId: tId, status: 'completed' });
+			},
+			{ rId: roomId, tId: taskId }
+		);
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// No dropdown for completed tasks
+		const menuButton = page.locator('[data-testid="task-options-menu"]');
+		await expect(menuButton).not.toBeVisible();
+	});
+
+	test('opens dropdown and shows Cancel Task item', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'pending'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Click the three-dot menu
+		await page.locator('[data-testid="task-options-menu"]').click();
+
+		// Cancel Task item should be visible
+		await expect(page.getByRole('menuitem', { name: /Cancel Task/ })).toBeVisible({
+			timeout: 5000,
+		});
+	});
+
+	test('shows Mark as Complete for in_progress task', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'in_progress'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Click the three-dot menu
+		await page.locator('[data-testid="task-options-menu"]').click();
+
+		// Both options should be visible
+		await expect(page.getByRole('menuitem', { name: /Mark as Complete/ })).toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.getByRole('menuitem', { name: /Cancel Task/ })).toBeVisible({
+			timeout: 5000,
+		});
+	});
+
+	test('opens cancel confirmation dialog on Cancel Task click', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'pending'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Open dropdown and click Cancel Task
+		await page.locator('[data-testid="task-options-menu"]').click();
+		await page.getByRole('menuitem', { name: /Cancel Task/ }).click();
+
+		// Cancel dialog should appear with the task name
+		await expect(page.locator('[data-testid="cancel-task-confirm"]')).toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.getByText(/E2E Test Task/)).toBeVisible();
+		await expect(page.getByText(/cannot be undone/i)).toBeVisible();
+	});
+
+	test('opens complete confirmation dialog on Mark as Complete click', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'in_progress'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Open dropdown and click Mark as Complete
+		await page.locator('[data-testid="task-options-menu"]').click();
+		await page.getByRole('menuitem', { name: /Mark as Complete/ }).click();
+
+		// Complete dialog should appear
+		await expect(page.locator('[data-testid="complete-task-confirm"]')).toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.getByText(/E2E Test Task/)).toBeVisible();
+	});
+
+	test('can dismiss cancel dialog with Keep Task button', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'pending'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Open dialog
+		await page.locator('[data-testid="task-options-menu"]').click();
+		await page.getByRole('menuitem', { name: /Cancel Task/ }).click();
+		await expect(page.locator('[data-testid="cancel-task-confirm"]')).toBeVisible();
+
+		// Dismiss with Keep Task button
+		await page.getByRole('button', { name: /Keep Task/ }).click();
+
+		// Dialog should close; task page should still be visible
+		await expect(page.locator('[data-testid="cancel-task-confirm"]')).not.toBeVisible();
+		await expect(page.locator('text=E2E Test Task')).toBeVisible();
+	});
+
+	test('cancels task and navigates away on confirmation', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'pending'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Open dropdown → Cancel Task → confirm
+		await page.locator('[data-testid="task-options-menu"]').click();
+		await page.getByRole('menuitem', { name: /Cancel Task/ }).click();
+		await expect(page.locator('[data-testid="cancel-task-confirm"]')).toBeVisible();
+		await page.locator('[data-testid="cancel-task-confirm"]').click();
+
+		// Should navigate away from the task page (back to room)
+		await expect(page).not.toHaveURL(new RegExp(`/task/${taskId}`), { timeout: 10000 });
+	});
+
+	test('completes task and navigates away on confirmation', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page, 'in_progress'));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+
+		// Open dropdown → Mark as Complete → confirm
+		await page.locator('[data-testid="task-options-menu"]').click();
+		await page.getByRole('menuitem', { name: /Mark as Complete/ }).click();
+		await expect(page.locator('[data-testid="complete-task-confirm"]')).toBeVisible();
+		await page.locator('[data-testid="complete-task-confirm"]').click();
+
+		// Should navigate away from the task page (back to room)
+		await expect(page).not.toHaveURL(new RegExp(`/task/${taskId}`), { timeout: 10000 });
+	});
+});

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -793,9 +793,9 @@ describe('TaskView — cancelled flag prevents post-unmount state updates', () =
 	});
 });
 
-// ─── Cancel Button Tests ───
+// ─── Task Options Dropdown Tests ───
 
-describe('TaskView — Cancel button', () => {
+describe('TaskView — Task options dropdown menu', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
 		mockOnEvent.mockReset();
@@ -811,7 +811,7 @@ describe('TaskView — Cancel button', () => {
 		cleanup();
 	});
 
-	it('shows cancel button for pending tasks', async () => {
+	it('shows task options menu for pending tasks (cancel only)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
 			if (method === 'task.getGroup') return { group: null };
@@ -824,11 +824,11 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).not.toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).not.toBeNull();
 	});
 
-	it('shows cancel button for in_progress tasks', async () => {
+	it('shows task options menu for in_progress tasks (complete + cancel)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -841,11 +841,11 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).not.toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).not.toBeNull();
 	});
 
-	it('shows cancel button for review tasks', async () => {
+	it('shows task options menu for review tasks (complete + cancel)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
@@ -858,11 +858,11 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).not.toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).not.toBeNull();
 	});
 
-	it('does NOT show cancel button for completed tasks', async () => {
+	it('does NOT show task options menu for completed tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
 			if (method === 'task.getGroup') return { group: null };
@@ -875,11 +875,11 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).toBeNull();
 	});
 
-	it('does NOT show cancel button for failed tasks', async () => {
+	it('does NOT show task options menu for failed tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'failed') };
 			if (method === 'task.getGroup') return { group: null };
@@ -892,11 +892,11 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).toBeNull();
 	});
 
-	it('does NOT show cancel button for cancelled tasks', async () => {
+	it('does NOT show task options menu for cancelled tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
 			if (method === 'task.getGroup') return { group: null };
@@ -909,8 +909,214 @@ describe('TaskView — Cancel button', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const cancelButton = container.querySelector('button[title="Cancel task"]');
-		expect(cancelButton).toBeNull();
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
+		expect(menuButton).toBeNull();
+	});
+
+	it('opens dropdown and shows Cancel Task item for in_progress task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const labels = items.map((el) => el.textContent);
+			expect(labels.some((l) => l?.includes('Cancel Task'))).toBe(true);
+			expect(labels.some((l) => l?.includes('Mark as Complete'))).toBe(true);
+		});
+	});
+
+	it('opens dropdown and shows only Cancel Task for pending task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const labels = items.map((el) => el.textContent);
+			expect(labels.some((l) => l?.includes('Cancel Task'))).toBe(true);
+			expect(labels.some((l) => l?.includes('Mark as Complete'))).toBe(false);
+		});
+	});
+
+	it('opens cancel dialog when Cancel Task menu item is clicked', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open dropdown
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		// Click Cancel Task item
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const cancelItem = items.find((el) => el.textContent?.includes('Cancel Task')) as HTMLElement;
+			expect(cancelItem).not.toBeUndefined();
+			fireEvent.click(cancelItem);
+		});
+
+		// Cancel dialog should open
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="cancel-task-confirm"]')).not.toBeNull();
+		});
+	});
+
+	it('opens complete dialog when Mark as Complete menu item is clicked', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open dropdown
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		// Click Mark as Complete item
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const completeItem = items.find((el) =>
+				el.textContent?.includes('Mark as Complete')
+			) as HTMLElement;
+			expect(completeItem).not.toBeUndefined();
+			fireEvent.click(completeItem);
+		});
+
+		// Complete dialog should open
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="complete-task-confirm"]')).not.toBeNull();
+		});
+	});
+
+	it('calls task.cancel RPC and navigates away on cancel confirmation', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.cancel') return {};
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open dropdown and click cancel
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const cancelItem = items.find((el) => el.textContent?.includes('Cancel Task')) as HTMLElement;
+			fireEvent.click(cancelItem);
+		});
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="cancel-task-confirm"]')).not.toBeNull();
+		});
+
+		// Confirm cancellation
+		const confirmButton = document.querySelector(
+			'[data-testid="cancel-task-confirm"]'
+		) as HTMLElement;
+		await act(async () => {
+			fireEvent.click(confirmButton);
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.cancel', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+			});
+			expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		});
+	});
+
+	it('calls task.setStatus RPC and navigates away on complete confirmation', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.setStatus') return { task: makeTask('task-1', 'completed') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open dropdown and click Mark as Complete
+		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
+		fireEvent.click(menuButton);
+
+		await waitFor(() => {
+			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+			const completeItem = items.find((el) =>
+				el.textContent?.includes('Mark as Complete')
+			) as HTMLElement;
+			fireEvent.click(completeItem);
+		});
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="complete-task-confirm"]')).not.toBeNull();
+		});
+
+		// Confirm completion
+		const confirmButton = document.querySelector(
+			'[data-testid="complete-task-confirm"]'
+		) as HTMLElement;
+		await act(async () => {
+			fireEvent.click(confirmButton);
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.setStatus', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				status: 'completed',
+				result: 'Marked complete by user',
+			});
+			expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		});
 	});
 });
 

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -22,7 +22,8 @@ import { useMessageHub } from '../../hooks/useMessageHub';
 import { useModal } from '../../hooks/useModal';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
 import { copyToClipboard } from '../../lib/utils';
-import { ConfirmModal } from '../ui/ConfirmModal';
+import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
+import { Modal } from '../ui/Modal';
 import { RejectModal } from '../ui/RejectModal';
 import { InputTextarea } from '../InputTextarea';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
@@ -377,6 +378,205 @@ function HumanInputArea({
 	);
 }
 
+interface CompleteTaskDialogProps {
+	task: NeoTask;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: (summary: string) => Promise<void>;
+}
+
+function CompleteTaskDialog({ task, isOpen, onClose, onConfirm }: CompleteTaskDialogProps) {
+	const [summary, setSummary] = useState('');
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleClose = () => {
+		setSummary('');
+		setError(null);
+		onClose();
+	};
+
+	const handleConfirm = async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			await onConfirm(summary);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to complete task');
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={handleClose}
+			title="Mark Task as Complete?"
+			size="md"
+			showCloseButton
+		>
+			<div class="space-y-4">
+				<p class="text-sm text-gray-300">
+					You are about to mark <strong class="text-gray-100">{task.title}</strong> as completed.
+				</p>
+
+				<div class="bg-dark-800 border border-dark-600 rounded-lg p-3 text-xs text-gray-400">
+					<p class="font-medium text-gray-300 mb-1.5">What happens next:</p>
+					<ul class="list-disc list-inside space-y-1">
+						<li>
+							Task status changes to <span class="text-green-400">completed</span>
+						</li>
+						<li>All sessions will be terminated</li>
+						<li>Task slot will be freed</li>
+					</ul>
+				</div>
+
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Completion Summary <span class="text-gray-500 font-normal">(optional)</span>
+					</label>
+					<textarea
+						class="w-full h-24 bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-500 resize-none focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+						placeholder="Briefly describe what was accomplished..."
+						value={summary}
+						onInput={(e) => setSummary((e.target as HTMLTextAreaElement).value)}
+						disabled={loading}
+					/>
+				</div>
+
+				{error && (
+					<p class="text-sm text-red-400 bg-red-900/20 border border-red-800/50 rounded px-3 py-2">
+						{error}
+					</p>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<button
+						type="button"
+						onClick={handleClose}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={() => void handleConfirm()}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:cursor-not-allowed bg-green-600 hover:bg-green-700 text-white disabled:bg-green-600/50 flex items-center gap-1.5"
+						data-testid="complete-task-confirm"
+					>
+						{loading ? (
+							'Completing…'
+						) : (
+							<>
+								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M5 13l4 4L19 7"
+									/>
+								</svg>
+								Mark Complete
+							</>
+						)}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}
+
+interface CancelTaskDialogProps {
+	task: NeoTask;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => Promise<void>;
+}
+
+function CancelTaskDialog({ task, isOpen, onClose, onConfirm }: CancelTaskDialogProps) {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleClose = () => {
+		setError(null);
+		onClose();
+	};
+
+	const handleConfirm = async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			await onConfirm();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to cancel task');
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Cancel Task?" size="sm" showCloseButton>
+			<div class="space-y-4">
+				<p class="text-sm text-gray-300">
+					You are about to cancel <strong class="text-gray-100">{task.title}</strong>.
+				</p>
+
+				<div class="bg-red-900/20 border border-red-800/50 rounded-lg p-3 text-xs text-gray-400">
+					<p class="font-medium text-red-400 mb-1.5">This action cannot be undone:</p>
+					<ul class="list-disc list-inside space-y-1">
+						<li>
+							Task will be marked as <span class="text-gray-300">cancelled</span>
+						</li>
+						<li>All sessions will be terminated</li>
+						<li>Isolated worktree and branch will be removed</li>
+					</ul>
+				</div>
+
+				{error && (
+					<p class="text-sm text-red-400 bg-red-900/20 border border-red-800/50 rounded px-3 py-2">
+						{error}
+					</p>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<button
+						type="button"
+						onClick={handleClose}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Keep Task
+					</button>
+					<button
+						type="button"
+						onClick={() => void handleConfirm()}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:cursor-not-allowed bg-red-600 hover:bg-red-700 text-white disabled:bg-red-600/50 flex items-center gap-1.5"
+						data-testid="cancel-task-confirm"
+					>
+						{loading ? (
+							'Cancelling…'
+						) : (
+							<>
+								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+								Cancel Task
+							</>
+						)}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}
+
 export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const { request, onEvent, joinRoom, leaveRoom } = useMessageHub();
 	const [task, setTask] = useState<NeoTask | null>(null);
@@ -394,10 +594,9 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const [showInfoPanel, setShowInfoPanel] = useState(false);
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 
-	// Cancel task modal state
+	// Task action modals
+	const completeModal = useModal();
 	const cancelModal = useModal();
-	const [cancelling, setCancelling] = useState(false);
-	const [cancelError, setCancelError] = useState<string | null>(null);
 
 	// Tracks whether the conversation pane is showing its first batch of messages.
 	// Starts true, resets to true each time the conversation reloads (conversationKey bumps),
@@ -547,26 +746,71 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 
 	const statusColor = TASK_STATUS_COLORS[task.status] ?? 'text-gray-400';
 
-	// Determine if cancel button should be shown (pending, in_progress, or review status)
+	// Determine which actions are available based on task status
+	// Only in_progress and review tasks can transition to completed
+	const canComplete = task.status === 'in_progress' || task.status === 'review';
+	// Pending, in_progress, and review tasks can be cancelled
 	const canCancel =
 		task.status === 'pending' || task.status === 'in_progress' || task.status === 'review';
 
-	// Cancel task handler
-	const cancelTask = async () => {
-		if (cancelling) return;
-		setCancelling(true);
-		setCancelError(null);
-		try {
-			await request('task.cancel', { roomId, taskId });
-			cancelModal.close();
-			// Navigate back to room since task is now cancelled
-			navigateToRoom(roomId);
-		} catch (err) {
-			setCancelError(err instanceof Error ? err.message : 'Failed to cancel task');
-		} finally {
-			setCancelling(false);
-		}
+	// Complete task handler — throws on error so the dialog can display it
+	const completeTask = async (summary: string) => {
+		await request('task.setStatus', {
+			roomId,
+			taskId,
+			status: 'completed',
+			result: summary || 'Marked complete by user',
+		});
+		completeModal.close();
+		navigateToRoom(roomId);
 	};
+
+	// Cancel task handler — throws on error so the dialog can display it
+	const cancelTask = async () => {
+		await request('task.cancel', { roomId, taskId });
+		cancelModal.close();
+		navigateToRoom(roomId);
+	};
+
+	// Build dropdown menu items for task actions
+	const dropdownItems: DropdownMenuItem[] = [];
+	if (canComplete) {
+		dropdownItems.push({
+			label: 'Mark as Complete',
+			icon: (
+				<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M5 13l4 4L19 7"
+					/>
+				</svg>
+			),
+			onClick: () => completeModal.open(),
+		});
+	}
+	if (canCancel) {
+		if (canComplete) {
+			dropdownItems.push({ type: 'divider' });
+		}
+		dropdownItems.push({
+			label: 'Cancel Task',
+			icon: (
+				<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M6 18L18 6M6 6l12 12"
+					/>
+				</svg>
+			),
+			danger: true,
+			onClick: () => cancelModal.open(),
+		});
+	}
+
 	return (
 		<div class="flex-1 flex flex-col overflow-hidden bg-dark-900">
 			{/* Header */}
@@ -614,23 +858,25 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						<span class="text-xs text-gray-400">{task.progress}%</span>
 					</div>
 				)}
-				{/* Cancel button - shown for pending, in_progress, or review tasks */}
-				{canCancel && (
-					<button
-						class="p-1.5 rounded text-red-400 hover:text-red-300 hover:bg-dark-700 transition-colors"
-						onClick={cancelModal.open}
-						title="Cancel task"
-						disabled={cancelling}
-					>
-						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								d="M6 18L18 6M6 6l12 12"
-							/>
-						</svg>
-					</button>
+				{/* Task options dropdown — shown when at least one action is available */}
+				{dropdownItems.length > 0 && (
+					<Dropdown
+						position="right"
+						trigger={
+							<button
+								class="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-dark-700 transition-colors"
+								title="Task options"
+								data-testid="task-options-menu"
+							>
+								<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+									<circle cx="12" cy="5" r="2" />
+									<circle cx="12" cy="12" r="2" />
+									<circle cx="12" cy="19" r="2" />
+								</svg>
+							</button>
+						}
+						items={dropdownItems}
+					/>
 				)}
 				{/* Info toggle button */}
 				<button
@@ -818,17 +1064,18 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				onMessageSentWithReload={() => setConversationKey((k) => k + 1)}
 			/>
 
-			{/* Cancel confirmation modal */}
-			<ConfirmModal
+			{/* Task action dialogs */}
+			<CompleteTaskDialog
+				task={task}
+				isOpen={completeModal.isOpen}
+				onClose={completeModal.close}
+				onConfirm={completeTask}
+			/>
+			<CancelTaskDialog
+				task={task}
 				isOpen={cancelModal.isOpen}
 				onClose={cancelModal.close}
 				onConfirm={cancelTask}
-				title="Cancel Task"
-				message="Are you sure you want to cancel this task? The task's isolated worktree and branch will be permanently removed. This action cannot be undone."
-				confirmText="Cancel Task"
-				confirmButtonVariant="danger"
-				isLoading={cancelling}
-				error={cancelError}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -403,6 +403,7 @@ function CompleteTaskDialog({ task, isOpen, onClose, onConfirm }: CompleteTaskDi
 			await onConfirm(summary);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to complete task');
+		} finally {
 			setLoading(false);
 		}
 	};
@@ -511,6 +512,7 @@ function CancelTaskDialog({ task, isOpen, onClose, onConfirm }: CancelTaskDialog
 			await onConfirm();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to cancel task');
+		} finally {
 			setLoading(false);
 		}
 	};


### PR DESCRIPTION
- Replace raw cancel button in TaskView header with a three-dot (⋮) dropdown menu
- Add "Mark as Complete" option for in_progress and review tasks, triggering
  task.setStatus RPC with status=completed and optional summary stored as result
- Update cancel flow to use a richer modal (CancelTaskDialog) with task title,
  warning list, and Keep Task / Cancel Task buttons
- Both operations show inline error state on failure (no navigation on error)
- Dropdown is hidden for completed, failed, and cancelled tasks
- Add CompleteTaskDialog and CancelTaskDialog sub-components in TaskView.tsx,
  following the same pattern as HeaderReviewBar and HumanInputArea
- Update existing Vitest tests to check for task-options-menu instead of
  the removed cancel button; add 8 new tests covering dropdown items, dialog
  opening, RPC calls, and navigation after confirm
- Add E2E Playwright test covering all key UX flows end-to-end
