### PR TITLE
Plan: Full first-class anthropic-copilot and anthropic-codex provider support

### DIFF
--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/00-overview.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/00-overview.md
@@ -1,0 +1,45 @@
+# Plan: Full First-Class Provider Support for anthropic-copilot and anthropic-to-codex-bridge
+
+## Goal
+
+Make `anthropic-copilot` (GitHub Copilot SDK backend) and `anthropic-codex` (Codex app-server backend) fully first-class providers in NeoKai. Both providers currently work for basic streaming and single-tool round-trips, but have significant gaps in type safety, UI integration, provider routing, parity, testing, and documentation.
+
+## High-Level Approach
+
+1. Fix the shared `Provider` type to include `anthropic-copilot` and `anthropic-codex`, eliminating unsafe `as any` casts throughout the codebase.
+2. Add collision-safe provider routing so model IDs shared between providers (e.g., `claude-opus-4.6` used by both Anthropic and anthropic-copilot) are correctly resolved using explicit `providerId`.
+3. Update the Web UI (model picker, session status bar, provider settings) to fully support both providers including provider-grouped model display and provider-aware session creation.
+4. Close the most impactful parity gaps: multiple tool results, Anthropic-style JSON error envelopes, token usage wiring, and `tool_choice` pass-through.
+5. Add comprehensive test coverage: unit tests, online provider test shards, and E2E tests for provider switching flows.
+6. Document setup, known limitations, and produce a final parity report.
+
+## Milestones
+
+1. **Shared Type System Updates** -- Widen the `Provider` type union, add `anthropic-copilot` and `anthropic-codex`, update `PROVIDER_LABELS` in web, remove unsafe casts.
+2. **Provider Routing Hardening** -- Make `detectProvider` collision-safe, ensure `session.config.provider` is always set and used, fix model-switch-handler type casts.
+3. **Web UI Provider Integration** -- Provider-grouped model picker, provider indicators in session status bar, provider-aware session creation, availability indicators.
+4. **Codex Bridge Parity Gaps** -- Multiple tool results, JSON error envelopes, token usage wiring, `tool_choice` pass-through.
+5. **Copilot Bridge Parity Gaps** -- Token usage accounting, `tool_choice` pass-through, error mapping improvements.
+6. **Auth UX and Health/Recovery** -- First-class auth status indicators in chat UI, health-check polling, graceful degradation on provider unavailability.
+7. **Test Coverage** -- Unit tests for type changes and routing, online test shard updates, E2E tests for model switching with both providers.
+8. **Documentation and Final Report** -- Setup docs, known limitations, final parity report.
+
+## Cross-Milestone Dependencies
+
+- Milestone 1 (types) must complete first -- all other milestones depend on the widened `Provider` type.
+- Milestone 2 (routing) depends on Milestone 1 and must complete before Milestone 3 (UI).
+- Milestones 4 and 5 (parity gaps) are independent of each other but depend on Milestone 1.
+- Milestone 6 (auth UX) depends on Milestones 1-3.
+- Milestone 7 (tests) depends on all functional milestones (1-6).
+- Milestone 8 (docs) depends on all other milestones.
+
+## Key Sequencing Decisions
+
+- Type system changes go first to unblock all downstream work and avoid accumulating more `as any` casts.
+- Parity gap work (Milestones 4-5) can run in parallel with UI work (Milestone 3) since they modify different parts of the codebase.
+- Auth UX depends on both routing and UI to be in place.
+- Tests run after all functional changes to avoid re-testing.
+
+## Estimated Total Task Count
+
+24 tasks across 8 milestones.

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/01-shared-type-system-updates.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/01-shared-type-system-updates.md
@@ -1,0 +1,95 @@
+# Milestone 1: Shared Type System Updates
+
+## Goal
+
+Widen the `Provider` type union in `packages/shared/src/types.ts` to include `anthropic-copilot` and `anthropic-codex`. Update all downstream type references, remove unsafe `as any` casts, and ensure the build passes.
+
+## Scope
+
+- `packages/shared/src/types.ts` -- Provider type union
+- `packages/shared/src/provider/auth-types.ts` -- Auth types for new providers
+- `packages/daemon/src/lib/agent/model-switch-handler.ts` -- Remove `as any` and `as 'anthropic' | 'glm'` casts
+- `packages/daemon/src/lib/provider-service.ts` -- Update `getProviderApiKey` to handle new providers
+- `packages/web/src/hooks/useModelSwitcher.ts` -- Add `PROVIDER_LABELS` entries
+- All files with unsafe `Provider` casts
+
+---
+
+### Task 1.1: Widen Provider Type Union
+
+**Description:** Add `'anthropic-copilot'` and `'anthropic-codex'` to the `Provider` type union in `packages/shared/src/types.ts`. Update the JSDoc comment to document each provider.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Read `packages/shared/src/types.ts` and locate the `Provider` type (line 188).
+2. Add `'anthropic-copilot' | 'anthropic-codex'` to the union.
+3. Update the JSDoc comment above the type to document all five providers.
+4. Run `bun run typecheck` to identify all type errors caused by the widened union.
+5. Fix any switch/exhaustive-check errors in shared package code.
+6. Run `bun run typecheck` again to confirm clean build.
+7. Run `bun run lint` to confirm no lint issues.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `Provider` type includes all five providers: `'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex'`.
+- `bun run typecheck` passes with zero errors.
+- `bun run lint` passes.
+- No `as any` casts related to provider type remain in the shared package.
+
+**Dependencies:** None
+
+---
+
+### Task 1.2: Remove Unsafe Provider Casts in Daemon
+
+**Description:** Remove all `as any` and `as 'anthropic' | 'glm'` casts when assigning `session.config.provider` throughout the daemon package. The widened `Provider` type should make these unnecessary.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Search for `as any` and `as 'anthropic'` patterns in `packages/daemon/src/` related to provider assignment.
+3. In `packages/daemon/src/lib/agent/model-switch-handler.ts`, remove the `as any` cast on line 160 and the `as 'anthropic' | 'glm'` cast on line 169. Use the proper `Provider` type.
+4. In `packages/daemon/src/lib/provider-service.ts`, update `getProviderApiKey` to handle `'anthropic-copilot'` and `'anthropic-codex'` cases (can return `undefined` for now since auth is handled internally by those providers).
+5. In `packages/daemon/src/lib/provider-service.ts`, ensure `toLegacyProviderInfo` handles the new provider IDs.
+6. Search for any other `provider.id as Provider` or `provider.id as any` patterns and fix them.
+7. Run `bun run typecheck` to confirm clean build.
+8. Run `bun run lint` to confirm no lint issues.
+9. Run daemon unit tests: `cd packages/daemon && bun test tests/unit/providers/ --timeout 60000`.
+10. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Zero `as any` or `as 'anthropic' | 'glm'` casts related to provider assignment in the daemon package.
+- `bun run typecheck` passes.
+- `bun run lint` passes.
+- All existing daemon provider unit tests pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 1.3: Update Web UI Provider Labels and Family Icons
+
+**Description:** Add provider labels and model family icons for `anthropic-copilot` and `anthropic-codex` in the web package, and ensure the `FAMILY_ORDER` sorting includes all model families from these providers.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/hooks/useModelSwitcher.ts`:
+   - Add `'anthropic-codex': 'Codex'` to `PROVIDER_LABELS`.
+   - Verify `'anthropic-copilot': 'Copilot'` already exists.
+   - Confirm `FAMILY_ORDER` has entries for `gpt` and `gemini` (used by copilot models).
+3. Run `bun run typecheck` to confirm clean build.
+4. Run `bun run lint`.
+5. Run web tests: `cd packages/web && bunx vitest run src/hooks/__tests__/useModelSwitcher.test.ts`.
+6. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `PROVIDER_LABELS` has entries for all five providers.
+- `FAMILY_ORDER` covers all model families used by both new providers.
+- `bun run typecheck` and `bun run lint` pass.
+- Existing web tests pass.
+
+**Dependencies:** Task 1.1

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/01-shared-type-system-updates.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/01-shared-type-system-updates.md
@@ -7,11 +7,15 @@ Widen the `Provider` type union in `packages/shared/src/types.ts` to include `an
 ## Scope
 
 - `packages/shared/src/types.ts` -- Provider type union
