### PR TITLE
feat: tighten leader agent tool permissions to read-only context subset

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -30,7 +30,7 @@ import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
 import type { DaemonHub } from '../../daemon-hub';
 import type { RoomRuntime } from '../runtime/room-runtime';
-import { createRoomAgentMcpServer } from '../tools/room-agent-tools';
+import { createLeaderContextMcpServer } from '../tools/room-agent-tools';
 
 const DEFAULT_LEADER_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -1034,10 +1034,11 @@ export function createLeaderAgentInit(
 ): AgentSessionInit {
 	const mcpServer = createLeaderMcpServer(config.groupId, callbacks);
 
-	// Create room-agent-tools MCP server for task/goal management (if dependencies provided)
+	// Create a read-only context MCP server for the leader (list/get tools only).
+	// Deliberately excludes write tools and human-only tools (approve_task, reject_task).
 	const roomAgentTools =
 		config.goalManager && config.taskManager && config.groupRepo
-			? (createRoomAgentMcpServer({
+			? (createLeaderContextMcpServer({
 					roomId: config.room.id,
 					goalManager: config.goalManager,
 					taskManager: config.taskManager,

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -74,7 +74,7 @@ export interface LeaderAgentConfig {
 	model?: string;
 	/** What type of work is being reviewed */
 	reviewContext?: ReviewContext;
-	/** Dependencies for room-agent-tools MCP server (optional - only needed when creating MCP server) */
+	/** Dependencies for the leader context MCP server (optional - only needed when creating MCP server) */
 	goalManager?: GoalManager;
 	taskManager?: TaskManager;
 	groupRepo?: SessionGroupRepository;
@@ -1035,7 +1035,8 @@ export function createLeaderAgentInit(
 	const mcpServer = createLeaderMcpServer(config.groupId, callbacks);
 
 	// Create a read-only context MCP server for the leader (list/get tools only).
-	// Deliberately excludes write tools and human-only tools (approve_task, reject_task).
+	// Deliberately excludes write tools, human-only tools (approve_task, reject_task),
+	// and write-capable dependencies (daemonHub, runtimeService).
 	const roomAgentTools =
 		config.goalManager && config.taskManager && config.groupRepo
 			? (createLeaderContextMcpServer({
@@ -1043,8 +1044,6 @@ export function createLeaderAgentInit(
 					goalManager: config.goalManager,
 					taskManager: config.taskManager,
 					groupRepo: config.groupRepo,
-					daemonHub: config.daemonHub,
-					runtimeService: config.runtimeService,
 				}) as unknown as McpServerConfig)
 			: undefined;
 

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -28,8 +28,6 @@ import type {
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
-import type { DaemonHub } from '../../daemon-hub';
-import type { RoomRuntime } from '../runtime/room-runtime';
 import { createLeaderContextMcpServer } from '../tools/room-agent-tools';
 
 const DEFAULT_LEADER_MODEL = 'claude-sonnet-4-5-20250929';
@@ -78,12 +76,6 @@ export interface LeaderAgentConfig {
 	goalManager?: GoalManager;
 	taskManager?: TaskManager;
 	groupRepo?: SessionGroupRepository;
-	/** Optional: DaemonHub for emitting events (used for UI notifications) */
-	daemonHub?: DaemonHub;
-	/** Optional: Runtime service for runtime operations */
-	runtimeService?: {
-		getRuntime(roomId: string): RoomRuntime | null;
-	};
 }
 
 /**
@@ -1093,7 +1085,7 @@ export function createLeaderAgentInit(
 			},
 			mcpServers: {
 				'leader-agent-tools': mcpServer as unknown as McpServerConfig,
-				...(roomAgentTools ? { 'room-agent-tools': roomAgentTools } : {}),
+				...(roomAgentTools ? { 'leader-context-tools': roomAgentTools } : {}),
 			},
 			features: LEADER_FEATURES,
 			context: { roomId: config.room.id },
@@ -1116,7 +1108,7 @@ export function createLeaderAgentInit(
 		},
 		mcpServers: {
 			'leader-agent-tools': mcpServer as unknown as McpServerConfig,
-			...(roomAgentTools ? { 'room-agent-tools': roomAgentTools } : {}),
+			...(roomAgentTools ? { 'leader-context-tools': roomAgentTools } : {}),
 		},
 		features: LEADER_FEATURES,
 		context: { roomId: config.room.id },

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -273,10 +273,6 @@ export class RoomRuntime {
 			getRoom: config.getRoom,
 			getTask: config.getTask,
 			getGoal: config.getGoal,
-			daemonHub: config.daemonHub,
-			runtimeService: {
-				getRuntime: (roomId: string) => (roomId === this.room.id ? this : null),
-			},
 		});
 
 		// Keep test and direct-runtime usage predictable: when no explicit leader model

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -26,8 +26,6 @@ import type { GoalManager } from '../managers/goal-manager';
 import type { LeaderToolCallbacks } from '../agents/leader-agent';
 import { createLeaderAgentInit } from '../agents/leader-agent';
 import type { LeaderAgentConfig, ReviewContext } from '../agents/leader-agent';
-import type { DaemonHub } from '../../daemon-hub';
-import type { RoomRuntime } from './room-runtime';
 
 /**
  * Convert a task title to a git branch name slug.
@@ -151,12 +149,6 @@ export interface TaskGroupManagerConfig {
 	getTask: (taskId: string) => Promise<NeoTask | null>;
 	/** Fetch goal from DB by ID. Used to get CURRENT goal data at route time. */
 	getGoal: (goalId: string) => Promise<RoomGoal | null>;
-	/** DaemonHub for emitting events (used for UI notifications) */
-	daemonHub?: DaemonHub;
-	/** Runtime service for runtime operations (task cancellation, etc.) */
-	runtimeService?: {
-		getRuntime(roomId: string): RoomRuntime | null;
-	};
 }
 
 export class TaskGroupManager {
@@ -171,10 +163,6 @@ export class TaskGroupManager {
 	readonly workspacePath: string;
 	private _model?: string;
 	readonly workerModel?: string;
-	private readonly daemonHub?: DaemonHub;
-	private readonly runtimeService?: {
-		getRuntime(roomId: string): RoomRuntime | null;
-	};
 
 	constructor(config: TaskGroupManagerConfig) {
 		this.groupRepo = config.groupRepo;
@@ -188,8 +176,6 @@ export class TaskGroupManager {
 		this.workspacePath = config.workspacePath;
 		this._model = config.model;
 		this.workerModel = config.workerModel;
-		this.daemonHub = config.daemonHub;
-		this.runtimeService = config.runtimeService;
 	}
 
 	/** Get the current model for leader sessions */
@@ -386,8 +372,6 @@ export class TaskGroupManager {
 				goalManager: this.goalManager,
 				taskManager: this.taskManager,
 				groupRepo: this.groupRepo,
-				daemonHub: this.daemonHub,
-				runtimeService: this.runtimeService,
 			};
 			const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -760,3 +760,59 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 }
 
 export type RoomAgentMcpServer = ReturnType<typeof createRoomAgentMcpServer>;
+
+/**
+ * Create a minimal read-only MCP server for the Leader agent.
+ *
+ * The leader only needs context tools — it should NOT have write or human-only tools.
+ * Excluded tools and reasons:
+ *   - approve_task / reject_task: human-only decisions
+ *   - create_goal / update_goal: not the leader's role
+ *   - create_task / update_task: leader delegates to worker via send_to_worker
+ *   - cancel_task / stop_session: not the leader's role
+ *   - set_task_status: leader uses complete_task / fail_task from leader-agent-tools instead
+ *   - send_message_to_task: leader uses send_to_worker from leader-agent-tools instead
+ */
+export function createLeaderContextMcpServer(config: RoomAgentToolsConfig) {
+	const handlers = createRoomAgentToolHandlers(config);
+
+	const tools = [
+		tool('list_goals', 'List all goals in this room', {}, () => handlers.list_goals()),
+		tool(
+			'list_tasks',
+			'List tasks in this room, optionally filtered by goal',
+			{
+				goal_id: z.string().optional().describe('Filter to tasks linked to this goal'),
+				status: z
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+					])
+					.optional()
+					.describe('Filter by status'),
+			},
+			(args) => handlers.list_tasks(args)
+		),
+		tool(
+			'get_task_detail',
+			'Get full details for a task including group session IDs and whether it is awaiting human review',
+			{ task_id: z.string().describe('ID of the task to get details for') },
+			(args) => handlers.get_task_detail(args)
+		),
+		tool(
+			'get_room_status',
+			'Get an overview of the room state including goals, tasks, active groups, and tasks needing review',
+			{},
+			() => handlers.get_room_status()
+		),
+	];
+
+	return createSdkMcpServer({ name: 'room-agent', tools });
+}
+
+export type LeaderContextMcpServer = ReturnType<typeof createLeaderContextMcpServer>;

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -762,7 +762,19 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 export type RoomAgentMcpServer = ReturnType<typeof createRoomAgentMcpServer>;
 
 /**
+ * Narrow config type for the leader context MCP server.
+ * Excludes daemonHub and runtimeService since read-only tools do not need them.
+ */
+export type LeaderContextMcpConfig = Pick<
+	RoomAgentToolsConfig,
+	'roomId' | 'goalManager' | 'taskManager' | 'groupRepo'
+>;
+
+/**
  * Create a minimal read-only MCP server for the Leader agent.
+ *
+ * Registered as `'leader-context'` (distinct from `'room-agent'` used by the full server).
+ * Exposes only 4 read-only tools: list_goals, list_tasks, get_task_detail, get_room_status.
  *
  * The leader only needs context tools — it should NOT have write or human-only tools.
  * Excluded tools and reasons:
@@ -773,7 +785,7 @@ export type RoomAgentMcpServer = ReturnType<typeof createRoomAgentMcpServer>;
  *   - set_task_status: leader uses complete_task / fail_task from leader-agent-tools instead
  *   - send_message_to_task: leader uses send_to_worker from leader-agent-tools instead
  */
-export function createLeaderContextMcpServer(config: RoomAgentToolsConfig) {
+export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 	const handlers = createRoomAgentToolHandlers(config);
 
 	const tools = [
@@ -812,7 +824,7 @@ export function createLeaderContextMcpServer(config: RoomAgentToolsConfig) {
 		),
 	];
 
-	return createSdkMcpServer({ name: 'room-agent', tools });
+	return createSdkMcpServer({ name: 'leader-context', tools });
 }
 
 export type LeaderContextMcpServer = ReturnType<typeof createLeaderContextMcpServer>;

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -402,14 +402,24 @@ describe('Leader Agent', () => {
 			expect(init.mcpServers!['leader-agent-tools']).toBeDefined();
 		});
 
-		it('should include room-agent-tools MCP server for read-only context', () => {
+		it('should include leader-context-tools MCP server for read-only context', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.mcpServers).toBeDefined();
-			expect(init.mcpServers!['room-agent-tools']).toBeDefined();
+			const ctxServer = init.mcpServers!['leader-context-tools'] as unknown as {
+				name: string;
+				instance: { _registeredTools: Record<string, unknown> };
+			};
+			expect(ctxServer).toBeDefined();
+			// Verify it is the narrow leader-context server, not the full room-agent server
+			expect(ctxServer.name).toBe('leader-context');
+			const toolNames = Object.keys(ctxServer.instance._registeredTools).sort();
+			expect(toolNames).toEqual(
+				['get_room_status', 'get_task_detail', 'list_goals', 'list_tasks'].sort()
+			);
 		});
 
-		it('should NOT include room-agent-tools when dependencies are missing', () => {
+		it('should NOT include leader-context-tools when dependencies are missing', () => {
 			const callbacks = makeCallbacks();
 			// Create config without goalManager, taskManager, groupRepo
 			const init = createLeaderAgentInit(
@@ -424,10 +434,10 @@ describe('Leader Agent', () => {
 				callbacks
 			);
 			expect(init.mcpServers).toBeDefined();
-			expect(init.mcpServers!['room-agent-tools']).toBeUndefined();
+			expect(init.mcpServers!['leader-context-tools']).toBeUndefined();
 		});
 
-		it('should NOT include room-agent-tools when only partial dependencies provided', () => {
+		it('should NOT include leader-context-tools when only partial dependencies provided', () => {
 			const callbacks = makeCallbacks();
 			// Provide only goalManager, but not taskManager and groupRepo
 			const init = createLeaderAgentInit(
@@ -443,12 +453,12 @@ describe('Leader Agent', () => {
 				callbacks
 			);
 			expect(init.mcpServers).toBeDefined();
-			expect(init.mcpServers!['room-agent-tools']).toBeUndefined();
+			expect(init.mcpServers!['leader-context-tools']).toBeUndefined();
 		});
 
-		it('should still include leader-agent-tools regardless of room-agent-tools availability', () => {
+		it('should still include leader-agent-tools regardless of leader-context-tools availability', () => {
 			const callbacks = makeCallbacks();
-			// Config without room-agent-tools dependencies
+			// Config without leader-context-tools dependencies
 			const init = createLeaderAgentInit(
 				{
 					task: makeTask(),

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -402,7 +402,7 @@ describe('Leader Agent', () => {
 			expect(init.mcpServers!['leader-agent-tools']).toBeDefined();
 		});
 
-		it('should include room-agent-tools MCP server for task/goal management', () => {
+		it('should include room-agent-tools MCP server for read-only context', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.mcpServers).toBeDefined();

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1579,65 +1579,70 @@ describe('Room Agent Tools', () => {
 	});
 
 	describe('createLeaderContextMcpServer', () => {
-		it('should create a non-null MCP server', () => {
+		/**
+		 * Helper: return the registered tool names from an SDK MCP server.
+		 * The SDK stores registered tools in `instance._registeredTools` keyed by tool name.
+		 */
+		function getRegisteredToolNames(server: {
+			instance: { _registeredTools: Record<string, unknown> };
+		}): string[] {
+			return Object.keys(server.instance._registeredTools).sort();
+		}
+
+		it('should expose exactly the 4 read-only context tools', () => {
 			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
-			expect(server).toBeDefined();
-			expect(server).not.toBeNull();
+			const names = getRegisteredToolNames(server as never);
+			expect(names).toEqual(['get_room_status', 'get_task_detail', 'list_goals', 'list_tasks']);
 		});
 
-		it('underlying handlers support list_goals', async () => {
-			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
-			// Verify list_goals works (read-only — no side effects)
-			const result = parseResult(await h.list_goals());
-			expect(result.success).toBe(true);
-			expect(Array.isArray(result.goals)).toBe(true);
+		it('should NOT expose approve_task', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			expect(names).not.toContain('approve_task');
 		});
 
-		it('underlying handlers support list_tasks', async () => {
-			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
-			const result = parseResult(await h.list_tasks({}));
-			expect(result.success).toBe(true);
-			expect(Array.isArray(result.tasks)).toBe(true);
+		it('should NOT expose reject_task', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			expect(names).not.toContain('reject_task');
 		});
 
-		it('underlying handlers support get_task_detail', async () => {
-			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
-			// Create a task first so we have something to fetch
-			const created = parseResult(
-				await h.create_task({ title: 'Context task', description: 'Used by leader context' })
-			);
-			const result = parseResult(await h.get_task_detail({ task_id: created.taskId as string }));
-			expect(result.success).toBe(true);
-			expect(result.task).toBeDefined();
+		it('should NOT expose any write tools', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			const writeTools = [
+				'create_goal',
+				'update_goal',
+				'create_task',
+				'update_task',
+				'cancel_task',
+				'stop_session',
+				'set_task_status',
+				'send_message_to_task',
+			];
+			for (const w of writeTools) {
+				expect(names).not.toContain(w);
+			}
 		});
 
-		it('underlying handlers support get_room_status', async () => {
-			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
-			const result = parseResult(await h.get_room_status());
-			expect(result.success).toBe(true);
-			expect(result.status).toBeDefined();
+		it('should use the distinct MCP server name "leader-context"', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			expect(server.name).toBe('leader-context');
 		});
 
-		it('server is distinct from the full createRoomAgentMcpServer', () => {
-			// createLeaderContextMcpServer must not expose approve_task / reject_task.
-			// We verify this by checking the server object reference differs from a full server
-			// created with createRoomAgentMcpServer — they share the same MCP server name
-			// but expose a different subset of tools.
+		it('full room-agent server name should remain "room-agent"', () => {
 			const { createRoomAgentMcpServer } = require('../../../src/lib/room/tools/room-agent-tools');
-			const leaderServer = createLeaderContextMcpServer({
-				roomId,
-				goalManager,
-				taskManager,
-				groupRepo,
-			});
-			const fullServer = createRoomAgentMcpServer({
-				roomId,
-				goalManager,
-				taskManager,
-				groupRepo,
-			});
-			// Both are MCP servers but separate instances
-			expect(leaderServer).not.toBe(fullServer);
+			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			expect(fullServer.name).toBe('room-agent');
+		});
+
+		it('full server exposes all 14 tools', () => {
+			const { createRoomAgentMcpServer } = require('../../../src/lib/room/tools/room-agent-tools');
+			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(fullServer as never);
+			expect(names).toHaveLength(14);
+			expect(names).toContain('approve_task');
+			expect(names).toContain('reject_task');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -3,7 +3,10 @@ import { Database } from 'bun:sqlite';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
-import { createRoomAgentToolHandlers } from '../../../src/lib/room/tools/room-agent-tools';
+import {
+	createRoomAgentToolHandlers,
+	createLeaderContextMcpServer,
+} from '../../../src/lib/room/tools/room-agent-tools';
 
 describe('Room Agent Tools', () => {
 	let db: Database;
@@ -1572,6 +1575,69 @@ describe('Room Agent Tools', () => {
 			);
 			expect(result.success).toBe(true);
 			expect(result.task.status).toBe('completed');
+		});
+	});
+
+	describe('createLeaderContextMcpServer', () => {
+		it('should create a non-null MCP server', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			expect(server).toBeDefined();
+			expect(server).not.toBeNull();
+		});
+
+		it('underlying handlers support list_goals', async () => {
+			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
+			// Verify list_goals works (read-only — no side effects)
+			const result = parseResult(await h.list_goals());
+			expect(result.success).toBe(true);
+			expect(Array.isArray(result.goals)).toBe(true);
+		});
+
+		it('underlying handlers support list_tasks', async () => {
+			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
+			const result = parseResult(await h.list_tasks({}));
+			expect(result.success).toBe(true);
+			expect(Array.isArray(result.tasks)).toBe(true);
+		});
+
+		it('underlying handlers support get_task_detail', async () => {
+			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
+			// Create a task first so we have something to fetch
+			const created = parseResult(
+				await h.create_task({ title: 'Context task', description: 'Used by leader context' })
+			);
+			const result = parseResult(await h.get_task_detail({ task_id: created.taskId as string }));
+			expect(result.success).toBe(true);
+			expect(result.task).toBeDefined();
+		});
+
+		it('underlying handlers support get_room_status', async () => {
+			const h = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
+			const result = parseResult(await h.get_room_status());
+			expect(result.success).toBe(true);
+			expect(result.status).toBeDefined();
+		});
+
+		it('server is distinct from the full createRoomAgentMcpServer', () => {
+			// createLeaderContextMcpServer must not expose approve_task / reject_task.
+			// We verify this by checking the server object reference differs from a full server
+			// created with createRoomAgentMcpServer — they share the same MCP server name
+			// but expose a different subset of tools.
+			const { createRoomAgentMcpServer } = require('../../../src/lib/room/tools/room-agent-tools');
+			const leaderServer = createLeaderContextMcpServer({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+			});
+			const fullServer = createRoomAgentMcpServer({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+			});
+			// Both are MCP servers but separate instances
+			expect(leaderServer).not.toBe(fullServer);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -5,6 +5,7 @@ import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
 import {
 	createRoomAgentToolHandlers,
+	createRoomAgentMcpServer,
 	createLeaderContextMcpServer,
 } from '../../../src/lib/room/tools/room-agent-tools';
 
@@ -1631,13 +1632,11 @@ describe('Room Agent Tools', () => {
 		});
 
 		it('full room-agent server name should remain "room-agent"', () => {
-			const { createRoomAgentMcpServer } = require('../../../src/lib/room/tools/room-agent-tools');
 			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			expect(fullServer.name).toBe('room-agent');
 		});
 
 		it('full server exposes all 14 tools', () => {
-			const { createRoomAgentMcpServer } = require('../../../src/lib/room/tools/room-agent-tools');
 			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(fullServer as never);
 			expect(names).toHaveLength(14);


### PR DESCRIPTION
The leader agent previously received all 14 room-agent-tools including
human-only operations (approve_task, reject_task) and write operations
(create_goal, create_task, cancel_task, set_task_status, etc.).

Introduce createLeaderContextMcpServer that exposes only 4 read-only tools:
- list_goals, list_tasks, get_task_detail, get_room_status

Excluded tools and rationale:
- approve_task / reject_task: human-only decisions, never for the leader AI
- create_goal / update_goal: not the leader's role
- create_task / update_task: leader delegates to worker via send_to_worker
- cancel_task / stop_session: not the leader's role
- set_task_status: leader uses complete_task / fail_task from its own MCP server
- send_message_to_task: leader uses send_to_worker from its own MCP server

Update leader-agent.ts to use createLeaderContextMcpServer and add tests
verifying the new read-only context server is properly created.
