### PR TITLE
feat: order tasks by most recently updated within each status

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -139,6 +139,7 @@ export class RoomManager {
 			activeSession: task.activeSession,
 			prUrl: task.prUrl,
 			prNumber: task.prNumber,
+			updatedAt: task.updatedAt,
 		});
 		const nonTerminal = tasks.filter(
 			(t) => t.status !== 'completed' && t.status !== 'needs_attention' && t.status !== 'cancelled'

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -21,8 +21,8 @@ export class TaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, task_type, assigned_agent, created_by_task_id, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO tasks (id, room_id, title, description, status, priority, depends_on, task_type, assigned_agent, created_by_task_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -36,6 +36,7 @@ export class TaskRepository {
 			params.taskType ?? 'coding',
 			params.assignedAgent ?? 'coder',
 			params.createdByTaskId ?? null,
+			now,
 			now
 		);
 
@@ -88,7 +89,7 @@ export class TaskRepository {
 			query += ` AND priority = ?`;
 			params.push(filter.priority);
 		}
-		query += ` ORDER BY created_at DESC`;
+		query += ` ORDER BY updated_at DESC`;
 
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(...params) as Record<string, unknown>[];
@@ -182,6 +183,8 @@ export class TaskRepository {
 			values.push(params.inputDraft ?? null);
 		}
 		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
 			values.push(id);
 			const stmt = this.db.prepare(`UPDATE tasks SET ${fields.join(', ')} WHERE id = ?`);
 			stmt.run(...values);
@@ -279,6 +282,7 @@ export class TaskRepository {
 			prUrl: (row.pr_url as string | null) ?? undefined,
 			prNumber: (row.pr_number as number | null) ?? undefined,
 			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,
+			updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
 		};
 	}
 }

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -50,9 +50,9 @@ export class TaskRepository {
 	promoteDraftTasksByCreator(createdByTaskId: string): number {
 		const result = this.db
 			.prepare(
-				`UPDATE tasks SET status = 'pending' WHERE created_by_task_id = ? AND status = 'draft'`
+				`UPDATE tasks SET status = 'pending', updated_at = ? WHERE created_by_task_id = ? AND status = 'draft'`
 			)
-			.run(createdByTaskId);
+			.run(Date.now(), createdByTaskId);
 		return result.changes;
 	}
 
@@ -207,8 +207,9 @@ export class TaskRepository {
 	 * Returns the updated task or null if not found.
 	 */
 	archiveTask(id: string): NeoTask | null {
-		const stmt = this.db.prepare(`UPDATE tasks SET archived_at = ? WHERE id = ?`);
-		stmt.run(Date.now(), id);
+		const now = Date.now();
+		const stmt = this.db.prepare(`UPDATE tasks SET archived_at = ?, updated_at = ? WHERE id = ?`);
+		stmt.run(now, now, id);
 		return this.getTask(id);
 	}
 

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -161,6 +161,7 @@ export function createTables(db: BunDatabase): void {
         pr_number INTEGER,
         pr_created_at INTEGER,
         input_draft TEXT,
+        updated_at INTEGER,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -299,6 +299,7 @@ function createIndexes(db: BunDatabase): void {
 	// Room indexes
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1211,14 +1211,15 @@ function runMigration27(db: BunDatabase): void {
 	if (!tableExists(db, 'tasks')) {
 		return;
 	}
-	if (tableHasColumn(db, 'tasks', 'updated_at')) {
-		return;
+	if (!tableHasColumn(db, 'tasks', 'updated_at')) {
+		db.exec(`ALTER TABLE tasks ADD COLUMN updated_at INTEGER`);
+		// Backfill updated_at with the best available timestamp for existing rows
+		db.exec(
+			`UPDATE tasks SET updated_at = COALESCE(completed_at, started_at, created_at) WHERE updated_at IS NULL`
+		);
 	}
-	db.exec(`ALTER TABLE tasks ADD COLUMN updated_at INTEGER`);
-	// Backfill updated_at with the best available timestamp for existing rows
-	db.exec(
-		`UPDATE tasks SET updated_at = COALESCE(completed_at, started_at, created_at) WHERE updated_at IS NULL`
-	);
+	// Add composite index for listTasks() query: WHERE room_id = ? ORDER BY updated_at DESC
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
 }
 
 function runMigrationRoomCleanup(db: BunDatabase): void {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -102,6 +102,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 26: Add input_draft column to tasks table for server-side draft persistence
 	runMigration26(db);
+
+	// Migration 27: Add updated_at column to tasks table for sorting by most recently updated
+	runMigration27(db);
 }
 
 /**
@@ -1202,6 +1205,20 @@ function runMigration26(db: BunDatabase): void {
 		return;
 	}
 	db.exec(`ALTER TABLE tasks ADD COLUMN input_draft TEXT`);
+}
+
+function runMigration27(db: BunDatabase): void {
+	if (!tableExists(db, 'tasks')) {
+		return;
+	}
+	if (tableHasColumn(db, 'tasks', 'updated_at')) {
+		return;
+	}
+	db.exec(`ALTER TABLE tasks ADD COLUMN updated_at INTEGER`);
+	// Backfill updated_at with the best available timestamp for existing rows
+	db.exec(
+		`UPDATE tasks SET updated_at = COALESCE(completed_at, started_at, created_at) WHERE updated_at IS NULL`
+	);
 }
 
 function runMigrationRoomCleanup(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -58,7 +58,8 @@ describe('Room Agent Tools', () => {
 				active_session TEXT,
 				pr_url TEXT,
 				pr_number INTEGER,
-				pr_created_at INTEGER
+				pr_created_at INTEGER,
+				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -135,7 +135,8 @@ const DB_SCHEMA = `
 		active_session TEXT,
 		pr_url TEXT,
 		pr_number INTEGER,
-		pr_created_at INTEGER
+		pr_created_at INTEGER,
+		updated_at INTEGER
 	);
 	CREATE TABLE session_groups (
 		id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -116,7 +116,8 @@ describe('Runtime Recovery', () => {
 				active_session TEXT,
 				pr_url TEXT,
 				pr_number INTEGER,
-				pr_created_at INTEGER
+				pr_created_at INTEGER,
+				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -39,7 +39,8 @@ describe('SessionGroupRepository', () => {
 				active_session TEXT,
 				pr_url TEXT,
 				pr_number INTEGER,
-				pr_created_at INTEGER
+				pr_created_at INTEGER,
+				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -205,7 +205,8 @@ describe('TaskGroupManager', () => {
 				active_session TEXT,
 				pr_url TEXT,
 				pr_number INTEGER,
-				pr_created_at INTEGER
+				pr_created_at INTEGER,
+				updated_at INTEGER
 			);
 			CREATE TABLE session_groups (
 				id TEXT PRIMARY KEY, group_type TEXT NOT NULL DEFAULT 'task',

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -45,7 +45,8 @@ describe('TaskRepository', () => {
 				active_session TEXT,
 				pr_url TEXT,
 				pr_number INTEGER,
-				pr_created_at INTEGER
+				pr_created_at INTEGER,
+				updated_at INTEGER
 			);
 
 			CREATE INDEX idx_tasks_room ON tasks(room_id);
@@ -91,7 +92,7 @@ describe('TaskRepository', () => {
 			expect(task.dependsOn).toEqual(['task-1', 'task-2']);
 		});
 
-		it('should set createdAt timestamp', () => {
+		it('should set createdAt and updatedAt timestamps', () => {
 			const beforeTime = Date.now();
 			const params: CreateTaskParams = {
 				roomId: 'room-1',
@@ -102,6 +103,8 @@ describe('TaskRepository', () => {
 			const task = repository.createTask(params);
 
 			expect(task.createdAt).toBeGreaterThanOrEqual(beforeTime);
+			expect(task.updatedAt).toBeGreaterThanOrEqual(beforeTime);
+			expect(task.updatedAt).toBeGreaterThanOrEqual(task.createdAt);
 		});
 
 		it('should support all priority levels', () => {
@@ -154,10 +157,18 @@ describe('TaskRepository', () => {
 			expect(tasks.map((t) => t.title)).toContain('Task 2');
 		});
 
-		it('should return tasks ordered by created_at DESC', async () => {
-			repository.createTask({ roomId: 'room-1', title: 'Oldest', description: 'Desc' });
+		it('should return tasks ordered by updated_at DESC', async () => {
+			const oldest = repository.createTask({
+				roomId: 'room-1',
+				title: 'Oldest',
+				description: 'Desc',
+			});
 			await new Promise((r) => setTimeout(r, 5));
-			repository.createTask({ roomId: 'room-1', title: 'Middle', description: 'Desc' });
+			const middle = repository.createTask({
+				roomId: 'room-1',
+				title: 'Middle',
+				description: 'Desc',
+			});
 			await new Promise((r) => setTimeout(r, 5));
 			repository.createTask({ roomId: 'room-1', title: 'Newest', description: 'Desc' });
 
@@ -166,6 +177,18 @@ describe('TaskRepository', () => {
 			expect(tasks[0].title).toBe('Newest');
 			expect(tasks[1].title).toBe('Middle');
 			expect(tasks[2].title).toBe('Oldest');
+
+			// After updating the oldest task, it should appear first
+			await new Promise((r) => setTimeout(r, 5));
+			repository.updateTask(oldest.id, { title: 'Oldest (updated)' });
+			const tasksAfterUpdate = repository.listTasks('room-1');
+			expect(tasksAfterUpdate[0].title).toBe('Oldest (updated)');
+
+			// After updating the middle task, it should now appear first
+			await new Promise((r) => setTimeout(r, 5));
+			repository.updateTask(middle.id, { title: 'Middle (updated)' });
+			const tasksAfterMiddleUpdate = repository.listTasks('room-1');
+			expect(tasksAfterMiddleUpdate[0].title).toBe('Middle (updated)');
 		});
 
 		it('should filter by status', () => {
@@ -343,6 +366,20 @@ describe('TaskRepository', () => {
 			const updated = repository.updateTask('non-existent', { title: 'New Title' });
 
 			expect(updated).toBeNull();
+		});
+
+		it('should update updatedAt timestamp on every update', async () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'Task',
+				description: 'Desc',
+			});
+			const originalUpdatedAt = task.updatedAt;
+
+			await new Promise((r) => setTimeout(r, 5));
+			const updated = repository.updateTask(task.id, { title: 'New Title' });
+
+			expect(updated?.updatedAt).toBeGreaterThan(originalUpdatedAt);
 		});
 
 		it('should update multiple fields at once', () => {

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -227,6 +227,8 @@ export interface NeoTask {
 	prNumber?: number | null;
 	/** When PR was created/submitted (milliseconds since epoch) */
 	prCreatedAt?: number | null;
+	/** Last update timestamp (milliseconds since epoch) */
+	updatedAt: number;
 }
 
 /**
@@ -349,6 +351,8 @@ export interface TaskSummary {
 	prUrl?: string | null;
 	/** Pull request number (if available) */
 	prNumber?: number | null;
+	/** Last update timestamp (milliseconds since epoch) */
+	updatedAt: number;
 }
 
 /**

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -26,6 +26,7 @@ describe('RoomTasks', () => {
 		priority: 'normal',
 		progress: 0,
 		dependsOn: [],
+		updatedAt: Date.now(),
 		...overrides,
 	});
 


### PR DESCRIPTION
## Summary

- Adds `updated_at` column to the `tasks` table, tracking the last modification time of each task
- Changes `listTasks()` sort order from `created_at DESC` to `updated_at DESC`, so tasks within each status group (active, review, done, needs_attention) are ordered by most recently updated on top
- Exposes `updatedAt` on both `NeoTask` and `TaskSummary` types for use by the frontend

## Implementation Details

- **Migration 27**: Adds `updated_at INTEGER` column to existing databases, backfilling with `COALESCE(completed_at, started_at, created_at)` as the best available approximation
- **Initial schema**: Updated `schema/index.ts` to include `updated_at` so fresh databases have the column from the start
- **TaskRepository**: `createTask()` sets `updated_at = now`; `updateTask()` always sets `updated_at = now` when any field changes
- **RoomManager**: `toSummary()` now includes `updatedAt` so clients can sort/display by update time

## Test plan

- [x] `task-repository.test.ts` — new tests for `updatedAt` on creation, update, and sort order by `updated_at DESC`
- [x] All 2041 daemon unit tests pass
- [x] All 49 web `RoomTasks` tests pass
- [x] TypeScript typecheck clean