-- `packages/shared/src/provider/auth-types.ts` -- Auth types for new providers
 - `packages/daemon/src/lib/agent/model-switch-handler.ts` -- Remove `as any` and `as 'anthropic' | 'glm'` casts
+- `packages/daemon/src/lib/session/session-lifecycle.ts` -- Remove `as 'anthropic' | 'glm' | 'minimax'` cast (line 733)
 - `packages/daemon/src/lib/provider-service.ts` -- Update `getProviderApiKey` to handle new providers
 - `packages/web/src/hooks/useModelSwitcher.ts` -- Add `PROVIDER_LABELS` entries
 - All files with unsafe `Provider` casts
+
+> **Note on dual `Provider` types:** The codebase has two types named `Provider`:
+> 1. `packages/shared/src/types.ts` line 188: `type Provider = 'anthropic' | 'glm' | 'minimax'` (narrow string union used in `SessionConfig.provider`) — **this is what Task 1.1 widens.**
+> 2. `packages/shared/src/provider/types.ts` line 112: `interface Provider { id: ProviderId; ... }` (provider interface where `ProviderId = string`) — **this already accepts any string and needs no change.**
 
 ---
 
@@ -50,10 +54,11 @@ Widen the `Provider` type union in `packages/shared/src/types.ts` to include `an
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. Search for `as any` and `as 'anthropic'` patterns in `packages/daemon/src/` related to provider assignment.
-3. In `packages/daemon/src/lib/agent/model-switch-handler.ts`, remove the `as any` cast on line 160 and the `as 'anthropic' | 'glm'` cast on line 169. Use the proper `Provider` type.
-4. In `packages/daemon/src/lib/provider-service.ts`, update `getProviderApiKey` to handle `'anthropic-copilot'` and `'anthropic-codex'` cases (can return `undefined` for now since auth is handled internally by those providers).
-5. In `packages/daemon/src/lib/provider-service.ts`, ensure `toLegacyProviderInfo` handles the new provider IDs.
-6. Search for any other `provider.id as Provider` or `provider.id as any` patterns and fix them.
+3. In `packages/daemon/src/lib/agent/model-switch-handler.ts`, remove the `as any` casts on lines 160, 169, 195, 204 and the `as 'anthropic' | 'glm'` casts. Use the proper widened `Provider` type.
+4. In `packages/daemon/src/lib/session/session-lifecycle.ts`, remove the `as 'anthropic' | 'glm' | 'minimax'` cast on line 733. The widened `Provider` union now includes all providers, making this cast unnecessary.
+5. In `packages/daemon/src/lib/provider-service.ts`, update `getProviderApiKey` to handle `'anthropic-copilot'` and `'anthropic-codex'` cases (can return `undefined` for now since auth is handled internally by those providers).
+6. In `packages/daemon/src/lib/provider-service.ts`, ensure `toLegacyProviderInfo` handles the new provider IDs.
+7. Search for any other `provider.id as Provider` or `provider.id as any` patterns and fix them.
 7. Run `bun run typecheck` to confirm clean build.
 8. Run `bun run lint` to confirm no lint issues.
 9. Run daemon unit tests: `cd packages/daemon && bun test tests/unit/providers/ --timeout 60000`.
@@ -69,26 +74,23 @@ Widen the `Provider` type union in `packages/shared/src/types.ts` to include `an
 
 ---
 
-### Task 1.3: Update Web UI Provider Labels and Family Icons
+### Task 1.3: Update Web UI Provider Labels
 
-**Description:** Add provider labels and model family icons for `anthropic-copilot` and `anthropic-codex` in the web package, and ensure the `FAMILY_ORDER` sorting includes all model families from these providers.
+**Description:** Add the missing `'anthropic-codex': 'Codex'` entry to `PROVIDER_LABELS` in the web package. (`'anthropic-copilot': 'Copilot'` already exists at line 79, and `FAMILY_ORDER` already contains `gpt` and `gemini` at lines 69-70 — no changes needed for those.)
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. In `packages/web/src/hooks/useModelSwitcher.ts`:
-   - Add `'anthropic-codex': 'Codex'` to `PROVIDER_LABELS`.
-   - Verify `'anthropic-copilot': 'Copilot'` already exists.
-   - Confirm `FAMILY_ORDER` has entries for `gpt` and `gemini` (used by copilot models).
+   - Add `'anthropic-codex': 'Codex'` to `PROVIDER_LABELS` (the only missing entry).
 3. Run `bun run typecheck` to confirm clean build.
 4. Run `bun run lint`.
 5. Run web tests: `cd packages/web && bunx vitest run src/hooks/__tests__/useModelSwitcher.test.ts`.
 6. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 **Acceptance criteria:**
-- `PROVIDER_LABELS` has entries for all five providers.
-- `FAMILY_ORDER` covers all model families used by both new providers.
+- `PROVIDER_LABELS` has entries for all five providers (anthropic, glm, minimax, anthropic-copilot, anthropic-codex).
 - `bun run typecheck` and `bun run lint` pass.
 - Existing web tests pass.
 

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/02-provider-routing-hardening.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/02-provider-routing-hardening.md
@@ -16,28 +16,33 @@ Ensure collision-safe provider routing when model IDs are shared between provide
 
 ### Task 2.1: Make detectProvider Provider-Aware with Collision Logging
 
-**Description:** Update `ProviderRegistry.detectProvider` to log warnings when multiple providers claim the same model ID. Add a `detectProviderForModel(modelId, preferredProviderId?)` method that prefers the explicit provider when available.
+**Description:** Add a `detectProviderForModel(modelId, preferredProviderId?)` method to `ProviderRegistry` that prefers an explicit provider when available and logs warnings on collisions. Then update `detectProvider` to delegate to it.
 
 **Agent type:** coder
+
+**Important implementation note:** The existing `detectProvider` short-circuits via `for...of` and returns on the first match. The new `detectProviderForModel` must instead **collect all matching providers** before returning, so it can detect and log collisions. When `detectProvider` delegates to the new method (with no preference), the **return value stays the same** (first registered match), but the **internal behavior changes**: it now iterates all providers to check for collisions and logs a warning if multiple providers claim the same model ID. This is an intentional behavioral change needed for collision detection.
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. In `packages/daemon/src/lib/providers/registry.ts`, add a new method `detectProviderForModel(modelId: string, preferredProviderId?: string)`:
-   - If `preferredProviderId` is provided and that provider claims the model, return it.
-   - Otherwise, iterate all providers that claim the model. If more than one, log a warning with the colliding provider IDs.
-   - Return the first match (preserving existing behavior for backwards compatibility).
-3. Update `detectProvider` to call the new method with no preference (no behavioral change).
+   - Iterate **all** registered providers, collecting those whose `ownsModel(modelId)` returns true.
+   - If `preferredProviderId` is provided and exists in the match set, return it.
+   - If more than one provider claims the model, log a warning with all colliding provider IDs (e.g., `"Model 'claude-opus-4.6' claimed by multiple providers: anthropic, anthropic-copilot. Using anthropic."`).
+   - Return the first match from the collected set (preserving existing ordering for backwards compatibility).
+3. Update `detectProvider` to delegate to `detectProviderForModel(modelId)` with no preference. The return value is unchanged, but collision warnings will now fire.
 4. Write unit tests in `packages/daemon/tests/unit/providers/provider-registry.test.ts`:
    - Test that `detectProviderForModel('claude-opus-4.6', 'anthropic-copilot')` returns the copilot provider.
-   - Test that `detectProviderForModel('claude-opus-4.6')` returns the first registered (anthropic).
+   - Test that `detectProviderForModel('claude-opus-4.6')` returns the first registered (anthropic) and logs a collision warning.
    - Test that `detectProviderForModel('gpt-5.3-codex', 'anthropic-codex')` returns the codex provider.
