### PR TITLE
docs: Goal V2 Mission System -- Autonomous Agent Workflows plan

### DIFF
--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/00-overview.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/00-overview.md
@@ -1,0 +1,57 @@
+# Goal V2: Mission System -- Autonomous Agent Workflows
+
+## Goal Summary
+
+Evolve NeoKai's current "Goal" feature into a fully autonomous agent workflow system called **"Mission"**. The current system supports basic goal-to-task decomposition with human approval gates. V2 adds support for measurable outcome-based missions, recurring/scheduled missions, adaptive replanning, and tiered autonomy levels -- enabling agents to work continuously on long-term objectives with minimal human intervention.
+
+## Naming Strategy
+
+"Mission" is the user-facing name for the concept currently called "Goal" internally. `goal` remains the internal name across storage, RPCs, events, and backend code. `Mission` is introduced at the **type-alias layer** (`type Mission = RoomGoal` in shared types) and the **UI copy layer** (labels, text, component names) only. A full backend/API rename is deferred to avoid creating a giant cross-cutting conflict surface.
+
+## Approach
+
+1. Foundation first: extend the shared type system and database schema with new mission fields
+2. Backend logic: implement each new capability (measurable KPIs, recurring scheduling, semi-autonomous approval) as isolated daemon features
+3. RPC layer: extend existing RPC handlers to support new fields and add new dedicated RPCs
+4. Frontend: update UI copy to "Mission" terminology, then add type-specific creation/display features
+5. Tests: comprehensive unit, integration, and E2E coverage
+
+Feature branches are created from `dev`. All PRs target `dev`.
+
+## Milestones
+
+1. **Shared Types and Mission Aliases** -- Extend `RoomGoal` with `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, and related fields; export `Mission` type alias; add new supporting interfaces.
+2. **Database Schema Migration** -- Add new columns to the `goals` table via a numbered migration; create `mission_metric_history` and `mission_executions` tables; update `GoalRepository` to handle all new fields.
+3. **Measurable Missions: Metrics and Adaptive Replanning** -- Implement structured KPI tracking in `GoalManager`, runtime auto-replan logic when metric targets aren't met, and MCP tools for metric reporting.
+4. **Recurring Missions: Scheduling and Execution Identity** -- Cron-based scheduler inside `RoomRuntime`, execution identity via `mission_executions`, per-execution task isolation, overlap prevention, and recovery after daemon restart.
+5. **Semi-Autonomous Mode** -- Auto-approve coder/general tasks under `semi_autonomous` autonomy level, deferred post-tool callback for auto-resume, `approvalSource` in session group metadata, consecutive-failure escalation.
+6. **RPC Layer Extensions** -- Extend `goal.create`/`goal.update` RPCs to accept and persist new fields; add `goal.update_kpi` and `goal.trigger_replan` RPCs; update `DaemonEventMap` with new goal events.
+7. **UI: Mission Creation, Dashboard, and Status** -- Rename all UI copy from "Goal" to "Mission"; add mission-type selector, conditional form fields, type-specific detail views, KPI progress display, recurrence indicators, and execution history.
+
+## Cross-Milestone Dependencies
+
+```
+Milestone 1 (Types)
+  -> Milestone 2 (Schema)
+       -> Milestone 3 (Measurable)
+       -> Milestone 4 (Recurring)
+       -> Milestone 5 (Semi-Auto)
+       -> Milestone 6 (RPC)
+            -> Milestone 7 (UI)
+```
+
+Milestones 3, 4, 5, and 6 all depend on Milestones 1 and 2 and can run in parallel. Milestone 7 depends on Milestone 6 (RPCs must accept new fields before UI forms can function end-to-end).
+
+## Key Design Decisions
+
+- **`schedulePaused` as a boolean flag**: Recurring mission pause is a schedule-level flag, NOT a new `GoalStatus`. Current status CHECK constraint stays unchanged.
+- **Metrics precedence**: `structured_metrics` is the authoritative source for measurable missions; the legacy `metrics` column becomes a derived read-only view.
+- **`maxPlanningAttempts` precedence**: Mission-level `maxPlanningAttempts` overrides room-level `config.maxPlanningRetries + 1`; default 5.
+- **Execution identity**: Each recurring trigger creates a `mission_executions` row. Overlap is prevented by a DB-level partial unique index AND an app-level check.
+- **Per-execution task isolation**: `goals.linked_task_ids` is overwritten per execution so existing runtime progress aggregation code works unchanged.
+- **Semi-autonomous scope**: Only coder/general tasks auto-approve. Planning tasks always require human sign-off.
+- **Auto-resume timing**: Deferred via post-tool callback, not inline from `handleLeaderTool`.
+
+## Estimated Task Count
+
+7 milestones, 15 total tasks.

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/00-overview.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/00-overview.md
@@ -33,14 +33,14 @@ Feature branches are created from `dev`. All PRs target `dev`.
 ```
 Milestone 1 (Types)
   -> Milestone 2 (Schema)
