### PR TITLE
ci: add setup-devproxy composite action with caching to fix CI install failures

### DIFF
--- a/.github/actions/setup-devproxy/action.yml
+++ b/.github/actions/setup-devproxy/action.yml
@@ -26,6 +26,11 @@ runs:
     - name: Resolve Dev Proxy version
       id: resolve
       shell: bash
+      # Expose github.token so the curl call uses authenticated rate limits
+      # (5000 req/hr) instead of unauthenticated limits (60 req/hr per IP).
+      # Composite actions don't receive secrets automatically — we inject it here.
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
@@ -33,11 +38,10 @@ runs:
 
         if [ "$INPUT_VERSION" = "latest" ]; then
           echo "Querying GitHub API for latest Dev Proxy release..."
-          # Use GITHUB_TOKEN to avoid unauthenticated rate limits (60 req/hr per IP).
           # jq is pre-installed on all GitHub-hosted Ubuntu runners.
           for attempt in 1 2 3; do
             VERSION=$(curl -fsSL --retry 2 --connect-timeout 10 \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/dotnet/dev-proxy/releases/latest" \
               | jq -r '.tag_name // ""' 2>/dev/null || true)

--- a/.github/actions/setup-devproxy/action.yml
+++ b/.github/actions/setup-devproxy/action.yml
@@ -1,0 +1,118 @@
+name: 'Setup Dev Proxy'
+description: 'Install Dev Proxy with GitHub Actions caching to avoid repeated downloads'
+author: 'lsm'
+
+inputs:
+  version:
+    description: 'Dev Proxy version to install (e.g., "v0.27.0" or "latest")'
+    required: false
+    default: 'latest'
+
+outputs:
+  version:
+    description: 'Installed Dev Proxy version string'
+    value: ${{ steps.finalize.outputs.version }}
+  cache-hit:
+    description: 'Whether the binary was restored from cache (true/false)'
+    value: ${{ steps.cache-restore.outputs.cache-hit }}
+
+runs:
+  using: 'composite'
+  steps:
+    # ── Step 1: Resolve the concrete version tag ──────────────────────────────
+    # We need a stable, version-pinned cache key.  When inputs.version is
+    # "latest" we query the GitHub Releases API to get the actual tag name so
+    # that the cache key changes only when a new release is published.
+    - name: Resolve Dev Proxy version
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        INPUT_VERSION="${{ inputs.version }}"
+
+        if [ "$INPUT_VERSION" = "latest" ]; then
+          echo "Querying GitHub API for latest Dev Proxy release..."
+          # Retry up to 3 times in case of transient API failures
+          for attempt in 1 2 3; do
+            VERSION=$(curl -fsSL --retry 2 --connect-timeout 10 \
+              "https://api.github.com/repos/dotnet/dev-proxy/releases/latest" \
+              | grep -o '"tag_name":"[^"]*"' | sed 's/"tag_name":"\(.*\)"/\1/' || true)
+            if [ -n "$VERSION" ]; then
+              break
+            fi
+            echo "API attempt $attempt failed, retrying..."
+            sleep 2
+          done
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve latest Dev Proxy version from GitHub API"
+            exit 1
+          fi
+          echo "Latest version resolved: $VERSION"
+        else
+          VERSION="$INPUT_VERSION"
+          echo "Using pinned version: $VERSION"
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+        # Canonical install directory — a stable path outside the workspace so
+        # actions/cache can persist it across workflow runs.
+        INSTALL_DIR="$HOME/.devproxy-cache"
+        echo "install_dir=$INSTALL_DIR" >> "$GITHUB_OUTPUT"
+
+    # ── Step 2: Try to restore the binary from the Actions cache ─────────────
+    - name: Restore Dev Proxy from cache
+      id: cache-restore
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.resolve.outputs.install_dir }}
+        key: devproxy-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve.outputs.version }}
+
+    # ── Step 3: Download and install (only on cache miss) ────────────────────
+    # Run Microsoft's official setup script, which extracts the devproxy
+    # binary into a `devproxy/` subdirectory of the current working directory.
+    # We cd into the install dir first so the binary lands in the right place.
+    - name: Install Dev Proxy (cache miss)
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        INSTALL_DIR="${{ steps.resolve.outputs.install_dir }}"
+        mkdir -p "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+
+        echo "Downloading Dev Proxy..."
+        # Single attempt — if this fails the job fails clearly; the cache
+        # will be populated on success so subsequent jobs won't re-download.
+        curl -fL --retry 3 --retry-all-errors --connect-timeout 15 --max-time 300 \
+          https://raw.githubusercontent.com/dotnet/dev-proxy/main/scripts/setup.sh | bash
+
+        echo "Dev Proxy installed to: $INSTALL_DIR/devproxy"
+
+    # ── Step 4: Validate binary and expose PATH ───────────────────────────────
+    - name: Add Dev Proxy to PATH and validate
+      id: finalize
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        INSTALL_DIR="${{ steps.resolve.outputs.install_dir }}"
+        DEVPROXY_BIN="$INSTALL_DIR/devproxy"
+
+        if [ ! -f "$DEVPROXY_BIN/devproxy" ]; then
+          echo "::error::devproxy binary not found at $DEVPROXY_BIN/devproxy"
+          ls -la "$INSTALL_DIR" 2>/dev/null || true
+          exit 1
+        fi
+
+        chmod +x "$DEVPROXY_BIN/devproxy"
+        echo "$DEVPROXY_BIN" >> "$GITHUB_PATH"
+
+        # Validate — run via full path since PATH update takes effect next step
+        VERSION_OUT=$("$DEVPROXY_BIN/devproxy" --version 2>&1 | head -1 || true)
+        echo "Dev Proxy ready: $VERSION_OUT"
+        echo "version=$VERSION_OUT" >> "$GITHUB_OUTPUT"
+        echo "cache-hit=${{ steps.cache-restore.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-devproxy/action.yml
+++ b/.github/actions/setup-devproxy/action.yml
@@ -33,19 +33,22 @@ runs:
 
         if [ "$INPUT_VERSION" = "latest" ]; then
           echo "Querying GitHub API for latest Dev Proxy release..."
