### PR TITLE
feat: rename TaskStatus 'failed' to 'needs_attention' for semantic clarity

### DIFF
--- a/docs/design/task-status-control-design.md
+++ b/docs/design/task-status-control-design.md
@@ -16,21 +16,21 @@ stateDiagram-v2
 
     in_progress --> review: Work done, awaiting review
     in_progress --> completed: Human marks complete
-    in_progress --> failed: Worker fails / Human marks failed
+    in_progress --> needs_attention: Worker fails / Human marks needs attention
     in_progress --> cancelled: Human cancels
 
     review --> completed: Human approves
-    review --> failed: Human marks failed (manual terminal)
+    review --> needs_attention: Human marks needs attention (manual terminal)
     review --> in_progress: Human rejects (task.reject)
 
-    failed --> pending: Restart (human retry)
-    failed --> in_progress: Restart (human retry)
+    needs_attention --> pending: Restart (human retry)
+    needs_attention --> in_progress: Restart (human retry)
 
     cancelled --> pending: Restart (human retry)
     cancelled --> in_progress: Restart (human retry)
 
     completed --> [*]
-    failed --> [*]
+    needs_attention --> [*]
     cancelled --> [*]
 ```
 
@@ -40,10 +40,10 @@ stateDiagram-v2
 |----------------|------------------------|-------|
 | `draft` | `pending` | Planning-created tasks, promoted when plan approved |
 | `pending` | `in_progress`, `cancelled` | Worker not started yet |
-| `in_progress` | `review`, `completed`, `failed`, `cancelled` | Worker is actively working |
-| `review` | `completed`, `failed`, `in_progress` | Awaiting human approval |
+| `in_progress` | `review`, `completed`, `needs_attention`, `cancelled` | Worker is actively working |
+| `review` | `completed`, `needs_attention`, `in_progress` | Awaiting human approval |
 | `completed` | _(none)_ | Terminal state - no transitions allowed |
-| `failed` | `pending`, `in_progress` | Restart: human can retry failed task |
+| `needs_attention` | `pending`, `in_progress`, `review` | Restart or revive to review for human attention |
 | `cancelled` | `pending`, `in_progress` | Restart: human can retry cancelled task |
 
 ## Session Group State (Current)
@@ -54,7 +54,7 @@ stateDiagram-v2
 - `awaiting_leader`
 - `awaiting_human`
 - `completed`
-- `failed`
+- `needs_attention`
 
 `hibernated` is not part of the current model.
 
@@ -65,23 +65,23 @@ stateDiagram-v2
 All status transitions are validated against `VALID_STATUS_TRANSITIONS` before applying:
 
 - **Validation**: Throws error if transition is not allowed
-- **Restart clearing**: When moving from `failed`/`cancelled` to `pending`/`in_progress`:
+- **Restart clearing**: When moving from `needs_attention`/`cancelled` to `pending`/`in_progress`:
   - Clears `error` field (sets to `null`)
   - Clears `result` field (sets to `null`)
   - Clears `progress` field (sets to `null`)
 - **Completion**: When moving to `completed`:
   - Sets `progress` to `100`
   - Optionally sets `result` if provided
-- **Failure**: When moving to `failed`:
+- **Failure**: When moving to `needs_attention`:
   - Optionally sets `error` if provided
 
 ### Active Group Cancellation
 
-When a task has an active session group (agents currently running) and transitions to a terminal state (`completed`, `failed`, `cancelled`), the system:
+When a task has an active session group (agents currently running) and transitions to a terminal state (`completed`, `needs_attention`, `cancelled`), the system:
 
 1. Looks up the active group for the task
 2. For `cancelled`, calls `runtime.cancelTask(taskId)` (task cancel + group/session cleanup)
-3. For `completed` or `failed`, calls `runtime.terminateTaskGroup(taskId)` (group/session cleanup only)
+3. For `completed` or `needs_attention`, calls `runtime.terminateTaskGroup(taskId)` (group/session cleanup only)
 4. If runtime cleanup fails, throws an error
 5. Only then applies (or returns) the final task status
 
@@ -91,7 +91,7 @@ For `task.cancel`, if runtime exists, the handler delegates directly to `runtime
 flowchart LR
     A["task.cancel"] --> B["runtime.cancelTask(taskId)"]
     C["task.setStatus(cancelled)"] --> B