+   - Test that `detectProvider('claude-opus-4.6')` still returns the same result as before (backwards-compatible).
 5. Run `bun run typecheck` and `bun run lint`.
 6. Run `cd packages/daemon && bun test tests/unit/providers/provider-registry.test.ts`.
 7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 **Acceptance criteria:**
 - `detectProviderForModel` correctly resolves to the preferred provider when specified.
-- Collision case logs a warning but still returns a result.
+- Collision case logs a warning listing all colliding provider IDs, then returns the first match.
+- `detectProvider` delegates to `detectProviderForModel` and returns the same value as before (first match), but now also logs collision warnings.
 - All existing registry tests pass plus new tests for collision handling.
 - `bun run typecheck` and `bun run lint` pass.
 
@@ -58,7 +63,7 @@ Ensure collision-safe provider routing when model IDs are shared between provide
 4. In `packages/daemon/src/lib/agent/model-switch-handler.ts`:
    - When looking up the new provider, use `detectProviderForModel` (from Task 2.1) with the current session's provider as a hint.
    - This prevents switching from `copilot-anthropic-sonnet` to `claude-sonnet-4.6` from losing the Copilot provider context.
-5. In `packages/daemon/src/lib/provider-service.ts`, update `getEnvVarsForModel` to use the new `detectProviderForModel` when `providerId` is provided.
+5. **Note:** `getEnvVarsForModel` in `packages/daemon/src/lib/provider-service.ts` (lines 385-406) already accepts an optional `providerId` parameter and uses `registry.get(providerId)` when supplied — no change needed to the method itself. Instead, audit its callers (e.g., `query-runner.ts`, `model-switch-handler.ts`) and ensure they pass `session.config.provider` as the `providerId` argument so the existing logic is actually exercised.
 6. Write unit tests for the model-switch-handler that cover:
    - Switching between models within the same provider (e.g., copilot opus -> copilot sonnet).
    - Switching between providers (e.g., anthropic sonnet -> copilot sonnet).

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/02-provider-routing-hardening.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/02-provider-routing-hardening.md
@@ -1,0 +1,105 @@
+# Milestone 2: Provider Routing Hardening
+
+## Goal
+
+Ensure collision-safe provider routing when model IDs are shared between providers (e.g., `claude-opus-4.6` is claimed by both `anthropic` and `anthropic-copilot`, `gpt-5.3-codex` is claimed by both `anthropic-codex` and `anthropic-copilot`). Make `session.config.provider` the authoritative routing source and never fall through to `detectProvider` ambiguity.
+
+## Scope
+
+- `packages/daemon/src/lib/providers/registry.ts` -- `detectProvider` collision handling
+- `packages/daemon/src/lib/provider-service.ts` -- provider-aware routing
+- `packages/daemon/src/lib/agent/query-runner.ts` -- explicit provider ID usage
+- `packages/daemon/src/lib/agent/model-switch-handler.ts` -- alias-to-provider resolution
+- `packages/daemon/src/lib/model-service.ts` -- model info with provider context
+
+---
+
+### Task 2.1: Make detectProvider Provider-Aware with Collision Logging
+
+**Description:** Update `ProviderRegistry.detectProvider` to log warnings when multiple providers claim the same model ID. Add a `detectProviderForModel(modelId, preferredProviderId?)` method that prefers the explicit provider when available.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/providers/registry.ts`, add a new method `detectProviderForModel(modelId: string, preferredProviderId?: string)`:
+   - If `preferredProviderId` is provided and that provider claims the model, return it.
+   - Otherwise, iterate all providers that claim the model. If more than one, log a warning with the colliding provider IDs.
+   - Return the first match (preserving existing behavior for backwards compatibility).
+3. Update `detectProvider` to call the new method with no preference (no behavioral change).
+4. Write unit tests in `packages/daemon/tests/unit/providers/provider-registry.test.ts`:
+   - Test that `detectProviderForModel('claude-opus-4.6', 'anthropic-copilot')` returns the copilot provider.
+   - Test that `detectProviderForModel('claude-opus-4.6')` returns the first registered (anthropic).
+   - Test that `detectProviderForModel('gpt-5.3-codex', 'anthropic-codex')` returns the codex provider.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run `cd packages/daemon && bun test tests/unit/providers/provider-registry.test.ts`.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `detectProviderForModel` correctly resolves to the preferred provider when specified.
+- Collision case logs a warning but still returns a result.
+- All existing registry tests pass plus new tests for collision handling.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 2.2: Ensure Provider ID Flows Through Session Create to Query Runner
+
+**Description:** Ensure that when a session is created with a specific provider (via `session.config.provider`), that provider ID is consistently used through the entire flow: session creation -> model switch -> query runner -> env var application.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/rpc-handlers/session-handlers.ts`, in `session.create` handler: if `req.config.provider` is set, verify it is preserved in the created session.
+3. In `packages/daemon/src/lib/agent/query-runner.ts`, verify that `explicitProviderId` is correctly sourced from `session.config.provider` (check around line 206).
+4. In `packages/daemon/src/lib/agent/model-switch-handler.ts`:
+   - When looking up the new provider, use `detectProviderForModel` (from Task 2.1) with the current session's provider as a hint.
+   - This prevents switching from `copilot-anthropic-sonnet` to `claude-sonnet-4.6` from losing the Copilot provider context.
+5. In `packages/daemon/src/lib/provider-service.ts`, update `getEnvVarsForModel` to use the new `detectProviderForModel` when `providerId` is provided.
+6. Write unit tests for the model-switch-handler that cover:
+   - Switching between models within the same provider (e.g., copilot opus -> copilot sonnet).
+   - Switching between providers (e.g., anthropic sonnet -> copilot sonnet).
+7. Run `bun run typecheck` and `bun run lint`.
+8. Run relevant daemon unit tests.
+9. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `session.config.provider` is preserved through the entire session lifecycle.
+- Switching models via alias correctly resolves the provider from model info.
+- `bun run typecheck` and `bun run lint` pass.
+- All existing tests pass plus new model-switch routing tests.
+
+**Dependencies:** Task 2.1, Task 1.2
+
+---
+
+### Task 2.3: Provider-Aware Model Resolution in model-service
+
+**Description:** Update `getModelInfo` and `resolveModelAlias` in model-service to support disambiguating models by provider context when the same model ID exists in multiple providers.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/model-service.ts`:
+   - Add an optional `providerId` parameter to `getModelInfo(idOrAlias, cacheKey?, providerId?)`.
+   - When `providerId` is specified, prefer models whose `provider` field matches.
+   - Add the same parameter to `resolveModelAlias`.
+3. Update callers that have provider context available:
+   - `model-switch-handler.ts` -- pass `session.config.provider` to `getModelInfo` and `resolveModelAlias`.
+   - `session-handlers.ts` `session.model.get` -- pass provider from session config.
+4. Write unit tests for provider-filtered model resolution.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run `cd packages/daemon && bun test tests/unit/` with relevant test files.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `getModelInfo('claude-sonnet-4.6', 'global', 'anthropic-copilot')` returns the copilot model entry.
+- `getModelInfo('claude-sonnet-4.6', 'global')` returns the first match (anthropic, for backward compatibility).
+- `bun run typecheck` and `bun run lint` pass.
+- All existing tests pass plus new provider-filtered resolution tests.
+
+**Dependencies:** Task 1.1, Task 1.2

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/03-web-ui-provider-integration.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/03-web-ui-provider-integration.md
@@ -1,0 +1,100 @@
+# Milestone 3: Web UI Provider Integration
+
+## Goal
+
+Make both providers fully selectable in the UI. Support create, resume, switch, and multi-session flows with provider-grouped model display, provider indicators, and availability indicators.
+
+## Scope
+
+- `packages/web/src/hooks/useModelSwitcher.ts` -- Provider grouping in model list
+- `packages/web/src/components/SessionStatusBar.tsx` -- Provider indicator
+- `packages/web/src/components/settings/ProvidersSettings.tsx` -- Auth status display
+- `packages/web/src/islands/MainContent.tsx` -- Session creation with provider
+- Model picker dropdown (wherever implemented)
+
+---
+
+### Task 3.1: Provider-Grouped Model Picker
+
+**Description:** Update the model picker dropdown to group models by provider, showing a provider header above each group. Include availability indicators (green/gray dot) next to each provider group header. Ensure cross-provider model switching works.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/hooks/useModelSwitcher.ts`:
+   - Modify model sorting to group by provider first, then by family order within each provider group.
+   - Export a helper function `groupModelsByProvider(models: ModelInfo[]): Map<string, ModelInfo[]>` for UI consumption.
+3. In `packages/web/src/components/SessionStatusBar.tsx`:
+   - Locate the model picker dropdown rendering.
+   - Render provider group headers using `getProviderLabel()`.
+   - Add a visual separator between provider groups.
+   - Show a green/gray availability dot in the provider group header based on whether the provider has authenticated.
+4. When a user selects a model from a different provider, pass the `provider` field from the model info along with the model ID in the `session.model.switch` call. (The daemon already handles this via model info lookup, but explicit is better.)
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run web tests: `cd packages/web && bunx vitest run`.
+7. Write a test in `packages/web/src/hooks/__tests__/useModelSwitcher.test.ts` for the `groupModelsByProvider` helper.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Models are visually grouped by provider in the dropdown.
+- Provider label is shown as group header.
+- Selecting a model from a different provider triggers a cross-provider model switch.
+- `bun run typecheck` and `bun run lint` pass.
+- New and existing web tests pass.
+
+**Dependencies:** Task 1.3, Task 2.2
+
+---
+
+### Task 3.2: Provider Indicator in Session Status Bar
+
+**Description:** Show the current provider name/icon in the session status bar next to the model name, so users can see at a glance which provider backend is active. This is important because the same model ID (e.g., `claude-opus-4.6`) can come from different providers.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/components/SessionStatusBar.tsx`:
+   - After the model name display, add a provider badge showing the provider label (e.g., "Copilot", "Codex", "Anthropic").
+   - Use a subtle chip/badge style that does not visually dominate but is clearly visible.
+   - Color-code by provider: Anthropic (default/no badge), Copilot (GitHub-style), Codex (OpenAI-style).
+3. Pass the model's `provider` field from `currentModelInfo` to the badge component.
+4. Run `bun run typecheck` and `bun run lint`.
+5. Run web tests: `cd packages/web && bunx vitest run src/components/__tests__/SessionStatusBar.test.tsx`.
+6. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Provider badge is visible next to model name in the session status bar.
+- Badge correctly shows the provider for the current session's model.
+- Anthropic provider shows minimal or no badge (it is the default).
+- `bun run typecheck` and `bun run lint` pass.
+- Tests pass.
+
+**Dependencies:** Task 1.3
+
+---
+
+### Task 3.3: Provider-Aware Session Creation
+
+**Description:** When creating a new session via the UI, allow the user to select a model from any available provider. Ensure the session's `config.provider` is set based on the selected model's provider field.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Find the session creation flow in the web codebase (likely in `packages/web/src/islands/MainContent.tsx` or a create-session component).
+3. If the session creation UI has a model selector, ensure it uses the provider-grouped model list from Task 3.1.
+4. When calling `session.create`, include `config.provider` derived from the selected model's `provider` field.
+5. If the session creation flow does not have an explicit model selector (it uses the default model), ensure the default model's provider is set correctly.
+6. Run `bun run typecheck` and `bun run lint`.
+7. Run web tests.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Sessions created with a Copilot model have `config.provider: 'anthropic-copilot'`.
+- Sessions created with a Codex model have `config.provider: 'anthropic-codex'`.
+- Default session creation still works with `'anthropic'` provider.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 3.1

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/03-web-ui-provider-integration.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/03-web-ui-provider-integration.md
@@ -30,7 +30,11 @@ Make both providers fully selectable in the UI. Support create, resume, switch, 
    - Render provider group headers using `getProviderLabel()`.
    - Add a visual separator between provider groups.
    - Show a green/gray availability dot in the provider group header based on whether the provider has authenticated.
-4. When a user selects a model from a different provider, pass the `provider` field from the model info along with the model ID in the `session.model.switch` call. (The daemon already handles this via model info lookup, but explicit is better.)
+4. **Cross-provider model switching requires an RPC interface change.** Currently `session.model.switch` only sends `{ sessionId, model: newModelId }` (see `packages/web/src/hooks/useModelSwitcher.ts` lines 195-202), and the daemon's `ModelSwitchHandler.switchModel()` infers provider from the alias via `modelInfo?.provider`. To support explicit cross-provider switching:
+   - In `packages/shared/`, update the `session.model.switch` RPC request type to include an optional `provider?: Provider` field.
+   - In `packages/daemon/src/lib/agent/model-switch-handler.ts`, update `switchModel()` to accept and prefer the explicit `provider` parameter when present (falling back to alias inference if absent, for backwards compatibility).
+   - In `packages/web/src/hooks/useModelSwitcher.ts`, when the selected model's `provider` field differs from the current session's provider, include `provider` in the `session.model.switch` RPC call.
+   - This is a non-trivial interface change that touches shared types, daemon handler, and web client. It depends on Task 2.2 (provider ID flow) being complete.
 5. Run `bun run typecheck` and `bun run lint`.
 6. Run web tests: `cd packages/web && bunx vitest run`.
 7. Write a test in `packages/web/src/hooks/__tests__/useModelSwitcher.test.ts` for the `groupModelsByProvider` helper.

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/04-codex-bridge-parity-gaps.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/04-codex-bridge-parity-gaps.md
@@ -6,10 +6,12 @@ Close the most impactful parity gaps in the `anthropic-to-codex-bridge` provider
 
 ## Scope
 
-- `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- Multiple tool results, error envelopes
+- `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- Multiple tool results, error envelopes, diagnostic cleanup
 - `packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts` -- `tool_choice` pass-through
 - `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` -- Token usage wiring
 - `packages/daemon/tests/unit/providers/codex-anthropic-bridge/` -- Unit tests for all changes
+
+> **Prerequisite cleanup:** `server.ts` lines 93-96 contain a leftover `process.stderr.write` diagnostic log (`[codex-bridge-server] drainToSSE event: ...`) that fires on every streaming event. This violates CLAUDE.md's `no-console` rule and must be replaced with the existing `logger` or removed entirely. This cleanup is included in Task 4.2 (error envelopes).
 
 ---
 
@@ -19,24 +21,33 @@ Close the most impactful parity gaps in the `anthropic-to-codex-bridge` provider
 
 **Agent type:** coder
 
+**Architecture context:** The bridge stores one suspended `ToolSession` per `callId` in a `Map` keyed by `tool_use_id`. Each `BridgeSession.provideResult(callId, result)` is a deferred resolver that unblocks the Codex read loop for that specific tool call. When the Anthropic client sends multiple `tool_result` blocks in one request, each block has a **different** `tool_use_id`, corresponding to a different suspended `ToolSession`.
+
 **Subtasks:**
 1. Run `bun install` at the worktree root.
-2. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- find the `toolResults[0]` usage.
-3. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` to understand how `BridgeSession` processes tool results and whether it supports multiple results.
-4. Modify the server to iterate over all tool results and resume with each one:
-   - If `BridgeSession.provideResult` only accepts one result at a time, call it for each result sequentially.
-   - If the underlying Codex app-server only supports one tool call per turn, document this as a known limitation and use the first result but log a warning for additional ones.
-5. Add unit tests in `packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts` covering:
+2. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- find the `toolResults[0]` usage (line 240).
+3. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` to understand:
+   - How `BridgeSession` stores suspended `ToolSession` instances (Map keyed by `tool_use_id`).
+   - How `provideResult(callId, result)` resolves the deferred for a specific tool call.
+   - Whether the Codex app-server can emit multiple tool calls in a single turn.
+4. Modify the server to iterate over **all** `toolResults` and call `provideResult` for each:
+   - For each `tool_result` block, look up the corresponding suspended `ToolSession` by its `tool_use_id` and call `provideResult`.
+   - If a `tool_use_id` does not have a matching suspended session (orphaned result), log a warning and skip it.
+   - If the Codex app-server only ever emits one tool call per turn (making multiple results impossible in practice), document this as a known limitation in a code comment but still handle the multi-result path correctly for forward compatibility.
+5. **Expected behavior when multiple results arrive but only one can be processed:** If the bridge only has one suspended `ToolSession` (because Codex emitted one tool call), resolve that one and log a warning for any extra `tool_result` blocks with unmatched `tool_use_id`s. Do **not** silently drop them.
+6. Add unit tests in `packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts` covering:
    - Single tool result (existing behavior preserved).
-   - Multiple tool results in one continuation request.
-6. Run `bun run typecheck` and `bun run lint`.
-7. Run `cd packages/daemon && bun test tests/unit/providers/codex-anthropic-bridge/`.
-8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+   - Multiple tool results in one continuation request, each with a matching suspended session.
+   - Multiple tool results where some `tool_use_id`s have no matching suspended session (warning logged, non-matching results skipped).
+7. Run `bun run typecheck` and `bun run lint`.
+8. Run `cd packages/daemon && bun test tests/unit/providers/codex-anthropic-bridge/`.
+9. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 **Acceptance criteria:**
-- The bridge handles multiple tool results from a single continuation request.
-- If the underlying backend does not support parallel tool results, a clear warning is logged and the first result is used.
-- Unit tests cover both single and multiple tool result cases.
+- The bridge iterates all `toolResults` and resolves each by its `tool_use_id`, not just `toolResults[0]`.
+- Orphaned tool results (no matching suspended session) produce a warning log, not a silent drop or crash.
+- If the Codex backend only supports one tool call per turn, this is documented as a known limitation in code comments.
+- Unit tests cover: single result, multiple results with matching sessions, and unmatched result IDs.
 - `bun run typecheck` and `bun run lint` pass.
 
 **Dependencies:** Task 1.1
@@ -57,6 +68,7 @@ Close the most impactful parity gaps in the `anthropic-to-codex-bridge` provider
    ```
    Error types: `invalid_request_error`, `authentication_error`, `not_found_error`, `api_error`, `overloaded_error`.
 3. In `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts`:
+   - **Cleanup first:** Remove the leftover `process.stderr.write` diagnostic log on lines 93-96 (`[codex-bridge-server] drainToSSE event: ...`). Replace with the existing `logger.debug()` if any logging is still needed, or remove entirely.
    - Replace all plain-text error responses (400, 404, 500) with JSON bodies matching the Anthropic error envelope format.
    - For streaming errors, emit an `error` SSE event with the Anthropic error JSON before closing the stream.
 4. Add a helper function `createAnthropicError(httpStatus: number, type: string, message: string)` in the translator or server to standardize error creation.

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/04-codex-bridge-parity-gaps.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/04-codex-bridge-parity-gaps.md
@@ -1,0 +1,116 @@
+# Milestone 4: Codex Bridge Parity Gaps
+
+## Goal
+
+Close the most impactful parity gaps in the `anthropic-to-codex-bridge` provider (backed by `codex app-server`). These gaps block real NeoKai usability with the Codex backend.
+
+## Scope
+
+- `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- Multiple tool results, error envelopes
+- `packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts` -- `tool_choice` pass-through
+- `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` -- Token usage wiring
+- `packages/daemon/tests/unit/providers/codex-anthropic-bridge/` -- Unit tests for all changes
+
+---
+
+### Task 4.1: Support Multiple Tool Results in Codex Bridge
+
+**Description:** The bridge currently uses only `toolResults[0]` when resuming a suspended session. This breaks multi-tool round-trips where the Codex model emits multiple tool calls in a single turn. Fix the server to resume with all tool results.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` -- find the `toolResults[0]` usage.
+3. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` to understand how `BridgeSession` processes tool results and whether it supports multiple results.
+4. Modify the server to iterate over all tool results and resume with each one:
+   - If `BridgeSession.provideResult` only accepts one result at a time, call it for each result sequentially.
+   - If the underlying Codex app-server only supports one tool call per turn, document this as a known limitation and use the first result but log a warning for additional ones.
+5. Add unit tests in `packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts` covering:
+   - Single tool result (existing behavior preserved).
+   - Multiple tool results in one continuation request.
+6. Run `bun run typecheck` and `bun run lint`.
+7. Run `cd packages/daemon && bun test tests/unit/providers/codex-anthropic-bridge/`.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- The bridge handles multiple tool results from a single continuation request.
+- If the underlying backend does not support parallel tool results, a clear warning is logged and the first result is used.
+- Unit tests cover both single and multiple tool result cases.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 4.2: Anthropic-Style JSON Error Envelopes for Codex Bridge
+
+**Description:** The bridge currently returns plain-text HTTP error bodies and embeds errors as `[Codex error: ...]` text blocks in SSE responses. Replace these with Anthropic-standard JSON error envelopes for HTTP errors and Anthropic-style `error` SSE events for streaming errors.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Read the Anthropic API error format documentation. Standard shape:
+   ```json
+   {"type":"error","error":{"type":"<error_type>","message":"<message>"}}
+   ```
+   Error types: `invalid_request_error`, `authentication_error`, `not_found_error`, `api_error`, `overloaded_error`.
+3. In `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts`:
+   - Replace all plain-text error responses (400, 404, 500) with JSON bodies matching the Anthropic error envelope format.
+   - For streaming errors, emit an `error` SSE event with the Anthropic error JSON before closing the stream.
+4. Add a helper function `createAnthropicError(httpStatus: number, type: string, message: string)` in the translator or server to standardize error creation.
+5. Add unit tests covering:
+   - 400 Bad Request returns proper JSON envelope.
+   - 404 Session Not Found returns proper JSON envelope.
+   - 500 Internal Server Error returns proper JSON envelope.
+   - Streaming error emits an `error` SSE event.
+6. Run `bun run typecheck` and `bun run lint`.
+7. Run `cd packages/daemon && bun test tests/unit/providers/codex-anthropic-bridge/`.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- All HTTP error responses use Anthropic JSON error envelope format.
+- Streaming errors emit an `error` SSE event with Anthropic-format payload.
+- No more plain-text error bodies in the codex bridge server.
+- Unit tests verify error envelope format for all error paths.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 4.3: Wire Token Usage from Codex Bridge
+
+**Description:** The bridge emits synthetic/zero `input_tokens` and heuristic `output_tokens`. Wire the `thread/tokenUsage/updated` notification from the Codex app-server process manager to populate accurate usage fields in the SSE `message_delta` event.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Read `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts`:
+   - Find how `thread/tokenUsage/updated` events are received.
+   - Understand the token usage data shape from the app-server.
+3. In `process-manager.ts`:
+   - Capture token usage from the `thread/tokenUsage/updated` notification.
+   - Expose it via `BridgeSession` (e.g., `getUsage()` method or an event emitter).
+4. In `server.ts`:
+   - When building the `message_delta` SSE event, use actual token usage from the bridge session if available.
+   - Fall back to heuristic estimation if the notification has not yet arrived.
+5. In `translator.ts`, update the `messageDeltaSSE` helper to accept actual usage values.
+6. Add unit tests covering:
+   - Token usage is captured from app-server notification.
+   - `message_delta` SSE event includes actual token counts when available.
+   - Fallback to heuristic when no notification arrives.
+7. Run `bun run typecheck` and `bun run lint`.
+8. Run `cd packages/daemon && bun test tests/unit/providers/codex-anthropic-bridge/`.
+9. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Token usage from `thread/tokenUsage/updated` is captured and exposed.
+- SSE `message_delta` events include actual token counts when available.
+- Fallback to heuristic estimation works when no notification arrives.
+- Unit tests verify usage wiring.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/05-copilot-bridge-parity-gaps.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/05-copilot-bridge-parity-gaps.md
@@ -1,0 +1,110 @@
+# Milestone 5: Copilot Bridge Parity Gaps
+
+## Goal
+
+Close the most impactful parity gaps in the `anthropic-copilot` provider (backed by `@github/copilot-sdk`). Focus on token usage, error mapping, and `tool_choice` pass-through.
+
+## Scope
+
+- `packages/daemon/src/lib/providers/anthropic-copilot/server.ts` -- Error mapping
+- `packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts` -- Token usage
+- `packages/daemon/src/lib/providers/anthropic-copilot/sse.ts` -- SSE event helpers
+- `packages/daemon/tests/unit/providers/anthropic-copilot/` -- Unit tests
+
+---
+
+### Task 5.1: Improve Error Mapping in Copilot Bridge
+
+**Description:** The copilot bridge currently returns inconsistent error responses. Standardize to Anthropic JSON error envelopes (same format as Task 4.2) for HTTP errors, and emit Anthropic-style `error` SSE events for streaming errors.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Read `packages/daemon/src/lib/providers/anthropic-copilot/server.ts` -- identify all error response paths.
+3. Create a shared `createAnthropicErrorResponse(status: number, errorType: string, message: string)` helper that both the copilot and codex bridges can use. Place it in a new file `packages/daemon/src/lib/providers/shared/error-envelope.ts` or add it to each bridge's own module.
+4. Replace all non-JSON error responses in the copilot server with Anthropic error envelopes.
+5. For streaming errors, emit an Anthropic-format `error` SSE event.
+6. Update or add unit tests in `packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts`:
+   - HTTP 400 returns JSON error envelope.
+   - HTTP 500 returns JSON error envelope.
+   - Streaming error emits `error` SSE event.
+7. Run `bun run typecheck` and `bun run lint`.
+8. Run `cd packages/daemon && bun test tests/unit/providers/anthropic-copilot/ --timeout 60000`.
+9. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- All HTTP error responses from the copilot bridge use Anthropic JSON error envelope format.
+- Streaming errors emit Anthropic-format `error` SSE events.
+- Error types are correctly mapped: invalid requests -> `invalid_request_error`, auth issues -> `authentication_error`, etc.
+- Unit tests verify error envelope format.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 5.2: Token Usage Accounting for Copilot Bridge
+
+**Description:** The copilot bridge emits `input_tokens: 0` and `output_tokens: 0` due to SDK limitations. Improve this by at least providing heuristic token counting based on text length, and documenting the limitation. If the Copilot SDK exposes usage data, wire it through.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Read `packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts` and `sse.ts` to understand how usage is currently set.
+3. Check the `@github/copilot-sdk` API for any usage/token reporting features.
+4. Implement heuristic token counting:
+   - Count input tokens based on the system prompt + messages text length (rough estimate: 4 chars per token).
+   - Count output tokens by accumulating text delta lengths during streaming.
+5. Update `message_start` SSE to include estimated `input_tokens`.
+6. Update `message_delta` SSE to include accumulated `output_tokens`.
+7. Add a comment documenting that these are heuristic estimates, not actual model-reported values.
+8. Add unit tests for heuristic token counting.
+9. Run `bun run typecheck` and `bun run lint`.
+10. Run `cd packages/daemon && bun test tests/unit/providers/anthropic-copilot/ --timeout 60000`.
+11. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `message_start` includes a non-zero `input_tokens` estimate.
+- `message_delta` includes accumulated `output_tokens` estimate.
+- Token estimates are reasonable (within 2x of actual for typical requests).
+- Documented as heuristic estimates in code comments.
+- Unit tests verify non-zero token counts in SSE events.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1
+
+---
+
+### Task 5.3: tool_choice Pass-Through for Both Bridges
+
+**Description:** Both bridges currently accept but ignore the `tool_choice` field. For the Copilot bridge, pass `tool_choice` through to the SDK if it supports it. For the Codex bridge, document the limitation. At minimum, log a warning when `tool_choice` is provided but not honored.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Check `@github/copilot-sdk` for `tool_choice` or `toolChoice` support in session creation or message sending.
+3. In `packages/daemon/src/lib/providers/anthropic-copilot/server.ts`:
+   - If the SDK supports `tool_choice`, pass it through when creating the session or sending messages.
+   - If not, log a warning when the request includes `tool_choice` and document the limitation.
+4. In `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts`:
+   - Log a warning when `tool_choice` is provided but not honored.
+5. In `packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts`:
+   - Add `tool_choice` to the `AnthropicRequest` interface for type completeness.
+6. Add unit tests that verify:
+   - A warning is logged when `tool_choice` is provided but not supported.
+   - The request is still processed successfully despite `tool_choice` being unsupported.
+7. Run `bun run typecheck` and `bun run lint`.
+8. Run relevant unit tests.
+9. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- `tool_choice` is passed through if the backend supports it.
+- A warning is logged when `tool_choice` is provided but not honored.
+- `tool_choice` is included in the `AnthropicRequest` type for both bridges.
+- Unit tests verify warning logging and graceful handling.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 1.1

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/05-copilot-bridge-parity-gaps.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/05-copilot-bridge-parity-gaps.md
@@ -66,20 +66,22 @@ Close the most impactful parity gaps in the `anthropic-copilot` provider (backed
 11. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 **Acceptance criteria:**
-- `message_start` includes a non-zero `input_tokens` estimate.
-- `message_delta` includes accumulated `output_tokens` estimate.
-- Token estimates are reasonable (within 2x of actual for typical requests).
-- Documented as heuristic estimates in code comments.
-- Unit tests verify non-zero token counts in SSE events.
+- `message_start` includes a non-zero `input_tokens` estimate for any non-empty input.
+- `message_delta` includes accumulated `output_tokens` estimate equal to `ceil(total_output_text_length / 4)`.
+- `input_tokens` estimate equals `ceil(total_input_text_length / 4)` (where input text = system prompt + serialized messages).
+- Documented as heuristic estimates in code comments (not actual model-reported values).
+- Unit tests verify: (a) non-zero token counts in SSE events for non-empty messages, (b) the 4-chars-per-token formula produces expected values for known inputs.
 - `bun run typecheck` and `bun run lint` pass.
 
 **Dependencies:** Task 1.1
 
 ---
 
-### Task 5.3: tool_choice Pass-Through for Both Bridges
+### Task 5.3: tool_choice Pass-Through for Both Bridges (Cross-Cutting)
 
 **Description:** Both bridges currently accept but ignore the `tool_choice` field. For the Copilot bridge, pass `tool_choice` through to the SDK if it supports it. For the Codex bridge, document the limitation. At minimum, log a warning when `tool_choice` is provided but not honored.
+
+> **Note:** This task is filed under Milestone 5 (Copilot) but modifies both bridges (including `codex-anthropic-bridge/server.ts` and `translator.ts`). It is grouped here because the Copilot bridge has the higher likelihood of supporting `tool_choice` pass-through. The Codex bridge changes are documentation/warning-only.
 
 **Agent type:** coder
 

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/06-auth-ux-and-health-recovery.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/06-auth-ux-and-health-recovery.md
@@ -56,7 +56,8 @@ Add first-class auth status indicators in the chat UI so users can see at a glan
 1. Run `bun install` at the worktree root.
 2. In the daemon's error handling layer (likely `packages/daemon/src/lib/error-manager.ts` or the agent session error handler):
    - Detect provider-specific errors: authentication failures (401/403), bridge server unreachable (ECONNREFUSED), Copilot SDK errors.
-   - Map these to a new `ErrorCategory` like `PROVIDER_AUTH_ERROR` or `PROVIDER_UNAVAILABLE`.
+   - Add new values to the `ErrorCategory` enum: `PROVIDER_AUTH_ERROR` and `PROVIDER_UNAVAILABLE`.
+   - **Important:** Before adding new enum values, search for exhaustive `switch` statements or type narrowing on `ErrorCategory` throughout the codebase (`grep -r "ErrorCategory" packages/`). Any exhaustive switch will break at compile time — update all exhaustive handlers to cover the new categories. This prevents TypeScript build failures downstream.
 3. In the web chat UI error display:
    - When a `PROVIDER_AUTH_ERROR` is received, show a banner with:
      - "Authentication with [Provider Name] has expired. Click here to re-authenticate."

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/06-auth-ux-and-health-recovery.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/06-auth-ux-and-health-recovery.md
@@ -1,0 +1,79 @@
+# Milestone 6: Auth UX and Health/Recovery
+
+## Goal
+
+Add first-class auth status indicators in the chat UI so users can see at a glance whether their provider is authenticated. Implement health-check polling and graceful degradation when a provider becomes unavailable mid-session.
+
+## Scope
+
+- `packages/web/src/components/SessionStatusBar.tsx` -- Auth status indicator
+- `packages/web/src/components/settings/ProvidersSettings.tsx` -- Provider health display
+- `packages/daemon/src/lib/rpc-handlers/auth-handlers.ts` -- Auth refresh triggers
+- `packages/daemon/src/lib/providers/anthropic-copilot/provider.ts` -- Health check
+- `packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts` -- Health check
+
+---
+
+### Task 6.1: Auth Status Indicator in Chat UI
+
+**Description:** Show a small auth status indicator near the provider badge in the session status bar. When the current session's provider is not authenticated or has an expiring token, show a warning icon with actionable tooltip text.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/components/SessionStatusBar.tsx`:
+   - After the provider badge (from Task 3.2), add a conditional auth status indicator:
+     - Green check: authenticated and healthy.
+     - Yellow warning: token expiring soon (`needsRefresh: true`).
+     - Red X: not authenticated.
+   - On click/hover, show a tooltip with the error message from `getAuthStatus()` and a link to the providers settings page.
+3. Fetch the auth status for the current session's provider via the `auth.providers` RPC endpoint on session load and when the provider changes.
+4. Cache the result in a signal to avoid excessive polling.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run web tests.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Auth status indicator is visible near the provider badge.
+- Unauthenticated state shows red indicator with actionable error message.
+- Token-expiring state shows yellow indicator.
+- Authenticated state shows green indicator (or no indicator for minimal visual noise).
+- Clicking the indicator navigates to provider settings.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 3.2
+
+---
+
+### Task 6.2: Graceful Degradation on Provider Unavailability
+
+**Description:** When a provider becomes unavailable mid-session (e.g., token expires, bridge server crashes), display a user-friendly error message in the chat UI instead of raw API errors. Provide actionable recovery options.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In the daemon's error handling layer (likely `packages/daemon/src/lib/error-manager.ts` or the agent session error handler):
+   - Detect provider-specific errors: authentication failures (401/403), bridge server unreachable (ECONNREFUSED), Copilot SDK errors.
+   - Map these to a new `ErrorCategory` like `PROVIDER_AUTH_ERROR` or `PROVIDER_UNAVAILABLE`.
+3. In the web chat UI error display:
+   - When a `PROVIDER_AUTH_ERROR` is received, show a banner with:
+     - "Authentication with [Provider Name] has expired. Click here to re-authenticate."
+     - A button that opens the provider settings or triggers the OAuth flow.
+   - When a `PROVIDER_UNAVAILABLE` error is received, show:
+     - "[Provider Name] is temporarily unavailable. You can switch to another provider or try again."
+     - A button to switch to the default provider.
+4. Add unit tests for error categorization.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run relevant daemon and web tests.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Provider auth errors are categorized and displayed with actionable messages.
+- Provider unavailability errors suggest switching to another provider.
+- No raw API errors are shown to the user for provider-specific failures.
+- Unit tests verify error categorization.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 3.2, Task 5.1

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/07-test-coverage.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/07-test-coverage.md
@@ -85,12 +85,16 @@ Add comprehensive test coverage for all changes: unit tests for type changes and
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. Create a new test file `packages/e2e/tests/features/provider-model-switching.e2e.ts`.
-3. Test scenarios (all via UI interactions, no RPC calls):
-   - Create a new session -- verify the model name is visible in the session status bar.
-   - Open the model picker dropdown -- verify models are grouped by provider with provider headers.
-   - Switch to a model from a different provider (if multiple providers are available) -- verify the provider badge updates.
-   - Verify the session continues working after provider switch (send a message, verify response).
-4. Since E2E tests require real providers, guard the provider-switching test with a check for whether multiple providers show models in the picker. If only one provider is available, skip the cross-provider switch but still test the model picker rendering.
+3. Create **two separate test suites** in the file to avoid masking configuration gaps:
+   - **Suite A: "Model picker UI rendering"** (works with any single provider):
+     - Create a new session -- verify the model name is visible in the session status bar.
+     - Open the model picker dropdown -- verify models are grouped by provider with provider headers.
+     - Verify provider labels appear as group headers.
+   - **Suite B: "Cross-provider model switching"** (requires multiple providers):
+     - Switch to a model from a different provider -- verify the provider badge updates.
+     - Verify the session continues working after provider switch (send a message, verify response).
+     - This suite must **fail clearly** (not skip) if only one provider is available, following the hard-fail spirit from CLAUDE.md. Use a `test.fail` or `expect` assertion like `expect(providerGroups.length).toBeGreaterThan(1)` with a clear error message: "Cross-provider switch test requires at least 2 configured providers."
+4. This separation ensures Suite A always runs (verifying UI rendering) while Suite B explicitly fails when the test environment lacks required providers — no silent skipping.
 5. Follow all E2E test rules from CLAUDE.md:
    - All actions through the UI (clicks, typing).
    - All assertions on visible DOM state.

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/07-test-coverage.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/07-test-coverage.md
@@ -1,0 +1,109 @@
+# Milestone 7: Test Coverage
+
+## Goal
+
+Add comprehensive test coverage for all changes: unit tests for type changes and routing, updates to the online provider test shards, and E2E tests for provider switching flows.
+
+## Scope
+
+- `packages/daemon/tests/unit/providers/` -- Unit tests
+- `packages/daemon/tests/online/providers/` -- Online provider tests
+- `packages/e2e/tests/` -- E2E Playwright tests
+- `.github/workflows/main.yml` -- CI configuration updates
+
+---
+
+### Task 7.1: Unit Tests for Provider Routing and Type Safety
+
+**Description:** Add comprehensive unit tests covering the widened `Provider` type, collision-safe routing, and provider-aware model resolution. Ensure all existing tests still pass.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/tests/unit/providers/provider-registry.test.ts`:
+   - Add tests for `detectProviderForModel` with collision scenarios (Task 2.1).
+   - Test that all five providers are registered by `initializeProviders`.
+   - Test that `ownsModel` correctly distinguishes between providers that share model IDs.
+3. In `packages/daemon/tests/unit/providers/context-manager.test.ts`:
+   - Add tests for creating a provider context with `anthropic-copilot` and `anthropic-codex` provider IDs.
+4. Add a new test file `packages/daemon/tests/unit/model-service-provider-routing.test.ts`:
+   - Test `getModelInfo` with `providerId` parameter for disambiguation.
+   - Test `resolveModelAlias` with `providerId` parameter.
+   - Test that the global cache contains models from all available providers.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Run all unit tests: `cd packages/daemon && bun test tests/unit/ --timeout 60000`.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- All new tests pass.
+- All existing tests still pass.
+- Coverage includes: collision routing, provider-aware resolution, type safety.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 2.1, Task 2.2, Task 2.3
+
+---
+
+### Task 7.2: Update Online Provider Test Shards
+
+**Description:** Update the online tests for both provider shards (`providers-anthropic-copilot` and `providers-anthropic-to-codex-bridge`) to cover the new functionality: error envelopes, token usage, provider-aware session creation.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts`:
+   - Add a test that creates a session with explicit `config.provider: 'anthropic-copilot'` and verifies the session uses the copilot backend.
+   - Add a test that verifies error responses use Anthropic JSON error envelopes.
+   - Add a test that verifies non-zero token usage in the response.
+3. In `packages/daemon/tests/online/providers/anthropic-to-codex-bridge-provider.test.ts`:
+   - Add a test that creates a session with explicit `config.provider: 'anthropic-codex'` and verifies the session uses the codex backend.
+   - Add a test that verifies error responses use Anthropic JSON error envelopes.
+   - Add a test that verifies non-zero token usage in the response.
+4. Ensure all tests follow the "hard fail" rule: no skip guards for missing credentials.
+5. Run `bun run typecheck` and `bun run lint`.
+6. Verify CI workflow configuration in `.github/workflows/main.yml` still has both shards and the correct test paths.
+7. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Online tests for both providers cover: explicit provider creation, error envelopes, token usage.
+- No skip guards -- tests fail if credentials are missing.
+- CI workflow configuration is correct for both shards.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 4.2, Task 4.3, Task 5.1, Task 5.2
+
+---
+
+### Task 7.3: E2E Tests for Provider Switching
+
+**Description:** Add Playwright E2E tests that verify the user can switch between providers via the model picker UI. These tests must be pure browser-based interactions following the E2E test rules in CLAUDE.md.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create a new test file `packages/e2e/tests/features/provider-model-switching.e2e.ts`.
+3. Test scenarios (all via UI interactions, no RPC calls):
+   - Create a new session -- verify the model name is visible in the session status bar.
+   - Open the model picker dropdown -- verify models are grouped by provider with provider headers.
+   - Switch to a model from a different provider (if multiple providers are available) -- verify the provider badge updates.
+   - Verify the session continues working after provider switch (send a message, verify response).
+4. Since E2E tests require real providers, guard the provider-switching test with a check for whether multiple providers show models in the picker. If only one provider is available, skip the cross-provider switch but still test the model picker rendering.
+5. Follow all E2E test rules from CLAUDE.md:
+   - All actions through the UI (clicks, typing).
+   - All assertions on visible DOM state.
+   - No direct RPC calls or internal state access.
+6. Run `bun run typecheck` and `bun run lint`.
+7. Run the test: `make run-e2e TEST=tests/features/provider-model-switching.e2e.ts`.
+8. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- E2E test verifies model picker displays provider groups.
+- E2E test verifies provider badge updates on model switch.
+- E2E test follows all CLAUDE.md E2E rules.
+- Test runs successfully via `make run-e2e`.
+- `bun run typecheck` and `bun run lint` pass.
+
+**Dependencies:** Task 3.1, Task 3.2

