### PR TITLE
chore: release version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.7.0] - 2026-03-14
+
+### Added
+- **PR as first-class task data**: PR number, URL, and creation timestamp are now stored on tasks and surfaced in the UI with quick-access buttons in task view and task overview
+- **Bypass markers for research/verification tasks**: Workers can now skip git/PR gates for research-only tasks using markers (`RESEARCH_ONLY:`, `VERIFICATION_COMPLETE:`, `INVESTIGATION_RESULT:`, `ANALYSIS_COMPLETE:`) as the first line of their final response — prevents unnecessary PRs for pure analysis work
+- **Active session tracking**: Added `activeSession` field on tasks to display real-time working indicators (pulsing badges) without status thrashing when a human injects a message into a running session
+- **SDK sub-agent architecture**: Added worker and leader sub-agents to avoid context overflow in long-running tasks; configurable via `room.config.agentSubagents`; built-in Tester sub-agent auto-included for coder agents; leader analysis helpers for read-only tasks; planner plan-writer sub-agent with scope-adaptive file structure
+- **Task completion/cancellation UX redesign**: Replaced raw cancel button with a three-dot dropdown menu with `CompleteTaskDialog` and `CancelTaskDialog` modals (confirmation flow, optional summary/reason fields)
+- **Stop/terminate sessions from task view**: Amber interrupt button in task view header to interrupt running worker or leader sessions mid-stream without changing task status
+- **Dead loop detection**: Levenshtein similarity + count/time-based detection (5 failures / 5 min / 75% similarity) prevents infinite bounce cycles in runtime gates
+- **Leader gets room-agent-tools**: Leader agent now has access to task/goal management tools via the `room-agent-tools` MCP server for dynamic plan adjustment
+
+### Changed
+- **Task status rename**: `failed` → `needs_attention` for clearer semantic meaning; UI tab labels and localStorage keys updated with backward compatibility
+- **Planner workflow**: Planner now correctly creates PR and draft tasks before completing; added planning-specific post-approval workflow where the leader sends the planner back to run Phase 2 instead of merging directly
+
+### Fixed
+- **Question handling**: Tasks now pause (stay in `waiting_for_input`) when a worker or leader asks a question via `AskUserQuestion` instead of cancelling or routing to the next agent
+- **Worker→Leader routing**: Fixed bug where worker finishes first round but gets stuck without triggering leader; added zombie group detection fix, silent routing failure logging, and `recoverStuckWorkers()` for automatic recovery
+- **Real-time task status synchronization**: Fixed 7 room/goal DaemonHub events (`room.task.update`, `room.overview`, `room.runtime.stateChanged`, `goal.*`) not being forwarded to WebSocket clients; added event bridge in `StateManager`
+- **State synchronization**: Fixed `submittedForReview` flag not being set on `set_task_status` → `review` transitions, and `resumeWorkerFromHuman` no longer incorrectly changes task to `in_progress` for approvals
+- **PR mergeability checks**: Leader now validates PR health (merge conflicts, failing CI) before submitting for human review
+- **Duplicate messages after restart**: Fixed race condition where tick loop ran before recovery completed, causing duplicate restart injection messages
+- **Model field handling**: Fixed inconsistent model resolution in `buildLeaderHelperAgents` — now uses `resolveModelId`/`resolveProvider` helpers consistently with `buildReviewerAgents`
+- **Removed `handoff_to_worker` no-op tool**: Removed legacy compatibility shim from leader agent; updated all prompts and tests
+- **Auto-revive failed tasks**: Sending a message to a `needs_attention` task now auto-revives it to `review` status with sessions restored
+- **Fail tasks on terminal API errors**: Tasks now fail immediately on terminal API errors instead of bouncing indefinitely
+
+## [0.6.2] - 2026-03-13
+
+### Fixed
+- **Configuration**: Bumped patch version for dependency updates
+
 ## [0.6.1] - 2026-03-12
 
 ### Fixed

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -6,10 +6,10 @@
 		"kai": "bin/kai.js"
 	},
 	"optionalDependencies": {
-		"@neokai/cli-darwin-arm64": "0.6.2",
-		"@neokai/cli-darwin-x64": "0.6.2",
-		"@neokai/cli-linux-x64": "0.6.2",
-		"@neokai/cli-linux-arm64": "0.6.2"
+		"@neokai/cli-darwin-arm64": "0.7.0",
+		"@neokai/cli-darwin-x64": "0.7.0",
+		"@neokai/cli-linux-x64": "0.7.0",
+		"@neokai/cli-linux-arm64": "0.7.0"
 	},
 	"files": [
 		"bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.6.2",
+	"version": "0.7.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.6.2 to 0.7.0
- Update CHANGELOG.md with comprehensive release notes for all changes since 0.6.1

## Changes in 0.7.0

### New Features
- PR number and URL as first-class task fields with UI buttons
- Bypass markers for research/verification tasks (skip git/PR gates)
- Active session tracking on tasks (real-time pulsing indicators)
- SDK sub-agent architecture for worker and leader (avoid context overflow)
- Task completion/cancellation UX redesign with dropdown menu and confirmation dialogs
- Stop/terminate sessions from task view (interrupt button)
- Dead loop detection for runtime gates
- Leader agent gets room-agent-tools MCP server access

### Bug Fixes
- Question handling: pause task instead of cancel when worker/leader asks a question
- Worker→Leader routing: fixed stuck workers not triggering leader; added `recoverStuckWorkers()`
- Real-time task status synchronization: fixed 7 DaemonHub events not forwarded to WebSocket
- State synchronization: fixed `submittedForReview` flag and approval review status
- PR mergeability checks before leader submits for review
- Duplicate messages after server restart
- Model field handling in `buildLeaderHelperAgents`
- Auto-revive `needs_attention` tasks when message is sent

### Changes
- Task status `failed` renamed to `needs_attention`
- Planner workflow: correct two-phase PR creation before completion
- Removed `handoff_to_worker` no-op compatibility tool

## Test Plan
- [ ] All version numbers updated to 0.7.0 ✅
- [ ] CHANGELOG.md updated ✅
- [ ] TypeScript build passes ✅
- [ ] Web bundle build passes ✅
- [ ] Pre-commit checks pass ✅