### PR TITLE
fix: show PR link for all task statuses once created

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -647,5 +647,53 @@ describe('RoomTasks', () => {
 
 			expect(container.textContent).toContain('PR #99');
 		});
+
+		it('should render PR button for in_progress task with prUrl', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [
+				createTask('t1', 'in_progress', {
+					prUrl: 'https://github.com/org/repo/pull/10',
+					prNumber: 10,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/10"]');
+			expect(prLink).toBeTruthy();
+			expect(container.textContent).toContain('PR #10');
+		});
+
+		it('should render PR button for completed task with prUrl', () => {
+			selectedTabSignal.value = 'done';
+			const tasks = [
+				createTask('t1', 'completed', {
+					prUrl: 'https://github.com/org/repo/pull/20',
+					prNumber: 20,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/20"]');
+			expect(prLink).toBeTruthy();
+			expect(container.textContent).toContain('PR #20');
+		});
+
+		it('should render PR button for needs_attention task with prUrl', () => {
+			selectedTabSignal.value = 'needs_attention';
+			const tasks = [
+				createTask('t1', 'needs_attention', {
+					prUrl: 'https://github.com/org/repo/pull/30',
+					prNumber: 30,
+				}),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/30"]');
+			expect(prLink).toBeTruthy();
+			expect(container.textContent).toContain('PR #30');
+		});
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1517,7 +1517,7 @@ describe('TaskView — PR link in header', () => {
 		expect(container.textContent).not.toContain('PR #');
 	});
 
-	it('does not show PR link in header for review task (review bar shows it instead)', async () => {
+	it('shows PR link in header AND in review bar for review task (both render)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get')
 				return {
@@ -1534,15 +1534,12 @@ describe('TaskView — PR link in header', () => {
 		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
 
 		await waitFor(() => {
-			expect(container.textContent).not.toContain('Loading task');
+			expect(container.textContent).toContain('PR #99');
 		});
 
-		// The PR link should appear in the review bar but NOT in the header title area.
-		// Since the review bar and header both render, there will be exactly one PR link
-		// (in the review bar). The header div does not render a second PR badge.
+		// PR link appears in both the header badge and the review bar button.
 		const prLinks = container.querySelectorAll('a[href="https://github.com/org/repo/pull/99"]');
-		// Only the review bar link should exist (not a second one from the header)
-		expect(prLinks.length).toBe(1);
+		expect(prLinks.length).toBe(2);
 	});
 
 	it('shows PR link in header for needs_attention task with prUrl', async () => {
@@ -1566,6 +1563,56 @@ describe('TaskView — PR link in header', () => {
 		});
 
 		const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/7"]');
+		expect(prLink).not.toBeNull();
+	});
+
+	it('shows PR link in header for review task even without submittedForReview (no review bar)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get')
+				return {
+					task: {
+						...makeTask('task-1', 'review'),
+						prUrl: 'https://github.com/org/repo/pull/55',
+						prNumber: 55,
+					},
+				};
+			// group not awaiting_human, so submittedForReview is false → review bar hidden
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('PR #55');
+		});
+
+		// PR link is in the header only (no review bar since submittedForReview is false)
+		const prLinks = container.querySelectorAll('a[href="https://github.com/org/repo/pull/55"]');
+		expect(prLinks.length).toBe(1);
+	});
+
+	it('shows PR link in header for completed task with prUrl', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get')
+				return {
+					task: {
+						...makeTask('task-1', 'completed'),
+						prUrl: 'https://github.com/org/repo/pull/101',
+						prNumber: 101,
+					},
+				};
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('PR #101');
+		});
+
+		const prLink = container.querySelector('a[href="https://github.com/org/repo/pull/101"]');
 		expect(prLink).not.toBeNull();
 	});
 });

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -903,8 +903,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 								{task.taskType}
 							</span>
 						)}
-						{/* PR link for non-review states (review bar shows it for review status) */}
-						{task.prUrl && task.status !== 'review' && (
+						{/* PR link — shown for all statuses once the PR has been created */}
+						{task.prUrl && (
 							<a
 								href={task.prUrl}
 								target="_blank"


### PR DESCRIPTION
Previously the TaskView header only rendered the PR badge when
task.status !== 'review', relying on the HeaderReviewBar to surface it
during review. This meant the PR was invisible when the task was in
review status but submittedForReview was false (e.g. an escalated
review). Now the PR badge is always shown in the header whenever
task.prUrl is set, regardless of status.

RoomTasks.tsx (task list) already showed the PR for all statuses;
tests are added to confirm that behaviour for in_progress, completed,
and needs_attention tasks.
