### PR TITLE
work on pr 301

### DIFF
--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -13,7 +13,7 @@ import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
 
 export interface TaskOperator {
 	getTask(taskId: string): Promise<{ status: TaskStatus } | null>;
-	updateTaskStatus(taskId: string, status: TaskStatus, updates?: Partial<{ status: TaskStatus }>): Promise<unknown>;
+	setTaskStatus(taskId: string, status: TaskStatus, options?: { result?: string; error?: string }): Promise<unknown>;
 }
 
 export interface HumanMessageResult {
@@ -74,7 +74,7 @@ export async function routeHumanMessageToGroup(
 
 			// Transition task to in_progress
 			try {
-				await taskManager.updateTaskStatus(taskId, 'in_progress');
+				await taskManager.setTaskStatus(taskId, 'in_progress');
 			} catch (error) {
 				// Rollback group state on failure (group was already reset, so use previousVersion + 1)
 				groupRepo.failGroup(group.id, previousVersion + 1);
@@ -94,7 +94,7 @@ export async function routeHumanMessageToGroup(
 				// Rollback: restore group to failed state and revert task status
 				groupRepo.failGroup(group.id, previousVersion + 1);
 				try {
-					await taskManager.updateTaskStatus(taskId, previousStatus);
+					await taskManager.setTaskStatus(taskId, previousStatus);
 				} catch {
 					// Rollback failure is logged but the main error is the injection failure
 				}

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -55,6 +55,10 @@ export async function routeHumanMessageToGroup(
 				return { success: false, error: `Task in '${task.status}' status cannot be restarted` };
 			}
 
+			// Save previous status for potential rollback
+			const previousStatus = task.status;
+			const previousVersion = group.version;
+
 			// Reset the group for restart (clears completedAt, resets state)
 			const reset = groupRepo.resetGroupForRestart(group.id);
 			if (!reset) {
@@ -65,8 +69,35 @@ export async function routeHumanMessageToGroup(
 			try {
 				await runtime.taskManager.updateTaskStatus(taskId, 'in_progress');
 			} catch (error) {
+				// Rollback group state on failure
+				groupRepo.failGroup(group.id, previousVersion);
 				return { success: false, error: `Failed to transition task to in_progress: ${error}` };
 			}
+
+			// Try to inject the message
+			let injected = false;
+			if (target === 'leader') {
+				injected = await runtime.injectMessageToLeader(taskId, message);
+			} else {
+				injected = await runtime.injectMessageToWorker(taskId, message);
+			}
+
+			// If injection failed, rollback the status and group changes
+			if (!injected) {
+				// Rollback: restore group to failed state and revert task status
+				groupRepo.failGroup(group.id, previousVersion + 1);
+				try {
+					await runtime.taskManager.updateTaskStatus(taskId, previousStatus);
+				} catch {
+					// Rollback failure is logged but the main error is the injection failure
+				}
+				return {
+					success: false,
+					error: `Failed to inject message into ${target} session`,
+				};
+			}
+
+			return { success: true };
 		} else {
 			// For other terminated states (completed), still block messages
 			return { success: false, error: 'Task is already completed' };

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -2,11 +2,14 @@
  * Human Message Routing
  *
  * Routes a human message to the worker or leader session.
- * No state gates - messages can be sent to either agent at any time.
+ * - Active groups: messages are injected directly
+ * - Failed tasks: group is reset and task transitions to in_progress before injecting
  */
 
 import type { RoomRuntime } from './room-runtime';
 import type { SessionGroupRepository } from '../state/session-group-repository';
+import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
+import type { TaskStatus } from '@neokai/shared';
 
 export interface HumanMessageResult {
 	success: boolean;
@@ -39,7 +42,35 @@ export async function routeHumanMessageToGroup(
 
 	// Check if group is terminated using completedAt timestamp
 	if (group.completedAt !== null) {
-		return { success: false, error: 'Task is already completed or failed' };
+		// Get the task to check its status - we may be able to restart a failed task
+		const task = await runtime.taskManager.getTask(taskId);
+		if (!task) {
+			return { success: false, error: 'Task not found' };
+		}
+
+		// Allow restarting failed (or cancelled) tasks - transition to in_progress
+		if (task.status === 'failed' || task.status === 'cancelled') {
+			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status as TaskStatus];
+			if (!allowedTransitions.includes('in_progress')) {
+				return { success: false, error: `Task in '${task.status}' status cannot be restarted` };
+			}
+
+			// Reset the group for restart (clears completedAt, resets state)
+			const reset = groupRepo.resetGroupForRestart(group.id);
+			if (!reset) {
+				return { success: false, error: 'Failed to reset task group for restart' };
+			}
+
+			// Transition task to in_progress
+			try {
+				await runtime.taskManager.updateTaskStatus(taskId, 'in_progress');
+			} catch (error) {
+				return { success: false, error: `Failed to transition task to in_progress: ${error}` };
+			}
+		} else {
+			// For other terminated states (completed), still block messages
+			return { success: false, error: 'Task is already completed' };
+		}
 	}
 
 	// Simple routing - no state checks

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -3,13 +3,13 @@
  *
  * Routes a human message to the worker or leader session.
  * - Active groups: messages are injected directly
- * - needs_attention/cancelled tasks: group is reset and task transitions to in_progress before injecting
+ * - needs_attention tasks: group is reset and task transitions to in_progress before injecting
+ * - cancelled/completed tasks: messages are blocked (caller should use set_task_status to restart)
  */
 
 import type { TaskStatus } from '@neokai/shared';
 import type { RoomRuntime } from './room-runtime';
 import type { SessionGroupRepository } from '../state/session-group-repository';
-import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
 
 export interface TaskOperator {
 	getTask(taskId: string): Promise<{ status: TaskStatus } | null>;
@@ -53,66 +53,65 @@ export async function routeHumanMessageToGroup(
 
 	// Check if group is terminated using completedAt timestamp
 	if (group.completedAt !== null) {
-		// Get the task to check its status - we may be able to restart a failed task
+		// Get the task to check its status - we may be able to restart a needs_attention task
 		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			return { success: false, error: 'Task not found' };
 		}
 
-		// Allow restarting needs_attention (failed) or cancelled tasks - transition to in_progress
-		if (task.status === 'needs_attention' || task.status === 'cancelled') {
-			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
-			if (!allowedTransitions.includes('in_progress')) {
-				return { success: false, error: `Task in '${task.status}' status cannot be restarted` };
-			}
-
-			// Save previous status for potential rollback
-			const previousStatus = task.status;
-			const previousVersion = group.version;
-
-			// Reset the group for restart (clears completedAt, resets state)
-			const reset = groupRepo.resetGroupForRestart(group.id);
-			if (!reset) {
-				return { success: false, error: 'Failed to reset task group for restart' };
-			}
-
-			// Transition task to in_progress
-			try {
-				await taskManager.setTaskStatus(taskId, 'in_progress');
-			} catch (error) {
-				// Rollback group state on failure (group was already reset, so use previousVersion + 1)
-				groupRepo.failGroup(group.id, previousVersion + 1);
-				return { success: false, error: `Failed to transition task to in_progress: ${error}` };
-			}
-
-			// Try to inject the message
-			let injected = false;
-			if (target === 'leader') {
-				injected = await runtime.injectMessageToLeader(taskId, message);
-			} else {
-				injected = await runtime.injectMessageToWorker(taskId, message);
-			}
-
-			// If injection failed, rollback the status and group changes
-			if (!injected) {
-				// Rollback: restore group to failed state and revert task status
-				groupRepo.failGroup(group.id, previousVersion + 1);
-				try {
-					await taskManager.setTaskStatus(taskId, previousStatus);
-				} catch {
-					// Rollback failure is logged but the main error is the injection failure
-				}
-				return {
-					success: false,
-					error: `Failed to inject message into ${target} session`,
-				};
-			}
-
-			return { success: true };
-		} else {
-			// For other terminated states (completed), still block messages
-			return { success: false, error: 'Task is already completed' };
+		// Only needs_attention tasks can be restarted via message injection.
+		// Cancelled tasks have their workspace cleaned up on cancellation, so
+		// restarting them via session injection would point at a gone workspace.
+		// Completed tasks are terminal. For both, the caller should use set_task_status.
+		if (task.status !== 'needs_attention') {
+			return {
+				success: false,
+				error: `Task is in '${task.status}' status and cannot receive messages. Use set_task_status to restart it.`,
+			};
 		}
+
+		// Save previous status for potential rollback
+		const previousStatus = task.status;
+
+		// Reset the group for restart (clears completedAt, resets state, bumps version)
+		const resetGroup = groupRepo.resetGroupForRestart(group.id);
+		if (!resetGroup) {
+			return { success: false, error: 'Failed to reset task group for restart' };
+		}
+
+		// Transition task to in_progress
+		try {
+			await taskManager.setTaskStatus(taskId, 'in_progress');
+		} catch (error) {
+			// Rollback group state on failure (use the version returned by resetGroupForRestart)
+			groupRepo.failGroup(group.id, resetGroup.version);
+			return { success: false, error: `Failed to transition task to in_progress: ${error}` };
+		}
+
+		// Try to inject the message
+		let injected = false;
+		if (target === 'leader') {
+			injected = await runtime.injectMessageToLeader(taskId, message);
+		} else {
+			injected = await runtime.injectMessageToWorker(taskId, message);
+		}
+
+		// If injection failed, rollback the status and group changes
+		if (!injected) {
+			// Rollback: restore group to needs_attention state and revert task status
+			groupRepo.failGroup(group.id, resetGroup.version);
+			try {
+				await taskManager.setTaskStatus(taskId, previousStatus);
+			} catch {
+				// Rollback failure is best-effort; swallow to avoid masking the injection error
+			}
+			return {
+				success: false,
+				error: `Failed to inject message into ${target} session`,
+			};
+		}
+
+		return { success: true };
 	}
 
 	// Simple routing - no state checks

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -69,8 +69,8 @@ export async function routeHumanMessageToGroup(
 			try {
 				await runtime.taskManager.updateTaskStatus(taskId, 'in_progress');
 			} catch (error) {
-				// Rollback group state on failure
-				groupRepo.failGroup(group.id, previousVersion);
+				// Rollback group state on failure (group was already reset, so use previousVersion + 1)
+				groupRepo.failGroup(group.id, previousVersion + 1);
 				return { success: false, error: `Failed to transition task to in_progress: ${error}` };
 			}
 

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -3,7 +3,7 @@
  *
  * Routes a human message to the worker or leader session.
  * - Active groups: messages are injected directly
- * - Failed tasks: group is reset and task transitions to in_progress before injecting
+ * - needs_attention/cancelled tasks: group is reset and task transitions to in_progress before injecting
  */
 
 import type { TaskStatus } from '@neokai/shared';
@@ -13,7 +13,11 @@ import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
 
 export interface TaskOperator {
 	getTask(taskId: string): Promise<{ status: TaskStatus } | null>;
-	setTaskStatus(taskId: string, status: TaskStatus, options?: { result?: string; error?: string }): Promise<unknown>;
+	setTaskStatus(
+		taskId: string,
+		status: TaskStatus,
+		options?: { result?: string; error?: string }
+	): Promise<unknown>;
 }
 
 export interface HumanMessageResult {
@@ -55,9 +59,9 @@ export async function routeHumanMessageToGroup(
 			return { success: false, error: 'Task not found' };
 		}
 
-		// Allow restarting failed (or cancelled) tasks - transition to in_progress
-		if (task.status === 'failed' || task.status === 'cancelled') {
-			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status as TaskStatus];
+		// Allow restarting needs_attention (failed) or cancelled tasks - transition to in_progress
+		if (task.status === 'needs_attention' || task.status === 'cancelled') {
+			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
 			if (!allowedTransitions.includes('in_progress')) {
 				return { success: false, error: `Task in '${task.status}' status cannot be restarted` };
 			}

--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -6,10 +6,15 @@
  * - Failed tasks: group is reset and task transitions to in_progress before injecting
  */
 
+import type { TaskStatus } from '@neokai/shared';
 import type { RoomRuntime } from './room-runtime';
 import type { SessionGroupRepository } from '../state/session-group-repository';
 import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
-import type { TaskStatus } from '@neokai/shared';
+
+export interface TaskOperator {
+	getTask(taskId: string): Promise<{ status: TaskStatus } | null>;
+	updateTaskStatus(taskId: string, status: TaskStatus, updates?: Partial<{ status: TaskStatus }>): Promise<unknown>;
+}
 
 export interface HumanMessageResult {
 	success: boolean;
@@ -23,6 +28,7 @@ export type HumanMessageTarget = 'worker' | 'leader';
  *
  * @param runtime       The RoomRuntime instance for the room
  * @param groupRepo     The SessionGroupRepository for DB access
+ * @param taskManager   The TaskManager for task operations
  * @param taskId        The task ID to route the message to
  * @param message       The human message content
  * @param target        Target agent ('worker' | 'leader'), defaults to 'worker'
@@ -30,6 +36,7 @@ export type HumanMessageTarget = 'worker' | 'leader';
 export async function routeHumanMessageToGroup(
 	runtime: RoomRuntime,
 	groupRepo: SessionGroupRepository,
+	taskManager: TaskOperator,
 	taskId: string,
 	message: string,
 	target: HumanMessageTarget = 'worker'
@@ -43,7 +50,7 @@ export async function routeHumanMessageToGroup(
 	// Check if group is terminated using completedAt timestamp
 	if (group.completedAt !== null) {
 		// Get the task to check its status - we may be able to restart a failed task
-		const task = await runtime.taskManager.getTask(taskId);
+		const task = await taskManager.getTask(taskId);
 		if (!task) {
 			return { success: false, error: 'Task not found' };
 		}
@@ -67,7 +74,7 @@ export async function routeHumanMessageToGroup(
 
 			// Transition task to in_progress
 			try {
-				await runtime.taskManager.updateTaskStatus(taskId, 'in_progress');
+				await taskManager.updateTaskStatus(taskId, 'in_progress');
 			} catch (error) {
 				// Rollback group state on failure (group was already reset, so use previousVersion + 1)
 				groupRepo.failGroup(group.id, previousVersion + 1);
@@ -87,7 +94,7 @@ export async function routeHumanMessageToGroup(
 				// Rollback: restore group to failed state and revert task status
 				groupRepo.failGroup(group.id, previousVersion + 1);
 				try {
-					await runtime.taskManager.updateTaskStatus(taskId, previousStatus);
+					await taskManager.updateTaskStatus(taskId, previousStatus);
 				} catch {
 					// Rollback failure is logged but the main error is the injection failure
 				}

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -389,6 +389,17 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				args.task_id,
 				args.message
 			);
+			// Emit task update after successful message routing (may have changed status)
+			if (success) {
+				const updatedTask = await taskManager.getTask(args.task_id);
+				if (updatedTask && daemonHub) {
+					void daemonHub.emit('room.task.update', {
+						sessionId: `room:${roomId}`,
+						roomId,
+						task: updatedTask,
+					});
+				}
+			}
 			return jsonResult(error !== undefined ? { success, error } : { success });
 		},
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -385,6 +385,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			const { success, error } = await routeHumanMessageToGroup(
 				runtime,
 				groupRepo,
+				taskManager,
 				args.task_id,
 				args.message
 			);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -37,7 +37,7 @@ export type TaskManagerLike = Pick<
 	| 'cancelTask'
 	| 'setTaskStatus'
 	| 'archiveTask'
-  | 'updateTaskStatus'
+	| 'updateTaskStatus'
 >;
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -680,6 +680,12 @@ export function setupTaskHandlers(
 			throw new Error(result.error ?? 'Failed to send human message');
 		}
 
+		// Emit task update after successful message routing (may have changed status)
+		const updatedTask = await taskManager.getTask(params.taskId);
+		if (updatedTask) {
+			emitTaskUpdate(params.roomId, updatedTask);
+		}
+
 		return { success: true };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -29,7 +29,7 @@ const log = new Logger('task-handlers');
 
 export type TaskManagerLike = Pick<
 	TaskManager,
-	'createTask' | 'getTask' | 'listTasks' | 'failTask' | 'cancelTask' | 'setTaskStatus'
+	'createTask' | 'getTask' | 'listTasks' | 'failTask' | 'cancelTask' | 'setTaskStatus' | 'updateTaskStatus'
 >;
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;
@@ -670,6 +670,7 @@ export function setupTaskHandlers(
 		const result = await routeHumanMessageToGroup(
 			runtime,
 			groupRepo,
+			taskManager,
 			params.taskId,
 			params.message.trim(),
 			target

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -37,7 +37,6 @@ export type TaskManagerLike = Pick<
 	| 'cancelTask'
 	| 'setTaskStatus'
 	| 'archiveTask'
-	| 'updateTaskStatus'
 >;
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;
@@ -759,6 +758,17 @@ export function setupTaskHandlers(
 		const task = await taskManager.getTask(params.taskId);
 		if (!task) {
 			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
+		}
+
+		// Cancelled tasks have their workspace cleaned up on cancellation.
+		// Restarting via session injection would point at a gone workspace.
+		// Direct the caller to use set_task_status to restart from scratch.
+		if (task.status === 'cancelled') {
+			throw new Error(
+				`Task ${params.taskId} is cancelled. Cancelled tasks cannot receive messages ` +
+					'because their workspace has been cleaned up. Use set_task_status to restart it ' +
+					'(e.g. status: "pending" or "in_progress").'
+			);
 		}
 
 		const groupRepo = new SessionGroupRepository(db.getDatabase());

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -1,8 +1,10 @@
 /**
  * Tests for routeHumanMessageToGroup
  *
- * Simplified routing: Messages can be sent to worker or leader at any time.
- * Only fails if no group or group is completed (completedAt !== null).
+ * Routing behavior:
+ * - Active groups (completedAt = null): messages injected directly
+ * - Failed/cancelled tasks: group is reset and task transitions to in_progress
+ * - Completed tasks: message is blocked
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -12,6 +14,7 @@ import type {
 	SessionGroupRepository,
 	SessionGroup,
 } from '../../../../src/lib/room/state/session-group-repository';
+import type { NeoTask } from '@neokai/shared';
 
 function makeGroup(completedAt: number | null): SessionGroup {
 	return {
@@ -38,104 +41,226 @@ function makeGroup(completedAt: number | null): SessionGroup {
 	};
 }
 
-function makeRuntime(
-	resumeResult = true,
-	injectResult = true
-): {
-	runtime: RoomRuntime;
-	resumeWorkerFromHuman: ReturnType<typeof mock>;
-	injectMessageToLeader: ReturnType<typeof mock>;
-	injectMessageToWorker: ReturnType<typeof mock>;
-} {
-	const resumeWorkerFromHuman = mock(async () => resumeResult);
-	const injectMessageToLeader = mock(async () => injectResult);
-	const injectMessageToWorker = mock(async () => injectResult);
-
-	const runtime = {
-		resumeWorkerFromHuman,
-		injectMessageToLeader,
-		injectMessageToWorker,
-	} as unknown as RoomRuntime;
-
-	return { runtime, resumeWorkerFromHuman, injectMessageToLeader, injectMessageToWorker };
+function makeTask(status: string): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		description: '',
+		status: status as NeoTask['status'],
+		priority: 'normal',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		result: null,
+		error: null,
+		dependsOn: [],
+		dependsOnMet: true,
+		dependsOnCount: 0,
+		metadata: null,
+	};
 }
 
-function makeGroupRepo(group: SessionGroup | null): {
+function makeRuntime(
+	injectResult = true,
+	task?: NeoTask | null
+): {
+	runtime: RoomRuntime;
+	injectMessageToLeader: ReturnType<typeof mock>;
+	injectMessageToWorker: ReturnType<typeof mock>;
+	taskManager: {
+		getTask: ReturnType<typeof mock>;
+		updateTaskStatus: ReturnType<typeof mock>;
+	};
+} {
+	const injectMessageToLeader = mock(async () => injectResult);
+	const injectMessageToWorker = mock(async () => injectResult);
+	const getTask = mock(async () => task ?? null);
+	const updateTaskStatus = mock(async () => undefined);
+
+	const taskManager = {
+		getTask,
+		updateTaskStatus,
+	};
+
+	const runtime = {
+		injectMessageToLeader,
+		injectMessageToWorker,
+		taskManager,
+	} as unknown as RoomRuntime;
+
+	return { runtime, injectMessageToLeader, injectMessageToWorker, taskManager };
+}
+
+function makeGroupRepo(
+	group: SessionGroup | null,
+	resetGroupForRestartResult = true
+): {
 	groupRepo: SessionGroupRepository;
 	getGroupByTaskId: ReturnType<typeof mock>;
+	resetGroupForRestart: ReturnType<typeof mock>;
 } {
 	const getGroupByTaskId = mock(() => group);
+	const resetGroupForRestart = mock(() => (resetGroupForRestartResult ? group : null));
 
 	const groupRepo = {
 		getGroupByTaskId,
+		resetGroupForRestart,
 	} as unknown as SessionGroupRepository;
 
-	return { groupRepo, getGroupByTaskId };
+	return { groupRepo, getGroupByTaskId, resetGroupForRestart };
 }
 
 describe('routeHumanMessageToGroup', () => {
 	const taskId = 'task-1';
 	const message = 'Hello from human';
 
-	describe('target=worker (default)', () => {
-		it('injects to worker and returns success', async () => {
-			const { runtime, injectMessageToWorker } = makeRuntime(true, true);
-			const { groupRepo } = makeGroupRepo(makeGroup(null));
+	describe('active group (completedAt = null)', () => {
+		describe('target=worker (default)', () => {
+			it('injects to worker and returns success', async () => {
+				const { runtime, injectMessageToWorker } = makeRuntime(true, makeTask('in_progress'));
+				const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+				expect(result.success).toBe(true);
+				expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
+			});
+
+			it('returns error when injectMessageToWorker fails', async () => {
+				const { runtime } = makeRuntime(false, makeTask('in_progress'));
+				const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Failed to inject message into worker session');
+			});
+		});
+
+		describe('target=leader', () => {
+			it('injects to leader and returns success', async () => {
+				const { runtime, injectMessageToLeader } = makeRuntime(true, makeTask('in_progress'));
+				const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+				const result = await routeHumanMessageToGroup(
+					runtime,
+					groupRepo,
+					taskId,
+					message,
+					'leader'
+				);
+
+				expect(result.success).toBe(true);
+				expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);
+			});
+
+			it('returns error when injectMessageToLeader fails', async () => {
+				const { runtime } = makeRuntime(false, makeTask('in_progress'));
+				const { groupRepo } = makeGroupRepo(makeGroup(null));
+
+				const result = await routeHumanMessageToGroup(
+					runtime,
+					groupRepo,
+					taskId,
+					message,
+					'leader'
+				);
+
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Failed to inject message into leader session');
+			});
+		});
+	});
+
+	describe('failed task (completedAt set, task status = failed)', () => {
+		it('resets group, transitions to in_progress, and injects message', async () => {
+			const failedTask = makeTask('failed');
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
+			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(true);
+			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
+			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 		});
 
-		it('returns error when injectMessageToWorker fails', async () => {
-			const { runtime } = makeRuntime(true, false);
-			const { groupRepo } = makeGroupRepo(makeGroup(null));
+		it('returns error when resetGroupForRestart fails', async () => {
+			const failedTask = makeTask('failed');
+			const { runtime, taskManager } = makeRuntime(true, failedTask);
+			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), false);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('Failed to inject message into worker session');
+			expect(result.error).toContain('Failed to reset task group');
+			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+		});
+
+		it('returns error when updateTaskStatus fails', async () => {
+			const failedTask = makeTask('failed');
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
+			taskManager.updateTaskStatus = mock(async () => {
+				throw new Error('Status update failed');
+			});
+			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to transition task to in_progress');
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});
 
-	describe('target=leader', () => {
-		it('injects to leader and returns success', async () => {
-			const { runtime, injectMessageToLeader } = makeRuntime(true, true);
-			const { groupRepo } = makeGroupRepo(makeGroup(null));
+	describe('cancelled task (completedAt set, task status = cancelled)', () => {
+		it('resets group, transitions to in_progress, and injects message', async () => {
+			const cancelledTask = makeTask('cancelled');
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, cancelledTask);
+			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(true);
-			expect(injectMessageToLeader).toHaveBeenCalledWith(taskId, message);
-		});
-
-		it('returns error when injectMessageToLeader fails', async () => {
-			const { runtime } = makeRuntime(true, false);
-			const { groupRepo } = makeGroupRepo(makeGroup(null));
-
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message, 'leader');
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('Failed to inject message into leader session');
+			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
+			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
+			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 		});
 	});
 
-	describe('completed group', () => {
-		it('returns failure when group has completedAt set', async () => {
-			const { runtime } = makeRuntime();
-			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()));
+	describe('completed task (completedAt set, task status = completed)', () => {
+		it('returns failure - completed tasks cannot be restarted', async () => {
+			const completedTask = makeTask('completed');
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, completedTask);
+			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('completed');
+			expect(result.error).toContain('Task is already completed');
+			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('no task found (completedAt set)', () => {
+		it('returns failure when task not found', async () => {
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, null);
+			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Task not found');
+			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('no group', () => {
 		it('returns failure when no group is found', async () => {
-			const { runtime } = makeRuntime();
+			const { runtime } = makeRuntime(true, makeTask('in_progress'));
 			const { groupRepo } = makeGroupRepo(null);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -125,20 +125,20 @@ describe('routeHumanMessageToGroup', () => {
 	describe('active group (completedAt = null)', () => {
 		describe('target=worker (default)', () => {
 			it('injects to worker and returns success', async () => {
-				const { runtime, injectMessageToWorker } = makeRuntime(true, makeTask('in_progress'));
+				const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, makeTask('in_progress'));
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
-				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 				expect(result.success).toBe(true);
 				expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 			});
 
 			it('returns error when injectMessageToWorker fails', async () => {
-				const { runtime } = makeRuntime(false, makeTask('in_progress'));
+				const { runtime, taskManager } = makeRuntime(false, makeTask('in_progress'));
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
-				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Failed to inject message into worker session');
@@ -147,12 +147,13 @@ describe('routeHumanMessageToGroup', () => {
 
 		describe('target=leader', () => {
 			it('injects to leader and returns success', async () => {
-				const { runtime, injectMessageToLeader } = makeRuntime(true, makeTask('in_progress'));
+				const { runtime, injectMessageToLeader, taskManager } = makeRuntime(true, makeTask('in_progress'));
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
 				const result = await routeHumanMessageToGroup(
 					runtime,
 					groupRepo,
+					taskManager,
 					taskId,
 					message,
 					'leader'
@@ -163,12 +164,13 @@ describe('routeHumanMessageToGroup', () => {
 			});
 
 			it('returns error when injectMessageToLeader fails', async () => {
-				const { runtime } = makeRuntime(false, makeTask('in_progress'));
+				const { runtime, taskManager } = makeRuntime(false, makeTask('in_progress'));
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
 				const result = await routeHumanMessageToGroup(
 					runtime,
 					groupRepo,
+					taskManager,
 					taskId,
 					message,
 					'leader'
@@ -186,7 +188,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
@@ -199,7 +201,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, taskManager } = makeRuntime(true, failedTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), false);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to reset task group');
@@ -217,7 +219,7 @@ describe('routeHumanMessageToGroup', () => {
 			group.version = 1;
 			const { groupRepo, failGroup, failGroupCalls } = makeGroupRepo(group, true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to transition task to in_progress');
@@ -239,7 +241,7 @@ describe('routeHumanMessageToGroup', () => {
 				true
 			);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to inject message');
@@ -263,7 +265,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, cancelledTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
@@ -278,7 +280,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, completedTask);
 			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task is already completed');
@@ -292,7 +294,7 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, null);
 			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task not found');
@@ -303,10 +305,10 @@ describe('routeHumanMessageToGroup', () => {
 
 	describe('no group', () => {
 		it('returns failure when no group is found', async () => {
-			const { runtime } = makeRuntime(true, makeTask('in_progress'));
+			const { runtime, taskManager } = makeRuntime(true, makeTask('in_progress'));
 			const { groupRepo } = makeGroupRepo(null);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('No active session group');

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -69,17 +69,17 @@ function makeRuntime(
 	injectMessageToWorker: ReturnType<typeof mock>;
 	taskManager: {
 		getTask: ReturnType<typeof mock>;
-		updateTaskStatus: ReturnType<typeof mock>;
+		setTaskStatus: ReturnType<typeof mock>;
 	};
 } {
 	const injectMessageToLeader = mock(async () => injectResult);
 	const injectMessageToWorker = mock(async () => injectResult);
 	const getTask = mock(async () => task ?? null);
-	const updateTaskStatus = mock(async () => undefined);
+	const setTaskStatus = mock(async () => undefined);
 
 	const taskManager = {
 		getTask,
-		updateTaskStatus,
+		setTaskStatus,
 	};
 
 	const runtime = {
@@ -192,7 +192,7 @@ describe('routeHumanMessageToGroup', () => {
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
-			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 		});
 
@@ -205,13 +205,13 @@ describe('routeHumanMessageToGroup', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to reset task group');
-			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 		});
 
 		it('returns error when updateTaskStatus fails', async () => {
 			const failedTask = makeTask('failed');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
-			taskManager.updateTaskStatus = mock(async () => {
+			taskManager.setTaskStatus = mock(async () => {
 				throw new Error('Status update failed');
 			});
 			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
@@ -248,14 +248,14 @@ describe('routeHumanMessageToGroup', () => {
 			// Group was reset
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
 			// Status was changed to in_progress
-			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			// Tried to inject
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 			// Rolled back to failed with correct version (1 + 1 = 2)
 			expect(failGroup).toHaveBeenCalled();
 			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
 			// Status rolled back to failed
-			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'failed');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'failed');
 		});
 	});
 
@@ -269,7 +269,7 @@ describe('routeHumanMessageToGroup', () => {
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
-			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
 		});
 	});
@@ -284,7 +284,7 @@ describe('routeHumanMessageToGroup', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task is already completed');
-			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});
@@ -298,7 +298,7 @@ describe('routeHumanMessageToGroup', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task not found');
-			expect(taskManager.updateTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -3,8 +3,8 @@
  *
  * Routing behavior:
  * - Active groups (completedAt = null): messages injected directly
- * - needs_attention/cancelled tasks: group is reset and task transitions to in_progress
- * - Completed tasks: message is blocked
+ * - needs_attention tasks: group is reset and task transitions to in_progress
+ * - Cancelled/completed tasks: messages are blocked (caller should use set_task_status to restart)
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -102,7 +102,9 @@ function makeGroupRepo(
 	failGroupCalls: { groupId: string; version: number }[];
 } {
 	const getGroupByTaskId = mock(() => group);
-	const resetGroupForRestart = mock(() => (resetGroupForRestartResult ? group : null));
+	// Simulate the real DB behaviour: version is incremented by resetGroupForRestart
+	const resetGroup = group ? { ...group, version: group.version + 1 } : null;
+	const resetGroupForRestart = mock(() => (resetGroupForRestartResult ? resetGroup : null));
 	const failGroupCalls: { groupId: string; version: number }[] = [];
 	const failGroup = mock((groupId: string, version: number) => {
 		failGroupCalls.push({ groupId, version });
@@ -238,13 +240,13 @@ describe('routeHumanMessageToGroup', () => {
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 		});
 
-		it('returns error when updateTaskStatus fails', async () => {
+		it('returns error when setTaskStatus throws', async () => {
 			const failedTask = makeTask('needs_attention');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
 			taskManager.setTaskStatus = mock(async () => {
 				throw new Error('Status update failed');
 			});
-			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
+			// Group starts at version 1; resetGroupForRestart bumps it to 2
 			const group = makeGroup(Date.now());
 			group.version = 1;
 			const { groupRepo, failGroup, failGroupCalls } = makeGroupRepo(group, true);
@@ -260,7 +262,7 @@ describe('routeHumanMessageToGroup', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to transition task to in_progress');
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
-			// Should have rolled back the group state with correct version (1 + 1 = 2)
+			// Rollback uses the version returned by resetGroupForRestart (version 2)
 			expect(failGroup).toHaveBeenCalled();
 			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
 		});
@@ -269,7 +271,7 @@ describe('routeHumanMessageToGroup', () => {
 			const failedTask = makeTask('needs_attention');
 			// injectResult = false to simulate injection failure
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(false, failedTask);
-			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
+			// Group starts at version 1; resetGroupForRestart bumps it to 2
 			const group = makeGroup(Date.now());
 			group.version = 1;
 			const { groupRepo, resetGroupForRestart, failGroup, failGroupCalls } = makeGroupRepo(
@@ -293,7 +295,7 @@ describe('routeHumanMessageToGroup', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			// Tried to inject
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
-			// Rolled back to needs_attention with correct version (1 + 1 = 2)
+			// Rollback uses the version returned by resetGroupForRestart (version 2)
 			expect(failGroup).toHaveBeenCalled();
 			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
 			// Status rolled back to needs_attention
@@ -302,7 +304,7 @@ describe('routeHumanMessageToGroup', () => {
 	});
 
 	describe('cancelled task (completedAt set, task status = cancelled)', () => {
-		it('resets group, transitions to in_progress, and injects message', async () => {
+		it('returns failure - cancelled tasks cannot receive messages (workspace cleaned up)', async () => {
 			const cancelledTask = makeTask('cancelled');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, cancelledTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
@@ -315,15 +317,16 @@ describe('routeHumanMessageToGroup', () => {
 				message
 			);
 
-			expect(result.success).toBe(true);
-			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
-			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
-			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("'cancelled' status");
+			expect(resetGroupForRestart).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('completed task (completedAt set, task status = completed)', () => {
-		it('returns failure - completed tasks cannot be restarted', async () => {
+		it('returns failure - completed tasks cannot receive messages', async () => {
 			const completedTask = makeTask('completed');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, completedTask);
 			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
@@ -337,7 +340,7 @@ describe('routeHumanMessageToGroup', () => {
 			);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('Task is already completed');
+			expect(result.error).toContain("'completed' status");
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -3,7 +3,7 @@
  *
  * Routing behavior:
  * - Active groups (completedAt = null): messages injected directly
- * - Failed/cancelled tasks: group is reset and task transitions to in_progress
+ * - needs_attention/cancelled tasks: group is reset and task transitions to in_progress
  * - Completed tasks: message is blocked
  */
 
@@ -125,10 +125,19 @@ describe('routeHumanMessageToGroup', () => {
 	describe('active group (completedAt = null)', () => {
 		describe('target=worker (default)', () => {
 			it('injects to worker and returns success', async () => {
-				const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, makeTask('in_progress'));
+				const { runtime, injectMessageToWorker, taskManager } = makeRuntime(
+					true,
+					makeTask('in_progress')
+				);
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
-				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+				const result = await routeHumanMessageToGroup(
+					runtime,
+					groupRepo,
+					taskManager,
+					taskId,
+					message
+				);
 
 				expect(result.success).toBe(true);
 				expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
@@ -138,7 +147,13 @@ describe('routeHumanMessageToGroup', () => {
 				const { runtime, taskManager } = makeRuntime(false, makeTask('in_progress'));
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
-				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+				const result = await routeHumanMessageToGroup(
+					runtime,
+					groupRepo,
+					taskManager,
+					taskId,
+					message
+				);
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Failed to inject message into worker session');
@@ -147,7 +162,10 @@ describe('routeHumanMessageToGroup', () => {
 
 		describe('target=leader', () => {
 			it('injects to leader and returns success', async () => {
-				const { runtime, injectMessageToLeader, taskManager } = makeRuntime(true, makeTask('in_progress'));
+				const { runtime, injectMessageToLeader, taskManager } = makeRuntime(
+					true,
+					makeTask('in_progress')
+				);
 				const { groupRepo } = makeGroupRepo(makeGroup(null));
 
 				const result = await routeHumanMessageToGroup(
@@ -182,13 +200,19 @@ describe('routeHumanMessageToGroup', () => {
 		});
 	});
 
-	describe('failed task (completedAt set, task status = failed)', () => {
+	describe('needs_attention task (completedAt set, task status = needs_attention)', () => {
 		it('resets group, transitions to in_progress, and injects message', async () => {
-			const failedTask = makeTask('failed');
+			const failedTask = makeTask('needs_attention');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
@@ -197,11 +221,17 @@ describe('routeHumanMessageToGroup', () => {
 		});
 
 		it('returns error when resetGroupForRestart fails', async () => {
-			const failedTask = makeTask('failed');
+			const failedTask = makeTask('needs_attention');
 			const { runtime, taskManager } = makeRuntime(true, failedTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), false);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to reset task group');
@@ -209,7 +239,7 @@ describe('routeHumanMessageToGroup', () => {
 		});
 
 		it('returns error when updateTaskStatus fails', async () => {
-			const failedTask = makeTask('failed');
+			const failedTask = makeTask('needs_attention');
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, failedTask);
 			taskManager.setTaskStatus = mock(async () => {
 				throw new Error('Status update failed');
@@ -219,7 +249,13 @@ describe('routeHumanMessageToGroup', () => {
 			group.version = 1;
 			const { groupRepo, failGroup, failGroupCalls } = makeGroupRepo(group, true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to transition task to in_progress');
@@ -230,7 +266,7 @@ describe('routeHumanMessageToGroup', () => {
 		});
 
 		it('rolls back status and group when message injection fails', async () => {
-			const failedTask = makeTask('failed');
+			const failedTask = makeTask('needs_attention');
 			// injectResult = false to simulate injection failure
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(false, failedTask);
 			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
@@ -241,7 +277,13 @@ describe('routeHumanMessageToGroup', () => {
 				true
 			);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to inject message');
@@ -251,11 +293,11 @@ describe('routeHumanMessageToGroup', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			// Tried to inject
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
-			// Rolled back to failed with correct version (1 + 1 = 2)
+			// Rolled back to needs_attention with correct version (1 + 1 = 2)
 			expect(failGroup).toHaveBeenCalled();
 			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
-			// Status rolled back to failed
-			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'failed');
+			// Status rolled back to needs_attention
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith(taskId, 'needs_attention');
 		});
 	});
 
@@ -265,7 +307,13 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, cancelledTask);
 			const { groupRepo, resetGroupForRestart } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(true);
 			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
@@ -280,7 +328,13 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, completedTask);
 			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task is already completed');
@@ -294,7 +348,13 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(true, null);
 			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Task not found');
@@ -308,7 +368,13 @@ describe('routeHumanMessageToGroup', () => {
 			const { runtime, taskManager } = makeRuntime(true, makeTask('in_progress'));
 			const { groupRepo } = makeGroupRepo(null);
 
-			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskManager, taskId, message);
+			const result = await routeHumanMessageToGroup(
+				runtime,
+				groupRepo,
+				taskManager,
+				taskId,
+				message
+			);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('No active session group');

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -99,10 +99,15 @@ function makeGroupRepo(
 	getGroupByTaskId: ReturnType<typeof mock>;
 	resetGroupForRestart: ReturnType<typeof mock>;
 	failGroup: ReturnType<typeof mock>;
+	failGroupCalls: { groupId: string; version: number }[];
 } {
 	const getGroupByTaskId = mock(() => group);
 	const resetGroupForRestart = mock(() => (resetGroupForRestartResult ? group : null));
-	const failGroup = mock(() => group);
+	const failGroupCalls: { groupId: string; version: number }[] = [];
+	const failGroup = mock((groupId: string, version: number) => {
+		failGroupCalls.push({ groupId, version });
+		return group;
+	});
 
 	const groupRepo = {
 		getGroupByTaskId,
@@ -110,7 +115,7 @@ function makeGroupRepo(
 		failGroup,
 	} as unknown as SessionGroupRepository;
 
-	return { groupRepo, getGroupByTaskId, resetGroupForRestart, failGroup };
+	return { groupRepo, getGroupByTaskId, resetGroupForRestart, failGroup, failGroupCalls };
 }
 
 describe('routeHumanMessageToGroup', () => {
@@ -207,23 +212,30 @@ describe('routeHumanMessageToGroup', () => {
 			taskManager.updateTaskStatus = mock(async () => {
 				throw new Error('Status update failed');
 			});
-			const { groupRepo, failGroup } = makeGroupRepo(makeGroup(Date.now()), true);
+			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
+			const group = makeGroup(Date.now());
+			group.version = 1;
+			const { groupRepo, failGroup, failGroupCalls } = makeGroupRepo(group, true);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to transition task to in_progress');
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
-			// Should have rolled back the group state
+			// Should have rolled back the group state with correct version (1 + 1 = 2)
 			expect(failGroup).toHaveBeenCalled();
+			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
 		});
 
 		it('rolls back status and group when message injection fails', async () => {
 			const failedTask = makeTask('failed');
 			// injectResult = false to simulate injection failure
 			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(false, failedTask);
-			const { groupRepo, resetGroupForRestart, failGroup } = makeGroupRepo(
-				makeGroup(Date.now()),
+			// Group version is 1, so rollback should use version 2 (previousVersion + 1)
+			const group = makeGroup(Date.now());
+			group.version = 1;
+			const { groupRepo, resetGroupForRestart, failGroup, failGroupCalls } = makeGroupRepo(
+				group,
 				true
 			);
 
@@ -237,8 +249,9 @@ describe('routeHumanMessageToGroup', () => {
 			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
 			// Tried to inject
 			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
-			// Rolled back to failed
+			// Rolled back to failed with correct version (1 + 1 = 2)
 			expect(failGroup).toHaveBeenCalled();
+			expect(failGroupCalls).toEqual([{ groupId: 'group-1', version: 2 }]);
 			// Status rolled back to failed
 			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'failed');
 		});

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -98,16 +98,19 @@ function makeGroupRepo(
 	groupRepo: SessionGroupRepository;
 	getGroupByTaskId: ReturnType<typeof mock>;
 	resetGroupForRestart: ReturnType<typeof mock>;
+	failGroup: ReturnType<typeof mock>;
 } {
 	const getGroupByTaskId = mock(() => group);
 	const resetGroupForRestart = mock(() => (resetGroupForRestartResult ? group : null));
+	const failGroup = mock(() => group);
 
 	const groupRepo = {
 		getGroupByTaskId,
 		resetGroupForRestart,
+		failGroup,
 	} as unknown as SessionGroupRepository;
 
-	return { groupRepo, getGroupByTaskId, resetGroupForRestart };
+	return { groupRepo, getGroupByTaskId, resetGroupForRestart, failGroup };
 }
 
 describe('routeHumanMessageToGroup', () => {
@@ -204,13 +207,40 @@ describe('routeHumanMessageToGroup', () => {
 			taskManager.updateTaskStatus = mock(async () => {
 				throw new Error('Status update failed');
 			});
-			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()), true);
+			const { groupRepo, failGroup } = makeGroupRepo(makeGroup(Date.now()), true);
 
 			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Failed to transition task to in_progress');
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
+			// Should have rolled back the group state
+			expect(failGroup).toHaveBeenCalled();
+		});
+
+		it('rolls back status and group when message injection fails', async () => {
+			const failedTask = makeTask('failed');
+			// injectResult = false to simulate injection failure
+			const { runtime, injectMessageToWorker, taskManager } = makeRuntime(false, failedTask);
+			const { groupRepo, resetGroupForRestart, failGroup } = makeGroupRepo(
+				makeGroup(Date.now()),
+				true
+			);
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Failed to inject message');
+			// Group was reset
+			expect(resetGroupForRestart).toHaveBeenCalledWith('group-1');
+			// Status was changed to in_progress
+			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'in_progress');
+			// Tried to inject
+			expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
+			// Rolled back to failed
+			expect(failGroup).toHaveBeenCalled();
+			// Status rolled back to failed
+			expect(taskManager.updateTaskStatus).toHaveBeenCalledWith(taskId, 'failed');
 		});
 	});
 


### PR DESCRIPTION
- **feat(tasks): allow failed tasks to accept messages and auto-retry**
- **fix(tasks): add rollback when message injection fails after restart**
- **fix(tasks): use correct version number for rollback**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: propagate taskManager param to room-agent-tools caller**
- **fix: use setTaskStatus for proper validation and emit task updates**
- **fix: use 'needs_attention' instead of invalid 'failed' TaskStatus**
