### PR TITLE
feat: widen Provider type union to include anthropic-copilot and anthropic-codex

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -184,8 +184,10 @@ export type SessionStatus = 'active' | 'pending_worktree_choice' | 'paused' | 'e
  * - 'anthropic': Default Claude API provider
  * - 'glm': GLM (智谱AI) via Anthropic-compatible API
  * - 'minimax': MiniMax via Anthropic-compatible API
+ * - 'anthropic-copilot': GitHub Copilot backend via Anthropic-compatible embedded server
+ * - 'anthropic-codex': Anthropic-compatible HTTP bridge backed by Codex app-server
  */
-export type Provider = 'anthropic' | 'glm' | 'minimax';
+export type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex';
 
 /**
  * Provider-specific configuration


### PR DESCRIPTION
Add 'anthropic-copilot' and 'anthropic-codex' to the Provider type union
in packages/shared/src/types.ts. Update JSDoc to document all five providers.
