### PR TITLE
fix: pause task when worker/leader asks question instead of routing to next agent

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -419,6 +419,23 @@ export class RoomRuntime {
 		const task = await this.taskManager.getTask(group.taskId);
 		if (!task) return;
 
+		// Check if worker is waiting for user input (asked a question)
+		// Pause routing to leader — task resumes when question is answered
+		if (terminalState.kind === 'waiting_for_input') {
+			log.info(`Worker ${group.workerSessionId} is waiting for user input - pausing task`);
+			this.groupRepo.setWaitingForQuestion(groupId, true, 'worker');
+			this.appendGroupEvent(groupId, 'status', {
+				text: 'Worker asked a question. Waiting for human response.',
+			});
+			await this.emitTaskUpdateById(group.taskId);
+			return;
+		}
+
+		// Clear waiting flag if it was set (worker resumed after question was answered)
+		if (group.waitingForQuestion && group.waitingSession === 'worker') {
+			this.groupRepo.setWaitingForQuestion(groupId, false, null);
+		}
+
 		// Check if generation was interrupted by human — skip routing to leader, await user input
 		if (group.humanInterrupted) {
 			this.groupRepo.setHumanInterrupted(groupId, false);
@@ -600,9 +617,26 @@ export class RoomRuntime {
 	 * Called when Leader reaches a terminal state.
 	 * No state checks - leader can finish without calling a tool.
 	 */
-	async onLeaderTerminalState(groupId: string, _terminalState: TerminalState): Promise<void> {
+	async onLeaderTerminalState(groupId: string, terminalState: TerminalState): Promise<void> {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return;
+
+		// Check if leader is waiting for user input (asked a question)
+		// Pause — task resumes when question is answered
+		if (terminalState.kind === 'waiting_for_input') {
+			log.info(`Leader ${group.leaderSessionId} is waiting for user input - pausing task`);
+			this.groupRepo.setWaitingForQuestion(groupId, true, 'leader');
+			this.appendGroupEvent(groupId, 'status', {
+				text: 'Leader asked a question. Waiting for human response.',
+			});
+			await this.emitTaskUpdateById(group.taskId);
+			return;
+		}
+
+		// Clear waiting flag if it was set (leader resumed after question was answered)
+		if (group.waitingForQuestion && group.waitingSession === 'leader') {
+			this.groupRepo.setWaitingForQuestion(groupId, false, null);
+		}
 
 		// Check rate limit backoff
 		if (this.groupRepo.isRateLimited(groupId)) {

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -66,6 +66,10 @@ interface TaskGroupMetadata {
 	humanInterrupted?: boolean;
 	/** Gate failure history for dead loop detection */
 	gateFailures?: GateFailureRecord[];
+	/** Whether the group is paused waiting for a question to be answered */
+	waitingForQuestion?: boolean;
+	/** Which session is waiting for a question answer ('worker' | 'leader' | null) */
+	waitingSession?: 'worker' | 'leader' | null;
 }
 
 function defaultMetadata(): TaskGroupMetadata {
@@ -118,6 +122,10 @@ export interface SessionGroup {
 	deferredLeader: DeferredLeaderConfig | null;
 	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
 	humanInterrupted: boolean;
+	/** Whether the group is paused waiting for a question to be answered */
+	waitingForQuestion: boolean;
+	/** Which session is waiting for a question answer ('worker' | 'leader' | null) */
+	waitingSession: 'worker' | 'leader' | null;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -461,6 +469,28 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Set waitingForQuestion flag without version check.
+	 * When set, the group is paused waiting for a human answer to an agent question.
+	 */
+	setWaitingForQuestion(
+		groupId: string,
+		waiting: boolean,
+		session: 'worker' | 'leader' | null
+	): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		const merged = { ...currentMeta, waitingForQuestion: waiting, waitingSession: session };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
 	 * Persist deferred Leader bootstrap configuration.
 	 * Stored in metadata so runtime restart can still lazy-create the leader session.
 	 */
@@ -678,6 +708,8 @@ export class SessionGroupRepository {
 			rateLimit: meta.rateLimit ?? null,
 			deferredLeader: meta.deferredLeader ?? null,
 			humanInterrupted: meta.humanInterrupted === true,
+			waitingForQuestion: meta.waitingForQuestion ?? false,
+			waitingSession: meta.waitingSession ?? null,
 			createdAt: row.created_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
 		};

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -160,6 +160,70 @@ describe('RoomRuntime flow', () => {
 			const updated = ctx.groupRepo.getGroup(group.id);
 			expect(updated!.submittedForReview).toBe(false);
 		});
+
+		it('should pause task (not route to leader) when worker is waiting_for_input', async () => {
+			await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const groups = ctx.groupRepo.getActiveGroups('room-1');
+			const group = groups[0];
+
+			// Record factory calls before worker terminal state
+			const callsBefore = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			).length;
+
+			// Worker asks a question
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'waiting_for_input',
+			});
+
+			// Should NOT have routed to leader
+			const leaderCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			);
+			expect(leaderCalls.length).toBe(callsBefore);
+
+			// Group should be marked as waiting for question
+			const updated = ctx.groupRepo.getGroup(group.id);
+			expect(updated!.waitingForQuestion).toBe(true);
+			expect(updated!.waitingSession).toBe('worker');
+
+			// Group should still be active (not completed)
+			expect(updated!.completedAt).toBeNull();
+		});
+
+		it('should resume routing after worker answers question and returns idle', async () => {
+			await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const groups = ctx.groupRepo.getActiveGroups('room-1');
+			const group = groups[0];
+
+			// Step 1: Worker asks a question → task pauses
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'waiting_for_input',
+			});
+
+			const afterQuestion = ctx.groupRepo.getGroup(group.id)!;
+			expect(afterQuestion.waitingForQuestion).toBe(true);
+			expect(afterQuestion.waitingSession).toBe('worker');
+
+			// Step 2: Question answered, worker completes work → idle
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// waiting flag should be cleared
+			const afterResume = ctx.groupRepo.getGroup(group.id)!;
+			expect(afterResume.waitingForQuestion).toBe(false);
+			expect(afterResume.waitingSession).toBeNull();
+		});
 	});
 
 	describe('cancelTask', () => {
@@ -799,6 +863,49 @@ describe('RoomRuntime flow', () => {
 			// Leader terminal state should be no-op (tool was called)
 			const updated = ctx.groupRepo.getGroup(group.id);
 			expect(updated!.completedAt).not.toBeNull();
+		});
+
+		it('should pause task (not complete/route) when leader is waiting_for_input', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+
+			// Leader asks a question
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'waiting_for_input',
+			});
+
+			// Group should be marked as waiting for question
+			const updated = ctx.groupRepo.getGroup(group.id);
+			expect(updated!.waitingForQuestion).toBe(true);
+			expect(updated!.waitingSession).toBe('leader');
+
+			// Group should still be active (not completed)
+			expect(updated!.completedAt).toBeNull();
+		});
+
+		it('should clear waiting flag when leader resumes and reaches idle', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+
+			// Step 1: Leader asks a question
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'waiting_for_input',
+			});
+
+			const afterQuestion = ctx.groupRepo.getGroup(group.id)!;
+			expect(afterQuestion.waitingForQuestion).toBe(true);
+			expect(afterQuestion.waitingSession).toBe('leader');
+
+			// Step 2: Question answered, leader resumes → idle
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// waiting flag should be cleared
+			const afterResume = ctx.groupRepo.getGroup(group.id)!;
+			expect(afterResume.waitingForQuestion).toBe(false);
+			expect(afterResume.waitingSession).toBeNull();
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -396,6 +396,39 @@ describe('SessionGroupRepository', () => {
 		});
 	});
 