-       -> Milestone 3 (Measurable)
-       -> Milestone 4 (Recurring)
-       -> Milestone 5 (Semi-Auto)
-       -> Milestone 6 (RPC)
-            -> Milestone 7 (UI)
+       -> Milestone 3 (Measurable)  ─┐
+       -> Milestone 4 (Recurring)   ─┤-> Milestone 6 (RPC)
+       -> Milestone 5 (Semi-Auto)   ─┘      -> Milestone 7 (UI)
 ```
 
-Milestones 3, 4, 5, and 6 all depend on Milestones 1 and 2 and can run in parallel. Milestone 7 depends on Milestone 6 (RPCs must accept new fields before UI forms can function end-to-end).
+Milestones 3, 4, and 5 all depend on Milestones 1 and 2 and can run in parallel with each other. Milestone 6 depends on Milestones 3, 4, and 5 (it consolidates `DaemonEventMap` entries from those milestones and references their manager methods). Milestone 7 depends on Milestone 6 (RPCs must accept new fields before UI forms can function end-to-end).
+
+**Note on `DaemonEventMap`**: The `goal.task.auto_completed` event entry is defined exclusively in Milestone 6 (not in Milestone 5) to avoid merge conflicts when 3–5 run on parallel branches.
 
 ## Key Design Decisions
 
@@ -54,4 +54,4 @@ Milestones 3, 4, 5, and 6 all depend on Milestones 1 and 2 and can run in parall
 
 ## Estimated Task Count
 
-7 milestones, 15 total tasks.
+7 milestones, 10 total tasks (1.1, 2.1, 2.2, 3.1, 4.1, 5.1, 6.1, 7.1, 7.2, 7.3).

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/01-shared-types-and-mission-aliases.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/01-shared-types-and-mission-aliases.md
@@ -82,14 +82,15 @@ Extend the `RoomGoal` interface and shared type system with all mission V2 metad
    - `maxConsecutiveFailures?: number`
    - `maxPlanningAttempts?: number`
    - `consecutiveFailures?: number`
+   - `replanCount?: number` (lifetime counter of replanning events across all executions; incremented by `goal.trigger_replan` and by the auto-replan logic in Milestone 3; distinct from `mission_executions.planning_attempts` which is per-execution)
 
 9. Add `type Mission = RoomGoal` type alias and export it from `packages/shared/src/types/neo.ts`.
 
 10. Export all new types from `packages/shared/src/mod.ts` (or wherever shared exports are re-exported).
 
-11. Update `CreateGoalParams` in `packages/daemon/src/storage/repositories/goal-repository.ts` to accept the new optional fields: `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`, `nextRunAt`, `maxConsecutiveFailures`, `maxPlanningAttempts`.
+11. Update `CreateGoalParams` in `packages/daemon/src/storage/repositories/goal-repository.ts` to accept the new optional fields: `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`, `nextRunAt`, `maxConsecutiveFailures`, `maxPlanningAttempts`, `replanCount`.
 
-12. Update `UpdateGoalParams` in the same file to accept the same optional fields plus `consecutiveFailures`.
+12. Update `UpdateGoalParams` in the same file to accept the same optional fields plus `consecutiveFailures` and `replanCount`.
 
 13. Verify TypeScript compiles with zero new errors: `bun run typecheck`.
 

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/01-shared-types-and-mission-aliases.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/01-shared-types-and-mission-aliases.md
@@ -1,0 +1,105 @@
+# Milestone 1: Shared Types and Mission Aliases
+
+## Milestone Goal
+
+Extend the `RoomGoal` interface and shared type system with all mission V2 metadata fields, export the `Mission` type alias, and add supporting interfaces. This milestone has no runtime behavior changes -- it is purely type-system and no-op default values. All downstream milestones depend on this.
+
+## Tasks
+
+### Task 1.1: Define New Mission Types and Extend RoomGoal
+
+**Agent**: coder
+**Description**: Add all V2 mission types to `packages/shared/src/types/neo.ts` and extend the `RoomGoal` interface with the new fields.
+
+**Subtasks** (ordered implementation steps):
+
+1. Add `MissionType` union type:
+   ```ts
+   export type MissionType = 'one_shot' | 'measurable' | 'recurring';
+   ```
+
+2. Add `AutonomyLevel` union type:
+   ```ts
+   export type AutonomyLevel = 'supervised' | 'semi_autonomous';
+   ```
+
+3. Add `MissionMetric` interface:
+   ```ts
+   export interface MissionMetric {
+     name: string;
+     target: number;
+     current: number;
+     unit?: string;
+     direction?: 'increase' | 'decrease'; // default: 'increase'
+     baseline?: number; // required for 'decrease' direction
+   }
+   ```
+
+4. Add `MetricHistoryEntry` interface:
+   ```ts
+   export interface MetricHistoryEntry {
+     metricName: string;
+     value: number;
+     recordedAt: number; // unix timestamp ms
+   }
+   ```
+
+5. Add `CronSchedule` interface:
+   ```ts
+   export interface CronSchedule {
+     expression: string; // e.g. "0 9 * * *" or "@daily"
+     timezone: string;   // e.g. "UTC", "America/New_York"
+   }
+   ```
+
+6. Add `MissionExecutionStatus` union type:
+   ```ts
+   export type MissionExecutionStatus = 'running' | 'completed' | 'failed';
+   ```
+
+7. Add `MissionExecution` interface:
+   ```ts
+   export interface MissionExecution {
+     id: string;
+     goalId: string;
+     executionNumber: number;
+     startedAt?: number;
+     completedAt?: number;
+     status: MissionExecutionStatus;
+     resultSummary?: string;
+     taskIds: string[];
+     planningAttempts: number;
+   }
+   ```
+
+8. Extend `RoomGoal` interface with optional mission V2 fields:
+   - `missionType?: MissionType`
+   - `autonomyLevel?: AutonomyLevel`
+   - `structuredMetrics?: MissionMetric[]`
+   - `schedule?: CronSchedule`
+   - `schedulePaused?: boolean`
+   - `nextRunAt?: number` (unix timestamp ms; dedicated field for scheduler queries, NOT inside schedule JSON)
+   - `maxConsecutiveFailures?: number`
+   - `maxPlanningAttempts?: number`
+   - `consecutiveFailures?: number`
+
+9. Add `type Mission = RoomGoal` type alias and export it from `packages/shared/src/types/neo.ts`.
+
+10. Export all new types from `packages/shared/src/mod.ts` (or wherever shared exports are re-exported).
+
+11. Update `CreateGoalParams` in `packages/daemon/src/storage/repositories/goal-repository.ts` to accept the new optional fields: `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`, `nextRunAt`, `maxConsecutiveFailures`, `maxPlanningAttempts`.
+
+12. Update `UpdateGoalParams` in the same file to accept the same optional fields plus `consecutiveFailures`.
+
+13. Verify TypeScript compiles with zero new errors: `bun run typecheck`.
+
+**Acceptance Criteria**:
+- All new types are exported from `@neokai/shared`
+- `type Mission = RoomGoal` alias compiles and is exported
+- `RoomGoal` interface includes all new optional V2 fields
+- `CreateGoalParams` and `UpdateGoalParams` accept the new fields
+- Existing code that creates/reads `RoomGoal` objects compiles without changes
+- `bun run typecheck` passes with no new errors
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Nothing (this is the foundation task)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/02-database-schema-migration.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/02-database-schema-migration.md
@@ -1,0 +1,153 @@
+# Milestone 2: Database Schema Migration
+
+## Milestone Goal
+
+Add new mission V2 columns to the `goals` table via a numbered migration, create two new supporting tables (`mission_metric_history` and `mission_executions`), and update the `GoalRepository` class to read/write all new fields. The physical table name stays `goals`; all existing SQL continues to work.
+
+## Tasks
+
+### Task 2.1: Write Database Migration (Migration 28)
+
+**Agent**: coder
+**Description**: Add a new migration function `runMigration28` to `packages/daemon/src/storage/schema/migrations.ts` that adds the mission V2 columns to the `goals` table and creates the two new tables. Register it in `runMigrations`.
+
+**Subtasks** (ordered implementation steps):
+
+1. In `migrations.ts`, add `runMigration28(db)` to the `runMigrations` function body after the existing `runMigration27(db)` call.
+
+2. Implement `runMigration28`:
+   a. Add columns to `goals` table (each wrapped in try/catch or column-exists check for idempotency):
+      - `mission_type TEXT DEFAULT 'one_shot' CHECK(mission_type IN ('one_shot', 'measurable', 'recurring'))`
+      - `autonomy_level TEXT DEFAULT 'supervised' CHECK(autonomy_level IN ('supervised', 'semi_autonomous'))`
+      - `schedule TEXT` (nullable JSON)
+      - `schedule_paused INTEGER DEFAULT 0`
+      - `next_run_at INTEGER` (nullable)
+      - `structured_metrics TEXT` (nullable JSON)
+      - `max_consecutive_failures INTEGER DEFAULT 3`
+      - `max_planning_attempts INTEGER DEFAULT 5`
+      - `consecutive_failures INTEGER DEFAULT 0`
+
+   b. Create `mission_metric_history` table (IF NOT EXISTS):
+      ```sql
+      CREATE TABLE IF NOT EXISTS mission_metric_history (
+        id TEXT PRIMARY KEY,
+        goal_id TEXT NOT NULL,
+        metric_name TEXT NOT NULL,
+        value REAL NOT NULL,
+        recorded_at INTEGER NOT NULL,
+        FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE
+      )
+      ```
+
+   c. Create `mission_executions` table (IF NOT EXISTS):
+      ```sql
+      CREATE TABLE IF NOT EXISTS mission_executions (
+        id TEXT PRIMARY KEY,
+        goal_id TEXT NOT NULL,
+        execution_number INTEGER NOT NULL,
+        started_at INTEGER,
+        completed_at INTEGER,
+        status TEXT NOT NULL DEFAULT 'running'
+          CHECK(status IN ('running', 'completed', 'failed')),
+        result_summary TEXT,
+        task_ids TEXT NOT NULL DEFAULT '[]',
+        planning_attempts INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE,
+        UNIQUE (goal_id, execution_number)
+      )
+      ```
+
+   d. Create indexes:
+      - `CREATE INDEX IF NOT EXISTS idx_mission_metric_history ON mission_metric_history(goal_id, metric_name, recorded_at)`
+      - `CREATE INDEX IF NOT EXISTS idx_mission_executions_goal ON mission_executions(goal_id, status)`
+      - `CREATE INDEX IF NOT EXISTS idx_goals_mission_scheduler ON goals(mission_type, schedule_paused, next_run_at)`
+      - `CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running ON mission_executions(goal_id) WHERE status = 'running'`
+
+   e. Backfill existing rows: `UPDATE goals SET mission_type = 'one_shot', autonomy_level = 'supervised' WHERE mission_type IS NULL`
+
+3. Update `createTables` in `packages/daemon/src/storage/schema/index.ts` to include the two new tables and their indexes in the initial schema (for fresh database installs). Mirror the same DDL from step 2b and 2c.
+
+4. Write a migration test at `packages/daemon/tests/unit/storage/migrations/migration-28_test.ts` following the pattern of `migration-24_test.ts`:
+   - Verify new columns exist with correct defaults on a migrated DB
+   - Verify `mission_metric_history` and `mission_executions` tables exist
+   - Verify the partial unique index prevents two `'running'` executions for the same goal
+   - Verify the migration is idempotent (run twice, no error)
+   - Verify existing goal rows are backfilled with `mission_type = 'one_shot'`
+
+**Acceptance Criteria**:
+- Migration runs cleanly on a fresh database
+- Migration runs cleanly on an existing database with existing goal rows
+- Existing goals are backfilled with `mission_type = 'one_shot'` and `autonomy_level = 'supervised'`
+- `mission_metric_history` and `mission_executions` tables exist and are queryable
+- Partial unique index prevents concurrent `'running'` executions for the same goal
+- Migration is idempotent (running it twice throws no errors)
+- Migration test passes
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Task 1.1 (new column names must match new TypeScript field names)
+
+---
+
+### Task 2.2: Update GoalRepository and GoalManager
+
+**Agent**: coder
+**Description**: Update `GoalRepository` and `GoalManager` to read/write the new columns, add CRUD methods for `mission_metric_history` and `mission_executions`, and implement the `getEffectiveMaxPlanningAttempts` helper.
+
+**Subtasks** (ordered implementation steps):
+
+1. In `packages/daemon/src/storage/repositories/goal-repository.ts`:
+
+   a. Update `createGoal`: include all new columns in the INSERT statement with their defaults (`mission_type`, `autonomy_level`, `schedule`, `schedule_paused`, `next_run_at`, `structured_metrics`, `max_consecutive_failures`, `max_planning_attempts`, `consecutive_failures`). Accept them via `CreateGoalParams`.
+
+   b. Update `updateGoal`: handle all new fields in the partial update path (`missionType`, `autonomyLevel`, `schedule`, `schedulePaused`, `nextRunAt`, `structuredMetrics`, `maxConsecutiveFailures`, `maxPlanningAttempts`, `consecutiveFailures`).
+
+   c. Update `rowToGoal` to parse and populate all new fields from the DB row. Parse JSON fields (`schedule`, `structuredMetrics`) safely, defaulting to `undefined` if null.
+
+   d. Add metric history methods:
+      - `insertMetricHistory(goalId, metricName, value, recordedAt)`: insert a row into `mission_metric_history`
+      - `getMetricHistory(goalId, metricName, fromTs?, toTs?)`: query by `(goal_id, metric_name, recorded_at)` index, optional time range filter
+
+   e. Add execution CRUD methods:
+      - `createExecution(goalId, executionNumber)`: INSERT into `mission_executions`, returns the new row
+      - `getActiveExecution(goalId)`: SELECT WHERE `goal_id = ? AND status = 'running'`
+      - `getExecution(executionId)`: SELECT by primary key
+      - `listExecutions(goalId)`: SELECT all for a goal, ordered by `execution_number DESC`
+      - `updateExecutionStatus(executionId, status, resultSummary?, completedAt?)`: UPDATE status/result
+      - `appendExecutionTaskId(executionId, taskId)`: read `task_ids` JSON, append, write back (single transaction)
+      - `getNextExecutionNumber(goalId)`: SELECT MAX(execution_number) + 1 (or 1 if no rows)
+
+2. In `packages/daemon/src/lib/room/managers/goal-manager.ts`:
+
+   a. Expose thin async wrappers for all new repository methods (metric history insert/query, execution CRUD). Keep the same async pattern as existing manager methods.
+
+   b. Implement `getEffectiveMaxPlanningAttempts(goalId, roomConfig)`:
+      - Fetch the goal
+      - If `goal.maxPlanningAttempts` is set (>= 1), return it
+      - Else if `roomConfig?.maxPlanningRetries` is set, return `roomConfig.maxPlanningRetries + 1`
+      - Else return 5 (hardcoded default)
+      - Export this as a standalone helper function (not just a method) so it can be called with a `RoomGoal` object directly (for use in runtime without a manager instance)
+
+   c. Add `linkTaskToExecution(goalId, executionId, taskId)` method:
+      - Atomically updates both `mission_executions.task_ids` (via `appendExecutionTaskId`) and `goals.linked_task_ids` (via `linkTaskToGoal`) in a single SQLite transaction
+      - For non-recurring missions, continue using the existing `linkTaskToGoal` unchanged
+
+3. Write unit tests in `packages/daemon/tests/unit/room/goal-manager.test.ts`:
+   - New goal creation with `missionType` and `autonomyLevel` persists correctly
+   - Metric history: insert, query with time range, empty result for no history
+   - Execution CRUD: create, get active, update status, list
+   - `appendExecutionTaskId` dual-write atomicity
+   - `getEffectiveMaxPlanningAttempts`: mission-level override, room-level fallback, default fallback
+   - `linkTaskToExecution` updates both stores atomically
+
+**Acceptance Criteria**:
+- `GoalRepository.createGoal` and `updateGoal` handle all new fields
+- `rowToGoal` correctly deserializes all new fields from DB rows
+- Metric history CRUD works end-to-end
+- Execution CRUD works end-to-end
+- Partial unique index constraint is surfaced as an error on duplicate `'running'` execution insert
+- `getEffectiveMaxPlanningAttempts` returns correct priority: mission > room config > default 5
+- `linkTaskToExecution` atomically updates both `mission_executions.task_ids` and `goals.linked_task_ids`
+- All new tests pass; existing `goal-manager` tests still pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Task 2.1 (migration must exist so tables/columns are present during tests)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/02-database-schema-migration.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/02-database-schema-migration.md
@@ -26,6 +26,7 @@ Add new mission V2 columns to the `goals` table via a numbered migration, create
       - `max_consecutive_failures INTEGER DEFAULT 3`
       - `max_planning_attempts INTEGER DEFAULT 5`
       - `consecutive_failures INTEGER DEFAULT 0`
+      - `replan_count INTEGER DEFAULT 0` (lifetime counter; incremented on every manual or automatic replan trigger; never reset)
 
    b. Create `mission_metric_history` table (IF NOT EXISTS):
       ```sql
