### PR TITLE
fix: bridge room events from DaemonHub to WebSocket clients in StateManager

### DIFF
--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -211,6 +211,61 @@ export class StateManager {
 			this.errorCache.set(data.sessionId, null);
 			await this.broadcastSessionStateChange(data.sessionId);
 		});
+
+		// =====================================================================
+		// Room event bridge: forward DaemonHub room events → WebSocket clients
+		//
+		// DaemonHub (TypedHub/InProcessTransportBus) is internal-only and never
+		// reaches frontend WebSocket clients directly. Each event below must be
+		// forwarded to messageHub so the router delivers it to the room channel
+		// (clients that called hub.joinChannel(`room:${roomId}`)).
+		// =====================================================================
+
+		// Task status changes — main real-time sync event
+		this.eventBus.on('room.task.update', (data) => {
+			this.messageHub.event('room.task.update', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		// Full room overview (sessions + tasks) — sent on join and after broad changes
+		this.eventBus.on('room.overview', (data) => {
+			this.messageHub.event('room.overview', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		// Runtime state changes (running/paused/stopped)
+		this.eventBus.on('room.runtime.stateChanged', (data) => {
+			this.messageHub.event('room.runtime.stateChanged', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		// Goal lifecycle events
+		this.eventBus.on('goal.created', (data) => {
+			this.messageHub.event('goal.created', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		this.eventBus.on('goal.updated', (data) => {
+			this.messageHub.event('goal.updated', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		this.eventBus.on('goal.completed', (data) => {
+			this.messageHub.event('goal.completed', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
+
+		this.eventBus.on('goal.progressUpdated', (data) => {
+			this.messageHub.event('goal.progressUpdated', data, {
+				channel: data.sessionId, // 'room:${roomId}'
+			});
+		});
 	}
 
 	/**

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -565,6 +565,173 @@ describe('StateManager', () => {
 				expect(systemCall[1].apiConnection).toEqual(connectionData);
 			});
 		});
+
+		describe('room event bridge', () => {
+			it('should register room event handlers on initialization', () => {
+				expect(eventHandlers.has('room.task.update')).toBe(true);
+				expect(eventHandlers.has('room.overview')).toBe(true);
+				expect(eventHandlers.has('room.runtime.stateChanged')).toBe(true);
+				expect(eventHandlers.has('goal.created')).toBe(true);
+				expect(eventHandlers.has('goal.updated')).toBe(true);
+				expect(eventHandlers.has('goal.completed')).toBe(true);
+				expect(eventHandlers.has('goal.progressUpdated')).toBe(true);
+			});
+
+			describe('room.task.update', () => {
+				it('should forward task update to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('room.task.update');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						task: { id: 'task-1', title: 'Task 1', status: 'in_progress' },
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('room.task.update', data, {
+						channel: 'room:room-123',
+					});
+				});
+
+				it('should use sessionId as channel (supports any room)', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('room.task.update');
+					const data = {
+						sessionId: 'room:another-room',
+						roomId: 'another-room',
+						task: { id: 'task-2', title: 'Task 2', status: 'pending' },
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('room.task.update', data, {
+						channel: 'room:another-room',
+					});
+				});
+			});
+
+			describe('room.overview', () => {
+				it('should forward room overview to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('room.overview');
+					const data = {
+						sessionId: 'room:room-123',
+						room: { id: 'room-123', name: 'Test Room' },
+						sessions: [],
+						activeTasks: [],
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('room.overview', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+
+			describe('room.runtime.stateChanged', () => {
+				it('should forward runtime state change to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('room.runtime.stateChanged');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						state: 'running',
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('room.runtime.stateChanged', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+
+			describe('goal.created', () => {
+				it('should forward goal creation to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('goal.created');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						goalId: 'goal-1',
+						goal: { id: 'goal-1', title: 'Goal 1', status: 'active' },
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.created', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+
+			describe('goal.updated', () => {
+				it('should forward goal updates to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('goal.updated');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						goalId: 'goal-1',
+						goal: { title: 'Updated Goal 1' },
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.updated', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+
+			describe('goal.completed', () => {
+				it('should forward goal completion to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('goal.completed');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						goalId: 'goal-1',
+						goal: { id: 'goal-1', title: 'Goal 1', status: 'completed' },
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.completed', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+
+			describe('goal.progressUpdated', () => {
+				it('should forward goal progress updates to room channel', () => {
+					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+
+					const handler = eventHandlers.get('goal.progressUpdated');
+					const data = {
+						sessionId: 'room:room-123',
+						roomId: 'room-123',
+						goalId: 'goal-1',
+						progress: 75,
+					};
+
+					handler!(data);
+
+					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.progressUpdated', data, {
+						channel: 'room:room-123',
+					});
+				});
+			});
+		});
 	});
 
 	describe('broadcastSessionsChange', () => {


### PR DESCRIPTION
Task status updates (room.task.update, room.overview, room.runtime.stateChanged,
goal.created/updated/completed/progressUpdated) were emitted to DaemonHub
(TypedHub/InProcessTransportBus) but never forwarded to WebSocket clients,
causing the UI to only reflect state after a page refresh.

Root cause: DaemonHub is an in-process event bus completely separate from the
WebSocket MessageHub. StateManager already bridged session events but had no
bridge for room events.

Fix: Add event listeners in StateManager.setupEventListeners() that subscribe
to each room event on the DaemonHub and forward them to messageHub.event()
with channel set to data.sessionId ('room:${roomId}'), routing to all frontend
clients that have joined the room channel.

Add tests verifying all 7 bridged events are registered and forwarded correctly.
