### PR TITLE
feat: add GLM-5-Turbo model support

### DIFF
--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -53,6 +53,17 @@ export class GlmProvider implements Provider {
 			available: true,
 		},
 		{
+			id: 'glm-5-turbo',
+			name: 'GLM-5-Turbo',
+			alias: 'glm-5-turbo',
+			family: 'glm',
+			provider: 'glm',
+			contextWindow: 200000,
+			description: 'GLM-5-Turbo · Optimized for long-chain agent tasks and tool calling',
+			releaseDate: '2026-03-15',
+			available: true,
+		},
+		{
 			id: 'glm-4.7',
 			name: 'GLM-4.7',
 			alias: 'glm-4.7',

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -44,6 +44,8 @@ export class GlmProvider implements Provider {
 		{
 			id: 'glm-5',
 			name: 'GLM-5',
+			// Intentionally shorter alias 'glm' (not 'glm-5') so users can type a short
+			// provider-level shorthand. This asymmetry with other GLM model aliases is deliberate.
 			alias: 'glm',
 			family: 'glm',
 			provider: 'glm',
@@ -114,10 +116,12 @@ export class GlmProvider implements Provider {
 	/**
 	 * Get model for a specific tier
 	 * Maps Anthropic tiers to GLM models
-	 * All tiers use glm-5 (flagship model)
+	 *
+	 * Always pins to glm-5 regardless of which GLM model is active in the session.
+	 * This is an intentional policy: tier fallbacks and title generation use the
+	 * flagship model (glm-5), not the session model (which may be glm-5-turbo or glm-4.7).
 	 */
 	getModelForTier(_tier: ModelTier): string | undefined {
-		// All tiers use glm-5
 		return 'glm-5';
 	}
 

--- a/packages/daemon/tests/online/glm/glm-provider.test.ts
+++ b/packages/daemon/tests/online/glm/glm-provider.test.ts
@@ -43,6 +43,7 @@ describe('GLM Provider Integration', () => {
 
 			// GLM models start with "glm-"
 			expect(providerService.isGlmModel('glm-5')).toBe(true);
+			expect(providerService.isGlmModel('glm-5-turbo')).toBe(true);
 			expect(providerService.isGlmModel('glm-4')).toBe(true);
 			expect(providerService.isGlmModel('GLM-4.7')).toBe(true); // case insensitive
 
@@ -57,6 +58,7 @@ describe('GLM Provider Integration', () => {
 			const providerService = new ProviderService();
 
 			expect(providerService.detectProviderFromModel('glm-5')).toBe('glm');
+			expect(providerService.detectProviderFromModel('glm-5-turbo')).toBe('glm');
 			expect(providerService.detectProviderFromModel('GLM-4')).toBe('glm');
 			expect(providerService.detectProviderFromModel('default')).toBe('anthropic');
 			expect(providerService.detectProviderFromModel('opus')).toBe('anthropic');
@@ -120,6 +122,33 @@ describe('GLM Provider Integration', () => {
 				expect(envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5');
 				// Extended timeout
 				expect(envVars.API_TIMEOUT_MS).toBe('3000000');
+			} finally {
+				if (originalGlmKey !== undefined) {
+					process.env.GLM_API_KEY = originalGlmKey;
+				} else {
+					delete process.env.GLM_API_KEY;
+				}
+			}
+		});
+
+		it('should return correct env vars for glm-5-turbo model ID', () => {
+			const providerService = new ProviderService();
+
+			const originalGlmKey = process.env.GLM_API_KEY;
+			process.env.GLM_API_KEY = 'test-glm-api-key';
+
+			try {
+				const envVars = providerService.getEnvVarsForModel('glm-5-turbo');
+
+				expect(envVars.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic');
+				expect(envVars.ANTHROPIC_AUTH_TOKEN).toBe('test-glm-api-key');
+				expect(envVars.ANTHROPIC_API_KEY).toBeUndefined();
+				expect(envVars.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe('1');
+				expect(envVars.API_TIMEOUT_MS).toBe('3000000');
+				// glm-5-turbo routes haiku/sonnet to itself, opus stays on glm-5
+				expect(envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo');
+				expect(envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo');
+				expect(envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5');
 			} finally {
 				if (originalGlmKey !== undefined) {
 					process.env.GLM_API_KEY = originalGlmKey;
@@ -543,6 +572,55 @@ describe('GLM Provider Integration', () => {
 	});
 
 	describe('GLM API Call', () => {
+		it('should make actual API call to GLM with glm-5-turbo', async () => {
+			const glmApiKey = process.env.GLM_API_KEY || process.env.ZHIPU_API_KEY;
+
+			if (!glmApiKey) {
+				console.log('Skipping GLM-5-Turbo API call test - no GLM_API_KEY set');
+				return;
+			}
+
+			const baseUrl = 'https://open.bigmodel.cn/api/anthropic';
+
+			const response = await fetch(`${baseUrl}/v1/messages`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-api-key': glmApiKey!,
+					'anthropic-version': '2023-06-01',
+				},
+				body: JSON.stringify({
+					model: 'glm-5-turbo',
+					max_tokens: 100,
+					messages: [
+						{
+							role: 'user',
+							content: 'Say "Hello from GLM-5-Turbo" in exactly 6 words.',
+						},
+					],
+				}),
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw new Error(`GLM API error: ${response.status} ${errorText}`);
+			}
+
+			const data = (await response.json()) as {
+				content: Array<{ type: string; text?: string }>;
+				stop_reason: string;
+			};
+
+			expect(data.content).toBeDefined();
+			expect(data.content.length).toBeGreaterThan(0);
+
+			const textContent = data.content.find((c) => c.type === 'text');
+			expect(textContent).toBeDefined();
+			console.log('GLM-5-Turbo Response:', textContent?.text);
+
+			expect(data.stop_reason).toBe('end_turn');
+		}, 30000);
+
 		it('should make actual API call to GLM', async () => {
 			const glmApiKey = process.env.GLM_API_KEY || process.env.ZHIPU_API_KEY;
 

--- a/packages/daemon/tests/unit/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/glm-provider.test.ts
@@ -72,8 +72,8 @@ describe('GlmProvider', () => {
 
 			const models = await provider.getModels();
 
-			expect(models).toHaveLength(2);
-			expect(models.map((m) => m.id)).toEqual(['glm-5', 'glm-4.7']);
+			expect(models).toHaveLength(3);
+			expect(models.map((m) => m.id)).toEqual(['glm-5', 'glm-5-turbo', 'glm-4.7']);
 		});
 
 		it('should return empty array when API key is not available', async () => {
@@ -98,6 +98,7 @@ describe('GlmProvider', () => {
 	describe('ownsModel', () => {
 		it('should own glm- prefixed models', () => {
 			expect(provider.ownsModel('glm-5')).toBe(true);
+			expect(provider.ownsModel('glm-5-turbo')).toBe(true);
 			expect(provider.ownsModel('glm-4.7')).toBe(true);
 			expect(provider.ownsModel('GLM-4')).toBe(true); // case insensitive
 		});
@@ -146,6 +147,19 @@ describe('GlmProvider', () => {
 			expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5');
 		});
 
+		it('should build correct config for glm-5-turbo', () => {
+			process.env.GLM_API_KEY = 'test-key';
+
+			const config = provider.buildSdkConfig('glm-5-turbo');
+
+			expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5-turbo');
+			expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5-turbo');
+			expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5');
+			expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic');
+			expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('test-key');
+			expect(config.isAnthropicCompatible).toBe(true);
+		});
+
 		it('should use session config API key override', () => {
 			process.env.GLM_API_KEY = 'env-key';
 
@@ -179,6 +193,10 @@ describe('GlmProvider', () => {
 			expect(provider.translateModelIdForSdk('glm-5')).toBe('default');
 		});
 
+		it('should translate glm-5-turbo to default', () => {
+			expect(provider.translateModelIdForSdk('glm-5-turbo')).toBe('default');
+		});
+
 		it('should translate other GLM models to default', () => {
 			expect(provider.translateModelIdForSdk('glm-4')).toBe('default');
 		});
@@ -192,8 +210,19 @@ describe('GlmProvider', () => {
 
 	describe('static models', () => {
 		it('should have static models defined', () => {
-			expect(GlmProvider.MODELS).toHaveLength(2);
-			expect(GlmProvider.MODELS.map((m) => m.id)).toEqual(['glm-5', 'glm-4.7']);
+			expect(GlmProvider.MODELS).toHaveLength(3);
+			expect(GlmProvider.MODELS.map((m) => m.id)).toEqual(['glm-5', 'glm-5-turbo', 'glm-4.7']);
+		});
+
+		it('should have correct glm-5-turbo model definition', () => {
+			const turbo = GlmProvider.MODELS.find((m) => m.id === 'glm-5-turbo');
+			expect(turbo).toBeDefined();
+			expect(turbo!.name).toBe('GLM-5-Turbo');
+			expect(turbo!.alias).toBe('glm-5-turbo');
+			expect(turbo!.family).toBe('glm');
+			expect(turbo!.provider).toBe('glm');
+			expect(turbo!.contextWindow).toBe(200000);
+			expect(turbo!.available).toBe(true);
 		});
 
 		it('should have correct base URL', () => {


### PR DESCRIPTION
Add GLM-5-Turbo to the GLM provider. The model was released 2026-03-15
and is optimized for long-chain agent tasks, tool calling, and complex
instruction decomposition. Specs: 200K context window, 128K max output,
Anthropic-compatible API (model ID: glm-5-turbo).

- Add glm-5-turbo entry to GlmProvider.MODELS
- Unit tests: cover model listing, ownsModel, buildSdkConfig, translateModelIdForSdk
- Online tests: detection, env var routing, and live API call test
