### PR TITLE
feat: add mission metadata schema and types for Goal V2

### DIFF
--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -35,7 +35,13 @@ import { JobQueueRepository } from './repositories/job-queue-repository';
 export type { SendStatus } from './repositories/sdk-message-repository';
 export type { SQLiteValue } from './types';
 export type { CreateInboxItemParams, InboxItemFilter } from './repositories/inbox-item-repository';
-export type { CreateGoalParams, UpdateGoalParams } from './repositories/goal-repository';
+export type {
+	CreateGoalParams,
+	UpdateGoalParams,
+	CreateExecutionParams,
+	UpdateExecutionParams,
+} from './repositories/goal-repository';
+export { getEffectiveMaxPlanningAttempts } from './repositories/goal-repository';
 export type { Job, EnqueueParams } from './repositories/job-queue-repository';
 export { JobQueueProcessor } from './job-queue-processor';
 export type { JobHandler, JobQueueProcessorOptions } from './job-queue-processor';

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -7,7 +7,18 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
-import type { RoomGoal, GoalStatus, GoalPriority } from '@neokai/shared';
+import type {
+	RoomGoal,
+	GoalStatus,
+	GoalPriority,
+	MissionType,
+	AutonomyLevel,
+	MissionMetric,
+	CronSchedule,
+	MetricHistoryEntry,
+	MissionExecution,
+	MissionExecutionStatus,
+} from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 
 export interface CreateGoalParams {
@@ -15,6 +26,14 @@ export interface CreateGoalParams {
 	title: string;
 	description?: string;
 	priority?: GoalPriority;
+	missionType?: MissionType;
+	autonomyLevel?: AutonomyLevel;
+	structuredMetrics?: MissionMetric[];
+	schedule?: CronSchedule;
+	schedulePaused?: boolean;
+	nextRunAt?: number;
+	maxConsecutiveFailures?: number;
+	maxPlanningAttempts?: number;
 }
 
 export interface UpdateGoalParams {
@@ -26,6 +45,30 @@ export interface UpdateGoalParams {
 	linkedTaskIds?: string[];
 	metrics?: Record<string, number>;
 	planning_attempts?: number;
+	missionType?: MissionType;
+	autonomyLevel?: AutonomyLevel;
+	structuredMetrics?: MissionMetric[] | null;
+	schedule?: CronSchedule | null;
+	schedulePaused?: boolean;
+	nextRunAt?: number | null;
+	maxConsecutiveFailures?: number;
+	maxPlanningAttempts?: number;
+	consecutiveFailures?: number;
+}
+
+export interface CreateExecutionParams {
+	goalId: string;
+	executionNumber: number;
+	startedAt?: number;
+	taskIds?: string[];
+}
+
+export interface UpdateExecutionParams {
+	status?: MissionExecutionStatus;
+	completedAt?: number;
+	resultSummary?: string;
+	taskIds?: string[];
+	planningAttempts?: number;
 }
 
 export class GoalRepository {
@@ -39,8 +82,13 @@ export class GoalRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO goals (id, room_id, title, description, status, priority, progress, linked_task_ids, metrics, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO goals (
+				id, room_id, title, description, status, priority, progress, linked_task_ids,
+				metrics, created_at, updated_at,
+				mission_type, autonomy_level, schedule, schedule_paused, next_run_at,
+				structured_metrics, max_consecutive_failures, max_planning_attempts, consecutive_failures
+			)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -54,7 +102,16 @@ export class GoalRepository {
 			'[]',
 			'{}',
 			now,
-			now
+			now,
+			params.missionType ?? 'one_shot',
+			params.autonomyLevel ?? 'supervised',
+			params.schedule ? JSON.stringify(params.schedule) : null,
+			params.schedulePaused ? 1 : 0,
+			params.nextRunAt ?? null,
+			params.structuredMetrics ? JSON.stringify(params.structuredMetrics) : null,
+			params.maxConsecutiveFailures ?? 3,
+			params.maxPlanningAttempts ?? 5,
+			0
 		);
 
 		return this.getGoal(id)!;
@@ -135,6 +192,44 @@ export class GoalRepository {
 			fields.push('planning_attempts = ?');
 			values.push(params.planning_attempts);
 		}
+		if (params.missionType !== undefined) {
+			fields.push('mission_type = ?');
+			values.push(params.missionType);
+		}
+		if (params.autonomyLevel !== undefined) {
+			fields.push('autonomy_level = ?');
+			values.push(params.autonomyLevel);
+		}
+		if (params.structuredMetrics !== undefined) {
+			fields.push('structured_metrics = ?');
+			values.push(
+				params.structuredMetrics !== null ? JSON.stringify(params.structuredMetrics) : null
+			);
+		}
+		if (params.schedule !== undefined) {
+			fields.push('schedule = ?');
+			values.push(params.schedule !== null ? JSON.stringify(params.schedule) : null);
+		}
+		if (params.schedulePaused !== undefined) {
+			fields.push('schedule_paused = ?');
+			values.push(params.schedulePaused ? 1 : 0);
+		}
+		if (params.nextRunAt !== undefined) {
+			fields.push('next_run_at = ?');
+			values.push(params.nextRunAt);
+		}
+		if (params.maxConsecutiveFailures !== undefined) {
+			fields.push('max_consecutive_failures = ?');
+			values.push(params.maxConsecutiveFailures);
+		}
+		if (params.maxPlanningAttempts !== undefined) {
+			fields.push('max_planning_attempts = ?');
+			values.push(params.maxPlanningAttempts);
+		}
+		if (params.consecutiveFailures !== undefined) {
+			fields.push('consecutive_failures = ?');
+			values.push(params.consecutiveFailures);
+		}
 
 		if (fields.length === 0) {
 			return this.getGoal(id);
@@ -205,6 +300,187 @@ export class GoalRepository {
 		return row?.count ?? 0;
 	}
 
+	// =========================================================================
+	// Mission Metric History
+	// =========================================================================
+
+	/**
+	 * Insert a metric history data point for a goal
+	 */
+	insertMetricHistory(
+		goalId: string,
+		metricName: string,
+		value: number,
+		recordedAt?: number
+	): MetricHistoryEntry {
+		const id = generateUUID();
+		const ts = recordedAt ?? Math.floor(Date.now() / 1000);
+
+		this.db
+			.prepare(
+				`INSERT INTO mission_metric_history (id, goal_id, metric_name, value, recorded_at)
+				 VALUES (?, ?, ?, ?, ?)`
+			)
+			.run(id, goalId, metricName, value, ts);
+
+		return { metricName, value, recordedAt: ts };
+	}
+
+	/**
+	 * Query metric history for a goal, optionally filtered by metric name and time range
+	 */
+	queryMetricHistory(
+		goalId: string,
+		opts: {
+			metricName?: string;
+			fromTs?: number;
+			toTs?: number;
+			limit?: number;
+		} = {}
+	): MetricHistoryEntry[] {
+		let query = `SELECT metric_name, value, recorded_at FROM mission_metric_history WHERE goal_id = ?`;
+		const params: SQLiteValue[] = [goalId];
+
+		if (opts.metricName) {
+			query += ` AND metric_name = ?`;
+			params.push(opts.metricName);
+		}
+		if (opts.fromTs !== undefined) {
+			query += ` AND recorded_at >= ?`;
+			params.push(opts.fromTs);
+		}
+		if (opts.toTs !== undefined) {
+			query += ` AND recorded_at <= ?`;
+			params.push(opts.toTs);
+		}
+
+		query += ` ORDER BY recorded_at ASC`;
+
+		if (opts.limit !== undefined) {
+			query += ` LIMIT ?`;
+			params.push(opts.limit);
+		}
+
+		const rows = this.db.prepare(query).all(...params) as Array<{
+			metric_name: string;
+			value: number;
+			recorded_at: number;
+		}>;
+
+		return rows.map((r) => ({
+			metricName: r.metric_name,
+			value: r.value,
+			recordedAt: r.recorded_at,
+		}));
+	}
+
+	// =========================================================================
+	// Mission Executions
+	// =========================================================================
+
+	/**
+	 * Insert a new mission execution record
+	 */
+	insertExecution(params: CreateExecutionParams): MissionExecution {
+		const id = generateUUID();
+		const now = Math.floor(Date.now() / 1000);
+
+		this.db
+			.prepare(
+				`INSERT INTO mission_executions
+				 (id, goal_id, execution_number, started_at, status, task_ids, planning_attempts)
+				 VALUES (?, ?, ?, ?, 'running', ?, 0)`
+			)
+			.run(
+				id,
+				params.goalId,
+				params.executionNumber,
+				params.startedAt ?? now,
+				JSON.stringify(params.taskIds ?? [])
+			);
+
+		return this.getExecution(id)!;
+	}
+
+	/**
+	 * Get a single execution by ID
+	 */
+	getExecution(id: string): MissionExecution | null {
+		const row = this.db
+			.prepare(`SELECT * FROM mission_executions WHERE id = ?`)
+			.get(id) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToExecution(row);
+	}
+
+	/**
+	 * List executions for a goal (most recent first)
+	 */
+	listExecutions(goalId: string, limit?: number): MissionExecution[] {
+		let query = `SELECT * FROM mission_executions WHERE goal_id = ? ORDER BY execution_number DESC`;
+		const params: SQLiteValue[] = [goalId];
+		if (limit !== undefined) {
+			query += ` LIMIT ?`;
+			params.push(limit);
+		}
+		const rows = this.db.prepare(query).all(...params) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToExecution(r));
+	}
+
+	/**
+	 * Update a mission execution (status, completedAt, resultSummary, taskIds, planningAttempts)
+	 */
+	updateExecution(id: string, params: UpdateExecutionParams): MissionExecution | null {
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+		}
+		if (params.completedAt !== undefined) {
+			fields.push('completed_at = ?');
+			values.push(params.completedAt);
+		}
+		if (params.resultSummary !== undefined) {
+			fields.push('result_summary = ?');
+			values.push(params.resultSummary);
+		}
+		if (params.taskIds !== undefined) {
+			fields.push('task_ids = ?');
+			values.push(JSON.stringify(params.taskIds));
+		}
+		if (params.planningAttempts !== undefined) {
+			fields.push('planning_attempts = ?');
+			values.push(params.planningAttempts);
+		}
+
+		if (fields.length === 0) return this.getExecution(id);
+
+		values.push(id);
+		this.db
+			.prepare(`UPDATE mission_executions SET ${fields.join(', ')} WHERE id = ?`)
+			.run(...values);
+		return this.getExecution(id);
+	}
+
+	/**
+	 * Get the currently running execution for a goal (at most one due to partial unique index)
+	 */
+	getActiveExecution(goalId: string): MissionExecution | null {
+		const row = this.db
+			.prepare(
+				`SELECT * FROM mission_executions WHERE goal_id = ? AND status = 'running' LIMIT 1`
+			)
+			.get(goalId) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToExecution(row);
+	}
+
+	// =========================================================================
+	// Private helpers
+	// =========================================================================
+
 	/**
 	 * Convert a database row to a RoomGoal object
 	 */
@@ -223,7 +499,74 @@ export class GoalRepository {
 			goal_review_attempts: (row.goal_review_attempts as number | null) ?? 0,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
-			completedAt: row.completed_at as number | undefined,
+			completedAt: (row.completed_at as number | null) ?? undefined,
+			// Mission V2 fields
+			missionType: (row.mission_type as MissionType | null) ?? 'one_shot',
+			autonomyLevel: (row.autonomy_level as AutonomyLevel | null) ?? 'supervised',
+			structuredMetrics:
+				row.structured_metrics != null
+					? (JSON.parse(row.structured_metrics as string) as MissionMetric[])
+					: undefined,
+			schedule:
+				row.schedule != null
+					? (JSON.parse(row.schedule as string) as CronSchedule)
+					: undefined,
+			schedulePaused: row.schedule_paused === 1,
+			nextRunAt: (row.next_run_at as number | null) ?? undefined,
+			maxConsecutiveFailures: (row.max_consecutive_failures as number | null) ?? 3,
+			maxPlanningAttempts: (row.max_planning_attempts as number | null) ?? 5,
+			consecutiveFailures: (row.consecutive_failures as number | null) ?? 0,
 		};
 	}
+
+	/**
+	 * Convert a database row to a MissionExecution object
+	 */
+	private rowToExecution(row: Record<string, unknown>): MissionExecution {
+		return {
+			id: row.id as string,
+			goalId: row.goal_id as string,
+			executionNumber: row.execution_number as number,
+			startedAt: row.started_at as number,
+			completedAt: (row.completed_at as number | null) ?? undefined,
+			status: row.status as MissionExecutionStatus,
+			resultSummary: (row.result_summary as string | null) ?? undefined,
+			taskIds: JSON.parse(row.task_ids as string) as string[],
+			planningAttempts: (row.planning_attempts as number | null) ?? 0,
+		};
+	}
+}
+
+/**
+ * Compute the effective max planning attempts for a goal.
+ *
+ * Priority order:
+ * 1. goal.maxPlanningAttempts (per-goal override, stored in DB)
+ * 2. roomConfig.maxPlanningRetries + 1 (room-level config, legacy key)
+ * 3. Default: 1 (no retries)
+ */
+export function getEffectiveMaxPlanningAttempts(
+	goal: RoomGoal,
+	roomConfig?: Record<string, unknown>
+): number {
+	// Per-goal override takes highest precedence
+	if (
+		goal.maxPlanningAttempts !== undefined &&
+		Number.isInteger(goal.maxPlanningAttempts) &&
+		goal.maxPlanningAttempts > 0
+	) {
+		return goal.maxPlanningAttempts;
+	}
+
+	// Room-level config: maxPlanningRetries is "retries after first failure"
+	// so 0 means 1 total attempt, N means N+1 total attempts
+	if (roomConfig !== undefined) {
+		const retries = roomConfig['maxPlanningRetries'];
+		if (typeof retries === 'number' && Number.isInteger(retries) && retries >= 0) {
+			return retries + 1;
+		}
+	}
+
+	// Global default: 1 total attempt (no retries)
+	return 1;
 }

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -406,9 +406,9 @@ export class GoalRepository {
 	 * Get a single execution by ID
 	 */
 	getExecution(id: string): MissionExecution | null {
-		const row = this.db
-			.prepare(`SELECT * FROM mission_executions WHERE id = ?`)
-			.get(id) as Record<string, unknown> | undefined;
+		const row = this.db.prepare(`SELECT * FROM mission_executions WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
 		if (!row) return null;
 		return this.rowToExecution(row);
 	}
@@ -469,9 +469,7 @@ export class GoalRepository {
 	 */
 	getActiveExecution(goalId: string): MissionExecution | null {
 		const row = this.db
-			.prepare(
-				`SELECT * FROM mission_executions WHERE goal_id = ? AND status = 'running' LIMIT 1`
-			)
+			.prepare(`SELECT * FROM mission_executions WHERE goal_id = ? AND status = 'running' LIMIT 1`)
 			.get(goalId) as Record<string, unknown> | undefined;
 		if (!row) return null;
 		return this.rowToExecution(row);
@@ -508,9 +506,7 @@ export class GoalRepository {
 					? (JSON.parse(row.structured_metrics as string) as MissionMetric[])
 					: undefined,
 			schedule:
-				row.schedule != null
-					? (JSON.parse(row.schedule as string) as CronSchedule)
-					: undefined,
+				row.schedule != null ? (JSON.parse(row.schedule as string) as CronSchedule) : undefined,
 			schedulePaused: row.schedule_paused === 1,
 			nextRunAt: (row.next_run_at as number | null) ?? undefined,
 			maxConsecutiveFailures: (row.max_consecutive_failures as number | null) ?? 3,

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -185,7 +185,47 @@ export function createTables(db: BunDatabase): void {
         completed_at INTEGER,
         planning_attempts INTEGER DEFAULT 0,
         goal_review_attempts INTEGER DEFAULT 0,
+        mission_type TEXT NOT NULL DEFAULT 'one_shot'
+          CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+        autonomy_level TEXT NOT NULL DEFAULT 'supervised'
+          CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+        schedule TEXT,
+        schedule_paused INTEGER NOT NULL DEFAULT 0,
+        next_run_at INTEGER,
+        structured_metrics TEXT,
+        max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+        max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+      )
+    `);
+
+	// Mission metric history table
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS mission_metric_history (
+        id TEXT PRIMARY KEY,
+        goal_id TEXT NOT NULL,
+        metric_name TEXT NOT NULL,
+        value REAL NOT NULL,
+        recorded_at INTEGER NOT NULL,
+        FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE
+      )
+    `);
+
+	// Mission executions table
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS mission_executions (
+        id TEXT PRIMARY KEY,
+        goal_id TEXT NOT NULL,
+        execution_number INTEGER NOT NULL,
+        started_at INTEGER,
+        completed_at INTEGER,
+        status TEXT NOT NULL DEFAULT 'running',
+        result_summary TEXT,
+        task_ids TEXT NOT NULL DEFAULT '[]',
+        planning_attempts INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE,
+        UNIQUE(goal_id, execution_number)
       )
     `);
 
@@ -302,6 +342,15 @@ function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_goals_mission_scheduler ON goals(mission_type, schedule_paused, next_run_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mission_metric_history_lookup ON mission_metric_history(goal_id, metric_name, recorded_at)`
+	);
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running ON mission_executions(goal_id) WHERE status = 'running'`
+	);
 
 	// GitHub integration indexes
 	db.exec(

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -105,6 +105,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 27: Add updated_at column to tasks table for sorting by most recently updated
 	runMigration27(db);
+
+	// Migration 28: Add mission metadata columns to goals table, create mission_metric_history
+	// and mission_executions tables for Goal V2 / Mission System
+	runMigration28(db);
 }
 
 /**
@@ -1319,4 +1323,112 @@ function runMigrationRoomCleanup(db: BunDatabase): void {
 	} finally {
 		db.exec(`PRAGMA foreign_keys = ON`);
 	}
+}
+
+/**
+ * Migration 28: Add mission metadata columns to goals table and create
+ * mission_metric_history and mission_executions tables.
+ *
+ * New columns on goals:
+ * - mission_type, autonomy_level (with CHECK constraints)
+ * - schedule (JSON), schedule_paused, next_run_at
+ * - structured_metrics (JSON)
+ * - max_consecutive_failures, max_planning_attempts, consecutive_failures
+ *
+ * New tables:
+ * - mission_metric_history: metric data points per goal
+ * - mission_executions: execution runs per goal (with partial unique index
+ *   on (goal_id) WHERE status = 'running' for at-most-one-running invariant)
+ *
+ * Backfills existing goals: mission_type = 'one_shot', autonomy_level = 'supervised'
+ */
+function runMigration28(db: BunDatabase): void {
+	// --- Add columns to goals table ---
+	if (tableExists(db, 'goals')) {
+		if (!tableHasColumn(db, 'goals', 'mission_type')) {
+			db.exec(
+				`ALTER TABLE goals ADD COLUMN mission_type TEXT NOT NULL DEFAULT 'one_shot'` +
+					` CHECK(mission_type IN ('one_shot', 'measurable', 'recurring'))`
+			);
+			// Backfill existing rows (ALTER TABLE DEFAULT already handles it, but be explicit)
+			db.exec(`UPDATE goals SET mission_type = 'one_shot' WHERE mission_type IS NULL`);
+		}
+		if (!tableHasColumn(db, 'goals', 'autonomy_level')) {
+			db.exec(
+				`ALTER TABLE goals ADD COLUMN autonomy_level TEXT NOT NULL DEFAULT 'supervised'` +
+					` CHECK(autonomy_level IN ('supervised', 'semi_autonomous'))`
+			);
+			db.exec(`UPDATE goals SET autonomy_level = 'supervised' WHERE autonomy_level IS NULL`);
+		}
+		if (!tableHasColumn(db, 'goals', 'schedule')) {
+			db.exec(`ALTER TABLE goals ADD COLUMN schedule TEXT`);
+		}
+		if (!tableHasColumn(db, 'goals', 'schedule_paused')) {
+			db.exec(`ALTER TABLE goals ADD COLUMN schedule_paused INTEGER NOT NULL DEFAULT 0`);
+		}
+		if (!tableHasColumn(db, 'goals', 'next_run_at')) {
+			db.exec(`ALTER TABLE goals ADD COLUMN next_run_at INTEGER`);
+		}
+		if (!tableHasColumn(db, 'goals', 'structured_metrics')) {
+			db.exec(`ALTER TABLE goals ADD COLUMN structured_metrics TEXT`);
+		}
+		if (!tableHasColumn(db, 'goals', 'max_consecutive_failures')) {
+			db.exec(
+				`ALTER TABLE goals ADD COLUMN max_consecutive_failures INTEGER NOT NULL DEFAULT 3`
+			);
+		}
+		if (!tableHasColumn(db, 'goals', 'max_planning_attempts')) {
+			db.exec(
+				`ALTER TABLE goals ADD COLUMN max_planning_attempts INTEGER NOT NULL DEFAULT 5`
+			);
+		}
+		if (!tableHasColumn(db, 'goals', 'consecutive_failures')) {
+			db.exec(
+				`ALTER TABLE goals ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0`
+			);
+		}
+		// Composite index for efficient scheduler queries
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_goals_mission_scheduler` +
+				` ON goals(mission_type, schedule_paused, next_run_at)`
+		);
+	}
+
+	// --- Create mission_metric_history table ---
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mission_metric_history (
+			id TEXT PRIMARY KEY,
+			goal_id TEXT NOT NULL,
+			metric_name TEXT NOT NULL,
+			value REAL NOT NULL,
+			recorded_at INTEGER NOT NULL,
+			FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mission_metric_history_lookup` +
+			` ON mission_metric_history(goal_id, metric_name, recorded_at)`
+	);
+
+	// --- Create mission_executions table ---
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mission_executions (
+			id TEXT PRIMARY KEY,
+			goal_id TEXT NOT NULL,
+			execution_number INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			status TEXT NOT NULL DEFAULT 'running',
+			result_summary TEXT,
+			task_ids TEXT NOT NULL DEFAULT '[]',
+			planning_attempts INTEGER NOT NULL DEFAULT 0,
+			FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE,
+			UNIQUE(goal_id, execution_number)
+		)
+	`);
+	// Partial unique index: at most one running execution per goal
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running` +
+			` ON mission_executions(goal_id) WHERE status = 'running'`
+	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1373,19 +1373,13 @@ function runMigration28(db: BunDatabase): void {
 			db.exec(`ALTER TABLE goals ADD COLUMN structured_metrics TEXT`);
 		}
 		if (!tableHasColumn(db, 'goals', 'max_consecutive_failures')) {
-			db.exec(
-				`ALTER TABLE goals ADD COLUMN max_consecutive_failures INTEGER NOT NULL DEFAULT 3`
-			);
+			db.exec(`ALTER TABLE goals ADD COLUMN max_consecutive_failures INTEGER NOT NULL DEFAULT 3`);
 		}
 		if (!tableHasColumn(db, 'goals', 'max_planning_attempts')) {
-			db.exec(
-				`ALTER TABLE goals ADD COLUMN max_planning_attempts INTEGER NOT NULL DEFAULT 5`
-			);
+			db.exec(`ALTER TABLE goals ADD COLUMN max_planning_attempts INTEGER NOT NULL DEFAULT 5`);
 		}
 		if (!tableHasColumn(db, 'goals', 'consecutive_failures')) {
-			db.exec(
-				`ALTER TABLE goals ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0`
-			);
+			db.exec(`ALTER TABLE goals ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0`);
 		}
 		// Composite index for efficient scheduler queries
 		db.exec(

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -34,7 +34,20 @@ describe('Room Agent Tools', () => {
 				metrics TEXT DEFAULT '{}',
 				created_at INTEGER NOT NULL,
 				updated_at INTEGER NOT NULL,
-				completed_at INTEGER
+				completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0,
+				goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT NOT NULL DEFAULT 'one_shot'
+					CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised'
+					CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+				schedule TEXT,
+				schedule_paused INTEGER NOT NULL DEFAULT 0,
+				next_run_at INTEGER,
+				structured_metrics TEXT,
+				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+				consecutive_failures INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -119,7 +119,18 @@ const DB_SCHEMA = `
 		priority TEXT NOT NULL DEFAULT 'normal', progress INTEGER DEFAULT 0,
 		linked_task_ids TEXT DEFAULT '[]', metrics TEXT DEFAULT '{}',
 		created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER,
-		planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0
+		planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0,
+		mission_type TEXT NOT NULL DEFAULT 'one_shot'
+			CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+		autonomy_level TEXT NOT NULL DEFAULT 'supervised'
+			CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+		schedule TEXT,
+		schedule_paused INTEGER NOT NULL DEFAULT 0,
+		next_run_at INTEGER,
+		structured_metrics TEXT,
+		max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+		max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+		consecutive_failures INTEGER NOT NULL DEFAULT 0
 	);
 	CREATE TABLE tasks (
 		id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -100,7 +100,19 @@ describe('Runtime Recovery', () => {
 				description TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
 				priority TEXT NOT NULL DEFAULT 'normal', progress INTEGER DEFAULT 0,
 				linked_task_ids TEXT DEFAULT '[]', metrics TEXT DEFAULT '{}',
-				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT NOT NULL DEFAULT 'one_shot'
+					CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised'
+					CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+				schedule TEXT,
+				schedule_paused INTEGER NOT NULL DEFAULT 0,
+				next_run_at INTEGER,
+				structured_metrics TEXT,
+				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+				consecutive_failures INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -189,7 +189,19 @@ describe('TaskGroupManager', () => {
 				description TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
 				priority TEXT NOT NULL DEFAULT 'normal', progress INTEGER DEFAULT 0,
 				linked_task_ids TEXT DEFAULT '[]', metrics TEXT DEFAULT '{}',
-				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0, goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT NOT NULL DEFAULT 'one_shot'
+					CHECK(mission_type IN ('one_shot', 'measurable', 'recurring')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised'
+					CHECK(autonomy_level IN ('supervised', 'semi_autonomous')),
+				schedule TEXT,
+				schedule_paused INTEGER NOT NULL DEFAULT 0,
+				next_run_at INTEGER,
+				structured_metrics TEXT,
+				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+				consecutive_failures INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
@@ -1,0 +1,557 @@
+/**
+ * Migration 28 Tests
+ *
+ * Tests for Migration 28: Goal V2 / Mission System schema additions.
+ *
+ * Covers:
+ * - Migration runs cleanly on fresh DB
+ * - Migration runs cleanly on DB with existing goals rows (idempotent)
+ * - New columns have correct defaults
+ * - New tables (mission_metric_history, mission_executions) are created
+ * - Partial unique index prevents two running executions for same goal
+ * - GoalRepository CRUD for new columns
+ * - GoalRepository metric history CRUD
+ * - GoalRepository execution CRUD
+ * - getEffectiveMaxPlanningAttempts helper
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { createTables } from '../../../../src/storage/schema/index.ts';
+import {
+	GoalRepository,
+	getEffectiveMaxPlanningAttempts,
+} from '../../../../src/storage/repositories/goal-repository.ts';
+
+// ---------------------------------------------------------------------------
+// Shared test database setup helpers
+// ---------------------------------------------------------------------------
+
+function createLegacyGoalsTable(db: BunDatabase): void {
+	// Create the goals table as it existed before Migration 28
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS goals (
+			id TEXT PRIMARY KEY,
+			room_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'needs_human', 'completed', 'archived')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			progress INTEGER DEFAULT 0,
+			linked_task_ids TEXT DEFAULT '[]',
+			metrics TEXT DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			planning_attempts INTEGER DEFAULT 0,
+			goal_review_attempts INTEGER DEFAULT 0,
+			FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`PRAGMA foreign_keys = ON`);
+}
+
+function insertRoom(db: BunDatabase, id = 'room-1'): void {
+	const now = Date.now();
+	db.exec(
+		`INSERT OR IGNORE INTO rooms (id, name, created_at, updated_at)
+		 VALUES ('${id}', 'Test Room', ${now}, ${now})`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Describe blocks
+// ---------------------------------------------------------------------------
+
+describe('Migration 28: mission metadata schema additions', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-28', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+
+		// Create rooms table (needed for FK)
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				background_context TEXT,
+				instructions TEXT,
+				allowed_paths TEXT DEFAULT '[]',
+				default_path TEXT,
+				default_model TEXT,
+				allowed_models TEXT DEFAULT '[]',
+				session_ids TEXT DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'archived')),
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		insertRoom(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('migration runs cleanly on fresh DB (no goals table yet)', () => {
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+		// goals table should not exist yet (created by createTables, not migrations)
+		// But the new support tables should exist after runMigrations
+		const mmhExists = db
+			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='mission_metric_history'`)
+			.get();
+		const meExists = db
+			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='mission_executions'`)
+			.get();
+		expect(mmhExists).toBeTruthy();
+		expect(meExists).toBeTruthy();
+	});
+
+	test('migration adds new columns to existing goals table and backfills defaults', () => {
+		// Simulate a pre-migration database with legacy goals table
+		createLegacyGoalsTable(db);
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO goals (id, room_id, title, description, status, priority, created_at, updated_at)
+			 VALUES ('goal-1', 'room-1', 'Old Goal', '', 'active', 'normal', ${now}, ${now})`
+		);
+
+		runMigrations(db, () => {});
+
+		// Check new columns exist with correct values
+		const row = db.prepare(`SELECT * FROM goals WHERE id = 'goal-1'`).get() as Record<
+			string,
+			unknown
+		>;
+		expect(row.mission_type).toBe('one_shot');
+		expect(row.autonomy_level).toBe('supervised');
+		expect(row.schedule_paused).toBe(0);
+		expect(row.max_consecutive_failures).toBe(3);
+		expect(row.max_planning_attempts).toBe(5);
+		expect(row.consecutive_failures).toBe(0);
+		expect(row.schedule).toBeNull();
+		expect(row.next_run_at).toBeNull();
+		expect(row.structured_metrics).toBeNull();
+	});
+
+	test('migration is idempotent — running twice does not throw', () => {
+		createLegacyGoalsTable(db);
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+	});
+
+	test('CHECK constraint on mission_type is enforced after migration', () => {
+		createLegacyGoalsTable(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		expect(() => {
+			db.exec(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, mission_type, autonomy_level, created_at, updated_at)
+				 VALUES ('g-ok', 'room-1', 'T', '', 'active', 'normal', 'recurring', 'supervised', ${now}, ${now})`
+			);
+		}).not.toThrow();
+
+		expect(() => {
+			db.exec(
+				`INSERT INTO goals (id, room_id, title, description, status, priority, mission_type, autonomy_level, created_at, updated_at)
+				 VALUES ('g-bad', 'room-1', 'T', '', 'active', 'normal', 'invalid_type', 'supervised', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	test('mission_metric_history table has correct schema and cascade delete', () => {
+		createLegacyGoalsTable(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO goals (id, room_id, title, description, status, priority, mission_type, autonomy_level, created_at, updated_at)
+			 VALUES ('g-cascade', 'room-1', 'Cascade Goal', '', 'active', 'normal', 'one_shot', 'supervised', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO mission_metric_history (id, goal_id, metric_name, value, recorded_at)
+			 VALUES ('mh-1', 'g-cascade', 'velocity', 42.5, 1000)`
+		);
+
+		// Delete goal → should cascade
+		db.exec(`DELETE FROM goals WHERE id = 'g-cascade'`);
+
+		const remaining = db
+			.prepare(`SELECT * FROM mission_metric_history WHERE goal_id = 'g-cascade'`)
+			.all();
+		expect(remaining).toHaveLength(0);
+	});
+
+	test('partial unique index on mission_executions prevents two running executions per goal', () => {
+		createLegacyGoalsTable(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO goals (id, room_id, title, description, status, priority, mission_type, autonomy_level, created_at, updated_at)
+			 VALUES ('g-exec', 'room-1', 'Exec Goal', '', 'active', 'normal', 'one_shot', 'supervised', ${now}, ${now})`
+		);
+
+		// Insert first running execution — should succeed
+		db.exec(
+			`INSERT INTO mission_executions (id, goal_id, execution_number, status, task_ids, planning_attempts)
+			 VALUES ('e-1', 'g-exec', 1, 'running', '[]', 0)`
+		);
+
+		// Insert second running execution for same goal — should fail due to partial unique index
+		expect(() => {
+			db.exec(
+				`INSERT INTO mission_executions (id, goal_id, execution_number, status, task_ids, planning_attempts)
+				 VALUES ('e-2', 'g-exec', 2, 'running', '[]', 0)`
+			);
+		}).toThrow();
+
+		// Two completed executions should be allowed
+		db.exec(`UPDATE mission_executions SET status = 'completed' WHERE id = 'e-1'`);
+		expect(() => {
+			db.exec(
+				`INSERT INTO mission_executions (id, goal_id, execution_number, status, task_ids, planning_attempts)
+				 VALUES ('e-2', 'g-exec', 2, 'running', '[]', 0)`
+			);
+		}).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GoalRepository tests (using fresh in-memory DB via createTables)
+// ---------------------------------------------------------------------------
+
+describe('GoalRepository: mission metadata CRUD', () => {
+	let db: BunDatabase;
+	let repo: GoalRepository;
+	let roomId: string;
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+		createTables(db);
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
+		);
+		roomId = 'room-1';
+		repo = new GoalRepository(db);
+	});
+
+	test('createGoal defaults to one_shot / supervised', () => {
+		const goal = repo.createGoal({ roomId, title: 'My goal' });
+		expect(goal.missionType).toBe('one_shot');
+		expect(goal.autonomyLevel).toBe('supervised');
+		expect(goal.schedulePaused).toBe(false);
+		expect(goal.maxConsecutiveFailures).toBe(3);
+		expect(goal.maxPlanningAttempts).toBe(5);
+		expect(goal.consecutiveFailures).toBe(0);
+	});
+
+	test('createGoal accepts mission V2 params', () => {
+		const goal = repo.createGoal({
+			roomId,
+			title: 'Measurable goal',
+			missionType: 'measurable',
+			autonomyLevel: 'semi_autonomous',
+			maxConsecutiveFailures: 2,
+			maxPlanningAttempts: 10,
+			structuredMetrics: [{ name: 'velocity', target: 100, current: 0 }],
+		});
+		expect(goal.missionType).toBe('measurable');
+		expect(goal.autonomyLevel).toBe('semi_autonomous');
+		expect(goal.maxConsecutiveFailures).toBe(2);
+		expect(goal.maxPlanningAttempts).toBe(10);
+		expect(goal.structuredMetrics).toHaveLength(1);
+		expect(goal.structuredMetrics![0].name).toBe('velocity');
+	});
+
+	test('updateGoal updates mission V2 fields', () => {
+		const goal = repo.createGoal({ roomId, title: 'G' });
+
+		const updated = repo.updateGoal(goal.id, {
+			missionType: 'recurring',
+			autonomyLevel: 'semi_autonomous',
+			schedule: { expression: '0 * * * *', timezone: 'UTC' },
+			schedulePaused: true,
+			nextRunAt: 9999,
+			consecutiveFailures: 2,
+			maxConsecutiveFailures: 5,
+		});
+
+		expect(updated?.missionType).toBe('recurring');
+		expect(updated?.autonomyLevel).toBe('semi_autonomous');
+		expect(updated?.schedule?.expression).toBe('0 * * * *');
+		expect(updated?.schedulePaused).toBe(true);
+		expect(updated?.nextRunAt).toBe(9999);
+		expect(updated?.consecutiveFailures).toBe(2);
+		expect(updated?.maxConsecutiveFailures).toBe(5);
+	});
+
+	test('updateGoal can clear schedule and nextRunAt (null)', () => {
+		const goal = repo.createGoal({
+			roomId,
+			title: 'G',
+			missionType: 'recurring',
+			schedule: { expression: '0 * * * *', timezone: 'UTC' },
+			nextRunAt: 9999,
+		});
+
+		const updated = repo.updateGoal(goal.id, { schedule: null, nextRunAt: null });
+		expect(updated?.schedule).toBeUndefined();
+		expect(updated?.nextRunAt).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GoalRepository: metric history tests
+// ---------------------------------------------------------------------------
+
+describe('GoalRepository: mission_metric_history', () => {
+	let db: BunDatabase;
+	let repo: GoalRepository;
+	let goalId: string;
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+		createTables(db);
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
+		);
+		repo = new GoalRepository(db);
+		const goal = repo.createGoal({ roomId: 'room-1', title: 'Metric Goal' });
+		goalId = goal.id;
+	});
+
+	test('insertMetricHistory stores a data point', () => {
+		const entry = repo.insertMetricHistory(goalId, 'velocity', 42.5, 1000);
+		expect(entry.metricName).toBe('velocity');
+		expect(entry.value).toBe(42.5);
+		expect(entry.recordedAt).toBe(1000);
+	});
+
+	test('queryMetricHistory returns entries in ascending order', () => {
+		repo.insertMetricHistory(goalId, 'velocity', 10, 1000);
+		repo.insertMetricHistory(goalId, 'velocity', 20, 2000);
+		repo.insertMetricHistory(goalId, 'velocity', 30, 3000);
+
+		const entries = repo.queryMetricHistory(goalId);
+		expect(entries).toHaveLength(3);
+		expect(entries[0].value).toBe(10);
+		expect(entries[2].value).toBe(30);
+	});
+
+	test('queryMetricHistory filters by metricName', () => {
+		repo.insertMetricHistory(goalId, 'velocity', 10, 1000);
+		repo.insertMetricHistory(goalId, 'coverage', 80, 1000);
+
+		const velocityEntries = repo.queryMetricHistory(goalId, { metricName: 'velocity' });
+		expect(velocityEntries).toHaveLength(1);
+		expect(velocityEntries[0].metricName).toBe('velocity');
+	});
+
+	test('queryMetricHistory filters by time range', () => {
+		repo.insertMetricHistory(goalId, 'velocity', 10, 1000);
+		repo.insertMetricHistory(goalId, 'velocity', 20, 2000);
+		repo.insertMetricHistory(goalId, 'velocity', 30, 3000);
+
+		const entries = repo.queryMetricHistory(goalId, { fromTs: 1500, toTs: 2500 });
+		expect(entries).toHaveLength(1);
+		expect(entries[0].value).toBe(20);
+	});
+
+	test('queryMetricHistory respects limit', () => {
+		for (let i = 0; i < 10; i++) {
+			repo.insertMetricHistory(goalId, 'velocity', i, 1000 + i);
+		}
+		const entries = repo.queryMetricHistory(goalId, { limit: 3 });
+		expect(entries).toHaveLength(3);
+	});
+
+	test('metric history is cascade deleted when goal is deleted', () => {
+		repo.insertMetricHistory(goalId, 'velocity', 42, 1000);
+		repo.deleteGoal(goalId);
+
+		const entries = repo.queryMetricHistory(goalId);
+		expect(entries).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GoalRepository: execution tests
+// ---------------------------------------------------------------------------
+
+describe('GoalRepository: mission_executions', () => {
+	let db: BunDatabase;
+	let repo: GoalRepository;
+	let goalId: string;
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+		createTables(db);
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
+		);
+		repo = new GoalRepository(db);
+		const goal = repo.createGoal({ roomId: 'room-1', title: 'Exec Goal' });
+		goalId = goal.id;
+	});
+
+	test('insertExecution creates a running execution', () => {
+		const exec = repo.insertExecution({ goalId, executionNumber: 1 });
+		expect(exec.status).toBe('running');
+		expect(exec.executionNumber).toBe(1);
+		expect(exec.goalId).toBe(goalId);
+		expect(exec.taskIds).toEqual([]);
+		expect(exec.planningAttempts).toBe(0);
+	});
+
+	test('getActiveExecution returns the running execution', () => {
+		repo.insertExecution({ goalId, executionNumber: 1 });
+		const active = repo.getActiveExecution(goalId);
+		expect(active).not.toBeNull();
+		expect(active?.executionNumber).toBe(1);
+	});
+
+	test('getActiveExecution returns null when no running execution', () => {
+		const exec = repo.insertExecution({ goalId, executionNumber: 1 });
+		repo.updateExecution(exec.id, { status: 'completed' });
+		expect(repo.getActiveExecution(goalId)).toBeNull();
+	});
+
+	test('updateExecution updates status and completedAt', () => {
+		const exec = repo.insertExecution({ goalId, executionNumber: 1 });
+		const updated = repo.updateExecution(exec.id, {
+			status: 'completed',
+			completedAt: 9999,
+			resultSummary: 'Done!',
+		});
+		expect(updated?.status).toBe('completed');
+		expect(updated?.completedAt).toBe(9999);
+		expect(updated?.resultSummary).toBe('Done!');
+	});
+
+	test('listExecutions returns most recent first', () => {
+		repo.insertExecution({ goalId, executionNumber: 1 });
+
+		// Complete first, then start second
+		const e1 = repo.getActiveExecution(goalId)!;
+		repo.updateExecution(e1.id, { status: 'completed' });
+		repo.insertExecution({ goalId, executionNumber: 2 });
+
+		const list = repo.listExecutions(goalId);
+		expect(list).toHaveLength(2);
+		expect(list[0].executionNumber).toBe(2);
+		expect(list[1].executionNumber).toBe(1);
+	});
+
+	test('listExecutions respects limit', () => {
+		for (let i = 1; i <= 5; i++) {
+			const exec = repo.insertExecution({ goalId, executionNumber: i });
+			if (i < 5) {
+				repo.updateExecution(exec.id, { status: 'completed' });
+			}
+		}
+		const limited = repo.listExecutions(goalId, 2);
+		expect(limited).toHaveLength(2);
+	});
+
+	test('at-most-one running execution is enforced by unique index', () => {
+		repo.insertExecution({ goalId, executionNumber: 1 });
+		expect(() => {
+			repo.insertExecution({ goalId, executionNumber: 2 });
+		}).toThrow();
+	});
+
+	test('updateExecution increments planningAttempts', () => {
+		const exec = repo.insertExecution({ goalId, executionNumber: 1 });
+		const updated = repo.updateExecution(exec.id, { planningAttempts: 3 });
+		expect(updated?.planningAttempts).toBe(3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getEffectiveMaxPlanningAttempts helper tests
+// ---------------------------------------------------------------------------
+
+describe('getEffectiveMaxPlanningAttempts', () => {
+	function makeGoal(maxPlanningAttempts?: number): Parameters<
+		typeof getEffectiveMaxPlanningAttempts
+	>[0] {
+		return {
+			id: 'g-1',
+			roomId: 'r-1',
+			title: 'T',
+			description: '',
+			status: 'active',
+			priority: 'normal',
+			progress: 0,
+			linkedTaskIds: [],
+			createdAt: 0,
+			updatedAt: 0,
+			maxPlanningAttempts,
+		};
+	}
+
+	test('returns goal-level override when set', () => {
+		const goal = makeGoal(7);
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 5 })).toBe(7);
+	});
+
+	test('falls back to roomConfig.maxPlanningRetries + 1', () => {
+		const goal = makeGoal(undefined);
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 2 })).toBe(3);
+	});
+
+	test('roomConfig.maxPlanningRetries = 0 means 1 total attempt', () => {
+		const goal = makeGoal(undefined);
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 0 })).toBe(1);
+	});
+
+	test('returns 1 when neither goal nor roomConfig specifies', () => {
+		const goal = makeGoal(undefined);
+		expect(getEffectiveMaxPlanningAttempts(goal)).toBe(1);
+	});
+
+	test('returns 1 when roomConfig has no maxPlanningRetries', () => {
+		const goal = makeGoal(undefined);
+		expect(getEffectiveMaxPlanningAttempts(goal, { someOtherKey: 99 })).toBe(1);
+	});
+
+	test('ignores goal.maxPlanningAttempts of 0 (falls through to roomConfig)', () => {
+		// 0 is not a valid value (must be > 0)
+		const goal = makeGoal(0);
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 4 })).toBe(5);
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
@@ -120,7 +120,9 @@ describe('Migration 28: mission metadata schema additions', () => {
 		// goals table should not exist yet (created by createTables, not migrations)
 		// But the new support tables should exist after runMigrations
 		const mmhExists = db
-			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='mission_metric_history'`)
+			.prepare(
+				`SELECT name FROM sqlite_master WHERE type='table' AND name='mission_metric_history'`
+			)
 			.get();
 		const meExists = db
 			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='mission_executions'`)
@@ -506,9 +508,9 @@ describe('GoalRepository: mission_executions', () => {
 // ---------------------------------------------------------------------------
 
 describe('getEffectiveMaxPlanningAttempts', () => {
-	function makeGoal(maxPlanningAttempts?: number): Parameters<
-		typeof getEffectiveMaxPlanningAttempts
-	>[0] {
+	function makeGoal(
+		maxPlanningAttempts?: number
+	): Parameters<typeof getEffectiveMaxPlanningAttempts>[0] {
 		return {
 			id: 'g-1',
 			roomId: 'r-1',

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -72,6 +72,73 @@ export type GoalStatus = 'active' | 'needs_human' | 'completed' | 'archived';
  */
 export type GoalPriority = 'low' | 'normal' | 'high' | 'urgent';
 
+// ============================================================================
+// Mission Types (Goal V2)
+// ============================================================================
+
+/**
+ * Mission type — determines execution model for a goal
+ */
+export type MissionType = 'one_shot' | 'measurable' | 'recurring';
+
+/**
+ * Autonomy level — determines how much human oversight is required
+ */
+export type AutonomyLevel = 'supervised' | 'semi_autonomous';
+
+/**
+ * A structured metric tracked by a measurable mission
+ */
+export interface MissionMetric {
+	name: string;
+	target: number;
+	current: number;
+	unit?: string;
+	/** Direction of improvement (default: 'increase') */
+	direction?: 'increase' | 'decrease';
+	/** Baseline value (required for 'decrease' direction) */
+	baseline?: number;
+}
+
+/**
+ * A single metric history data point
+ */
+export interface MetricHistoryEntry {
+	metricName: string;
+	value: number;
+	/** Unix timestamp (seconds) */
+	recordedAt: number;
+}
+
+/**
+ * Cron schedule definition for recurring missions
+ * nextRunAt is stored as a dedicated column on RoomGoal, not inside this JSON
+ */
+export interface CronSchedule {
+	expression: string;
+	timezone: string;
+}
+
+/**
+ * Status of a mission execution run
+ */
+export type MissionExecutionStatus = 'running' | 'completed' | 'failed';
+
+/**
+ * A single execution run for a recurring or one-shot mission
+ */
+export interface MissionExecution {
+	id: string;
+	goalId: string;
+	executionNumber: number;
+	startedAt: number;
+	completedAt?: number;
+	status: MissionExecutionStatus;
+	resultSummary?: string;
+	taskIds: string[];
+	planningAttempts: number;
+}
+
 /**
  * A structured objective for a room
  * Goals track progress via linked tasks
@@ -105,7 +172,31 @@ export interface RoomGoal {
 	updatedAt: number;
 	/** Completion timestamp (milliseconds since epoch) */
 	completedAt?: number;
+	// --- Mission V2 fields ---
+	/** Mission execution model (default: 'one_shot') */
+	missionType?: MissionType;
+	/** Autonomy level for this mission (default: 'supervised') */
+	autonomyLevel?: AutonomyLevel;
+	/** Structured KPI metrics for measurable missions */
+	structuredMetrics?: MissionMetric[];
+	/** Cron schedule for recurring missions */
+	schedule?: CronSchedule;
+	/** Whether the recurring schedule is paused */
+	schedulePaused?: boolean;
+	/** Unix timestamp (seconds) of next scheduled run */
+	nextRunAt?: number;
+	/** Max consecutive failures before escalating to human */
+	maxConsecutiveFailures?: number;
+	/** Max planning attempts override (takes precedence over room config) */
+	maxPlanningAttempts?: number;
+	/** Current count of consecutive failures */
+	consecutiveFailures?: number;
 }
+
+/**
+ * Type alias for the UI and type layer — RoomGoal is the canonical type
+ */
+export type Mission = RoomGoal;
 
 /**
  * Parameters for creating a new room


### PR DESCRIPTION
- New shared types: MissionType, AutonomyLevel, MissionMetric,
  MetricHistoryEntry, CronSchedule, MissionExecutionStatus,
  MissionExecution, Mission (alias for RoomGoal)
- Extend RoomGoal with V2 mission fields (missionType, autonomyLevel,
  structuredMetrics, schedule, schedulePaused, nextRunAt,
  maxConsecutiveFailures, maxPlanningAttempts, consecutiveFailures)
- Migration 28: add new columns to goals table (with CHECK constraints
  and backfill), create mission_metric_history and mission_executions
  tables with appropriate indexes (including partial unique index for
  at-most-one-running-execution invariant)
- Update createTables() to include new columns and tables for fresh DBs
- GoalRepository: CRUD for new V2 fields, insertMetricHistory,
  queryMetricHistory, insertExecution, listExecutions, updateExecution,
  getActiveExecution
- Export getEffectiveMaxPlanningAttempts helper (goal > roomConfig > 1)
- 30 unit tests covering migration, CRUD, and helper logic

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
