### PR TITLE
fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker

### DIFF
--- a/packages/daemon/tests/unit/rpc-handlers/dialog-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/dialog-handlers.test.ts
@@ -113,14 +113,31 @@ describe('Dialog RPC Handlers', () => {
 			expect(handler).toBeDefined();
 		});
 
-		it('handler is an async function returning a Promise', () => {
+		it('handler is an async function returning a Promise with a path field', async () => {
+			setPlatform('darwin');
+			spawnSpy.mockImplementation(
+				() => createMockProcess('/Users/test/project\n') as unknown as ReturnType<typeof Bun.spawn>
+			);
 			const handler = messageHubData.handlers.get('dialog.pickFolder');
 			expect(handler).toBeDefined();
 			expect(typeof handler).toBe('function');
 			const result = handler!({}, {});
 			expect(result).toBeInstanceOf(Promise);
-			// Await so the mock process resolves cleanly (no unhandled promise warnings)
-			return result;
+			const resolved = await result;
+			expect(resolved).toEqual({ path: '/Users/test/project' });
+		});
+
+		it('returns null when Bun.spawn throws an error (error-handling path)', async () => {
+			setPlatform('darwin');
+			spawnSpy.mockImplementation(() => {
+				throw new Error('spawn failed');
+			});
+
+			const handler = messageHubData.handlers.get('dialog.pickFolder')!;
+			const result = await handler({}, {});
+
+			// pickFolder catches errors and returns null
+			expect(result).toEqual({ path: null });
 		});
 
 		describe('macOS (darwin)', () => {


### PR DESCRIPTION
The existing dialog-handlers tests used an `itSkipCI` workaround that only
prevented tests from running in CI environments. When running tests locally,
`handler({}, {})` was called which invoked `pickFolder()` → `Bun.spawn(['osascript', ...])`
and triggered the actual macOS folder picker dialog.

Despite the comment claiming "these tests mock the platform and command execution",
no mocking of Bun.spawn was actually in place.

Fix: use `spyOn(Bun, 'spawn').mockImplementation(...)` to return a mock subprocess
that resolves immediately without spawning any real OS process. Remove `itSkipCI`
since tests are now safe to run in both CI and local development.

Also adds meaningful test coverage for all supported platforms (macOS, Linux, Windows)
and cancellation scenarios, covering zenity/kdialog fallback logic on Linux.