+	describe('setWaitingForQuestion', () => {
+		it('should default to waitingForQuestion=false and waitingSession=null', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			expect(group.waitingForQuestion).toBe(false);
+			expect(group.waitingSession).toBeNull();
+		});
+
+		it('should set waitingForQuestion=true and waitingSession=worker', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.setWaitingForQuestion(group.id, true, 'worker');
+			const updated = repo.getGroup(group.id)!;
+			expect(updated.waitingForQuestion).toBe(true);
+			expect(updated.waitingSession).toBe('worker');
+		});
+
+		it('should set waitingForQuestion=true and waitingSession=leader', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.setWaitingForQuestion(group.id, true, 'leader');
+			const updated = repo.getGroup(group.id)!;
+			expect(updated.waitingForQuestion).toBe(true);
+			expect(updated.waitingSession).toBe('leader');
+		});
+
+		it('should clear waitingForQuestion flag', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.setWaitingForQuestion(group.id, true, 'worker');
+			repo.setWaitingForQuestion(group.id, false, null);
+			const updated = repo.getGroup(group.id)!;
+			expect(updated.waitingForQuestion).toBe(false);
+			expect(updated.waitingSession).toBeNull();
+		});
+	});
+
 	describe('optimistic locking', () => {
 		it('should prevent concurrent updates', () => {
 			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);


### PR DESCRIPTION
When a worker or leader session reaches waiting_for_input state (AskUserQuestion
called), the runtime now pauses instead of routing to the next agent. The group
is marked with waitingForQuestion=true/waitingSession=worker|leader to track state.
When the session resumes after the question is answered and reaches idle, the
waiting flag is cleared and normal routing proceeds.

- Add waiting_for_input check in onWorkerTerminalState (return early, don't route to leader)
- Add waiting_for_input check in onLeaderTerminalState (return early, don't complete/route)
- Add waitingForQuestion and waitingSession fields to SessionGroup/TaskGroupMetadata
- Add setWaitingForQuestion() method to SessionGroupRepository
- Add unit tests for all new behavior
