### PR TITLE
feat: add PR number and URL as first-class task fields with UI buttons

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -137,6 +137,8 @@ export class RoomManager {
 			dependsOn: task.dependsOn,
 			error: task.error,
 			activeSession: task.activeSession,
+			prUrl: task.prUrl,
+			prNumber: task.prNumber,
 		});
 		const nonTerminal = tasks.filter(
 			(t) => t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -34,6 +34,15 @@ export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 };
 
 /**
+ * Parse PR URL to extract PR number.
+ * Supports: https://github.com/org/repo/pull/123
+ */
+export function extractPrNumber(prUrl: string): number | null {
+	const match = prUrl.match(/\/pull\/(\d+)/);
+	return match ? parseInt(match[1], 10) : null;
+}
+
+/**
  * Check if a status transition is valid
  */
 export function isValidStatusTransition(from: TaskStatus, to: TaskStatus): boolean {
@@ -266,9 +275,14 @@ export class TaskManager {
 	 * Move task to review (work done, awaiting human approval)
 	 */
 	async reviewTask(taskId: string, prUrl?: string): Promise<NeoTask> {
+		const prNumber = prUrl ? extractPrNumber(prUrl) : null;
+		const prCreatedAt = prUrl ? Date.now() : null;
 		return this.updateTaskStatus(taskId, 'review', {
-			currentStep: prUrl,
+			currentStep: prUrl ?? 'Awaiting review', // Keep for backward compatibility
 			progress: 80,
+			prUrl: prUrl ?? null,
+			prNumber,
+			prCreatedAt,
 		});
 	}
 

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -165,6 +165,18 @@ export class TaskRepository {
 			fields.push('active_session = ?');
 			values.push(null);
 		}
+		if (params.prUrl !== undefined) {
+			fields.push('pr_url = ?');
+			values.push(params.prUrl ?? null);
+		}
+		if (params.prNumber !== undefined) {
+			fields.push('pr_number = ?');
+			values.push(params.prNumber ?? null);
+		}
+		if (params.prCreatedAt !== undefined) {
+			fields.push('pr_created_at = ?');
+			values.push(params.prCreatedAt ?? null);
+		}
 		if (fields.length > 0) {
 			values.push(id);
 			const stmt = this.db.prepare(`UPDATE tasks SET ${fields.join(', ')} WHERE id = ?`);
@@ -259,6 +271,9 @@ export class TaskRepository {
 			completedAt: (row.completed_at as number | null) ?? undefined,
 			archivedAt: (row.archived_at as number | null) ?? undefined,
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,
+			prUrl: (row.pr_url as string | null) ?? undefined,
+			prNumber: (row.pr_number as number | null) ?? undefined,
+			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,
 		};
 	}
 }

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -157,6 +157,9 @@ export function createTables(db: BunDatabase): void {
         created_by_task_id TEXT,
         archived_at INTEGER,
         active_session TEXT,
+        pr_url TEXT,
+        pr_number INTEGER,
+        pr_created_at INTEGER,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -96,6 +96,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 24: Rename 'failed' task status to 'needs_attention' for better semantic clarity
 	runMigration24(db);
+
+	// Migration 25: Add PR fields to tasks table
+	runMigration25(db);
 }
 
 /**
@@ -1106,6 +1109,9 @@ function runMigration24(db: BunDatabase): void {
 				created_by_task_id TEXT,
 				archived_at INTEGER,
 				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
 				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
 			)
 		`);
@@ -1132,6 +1138,9 @@ function runMigration24(db: BunDatabase): void {
 			'created_by_task_id',
 			'archived_at',
 			'active_session',
+			'pr_url',
+			'pr_number',
+			'pr_created_at',
 		];
 		for (const col of optionalCols) {
 			if (tableHasColumn(db, 'tasks', col)) baseCols.push(col);
@@ -1155,6 +1164,27 @@ function runMigration24(db: BunDatabase): void {
 		db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
+	}
+}
+
+/**
+ * Migration 25: Add PR fields to tasks table.
+ *
+ * Adds pr_url, pr_number, pr_created_at as first-class columns so PR data
+ * is no longer stored as a hack in current_step.
+ */
+function runMigration25(db: BunDatabase): void {
+	if (!tableExists(db, 'tasks')) {
+		return;
+	}
+	if (!tableHasColumn(db, 'tasks', 'pr_url')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN pr_url TEXT`);
+	}
+	if (!tableHasColumn(db, 'tasks', 'pr_number')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN pr_number INTEGER`);
+	}
+	if (!tableHasColumn(db, 'tasks', 'pr_created_at')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN pr_created_at INTEGER`);
 	}
 }
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -55,7 +55,10 @@ describe('Room Agent Tools', () => {
 				started_at INTEGER,
 				completed_at INTEGER,
 				archived_at INTEGER,
-				active_session TEXT
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -132,7 +132,10 @@ const DB_SCHEMA = `
 		assigned_agent TEXT DEFAULT 'coder',
 		created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
 		archived_at INTEGER,
-		active_session TEXT
+		active_session TEXT,
+		pr_url TEXT,
+		pr_number INTEGER,
+		pr_created_at INTEGER
 	);
 	CREATE TABLE session_groups (
 		id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -113,7 +113,10 @@ describe('Runtime Recovery', () => {
 				assigned_agent TEXT DEFAULT 'coder',
 				created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
 				archived_at INTEGER,
-				active_session TEXT
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -36,7 +36,10 @@ describe('SessionGroupRepository', () => {
 				started_at INTEGER,
 				completed_at INTEGER,
 				archived_at INTEGER,
-				active_session TEXT
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -202,7 +202,10 @@ describe('TaskGroupManager', () => {
 				assigned_agent TEXT DEFAULT 'coder',
 				created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
 				archived_at INTEGER,
-				active_session TEXT
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
-import { TaskManager } from '../../../src/lib/room/managers/task-manager';
+import { TaskManager, extractPrNumber } from '../../../src/lib/room/managers/task-manager';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 
 describe('TaskManager', () => {
@@ -441,6 +441,31 @@ describe('TaskManager', () => {
 			const updated = await taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/1');
 
 			expect(updated.status).toBe('review');
+			expect(updated.prUrl).toBe('https://github.com/org/repo/pull/1');
+			expect(updated.prNumber).toBe(1);
+			expect(updated.prCreatedAt).toBeDefined();
+		});
+
+		it('should extract PR number from GitHub URL', async () => {
+			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
+
+			const updated = await taskManager.reviewTask(
+				task.id,
+				'https://github.com/myorg/myrepo/pull/123'
+			);
+
+			expect(updated.prNumber).toBe(123);
+		});
+
+		it('should set null PR fields when no prUrl provided', async () => {
+			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
+
+			const updated = await taskManager.reviewTask(task.id);
+
+			expect(updated.status).toBe('review');
+			expect(updated.prUrl).toBeUndefined();
+			expect(updated.prNumber).toBeUndefined();
+			expect(updated.prCreatedAt).toBeUndefined();
 		});
 
 		it('should throw error for non-existent task', async () => {
@@ -884,5 +909,27 @@ describe('TaskManager', () => {
 			const fetched = await taskManager.getTask(task.id);
 			expect(fetched!.activeSession).toBe('worker');
 		});
+	});
+});
+
+describe('extractPrNumber', () => {
+	it('should extract PR number from GitHub URL', () => {
+		expect(extractPrNumber('https://github.com/org/repo/pull/123')).toBe(123);
+	});
+
+	it('should extract PR number from URL with trailing path', () => {
+		expect(extractPrNumber('https://github.com/org/repo/pull/42/files')).toBe(42);
+	});
+
+	it('should return null for URL without pull segment', () => {
+		expect(extractPrNumber('https://github.com/org/repo')).toBeNull();
+	});
+
+	it('should handle large PR numbers', () => {
+		expect(extractPrNumber('https://github.com/org/repo/pull/9999')).toBe(9999);
+	});
+
+	it('should return null for empty string', () => {
+		expect(extractPrNumber('')).toBeNull();
 	});
 });

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -42,7 +42,10 @@ describe('TaskRepository', () => {
 				started_at INTEGER,
 				completed_at INTEGER,
 				archived_at INTEGER,
-				active_session TEXT
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER
 			);
 
 			CREATE INDEX idx_tasks_room ON tasks(room_id);
@@ -578,6 +581,65 @@ describe('TaskRepository', () => {
 
 			const reviewed = repository.getTask(task.id);
 			expect(reviewed?.status).toBe('review');
+		});
+	});
+
+	describe('PR fields', () => {
+		it('should default PR fields to undefined on creation', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'Task without PR',
+				description: '',
+			});
+
+			expect(task.prUrl).toBeUndefined();
+			expect(task.prNumber).toBeUndefined();
+			expect(task.prCreatedAt).toBeUndefined();
+		});
+
+		it('should update PR fields', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'PR Task',
+				description: '',
+			});
+			const now = Date.now();
+
+			repository.updateTask(task.id, {
+				prUrl: 'https://github.com/org/repo/pull/42',
+				prNumber: 42,
+				prCreatedAt: now,
+			});
+
+			const updated = repository.getTask(task.id);
+			expect(updated?.prUrl).toBe('https://github.com/org/repo/pull/42');
+			expect(updated?.prNumber).toBe(42);
+			expect(updated?.prCreatedAt).toBe(now);
+		});
+
+		it('should allow clearing PR fields to null', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'PR Task',
+				description: '',
+			});
+
+			repository.updateTask(task.id, {
+				prUrl: 'https://github.com/org/repo/pull/1',
+				prNumber: 1,
+				prCreatedAt: Date.now(),
+			});
+
+			repository.updateTask(task.id, {
+				prUrl: null,
+				prNumber: null,
+				prCreatedAt: null,
+			});
+
+			const cleared = repository.getTask(task.id);
+			expect(cleared?.prUrl).toBeUndefined();
+			expect(cleared?.prNumber).toBeUndefined();
+			expect(cleared?.prCreatedAt).toBeUndefined();
 		});
 	});
 });

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -302,6 +302,7 @@ export interface SubagentConfig {
 	name?: string;
 	/** Optional description of what this sub-agent specializes in */
 	description?: string;
+}
 
 // ============================================================================
 // Runtime Types

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -219,6 +219,12 @@ export interface NeoTask {
 	 * Allows the UI to show a "working" indicator even when status is 'review'.
 	 */
 	activeSession?: 'worker' | 'leader' | null;
+	/** Pull request URL (when task has associated PR) */
+	prUrl?: string | null;
+	/** Pull request number (extracted from URL for display) */
+	prNumber?: number | null;
+	/** When PR was created/submitted (milliseconds since epoch) */
+	prCreatedAt?: number | null;
 }
 
 /**
@@ -265,6 +271,9 @@ export interface UpdateTaskParams {
 	dependsOn?: string[];
 	/** Which session is actively generating output. null clears the indicator. */
 	activeSession?: 'worker' | 'leader' | null;
