### PR TITLE
fix(room): re-establish message mirroring in recoverZombieGroups after daemon restart

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1792,9 +1792,17 @@ export class RoomRuntime {
 				}
 			}
 
+			// Re-establish message mirroring for this recovered group so real-time messages
+			// from restored sessions are forwarded to the frontend TaskView.
+			// mirroringCleanups is in-memory and is lost on daemon restart, so we must
+			// re-subscribe here for any group that was active before the restart.
+			if (!this.mirroringCleanups.has(group.id)) {
+				this.setupMirroring(group);
+			}
+
 			// Inject continuation message for restored sessions.
 			// The SDK query is started lazily by injectMessage → ensureQueryStarted().
-			// Groups awaiting human review don't need a message — human will provide one.
+			// Groups awaiting human review don’t need a message — human will provide one.
 			if (group.submittedForReview) {
 				continue; // Awaiting human - no continuation message needed
 			}

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -295,6 +295,85 @@ describe('Zombie detection in tick', () => {
 
 		expect(ctx.observer.isObserving(leaderSessionId)).toBe(true);
 	});
+
+	it('should set up mirroring for worker session after zombie recovery', async () => {
+		const { workerSessionId } = await createTaskWithGroup(ctx);
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Mirroring should be set up: sdk.message handler registered for worker session
+		expect(ctx.daemonHub.hasHandlerFor('sdk.message', workerSessionId)).toBe(true);
+	});
+
+	it('should set up mirroring for leader session after zombie recovery', async () => {
+		const { leaderSessionId } = await createTaskWithGroup(ctx);
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Mirroring should be set up: sdk.message handler registered for leader session
+		expect(ctx.daemonHub.hasHandlerFor('sdk.message', leaderSessionId)).toBe(true);
+	});
+
+	it('should set up mirroring for submitted_for_review group after zombie recovery', async () => {
+		const { workerSessionId, leaderSessionId } = await createTaskWithGroup(ctx, true);
+
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (!restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Mirroring should be set up even for groups awaiting human review,
+		// so messages flow when the human responds.
+		expect(ctx.daemonHub.hasHandlerFor('sdk.message', workerSessionId)).toBe(true);
+		expect(ctx.daemonHub.hasHandlerFor('sdk.message', leaderSessionId)).toBe(true);
+	});
+
+	it('should NOT set up mirroring when worker restore fails', async () => {
+		const { workerSessionId } = await createTaskWithGroup(ctx);
+
+		// Worker missing and cannot be restored
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async () => false;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Worker restore failed — group was failed, no mirroring should be set up
+		expect(ctx.daemonHub.hasHandlerFor('sdk.message', workerSessionId)).toBe(false);
+	});
 });
 
 describe('resumeWorkerFromHuman rollback', () => {

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -34,6 +34,16 @@ export function createMockDaemonHub() {
 				}
 			};
 		},
+		async emit(_event: string, _data: unknown): Promise<void> {
+			// No-op for tests — runtime calls emit for task/goal updates
+		},
+		/** Check if a handler is registered for a given event + optional sessionId */
+		hasHandlerFor(event: string, sessionId?: string): boolean {
+			const eventHandlers = handlers.get(event);
+			if (!eventHandlers) return false;
+			const list = eventHandlers.get(sessionId);
+			return !!list && list.length > 0;
+		},
 	};
 }
 
@@ -164,6 +174,7 @@ export interface RuntimeTestContext {
 	groupRepo: SessionGroupRepository;
 	sessionFactory: ReturnType<typeof createMockSessionFactory>;
 	observer: SessionObserver;
+	daemonHub: ReturnType<typeof createMockDaemonHub>;
 }
 
 export interface RuntimeTestContextOptions {
@@ -205,6 +216,7 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 		maxConcurrentGroups: opts?.maxConcurrentGroups ?? 1,
 		maxFeedbackIterations: opts?.maxFeedbackIterations,
 		tickInterval: 60_000,
+		daemonHub: mockHub as unknown as DaemonHub,
 		hookOptions:
 			opts?.hookOptions ??
 			({
@@ -217,7 +229,16 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 		getGoal: (goalId) => goalManager.getGoal(goalId),
 	});
 
-	return { db, runtime, taskManager, goalManager, groupRepo, sessionFactory, observer };
+	return {
+		db,
+		runtime,
+		taskManager,
+		goalManager,
+		groupRepo,
+		sessionFactory,
+		observer,
+		daemonHub: mockHub,
+	};
 }
 
 export async function createGoalAndTask(


### PR DESCRIPTION
When the daemon restarts, the in-memory mirroringCleanups Map is wiped.
recoverZombieGroups() was restoring sessions but not calling setupMirroring(),
so daemonHub sdk.message events from recovered sessions had no subscriber to
forward them to the frontend via state.groupMessages.delta. This caused worker
messages to be silently dropped in the TaskView UI after a daemon restart.

Fix: call setupMirroring(group) (guarded by !mirroringCleanups.has(group.id))
before the submittedForReview check in recoverZombieGroups, ensuring all
recovered groups (including review-awaiting ones) get mirroring re-established.

Also wire daemonHub mock into RoomRuntime in test helpers so setupMirroring
invocations in unit tests are exercised via hasHandlerFor assertions.