@@ -120,12 +121,16 @@ Add new mission V2 columns to the `goals` table via a numbered migration, create
 
    a. Expose thin async wrappers for all new repository methods (metric history insert/query, execution CRUD). Keep the same async pattern as existing manager methods.
 
-   b. Implement `getEffectiveMaxPlanningAttempts(goalId, roomConfig)`:
-      - Fetch the goal
+   b. Implement `getEffectiveMaxPlanningAttempts(goal, roomConfig)`:
       - If `goal.maxPlanningAttempts` is set (>= 1), return it
       - Else if `roomConfig?.maxPlanningRetries` is set, return `roomConfig.maxPlanningRetries + 1`
       - Else return 5 (hardcoded default)
-      - Export this as a standalone helper function (not just a method) so it can be called with a `RoomGoal` object directly (for use in runtime without a manager instance)
+      - Export as a standalone helper (not just a method) so it can be called with a `RoomGoal` object directly
+
+   **`planning_attempts` scope rule** (critical for recurring missions):
+   - For `mission_type = 'recurring'`: the runtime's replanning guard reads `mission_executions.planning_attempts` (the current execution row), NOT any goal-level field. This ensures the counter resets automatically each new execution.
+   - For `mission_type = 'one_shot'` or `'measurable'`: the runtime reads the goal-level `planning_attempts` field (already present on `goals` table from earlier migrations).
+   - `getEffectiveMaxPlanningAttempts` returns the ceiling for both paths — callers are responsible for reading the correct current-attempt counter.
 
    c. Add `linkTaskToExecution(goalId, executionId, taskId)` method:
       - Atomically updates both `mission_executions.task_ids` (via `appendExecutionTaskId`) and `goals.linked_task_ids` (via `linkTaskToGoal`) in a single SQLite transaction

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/03-measurable-missions.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/03-measurable-missions.md
@@ -1,0 +1,68 @@
+# Milestone 3: Measurable Missions -- Structured Metrics and Adaptive Replanning
+
+## Milestone Goal
+
+Implement the measurable mission type with structured KPI tracking, progress calculation from metric targets, runtime auto-replan logic when targets are not met after task completion, and MCP tools for agents to report metric progress.
+
+## Tasks
+
+### Task 3.1: Measurable Mission Logic in GoalManager and RoomRuntime
+
+**Agent**: coder
+**Description**: Add metric management methods to `GoalManager`, update progress calculation for measurable missions, integrate metric-aware replanning into `RoomRuntime`, and expose agent MCP tools for metric reporting.
+
+**Subtasks** (ordered implementation steps):
+
+1. In `packages/daemon/src/lib/room/managers/goal-manager.ts`, add `recordMetric(goalId, metricName, value, timestamp?)`:
+   - Insert a row into `mission_metric_history` (via the repository method from Milestone 2)
+   - Update `structuredMetrics[metric_name].current` in the `structured_metrics` JSON column
+   - Derive and write the legacy `metrics` field (`Record<string, number>` as `{[name]: current}`) for backward compatibility with any existing callers that read `goal.metrics`
+   - One writer only -- the only path that mutates `structuredMetrics` goes through `recordMetric`
+
+2. Add `getMetricHistory(goalId, metricName, timeRange?)` wrapper (thin delegation to `GoalRepository`).
+
+3. Add `checkMetricTargets(goalId)` -- returns `{ allMet: boolean; results: Array<{name, met, current, target, direction}> }`:
+   - For `direction = 'increase'` (default): `met = current >= target`
+   - For `direction = 'decrease'`: `met = current <= target`
+   - Validation: reject `target <= 0` for `increase`; reject missing `baseline` or `baseline <= target` for `decrease`; guard against divide-by-zero
+
+4. Add `calculateMeasurableProgress(goal)`:
+   - For `increase`: `min(current / target, 1.0) * 100`, averaged across all metrics
+   - For `decrease`: `min((baseline - current) / (baseline - target), 1.0) * 100`, averaged across all metrics
+   - Returns 0 if no `structuredMetrics` or empty array
+   - Called from the existing `calculateProgressFromTasks` when `missionType === 'measurable'`
+
+5. Update `calculateProgressFromTasks` in `GoalManager` to delegate to `calculateMeasurableProgress` when `goal.missionType === 'measurable'` and `goal.structuredMetrics` is non-empty. Existing task-based progress aggregation runs unchanged for `one_shot` missions.
+
+6. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`, update the section that runs after all linked tasks have completed (around the `checkGoalCompletion` area):
+   a. If `missionType === 'measurable'`:
+      - Call `goalManager.checkMetricTargets(goalId)`
+      - If all targets met: complete the mission (existing completion path)
+      - If targets not met AND `planning_attempts < getEffectiveMaxPlanningAttempts(goal, roomConfig)`: call `triggerReplan(goalId, replanContext)` with a context that includes current metric values, historical trend summary (last N data points), completed task IDs, and any failed task errors
+      - If targets not met AND attempts exhausted: set goal status to `needs_human`
+   b. For `one_shot` missions: existing behavior unchanged
+
+7. Update the planner agent context builder (`buildPlannerTaskMessage` in `packages/daemon/src/lib/room/agents/planner-agent.ts`) to include metric targets and current values in the planning prompt when the mission is measurable. Also include a brief history of previous planning attempts and their outcomes if available.
+
+8. In `packages/daemon/src/lib/room/tools/room-agent-tools.ts`, add two new MCP tools:
+   - `record_metric(goal_id, metric_name, value)`: calls `GoalManager.recordMetric`; agents report metric progress during or after task execution
+   - `get_metrics(goal_id)`: returns current `structuredMetrics` state and targets; agents can query current KPI status
+
+9. Write unit tests in `packages/daemon/tests/unit/room/`:
+   - `goal-manager.test.ts`: `recordMetric` dual-write, `checkMetricTargets` both directions, validation rejections, `calculateMeasurableProgress` with `increase` and `decrease` directions, zero-division guard
+   - `room-runtime.test.ts` (or new file `room-runtime-measurable.test.ts`): measurable mission completes when all targets met, triggers replan when targets not met and attempts remain, escalates to `needs_human` when attempts exhausted
+
+10. Write an online integration test at `packages/daemon/tests/online/room/room-measurable-mission.test.ts` covering the full measure -> replan -> re-execute loop.
+
+**Acceptance Criteria**:
+- `structured_metrics` is the authoritative source; legacy `metrics` is derived automatically on each `recordMetric` call
+- Metrics are inserted into `mission_metric_history` on each `recordMetric` call
+- `checkMetricTargets` works for both `increase` and `decrease` directions
+- Validation rejects `target <= 0` (increase), missing `baseline` (decrease), `baseline <= target` (decrease)
+- Measurable missions auto-replan when tasks complete but targets are not met
+- Replanning stops after max attempts and escalates to `needs_human`
+- `record_metric` and `get_metrics` MCP tools are exposed to room agents
+- All unit tests and online tests pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 1 (types), Milestone 2 (schema and repository methods)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/04-recurring-missions.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/04-recurring-missions.md
@@ -14,11 +14,12 @@ Implement cron-based scheduling for recurring missions inside `RoomRuntime`, cre
 **Subtasks** (ordered implementation steps):
 
 1. Add a cron parsing utility at `packages/daemon/src/lib/room/runtime/cron-utils.ts`:
-   - Parse cron expressions (five-field `* * * * *` syntax)
-   - Support presets: `@hourly`, `@daily`, `@weekly`, `@monthly`
-   - Calculate `nextRunAt(expression, timezone, fromDate?)`: returns the next unix timestamp after `fromDate` (defaults to `Date.now()`)
-   - Input validation: reject malformed expressions; throw a descriptive error
-   - This file should have NO external cron library dependencies; implement a minimal parser for the five-field standard or use Bun's built-in date facilities
+   - **Use the `croner` npm package** (`bun add croner`). It is a lightweight, battle-tested library with IANA timezone and DST support, no transitive dependencies, and ESM/CJS dual-format. Do NOT hand-roll a cron parser.
+   - Wrap `croner` in a thin module-local helper:
+     - `nextRunAt(expression: string, timezone: string, fromDate?: Date): number` — returns the next unix timestamp (ms) after `fromDate` (defaults to `new Date()`)
+     - `validateCron(expression: string, timezone: string): void` — throws a descriptive `Error` if the expression or timezone is invalid (let `croner` surface the error; re-throw with context)
+   - Support presets: `@hourly`, `@daily`, `@weekly`, `@monthly` (croner handles these natively)
+   - The public API of `cron-utils.ts` is the two functions above; callers never import `croner` directly
 
 2. In `packages/daemon/src/types/task-group.ts` (or wherever `TaskGroupMetadata` is defined), add optional field:
    ```ts