-    D["task.setStatus(completed|failed)"] --> E["runtime.terminateTaskGroup(taskId)"]
+    D["task.setStatus(completed|needs_attention)"] --> E["runtime.terminateTaskGroup(taskId)"]
     E --> F["persist requested terminal status"]
 ```
 
@@ -118,11 +118,11 @@ flowchart LR
       task_id: { type: 'string', description: 'Task ID to update' },
       status: {
         type: 'string',
-        enum: ['draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled'],
+        enum: ['draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled'],
         description: 'New status to set'
       },
       result: { type: 'string', description: 'Optional result message (for completed status)' },
-      error: { type: 'string', description: 'Optional error message (for failed status)' }
+      error: { type: 'string', description: 'Optional error message (for needs_attention status)' }
     },
     required: ['task_id', 'status']
   }

--- a/docs/design/task-status-control-design.md
+++ b/docs/design/task-status-control-design.md
@@ -54,7 +54,10 @@ stateDiagram-v2
 - `awaiting_leader`
 - `awaiting_human`
 - `completed`
-- `needs_attention`
+- `failed`
+
+Note: `session_groups.state` has its own `failed` value which is **separate from `TaskStatus`**
+and was not renamed. It marks a terminal group state when the agent session ends abnormally.
 
 `hibernated` is not part of the current model.
 

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -185,8 +185,8 @@ export class GoalManager {
 			if (task && task.roomId === this.roomId) {
 				if (task.status === 'completed') {
 					totalProgress += 100;
-				} else if (task.status === 'failed' || task.status === 'cancelled') {
-					// Terminal tasks (failed or cancelled) don't contribute to progress
+				} else if (task.status === 'needs_attention' || task.status === 'cancelled') {
+					// Terminal tasks (needs_attention or cancelled) don't contribute to progress
 					totalProgress += 0;
 				} else {
 					totalProgress += task.progress ?? 0;

--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -139,7 +139,7 @@ export class RoomManager {
 			activeSession: task.activeSession,
 		});
 		const nonTerminal = tasks.filter(
-			(t) => t.status !== 'completed' && t.status !== 'failed' && t.status !== 'cancelled'
+			(t) => t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'
 		);
 		const taskSummaries = nonTerminal.map(toSummary);
 		const allTaskSummaries = allTasks.map(toSummary);

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -26,10 +26,10 @@ import type {
 export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	draft: ['pending'],
 	pending: ['in_progress', 'cancelled'],
-	in_progress: ['review', 'completed', 'failed', 'cancelled'],
-	review: ['completed', 'failed', 'in_progress'],
+	in_progress: ['review', 'completed', 'needs_attention', 'cancelled'],
+	review: ['completed', 'needs_attention', 'in_progress'],
 	completed: [], // Terminal state
-	failed: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review via message
+	needs_attention: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review via message
 	cancelled: ['pending', 'in_progress'], // Restart only — worktree is cleaned up on cancel
 };
 
@@ -198,17 +198,17 @@ export class TaskManager {
 			}
 		}
 
-		if (newStatus === 'failed') {
+		if (newStatus === 'needs_attention') {
 			if (options?.error) {
 				updates.error = options.error;
 			}
 		}
 
-		// Clear error/result when restarting from failed/cancelled, or when reviving
-		// a failed task to review. The 'review' case only applies to 'failed' since
+		// Clear error/result when restarting from needs_attention/cancelled, or when reviving
+		// a needs_attention task to review. The 'review' case only applies to 'needs_attention' since
 		// 'cancelled → review' is not a valid transition (worktree is cleaned up).
 		if (
-			(task.status === 'failed' || task.status === 'cancelled') &&
+			(task.status === 'needs_attention' || task.status === 'cancelled') &&
 			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')
 		) {
 			// Use null to explicitly clear these fields in the database
@@ -224,7 +224,7 @@ export class TaskManager {
 	 * Fail task
 	 */
 	async failTask(taskId: string, error: string): Promise<NeoTask> {
-		return this.updateTaskStatus(taskId, 'failed', {
+		return this.updateTaskStatus(taskId, 'needs_attention', {
 			error,
 		});
 	}

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -4,7 +4,7 @@
  * Handles:
  * - Creating tasks
  * - Listing and filtering tasks
- * - Status transitions (draft -> pending -> in_progress -> completed/failed/cancelled/review)
+ * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review)
  * - Task assignment to sessions
  */
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1953,7 +1953,7 @@ export class RoomRuntime {
 	 *
 	 * A goal needs planning when:
 	 * - status is 'active'
-	 * - has no linked tasks at all, OR all linked tasks are 'failed'
+	 * - has no linked tasks at all, OR all linked tasks need attention
 	 * - has no pending/in_progress/draft/escalated tasks
 	 * - planning_attempts < this.maxPlanningAttempts
 	 *
@@ -1974,7 +1974,7 @@ export class RoomRuntime {
 				// Check whether execution tasks need replanning.
 				// A goal needs replanning when:
 				// - No active (pending/in_progress/draft/escalated) tasks remain
-				// - All execution tasks (non-planning) are failed
+				// - All execution tasks (non-planning) need attention
 				// This handles both "all tasks failed" and "planning succeeded but
 				// all execution tasks failed" scenarios.
 				const linkedTasks = await Promise.all(
@@ -1989,7 +1989,8 @@ export class RoomRuntime {
 					)
 				);
 				const executionTasks = validTasks.filter((t) => t.taskType !== 'planning');
-				const isTerminal = (status: string) => status === 'failed' || status === 'cancelled';
+				const isTerminal = (status: string) =>
+					status === 'needs_attention' || status === 'cancelled';
 				const allExecutionFailed =
 					executionTasks.length > 0 && executionTasks.every((t) => isTerminal(t.status));
 				const allFailed = validTasks.length > 0 && validTasks.every((t) => isTerminal(t.status));

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -293,7 +293,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 							// There's an active group - cancel it first if moving to terminal state
 							if (
 								args.status === 'completed' ||
-								args.status === 'failed' ||
+								args.status === 'needs_attention' ||
 								args.status === 'cancelled'
 							) {
 								const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
@@ -309,8 +309,8 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 			}
 
-			// Handle restart/revive: update group state for failed/cancelled tasks
-			if (task.status === 'failed' || task.status === 'cancelled') {
+			// Handle restart/revive: update group state for needs_attention/cancelled tasks
+			if (task.status === 'needs_attention' || task.status === 'cancelled') {
 				const group = groupRepo.getGroupByTaskId(args.task_id);
 				if (group) {
 					if (args.status === 'pending' || args.status === 'in_progress') {
@@ -324,7 +324,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						}
 					} else if (
 						args.status === 'review' &&
-						task.status === 'failed' &&
+						task.status === 'needs_attention' &&
 						group.completedAt !== null
 					) {
 						// Lightweight revive (failed → review only): clear completedAt without
@@ -455,10 +455,10 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				});
 			}
 
-			// Auto-revive: if the task has failed, transition it to 'review' and
-			// restore the agent sessions so the message can be delivered. Failed
+			// Auto-revive: if the task needs attention, transition it to 'review' and
+			// restore the agent sessions so the message can be delivered. Needs_attention
 			// tasks preserve their worktree, so session restoration is safe.
-			if (task.status === 'failed') {
+			if (task.status === 'needs_attention') {
 				try {
 					await taskManager.setTaskStatus(args.task_id, 'review');
 				} catch (err) {
@@ -470,9 +470,9 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
 				if (!revived) {
-					// Roll back the task status; review → failed is a valid transition.
+					// Roll back the task status; review → needs_attention is a valid transition.
 					try {
-						await taskManager.setTaskStatus(args.task_id, 'failed');
+						await taskManager.setTaskStatus(args.task_id, 'needs_attention');
 					} catch {
 						// Rollback is best-effort; swallow to avoid masking the original error
 					}
@@ -480,12 +480,12 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						success: false,
 						error:
 							`Failed to revive task ${args.task_id}: agent sessions could not be restored. ` +
-							'Task status has been reset to failed.',
+							'Task status has been reset to needs_attention.',
 					});
 				}
 				return jsonResult({
 					success: true,
-					message: `Task ${args.task_id} revived from failed to review and message delivered to agent`,
+					message: `Task ${args.task_id} revived from needs_attention to review and message delivered to agent`,
 				});
 			}
 
@@ -551,7 +551,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						inProgress: tasks.filter((t) => t.status === 'in_progress').length,
 						review: tasks.filter((t) => t.status === 'review').length,
 						completed: tasks.filter((t) => t.status === 'completed').length,
-						failed: tasks.filter((t) => t.status === 'failed').length,
+						needsAttention: tasks.filter((t) => t.status === 'needs_attention').length,
 						cancelled: tasks.filter((t) => t.status === 'cancelled').length,
 					},
 					activeGroups: activeGroups.length,
@@ -633,7 +633,15 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			{
 				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
 				status: z
-					.enum(['draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled'])
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+					])
 					.optional()
 					.describe('Filter by status'),
 			},
@@ -656,7 +664,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'cancel_task',
-			'Cancel a task (marks as cancelled — distinct from failed — and cleans up agent sessions)',
+			'Cancel a task (marks as cancelled — distinct from needs_attention — and cleans up agent sessions)',
 			{ task_id: z.string().describe('ID of the task to cancel') },
 			(args) => handlers.cancel_task(args)
 		),
@@ -672,10 +680,18 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			{
 				task_id: z.string().describe('ID of the task to update'),
 				status: z
-					.enum(['draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled'])
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+					])
 					.describe('New status for the task'),
 				result: z.string().optional().describe('Result description (for completed status)'),
-				error: z.string().optional().describe('Error message (for failed status)'),
+				error: z.string().optional().describe('Error message (for needs_attention status)'),
 			},
 			(args) => handlers.set_task_status(args)
 		),

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -295,10 +295,10 @@ export function setupTaskHandlers(
 		}
 
 		// Validate task is in a terminal state before archiving
-		const TERMINAL_STATES: TaskStatus[] = ['completed', 'failed', 'cancelled'];
+		const TERMINAL_STATES: TaskStatus[] = ['completed', 'needs_attention', 'cancelled'];
 		if (!TERMINAL_STATES.includes(task.status)) {
 			throw new Error(
-				`Cannot archive task in '${task.status}' state. Only tasks in terminal states (completed, failed, cancelled) can be archived.`
+				`Cannot archive task in '${task.status}' state. Only tasks in terminal states (completed, needs_attention, cancelled) can be archived.`
 			);
 		}
 
@@ -362,7 +362,7 @@ export function setupTaskHandlers(
 			if (runtime) {
 				const isTerminalStatus =
 					params.status === 'completed' ||
-					params.status === 'failed' ||
+					params.status === 'needs_attention' ||
 					params.status === 'cancelled';
 				if (isTerminalStatus) {
 					if (params.status === 'cancelled') {
@@ -391,8 +391,8 @@ export function setupTaskHandlers(
 			}
 		}
 
-		// Handle restart: reset failed/cancelled group so runtime picks it up fresh
-		if (task.status === 'failed' || task.status === 'cancelled') {
+		// Handle restart: reset needs_attention/cancelled group so runtime picks it up fresh
+		if (task.status === 'needs_attention' || task.status === 'cancelled') {
 			if (params.status === 'pending' || params.status === 'in_progress') {
 				const groupRepo = new SessionGroupRepository(db.getDatabase());
 				const group = groupRepo.getGroupByTaskId(params.taskId);

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -158,7 +158,9 @@ export class TaskRepository {
 		// Auto-clear active_session when task reaches a terminal status (unless already set explicitly)
 		if (
 			params.activeSession === undefined &&
-			(params.status === 'completed' || params.status === 'failed' || params.status === 'cancelled')
+			(params.status === 'completed' ||
+				params.status === 'needs_attention' ||
+				params.status === 'cancelled')
 		) {
 			fields.push('active_session = ?');
 			values.push(null);

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -120,7 +120,7 @@ export class TaskRepository {
 				values.push(Date.now());
 			} else if (
 				params.status === 'completed' ||
-				params.status === 'failed' ||
+				params.status === 'needs_attention' ||
 				params.status === 'cancelled'
 			) {
 				fields.push('completed_at = ?');
@@ -211,11 +211,11 @@ export class TaskRepository {
 	}
 
 	/**
-	 * Count all active (non-completed, non-failed, non-cancelled) tasks for a room
+	 * Count all active (non-completed, non-needs_attention, non-cancelled) tasks for a room
 	 */
 	countActiveTasks(roomId: string): number {
 		const stmt = this.db.prepare(
-			`SELECT COUNT(*) as count FROM tasks WHERE room_id = ? AND status NOT IN ('completed', 'failed', 'cancelled')`
+			`SELECT COUNT(*) as count FROM tasks WHERE room_id = ? AND status NOT IN ('completed', 'needs_attention', 'cancelled')`
 		);
 		const result = stmt.get(roomId) as { count: number };
 		return result.count;

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -142,7 +142,7 @@ export function createTables(db: BunDatabase): void {
         room_id TEXT NOT NULL,
         title TEXT NOT NULL,
         description TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled')),
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
         priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
         progress INTEGER,
         current_step TEXT,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -93,6 +93,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 23: Add active_session column to tasks table
 	runMigration23(db);
+
+	// Migration 24: Rename 'failed' task status to 'needs_attention' for better semantic clarity
+	runMigration24(db);
 }
 
 /**
@@ -1057,6 +1060,102 @@ function runMigration23(db: BunDatabase): void {
 		return;
 	}
 	db.exec(`ALTER TABLE tasks ADD COLUMN active_session TEXT`);
+}
+
+/**
+ * Migration 24: Rename 'failed' task status to 'needs_attention'.
+ *
+ * Uses the table-rebuild pattern required by SQLite's lack of ALTER CONSTRAINT support.
+ * Also updates any existing task rows with status='failed' to 'needs_attention'.
+ */
+function runMigration24(db: BunDatabase): void {
+	if (!tableExists(db, 'tasks')) {
+		return;
+	}
+
+	// Check if migration is needed by inspecting the CHECK constraint.
+	const tableInfo = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'`)
+		.get() as { sql: string } | null;
+	const needsMigration = tableInfo !== null && tableInfo.sql.includes("'failed'");
+
+	if (!needsMigration) return;
+
+	db.exec('PRAGMA foreign_keys = OFF');
+	try {
+		db.exec(`DROP TABLE IF EXISTS tasks_new`);
+
+		db.exec(`
+			CREATE TABLE tasks_new (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				task_type TEXT DEFAULT 'coding' CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'goal_review')),
+				assigned_agent TEXT DEFAULT 'coder',
+				created_by_task_id TEXT,
+				archived_at INTEGER,
+				active_session TEXT,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+
+		// Build column list dynamically for the INSERT SELECT (handles optional columns)
+		const baseCols = [
+			'id',
+			'room_id',
+			'title',
+			'description',
+			'priority',
+			'progress',
+			'current_step',
+			'result',
+			'error',
+			'depends_on',
+			'created_at',
+			'started_at',
+			'completed_at',
+		];
+		const optionalCols = [
+			'task_type',
+			'assigned_agent',
+			'created_by_task_id',
+			'archived_at',
+			'active_session',
+		];
+		for (const col of optionalCols) {
+			if (tableHasColumn(db, 'tasks', col)) baseCols.push(col);
+		}
+
+		// Rename 'failed' → 'needs_attention' during the copy using CASE expression
+		const colsWithoutStatus = baseCols.join(', ');
+		db.exec(`PRAGMA ignore_check_constraints = 1`);
+		db.exec(`
+			INSERT INTO tasks_new (status, ${colsWithoutStatus})
+			SELECT
+				CASE WHEN status = 'failed' THEN 'needs_attention' ELSE status END,
+				${colsWithoutStatus}
+			FROM tasks
+		`);
+		db.exec(`PRAGMA ignore_check_constraints = 0`);
+
+		db.exec(`DROP TABLE tasks`);
+		db.exec(`ALTER TABLE tasks_new RENAME TO tasks`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+	} finally {
+		db.exec('PRAGMA foreign_keys = ON');
+	}
 }
 
 function runMigrationRoomCleanup(db: BunDatabase): void {

--- a/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
+++ b/packages/daemon/tests/online/room/room-advanced-scenarios.test.ts
@@ -72,12 +72,12 @@ describe('Room Advanced Scenarios (API-dependent)', () => {
 			const terminalPlanning = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'planning', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalPlanning.status === 'failed') {
+			if (terminalPlanning.status === 'needs_attention') {
 				throw new Error(
-					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
+					`Planning task needs attention: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			// If planning is in 'review', approve via task.approve to trigger phase 2
@@ -118,12 +118,12 @@ describe('Room Advanced Scenarios (API-dependent)', () => {
 			const terminalCoding = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'coding', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'coding', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalCoding.status === 'failed') {
+			if (terminalCoding.status === 'needs_attention') {
 				throw new Error(
-					`Coding task failed: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
+					`Coding task needs attention: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			if (terminalCoding.status === 'review') {

--- a/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-multi-agent-flow.test.ts
@@ -96,7 +96,7 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 				daemon,
 				roomId,
 				planningTask.id,
-				['awaiting_worker', 'awaiting_leader', 'completed', 'failed'],
+				['awaiting_worker', 'awaiting_leader', 'completed', 'needs_attention'],
 				30_000
 			);
 			expect(planningGroup.id).toBeTruthy();
@@ -106,12 +106,12 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 			const terminalPlanning = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'planning', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalPlanning.status === 'failed') {
+			if (terminalPlanning.status === 'needs_attention') {
 				throw new Error(
-					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
+					`Planning task needs attention: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			// If planning is in 'review', approve via task.approve to trigger phase 2
@@ -147,12 +147,12 @@ describe('Room Multi-Agent Flow (API-dependent)', () => {
 			const terminalCoding = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'coding', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'coding', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalCoding.status === 'failed') {
+			if (terminalCoding.status === 'needs_attention') {
 				throw new Error(
-					`Coding task failed: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
+					`Coding task needs attention: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			// If coding is in 'review', approve via task.approve to trigger PR merge

--- a/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
+++ b/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
@@ -134,14 +134,14 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 			const reviewTask = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['review', 'completed', 'failed'] },
+				{ taskType: 'planning', status: ['review', 'completed', 'needs_attention'] },
 				PLANNING_TIMEOUT
 			);
 			console.log(`Planning task reached: ${reviewTask.status}`);
 
-			if (reviewTask.status === 'failed') {
+			if (reviewTask.status === 'needs_attention') {
 				const error = (reviewTask as { error?: string }).error ?? 'unknown error';
-				console.warn(`Planning task failed: ${error}`);
+				console.warn(`Planning task needs attention: ${error}`);
 				// Don't hard-fail — log and continue checking what we can
 			}
 
@@ -235,7 +235,7 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 					daemon,
 					roomId,
 					planningTask.id,
-					['completed', 'failed'],
+					['completed', 'needs_attention'],
 					PLANNING_TIMEOUT
 				);
 				console.log(
@@ -246,7 +246,7 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 				const completedPlanning = await waitForTask(
 					daemon,
 					roomId,
-					{ taskType: 'planning', status: ['completed', 'failed'] },
+					{ taskType: 'planning', status: ['completed', 'needs_attention'] },
 					10_000
 				);
 				console.log(`Planning task final: ${completedPlanning.status}`);

--- a/packages/daemon/tests/online/room/room-replan-recovery.test.ts
+++ b/packages/daemon/tests/online/room/room-replan-recovery.test.ts
@@ -74,12 +74,12 @@ describe('Room Replan Recovery (API-dependent)', () => {
 			const terminalPlanning = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'planning', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalPlanning.status === 'failed') {
+			if (terminalPlanning.status === 'needs_attention') {
 				throw new Error(
-					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
+					`Planning task needs attention: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			// If planning is in 'review', approve via task.approve to trigger phase 2
@@ -99,12 +99,12 @@ describe('Room Replan Recovery (API-dependent)', () => {
 			const terminalCoding = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'coding', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'coding', status: ['completed', 'review', 'needs_attention'] },
 				120_000
 			);
-			if (terminalCoding.status === 'failed') {
+			if (terminalCoding.status === 'needs_attention') {
 				throw new Error(
-					`Coding task failed: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
+					`Coding task needs attention: ${(terminalCoding as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 			if (terminalCoding.status === 'review') {
@@ -132,13 +132,13 @@ describe('Room Replan Recovery (API-dependent)', () => {
 				});
 			}
 
-			// Verify the original tasks are now failed (new tasks may have
+			// Verify the original task needs attention (new tasks may have
 			// already been spawned by the runtime tick since task.fail emits
 			// room.task.update → immediate scheduleTick())
 			const tasksAfterFail = await listTasks(daemon, roomId);
 			for (const task of tasksAfterFail) {
 				if (existingTaskIds.has(task.id)) {
-					expect(task.status).toBe('failed');
+					expect(task.status).toBe('needs_attention');
 				}
 			}
 
@@ -163,7 +163,7 @@ describe('Room Replan Recovery (API-dependent)', () => {
 			const newTerminalPlanning = await waitForNewTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'planning', status: ['completed', 'review', 'needs_attention'] },
 				existingTaskIds,
 				120_000
 			);

--- a/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
@@ -123,17 +123,17 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 			expect(planningTask.taskType).toBe('planning');
 
 			// Planning may end up in 'completed' (leader calls complete_task),
-			// 'review' (leader calls submit_for_review for human approval), or 'failed'.
+			// 'review' (leader calls submit_for_review for human approval), or 'needs_attention'.
 			const terminalPlanning = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'planning', status: ['completed', 'review', 'failed'] },
+				{ taskType: 'planning', status: ['completed', 'review', 'needs_attention'] },
 				PLANNING_TIMEOUT
 			);
 
-			if (terminalPlanning.status === 'failed') {
+			if (terminalPlanning.status === 'needs_attention') {
 				throw new Error(
-					`Planning task failed: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
+					`Planning task needs attention: ${(terminalPlanning as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 
@@ -148,7 +148,7 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 				await waitForTask(
 					daemon,
 					roomId,
-					{ taskType: 'planning', status: ['completed', 'failed'] },
+					{ taskType: 'planning', status: ['completed', 'needs_attention'] },
 					PLANNING_TIMEOUT
 				);
 			}
@@ -169,31 +169,33 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 			// - 'completed': leader approved after review
 			// - 'review': submit_for_review called (awaiting human)
 			// - 'needs_human': escalated (max iterations or other reason)
-			// - 'failed': if something goes wrong (less ideal but possible)
+			// - 'needs_attention': if something goes wrong (less ideal but possible)
 			const terminalTask = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'coding', status: ['completed', 'review', 'needs_human', 'failed'] },
+				{ taskType: 'coding', status: ['completed', 'review', 'needs_human', 'needs_attention'] },
 				CODING_TIMEOUT
 			);
 
 			// Log terminal status for debugging
 			console.log(`Coding task reached terminal state: ${terminalTask.status}`);
-			if (terminalTask.status === 'failed') {
+			if (terminalTask.status === 'needs_attention') {
 				console.warn(
-					`Coding task failed: ${(terminalTask as { error?: string }).error ?? 'unknown error'}`
+					`Coding task needs attention: ${(terminalTask as { error?: string }).error ?? 'unknown error'}`
 				);
 			}
 
 			// Accept any terminal state — the key assertion is reviewer dispatch evidence below
-			expect(['completed', 'review', 'needs_human', 'failed']).toContain(terminalTask.status);
+			expect(['completed', 'review', 'needs_human', 'needs_attention']).toContain(
+				terminalTask.status
+			);
 
 			// --- Stage 4: Verify group activity ---
 			const group = await waitForGroupState(
 				daemon,
 				roomId,
 				terminalTask.id,
-				['completed', 'awaiting_human', 'failed'],
+				['completed', 'awaiting_human', 'needs_attention'],
 				10_000
 			);
 
@@ -292,7 +294,7 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 			const completedTask = await waitForTask(
 				daemon,
 				roomId,
-				{ taskType: 'coding', status: ['completed', 'failed'] },
+				{ taskType: 'coding', status: ['completed', 'needs_attention'] },
 				180_000
 			);
 
@@ -304,7 +306,7 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 				daemon,
 				roomId,
 				codingTaskId,
-				['completed', 'failed'],
+				['completed', 'needs_attention'],
 				10_000
 			);
 			expect(group.state).toBe('completed');

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -522,7 +522,7 @@ describe('Room Agent Tools', () => {
 			const cancelledTasks = parseResult(await handlers.list_tasks({ status: 'cancelled' }));
 			expect((cancelledTasks.tasks as unknown[]).length).toBe(1);
 
-			const failedTasks = parseResult(await handlers.list_tasks({ status: 'failed' }));
+			const failedTasks = parseResult(await handlers.list_tasks({ status: 'needs_attention' }));
 			expect((failedTasks.tasks as unknown[]).length).toBe(0);
 		});
 
@@ -649,16 +649,16 @@ describe('Room Agent Tools', () => {
 			expect(status.tasksNeedingReview).toEqual([]);
 		});
 
-		it('should count cancelled tasks separately from failed', async () => {
+		it('should count cancelled tasks separately from needs_attention tasks', async () => {
 			const t1 = parseResult(await handlers.create_task({ title: 'To cancel', description: 'd' }));
 			await handlers.cancel_task({ task_id: t1.taskId as string });
 
 			const result = parseResult(await handlers.get_room_status());
 			const status = result.status as {
-				tasks: { total: number; failed: number; cancelled: number };
+				tasks: { total: number; needsAttention: number; cancelled: number };
 			};
 			expect(status.tasks.total).toBe(1);
-			expect(status.tasks.failed).toBe(0);
+			expect(status.tasks.needsAttention).toBe(0);
 			expect(status.tasks.cancelled).toBe(1);
 		});
 
@@ -999,7 +999,7 @@ describe('Room Agent Tools', () => {
 			expect(task!.status).toBe('cancelled');
 		});
 
-		it('should roll back task to failed when reviveTaskForMessage returns false', async () => {
+		it('should roll back task to needs_attention when reviveTaskForMessage returns false', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => false,
 				injectMessageToWorker: async () => true,
@@ -1022,11 +1022,11 @@ describe('Room Agent Tools', () => {
 				await h.send_message_to_task({ task_id: taskId, message: 'hello' })
 			);
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('failed');
+			expect(result.error).toContain('needs_attention');
 
 			// Task status should be rolled back to failed (not left in review)
 			const task = await taskManager.getTask(taskId);
-			expect(task!.status).toBe('failed');
+			expect(task!.status).toBe('needs_attention');
 		});
 	});
 
@@ -1402,12 +1402,12 @@ describe('Room Agent Tools', () => {
 			const result = parseResult(
 				await handlers.set_task_status({
 					task_id: taskId,
-					status: 'failed',
+					status: 'needs_attention',
 					error: 'Tests failed',
 				})
 			);
 			expect(result.success).toBe(true);
-			expect(result.task.status).toBe('failed');
+			expect(result.task.status).toBe('needs_attention');
 			expect(result.task.error).toBe('Tests failed');
 		});
 

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -442,7 +442,7 @@ describe('RoomManager', () => {
 					`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 				)
-				.run('task-4', room.id, 'Failed', 'Desc', 'failed', 'normal', '[]', Date.now());
+				.run('task-4', room.id, 'Failed', 'Desc', 'needs_attention', 'normal', '[]', Date.now());
 
 			const status = roomManager.getRoomStatus(room.id);
 

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -1505,12 +1505,12 @@ describe('RoomRuntime flow', () => {
 			isolCtx.runtime.start();
 
 			// tick() spawns a coder group and spawn() throws on null worktree;
-			// the runtime catches the error and the task is marked failed
+			// the runtime catches the error and the task needs attention
 			await isolCtx.runtime.tick();
 
 			// Task should be failed with a worktree-related error
 			const updatedTask = await isolCtx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 			expect(updatedTask!.error).toContain('worktree');
 		});
 
@@ -1537,8 +1537,8 @@ describe('RoomRuntime flow', () => {
 			isolCtx.runtime.start();
 			await isolCtx.runtime.tick();
 
-			// The planning task should have been created by spawnPlanningGroup and then failed
-			const allTasks = await isolCtx.taskManager.listTasks({ status: 'failed' });
+			// The planning task needs attention
+			const allTasks = await isolCtx.taskManager.listTasks({ status: 'needs_attention' });
 			expect(allTasks.length).toBeGreaterThan(0);
 			expect(allTasks[0].error).toContain('worktree');
 		});
@@ -1564,7 +1564,7 @@ describe('RoomRuntime flow', () => {
 
 			// Task should be failed with a worktree-related error
 			const updatedTask = await isolCtx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 			expect(updatedTask!.error).toContain('worktree');
 		});
 

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -46,7 +46,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(parsed.success).toBe(true);
 
 			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 		});
 
 		it('should handle send_to_worker and route turn back to worker', async () => {
@@ -306,11 +306,11 @@ describe('RoomRuntime leader tools', () => {
 			expect(parsed.success).toBe(true);
 			expect(parsed.message).toContain('Replanning triggered');
 
-			// The current task should be failed (leader explicitly failed it via replan_goal)
+			// The current task needs attention it via replan_goal)
 			const updatedTask = await ctx.taskManager.getTask(task1.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 
-			// Remaining pending tasks should be cancelled (not failed — intentionally stopped)
+			// Remaining pending task needs attention — intentionally stopped)
 			const t2 = await ctx.taskManager.getTask(task2.id);
 			const t3 = await ctx.taskManager.getTask(task3.id);
 			expect(t2!.status).toBe('cancelled');
@@ -386,7 +386,7 @@ describe('RoomRuntime leader tools', () => {
 
 			// Task should still be failed
 			const updatedTask = await ctx.taskManager.getTask(task1.id);
-			expect(updatedTask!.status).toBe('failed');
+			expect(updatedTask!.status).toBe('needs_attention');
 
 			// Goal should be escalated to needs_human
 			const updatedGoal = (await ctx.goalManager.listGoals())[0];
@@ -444,7 +444,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(planningTasks[0].title).toStartWith('Replan:');
 		});
 
-		it('should pass completed tasks and failed task in replan context', async () => {
+		it('should pass completed task needs attention task in replan context', async () => {
 			const goal = await ctx.goalManager.createGoal({
 				title: 'Build auth system',
 				description: 'Implement authentication',
@@ -469,7 +469,7 @@ describe('RoomRuntime leader tools', () => {
 			// Mark task1 as completed with a result
 			await ctx.taskManager.completeTask(task1.id, 'Login endpoint implemented with JWT');
 
-			// task2 is the one being worked on (will be failed by replan)
+			// task needs attention by replan)
 			await ctx.goalManager.incrementPlanningAttempts(goal.id);
 
 			ctx.runtime.start();
@@ -550,7 +550,7 @@ describe('RoomRuntime leader tools', () => {
 			});
 
 			// Task should be failed
-			expect((await ctx.taskManager.getTask(task1.id))!.status).toBe('failed');
+			expect((await ctx.taskManager.getTask(task1.id))!.status).toBe('needs_attention');
 
 			// But sibling tasks should still be pending (NOT cancelled by auto-replan)
 			expect((await ctx.taskManager.getTask(task2.id))!.status).toBe('pending');

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -306,11 +306,11 @@ describe('RoomRuntime leader tools', () => {
 			expect(parsed.success).toBe(true);
 			expect(parsed.message).toContain('Replanning triggered');
 
-			// The current task needs attention it via replan_goal)
+			// The current task should be needs_attention (leader explicitly failed it via replan_goal)
 			const updatedTask = await ctx.taskManager.getTask(task1.id);
 			expect(updatedTask!.status).toBe('needs_attention');
 
-			// Remaining pending task needs attention — intentionally stopped)
+			// Remaining pending tasks should be cancelled (not needs_attention — intentionally stopped)
 			const t2 = await ctx.taskManager.getTask(task2.id);
 			const t3 = await ctx.taskManager.getTask(task3.id);
 			expect(t2!.status).toBe('cancelled');
@@ -444,7 +444,7 @@ describe('RoomRuntime leader tools', () => {
 			expect(planningTasks[0].title).toStartWith('Replan:');
 		});
 
-		it('should pass completed task needs attention task in replan context', async () => {
+		it('should pass completed tasks and needs_attention task in replan context', async () => {
 			const goal = await ctx.goalManager.createGoal({
 				title: 'Build auth system',
 				description: 'Implement authentication',
@@ -469,7 +469,7 @@ describe('RoomRuntime leader tools', () => {
 			// Mark task1 as completed with a result
 			await ctx.taskManager.completeTask(task1.id, 'Login endpoint implemented with JWT');
 
-			// task needs attention by replan)
+			// task2 is the one being worked on (will be needs_attention by replan)
 			await ctx.goalManager.incrementPlanningAttempts(goal.id);
 
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -100,7 +100,7 @@ describe('Zombie detection in tick', () => {
 
 		// Task should be failed
 		const updatedTask = await ctx.taskManager.getTask(taskId);
-		expect(updatedTask!.status).toBe('failed');
+		expect(updatedTask!.status).toBe('needs_attention');
 	});
 
 	it('should restore a zombie leader session during tick', async () => {
@@ -254,7 +254,7 @@ describe('Zombie detection in tick', () => {
 		expect(updated!.completedAt).not.toBeNull();
 
 		const updatedTask = await ctx.taskManager.getTask(taskId);
-		expect(updatedTask!.status).toBe('failed');
+		expect(updatedTask!.status).toBe('needs_attention');
 	});
 
 	it('should reattach observer after restoring zombie worker', async () => {

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -226,7 +226,7 @@ describe('Runtime Recovery', () => {
 		expect(updatedGroup!.completedAt).not.toBeNull();
 
 		const task = await taskManager.getTask(taskId);
-		expect(task!.status).toBe('failed');
+		expect(task!.status).toBe('needs_attention');
 	});
 
 	it('should fail groups with lost leader sessions', async () => {
@@ -384,7 +384,7 @@ describe('Runtime Recovery', () => {
 		expect(updatedGroup!.completedAt).not.toBeNull();
 
 		const task = await taskManager.getTask(taskId);
-		expect(task!.status).toBe('failed');
+		expect(task!.status).toBe('needs_attention');
 	});
 
 	it('should restore sessions not live in cache for awaiting_worker', async () => {

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -758,7 +758,7 @@ describe('TaskGroupManager', () => {
 	});
 
 	describe('cancel', () => {
-		it('should fail the group and mark the task needs attention)', async () => {
+		it('should fail the group and mark the task with cancelled status (not needs_attention)', async () => {
 			const task = await createTask();
 			const goal = makeGoal(db);
 			const callbacks = createMockLeaderCallbacks();

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -554,7 +554,7 @@ describe('TaskGroupManager', () => {
 			expect(result).toBeNull();
 
 			const failedTask = await taskManager.getTask(task.id);
-			expect(failedTask!.status).toBe('failed');
+			expect(failedTask!.status).toBe('needs_attention');
 			expect(failedTask!.error).toContain('Leader session lost during restart');
 		});
 	});
@@ -680,7 +680,7 @@ describe('TaskGroupManager', () => {
 			expect(updated!.completedAt).toBeDefined();
 
 			const taskResult = await taskManager.getTask(task.id);
-			expect(taskResult!.status).toBe('failed');
+			expect(taskResult!.status).toBe('needs_attention');
 		});
 
 		it('should stop observing sessions', async () => {
@@ -758,7 +758,7 @@ describe('TaskGroupManager', () => {
 	});
 
 	describe('cancel', () => {
-		it('should fail the group and mark the task as cancelled (not failed)', async () => {
+		it('should fail the group and mark the task needs attention)', async () => {
 			const task = await createTask();
 			const goal = makeGoal(db);
 			const callbacks = createMockLeaderCallbacks();
@@ -775,7 +775,7 @@ describe('TaskGroupManager', () => {
 			const updated = await manager.cancel(group.id);
 
 			// Group becomes terminal and the underlying task status is 'cancelled'
-			// (semantically distinct from 'failed').
+			// (semantically distinct from 'needs_attention').
 			expect(updated!.completedAt).not.toBeNull();
 			const cancelledTask = await taskManager.getTask(task.id);
 			expect(cancelledTask?.status).toBe('cancelled');
@@ -823,7 +823,7 @@ describe('TaskGroupManager', () => {
 			expect(sessionFactory.removedWorktrees).not.toContain(group.workspacePath);
 		});
 
-		it('should cleanup worktree on archiveGroup (even for failed tasks)', async () => {
+		it('should cleanup worktree on archiveGroup (even for needs_attention tasks)', async () => {
 			const task = await createTask();
 			const goal = makeGoal(db);
 			const callbacks = createMockLeaderCallbacks();

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -228,12 +228,12 @@ describe('TaskManager', () => {
 			expect(updated.completedAt).toBeDefined();
 		});
 
-		it('should update task status to failed', async () => {
+		it('should update task needs attention', async () => {
 			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
 
-			const updated = await taskManager.updateTaskStatus(task.id, 'failed');
+			const updated = await taskManager.updateTaskStatus(task.id, 'needs_attention');
 
-			expect(updated.status).toBe('failed');
+			expect(updated.status).toBe('needs_attention');
 			expect(updated.completedAt).toBeDefined();
 		});
 
@@ -339,7 +339,7 @@ describe('TaskManager', () => {
 
 			const updated = await taskManager.failTask(task.id, 'Something went wrong');
 
-			expect(updated.status).toBe('failed');
+			expect(updated.status).toBe('needs_attention');
 			expect(updated.error).toBe('Something went wrong');
 			expect(updated.completedAt).toBeDefined();
 		});
@@ -352,7 +352,7 @@ describe('TaskManager', () => {
 	});
 
 	describe('cancelTask', () => {
-		it('should cancel task with cancelled status (not failed)', async () => {
+		it('should cancel task needs attention)', async () => {
 			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
 
 			const updated = await taskManager.cancelTask(task.id);
@@ -774,7 +774,7 @@ describe('TaskManager', () => {
 	});
 
 	describe('setTaskStatus — revive to review', () => {
-		it('should allow failed → review transition', async () => {
+		it('should allow needs_attention → review transition', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);
 			await taskManager.failTask(task.id, 'boom');
@@ -783,7 +783,7 @@ describe('TaskManager', () => {
 			expect(revived.status).toBe('review');
 		});
 
-		it('should clear error field on failed → review transition', async () => {
+		it('should clear error field on needs_attention → review transition', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);
 			await taskManager.failTask(task.id, 'something broke');

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -228,7 +228,7 @@ describe('TaskManager', () => {
 			expect(updated.completedAt).toBeDefined();
 		});
 
-		it('should update task needs attention', async () => {
+		it('should update task status to needs_attention', async () => {
 			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
 
 			const updated = await taskManager.updateTaskStatus(task.id, 'needs_attention');
@@ -352,7 +352,7 @@ describe('TaskManager', () => {
 	});
 
 	describe('cancelTask', () => {
-		it('should cancel task needs attention)', async () => {
+		it('should cancel task with cancelled status (not needs_attention)', async () => {
 			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
 
 			const updated = await taskManager.cancelTask(task.id);

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -385,8 +385,8 @@ describe('task.cancel RPC Handler', () => {
 			);
 		});
 
-		it('throws when task status is failed', async () => {
-			const failedTask = { ...mockTask, status: 'failed' as const };
+		it('throws when task needs attention', async () => {
+			const failedTask = { ...mockTask, status: 'needs_attention' as const };
 			setup({ task: failedTask, runtimeService: makeNullRuntimeService() });
 			await expect(getHandler()({ roomId: 'room-1', taskId: 'task-1' }, {})).rejects.toThrow(
 				'Task cannot be cancelled'
@@ -816,8 +816,8 @@ describe('task.setStatus RPC Handler', () => {
 			expect(result).toEqual({ task: { ...mockTask, status: 'completed' } });
 		});
 
-		it('allows valid transition from failed to pending (restart)', async () => {
-			const failedTask = { ...mockTask, status: 'failed' as const };
+		it('allows valid transition from needs_attention to pending (restart)', async () => {
+			const failedTask = { ...mockTask, status: 'needs_attention' as const };
 			setup({ task: failedTask, runtimeService: makeNullRuntimeService() });
 			const result = await getHandler()(
 				{ roomId: 'room-1', taskId: 'task-1', status: 'pending' },

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -60,7 +60,7 @@ const mockTaskManager = {
 				id: 'task-123',
 				roomId: 'room-123',
 				title: 'Test Task',
-				status: 'failed' as TaskStatus,
+				status: 'needs_attention' as TaskStatus,
 				error: 'Task failed',
 				failedAt: Date.now(),
 				updatedAt: Date.now(),

--- a/packages/daemon/tests/unit/storage/migrations/migration-24_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-24_test.ts
@@ -1,0 +1,151 @@
+/**
+ * Migration 24 Tests
+ *
+ * Tests for Migration 24: Rename 'failed' task status to 'needs_attention'.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+
+describe('Migration 24: rename failed → needs_attention', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-24', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+
+		// Create legacy rooms table (required by tasks foreign key)
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				background_context TEXT,
+				instructions TEXT,
+				allowed_paths TEXT DEFAULT '[]',
+				default_path TEXT,
+				default_model TEXT,
+				allowed_models TEXT DEFAULT '[]',
+				session_ids TEXT DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'archived')),
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at)
+			VALUES ('room-1', 'Test Room', ${Date.now()}, ${Date.now()})
+		`);
+
+		// Create legacy tasks table with the OLD 'failed' CHECK constraint
+		db.exec(`PRAGMA foreign_keys = OFF`);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'failed', 'cancelled')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				task_type TEXT DEFAULT 'coding' CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'goal_review')),
+				assigned_agent TEXT DEFAULT 'coder',
+				created_by_task_id TEXT,
+				archived_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`PRAGMA foreign_keys = ON`);
+	});
+
+	test('converts existing failed tasks to needs_attention', () => {
+		const now = Date.now();
+		db.exec(`PRAGMA ignore_check_constraints = 1`);
+		db.exec(`
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES
+				('t-failed', 'room-1', 'Failed Task', 'desc', 'failed', ${now}),
+				('t-pending', 'room-1', 'Pending Task', 'desc', 'pending', ${now}),
+				('t-completed', 'room-1', 'Completed Task', 'desc', 'completed', ${now}),
+				('t-cancelled', 'room-1', 'Cancelled Task', 'desc', 'cancelled', ${now})
+		`);
+		db.exec(`PRAGMA ignore_check_constraints = 0`);
+
+		runMigrations(db, () => {});
+
+		const failedTask = db.prepare(`SELECT status FROM tasks WHERE id = 't-failed'`).get() as {
+			status: string;
+		};
+		const pendingTask = db.prepare(`SELECT status FROM tasks WHERE id = 't-pending'`).get() as {
+			status: string;
+		};
+		const completedTask = db.prepare(`SELECT status FROM tasks WHERE id = 't-completed'`).get() as {
+			status: string;
+		};
+		const cancelledTask = db.prepare(`SELECT status FROM tasks WHERE id = 't-cancelled'`).get() as {
+			status: string;
+		};
+
+		expect(failedTask.status).toBe('needs_attention');
+		expect(pendingTask.status).toBe('pending');
+		expect(completedTask.status).toBe('completed');
+		expect(cancelledTask.status).toBe('cancelled');
+	});
+
+	test('updated constraint accepts needs_attention but rejects failed', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+
+		// Should accept needs_attention
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, created_at)
+				VALUES ('t-ok', 'room-1', 'Task', 'desc', 'needs_attention', ${now})
+			`);
+		}).not.toThrow();
+
+		// Should reject the old 'failed' status
+		expect(() => {
+			db.exec(`
+				INSERT INTO tasks (id, room_id, title, description, status, created_at)
+				VALUES ('t-bad', 'room-1', 'Task', 'desc', 'failed', ${now})
+			`);
+		}).toThrow();
+	});
+
+	test('is idempotent when run on already-migrated database', () => {
+		// Run migrations twice — should not throw
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// Ignore errors
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// Ignore errors
+		}
+	});
+});

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -281,9 +281,9 @@ describe('TaskRepository', () => {
 			const task = repository.createTask({ roomId: 'room-1', title: 'Task', description: 'Desc' });
 			const beforeTime = Date.now();
 
-			const updated = repository.updateTask(task.id, { status: 'failed' });
+			const updated = repository.updateTask(task.id, { status: 'needs_attention' });
 
-			expect(updated?.status).toBe('failed');
+			expect(updated?.status).toBe('needs_attention');
 			expect(updated?.completedAt).toBeDefined();
 			expect(updated?.completedAt).toBeGreaterThanOrEqual(beforeTime);
 		});
@@ -468,7 +468,7 @@ describe('TaskRepository', () => {
 
 			repository.updateTask(task1.id, { status: 'in_progress' });
 			repository.updateTask(task2.id, { status: 'completed' });
-			repository.updateTask(task3.id, { status: 'failed' });
+			repository.updateTask(task3.id, { status: 'needs_attention' });
 			// task4 stays pending
 
 			const activeCount = repository.countActiveTasks('room-1');
@@ -476,7 +476,7 @@ describe('TaskRepository', () => {
 			expect(activeCount).toBe(2); // pending + in_progress
 		});
 
-		it('should return 0 when all tasks are completed or failed', () => {
+		it('should return 0 when all task needs attention', () => {
 			const task1 = repository.createTask({
 				roomId: 'room-1',
 				title: 'Task 1',
@@ -489,7 +489,7 @@ describe('TaskRepository', () => {
 			});
 
 			repository.updateTask(task1.id, { status: 'completed' });
-			repository.updateTask(task2.id, { status: 'failed' });
+			repository.updateTask(task2.id, { status: 'needs_attention' });
 
 			const activeCount = repository.countActiveTasks('room-1');
 
@@ -557,12 +557,12 @@ describe('TaskRepository', () => {
 
 			// Fail task
 			repository.updateTask(task.id, {
-				status: 'failed',
+				status: 'needs_attention',
 				error: 'Connection timeout',
 			});
 
 			const failed = repository.getTask(task.id);
-			expect(failed?.status).toBe('failed');
+			expect(failed?.status).toBe('needs_attention');
 			expect(failed?.completedAt).toBeDefined();
 			expect(failed?.error).toBe('Connection timeout');
 		});

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -476,7 +476,7 @@ describe('TaskRepository', () => {
 			expect(activeCount).toBe(2); // pending + in_progress
 		});
 
-		it('should return 0 when all task needs attention', () => {
+		it('should return 0 when all tasks are completed or needs_attention', () => {
 			const task1 = repository.createTask({
 				roomId: 'room-1',
 				title: 'Task 1',

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -155,7 +155,7 @@ export type TaskStatus =
 	| 'in_progress'
 	| 'review'
 	| 'completed'
-	| 'failed'
+	| 'needs_attention'
 	| 'cancelled';
 
 /**

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -147,12 +147,13 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 		pending: 'bg-gray-700 text-gray-300',
 		in_progress: 'bg-yellow-900/50 text-yellow-300',
 		completed: 'bg-green-900/50 text-green-300',
-		failed: 'bg-red-900/50 text-red-300',
+		needs_attention: 'bg-red-900/50 text-red-300',
 		draft: 'bg-dark-600 text-gray-400',
 		review: 'bg-purple-900/50 text-purple-300',
 		cancelled: 'bg-gray-800 text-gray-400',
 	};
-	const label = status === 'in_progress' ? 'active' : status;
+	const label =
+		status === 'in_progress' ? 'active' : status === 'needs_attention' ? 'needs attention' : status;
 	return (
 		<span
 			class={cn(

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -66,7 +66,7 @@ describe('RoomTasks', () => {
 				createTask('t1', 'in_progress'),
 				createTask('t2', 'review'),
 				createTask('t3', 'completed'),
-				createTask('t4', 'failed'),
+				createTask('t4', 'needs_attention'),
 			];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
@@ -74,7 +74,7 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Active');
 			expect(container.textContent).toContain('Review');
 			expect(container.textContent).toContain('Done');
-			expect(container.textContent).toContain('Failed');
+			expect(container.textContent).toContain('Needs Attention');
 		});
 
 		it('should show correct counts on tabs', () => {
@@ -83,7 +83,7 @@ describe('RoomTasks', () => {
 				createTask('t2', 'pending'),
 				createTask('t3', 'review'),
 				createTask('t4', 'completed'),
-				createTask('t5', 'failed'),
+				createTask('t5', 'needs_attention'),
 				createTask('t6', 'cancelled'),
 			];
 
@@ -316,31 +316,31 @@ describe('RoomTasks', () => {
 		});
 	});
 
-	describe('Failed Tab', () => {
+	describe('Needs Attention Tab', () => {
 		beforeEach(() => {
-			selectedTabSignal.value = 'failed';
+			selectedTabSignal.value = 'needs_attention';
 		});
 
-		it('should render failed section with red header', () => {
-			const tasks = [createTask('t1', 'failed', { title: 'Broken task' })];
+		it('should render needs attention section with red header', () => {
+			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
 			const header = container.querySelector('h3.text-red-400');
 			expect(header).toBeTruthy();
-			expect(header?.textContent).toContain('Failed (1)');
+			expect(header?.textContent).toContain('Needs Attention (1)');
 		});
 
-		it('should show failed task titles', () => {
-			const tasks = [createTask('t1', 'failed', { title: 'Broken task' })];
+		it('should show needs attention task titles', () => {
+			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
 			expect(container.textContent).toContain('Broken task');
 		});
 
-		it('should have red background header for failed section', () => {
-			const tasks = [createTask('t1', 'failed')];
+		it('should have red background header for needs attention section', () => {
+			const tasks = [createTask('t1', 'needs_attention')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
@@ -348,9 +348,12 @@ describe('RoomTasks', () => {
 			expect(redHeader).toBeTruthy();
 		});
 
-		it('should show error message for failed tasks with error', () => {
+		it('should show error message for needs attention tasks with error', () => {
 			const tasks = [
-				createTask('t1', 'failed', { title: 'Broken task', error: 'Something went wrong' }),
+				createTask('t1', 'needs_attention', {
+					title: 'Broken task',
+					error: 'Something went wrong',
+				}),
 			];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
@@ -358,8 +361,8 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Something went wrong');
 		});
 
-		it('should not show error message for failed tasks without error', () => {
-			const tasks = [createTask('t1', 'failed', { title: 'Broken task' })];
+		it('should not show error message for needs attention tasks without error', () => {
+			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
@@ -401,9 +404,9 @@ describe('RoomTasks', () => {
 			expect(approveBtn).toBeFalsy();
 		});
 
-		it('should render cancelled separately from failed', () => {
+		it('should render cancelled separately from needs attention tasks', () => {
 			const tasks = [
-				createTask('t1', 'failed', { title: 'Error task' }),
+				createTask('t1', 'needs_attention', { title: 'Error task' }),
 				createTask('t2', 'cancelled', { title: 'Stopped task' }),
 			];
 
@@ -412,16 +415,16 @@ describe('RoomTasks', () => {
 			const headers = container.querySelectorAll('h3');
 			const headerTexts = Array.from(headers).map((h) => h.textContent);
 
-			expect(headerTexts).toContain('Failed (1)');
+			expect(headerTexts).toContain('Needs Attention (1)');
 			expect(headerTexts).toContain('Cancelled (1)');
 		});
 
-		it('should show empty state when no failed or cancelled tasks', () => {
+		it('should show empty state when no needs attention or cancelled tasks', () => {
 			const tasks = [createTask('t1', 'pending')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			expect(container.textContent).toContain('No failed tasks');
+			expect(container.textContent).toContain('No tasks needing attention');
 		});
 	});
 
@@ -463,21 +466,21 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Completed (1)');
 		});
 
-		it('should switch to failed tab when clicked', () => {
+		it('should switch to needs attention tab when clicked', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
-				createTask('t2', 'failed', { title: 'Failed task' }),
+				createTask('t2', 'needs_attention', { title: 'Needs attention task' }),
 			];
 
 			// Set to active BEFORE render
 			selectedTabSignal.value = 'active';
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			// Click failed tab
-			clickTab(container, 'Failed');
+			// Click needs attention tab
+			clickTab(container, 'Needs Attention');
 
-			// Should see failed section
-			expect(container.textContent).toContain('Failed (1)');
+			// Should see needs attention section
+			expect(container.textContent).toContain('Needs Attention (1)');
 		});
 	});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -5,20 +5,25 @@
  * - Active: pending + in_progress
  * - Review: review status (awaiting human action)
  * - Done: completed
- * - Failed: failed + cancelled
+ * - Needs Attention: needs_attention + cancelled
  */
 
 import { signal, effect } from '@preact/signals';
 import type { TaskSummary } from '@neokai/shared';
 
 /** Tab filter types */
-export type TaskFilterTab = 'active' | 'review' | 'done' | 'failed';
+export type TaskFilterTab = 'active' | 'review' | 'done' | 'needs_attention';
 
 /** Get initial tab from localStorage */
 function getInitialTab(): TaskFilterTab {
 	if (typeof window === 'undefined') return 'active';
 	const stored = localStorage.getItem('neokai:room:taskFilterTab');
-	if (stored === 'active' || stored === 'review' || stored === 'done' || stored === 'failed') {
+	if (
+		stored === 'active' ||
+		stored === 'review' ||
+		stored === 'done' ||
+		stored === 'needs_attention'
+	) {
 		return stored;
 	}
 	return 'active';
@@ -48,7 +53,8 @@ function getTabCounts(tasks: TaskSummary[]) {
 		active: tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress').length,
 		review: tasks.filter((t) => t.status === 'review').length,
 		done: tasks.filter((t) => t.status === 'completed').length,
-		failed: tasks.filter((t) => t.status === 'failed' || t.status === 'cancelled').length,
+		needs_attention: tasks.filter((t) => t.status === 'needs_attention' || t.status === 'cancelled')
+			.length,
 	};
 }
 
@@ -61,8 +67,8 @@ function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary
 			return tasks.filter((t) => t.status === 'review');
 		case 'done':
 			return tasks.filter((t) => t.status === 'completed');
-		case 'failed':
-			return tasks.filter((t) => t.status === 'failed' || t.status === 'cancelled');
+		case 'needs_attention':
+			return tasks.filter((t) => t.status === 'needs_attention' || t.status === 'cancelled');
 	}
 }
 
@@ -109,10 +115,10 @@ export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksPr
 					variant="green"
 				/>
 				<TabButton
-					label="Failed"
-					count={tabCounts.failed}
-					isActive={selectedTab === 'failed'}
-					onClick={() => handleTabClick('failed')}
+					label="Needs Attention"
+					count={tabCounts.needs_attention}
+					isActive={selectedTab === 'needs_attention'}
+					onClick={() => handleTabClick('needs_attention')}
 					variant="red"
 				/>
 			</div>
@@ -203,9 +209,9 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 			title: 'No completed tasks',
 			description: 'Completed tasks will appear here',
 		},
-		failed: {
-			title: 'No failed tasks',
-			description: 'Failed and cancelled tasks will appear here',
+		needs_attention: {
+			title: 'No tasks needing attention',
+			description: 'Tasks needing attention and cancelled tasks will appear here',
 		},
 	};
 
@@ -238,7 +244,7 @@ function TaskList({
 	// For Active tab, group by in_progress and pending
 	// For Review tab - all are review status
 	// For Done tab - all are completed
-	// For Failed tab - group by failed and cancelled
+	// For Needs Attention tab - group by needs_attention and cancelled
 
 	if (tab === 'active') {
 		const inProgress = tasks.filter((t) => t.status === 'in_progress');
@@ -302,18 +308,18 @@ function TaskList({
 		);
 	}
 
-	// Failed tab
-	const failed = tasks.filter((t) => t.status === 'failed');
+	// Needs Attention tab
+	const needsAttention = tasks.filter((t) => t.status === 'needs_attention');
 	const cancelled = tasks.filter((t) => t.status === 'cancelled');
 
 	return (
 		<div class="space-y-4">
-			{failed.length > 0 && (
+			{needsAttention.length > 0 && (
 				<TaskGroup
-					title="Failed"
-					count={failed.length}
+					title="Needs Attention"
+					count={needsAttention.length}
 					variant="red"
-					tasks={failed}
+					tasks={needsAttention}
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
 					showAlert
@@ -502,7 +508,7 @@ function TaskItem({
 					{isClickable && <span class="text-xs text-gray-600">&rarr;</span>}
 				</div>
 			</div>
-			{task.status === 'failed' && task.error && (
+			{task.status === 'needs_attention' && task.error && (
 				<p class="text-xs text-red-400 mt-1.5 line-clamp-2" title={task.error}>
 					{task.error}
 				</p>

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -18,6 +18,8 @@ export type TaskFilterTab = 'active' | 'review' | 'done' | 'needs_attention';
 function getInitialTab(): TaskFilterTab {
 	if (typeof window === 'undefined') return 'active';
 	const stored = localStorage.getItem('neokai:room:taskFilterTab');
+	// Migrate old 'failed' tab value to 'needs_attention'
+	if (stored === 'failed') return 'needs_attention';
 	if (
 		stored === 'active' ||
 		stored === 'review' ||

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -879,9 +879,9 @@ describe('TaskView — Task options dropdown menu', () => {
 		expect(menuButton).toBeNull();
 	});
 
-	it('does NOT show task options menu for failed tasks', async () => {
+	it('does NOT show cancel button for needs_attention tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
-			if (method === 'task.get') return { task: makeTask('task-1', 'failed') };
+			if (method === 'task.get') return { task: makeTask('task-1', 'needs_attention') };
 			if (method === 'task.getGroup') return { group: null };
 			return {};
 		});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -96,7 +96,7 @@ const TASK_STATUS_COLORS: Record<string, string> = {
 	pending: 'text-gray-400',
 	in_progress: 'text-yellow-400',
 	completed: 'text-green-400',
-	failed: 'text-red-400',
+	needs_attention: 'text-red-400',
 	review: 'text-purple-400',
 	draft: 'text-gray-500',
 	cancelled: 'text-gray-500',
@@ -1046,8 +1046,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 										? 'Waiting for the runtime to pick up this task.'
 										: task.status === 'completed'
 											? 'This task has been completed.'
-											: task.status === 'failed'
-												? 'This task has failed.'
+											: task.status === 'needs_attention'
+												? 'This task needs attention.'
 												: task.status === 'review'
 													? 'This task is awaiting human review.'
 													: task.status === 'draft'


### PR DESCRIPTION
Tasks with 'failed' status can be restarted, revived to review, and receive
human messages - 'needs_attention' better reflects this human-in-the-loop role.

Changes:
- Update TaskStatus union type in shared/src/types/neo.ts
- Update VALID_STATUS_TRANSITIONS in task-manager.ts
- Update setTaskStatus() and failTask() to use 'needs_attention'
- Add SQLite Migration 23 to rename existing 'failed' task rows
- Update runtime: task-handlers.ts, room-agent-tools.ts, room-runtime.ts,
  goal-manager.ts, room-manager.ts, task-repository.ts
- Update web UI: RoomTasks.tsx, TaskView.tsx, GoalsEditor.tsx
- Update all test files to expect 'needs_attention' status
- Add migration-23 unit test
- Update task-status-control-design.md

Note: session_groups.state 'failed', jobs.status 'failed', and
sdk_messages.send_status 'failed' are unchanged (separate domains).