+	prUrl?: string | null;
+	prNumber?: number | null;
+	prCreatedAt?: number | null;
 }
 
 // ============================================================================
@@ -293,7 +302,6 @@ export interface SubagentConfig {
 	name?: string;
 	/** Optional description of what this sub-agent specializes in */
 	description?: string;
-}
 
 // ============================================================================
 // Runtime Types
@@ -333,6 +341,10 @@ export interface TaskSummary {
 	error?: string | null;
 	/** Which session is actively generating output (see NeoTask.activeSession) */
 	activeSession?: 'worker' | 'leader' | null;
+	/** Pull request URL (if available) */
+	prUrl?: string | null;
+	/** Pull request number (if available) */
+	prNumber?: number | null;
 }
 
 /**

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -589,4 +589,62 @@ describe('RoomTasks', () => {
 			expect(container.textContent).not.toContain('Worker working');
 		});
 	});
+
+	describe('PR Button', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
+		it('should render PR button when prUrl is set', () => {
+			const tasks = [
+				createTask('t1', 'review', {
+					prUrl: 'https://github.com/org/repo/pull/42',
+					prNumber: 42,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/42"]');
+			expect(prLink).toBeTruthy();
+			expect(container.textContent).toContain('PR #42');
+		});
+
+		it('should not render PR button when prUrl is not set', () => {
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLinks = container.querySelectorAll('a[href*="/pull/"]');
+			expect(prLinks).toHaveLength(0);
+		});
+
+		it('should open PR link in new tab', () => {
+			const tasks = [
+				createTask('t1', 'review', {
+					prUrl: 'https://github.com/org/repo/pull/7',
+					prNumber: 7,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLink = container.querySelector('a[href*="/pull/"]') as HTMLAnchorElement;
+			expect(prLink?.target).toBe('_blank');
+			expect(prLink?.rel).toContain('noopener');
+		});
+
+		it('should show PR number in button text', () => {
+			const tasks = [
+				createTask('t1', 'review', {
+					prUrl: 'https://github.com/org/repo/pull/99',
+					prNumber: 99,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('PR #99');
+		});
+	});
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -485,6 +485,21 @@ function TaskItem({
 					{task.progress !== undefined && (
 						<span class="text-xs text-gray-400">{task.progress}%</span>
 					)}
+					{task.prUrl && (
+						<a
+							href={task.prUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={(e) => e.stopPropagation()}
+							class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-purple-400 bg-purple-500/10 hover:bg-purple-500/20 border border-purple-500/30 rounded transition-colors"
+							title="View Pull Request"
+						>
+							<svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16 16">
+								<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+							</svg>
+							<span>PR #{task.prNumber ?? '?'}</span>
+						</a>
+					)}
 					{showApprove && (
 						<button
 							onClick={(e) => {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -105,13 +105,15 @@ const TASK_STATUS_COLORS: Record<string, string> = {
 interface HeaderReviewBarProps {
 	roomId: string;
 	taskId: string;
+	/** Task data for PR link display */
+	task?: NeoTask | null;
 	/** Called after approval to refresh the conversation */
 	onApproved: () => void;
 	/** Called after rejection to refresh the conversation */
 	onRejected: () => void;
 }
 