--- a/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/08-documentation-and-final-report.md
+++ b/docs/plans/implement-anthropic-copilot-anthropic-to-codex-bridge-provid/08-documentation-and-final-report.md
@@ -1,0 +1,80 @@
+# Milestone 8: Documentation and Final Report
+
+## Goal
+
+Document the setup process for both providers, known limitations, and produce a final parity report summarizing completed closures and remaining gaps.
+
+## Scope
+
+- `docs/` -- Setup documentation, known limitations, final parity report
+
+---
+
+### Task 8.1: Provider Setup Documentation
+
+**Description:** Create or update documentation for setting up both the `anthropic-copilot` and `anthropic-codex` providers, including authentication methods, environment variables, and troubleshooting.
+
+**Agent type:** general
+
+**Subtasks:**
+1. Review existing documentation files under `docs/` for any provider setup information.
+2. Create `docs/providers/anthropic-copilot-setup.md` with:
+   - Overview of the provider and what it does.
+   - Authentication methods: NeoKai OAuth, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `gh auth login`, `~/.config/gh/hosts.yml`.
+   - Step-by-step setup for each method.
+   - Troubleshooting: classic PAT rejection, token validation failures, enterprise GitHub.
+   - Known limitations: no vision, no extended thinking, heuristic token counting, `tool_choice` limitations.
+3. Create `docs/providers/anthropic-codex-setup.md` with:
+   - Overview of the provider and what it does.
+   - Authentication methods: `OPENAI_API_KEY`, `CODEX_API_KEY`, NeoKai OAuth (ChatGPT Plus/Pro), `codex login` migration.
+   - Step-by-step setup for each method.
+   - Requirement: `codex` CLI must be on PATH.
+   - Troubleshooting: codex binary not found, OAuth token refresh, workspace isolation.
+   - Known limitations: no vision, no extended thinking, heuristic token counting (unless real usage wired), text-flattened conversation semantics, single-tool-result limitation.
+4. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Setup docs exist for both providers.
+- Each doc covers authentication, setup steps, and troubleshooting.
+- Known limitations are clearly documented.
+
+**Dependencies:** All Milestones 1-7
+
+---
+
+### Task 8.2: Final Parity Report
+
+**Description:** Produce a final parity report summarizing what was achieved, what parity gaps remain, and test evidence for each closure.
+
+**Agent type:** general
+
+**Subtasks:**
+1. Review the original parity reports:
+   - `docs/reports/anthropic-copilot-parity-report.md`
+   - `docs/codex-anthropic-api-parity-review.md`
+   - `docs/reports/codex-anthropic-parity-report.md`
+2. Create `docs/reports/provider-parity-final-report.md` with sections:
+   - **Executive Summary**: What was achieved and overall parity status.
+   - **anthropic-copilot Provider**:
+     - Closures: error mapping, token usage, type safety, UI integration, routing.
+     - Remaining gaps: vision, extended thinking, `tool_choice` (if not supported by SDK).
+     - Test evidence: list of tests and their results.
+   - **anthropic-codex Provider**:
+     - Closures: multiple tool results, error envelopes, token usage, type safety, UI integration, routing.
+     - Remaining gaps: `stream: false`, vision, extended thinking, `tool_choice`, full conversation semantics, `stop_sequences`.
+     - Test evidence: list of tests and their results.
+   - **Shared Improvements**:
+     - Type system widening.
+     - Collision-safe routing.
+     - Provider-grouped model picker.
+     - Auth UX indicators.
+   - **Remaining Work**: Prioritized list of gaps not addressed in this plan.
+3. Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Acceptance criteria:**
+- Final report covers both providers with per-gap closure status.
+- Test evidence is cited for each closure.
+- Remaining gaps are clearly listed with priority.
+- The report supersedes the three original parity reports.
+
+**Dependencies:** All Milestones 1-7