@@ -76,7 +77,7 @@ Implement cron-based scheduling for recurring missions inside `RoomRuntime`, cre
 - Partial unique index prevents two `'running'` executions for the same goal; app-level check provides the first gate
 - Daemon restart correctly recovers execution identity from group metadata
 - `linked_task_ids` is scoped per execution; previous execution's tasks are preserved in `mission_executions.task_ids`
-- `planning_attempts` resets per execution (uses `mission_executions.planning_attempts`)
+- For recurring missions: runtime reads `mission_executions.planning_attempts` (not goal-level) for the replanning guard; this resets automatically per new execution row
 - `schedule_paused` prevents scheduler from firing; resume recalculates `next_run_at` from current time
 - Catch-up after restart fires once immediately then advances to next interval
 - All unit and online tests pass

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/04-recurring-missions.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/04-recurring-missions.md
@@ -1,0 +1,85 @@
+# Milestone 4: Recurring Missions -- Scheduling and Execution Identity
+
+## Milestone Goal
+
+Implement cron-based scheduling for recurring missions inside `RoomRuntime`, create `mission_executions` row per trigger for execution identity, enforce at-most-one-running-execution invariant, isolate tasks per execution, and handle recovery after daemon restart.
+
+## Tasks
+
+### Task 4.1: Cron Scheduler and Execution Identity in RoomRuntime
+
+**Agent**: coder
+**Description**: Add cron parsing, next-run calculation, and the scheduling tick inside `RoomRuntime`; implement execution identity and per-execution task isolation; add recovery after daemon restart; add MCP schedule tools.
+
+**Subtasks** (ordered implementation steps):
+
+1. Add a cron parsing utility at `packages/daemon/src/lib/room/runtime/cron-utils.ts`:
+   - Parse cron expressions (five-field `* * * * *` syntax)
+   - Support presets: `@hourly`, `@daily`, `@weekly`, `@monthly`
+   - Calculate `nextRunAt(expression, timezone, fromDate?)`: returns the next unix timestamp after `fromDate` (defaults to `Date.now()`)
+   - Input validation: reject malformed expressions; throw a descriptive error
+   - This file should have NO external cron library dependencies; implement a minimal parser for the five-field standard or use Bun's built-in date facilities
+
+2. In `packages/daemon/src/types/task-group.ts` (or wherever `TaskGroupMetadata` is defined), add optional field:
+   ```ts
+   executionId?: string; // links session group to a mission_executions row
+   ```
+
+3. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`, update `getNextGoalForPlanning()` (the standard planning selector):
+   - Skip goals with `missionType === 'recurring'` entirely. Recurring missions are planned ONLY through the scheduler path.
+   - One-shot and measurable goals continue to be picked immediately when active.
+
+4. Add a scheduler method `tickRecurringMissions()` to `RoomRuntime`:
+   a. Query goals for this room where `mission_type = 'recurring'` AND `schedule_paused = false` AND `next_run_at <= now` AND no `'running'` execution exists (from `GoalManager.getActiveExecution(goalId)`)
+   b. For each eligible goal (in priority order):
+      - Begin a DB transaction:
+        - Call `goalManager.createExecution(goalId, nextExecutionNumber)` to create the `mission_executions` row with `status = 'running'`
+        - Advance `next_run_at` to the next cron interval (via `nextRunAt(schedule.expression, schedule.timezone)`) and persist it via `GoalManager`
+      - On unique constraint violation (another daemon beat us to it): log and skip
+      - Spawn a planning group with `executionId` added to the session group metadata
+
+5. Call `tickRecurringMissions()` at the end of each runtime tick, after the standard planning selector and after `recoverZombieGroups()` (so in-flight executions from before a restart are recovered before the scheduler fires).
+
+6. Update the execution completion path in `RoomRuntime` (where all tasks for a goal are done):
+   - If the goal is `recurring`: update the execution row to `status = 'completed'` with `resultSummary`; do NOT set goal status to `completed`; the goal stays `active`
+   - Pass `resultSummary` of the previous execution as context to the next planning group when the next trigger fires
+
+7. Per-execution task isolation -- update all task-linking call sites in the runtime path:
+   - In `room-runtime.ts`, where planner draft-task creation links tasks to goals: call `GoalManager.linkTaskToExecution(goalId, executionId, taskId)` if the goal is recurring and has an active execution; otherwise use the existing `GoalManager.linkTaskToGoal(goalId, taskId)`
+   - In `packages/daemon/src/lib/room/tools/room-agent-tools.ts`, the `create_task(goal_id)` tool: same conditional
+   - `goals.linked_task_ids` is overwritten per execution (the new execution's start clears it) so existing progress aggregation code works unchanged
+
+8. Update `recoverZombieGroups()` (in `packages/daemon/src/lib/room/runtime/runtime-recovery.ts` or wherever it lives) to read `executionId` from recovered group metadata and correlate it to the `mission_executions` row. If the execution row exists, confirm it is still `'running'`; if not, log a warning but proceed with recovery.
+
+9. Add lifecycle edge case handling in `tickRecurringMissions()`:
+   - **Catch-up after daemon restart**: if `next_run_at` is in the past, fire once immediately, then calculate the next interval from `Date.now()`
+   - **Overlap prevention**: if an active execution exists AND `next_run_at` is past-due, advance `next_run_at` to next interval and log a warning (skip the trigger)
+   - **Room runtime state**: only fire when `this.state === 'running'`
+   - **Precision / jitter**: up to 30 s (tick interval) is acceptable; document in a code comment
+
+10. Add schedule MCP tools in `packages/daemon/src/lib/room/tools/room-agent-tools.ts`:
+    - `set_schedule(goal_id, cron_expression, timezone)`: validates cron, calculates initial `next_run_at`, persists `schedule` and `next_run_at`
+    - `pause_schedule(goal_id)`: sets `schedule_paused = true`
+    - `resume_schedule(goal_id)`: sets `schedule_paused = false`, recalculates `next_run_at` from `Date.now()`
+
+11. Write unit tests in `packages/daemon/tests/unit/room/`:
+    - `cron-utils.test.ts`: valid expressions, preset aliases, timezone support, invalid expression error, next-run calculation
+    - New or existing runtime test file: `getNextGoalForPlanning()` skips recurring; scheduler fires when due; overlap prevention; catch-up after restart; `schedule_paused` blocks firing; `executionId` stored in group metadata; per-execution `planning_attempts` resets per new execution; `linked_task_ids` scoped to current execution
+
+12. Write an online integration test at `packages/daemon/tests/online/room/room-recurring-mission.test.ts` covering a full trigger -> execute -> next-trigger cycle.
+
+**Acceptance Criteria**:
+- `getNextGoalForPlanning()` skips `mission_type = 'recurring'` goals
+- Cron expressions and presets (`@daily`, etc.) are parsed with timezone support
+- Each scheduler trigger creates a `mission_executions` row with a unique `executionId`
+- `executionId` is stored in session group metadata
+- Partial unique index prevents two `'running'` executions for the same goal; app-level check provides the first gate
+- Daemon restart correctly recovers execution identity from group metadata
+- `linked_task_ids` is scoped per execution; previous execution's tasks are preserved in `mission_executions.task_ids`
+- `planning_attempts` resets per execution (uses `mission_executions.planning_attempts`)
+- `schedule_paused` prevents scheduler from firing; resume recalculates `next_run_at` from current time
+- Catch-up after restart fires once immediately then advances to next interval
+- All unit and online tests pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 1 (types), Milestone 2 (schema and repository, including execution CRUD and `linkTaskToExecution`)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/05-semi-autonomous-mode.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/05-semi-autonomous-mode.md
@@ -1,0 +1,81 @@
+# Milestone 5: Semi-Autonomous Mode
+
+## Milestone Goal
+
+Implement `semi_autonomous` autonomy level for coder and general tasks: the Leader auto-approves without waiting for human input, uses a deferred post-tool callback to avoid reentrancy, records `approvalSource` in session group metadata, and escalates to `needs_human` after consecutive failures. Planning tasks remain supervised regardless.
+
+## Tasks
+
+### Task 5.1: Auto-Approval Gate and Escalation Logic
+
+**Agent**: coder
+**Description**: Modify the `submit_for_review` branch of `handleLeaderTool` in `RoomRuntime` to auto-approve coder/general tasks when the goal's `autonomyLevel` is `semi_autonomous`. Add `approvalSource` to `TaskGroupMetadata`. Add consecutive-failure tracking and escalation.
+
+**Subtasks** (ordered implementation steps):
+
+1. Locate `TaskGroupMetadata` (in `packages/daemon/src/lib/room/state/session-group-repository.ts` or a shared types file) and add:
+   ```ts
+   approvalSource?: 'human' | 'leader_semi_auto';
+   ```
+
+2. In the `handleLeaderTool` function in `packages/daemon/src/lib/room/runtime/room-runtime.ts`, find the `submit_for_review` tool branch (around the area that calls `taskGroupManager.submitForReview()`). After `submitForReview()` succeeds:
+   a. Fetch the goal for this task (via `this.goalManager.getGoal(goalId)`)
+   b. Determine worker role from group metadata (`workerRole`)
+   c. If `goal.autonomyLevel === 'semi_autonomous'` AND `workerRole !== 'planner'`:
+      - Return a modified tool result text: `"PR submitted. Auto-approving under semi-autonomous mode."`
+      - Schedule a post-tool callback using `queueMicrotask(() => this.autoApproveTask(groupId, taskId))` (or `setTimeout(fn, 0)` as fallback). The callback MUST NOT run inline within `handleLeaderTool` to avoid reentrancy.
+   d. Otherwise (supervised or planner): existing behavior unchanged.
+
+3. Implement `autoApproveTask(groupId, taskId)` private method:
+   a. Idempotency guard: read group metadata; if `approvalSource` is already set, log and return immediately (prevents double-resume on retry or restart)
+   b. Set `approvalSource = 'leader_semi_auto'` in group metadata via `groupRepo.updateMetadata()`
+   c. Set `approved = true` in group metadata
+   d. Call `resumeLeaderFromHuman(taskId, "PR auto-approved under semi-autonomous mode. Proceed with merge and complete_task.")` -- this injects the continuation message into the Leader session so it runs in a **follow-up turn**
+
+4. Update `resumeWorkerFromHuman` (where human approvals set `approved = true`) to also set `approvalSource = 'human'` in group metadata.
+
+5. Add `DaemonEventMap` entry for `goal.task.auto_completed` in `packages/daemon/src/lib/daemon-hub.ts`:
+   ```ts
+   'goal.task.auto_completed': {
+     sessionId: string;  // 'room:${roomId}'
+     roomId: string;
+     goalId: string;
+     taskId: string;
+     taskTitle: string;
+     prUrl?: string;
+     approvalSource: 'leader_semi_auto';
+   };
+   ```
+
+6. Emit `goal.task.auto_completed` in `autoApproveTask` after the resume call succeeds.
+
+7. Consecutive-failure escalation -- update the task completion/failure paths in `RoomRuntime`:
+   a. On successful task completion for a `semi_autonomous` goal: reset `consecutive_failures` to 0 via `GoalManager.updateGoal(goalId, { consecutiveFailures: 0 })`
+   b. On task failure (`needs_attention`) for a `semi_autonomous` goal: increment `consecutive_failures` via `GoalManager.updateGoal(goalId, { consecutiveFailures: goal.consecutiveFailures + 1 })`; if `consecutiveFailures >= goal.maxConsecutiveFailures`, call `GoalManager.needsHumanGoal(goalId)` and emit `goal.updated`
+
+8. Verify lifecycle hooks still run: `checkLeaderPrMerged()` / `checkWorkerPrMerged()` must not be bypassed by the auto-approval path.
+
+9. Write unit tests in `packages/daemon/tests/unit/room/`:
+   - Auto-approve fires for `semi_autonomous` coder task (checks group metadata after)
+   - Auto-approve does NOT fire for `supervised` goal
+   - Auto-approve does NOT fire for `planner` task even with `semi_autonomous`
+   - Idempotency: calling `autoApproveTask` twice does not double-resume
+   - `approvalSource` is set to `'human'` on human approval, `'leader_semi_auto'` on auto
+   - Consecutive failure counter increments on failure, resets on success
+   - Escalation to `needs_human` when `consecutiveFailures >= maxConsecutiveFailures`
+
+10. Write an online test at `packages/daemon/tests/online/room/room-semi-autonomous.test.ts` covering a coder task completing end-to-end without human approval.
+
+**Acceptance Criteria**:
+- `supervised` mode is completely unchanged
+- `semi_autonomous` auto-approves coder/general tasks via deferred callback (not inline)
+- Planning tasks always require human approval regardless of `autonomyLevel`
+- `approvalSource` is correctly set in session group metadata for both human and auto approval
+- Lifecycle hooks (`checkLeaderPrMerged`, `checkWorkerPrMerged`) still run
+- `goal.task.auto_completed` event is emitted with correct payload
+- Consecutive failure counter increments/resets correctly
+- Escalation to `needs_human` fires when threshold reached
+- All unit and online tests pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 1 (types, especially `AutonomyLevel`), Milestone 2 (schema for `consecutiveFailures`/`maxConsecutiveFailures` columns and GoalManager update methods)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/05-semi-autonomous-mode.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/05-semi-autonomous-mode.md
@@ -34,7 +34,7 @@ Implement `semi_autonomous` autonomy level for coder and general tasks: the Lead
 
 4. Update `resumeWorkerFromHuman` (where human approvals set `approved = true`) to also set `approvalSource = 'human'` in group metadata.
 
-5. Add `DaemonEventMap` entry for `goal.task.auto_completed` in `packages/daemon/src/lib/daemon-hub.ts`:
+5. (**`DaemonEventMap` entry is added in Milestone 6**, not here — to avoid merge conflicts when Milestones 3–5 run in parallel.) In `autoApproveTask`, emit the `goal.task.auto_completed` event using the existing hub emit pattern. The event shape (defined in Milestone 6) is:
    ```ts
    'goal.task.auto_completed': {
      sessionId: string;  // 'room:${roomId}'
@@ -46,6 +46,7 @@ Implement `semi_autonomous` autonomy level for coder and general tasks: the Lead
      approvalSource: 'leader_semi_auto';
    };
    ```
+   The TypeScript type is registered in `DaemonEventMap` by Milestone 6; this milestone's task only emits — it does NOT modify `daemon-hub.ts`.
 
 6. Emit `goal.task.auto_completed` in `autoApproveTask` after the resume call succeeds.
 

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/06-rpc-layer-extensions.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/06-rpc-layer-extensions.md
@@ -1,0 +1,73 @@
+# Milestone 6: RPC Layer Extensions
+
+## Milestone Goal
+
+Extend the existing `goal.create` and `goal.update` RPC handlers to accept and persist the new mission V2 fields (`missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`). Add two new RPCs: `goal.update_kpi` and `goal.trigger_replan`. Update `DaemonEventMap` and `GoalManagerLike` to include the new operations.
+
+## Tasks
+
+### Task 6.1: Extend Existing RPCs and Add New Goal RPCs
+
+**Agent**: coder
+**Description**: Update `packages/daemon/src/lib/rpc-handlers/goal-handlers.ts` to pass new fields through to the storage layer, add `goal.update_kpi` and `goal.trigger_replan` handlers, and update the `GoalManagerLike` type and `DaemonEventMap`.
+
+**Subtasks** (ordered implementation steps):
+
+1. In `packages/daemon/src/lib/rpc-handlers/goal-handlers.ts`, update the `goal.create` handler:
+   - Extend the params type to include: `missionType?: MissionType`, `autonomyLevel?: AutonomyLevel`, `structuredMetrics?: MissionMetric[]`, `schedule?: CronSchedule`, `schedulePaused?: boolean`
+   - Validate `missionType` if provided (must be one of the allowed values; default to `'one_shot'` if absent)
+   - If `missionType === 'measurable'` and `structuredMetrics` provided, validate each metric entry (non-empty name, positive target for `increase`, presence of `baseline` for `decrease`)
+   - If `missionType === 'recurring'` and `schedule` provided, validate the cron expression via the `cron-utils` module
+   - Pass all new fields through to `goalManager.createGoal()`
+
+2. Update the `goal.update` handler:
+   - Extend `updates` type to include the same new fields plus `consecutiveFailures?: number`
+   - Dispatch updates to `goalManager.updateGoalStatus()` for status changes, or to a new generic `goalManager.updateGoalFields()` method for the V2 fields (title, description, priority, missionType, autonomyLevel, structuredMetrics, schedule, schedulePaused, nextRunAt, maxConsecutiveFailures, maxPlanningAttempts)
+   - Emit `goal.updated` event after successful update
+
+3. Add `goal.update_kpi` handler:
+   ```
+   Params: { roomId: string; goalId: string; metricName: string; value: number; timestamp?: number }
+   ```
+   - Validates: roomId, goalId, metricName (non-empty), value (finite number)
+   - Calls `goalManager.recordMetric(goalId, metricName, value, timestamp ?? Date.now())`
+   - Emits `goal.progressUpdated` event with updated progress
+   - Returns `{ goal }` (full updated goal object)
+
+4. Add `goal.trigger_replan` handler:
+   ```
+   Params: { roomId: string; goalId: string; reason?: string }
+   ```
+   - Validates: roomId, goalId
+   - Fetches the goal; validates it is `active` or `needs_human` (not `completed` or `archived`)
+   - If goal is `needs_human`, reactivates it to `active` first
+   - Resets planning context so the runtime will spawn a new planning group on the next tick
+   - Emits `goal.updated` event
+   - Returns `{ goal, queued: true }`
+   - Note: this does NOT directly spawn a planning group; it puts the goal back into a state that the runtime tick will act on. The actual replanning logic lives in `RoomRuntime`.
+
+5. Update `GoalManagerLike` type alias in `goal-handlers.ts` to include any new manager methods referenced by the new handlers (e.g., `recordMetric`, `updateGoalFields` if added).
+
+6. Update `DaemonEventMap` in `packages/daemon/src/lib/daemon-hub.ts` -- add the `goal.task.auto_completed` event if not already added in Milestone 5 (consolidate here if Milestone 5 was done separately).
+
+7. Export the two new RPC names from the shared MessageHub type registry if the project uses a typed RPC registry (check `packages/shared/src/message-hub/` for an RPC name registry or type map and add `goal.update_kpi` and `goal.trigger_replan` if applicable).
+
+8. Update `packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts`:
+   - `goal.create` with `missionType = 'measurable'` and `structuredMetrics` passes validation and calls `createGoal` with correct params
+   - `goal.create` with `missionType = 'recurring'` and valid cron passes; invalid cron throws
+   - `goal.update` with new V2 fields passes them through correctly
+   - `goal.update_kpi`: happy path, missing goalId error, non-finite value error
+   - `goal.trigger_replan`: happy path, goal not found error, already archived error
+   - Existing handler tests still pass
+
+**Acceptance Criteria**:
+- `goal.create` accepts and persists `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`
+- `goal.update` accepts and persists all V2 fields
+- `goal.update_kpi` records a KPI data point and emits a progress update
+- `goal.trigger_replan` reactivates and queues replanning, emits `goal.updated`
+- Input validation rejects invalid cron expressions, non-finite KPI values, and archived goals
+- `goal.task.auto_completed` is in `DaemonEventMap`
+- All new and existing handler tests pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 1 (types), Milestone 2 (GoalManager methods), Milestone 3 (recordMetric), Milestone 4 (cron validation), Milestone 5 (DaemonEventMap entry)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/06-rpc-layer-extensions.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/06-rpc-layer-extensions.md
@@ -2,7 +2,7 @@
 
 ## Milestone Goal
 
-Extend the existing `goal.create` and `goal.update` RPC handlers to accept and persist the new mission V2 fields (`missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`). Add two new RPCs: `goal.update_kpi` and `goal.trigger_replan`. Update `DaemonEventMap` and `GoalManagerLike` to include the new operations.
+Extend the existing `goal.create` and `goal.update` RPC handlers to accept and persist the new mission V2 fields (`missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`). Add three new RPCs: `goal.update_kpi`, `goal.trigger_replan`, and `goal.list_executions`. Update `DaemonEventMap` and `GoalManagerLike` to include the new operations. This milestone is the sole owner of `DaemonEventMap` additions for mission V2 to avoid merge conflicts with Milestones 3–5.
 
 ## Tasks
 
@@ -23,6 +23,7 @@ Extend the existing `goal.create` and `goal.update` RPC handlers to accept and p
 2. Update the `goal.update` handler:
    - Extend `updates` type to include the same new fields plus `consecutiveFailures?: number`
    - Dispatch updates to `goalManager.updateGoalStatus()` for status changes, or to a new generic `goalManager.updateGoalFields()` method for the V2 fields (title, description, priority, missionType, autonomyLevel, structuredMetrics, schedule, schedulePaused, nextRunAt, maxConsecutiveFailures, maxPlanningAttempts)
+   - **`schedulePaused = false` side effect**: whenever `updates.schedulePaused` is explicitly `false` (resume), the handler MUST recalculate `next_run_at` from `Date.now()` using the goal's existing `schedule.expression` and `schedule.timezone` (via `nextRunAt()` from `cron-utils`), and include the updated `nextRunAt` in the write. This prevents a resumed mission from firing immediately if `next_run_at` is stale/in-the-past. Apply this same rule in all write paths (MCP `resume_schedule` tool in Milestone 4 already does this; this RPC handler must match).
    - Emit `goal.updated` event after successful update
 
 3. Add `goal.update_kpi` handler:
@@ -40,34 +41,61 @@ Extend the existing `goal.create` and `goal.update` RPC handlers to accept and p
    ```
    - Validates: roomId, goalId
    - Fetches the goal; validates it is `active` or `needs_human` (not `completed` or `archived`)