-function HeaderReviewBar({ roomId, taskId, onApproved, onRejected }: HeaderReviewBarProps) {
+function HeaderReviewBar({ roomId, taskId, task, onApproved, onRejected }: HeaderReviewBarProps) {
 	const { request } = useMessageHub();
 	const [approving, setApproving] = useState(false);
 	const [rejecting, setRejecting] = useState(false);
@@ -157,6 +159,33 @@ function HeaderReviewBar({ roomId, taskId, onApproved, onRejected }: HeaderRevie
 					<span class="text-amber-400 text-sm font-medium">
 						Review the PR and approve or provide feedback below
 					</span>
+					{/* PR link button */}
+					{task?.prUrl && (
+						<a
+							href={task.prUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-gray-300 bg-dark-700 hover:bg-dark-600 border border-dark-600 rounded transition-colors"
+						>
+							<svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16 16">
+								<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+							</svg>
+							<span>PR #{task.prNumber ?? '?'}</span>
+							<svg
+								class="w-3 h-3 text-gray-500"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+								/>
+							</svg>
+						</a>
+					)}
 				</div>
 				{/* Action buttons */}
 				<div class="flex items-center gap-2">
@@ -942,6 +971,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				<HeaderReviewBar
 					roomId={roomId}
 					taskId={taskId}
+					task={task}
 					onApproved={() => setConversationKey((k) => k + 1)}
 					onRejected={() => setConversationKey((k) => k + 1)}
 				/>


### PR DESCRIPTION
- Add prUrl, prNumber, prCreatedAt fields to NeoTask, TaskSummary, and UpdateTaskParams types
- Add migration 23 to add pr_url, pr_number, pr_created_at columns to tasks table
- Update task schema (createTables) to include PR columns for fresh databases
- Update task repository to persist/read new PR fields in rowToTask and updateTask
- Update room manager to include prUrl/prNumber in TaskSummary projections
- Update task manager reviewTask to extract PR number from URL and store all PR data
- Export extractPrNumber utility function from task-manager
- Add PR button to TaskView HeaderReviewBar when task has a prUrl
- Add PR button to RoomTasks TaskItem when task has a prUrl
- Add unit tests: extractPrNumber, reviewTask PR assertions, PR field CRUD
- Add frontend tests: PR button render/visibility/target/number display
- Update 5 test schema definitions to include new PR columns