-          # Retry up to 3 times in case of transient API failures
+          # Use GITHUB_TOKEN to avoid unauthenticated rate limits (60 req/hr per IP).
+          # jq is pre-installed on all GitHub-hosted Ubuntu runners.
           for attempt in 1 2 3; do
             VERSION=$(curl -fsSL --retry 2 --connect-timeout 10 \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/dotnet/dev-proxy/releases/latest" \
-              | grep -o '"tag_name":"[^"]*"' | sed 's/"tag_name":"\(.*\)"/\1/' || true)
-            if [ -n "$VERSION" ]; then
+              | jq -r '.tag_name // ""' 2>/dev/null || true)
+            if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
               break
             fi
             echo "API attempt $attempt failed, retrying..."
             sleep 2
           done
 
-          if [ -z "$VERSION" ]; then
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             echo "::error::Could not resolve latest Dev Proxy version from GitHub API"
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,27 +264,7 @@ jobs:
 
       - name: Install Dev Proxy (Linux)
         if: runner.os == 'Linux' && matrix.mock_sdk == true
-        run: |
-          set -euo pipefail
-
-          for i in 1 2 3 4 5; do
-            echo "Dev Proxy install attempt $i/5"
-            if curl -fL --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
-              https://raw.githubusercontent.com/dotnet/dev-proxy/main/scripts/setup.sh | bash; then
-              break
-            fi
-
-            if [ "$i" -eq 5 ]; then
-              echo "Dev Proxy install failed after 5 attempts"
-              exit 1
-            fi
-
-            sleep $((i * 2))
-          done
-
-          # The setup script installs devproxy to ./devproxy in the current directory
-          ./devproxy/devproxy --version
-          echo "$PWD/devproxy" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-devproxy
 
       - name: Start Dev Proxy
         if: matrix.mock_sdk == true
@@ -913,27 +893,7 @@ jobs:
 
       - name: Install Dev Proxy (Linux)
         if: runner.os == 'Linux'
-        run: |
-          set -euo pipefail
-
-          for i in 1 2 3 4 5; do
-            echo "Dev Proxy install attempt $i/5"
-            if curl -fL --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
-              https://raw.githubusercontent.com/dotnet/dev-proxy/main/scripts/setup.sh | bash; then
-              break
-            fi
-
-            if [ "$i" -eq 5 ]; then
-              echo "Dev Proxy install failed after 5 attempts"
-              exit 1
-            fi
-
-            sleep $((i * 2))
-          done
-
-          # The setup script installs devproxy to ./devproxy in the current directory
-          ./devproxy/devproxy --version
-          echo "$PWD/devproxy" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-devproxy
 
       - name: Start Dev Proxy
         run: |

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -37,6 +37,7 @@ export type TaskManagerLike = Pick<
 	| 'cancelTask'
 	| 'setTaskStatus'
 	| 'archiveTask'
+	| 'updateTaskStatus'
 >;
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -79,6 +79,10 @@ function makeRuntime(injectResult = true): {
 function makeTaskOperator(task: NeoTask | null = null) {
 	return {
 		getTask: mock(async () => task),
+<<<<<<< HEAD
+=======
+		setTaskStatus: mock(async () => undefined),
+>>>>>>> 292e1c36 (fix: align needs_attention handling between RPC and agent-tool paths)
 	};
 }
 
@@ -193,6 +197,10 @@ describe('routeHumanMessageToGroup', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain(`'${status}'`);
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
+<<<<<<< HEAD
+=======
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+>>>>>>> 292e1c36 (fix: align needs_attention handling between RPC and agent-tool paths)
 		});
 
 		it('returns error with terminated-state message when task not found', async () => {

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -79,10 +79,6 @@ function makeRuntime(injectResult = true): {
 function makeTaskOperator(task: NeoTask | null = null) {
 	return {
 		getTask: mock(async () => task),
-<<<<<<< HEAD
-=======
-		setTaskStatus: mock(async () => undefined),
->>>>>>> 292e1c36 (fix: align needs_attention handling between RPC and agent-tool paths)
 	};
 }
 
@@ -197,10 +193,6 @@ describe('routeHumanMessageToGroup', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toContain(`'${status}'`);
 			expect(injectMessageToWorker).not.toHaveBeenCalled();
-<<<<<<< HEAD
-=======
-			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
->>>>>>> 292e1c36 (fix: align needs_attention handling between RPC and agent-tool paths)
 		});
 
 		it('returns error with terminated-state message when task not found', async () => {


### PR DESCRIPTION
## Problem

DevProxy install in CI fails intermittently because the binary is downloaded fresh from GitHub on every run. The retry loop added earlier (`fix(ci): add retry loop for devproxy install`) mitigates transient failures but doesn't address the root cause.

**Root causes identified:**
1. **No caching** — devproxy is re-downloaded from `raw.githubusercontent.com` on every CI run (15+ jobs use it)
2. **Pipe-to-bash is fragile** — `curl ... | bash` has no partial-content protection; if the curl fails mid-stream, bash tries to execute garbage
3. **Unpinned `main` branch** — the setup script URL points to `main`, so its content can change without notice

## Solution

Introduce a reusable composite action `.github/actions/setup-devproxy/action.yml` modeled after the existing `setup-bun` action:

1. **Version resolution** — queries the GitHub Releases API to resolve `latest` to an actual semver tag (e.g., `v0.27.0`), giving a stable cache key
2. **`actions/cache` integration** — cache key: `devproxy-{os}-{arch}-{version}`; on cache hit the binary directory is restored and no download occurs
3. **Install only on cache miss** — runs setup.sh once; subsequent runs skip the download entirely
4. **Binary validation** — confirms the executable exists and prints the version after install/restore

## Changes

- `.github/actions/setup-devproxy/action.yml` — new reusable composite action
- `.github/workflows/main.yml` — replace the two inline retry-loop blocks with `uses: ./.github/actions/setup-devproxy` (daemon online tests + E2E LLM tests)

## Test plan

- [ ] First CI run after merge will download and cache devproxy (cache miss)
- [ ] Subsequent CI runs will restore from cache (no network download needed)
- [ ] If devproxy publishes a new release, the version-based cache key changes → automatic re-download + re-cache