-   - If goal is `needs_human`, reactivates it to `active` first
-   - Resets planning context so the runtime will spawn a new planning group on the next tick
+   - Performs the following **exact field mutations** (all in a single `goalManager.updateGoal()` call):
+     - `status`: if currently `needs_human`, set to `'active'`; otherwise leave unchanged
+     - `replanCount`: increment by 1 (e.g., `(goal.replanCount ?? 0) + 1`)
+     - `planningAttempts`: reset to `0` (so the runtime's replanning guard allows a fresh attempt). For recurring missions with an active execution, also call `goalManager.updateExecutionPlanningAttempts(executionId, 0)` to reset `mission_executions.planning_attempts`.
+   - How the runtime picks it up: the runtime tick's `getNextGoalForPlanning()` already checks `goal.status === 'active'` and `goal.planningAttempts < maxPlanningAttempts`. Resetting `planningAttempts` to 0 and ensuring `status = 'active'` is sufficient — no additional flag is needed.
    - Emits `goal.updated` event
    - Returns `{ goal, queued: true }`
-   - Note: this does NOT directly spawn a planning group; it puts the goal back into a state that the runtime tick will act on. The actual replanning logic lives in `RoomRuntime`.
+   - Note: this does NOT directly spawn a planning group; it puts the goal back into a state the runtime tick will act on next cycle.
 
-5. Update `GoalManagerLike` type alias in `goal-handlers.ts` to include any new manager methods referenced by the new handlers (e.g., `recordMetric`, `updateGoalFields` if added).
+5. Add `goal.list_executions` handler:
+   ```
+   Params: { roomId: string; goalId: string; limit?: number }
+   ```
+   - Validates: roomId, goalId; `limit` defaults to 20, max 100
+   - Calls `goalManager.listExecutions(goalId, limit)` (available from Milestone 2 repository layer)
+   - Returns `{ executions: MissionExecution[] }` ordered by `execution_number DESC`
+   - Registers the RPC name in the shared MessageHub type registry alongside other new RPC names
 
-6. Update `DaemonEventMap` in `packages/daemon/src/lib/daemon-hub.ts` -- add the `goal.task.auto_completed` event if not already added in Milestone 5 (consolidate here if Milestone 5 was done separately).
+6. Update `GoalManagerLike` type alias in `goal-handlers.ts` to include any new manager methods referenced by the new handlers (e.g., `recordMetric`, `updateGoalFields`, `listExecutions`, `updateExecutionPlanningAttempts` if added).
 
-7. Export the two new RPC names from the shared MessageHub type registry if the project uses a typed RPC registry (check `packages/shared/src/message-hub/` for an RPC name registry or type map and add `goal.update_kpi` and `goal.trigger_replan` if applicable).
+7. Update `DaemonEventMap` in `packages/daemon/src/lib/daemon-hub.ts` — this is the **sole location** for all mission V2 event additions:
+   ```ts
+   'goal.task.auto_completed': {
+     sessionId: string;  // 'room:${roomId}'
+     roomId: string;
+     goalId: string;
+     taskId: string;
+     taskTitle: string;
+     prUrl?: string;
+     approvalSource: 'leader_semi_auto';
+   };
+   ```
+   (Milestone 5 emits this event but does not register it in `DaemonEventMap` — that is done here only.)
 
-8. Update `packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts`:
+8. Export all three new RPC names from the shared MessageHub type registry (check `packages/shared/src/message-hub/` for an RPC name registry or type map and add `goal.update_kpi`, `goal.trigger_replan`, and `goal.list_executions`).
+
+9. Update `packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts`:
    - `goal.create` with `missionType = 'measurable'` and `structuredMetrics` passes validation and calls `createGoal` with correct params
    - `goal.create` with `missionType = 'recurring'` and valid cron passes; invalid cron throws
+   - `goal.update` with `schedulePaused = false` recalculates and persists `nextRunAt`
    - `goal.update` with new V2 fields passes them through correctly
    - `goal.update_kpi`: happy path, missing goalId error, non-finite value error
-   - `goal.trigger_replan`: happy path, goal not found error, already archived error
+   - `goal.trigger_replan`: happy path resets `planningAttempts` to 0, increments `replanCount`, sets status to `active` when `needs_human`; archived error
+   - `goal.list_executions`: returns ordered list, respects limit cap
    - Existing handler tests still pass
 
 **Acceptance Criteria**:
 - `goal.create` accepts and persists `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`
-- `goal.update` accepts and persists all V2 fields
+- `goal.update` accepts and persists all V2 fields; `schedulePaused = false` always recalculates `nextRunAt` from current time
 - `goal.update_kpi` records a KPI data point and emits a progress update
-- `goal.trigger_replan` reactivates and queues replanning, emits `goal.updated`
+- `goal.trigger_replan` sets `status = 'active'` (if `needs_human`), increments `replanCount`, resets `planningAttempts` to 0, emits `goal.updated`
+- `goal.list_executions` returns `MissionExecution[]` ordered by execution number descending
 - Input validation rejects invalid cron expressions, non-finite KPI values, and archived goals
-- `goal.task.auto_completed` is in `DaemonEventMap`
+- `goal.task.auto_completed` is in `DaemonEventMap` (defined here, emitted from Milestone 5)
 - All new and existing handler tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 
-**Depends on**: Milestone 1 (types), Milestone 2 (GoalManager methods), Milestone 3 (recordMetric), Milestone 4 (cron validation), Milestone 5 (DaemonEventMap entry)
+**Depends on**: Milestone 1 (types), Milestone 2 (GoalManager methods), Milestone 3 (recordMetric), Milestone 4 (cron validation and `croner` package), Milestone 5 (semi-auto logic)

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/07-ui-mission-creation-dashboard.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/07-ui-mission-creation-dashboard.md
@@ -117,7 +117,7 @@ Update all user-facing "Goal" text to "Mission" in the frontend. Add type-specif
    - Show "Next run: <formatted date>" from `goal.nextRunAt` (or "Paused" if `schedulePaused = true`)
    - Show "Schedule: <expression> (<timezone>)" from `goal.schedule`
    - Add "Pause schedule" / "Resume schedule" button that calls `goal.update` with `schedulePaused` toggled
-   - Show execution history list: fetch from a new `goal.list_executions` RPC or derive from cached state (see note below)
+   - Show execution history list: fetch via `goal.list_executions` RPC (defined in Milestone 6, Subtask 5). Add a `RoomStore.listExecutions(goalId)` method that calls this RPC and returns `MissionExecution[]`. Display the last 10 executions with status badge (running/completed/failed), start time, and result summary.
 
 5. Add `RoomStore.updateKpi(goalId, metricName, value)` method that calls `goal.update_kpi` RPC and refreshes goals.
 

--- a/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/07-ui-mission-creation-dashboard.md
+++ b/docs/plans/goal-v2-mission-system-autonomous-agent-workflows/07-ui-mission-creation-dashboard.md
@@ -1,0 +1,149 @@
+# Milestone 7: UI -- Mission Creation, Dashboard, and Status
+
+## Milestone Goal
+
+Update all user-facing "Goal" text to "Mission" in the frontend. Add type-specific mission creation form fields (KPI targets for measurable, cron schedule for recurring, autonomy level selector). Update the mission detail view with type-specific displays (metric progress, recurrence indicators, execution history). Update `roomStore` to call the new RPCs.
+
+## Tasks
+
+### Task 7.1: UI Copy Rename -- Goal to Mission Terminology
+
+**Agent**: coder
+**Description**: Replace all user-visible "Goal" text with "Mission" in the frontend. No new UI features -- just terminology. Backend event subscriptions and RPC names remain `goal.*`.
+
+**Subtasks** (ordered implementation steps):
+
+1. In `packages/web/src/components/room/GoalsEditor.tsx`:
+   - Replace all user-visible text strings: `"Goals"` -> `"Missions"`, `"Create Goal"` -> `"Create Mission"`, `"Delete Goal"` -> `"Delete Mission"`, `"No goals yet"` -> `"No missions yet"`, `"Create your first goal"` -> `"Create your first mission"`, heading `"Goals"` -> `"Missions"`, etc.
+   - Keep the component file name and internal signal/function names as-is (rename is UI copy only)
+   - Import the `Mission` type alias from `@neokai/shared` and use it in place of `RoomGoal` for the public props type where it makes the intent clearer (optional cosmetic improvement)
+
+2. In `packages/web/src/islands/Room.tsx`:
+   - Tab label `'goals'` stays as the tab key (internal); the displayed tab label text changes from `"Goals"` to `"Missions"` in the tab bar render
+
+3. In `packages/web/src/components/room/index.ts` (or wherever room components are re-exported):
+   - No changes needed (file names stay the same)
+
+4. Search for any remaining "Goal" or "goal" strings in user-visible JSX/text across all web component files and replace appropriately. Use Grep to be thorough. Examples to check: `RoomDashboard.tsx`, `RoomContext.tsx`, `CreateRoomModal.tsx`, `MessageInfoDropdown.tsx`.
+
+5. Write an E2E test update or new test in `packages/e2e/tests/` that verifies the "Missions" label is visible in the room tab bar and the "Create Mission" button text is correct.
+
+**Acceptance Criteria**:
+- All user-visible "Goal" text replaced with "Mission" across the web frontend
+- Backend event subscriptions still use `goal.*` (no backend changes in this task)
+- Existing UI functionality unchanged
+- E2E smoke test confirms "Missions" tab and "Create Mission" button are visible
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 1 (Mission type alias must exist in shared types)
+
+---
+
+### Task 7.2: Mission Creation Form -- Type-Specific Fields
+
+**Agent**: coder
+**Description**: Extend the mission creation form (`GoalsEditor.tsx`) with a mission type selector and conditional fields for measurable (KPI targets) and recurring (cron schedule) missions. Add autonomy level selector.
+
+**Subtasks** (ordered implementation steps):
+
+1. Extend `GoalFormProps` in `packages/web/src/components/room/GoalsEditor.tsx` to include `missionType` and `autonomyLevel` initial values in the form.
+
+2. Add a "Mission Type" radio-button or select control to the `GoalForm` component with three options: "One-Shot", "Measurable", "Recurring". Default: "One-Shot".
+
+3. Add conditional field set for **Measurable** missions (shown when type = 'measurable'):
+   - A repeating group of metric rows, each with: metric name (text input), target value (number input), unit (text input, optional), direction selector ("increase" / "decrease"), baseline value (number input, required when direction = "decrease")
+   - "Add Metric" button to add a new row; "Remove" button per row
+   - Client-side validation: non-empty name, positive target for "increase", baseline present and > target for "decrease"
+
+4. Add conditional field set for **Recurring** missions (shown when type = 'recurring'):
+   - Schedule preset dropdown: Daily (`@daily`), Weekly (`@weekly`), Hourly (`@hourly`), Custom
+   - When "Custom" is selected, show a text input for the cron expression (e.g., `0 9 * * 1-5`)
+   - Timezone selector (a `<select>` with a reasonable set of common IANA timezones)
+   - Show a human-readable "Next run: ..." preview (calculated client-side if possible, or just display the expression)
+
+5. Add an "Autonomy Level" select control: "Supervised (default)" and "Semi-Autonomous". Include a short description of each option near the control.
+
+6. Update the `onSubmit` call signature to pass `missionType`, `autonomyLevel`, `structuredMetrics` (if measurable), and `schedule` + `schedulePaused` (if recurring) to the parent `onCreateGoal` handler.
+
+7. Update the `CreateGoalParams` local interface in `packages/web/src/lib/room-store.ts` to include the new fields.
+
+8. Update `RoomStore.createGoal` in `room-store.ts` to pass all new fields to the `goal.create` RPC.
+
+9. Update the edit form flow in `GoalItem` to also show the type-specific fields (so existing missions can have their schedule or metrics updated via `goal.update`).
+
+10. Write unit/component tests in `packages/web/src/components/room/GoalsEditor.test.tsx`:
+    - Measurable fields appear when type = "measurable"; hidden otherwise
+    - Recurring fields appear when type = "recurring"; hidden otherwise
+    - Autonomy level selector renders
+    - Metric add/remove works
+    - Client-side validation blocks submit with invalid metrics (missing baseline for decrease)
+
+**Acceptance Criteria**:
+- Mission type selector with three options is present in the create form
+- Measurable: metric row add/remove works, client-side validation rejects missing baseline
+- Recurring: preset dropdown and custom cron input work, timezone selector present
+- Autonomy level selector present with descriptions
+- All new field values are passed to `goal.create` RPC
+- Existing "one-shot" creation flow is unchanged
+- Unit tests for conditional rendering pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 6 (RPC must accept new fields), Task 7.1 (Mission terminology already renamed)
+
+---
+
+### Task 7.3: Mission Detail View -- Type-Specific Status Displays
+
+**Agent**: coder
+**Description**: Update the mission detail view (expanded `GoalItem` and/or a dedicated detail panel) to show type-specific information: KPI progress for measurable missions, execution history and recurrence indicator for recurring missions, and autonomy level badge for all missions.
+
+**Subtasks** (ordered implementation steps):
+
+1. Add a `MissionTypeBadge` component in `GoalsEditor.tsx`:
+   - "One-Shot" badge (gray)
+   - "Measurable" badge (blue)
+   - "Recurring" badge (purple)
+   - Shown in the goal item header row alongside the priority badge
+
+2. Add an `AutonomyBadge` component:
+   - "Supervised" badge (gray, small, only shown if user has expanded the goal or in detail view)
+   - "Semi-Auto" badge (amber, shown prominently when `autonomyLevel = 'semi_autonomous'`)
+
+3. Extend the `GoalItem` expanded content section for **Measurable** missions:
+   - If `structuredMetrics` is present, replace or augment the generic progress bar with a per-metric row showing: metric name, current value, target, unit, a mini progress bar capped at 100%
+   - Use `goal.update_kpi` RPC (via a new `RoomStore.updateKpi` method) to allow manual KPI updates from the UI for testing purposes (simple input field + button)
+
+4. Extend the `GoalItem` expanded content section for **Recurring** missions:
+   - Show "Next run: <formatted date>" from `goal.nextRunAt` (or "Paused" if `schedulePaused = true`)
+   - Show "Schedule: <expression> (<timezone>)" from `goal.schedule`
+   - Add "Pause schedule" / "Resume schedule" button that calls `goal.update` with `schedulePaused` toggled
+   - Show execution history list: fetch from a new `goal.list_executions` RPC or derive from cached state (see note below)
+
+5. Add `RoomStore.updateKpi(goalId, metricName, value)` method that calls `goal.update_kpi` RPC and refreshes goals.
+
+6. Add `RoomStore.triggerReplan(goalId, reason?)` method that calls `goal.trigger_replan` RPC.
+
+7. Expose a "Trigger Replan" button in the expanded goal view for goals in `needs_human` status (or any active goal). This manually enqueues replanning.
+
+8. Subscribe to `goal.task.auto_completed` events in `room-store.ts` (alongside other goal events) and show a toast notification: `"Task '<title>' auto-completed by agent (PR: #<number>)"`.
+
+9. Update `packages/web/src/lib/room-store.ts` `CreateGoalParams` interface to match the form's output from Task 7.2 (if not already done there).
+
+10. Write unit/component tests in `GoalsEditor.test.tsx`:
+    - Measurable goal shows per-metric rows with progress bars
+    - Recurring goal shows "Next run" and schedule display
+    - "Pause/Resume" schedule button triggers correct RPC call
+    - `MissionTypeBadge` renders correct label for each type
+    - `AutonomyBadge` renders "Semi-Auto" amber badge for `semi_autonomous`
+
+**Acceptance Criteria**:
+- `MissionTypeBadge` shown in goal item header for all mission types
+- Measurable goals display per-metric KPI progress bars
+- Recurring goals display next-run time, schedule expression, and pause/resume control
+- `AutonomyBadge` shows correct styling for `semi_autonomous`
+- `goal.task.auto_completed` event shows a toast notification
+- "Trigger Replan" button available for blocked/active goals
+- All component tests pass
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+
+**Depends on**: Milestone 6 (new RPCs must exist), Task 7.1 (Mission terminology), Task 7.2 (creation form)


### PR DESCRIPTION
## Summary

- Adds a structured 7-milestone plan for the Goal V2 Mission System feature at `docs/plans/goal-v2-mission-system-autonomous-agent-workflows/`
- Covers all milestones from the goal description: shared types, DB migration, measurable KPI tracking, recurring scheduling, semi-autonomous mode, RPC extensions, and UI overhaul
- Plan is grounded in thorough exploration of existing `goal` feature code (RoomGoal types, GoalRepository, GoalManager, goal-handlers, GoalsEditor, room-store)

## Plan Structure

7 milestones, 9 total tasks (some milestones have 1 task, some have 2):

1. **Shared Types and Mission Aliases** (1 task) -- `MissionType`, `AutonomyLevel`, `MissionMetric`, `CronSchedule`, `MissionExecution`, extend `RoomGoal`, add `type Mission = RoomGoal`
2. **Database Schema Migration** (2 tasks) -- Migration 28 adds 9 new columns to `goals`, creates `mission_metric_history` and `mission_executions` tables; `GoalRepository`/`GoalManager` updates
3. **Measurable Missions** (1 task) -- Structured KPI tracking, dual-write to history table, metric-based progress calculation, auto-replan when targets not met, MCP tools
4. **Recurring Missions** (1 task) -- Cron parser, scheduler tick, execution identity, per-execution task isolation, overlap prevention, daemon restart recovery
5. **Semi-Autonomous Mode** (1 task) -- Deferred post-tool auto-approval, `approvalSource` in group metadata, consecutive-failure escalation, `goal.task.auto_completed` event
6. **RPC Layer Extensions** (1 task) -- Extend `goal.create`/`goal.update`, add `goal.update_kpi` and `goal.trigger_replan` handlers
7. **UI: Mission Creation, Dashboard, Status** (3 tasks) -- Terminology rename (Goal -> Mission), type-specific creation form fields, type-specific detail views and badges

## Test plan

- [ ] Review milestone ordering and dependency chain
- [ ] Verify acceptance criteria are testable and specific
- [ ] Confirm file paths and module references match the actual codebase structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)