### PR TITLE
feat: add activeSession indicator to show agent activity in review tasks

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -136,6 +136,7 @@ export class RoomManager {
 			progress: task.progress,
 			dependsOn: task.dependsOn,
 			error: task.error,
+			activeSession: task.activeSession,
 		});
 		const nonTerminal = tasks.filter(
 			(t) => t.status !== 'completed' && t.status !== 'failed' && t.status !== 'cancelled'

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -419,6 +419,11 @@ export class RoomRuntime {
 		const task = await this.taskManager.getTask(group.taskId);
 		if (!task) return;
 
+		// Clear active session indicator — worker is no longer generating output
+		if (task.activeSession === 'worker') {
+			await this.taskManager.updateTaskStatus(task.id, task.status, { activeSession: null });
+		}
+
 		// Check if worker is waiting for user input (asked a question)
 		// Pause routing to leader — task resumes when question is answered
 		if (terminalState.kind === 'waiting_for_input') {
@@ -620,6 +625,14 @@ export class RoomRuntime {
 	async onLeaderTerminalState(groupId: string, terminalState: TerminalState): Promise<void> {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return;
+
+		// Clear active session indicator — leader is no longer generating output
+		const leaderTask = await this.taskManager.getTask(group.taskId);
+		if (leaderTask?.activeSession === 'leader') {
+			await this.taskManager.updateTaskStatus(leaderTask.id, leaderTask.status, {
+				activeSession: null,
+			});
+		}
 
 		// Check if leader is waiting for user input (asked a question)
 		// Pause — task resumes when question is answered
@@ -1259,6 +1272,16 @@ export class RoomRuntime {
 			log.error(`Failed to inject message into worker session ${group.workerSessionId}:`, error);
 			return false;
 		}
+
+		// Mark worker as active so the UI can show a "working" indicator
+		const injectTask = await this.taskManager.getTask(taskId);
+		if (injectTask) {
+			await this.taskManager.updateTaskStatus(injectTask.id, injectTask.status, {
+				activeSession: 'worker',
+			});
+			await this.emitTaskUpdateById(taskId);
+		}
+
 		return true;
 	}
 
@@ -1284,6 +1307,16 @@ export class RoomRuntime {
 			log.error(`Failed to inject message into leader session ${group.leaderSessionId}:`, error);
 			return false;
 		}
+
+		// Mark leader as active so the UI can show a "working" indicator
+		const injectLeaderTask = await this.taskManager.getTask(taskId);
+		if (injectLeaderTask) {
+			await this.taskManager.updateTaskStatus(injectLeaderTask.id, injectLeaderTask.status, {
+				activeSession: 'leader',
+			});
+			await this.emitTaskUpdateById(taskId);
+		}
+
 		return true;
 	}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -422,6 +422,7 @@ export class RoomRuntime {
 		// Clear active session indicator — worker is no longer generating output
 		if (task.activeSession === 'worker') {
 			await this.taskManager.updateTaskStatus(task.id, task.status, { activeSession: null });
+			await this.emitTaskUpdateById(task.id);
 		}
 
 		// Check if worker is waiting for user input (asked a question)
@@ -632,6 +633,7 @@ export class RoomRuntime {
 			await this.taskManager.updateTaskStatus(leaderTask.id, leaderTask.status, {
 				activeSession: null,
 			});
+			await this.emitTaskUpdateById(group.taskId);
 		}
 
 		// Check if leader is waiting for user input (asked a question)
@@ -1241,6 +1243,12 @@ export class RoomRuntime {
 			}
 		}
 
+		// Clear activeSession indicator — the agent is no longer generating output
+		if (task.activeSession !== null) {
+			await this.taskManager.updateTaskStatus(task.id, task.status, { activeSession: null });
+			await this.emitTaskUpdateById(taskId);
+		}
+
 		this.appendGroupEvent(group.id, 'status', {
 			text: 'Generation interrupted by user. Awaiting input.',
 		});
@@ -1266,20 +1274,28 @@ export class RoomRuntime {
 			this.groupRepo.setHumanInterrupted(group.id, false);
 		}
 
-		try {
-			await this.sessionFactory.injectMessage(group.workerSessionId, message);
-		} catch (error) {
-			log.error(`Failed to inject message into worker session ${group.workerSessionId}:`, error);
-			return false;
-		}
-
-		// Mark worker as active so the UI can show a "working" indicator
+		// Mark worker as active BEFORE injecting so the terminal-state handler always sees
+		// and clears the value correctly, even if the session responds before the DB write.
 		const injectTask = await this.taskManager.getTask(taskId);
 		if (injectTask) {
 			await this.taskManager.updateTaskStatus(injectTask.id, injectTask.status, {
 				activeSession: 'worker',
 			});
 			await this.emitTaskUpdateById(taskId);
+		}
+
+		try {
+			await this.sessionFactory.injectMessage(group.workerSessionId, message);
+		} catch (error) {
+			log.error(`Failed to inject message into worker session ${group.workerSessionId}:`, error);
+			// Clear the indicator — the session never started working
+			if (injectTask) {
+				await this.taskManager.updateTaskStatus(injectTask.id, injectTask.status, {
+					activeSession: null,
+				});
+				await this.emitTaskUpdateById(taskId);
+			}
+			return false;
 		}
 
 		return true;
@@ -1301,20 +1317,28 @@ export class RoomRuntime {
 		if (!group) return false;
 		if (!this.sessionFactory.hasSession(group.leaderSessionId)) return false;
 
-		try {
-			await this.sessionFactory.injectMessage(group.leaderSessionId, message);
-		} catch (error) {
-			log.error(`Failed to inject message into leader session ${group.leaderSessionId}:`, error);
-			return false;
-		}
-
-		// Mark leader as active so the UI can show a "working" indicator
+		// Mark leader as active BEFORE injecting so the terminal-state handler always sees
+		// and clears the value correctly, even if the session responds before the DB write.
 		const injectLeaderTask = await this.taskManager.getTask(taskId);
 		if (injectLeaderTask) {
 			await this.taskManager.updateTaskStatus(injectLeaderTask.id, injectLeaderTask.status, {
 				activeSession: 'leader',
 			});
 			await this.emitTaskUpdateById(taskId);
+		}
+
+		try {
+			await this.sessionFactory.injectMessage(group.leaderSessionId, message);
+		} catch (error) {
+			log.error(`Failed to inject message into leader session ${group.leaderSessionId}:`, error);
+			// Clear the indicator — the session never started working
+			if (injectLeaderTask) {
+				await this.taskManager.updateTaskStatus(injectLeaderTask.id, injectLeaderTask.status, {
+					activeSession: null,
+				});
+				await this.emitTaskUpdateById(taskId);
+			}
+			return false;
 		}
 
 		return true;

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -151,6 +151,18 @@ export class TaskRepository {
 			fields.push('depends_on = ?');
 			values.push(JSON.stringify(params.dependsOn));
 		}
+		if (params.activeSession !== undefined) {
+			fields.push('active_session = ?');
+			values.push(params.activeSession ?? null);
+		}
+		// Auto-clear active_session when task reaches a terminal status (unless already set explicitly)
+		if (
+			params.activeSession === undefined &&
+			(params.status === 'completed' || params.status === 'failed' || params.status === 'cancelled')
+		) {
+			fields.push('active_session = ?');
+			values.push(null);
+		}
 		if (fields.length > 0) {
 			values.push(id);
 			const stmt = this.db.prepare(`UPDATE tasks SET ${fields.join(', ')} WHERE id = ?`);
@@ -244,6 +256,7 @@ export class TaskRepository {
 			startedAt: (row.started_at as number | null) ?? undefined,
 			completedAt: (row.completed_at as number | null) ?? undefined,
 			archivedAt: (row.archived_at as number | null) ?? undefined,
+			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,
 		};
 	}
 }

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -156,6 +156,7 @@ export function createTables(db: BunDatabase): void {
         assigned_agent TEXT DEFAULT 'coder',
         created_by_task_id TEXT,
         archived_at INTEGER,
+        active_session TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -90,6 +90,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 22: Drop legacy session_groups.state column and index
 	runMigration22(db);
+
+	// Migration 23: Add active_session column to tasks table
+	runMigration23(db);
 }
 
 /**
@@ -1039,6 +1042,21 @@ function runMigration22(db: BunDatabase): void {
 	}
 
 	db.exec(`ALTER TABLE session_groups DROP COLUMN state`);
+}
+
+/**
+ * Migration 23: Add active_session column to tasks table.
+ * Tracks which agent session is currently generating output ('worker' | 'leader' | null).
+ * Allows the UI to show a "working" indicator even when the task status is 'review'.
+ */
+function runMigration23(db: BunDatabase): void {
+	if (!tableExists(db, 'tasks')) {
+		return;
+	}
+	if (tableHasColumn(db, 'tasks', 'active_session')) {
+		return;
+	}
+	db.exec(`ALTER TABLE tasks ADD COLUMN active_session TEXT`);
 }
 
 function runMigrationRoomCleanup(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -54,7 +54,8 @@ describe('Room Agent Tools', () => {
 				created_at INTEGER NOT NULL,
 				started_at INTEGER,
 				completed_at INTEGER,
-				archived_at INTEGER
+				archived_at INTEGER,
+				active_session TEXT
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -2544,5 +2544,42 @@ describe('RoomRuntime flow', () => {
 			const taskAfter = await ctx.taskManager.getTask(task.id);
 			expect(taskAfter!.activeSession).toBe('leader');
 		});
+
+		it('should clear activeSession when interruptTaskSession is called', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			// Set activeSession to 'worker' (simulating active generation)
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+			const taskWithActive = await ctx.taskManager.getTask(task.id);
+			expect(taskWithActive!.activeSession).toBe('worker');
+
+			// Interrupt the session
+			const result = await ctx.runtime.interruptTaskSession(task.id);
+			expect(result.success).toBe(true);
+
+			// activeSession should be cleared
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBeNull();
+		});
+
+		it('should be idempotent when interruptTaskSession is called with no active session', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			// activeSession starts as null
+			const taskBefore = await ctx.taskManager.getTask(task.id);
+			expect(taskBefore!.activeSession).toBeNull();
+
+			// Interrupt should succeed even when no activeSession is set
+			const result = await ctx.runtime.interruptTaskSession(task.id);
+			expect(result.success).toBe(true);
+
+			// activeSession stays null
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBeNull();
+		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -2444,4 +2444,105 @@ describe('RoomRuntime flow', () => {
 			expect((await ctx.taskManager.getTask(taskC.id))!.status).toBe('in_progress');
 		});
 	});
+
+	describe('activeSession indicator', () => {
+		it('should set activeSession to worker when injecting message to worker', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+			expect(group).toBeDefined();
+
+			// Task starts with no activeSession
+			const taskBefore = await ctx.taskManager.getTask(task.id);
+			expect(taskBefore!.activeSession).toBeNull();
+
+			// Inject message to worker
+			const result = await ctx.runtime.injectMessageToWorker(task.id, 'Please add error handling');
+			expect(result).toBe(true);
+
+			// activeSession should now be 'worker'
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBe('worker');
+		});
+
+		it('should set activeSession to leader when injecting message to leader', async () => {
+			const { task } = await spawnAndRouteToLeader(ctx);
+
+			// Inject message to leader
+			const result = await ctx.runtime.injectMessageToLeader(
+				task.id,
+				'Please reconsider the approach'
+			);
+			expect(result).toBe(true);
+
+			// activeSession should now be 'leader'
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBe('leader');
+		});
+
+		it('should clear activeSession when worker reaches terminal state', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// Set activeSession to 'worker' manually
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+			const taskWithActive = await ctx.taskManager.getTask(task.id);
+			expect(taskWithActive!.activeSession).toBe('worker');
+
+			// Worker reaches terminal state
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// activeSession should be cleared
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBeNull();
+		});
+
+		it('should clear activeSession when leader reaches terminal state', async () => {
+			const { task, group } = await spawnAndRouteToLeader(ctx);
+
+			// Set activeSession to 'leader' manually
+			await ctx.taskManager.updateTaskStatus(task.id, task.status, { activeSession: 'leader' });
+			const taskWithActive = await ctx.taskManager.getTask(task.id);
+			expect(taskWithActive!.activeSession).toBe('leader');
+
+			// Leader reaches terminal state
+			await ctx.runtime.onLeaderTerminalState(group.id, {
+				sessionId: group.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// activeSession should be cleared
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBeNull();
+		});
+
+		it('should not clear activeSession when worker terminal state is for a different session', async () => {
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// Set activeSession to 'leader' (different from the worker that just finished)
+			await ctx.taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'leader' });
+
+			// Worker reaches terminal state — should NOT clear activeSession (it's 'leader')
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+
+			// activeSession should still be 'leader'
+			const taskAfter = await ctx.taskManager.getTask(task.id);
+			expect(taskAfter!.activeSession).toBe('leader');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -111,7 +111,8 @@ const DB_SCHEMA = `
 		created_by_task_id TEXT,
 		assigned_agent TEXT DEFAULT 'coder',
 		created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
-		archived_at INTEGER
+		archived_at INTEGER,
+		active_session TEXT
 	);
 	CREATE TABLE session_groups (
 		id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -112,7 +112,8 @@ describe('Runtime Recovery', () => {
 				created_by_task_id TEXT,
 				assigned_agent TEXT DEFAULT 'coder',
 				created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
-				archived_at INTEGER
+				archived_at INTEGER,
+				active_session TEXT
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -35,7 +35,8 @@ describe('SessionGroupRepository', () => {
 				created_at INTEGER NOT NULL,
 				started_at INTEGER,
 				completed_at INTEGER,
-				archived_at INTEGER
+				archived_at INTEGER,
+				active_session TEXT
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -201,7 +201,8 @@ describe('TaskGroupManager', () => {
 				created_by_task_id TEXT,
 				assigned_agent TEXT DEFAULT 'coder',
 				created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
-				archived_at INTEGER
+				archived_at INTEGER,
+				active_session TEXT
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -814,4 +814,75 @@ describe('TaskManager', () => {
 			);
 		});
 	});
+
+	describe('activeSession field', () => {
+		it('should be null by default on a new task', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			expect(task.activeSession).toBeNull();
+		});
+
+		it('should be settable to worker via updateTaskStatus', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			const updated = await taskManager.updateTaskStatus(task.id, 'in_progress', {
+				activeSession: 'worker',
+			});
+			expect(updated.activeSession).toBe('worker');
+		});
+
+		it('should be settable to leader via updateTaskStatus', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			const updated = await taskManager.updateTaskStatus(task.id, 'in_progress', {
+				activeSession: 'leader',
+			});
+			expect(updated.activeSession).toBe('leader');
+		});
+
+		it('should be clearable back to null', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+			const cleared = await taskManager.updateTaskStatus(task.id, 'in_progress', {
+				activeSession: null,
+			});
+			expect(cleared.activeSession).toBeNull();
+		});
+
+		it('should be auto-cleared when task is completed', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+
+			const completed = await taskManager.completeTask(task.id, 'done');
+			expect(completed.activeSession).toBeNull();
+		});
+
+		it('should be auto-cleared when task is failed', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'leader' });
+
+			const failed = await taskManager.failTask(task.id, 'error occurred');
+			expect(failed.activeSession).toBeNull();
+		});
+
+		it('should be auto-cleared when task is cancelled', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+
+			const cancelled = await taskManager.cancelTask(task.id);
+			expect(cancelled.activeSession).toBeNull();
+		});
+
+		it('should persist across getTask calls', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.updateTaskStatus(task.id, 'in_progress', { activeSession: 'worker' });
+
+			const fetched = await taskManager.getTask(task.id);
+			expect(fetched!.activeSession).toBe('worker');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -41,7 +41,8 @@ describe('TaskRepository', () => {
 				created_at INTEGER NOT NULL,
 				started_at INTEGER,
 				completed_at INTEGER,
-				archived_at INTEGER
+				archived_at INTEGER,
+				active_session TEXT
 			);
 
 			CREATE INDEX idx_tasks_room ON tasks(room_id);

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -213,6 +213,12 @@ export interface NeoTask {
 	completedAt?: number;
 	/** Archive timestamp (milliseconds since epoch) - orthogonal to status */
 	archivedAt?: number | null;
+	/**
+	 * Which agent session is currently active (generating output).
+	 * Set when a human message is injected; cleared when the session reaches terminal state.
+	 * Allows the UI to show a "working" indicator even when status is 'review'.
+	 */
+	activeSession?: 'worker' | 'leader' | null;
 }
 
 /**
@@ -257,6 +263,8 @@ export interface UpdateTaskParams {
 	result?: string | null;
 	error?: string | null;
 	dependsOn?: string[];
+	/** Which session is actively generating output. null clears the indicator. */
+	activeSession?: 'worker' | 'leader' | null;
 }
 
 // ============================================================================
@@ -295,6 +303,8 @@ export interface TaskSummary {
 	dependsOn: string[];
 	/** Error message for failed tasks */
 	error?: string | null;
+	/** Which session is actively generating output (see NeoTask.activeSession) */
+	activeSession?: 'worker' | 'leader' | null;
 }
 
 /**

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -547,4 +547,43 @@ describe('RoomTasks', () => {
 			expect(progressBar).toBeTruthy();
 		});
 	});
+
+	describe('Working Indicator (activeSession)', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
+		it('should show worker working indicator when activeSession is worker on a review task', () => {
+			const tasks = [createTask('t1', 'review', { activeSession: 'worker' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Worker working');
+		});
+
+		it('should show leader working indicator when activeSession is leader on a review task', () => {
+			const tasks = [createTask('t1', 'review', { activeSession: 'leader' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Leader working');
+		});
+
+		it('should not show working indicator when activeSession is null on a review task', () => {
+			const tasks = [createTask('t1', 'review', { activeSession: null })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).not.toContain('working');
+		});
+
+		it('should not show working indicator when activeSession is set but task is not in review status', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'in_progress', { activeSession: 'worker' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).not.toContain('Worker working');
+		});
+	});
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -449,6 +449,8 @@ function TaskItem({
 	const blocked = task.status === 'pending' && isBlocked(task, allTasks);
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
 
+	const isWorking = task.status === 'review' && !!task.activeSession;
+
 	return (
 		<div
 			class={`px-4 py-3 ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
@@ -458,6 +460,12 @@ function TaskItem({
 				<div class="flex-1 min-w-0">
 					<div class="flex items-center gap-2">
 						<h4 class="text-sm font-medium text-gray-100 truncate">{task.title}</h4>
+						{isWorking && (
+							<span class="inline-flex items-center gap-1 text-xs font-medium text-blue-400 bg-blue-900/20 border border-blue-700/40 px-1.5 py-0.5 rounded-full flex-shrink-0">
+								<span class="w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
+								{task.activeSession === 'worker' ? 'Worker' : 'Leader'} working
+							</span>
+						)}
 						{blocked && (
 							<span class="text-xs px-1.5 py-0.5 rounded bg-orange-900/20 text-orange-400 flex-shrink-0">
 								Blocked

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -858,9 +858,15 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 							<p class="text-xs text-gray-500">
 								{group.feedbackIteration > 0 && `iteration ${group.feedbackIteration}`}
 							</p>
-							{group.submittedForReview && (
+							{group.submittedForReview && !task.activeSession && (
 								<span class="inline-flex items-center gap-1 text-xs font-medium text-amber-400 bg-amber-900/30 border border-amber-700/40 px-1.5 py-0.5 rounded-full animate-pulse">
 									Awaiting your review
+								</span>
+							)}
+							{task.status === 'review' && task.activeSession && (
+								<span class="inline-flex items-center gap-1 text-xs font-medium text-blue-400 bg-blue-900/30 border border-blue-700/40 px-1.5 py-0.5 rounded-full">
+									<span class="w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
+									{task.activeSession === 'worker' ? 'Worker' : 'Leader'} processing your message…
 								</span>
 							)}
 						</div>


### PR DESCRIPTION
When a task is in 'review' status and a human sends a message, the task
status correctly stays as 'review' (semantic accuracy) but the UI now
shows a pulsing "working" indicator to clarify that an agent is actively
processing the message.

Changes:
- Add `activeSession: 'worker' | 'leader' | null` field to NeoTask,
  UpdateTaskParams, and TaskSummary in shared types
- Add DB migration 23 to add `active_session` column to tasks table
- Update schema/index.ts to include the column in fresh databases
- Update task-repository.ts to persist/read activeSession; auto-clear
  it when task transitions to completed/failed/cancelled
- Update room-manager.ts toSummary to include activeSession
- Update room-runtime.ts:
  - injectMessageToWorker: sets activeSession='worker' after injection
  - injectMessageToLeader: sets activeSession='leader' after injection
  - onWorkerTerminalState: clears activeSession when worker finishes
  - onLeaderTerminalState: clears activeSession when leader finishes
- Add pulsing "Worker/Leader working" badge in RoomTasks TaskItem when
  task.status === 'review' && task.activeSession is set
- Add "processing your message" pill in TaskView header under same
  conditions; suppress "Awaiting your review" pill while agent is active
- Add 8 unit tests for TaskManager.activeSession field behavior
- Add 5 unit tests for RoomRuntime inject/terminal activeSession behavior
- Add 4 unit tests for RoomTasks working indicator rendering
- Update 5 test files to add active_session column to inline DB schemas
