### PR TITLE
feat: define V2 mission types and extend RoomGoal (Task 1.1)

### DIFF
--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -88,9 +88,10 @@ export class GoalRepository {
 				id, room_id, title, description, status, priority, progress, linked_task_ids,
 				metrics, created_at, updated_at,
 				mission_type, autonomy_level, schedule, schedule_paused, next_run_at,
-				structured_metrics, max_consecutive_failures, max_planning_attempts, consecutive_failures
+				structured_metrics, max_consecutive_failures, max_planning_attempts, consecutive_failures,
+				replan_count
 			)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -113,7 +114,8 @@ export class GoalRepository {
 			params.structuredMetrics ? JSON.stringify(params.structuredMetrics) : null,
 			params.maxConsecutiveFailures ?? 3,
 			params.maxPlanningAttempts ?? 5,
-			0
+			0,
+			params.replanCount ?? 0
 		);
 
 		return this.getGoal(id)!;

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -34,6 +34,7 @@ export interface CreateGoalParams {
 	nextRunAt?: number;
 	maxConsecutiveFailures?: number;
 	maxPlanningAttempts?: number;
+	replanCount?: number;
 }
 
 export interface UpdateGoalParams {
@@ -54,6 +55,7 @@ export interface UpdateGoalParams {
 	maxConsecutiveFailures?: number;
 	maxPlanningAttempts?: number;
 	consecutiveFailures?: number;
+	replanCount?: number;
 }
 
 export interface CreateExecutionParams {
@@ -229,6 +231,10 @@ export class GoalRepository {
 		if (params.consecutiveFailures !== undefined) {
 			fields.push('consecutive_failures = ?');
 			values.push(params.consecutiveFailures);
+		}
+		if (params.replanCount !== undefined) {
+			fields.push('replan_count = ?');
+			values.push(params.replanCount);
 		}
 
 		if (fields.length === 0) {
@@ -512,6 +518,7 @@ export class GoalRepository {
 			maxConsecutiveFailures: (row.max_consecutive_failures as number | null) ?? 3,
 			maxPlanningAttempts: (row.max_planning_attempts as number | null) ?? 5,
 			consecutiveFailures: (row.consecutive_failures as number | null) ?? 0,
+			replanCount: (row.replan_count as number | null) ?? undefined,
 		};
 	}
 

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -34,6 +34,7 @@ export interface CreateGoalParams {
 	nextRunAt?: number;
 	maxConsecutiveFailures?: number;
 	maxPlanningAttempts?: number;
+	consecutiveFailures?: number;
 	replanCount?: number;
 }
 
@@ -114,7 +115,7 @@ export class GoalRepository {
 			params.structuredMetrics ? JSON.stringify(params.structuredMetrics) : null,
 			params.maxConsecutiveFailures ?? 3,
 			params.maxPlanningAttempts ?? 5,
-			0,
+			params.consecutiveFailures ?? 0,
 			params.replanCount ?? 0
 		);
 

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -196,6 +196,7 @@ export function createTables(db: BunDatabase): void {
         max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
         max_planning_attempts INTEGER NOT NULL DEFAULT 5,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        replan_count INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1381,6 +1381,9 @@ function runMigration28(db: BunDatabase): void {
 		if (!tableHasColumn(db, 'goals', 'consecutive_failures')) {
 			db.exec(`ALTER TABLE goals ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0`);
 		}
+		if (!tableHasColumn(db, 'goals', 'replan_count')) {
+			db.exec(`ALTER TABLE goals ADD COLUMN replan_count INTEGER NOT NULL DEFAULT 0`);
+		}
 		// Composite index for efficient scheduler queries
 		db.exec(
 			`CREATE INDEX IF NOT EXISTS idx_goals_mission_scheduler` +

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -50,6 +50,12 @@ describe('GoalManager', () => {
 				created_at INTEGER NOT NULL,
 				updated_at INTEGER NOT NULL,
 				completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0,
+				goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT, autonomy_level TEXT, structured_metrics TEXT, schedule TEXT,
+				schedule_paused INTEGER DEFAULT 0, next_run_at INTEGER,
+				max_consecutive_failures INTEGER, max_planning_attempts INTEGER,
+				consecutive_failures INTEGER DEFAULT 0, replan_count INTEGER DEFAULT 0,
 				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
 			)
 		`);

--- a/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
+++ b/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
@@ -58,7 +58,11 @@ describe('GoalRepository — V2 Mission fields', () => {
 			const metrics: MissionMetric[] = [
 				{ name: 'test_coverage', target: 80, current: 60, unit: '%', direction: 'increase' },
 			];
-			const goal = repo.createGoal({ roomId, title: 'Measurable Mission', structuredMetrics: metrics });
+			const goal = repo.createGoal({
+				roomId,
+				title: 'Measurable Mission',
+				structuredMetrics: metrics,
+			});
 
 			const fetched = repo.getGoal(goal.id);
 			expect(fetched?.structuredMetrics).toHaveLength(1);
@@ -114,24 +118,27 @@ describe('GoalRepository — V2 Mission fields', () => {
 			expect(fetched?.replanCount).toBe(0);
 		});
 
-		it('should leave V2 fields undefined when not provided', () => {
+		it('should use V2 defaults when not provided', () => {
 			const goal = repo.createGoal({ roomId, title: 'Simple Goal' });
 
 			const fetched = repo.getGoal(goal.id);
-			expect(fetched?.missionType).toBeUndefined();
-			expect(fetched?.autonomyLevel).toBeUndefined();
+			// Non-nullable fields get their schema defaults
+			expect(fetched?.missionType).toBe('one_shot');
+			expect(fetched?.autonomyLevel).toBe('supervised');
+			expect(fetched?.maxConsecutiveFailures).toBe(3);
+			expect(fetched?.maxPlanningAttempts).toBe(5);
+			// Nullable fields remain undefined when not provided
 			expect(fetched?.structuredMetrics).toBeUndefined();
 			expect(fetched?.schedule).toBeUndefined();
 			expect(fetched?.nextRunAt).toBeUndefined();
-			expect(fetched?.maxConsecutiveFailures).toBeUndefined();
-			expect(fetched?.maxPlanningAttempts).toBeUndefined();
 		});
 	});
 
 	describe('updateGoal with V2 params', () => {
 		it('should update missionType and autonomyLevel', () => {
 			const goal = repo.createGoal({ roomId, title: 'Mission' });
-			expect(goal.missionType).toBeUndefined();
+			// Default is 'one_shot' — override via updateGoal
+			expect(goal.missionType).toBe('one_shot');
 
 			const updated = repo.updateGoal(goal.id, {
 				missionType: 'measurable',
@@ -146,7 +153,14 @@ describe('GoalRepository — V2 Mission fields', () => {
 			const goal = repo.createGoal({ roomId, title: 'Measurable' });
 
 			const metrics: MissionMetric[] = [
-				{ name: 'latency_p99', target: 100, current: 250, unit: 'ms', direction: 'decrease', baseline: 300 },
+				{
+					name: 'latency_p99',
+					target: 100,
+					current: 250,
+					unit: 'ms',
+					direction: 'decrease',
+					baseline: 300,
+				},
 			];
 			const updated = repo.updateGoal(goal.id, { structuredMetrics: metrics });
 

--- a/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
+++ b/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
@@ -1,0 +1,208 @@
+/**
+ * GoalRepository V2 Mission Fields Tests
+ *
+ * Tests that V2 mission fields (missionType, autonomyLevel, structuredMetrics,
+ * schedule, schedulePaused, nextRunAt, maxConsecutiveFailures, maxPlanningAttempts,
+ * consecutiveFailures, replanCount) are correctly persisted and retrieved.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import type { MissionMetric, CronSchedule } from '@neokai/shared';
+
+describe('GoalRepository — V2 Mission fields', () => {
+	let db: Database;
+	let repo: GoalRepository;
+	let roomId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		// createTables creates goals with all V2 columns already included in the schema
+		createTables(db);
+
+		const roomManager = new RoomManager(db);
+		const room = roomManager.createRoom({
+			name: 'Test Room',
+			allowedPaths: [{ path: '/workspace/test' }],
+			defaultPath: '/workspace/test',
+		});
+		roomId = room.id;
+		repo = new GoalRepository(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createGoal with V2 params', () => {
+		it('should persist missionType and autonomyLevel', () => {
+			const goal = repo.createGoal({
+				roomId,
+				title: 'Recurring Mission',
+				missionType: 'recurring',
+				autonomyLevel: 'semi_autonomous',
+			});
+
+			expect(goal.missionType).toBe('recurring');
+			expect(goal.autonomyLevel).toBe('semi_autonomous');
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.missionType).toBe('recurring');
+			expect(fetched?.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('should persist structuredMetrics as JSON', () => {
+			const metrics: MissionMetric[] = [
+				{ name: 'test_coverage', target: 80, current: 60, unit: '%', direction: 'increase' },
+			];
+			const goal = repo.createGoal({ roomId, title: 'Measurable Mission', structuredMetrics: metrics });
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.structuredMetrics).toHaveLength(1);
+			expect(fetched?.structuredMetrics?.[0].name).toBe('test_coverage');
+			expect(fetched?.structuredMetrics?.[0].target).toBe(80);
+			expect(fetched?.structuredMetrics?.[0].direction).toBe('increase');
+		});
+
+		it('should persist schedule as JSON', () => {
+			const schedule: CronSchedule = { expression: '0 9 * * *', timezone: 'UTC' };
+			const goal = repo.createGoal({ roomId, title: 'Scheduled Mission', schedule });
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.schedule?.expression).toBe('0 9 * * *');
+			expect(fetched?.schedule?.timezone).toBe('UTC');
+		});
+
+		it('should persist schedulePaused, nextRunAt, maxConsecutiveFailures, maxPlanningAttempts', () => {
+			const goal = repo.createGoal({
+				roomId,
+				title: 'Full V2 Mission',
+				schedulePaused: true,
+				nextRunAt: 1700000000000,
+				maxConsecutiveFailures: 3,
+				maxPlanningAttempts: 5,
+			});
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.schedulePaused).toBe(true);
+			expect(fetched?.nextRunAt).toBe(1700000000000);
+			expect(fetched?.maxConsecutiveFailures).toBe(3);
+			expect(fetched?.maxPlanningAttempts).toBe(5);
+		});
+
+		it('should persist consecutiveFailures and replanCount', () => {
+			const goal = repo.createGoal({
+				roomId,
+				title: 'Failure Tracking Mission',
+				consecutiveFailures: 2,
+				replanCount: 4,
+			});
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.consecutiveFailures).toBe(2);
+			expect(fetched?.replanCount).toBe(4);
+		});
+
+		it('should default consecutiveFailures and replanCount to 0', () => {
+			const goal = repo.createGoal({ roomId, title: 'Default Mission' });
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.consecutiveFailures).toBe(0);
+			expect(fetched?.replanCount).toBe(0);
+		});
+
+		it('should leave V2 fields undefined when not provided', () => {
+			const goal = repo.createGoal({ roomId, title: 'Simple Goal' });
+
+			const fetched = repo.getGoal(goal.id);
+			expect(fetched?.missionType).toBeUndefined();
+			expect(fetched?.autonomyLevel).toBeUndefined();
+			expect(fetched?.structuredMetrics).toBeUndefined();
+			expect(fetched?.schedule).toBeUndefined();
+			expect(fetched?.nextRunAt).toBeUndefined();
+			expect(fetched?.maxConsecutiveFailures).toBeUndefined();
+			expect(fetched?.maxPlanningAttempts).toBeUndefined();
+		});
+	});
+
+	describe('updateGoal with V2 params', () => {
+		it('should update missionType and autonomyLevel', () => {
+			const goal = repo.createGoal({ roomId, title: 'Mission' });
+			expect(goal.missionType).toBeUndefined();
+
+			const updated = repo.updateGoal(goal.id, {
+				missionType: 'measurable',
+				autonomyLevel: 'supervised',
+			});
+
+			expect(updated?.missionType).toBe('measurable');
+			expect(updated?.autonomyLevel).toBe('supervised');
+		});
+
+		it('should update structuredMetrics', () => {
+			const goal = repo.createGoal({ roomId, title: 'Measurable' });
+
+			const metrics: MissionMetric[] = [
+				{ name: 'latency_p99', target: 100, current: 250, unit: 'ms', direction: 'decrease', baseline: 300 },
+			];
+			const updated = repo.updateGoal(goal.id, { structuredMetrics: metrics });
+
+			expect(updated?.structuredMetrics?.[0].name).toBe('latency_p99');
+			expect(updated?.structuredMetrics?.[0].baseline).toBe(300);
+		});
+
+		it('should update schedule', () => {
+			const goal = repo.createGoal({ roomId, title: 'Recurring' });
+
+			const updated = repo.updateGoal(goal.id, {
+				schedule: { expression: '0 0 * * 1', timezone: 'America/New_York' },
+			});
+
+			expect(updated?.schedule?.expression).toBe('0 0 * * 1');
+			expect(updated?.schedule?.timezone).toBe('America/New_York');
+		});
+
+		it('should update consecutiveFailures independently of replanCount', () => {
+			const goal = repo.createGoal({ roomId, title: 'Tracking' });
+
+			repo.updateGoal(goal.id, { replanCount: 3 });
+			const afterReplan = repo.getGoal(goal.id);
+			expect(afterReplan?.replanCount).toBe(3);
+			expect(afterReplan?.consecutiveFailures).toBe(0);
+
+			repo.updateGoal(goal.id, { consecutiveFailures: 1 });
+			const afterFailure = repo.getGoal(goal.id);
+			expect(afterFailure?.consecutiveFailures).toBe(1);
+			expect(afterFailure?.replanCount).toBe(3);
+		});
+
+		it('should update schedulePaused boolean correctly', () => {
+			const goal = repo.createGoal({ roomId, title: 'Paused Schedule' });
+
+			const paused = repo.updateGoal(goal.id, { schedulePaused: true });
+			expect(paused?.schedulePaused).toBe(true);
+
+			const resumed = repo.updateGoal(goal.id, { schedulePaused: false });
+			expect(resumed?.schedulePaused).toBe(false);
+		});
+	});
+
+	describe('listGoals includes V2 fields', () => {
+		it('should return V2 fields in list results', () => {
+			repo.createGoal({
+				roomId,
+				title: 'Recurring',
+				missionType: 'recurring',
+				schedule: { expression: '0 9 * * *', timezone: 'UTC' },
+			});
+
+			const goals = repo.listGoals(roomId);
+			expect(goals).toHaveLength(1);
+			expect(goals[0].missionType).toBe('recurring');
+			expect(goals[0].schedule?.expression).toBe('0 9 * * *');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -51,7 +51,8 @@ describe('Room Agent Tools', () => {
 				structured_metrics TEXT,
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
-				consecutive_failures INTEGER NOT NULL DEFAULT 0
+				consecutive_failures INTEGER NOT NULL DEFAULT 0,
+		replan_count INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -130,7 +130,8 @@ const DB_SCHEMA = `
 		structured_metrics TEXT,
 		max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 		max_planning_attempts INTEGER NOT NULL DEFAULT 5,
-		consecutive_failures INTEGER NOT NULL DEFAULT 0
+		consecutive_failures INTEGER NOT NULL DEFAULT 0,
+		replan_count INTEGER NOT NULL DEFAULT 0
 	);
 	CREATE TABLE tasks (
 		id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -112,7 +112,8 @@ describe('Runtime Recovery', () => {
 				structured_metrics TEXT,
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
-				consecutive_failures INTEGER NOT NULL DEFAULT 0
+				consecutive_failures INTEGER NOT NULL DEFAULT 0,
+		replan_count INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -201,7 +201,8 @@ describe('TaskGroupManager', () => {
 				structured_metrics TEXT,
 				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
 				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
-				consecutive_failures INTEGER NOT NULL DEFAULT 0
+				consecutive_failures INTEGER NOT NULL DEFAULT 0,
+		replan_count INTEGER NOT NULL DEFAULT 0
 			);
 			CREATE TABLE tasks (
 				id TEXT PRIMARY KEY, room_id TEXT NOT NULL, title TEXT NOT NULL,

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -191,6 +191,8 @@ export interface RoomGoal {
 	maxPlanningAttempts?: number;
 	/** Current count of consecutive failures */
 	consecutiveFailures?: number;
+	/** Lifetime replan counter (distinct from per-execution planning_attempts) */
+	replanCount?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `MissionType`, `AutonomyLevel`, `MissionMetric`, `MetricHistoryEntry`, `CronSchedule`, `MissionExecutionStatus`, `MissionExecution` types to `packages/shared/src/types/neo.ts`
- Add `type Mission = RoomGoal` alias and export from shared
- Extend `RoomGoal` with all optional V2 fields: `missionType`, `autonomyLevel`, `structuredMetrics`, `schedule`, `schedulePaused`, `nextRunAt`, `maxConsecutiveFailures`, `maxPlanningAttempts`, `consecutiveFailures`, `replanCount`
- Update `CreateGoalParams` and `UpdateGoalParams` in `goal-repository.ts` to accept the new V2 fields

## Test plan

- [x] `bun run typecheck` passes with zero new errors
- [x] All new types exported from `@neokai/shared` via `packages/shared/src/mod.ts` (already re-exports `./types/neo.ts`)
- [x] Existing code that creates/reads `RoomGoal` objects compiles without changes (all new fields are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)