### PR DESCRIPTION
## Summary

Structured implementation plan for making `anthropic-copilot` (GitHub Copilot SDK) and `anthropic-codex` (Codex app-server) fully first-class providers in NeoKai.

### 8 Milestones, 24 Tasks

1. **Shared Type System Updates** (3 tasks) -- Widen `Provider` type union, remove unsafe `as any` casts, update web labels
2. **Provider Routing Hardening** (3 tasks) -- Collision-safe `detectProvider`, provider-aware session flow, model disambiguation
3. **Web UI Provider Integration** (3 tasks) -- Provider-grouped model picker, provider badge in status bar, provider-aware session creation
4. **Codex Bridge Parity Gaps** (3 tasks) -- Multiple tool results, JSON error envelopes, token usage wiring
5. **Copilot Bridge Parity Gaps** (3 tasks) -- Error mapping, token usage accounting, tool_choice pass-through
6. **Auth UX and Health/Recovery** (2 tasks) -- Auth indicators in chat UI, graceful degradation on provider errors
7. **Test Coverage** (3 tasks) -- Unit tests for routing, online test shard updates, E2E tests for provider switching
8. **Documentation and Final Report** (2 tasks) -- Setup docs for both providers, final parity closure report

### Key Issues Addressed

- `Provider` type union only has `'anthropic' | 'glm' | 'minimax'` -- missing both new providers
- Model ID collisions (e.g., `claude-opus-4.6` claimed by Anthropic and anthropic-copilot)
- Unsafe `as any` type casts in model-switch-handler and provider-service
- Missing provider grouping in UI model picker
- Codex bridge only uses first tool result in multi-tool continuations
- Both bridges return plain-text errors instead of Anthropic JSON error envelopes
- Token usage is zero/heuristic in both bridges
- No auth status indicators in the chat UI

### Based on Parity Reports

- `docs/reports/anthropic-copilot-parity-report.md`
- `docs/codex-anthropic-api-parity-review.md`
- `docs/reports/codex-anthropic-parity-report.md`

## Test Plan

- [ ] All existing unit tests pass after type changes
- [ ] New collision-safe routing unit tests pass
- [ ] Web tests pass with updated provider labels
- [ ] Online provider test shards updated and passing
- [ ] E2E test for provider model switching
- [ ] `bun run check` (lint + typecheck + knip) passes