### PR TITLE
fix: skip max feedback iterations limit when task is in review state

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -801,7 +801,11 @@ export class RoomRuntime {
 			case 'send_to_worker': {
 				// Enforce max feedback iterations — runtime escalates to human review.
 				// The reason is persisted in the group timeline by escalateToHumanReview().
-				if (group.feedbackIteration >= this.maxFeedbackIterations) {
+				// Only apply this limit when the task is in 'in_progress' state.
+				// When the task is in 'review' state (human review phase), there is no limit.
+				const taskForCheck = await this.taskManager.getTask(group.taskId);
+				const isInProgress = !taskForCheck || taskForCheck.status === 'in_progress';
+				if (isInProgress && group.feedbackIteration >= this.maxFeedbackIterations) {
 					const reason = `Max feedback iterations (${this.maxFeedbackIterations}) reached`;
 					await this.taskGroupManager.escalateToHumanReview(groupId, reason);
 					this.appendGroupEvent(groupId, 'status', {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -801,11 +801,13 @@ export class RoomRuntime {
 			case 'send_to_worker': {
 				// Enforce max feedback iterations — runtime escalates to human review.
 				// The reason is persisted in the group timeline by escalateToHumanReview().
-				// Only apply this limit when the task is in 'in_progress' state.
+				// Only apply this limit when the task is NOT in 'review' state.
 				// When the task is in 'review' state (human review phase), there is no limit.
+				// Null task (record deleted): conservatively enforce the limit; escalateToHumanReview
+				// will throw in that case, which is acceptable as a defensive edge-case.
 				const taskForCheck = await this.taskManager.getTask(group.taskId);
-				const isInProgress = !taskForCheck || taskForCheck.status === 'in_progress';
-				if (isInProgress && group.feedbackIteration >= this.maxFeedbackIterations) {
+				const shouldEnforceLimit = !taskForCheck || taskForCheck.status !== 'review';
+				if (shouldEnforceLimit && group.feedbackIteration >= this.maxFeedbackIterations) {
 					const reason = `Max feedback iterations (${this.maxFeedbackIterations}) reached`;
 					await this.taskGroupManager.escalateToHumanReview(groupId, reason);
 					this.appendGroupEvent(groupId, 'status', {

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -753,6 +753,72 @@ describe('RoomRuntime flow', () => {
 			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(3);
 		});
 
+		it('should not apply max feedback iterations limit when task is in review state', async () => {
+			// When a human reviewer sends feedback (task is in 'review' state),
+			// the leader should be able to send unlimited messages to the worker.
+			ctx.runtime.stop();
+			ctx.db.close();
+			ctx = createRuntimeTestContext({ maxFeedbackIterations: 2 });
+
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
+
+			// Exhaust all 2 iterations (feedbackIteration reaches 2, escalation fires)
+			for (let i = 0; i < 1; i++) {
+				await ctx.runtime.onWorkerTerminalState(group.id, {
+					sessionId: group.workerSessionId,
+					kind: 'idle',
+				});
+				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+					message: `Round ${i + 1}`,
+					mode: 'queue',
+				});
+			}
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			// feedbackIteration is now 2 >= maxFeedbackIterations (2), trigger escalation
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Trigger escalation',
+				mode: 'queue',
+			});
+
+			// Task is now in 'review' state
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(2);
+
+			// Manually put task back to 'review' status (simulate human reviewer sending feedback)
+			// The feedbackIteration is still >= maxFeedbackIterations (not reset yet)
+			// but the limit should NOT apply because task is in 'review' state
+			await ctx.taskManager.reviewTask(task.id);
+
+			// Leader sends to worker while task is in 'review' state — should succeed
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			// Increment feedbackIteration via routeWorkerToLeader (now 3)
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBeGreaterThanOrEqual(2);
+
+			// Directly set task status to 'review' to simulate human-in-the-loop
+			await ctx.taskManager.reviewTask(task.id);
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
+
+			// Now call send_to_worker — limit should NOT apply in review state
+			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Human reviewer feedback to worker',
+				mode: 'queue',
+			});
+
+			// Should succeed even though feedbackIteration >= maxFeedbackIterations
+			expect(JSON.parse(result.content[0].text).success).toBe(true);
+			// Task should remain in review state (not escalated again)
+			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
+		});
+
 		it('should keep leader contract violations at 0 when leader reaches terminal without a tool', async () => {
 			await createGoalAndTask(ctx);
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -754,8 +754,10 @@ describe('RoomRuntime flow', () => {
 		});
 
 		it('should not apply max feedback iterations limit when task is in review state', async () => {
-			// When a human reviewer sends feedback (task is in 'review' state),
-			// the leader should be able to send unlimited messages to the worker.
+			// When the task is in 'review' state (human review phase), the leader
+			// should be able to forward feedback to the worker without the iteration limit.
+			// Scenario: auto-escalation moves task to 'review'; leader still active and
+			// tries send_to_worker on behalf of a human reviewer.
 			ctx.runtime.stop();
 			ctx.db.close();
 			ctx = createRuntimeTestContext({ maxFeedbackIterations: 2 });
@@ -765,57 +767,46 @@ describe('RoomRuntime flow', () => {
 			await ctx.runtime.tick();
 			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
 
-			// Exhaust all 2 iterations (feedbackIteration reaches 2, escalation fires)
-			for (let i = 0; i < 1; i++) {
-				await ctx.runtime.onWorkerTerminalState(group.id, {
-					sessionId: group.workerSessionId,
-					kind: 'idle',
-				});
-				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
-					message: `Round ${i + 1}`,
-					mode: 'queue',
-				});
-			}
+			// Round 1: worker done → feedbackIteration becomes 1, leader sends back
 			await ctx.runtime.onWorkerTerminalState(group.id, {
 				sessionId: group.workerSessionId,
 				kind: 'idle',
 			});
-			// feedbackIteration is now 2 >= maxFeedbackIterations (2), trigger escalation
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(1);
 			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Round 1',
+				mode: 'queue',
+			});
+
+			// Round 2: worker done → feedbackIteration becomes 2 (== maxFeedbackIterations)
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(2);
+
+			// Leader tries send_to_worker: 2 >= 2 → runtime escalates to human review
+			const escalationResult = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Trigger escalation',
 				mode: 'queue',
 			});
+			expect(JSON.parse(escalationResult.content[0].text).success).toBe(false);
+			expect(JSON.parse(escalationResult.content[0].text).error).toContain('human review');
 
-			// Task is now in 'review' state
+			// Task is now in 'review' state with feedbackIteration still at 2
 			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
 			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(2);
 
-			// Manually put task back to 'review' status (simulate human reviewer sending feedback)
-			// The feedbackIteration is still >= maxFeedbackIterations (not reset yet)
-			// but the limit should NOT apply because task is in 'review' state
-			await ctx.taskManager.reviewTask(task.id);
-
-			// Leader sends to worker while task is in 'review' state — should succeed
-			await ctx.runtime.onWorkerTerminalState(group.id, {
-				sessionId: group.workerSessionId,
-				kind: 'idle',
-			});
-			// Increment feedbackIteration via routeWorkerToLeader (now 3)
-			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBeGreaterThanOrEqual(2);
-
-			// Directly set task status to 'review' to simulate human-in-the-loop
-			await ctx.taskManager.reviewTask(task.id);
-			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
-
-			// Now call send_to_worker — limit should NOT apply in review state
+			// Human reviewer sends feedback to the leader (leader session still active).
+			// The leader calls send_to_worker to forward the feedback to the worker.
+			// This should succeed because task.status === 'review' — no limit applies.
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
-				message: 'Human reviewer feedback to worker',
+				message: 'Human reviewer feedback forwarded to worker',
 				mode: 'queue',
 			});
 
-			// Should succeed even though feedbackIteration >= maxFeedbackIterations
 			expect(JSON.parse(result.content[0].text).success).toBe(true);
-			// Task should remain in review state (not escalated again)
+			// Task remains in review state (not escalated again)
 			expect((await ctx.taskManager.getTask(task.id))!.status).toBe('review');
 		});
 

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -822,7 +822,8 @@ export function RoomAgents({ room }: RoomAgentsProps) {
 				<div>
 					<label class="block text-sm font-medium text-gray-300 mb-1">Max Review Rounds</label>
 					<p class="text-xs text-gray-500 mb-2">
-						Maximum number of review iterations before failing the task.
+						Maximum number of automated review iterations before escalating to human review. No
+						limit applies when the task is already in human review.
 					</p>
 					<input
 						type="number"


### PR DESCRIPTION
When a human reviewer sends feedback to the leader during the review
phase, the leader should be able to communicate freely with the worker
without hitting the automated review round limit.

The maxFeedbackIterations check in handleLeaderTool now reads the
current task status and only enforces the limit when the task is in
'in_progress' state. When the task is already in 'review' state
(human review phase), there is no iteration limit.

Also updates the UI description for the Max Review Rounds setting to
accurately reflect the new behavior.
