### PR TITLE
fix: preserve PR data on runtime escalation and show PR in task view header

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -275,15 +275,20 @@ export class TaskManager {
 	 * Move task to review (work done, awaiting human approval)
 	 */
 	async reviewTask(taskId: string, prUrl?: string): Promise<NeoTask> {
-		const prNumber = prUrl ? extractPrNumber(prUrl) : null;
-		const prCreatedAt = prUrl ? Date.now() : null;
-		return this.updateTaskStatus(taskId, 'review', {
+		const updates: Partial<NeoTask> = {
 			currentStep: prUrl ?? 'Awaiting review', // Keep for backward compatibility
 			progress: 80,
-			prUrl: prUrl ?? null,
-			prNumber,
-			prCreatedAt,
-		});
+		};
+
+		// Only update PR fields when prUrl is explicitly provided.
+		// When prUrl is omitted (e.g. runtime escalation), preserve any existing PR data.
+		if (prUrl !== undefined) {
+			updates.prUrl = prUrl;
+			updates.prNumber = extractPrNumber(prUrl);
+			updates.prCreatedAt = Date.now();
+		}
+
+		return this.updateTaskStatus(taskId, 'review', updates);
 	}
 
 	/**

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -457,7 +457,7 @@ describe('TaskManager', () => {
 			expect(updated.prNumber).toBe(123);
 		});
 
-		it('should set null PR fields when no prUrl provided', async () => {
+		it('should leave PR fields undefined when no prUrl provided on a fresh task', async () => {
 			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
 
 			const updated = await taskManager.reviewTask(task.id);
@@ -466,6 +466,38 @@ describe('TaskManager', () => {
 			expect(updated.prUrl).toBeUndefined();
 			expect(updated.prNumber).toBeUndefined();
 			expect(updated.prCreatedAt).toBeUndefined();
+		});
+
+		it('should preserve existing PR data when reviewed again without prUrl (runtime escalation)', async () => {
+			// Task first goes to review with a PR URL
+			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/42');
+
+			// Simulate rejection — move back to in_progress
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+
+			// Runtime escalates to review without a prUrl (max feedback iterations reached)
+			const escalated = await taskManager.reviewTask(task.id);
+
+			// PR data must be preserved — not wiped
+			expect(escalated.status).toBe('review');
+			expect(escalated.prUrl).toBe('https://github.com/org/repo/pull/42');
+			expect(escalated.prNumber).toBe(42);
+			expect(escalated.prCreatedAt).toBeDefined();
+		});
+
+		it('should overwrite PR data when reviewed again with a new prUrl', async () => {
+			const task = await taskManager.createTask({ title: 'Test Task', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/1');
+
+			// Move back to in_progress, then submit new PR
+			await taskManager.updateTaskStatus(task.id, 'in_progress');
+			const updated = await taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/2');
+
+			expect(updated.prUrl).toBe('https://github.com/org/repo/pull/2');
+			expect(updated.prNumber).toBe(2);
 		});
 
 		it('should throw error for non-existent task', async () => {

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1460,3 +1460,112 @@ describe('TaskView — draft-restored banner', () => {
 		expect(mockClearDraft).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe('TaskView — PR link in header', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows PR link in header for in_progress task with prUrl', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get')
+				return {
+					task: {
+						...makeTask('task-1', 'in_progress'),
+						prUrl: 'https://github.com/org/repo/pull/42',
+						prNumber: 42,
+					},
+				};
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('PR #42');
+		});
+
+		const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/42"]');
+		expect(prLink).not.toBeNull();
+	});
+
+	it('does not show PR link in header for in_progress task without prUrl', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.textContent).not.toContain('PR #');
+	});
+
+	it('does not show PR link in header for review task (review bar shows it instead)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get')
+				return {
+					task: {
+						...makeTask('task-1', 'review'),
+						prUrl: 'https://github.com/org/repo/pull/99',
+						prNumber: 99,
+					},
+				};
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// The PR link should appear in the review bar but NOT in the header title area.
+		// Since the review bar and header both render, there will be exactly one PR link
+		// (in the review bar). The header div does not render a second PR badge.
+		const prLinks = container.querySelectorAll('a[href="https://github.com/org/repo/pull/99"]');
+		// Only the review bar link should exist (not a second one from the header)
+		expect(prLinks.length).toBe(1);
+	});
+
+	it('shows PR link in header for needs_attention task with prUrl', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get')
+				return {
+					task: {
+						...makeTask('task-1', 'needs_attention'),
+						prUrl: 'https://github.com/org/repo/pull/7',
+						prNumber: 7,
+					},
+				};
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('PR #7');
+		});
+
+		const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/7"]');
+		expect(prLink).not.toBeNull();
+	});
+});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -903,6 +903,21 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 								{task.taskType}
 							</span>
 						)}
+						{/* PR link for non-review states (review bar shows it for review status) */}
+						{task.prUrl && task.status !== 'review' && (
+							<a
+								href={task.prUrl}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-purple-400 bg-purple-500/10 hover:bg-purple-500/20 border border-purple-500/30 rounded transition-colors"
+								title="View Pull Request"
+							>
+								<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 16 16">
+									<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+								</svg>
+								<span>PR #{task.prNumber ?? '?'}</span>
+							</a>
+						)}
 					</div>
 					{group && (
 						<div class="flex items-center gap-2 mt-0.5">


### PR DESCRIPTION
Two bugs fixed:

1. reviewTask() was always setting prUrl/prNumber/prCreatedAt in the DB update,
   even when no prUrl was provided. Since updateTask() treats null differently
   from undefined (null triggers a DB write), calling reviewTask() without a
   prUrl (e.g. runtime escalation on max feedback iterations) would clear any
   existing PR data stored from a prior review cycle.

   Fix: only include PR fields in the update when prUrl is explicitly provided;
   when omitted, existing PR data is preserved in the database.

2. TaskView only rendered the PR link inside HeaderReviewBar (review state only).
   When a task was rejected back to in_progress, the PR link disappeared from
   the task view header even though prUrl was still on the task.

   Fix: add a PR link badge in the task header for non-review statuses so the
   link is visible whenever the task has a prUrl, regardless of status.
