### PR TITLE
feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -593,9 +593,10 @@ export class AgentSession
 	// ============================================================================
 
 	async handleModelSwitch(
-		newModel: string
+		newModel: string,
+		newProvider?: string
 	): Promise<{ success: boolean; model: string; error?: string }> {
-		return this.modelSwitchHandler.switchModel(newModel);
+		return this.modelSwitchHandler.switchModel(newModel, newProvider);
 	}
 
 	getCurrentModel(): CurrentModelInfo {

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -151,10 +151,10 @@ export class ModelSwitchHandler {
 			// Use provider from model info to correctly handle shared canonical IDs
 			// (e.g., 'claude-sonnet-4.6' is owned by both Anthropic and anthropic-copilot).
 			// detectProvider() would otherwise return Anthropic for 'claude-sonnet-4.6'.
-			const newProviderInstance = modelInfo?.provider
-				? (providerRegistry.get(modelInfo.provider) ??
-					providerRegistry.detectProvider(resolvedModel))
-				: providerRegistry.detectProvider(resolvedModel);
+			const newProviderInstance = providerRegistry.detectProviderForModel(
+				resolvedModel,
+				modelInfo?.provider
+			);
 
 			if (!queryObject || !transportReady) {
 				// Query not started yet OR transport not ready - just update config

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -17,13 +17,7 @@
  */
 
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
-import type {
-	Provider,
-	Session,
-	SessionConfig,
-	CurrentModelInfo,
-	MessageHub,
-} from '@neokai/shared';
+import type { Provider, Session, SessionConfig, CurrentModelInfo, MessageHub } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ErrorManager } from '../error-manager';
@@ -151,30 +145,44 @@ export class ModelSwitchHandler {
 			const transportReady = firstMessageReceived;
 
 			// Resolve the target provider — deterministic when caller supplies newProvider.
-			// Fall back to model metadata or heuristic detection only for legacy paths.
+			// modelInfo?.provider is a secondary source (model registry metadata).
+			// detectProvider is a last-resort deprecated heuristic for callers that pre-date
+			// explicit routing (e.g. CLI, old integration tests). Log a warning so these
+			// paths are visible in production.
 			const providerRegistry = getProviderRegistry();
 			const targetProviderId = newProvider ?? modelInfo?.provider;
-			const newProviderInstance = targetProviderId
-				? providerRegistry.detectProviderForModel(resolvedModel, targetProviderId)
-				: providerRegistry.detectProvider(resolvedModel);
+			let newProviderInstance: ReturnType<typeof providerRegistry.detectProvider>;
+			if (targetProviderId) {
+				newProviderInstance = providerRegistry.detectProviderForModel(
+					resolvedModel,
+					targetProviderId
+				);
+			} else {
+				logger.warn(
+					`[model-switch] No provider supplied for model '${resolvedModel}' — ` +
+						'falling back to heuristic detection. Update callers to pass an explicit providerId.'
+				);
+				newProviderInstance = providerRegistry.detectProvider(resolvedModel);
+			}
+
+			if (!newProviderInstance) {
+				const errMsg = `Cannot switch to model '${resolvedModel}': provider '${targetProviderId ?? '(unknown)'}' is not registered.`;
+				logger.error(errMsg);
+				return { success: false, model: session.config.model, error: errMsg };
+			}
 
 			if (!queryObject || !transportReady) {
 				// Query not started yet OR transport not ready - just update config
 				session.config.model = resolvedModel;
-				// Keep provider aligned with model for pre-query switches too.
-				// Without this, a stale explicit provider can force wrong model routing.
-				if (newProviderInstance?.id) {
-					session.config.provider = newProviderInstance.id as Provider;
-				}
+				// newProviderInstance is guaranteed non-null here (we returned early above).
+				session.config.provider = newProviderInstance.id as Provider;
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
 					config: {
 						model: resolvedModel,
-						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as Provider,
-						}),
+						provider: newProviderInstance.id as Provider,
 					} as SessionConfig,
 				});
 
@@ -195,20 +203,15 @@ export class ModelSwitchHandler {
 
 				// Update session config first (will be used when query restarts)
 				session.config.model = resolvedModel;
-				// Keep provider aligned with model (same as the pre-query branch —
-				// unconditionally update so same-provider switches don’t leave stale state).
-				if (newProviderInstance?.id) {
-					session.config.provider = newProviderInstance.id as Provider;
-				}
+				// newProviderInstance is guaranteed non-null here (we returned early above).
+				session.config.provider = newProviderInstance.id as Provider;
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
 					config: {
 						model: resolvedModel,
-						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as Provider,
-						}),
+						provider: newProviderInstance.id as Provider,
 					} as SessionConfig,
 				});
 

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -81,13 +81,17 @@ export class ModelSwitchHandler {
 	}
 
 	/**
-	 * Switch to a different model mid-session
+	 * Switch to a different model mid-session.
 	 *
 	 * Always restarts the query to ensure SDK emits a fresh system:init message
 	 * with the correct model. This is necessary because SDK's setModel() doesn't
 	 * update the cached system:init, causing stale model info in the UI.
+	 *
+	 * @param newModel - Target model ID or alias
+	 * @param newProvider - Explicit provider ID. When provided, routing is deterministic.
+	 *   If omitted, the provider is inferred from the model's metadata (legacy path).
 	 */
-	async switchModel(newModel: string): Promise<ModelSwitchResult> {
+	async switchModel(newModel: string, newProvider?: string): Promise<ModelSwitchResult> {
 		const {
 			session,
 			db,
@@ -146,15 +150,13 @@ export class ModelSwitchHandler {
 			// Check if query is running AND ProcessTransport is ready
 			const transportReady = firstMessageReceived;
 
-			// Detect new provider instance to keep provider config aligned with the model
+			// Resolve the target provider — deterministic when caller supplies newProvider.
+			// Fall back to model metadata or heuristic detection only for legacy paths.
 			const providerRegistry = getProviderRegistry();
-			// Use provider from model info to correctly handle shared canonical IDs
-			// (e.g., 'claude-sonnet-4.6' is owned by both Anthropic and anthropic-copilot).
-			// detectProvider() would otherwise return Anthropic for 'claude-sonnet-4.6'.
-			const newProviderInstance = providerRegistry.detectProviderForModel(
-				resolvedModel,
-				modelInfo?.provider
-			);
+			const targetProviderId = newProvider ?? modelInfo?.provider;
+			const newProviderInstance = targetProviderId
+				? providerRegistry.detectProviderForModel(resolvedModel, targetProviderId)
+				: providerRegistry.detectProvider(resolvedModel);
 
 			if (!queryObject || !transportReady) {
 				// Query not started yet OR transport not ready - just update config

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -17,7 +17,13 @@
  */
 
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
-import type { Provider, Session, SessionConfig, CurrentModelInfo, MessageHub } from '@neokai/shared';
+import type {
+	Provider,
+	Session,
+	SessionConfig,
+	CurrentModelInfo,
+	MessageHub,
+} from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ErrorManager } from '../error-manager';

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -124,11 +124,13 @@ export class QueryRunner {
 			const { initializeProviders } = await import('../providers/factory.js');
 			const providerRegistry = initializeProviders();
 			const modelId = session.config.model || 'sonnet';
-			// Check explicit provider first (stored during session creation when model alias is resolved).
-			// This is critical when canonical model IDs are shared across providers
-			// (e.g., claude-sonnet-4.6), which would be misrouted if we only used detectProvider().
+			// Routing is deterministic: session.config.provider is always set by the model
+			// picker and stored on every model switch. Legacy sessions without a stored
+			// provider fall back to heuristic detection (@deprecated path).
 			const explicitProviderId = session.config.provider as string | undefined;
-			const provider = providerRegistry.detectProviderForModel(modelId, explicitProviderId);
+			const provider = explicitProviderId
+				? providerRegistry.detectProviderForModel(modelId, explicitProviderId)
+				: providerRegistry.detectProvider(modelId);
 
 			// Check if the provider supports getAuthStatus (OAuth-style providers)
 			if (provider?.getAuthStatus) {
@@ -191,10 +193,9 @@ export class QueryRunner {
 			{
 				const { getProviderService } = await import('../provider-service');
 				const providerService = getProviderService();
-				// Pass explicitProviderId so providers whose model IDs are also claimed by
-				// Anthropic (e.g. AnthropicToCopilotBridgeProvider uses claude-opus-4.6) are not
-				// incorrectly routed to Anthropic by detectProvider().
-				const originalEnvVars = providerService.applyEnvVarsToProcess(modelId, explicitProviderId);
+				// Use the resolved provider ID (falls back to 'anthropic' for legacy sessions)
+				const resolvedProviderId = explicitProviderId ?? provider?.id ?? 'anthropic';
+				const originalEnvVars = providerService.applyEnvVarsToProcess(modelId, resolvedProviderId);
 				this.ctx.originalEnvVars = originalEnvVars;
 			}
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -128,9 +128,7 @@ export class QueryRunner {
 			// This is critical when canonical model IDs are shared across providers
 			// (e.g., claude-sonnet-4.6), which would be misrouted if we only used detectProvider().
 			const explicitProviderId = session.config.provider as string | undefined;
-			const provider = explicitProviderId
-				? (providerRegistry.get(explicitProviderId) ?? providerRegistry.detectProvider(modelId))
-				: providerRegistry.detectProvider(modelId);
+			const provider = providerRegistry.detectProviderForModel(modelId, explicitProviderId);
 
 			// Check if the provider supports getAuthStatus (OAuth-style providers)
 			if (provider?.getAuthStatus) {

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -334,9 +334,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Detect if a model ID belongs to GLM provider
+	 * Detect if a model ID belongs to GLM provider.
 	 *
-	 * Delegates to registry.detectProvider()
+	 * @deprecated Use explicit `providerId` comparison instead. GLM model IDs are currently
+	 *   unique (no collision), but prefer routing by provider ID for consistency.
 	 */
 	isGlmModel(modelId: string): boolean {
 		const registry = this.getRegistry();
@@ -345,9 +346,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Detect provider from model ID
+	 * Detect provider from model ID alone.
 	 *
-	 * Delegates to registry.detectProvider()
+	 * @deprecated Use `detectProviderForModel(modelId, providerId)` with an explicit provider ID.
+	 *   This method is ambiguous when multiple providers claim the same model ID.
 	 */
 	detectProviderFromModel(modelId: string): Provider {
 		const registry = this.getRegistry();
@@ -356,9 +358,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Translate a model ID to an SDK-recognized model ID
+	 * Translate a model ID to an SDK-recognized model ID.
 	 *
-	 * Delegates to provider.translateModelIdForSdk()
+	 * @deprecated Pass explicit `providerId` to resolve which provider's translation to apply.
+	 *   Delegates to provider.translateModelIdForSdk()
 	 */
 	translateModelIdForSdk(modelId: string): string {
 		const registry = this.getRegistry();
@@ -373,16 +376,15 @@ export class ProviderService {
 	}
 
 	/**
-	 * Get environment variables for SDK subprocess based on model ID
+	 * Get environment variables for SDK subprocess based on explicit (modelId, providerId) pair.
 	 *
-	 * Delegates to provider.buildSdkConfig()
+	 * Both the model ID and provider ID must be known at the call site. Use
+	 * `getProviderEnvVars(session)` when you have a full session object.
 	 *
-	 * @param modelId - The model ID to get env vars for
-	 * @param providerId - When supplied, look up provider by ID instead of auto-detecting from
-	 *   modelId. Required when model IDs are shared across providers (e.g. claude-opus-4.6 is
-	 *   claimed by both Anthropic and AnthropicCopilot).
+	 * @param modelId - The model ID (used for SDK config building)
+	 * @param providerId - The provider ID — must be explicit; routing is deterministic
 	 */
-	getEnvVarsForModel(modelId: string, providerId?: string): ProviderEnvVars {
+	getEnvVarsForModel(modelId: string, providerId: string): ProviderEnvVars {
 		const registry = this.getRegistry();
 		const provider = registry.detectProviderForModel(modelId, providerId);
 
@@ -445,19 +447,18 @@ export class ProviderService {
 	}
 
 	/**
-	 * Apply provider environment variables to process.env
+	 * Apply provider environment variables to process.env.
 	 *
 	 * IMPORTANT: These must be set in the parent process before SDK query creation.
 	 * The SDK subprocess inherits these environment variables when spawned.
 	 *
 	 * This method saves the original values and returns them for restoration.
 	 *
-	 * @param modelId - The model ID to get env vars for
-	 * @param providerId - When supplied, look up provider by ID instead of auto-detecting from
-	 *   modelId. Required when model IDs are shared across providers.
+	 * @param modelId - The model ID (used for SDK config building)
+	 * @param providerId - The provider ID — must be explicit; routing is deterministic
 	 * @returns Original env vars that should be restored after SDK query
 	 */
-	applyEnvVarsToProcess(modelId: string, providerId?: string): OriginalEnvVars {
+	applyEnvVarsToProcess(modelId: string, providerId: string): OriginalEnvVars {
 		const envVars = this.getEnvVarsForModel(modelId, providerId);
 
 		// For Anthropic (or any non-overriding provider), explicitly clear routing

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -384,9 +384,7 @@ export class ProviderService {
 	 */
 	getEnvVarsForModel(modelId: string, providerId?: string): ProviderEnvVars {
 		const registry = this.getRegistry();
-		const provider = providerId
-			? (registry.get(providerId) ?? registry.detectProvider(modelId))
-			: registry.detectProvider(modelId);
+		const provider = registry.detectProviderForModel(modelId, providerId);
 
 		if (!provider || provider.id === 'anthropic') {
 			// When Dev Proxy is enabled, route Anthropic API calls through the proxy

--- a/packages/daemon/src/lib/providers/context-manager.ts
+++ b/packages/daemon/src/lib/providers/context-manager.ts
@@ -100,7 +100,7 @@ export class ProviderContextManager {
 	 * Resolve the provider for a session
 	 */
 	private resolveProvider(session: Session): Provider {
-		// 1. Try explicit provider first
+		// 1. Prefer explicit provider stored in session config (always set for new sessions)
 		if (session.config.provider) {
 			const provider = this.registry.get(session.config.provider);
 			if (provider) {
@@ -108,7 +108,8 @@ export class ProviderContextManager {
 			}
 		}
 
-		// 2. Detect provider from model ID
+		// 2. Legacy fallback: detect from model ID for old sessions that pre-date explicit routing.
+		// @deprecated — new sessions always store session.config.provider.
 		const modelId = session.config.model || 'default';
 		const detected = this.registry.detectProvider(modelId);
 		if (detected) {
@@ -125,21 +126,24 @@ export class ProviderContextManager {
 	}
 
 	/**
-	 * Check if a model switch requires a query restart
+	 * Check if a model switch requires a query restart.
 	 *
 	 * Cross-provider switches require restart because the SDK subprocess
 	 * needs different environment variables.
+	 *
+	 * @param session - Current session (used to resolve the current provider)
+	 * @param newModelId - Target model ID (informational)
+	 * @param newProviderId - Target provider ID (explicit — must be known by the caller)
 	 */
-	requiresQueryRestart(session: Session, newModelId: string): boolean {
+	requiresQueryRestart(session: Session, newModelId: string, newProviderId: string): boolean {
 		const currentProvider = this.resolveProvider(session);
-		const newProvider = this.registry.detectProvider(newModelId);
+		const newProvider = this.registry.get(newProviderId);
 
-		// If we can't detect the new provider, assume it's different
+		// If the new provider is unknown, assume a different one — safer to restart
 		if (!newProvider) {
 			return true;
 		}
 
-		// Restart if providers are different
 		return currentProvider.id !== newProvider.id;
 	}
 
@@ -151,7 +155,8 @@ export class ProviderContextManager {
 	}
 
 	/**
-	 * Detect provider from model ID
+	 * @deprecated Use `getProvider(providerId)` or `registry.detectProviderForModel(modelId, providerId)`.
+	 *   Heuristic model-ID-only detection is ambiguous when providers share model IDs.
 	 */
 	detectProvider(modelId: string): Provider | undefined {
 		return this.registry.detectProvider(modelId);

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -80,8 +80,10 @@ export class ProviderRegistry {
 	 * Detect provider for a model ID, optionally preferring a specific provider.
 	 *
 	 * Iterates ALL registered providers to collect every match, then:
-	 * - If `preferredProviderId` is given and it's in the match set, returns it.
-	 * - If multiple providers claim the model, logs a collision warning.
+	 * - If `preferredProviderId` is given and it's in the match set, returns it without warning
+	 *   (the caller has already resolved the ambiguity).
+	 * - If multiple providers claim the model and no preference resolves the collision, logs a
+	 *   warning listing all colliding provider IDs, then returns the first registered match.
 	 * - Returns the first match (preserving registration order for backwards compatibility).
 	 *
 	 * Returns undefined if no provider claims the model.
@@ -93,19 +95,20 @@ export class ProviderRegistry {
 			return undefined;
 		}
 
-		if (matches.length > 1) {
-			const ids = matches.map((p) => p.id).join(', ');
-			const resolvedId = preferredProviderId
-				? (matches.find((p) => p.id === preferredProviderId)?.id ?? matches[0].id)
-				: matches[0].id;
-			log.warn(`Model '${modelId}' claimed by multiple providers: ${ids}. Using ${resolvedId}.`);
-		}
-
+		// If the caller expressed a preference, try to honour it.
+		// When the preferred provider is in the match set the collision is resolved
+		// unambiguously — no warning needed.
 		if (preferredProviderId) {
 			const preferred = matches.find((p) => p.id === preferredProviderId);
 			if (preferred) {
 				return preferred;
 			}
+		}
+
+		// Multiple providers claim the model and the preference (if any) didn't resolve it.
+		if (matches.length > 1) {
+			const ids = matches.map((p) => p.id).join(', ');
+			log.warn(`Model '${modelId}' claimed by multiple providers: ${ids}. Using ${matches[0].id}.`);
 		}
 
 		return matches[0];

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -77,51 +77,37 @@ export class ProviderRegistry {
 	}
 
 	/**
-	 * Detect provider for a model ID, optionally preferring a specific provider.
+	 * Resolve provider by explicit (modelId, providerId) pair — fully deterministic.
 	 *
-	 * Iterates ALL registered providers to collect every match, then:
-	 * - If `preferredProviderId` is given and it's in the match set, returns it without warning
-	 *   (the caller has already resolved the ambiguity).
-	 * - If multiple providers claim the model and no preference resolves the collision, logs a
-	 *   warning listing all colliding provider IDs, then returns the first registered match.
-	 * - Returns the first match (preserving registration order for backwards compatibility).
+	 * Both the model ID and provider ID must be known at the call site. This is the
+	 * preferred routing method: when the UI selects a model it always has the associated
+	 * provider ID, so there is never any ambiguity.
 	 *
-	 * Returns undefined if no provider claims the model.
+	 * Logs an error and returns `undefined` if the provider is not registered.
 	 */
-	detectProviderForModel(modelId: string, preferredProviderId?: string): Provider | undefined {
-		const matches = this.getAll().filter((p) => p.ownsModel(modelId));
-
-		if (matches.length === 0) {
-			return undefined;
+	detectProviderForModel(modelId: string, providerId: string): Provider | undefined {
+		const provider = this.providers.get(providerId);
+		if (!provider) {
+			log.error(`[routing] Unknown provider '${providerId}' for model '${modelId}'`);
 		}
-
-		// If the caller expressed a preference, try to honour it.
-		// When the preferred provider is in the match set the collision is resolved
-		// unambiguously — no warning needed.
-		if (preferredProviderId) {
-			const preferred = matches.find((p) => p.id === preferredProviderId);
-			if (preferred) {
-				return preferred;
-			}
-		}
-
-		// Multiple providers claim the model and the preference (if any) didn't resolve it.
-		if (matches.length > 1) {
-			const ids = matches.map((p) => p.id).join(', ');
-			log.warn(`Model '${modelId}' claimed by multiple providers: ${ids}. Using ${matches[0].id}.`);
-		}
-
-		return matches[0];
+		return provider;
 	}
 
 	/**
-	 * Detect provider from model ID
-	 * Asks each provider if it owns the model
+	 * Heuristic provider detection from model ID alone.
 	 *
-	 * Returns undefined if no provider claims the model
+	 * @deprecated Use `detectProviderForModel(modelId, providerId)` with an explicit provider ID.
+	 *   This method is ambiguous when multiple providers claim the same model ID
+	 *   (e.g. 'claude-sonnet-4.6' is owned by both Anthropic and anthropic-copilot).
+	 *   It is retained only for legacy paths (e.g. old sessions without a stored provider).
 	 */
 	detectProvider(modelId: string): Provider | undefined {
-		return this.detectProviderForModel(modelId);
+		for (const provider of this.getAll()) {
+			if (provider.ownsModel(modelId)) {
+				return provider;
+			}
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -10,7 +10,10 @@
  * - Provider auto-detection from model IDs
  */
 
+import { createLogger } from '@neokai/shared/logger';
 import type { Provider, ProviderId, ProviderInfo } from '@neokai/shared/provider';
+
+const log = createLogger('kai:providers:registry');
 
 /**
  * Provider Registry class
@@ -74,18 +77,48 @@ export class ProviderRegistry {
 	}
 
 	/**
+	 * Detect provider for a model ID, optionally preferring a specific provider.
+	 *
+	 * Iterates ALL registered providers to collect every match, then:
+	 * - If `preferredProviderId` is given and it's in the match set, returns it.
+	 * - If multiple providers claim the model, logs a collision warning.
+	 * - Returns the first match (preserving registration order for backwards compatibility).
+	 *
+	 * Returns undefined if no provider claims the model.
+	 */
+	detectProviderForModel(modelId: string, preferredProviderId?: string): Provider | undefined {
+		const matches = this.getAll().filter((p) => p.ownsModel(modelId));
+
+		if (matches.length === 0) {
+			return undefined;
+		}
+
+		if (matches.length > 1) {
+			const ids = matches.map((p) => p.id).join(', ');
+			const resolvedId = preferredProviderId
+				? (matches.find((p) => p.id === preferredProviderId)?.id ?? matches[0].id)
+				: matches[0].id;
+			log.warn(`Model '${modelId}' claimed by multiple providers: ${ids}. Using ${resolvedId}.`);
+		}
+
+		if (preferredProviderId) {
+			const preferred = matches.find((p) => p.id === preferredProviderId);
+			if (preferred) {
+				return preferred;
+			}
+		}
+
+		return matches[0];
+	}
+
+	/**
 	 * Detect provider from model ID
 	 * Asks each provider if it owns the model
 	 *
 	 * Returns undefined if no provider claims the model
 	 */
 	detectProvider(modelId: string): Provider | undefined {
-		for (const provider of this.getAll()) {
-			if (provider.ownsModel(modelId)) {
-				return provider;
-			}
-		}
-		return undefined;
+		return this.detectProviderForModel(modelId);
 	}
 
 	/**

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -371,9 +371,15 @@ export function setupSessionHandlers(
 	// Handle model switching
 	// Returns synchronous result for test compatibility and immediate feedback
 	messageHub.onRequest('session.model.switch', async (data) => {
-		const { sessionId: targetSessionId, model } = data as {
+		const {
+			sessionId: targetSessionId,
+			model,
+			provider,
+		} = data as {
 			sessionId: string;
 			model: string;
+			/** Explicit provider ID — always supply this from the UI model picker. */
+			provider?: string;
 		};
 
 		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
@@ -382,7 +388,7 @@ export function setupSessionHandlers(
 		}
 
 		// Call handleModelSwitch directly - returns {success, model, error}
-		const result = await agentSession.handleModelSwitch(model);
+		const result = await agentSession.handleModelSwitch(model, provider);
 
 		// Broadcast model switch result via state channels for UI updates
 		if (result.success) {

--- a/packages/daemon/tests/online/glm/model-switching.test.ts
+++ b/packages/daemon/tests/online/glm/model-switching.test.ts
@@ -55,6 +55,7 @@ describe('GLM Model Switching', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			})) as { success: boolean; model: string; error?: string };
 
 			expect(result.success).toBe(true);
@@ -98,6 +99,7 @@ describe('GLM Model Switching', () => {
 			await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			});
 
 			// Get state after switch
@@ -142,12 +144,19 @@ describe('GLM Model Switching', () => {
 			daemon.trackSession(sessionId);
 
 			// Perform rapid switches between Claude and GLM
-			const switches = ['glm-5', 'haiku', 'glm-5', 'sonnet', 'glm-5'];
+			const switches: Array<{ model: string; provider: string }> = [
+				{ model: 'glm-5', provider: 'glm' },
+				{ model: 'haiku', provider: 'anthropic' },
+				{ model: 'glm-5', provider: 'glm' },
+				{ model: 'sonnet', provider: 'anthropic' },
+				{ model: 'glm-5', provider: 'glm' },
+			];
 
-			for (const model of switches) {
+			for (const { model, provider } of switches) {
 				const result = (await daemon.messageHub.request('session.model.switch', {
 					sessionId,
 					model,
+					provider,
 				})) as { success: boolean };
 				expect(result.success).toBe(true);
 			}
@@ -176,6 +185,7 @@ describe('GLM Model Switching', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			})) as { success: boolean; model: string };
 
 			expect(result.success).toBe(true);

--- a/packages/daemon/tests/online/rpc/rpc-model-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-model-handlers.test.ts
@@ -78,6 +78,7 @@ describe('Model RPC Handlers', () => {
 				daemon.messageHub.request('session.model.switch', {
 					sessionId: 'non-existent',
 					model: 'claude-opus-4-20250514',
+					provider: 'anthropic',
 				})
 			).rejects.toThrow();
 		});
@@ -88,6 +89,7 @@ describe('Model RPC Handlers', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'invalid-model-name',
+				provider: 'anthropic',
 			})) as { success: boolean; error?: string };
 
 			expect(result.success).toBe(false);
@@ -104,6 +106,7 @@ describe('Model RPC Handlers', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: currentModel,
+				provider: 'anthropic',
 			})) as { success: boolean; model: string };
 
 			expect(result.success).toBe(true);

--- a/packages/daemon/tests/online/rpc/rpc-model-switching.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-model-switching.test.ts
@@ -80,6 +80,7 @@ describe('Model Switching', () => {
 				daemon.messageHub.request('session.model.switch', {
 					sessionId: 'non-existent-session',
 					model: 'sonnet',
+					provider: 'anthropic',
 				})
 			).rejects.toThrow();
 		});

--- a/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
@@ -149,6 +149,7 @@ describe('Session RPC Handlers - Extended', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'haiku',
+				provider: 'anthropic',
 			})) as { success: boolean };
 
 			expect(result.success).toBe(true);
@@ -166,6 +167,7 @@ describe('Session RPC Handlers - Extended', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'invalid-model-id',
+				provider: 'anthropic',
 			})) as { success: boolean; error?: string };
 
 			expect(result.success).toBe(false);

--- a/packages/daemon/tests/unit/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/agent/agent-session.test.ts
@@ -536,9 +536,9 @@ describe('AgentSession', () => {
 				switchModel: switchModelSpy,
 			};
 
-			const result = await agentSession.handleModelSwitch('claude-opus-4-20250514');
+			const result = await agentSession.handleModelSwitch('claude-opus-4-20250514', 'anthropic');
 
-			expect(switchModelSpy).toHaveBeenCalledWith('claude-opus-4-20250514');
+			expect(switchModelSpy).toHaveBeenCalledWith('claude-opus-4-20250514', 'anthropic');
 			expect(result).toEqual(mockResult);
 		});
 

--- a/packages/daemon/tests/unit/core/provider-service.test.ts
+++ b/packages/daemon/tests/unit/core/provider-service.test.ts
@@ -508,12 +508,12 @@ describe('ProviderService', () => {
 
 	describe('getEnvVarsForModel', () => {
 		it('should return empty object for anthropic model', () => {
-			const envVars = service.getEnvVarsForModel('claude-3-opus');
+			const envVars = service.getEnvVarsForModel('claude-3-opus', 'anthropic');
 			expect(envVars).toEqual({});
 		});
 
 		it('should return env vars for GLM model', () => {
-			const envVars = service.getEnvVarsForModel('glm-4');
+			const envVars = service.getEnvVarsForModel('glm-4', 'glm');
 
 			expect(envVars.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 			expect(envVars.API_TIMEOUT_MS).toBe('120000');
@@ -669,7 +669,7 @@ describe('ProviderService', () => {
 
 	describe('applyEnvVarsToProcess', () => {
 		it('should return empty object for anthropic model', () => {
-			const original = service.applyEnvVarsToProcess('claude-3-opus');
+			const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 			expect(original).toEqual({});
 		});
 
@@ -678,7 +678,7 @@ describe('ProviderService', () => {
 			process.env.API_TIMEOUT_MS = '120000';
 			process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'glm-4';
 
-			const original = service.applyEnvVarsToProcess('claude-3-opus');
+			const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
 			expect(original.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 			expect(original.API_TIMEOUT_MS).toBe('120000');
@@ -692,7 +692,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_AUTH_TOKEN = 'original-token';
 			process.env.ANTHROPIC_BASE_URL = 'original-url';
 
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Check original values were saved
 			expect(original.ANTHROPIC_AUTH_TOKEN).toBe('original-token');
@@ -725,14 +725,14 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
 
 			// Apply GLM env vars
-			const originalFromGlm = service.applyEnvVarsToProcess('glm-4');
+			const originalFromGlm = service.applyEnvVarsToProcess('glm-4', 'glm');
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 
 			// Restore from GLM query
 			service.restoreEnvVars(originalFromGlm);
 
 			// Switch to anthropic - leaked GLM URL should be cleared
-			const originalFromAnthropic = service.applyEnvVarsToProcess('claude-3-opus');
+			const originalFromAnthropic = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
 			// The leaked GLM URL should be cleared
 			expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
@@ -776,7 +776,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_BASE_URL = 'original-url';
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Verify env vars changed
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -795,7 +795,7 @@ describe('ProviderService', () => {
 			delete process.env.ANTHROPIC_BASE_URL;
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Verify env vars were set
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -838,7 +838,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'opus-model';
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Restore
 			service.restoreEnvVars(original);

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -541,87 +541,49 @@ describe('ProviderContextManager', () => {
 	});
 
 	describe('requiresQueryRestart', () => {
-		it('should return true for cross-provider switch', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
+		const anthropicSession: Session = {
+			id: 'test-session',
+			title: 'Test',
+			workspacePath: '/test',
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'active',
+			config: {
+				model: 'claude-3-opus',
+				maxTokens: 8192,
+				temperature: 1.0,
+				provider: 'anthropic',
+			},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+			},
+		};
 
-			const requires = manager.requiresQueryRestart(session, 'glm-4');
+		it('should return true for cross-provider switch', () => {
+			const requires = manager.requiresQueryRestart(anthropicSession, 'glm-4', 'glm');
 			expect(requires).toBe(true);
 		});
 
 		it('should return false for same-provider switch', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
-
-			const requires = manager.requiresQueryRestart(session, 'claude-3-sonnet');
+			const requires = manager.requiresQueryRestart(
+				anthropicSession,
+				'claude-3-sonnet',
+				'anthropic'
+			);
 			expect(requires).toBe(false);
 		});
 
-		it('should return true when new provider cannot be detected', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
-
-			const requires = manager.requiresQueryRestart(session, 'unknown-model-xyz');
+		it('should return true when the new provider is not registered', () => {
+			const requires = manager.requiresQueryRestart(
+				anthropicSession,
+				'unknown-model-xyz',
+				'unknown-provider-xyz'
+			);
 			expect(requires).toBe(true);
 		});
 	});
@@ -639,7 +601,7 @@ describe('ProviderContextManager', () => {
 		});
 	});
 
-	describe('detectProvider', () => {
+	describe('detectProvider (deprecated legacy heuristic)', () => {
 		it('should detect provider from model ID', () => {
 			const provider = manager.detectProvider('claude-3-opus');
 			expect(provider?.id).toBe('anthropic');

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -2,8 +2,9 @@
  * Unit tests for Provider Registry
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { ModelInfo } from '@neokai/shared';
+import { Logger } from '@neokai/shared/logger';
 import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
 import { resetProviderFactory } from '../../../src/lib/providers/factory';
 import { ProviderRegistry, resetProviderRegistry } from '../../../src/lib/providers/registry';
@@ -59,6 +60,37 @@ class MockProvider implements Provider {
 			isAnthropicCompatible: true,
 		};
 	}
+}
+
+// Provider subclass factories for collision tests
+function makeAnthropicProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic' as const;
+		readonly displayName = 'Anthropic';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('claude-');
+		}
+	})();
+}
+
+function makeAnthropicCopilotProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic-copilot' as const;
+		readonly displayName = 'Anthropic Copilot';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('claude-');
+		}
+	})();
+}
+
+function makeAnthropicCodexProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic-codex' as const;
+		readonly displayName = 'Anthropic Codex';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('gpt-') || modelId.startsWith('claude-');
+		}
+	})();
 }
 
 describe('ProviderRegistry', () => {
@@ -205,6 +237,85 @@ describe('ProviderRegistry', () => {
 
 		it('should return undefined when no providers registered', () => {
 			expect(registry.detectProvider('any-model')).toBeUndefined();
+		});
+
+		it('should return the same result as before (backwards compatible) when multiple providers claim a model', () => {
+			// Register anthropic first — it should be the first match
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProvider('claude-opus-4.6');
+			expect(result?.id).toBe('anthropic');
+		});
+	});
+
+	describe('detectProviderForModel', () => {
+		it('should return preferred provider when it claims the model', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
+			expect(result?.id).toBe('anthropic-copilot');
+		});
+
+		it('should return first registered provider and log collision when no preference and multiple matches', () => {
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
+
+			try {
+				registry.register(makeAnthropicProvider());
+				registry.register(makeAnthropicCopilotProvider());
+
+				const result = registry.detectProviderForModel('claude-opus-4.6');
+				expect(result?.id).toBe('anthropic');
+
+				// Warn should have been called once with collision info
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+				const warnArg = warnSpy.mock.calls[0][0] as string;
+				expect(warnArg).toContain('anthropic');
+				expect(warnArg).toContain('anthropic-copilot');
+				expect(warnArg).toContain('claude-opus-4.6');
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it('should return codex provider when preferred and model starts with gpt-', () => {
+			// anthropic-codex owns both claude- and gpt- models; register anthropic first
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCodexProvider());
+
+			const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
+			expect(result?.id).toBe('anthropic-codex');
+		});
+
+		it('should return undefined when no provider claims the model', () => {
+			registry.register(makeAnthropicProvider());
+
+			expect(registry.detectProviderForModel('unknown-xyz-model')).toBeUndefined();
+		});
+
+		it('should return single match without logging collision', () => {
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
+
+			try {
+				registry.register(makeAnthropicProvider());
+
+				const result = registry.detectProviderForModel('claude-opus-4.6');
+				expect(result?.id).toBe('anthropic');
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it('should fall back to first match when preferred provider does not claim the model', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			// 'anthropic-codex' is not registered but even if it were it doesn't own this model
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'nonexistent-provider');
+			// Falls back to first match
+			expect(result?.id).toBe('anthropic');
 		});
 	});
 

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -239,115 +239,67 @@ describe('ProviderRegistry', () => {
 			expect(registry.detectProvider('any-model')).toBeUndefined();
 		});
 
-		it('should return the same result as before (backwards compatible) when multiple providers claim a model', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
+		it('should return the first registered provider (legacy heuristic, no warning)', () => {
+			// detectProvider is deprecated — it does simple first-match, no collision warning
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
 
-			try {
-				// Register anthropic first — it should be the first match
-				registry.register(makeAnthropicProvider());
-				registry.register(makeAnthropicCopilotProvider());
-
-				const result = registry.detectProvider('claude-opus-4.6');
-				expect(result?.id).toBe('anthropic');
-				// Collision warning should fire (no preference was given)
-				expect(warnSpy).toHaveBeenCalledTimes(1);
-			} finally {
-				warnSpy.mockRestore();
-			}
+			const result = registry.detectProvider('claude-opus-4.6');
+			expect(result?.id).toBe('anthropic');
 		});
 	});
 
 	describe('detectProviderForModel', () => {
-		it('should return preferred provider when it claims the model without logging a warning', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
-
-			try {
-				registry.register(makeAnthropicProvider());
-				registry.register(makeAnthropicCopilotProvider());
-
-				const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
-				expect(result?.id).toBe('anthropic-copilot');
-				// Preference resolved the collision — no warning should be emitted
-				expect(warnSpy).not.toHaveBeenCalled();
-			} finally {
-				warnSpy.mockRestore();
-			}
-		});
-
-		it('should return first registered provider and log collision when no preference and multiple matches', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
-
-			try {
-				registry.register(makeAnthropicProvider());
-				registry.register(makeAnthropicCopilotProvider());
-
-				const result = registry.detectProviderForModel('claude-opus-4.6');
-				expect(result?.id).toBe('anthropic');
-
-				// Warn should have been called once with collision info
-				expect(warnSpy).toHaveBeenCalledTimes(1);
-				const warnArg = warnSpy.mock.calls[0][0] as string;
-				expect(warnArg).toContain('anthropic');
-				expect(warnArg).toContain('anthropic-copilot');
-				expect(warnArg).toContain('claude-opus-4.6');
-			} finally {
-				warnSpy.mockRestore();
-			}
-		});
-
-		it('should return codex provider when preferred and model starts with gpt-, no warning', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
-
-			try {
-				// anthropic-codex owns both claude- and gpt- models; only it owns gpt- here
-				registry.register(makeAnthropicCodexProvider());
-
-				const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
-				expect(result?.id).toBe('anthropic-codex');
-				expect(warnSpy).not.toHaveBeenCalled();
-			} finally {
-				warnSpy.mockRestore();
-			}
-		});
-
-		it('should return undefined when no provider claims the model', () => {
+		it('should return copilot provider when providerId is anthropic-copilot', () => {
 			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
 
-			expect(registry.detectProviderForModel('unknown-xyz-model')).toBeUndefined();
+			// Deterministic: explicit providerId → always the right provider regardless of model
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
+			expect(result?.id).toBe('anthropic-copilot');
 		});
 
-		it('should return single match without logging collision', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
+		it('should return anthropic provider when providerId is anthropic', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic');
+			expect(result?.id).toBe('anthropic');
+		});
+
+		it('should return codex provider for gpt- model when providerId is anthropic-codex', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCodexProvider());
+
+			const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
+			expect(result?.id).toBe('anthropic-codex');
+		});
+
+		it('should return undefined and log an error when providerId is not registered', () => {
+			const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(mock(() => {}));
 
 			try {
 				registry.register(makeAnthropicProvider());
 
-				const result = registry.detectProviderForModel('claude-opus-4.6');
-				expect(result?.id).toBe('anthropic');
-				expect(warnSpy).not.toHaveBeenCalled();
-			} finally {
-				warnSpy.mockRestore();
-			}
-		});
-
-		it('should fall back to first match and log collision when preference is not in match set', () => {
-			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
-
-			try {
-				registry.register(makeAnthropicProvider());
-				registry.register(makeAnthropicCopilotProvider());
-
-				// 'nonexistent-provider' is not in the match set — collision is unresolved
 				const result = registry.detectProviderForModel('claude-opus-4.6', 'nonexistent-provider');
-				// Falls back to first match
-				expect(result?.id).toBe('anthropic');
-				// Collision warning should have fired since preference couldn't resolve it
-				expect(warnSpy).toHaveBeenCalledTimes(1);
-				const warnArg = warnSpy.mock.calls[0][0] as string;
-				expect(warnArg).toContain('claude-opus-4.6');
+				expect(result).toBeUndefined();
+				// Error should be logged for the unknown provider
+				expect(errorSpy).toHaveBeenCalledTimes(1);
+				const errArg = errorSpy.mock.calls[0][0] as string;
+				expect(errArg).toContain('nonexistent-provider');
+				expect(errArg).toContain('claude-opus-4.6');
 			} finally {
-				warnSpy.mockRestore();
+				errorSpy.mockRestore();
 			}
+		});
+
+		it('detectProvider (deprecated) still returns first-registered match for legacy paths', () => {
+			// anthropic registered first — heuristic fallback returns it
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProvider('claude-opus-4.6');
+			expect(result?.id).toBe('anthropic');
 		});
 	});
 

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -240,22 +240,38 @@ describe('ProviderRegistry', () => {
 		});
 
 		it('should return the same result as before (backwards compatible) when multiple providers claim a model', () => {
-			// Register anthropic first — it should be the first match
-			registry.register(makeAnthropicProvider());
-			registry.register(makeAnthropicCopilotProvider());
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
 
-			const result = registry.detectProvider('claude-opus-4.6');
-			expect(result?.id).toBe('anthropic');
+			try {
+				// Register anthropic first — it should be the first match
+				registry.register(makeAnthropicProvider());
+				registry.register(makeAnthropicCopilotProvider());
+
+				const result = registry.detectProvider('claude-opus-4.6');
+				expect(result?.id).toBe('anthropic');
+				// Collision warning should fire (no preference was given)
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 	});
 
 	describe('detectProviderForModel', () => {
-		it('should return preferred provider when it claims the model', () => {
-			registry.register(makeAnthropicProvider());
-			registry.register(makeAnthropicCopilotProvider());
+		it('should return preferred provider when it claims the model without logging a warning', () => {
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
 
-			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
-			expect(result?.id).toBe('anthropic-copilot');
+			try {
+				registry.register(makeAnthropicProvider());
+				registry.register(makeAnthropicCopilotProvider());
+
+				const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
+				expect(result?.id).toBe('anthropic-copilot');
+				// Preference resolved the collision — no warning should be emitted
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 
 		it('should return first registered provider and log collision when no preference and multiple matches', () => {
@@ -279,13 +295,19 @@ describe('ProviderRegistry', () => {
 			}
 		});
 
-		it('should return codex provider when preferred and model starts with gpt-', () => {
-			// anthropic-codex owns both claude- and gpt- models; register anthropic first
-			registry.register(makeAnthropicProvider());
-			registry.register(makeAnthropicCodexProvider());
+		it('should return codex provider when preferred and model starts with gpt-, no warning', () => {
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
 
-			const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
-			expect(result?.id).toBe('anthropic-codex');
+			try {
+				// anthropic-codex owns both claude- and gpt- models; only it owns gpt- here
+				registry.register(makeAnthropicCodexProvider());
+
+				const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
+				expect(result?.id).toBe('anthropic-codex');
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 
 		it('should return undefined when no provider claims the model', () => {
@@ -308,14 +330,24 @@ describe('ProviderRegistry', () => {
 			}
 		});
 
-		it('should fall back to first match when preferred provider does not claim the model', () => {
-			registry.register(makeAnthropicProvider());
-			registry.register(makeAnthropicCopilotProvider());
+		it('should fall back to first match and log collision when preference is not in match set', () => {
+			const warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(mock(() => {}));
 
-			// 'anthropic-codex' is not registered but even if it were it doesn't own this model
-			const result = registry.detectProviderForModel('claude-opus-4.6', 'nonexistent-provider');
-			// Falls back to first match
-			expect(result?.id).toBe('anthropic');
+			try {
+				registry.register(makeAnthropicProvider());
+				registry.register(makeAnthropicCopilotProvider());
+
+				// 'nonexistent-provider' is not in the match set — collision is unresolved
+				const result = registry.detectProviderForModel('claude-opus-4.6', 'nonexistent-provider');
+				// Falls back to first match
+				expect(result?.id).toBe('anthropic');
+				// Collision warning should have fired since preference couldn't resolve it
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+				const warnArg = warnSpy.mock.calls[0][0] as string;
+				expect(warnArg).toContain('claude-opus-4.6');
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -701,17 +701,20 @@ describe('Session RPC Handlers', () => {
 			const params = {
 				sessionId: 'session-123',
 				model: 'claude-opus-4-6',
+				provider: 'anthropic',
 			};
 
-			const { mocks } = createMockAgentSession();
+			const { agentSession, mocks } = createMockAgentSession();
 			mocks.handleModelSwitch.mockResolvedValueOnce({
 				success: true,
 				model: 'claude-opus-4-6',
 			});
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
 
 			const result = await handler!(params, {});
 
 			expect(result).toHaveProperty('success');
+			expect(mocks.handleModelSwitch).toHaveBeenCalledWith('claude-opus-4-6', 'anthropic');
 		});
 
 		it('broadcasts session.updated on successful switch', async () => {

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -721,7 +721,10 @@ describe('Session RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('session.model.switch');
 			expect(handler).toBeDefined();
 
-			await handler!({ sessionId: 'session-123', model: 'claude-opus-4-6' }, {});
+			await handler!(
+				{ sessionId: 'session-123', model: 'claude-opus-4-6', provider: 'anthropic' },
+				{}
+			);
 
 			expect(messageHubData.hub.event).toHaveBeenCalledWith('session.updated', expect.any(Object), {
 				channel: 'session:session-123',

--- a/packages/web/src/components/InputActionsMenu.tsx
+++ b/packages/web/src/components/InputActionsMenu.tsx
@@ -26,7 +26,7 @@ export interface InputActionsMenuProps {
 	availableModels?: ModelInfo[];
 	modelSwitching?: boolean;
 	modelLoading?: boolean;
-	onModelSwitch?: (modelId: string) => void;
+	onModelSwitch?: (modelId: string, providerId: string) => void;
 	/** Auto-scroll state */
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -239,8 +239,8 @@ export default function MessageInput({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string) => {
-			await switchModel(modelId);
+		async (modelId: string, providerId: string) => {
+			await switchModel(modelId, providerId);
 			actionsMenu.close();
 		},
 		[switchModel, actionsMenu]

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -144,7 +144,7 @@ interface SessionStatusBarProps {
 	availableModels: ModelInfo[];
 	modelSwitching: boolean;
 	modelLoading: boolean;
-	onModelSwitch: (modelId: string) => void;
+	onModelSwitch: (modelId: string, providerId: string) => void;
 	// Auto-scroll
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;
@@ -243,8 +243,8 @@ export default function SessionStatusBar({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string) => {
-			await onModelSwitch(modelId);
+		async (modelId: string, providerId: string) => {
+			await onModelSwitch(modelId, providerId);
 			modelDropdown.close();
 		},
 		[onModelSwitch, modelDropdown]
@@ -381,7 +381,7 @@ export default function SessionStatusBar({
 									class={`w-full text-left px-3 py-2 hover:bg-dark-700 text-xs flex items-center gap-2 ${
 										model.id === currentModelInfo?.id ? 'text-blue-400' : 'text-gray-200'
 									}`}
-									onClick={() => handleModelSwitch(model.alias)}
+									onClick={() => handleModelSwitch(model.alias, model.provider)}
 									disabled={modelSwitching}
 								>
 									<span class="text-base">{getModelFamilyIcon(model.family)}</span>

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -31,6 +31,7 @@ describe('SessionStatusBar', () => {
 			alias: 'opus',
 			name: 'Opus 4.5',
 			family: 'opus',
+			provider: 'anthropic',
 			isDefault: false,
 		},
 		{
@@ -38,6 +39,7 @@ describe('SessionStatusBar', () => {
 			alias: 'sonnet',
 			name: 'Sonnet 4.5',
 			family: 'sonnet',
+			provider: 'anthropic',
 			isDefault: true,
 		},
 		{
@@ -45,6 +47,7 @@ describe('SessionStatusBar', () => {
 			alias: 'haiku',
 			name: 'Haiku 4.5',
 			family: 'haiku',
+			provider: 'anthropic',
 			isDefault: false,
 		},
 	];
@@ -425,7 +428,7 @@ describe('SessionStatusBar', () => {
 			const opusButton = buttons.find((btn) => btn.textContent?.includes('Opus 4.5'));
 			fireEvent.click(opusButton!);
 
-			expect(mockOnModelSwitch).toHaveBeenCalledWith('opus');
+			expect(mockOnModelSwitch).toHaveBeenCalledWith('opus', 'anthropic');
 		});
 
 		it('should close model dropdown when clicking it again', () => {

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -442,7 +442,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-sonnet-4-20250514');
+				await result.current.switchModel('claude-sonnet-4-20250514', 'anthropic');
 			});
 
 			expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Already using'));
@@ -476,7 +476,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(result.current.currentModel).toBe('claude-opus-4-5-20251101');
@@ -506,7 +506,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Model not available');
@@ -534,7 +534,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Failed to switch model');
@@ -562,7 +562,7 @@ describe('useModelSwitcher', () => {
 			mockGetHubIfConnected.mockReturnValue(null);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Not connected to server');
@@ -598,7 +598,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Connection lost');
@@ -634,7 +634,7 @@ describe('useModelSwitcher', () => {
 			switchingStates.push(result.current.switching);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			// After switch completes, should not be switching
@@ -645,6 +645,7 @@ describe('useModelSwitcher', () => {
 			expect(mockHub.request).toHaveBeenCalledWith('session.model.switch', {
 				sessionId: 'session-1',
 				model: 'claude-opus-4-5-20251101',
+				provider: 'anthropic',
 			});
 		});
 
@@ -676,7 +677,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
 			});
 
 			expect(result.current.currentModelInfo?.id).toBe('claude-opus-4-5-20251101');

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -33,8 +33,8 @@ export interface UseModelSwitcherResult {
 	switching: boolean;
 	/** Whether models are being loaded */
 	loading: boolean;
-	/** Switch to a different model */
-	switchModel: (modelId: string) => Promise<void>;
+	/** Switch to a different model. Both model ID and provider ID must be supplied. */
+	switchModel: (modelId: string, providerId: string) => Promise<void>;
 	/** Reload model info */
 	reload: () => Promise<void>;
 }
@@ -177,7 +177,7 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 	}, [loadModelInfo]);
 
 	const switchModel = useCallback(
-		async (newModelId: string) => {
+		async (newModelId: string, newProviderId: string) => {
 			if (newModelId === currentModel) {
 				toast.info(`Already using ${currentModelInfo?.name || currentModel}`);
 				return;
@@ -194,6 +194,7 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 				const result = (await hub.request('session.model.switch', {
 					sessionId,
 					model: newModelId,
+					provider: newProviderId,
 				})) as {
 					success: boolean;
 					model: string;

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -403,14 +403,14 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 
 	// Model switch with processing confirmation
 	const handleModelSwitchWithConfirmation = useCallback(
-		async (modelId: string) => {
+		async (modelId: string, providerId: string) => {
 			if (isProcessing) {
 				const confirmed = confirm(
 					'The agent is currently processing. Switching the model will interrupt the current operation. Continue?'
 				);
 				if (!confirmed) return;
 			}
-			await switchModel(modelId);
+			await switchModel(modelId, providerId);
 		},
 		[switchModel, isProcessing]
 	);


### PR DESCRIPTION
## Summary

Replaces heuristic provider detection with deterministic, explicit routing: callers always supply both a model ID and a provider ID together. This closes the ambiguity window where two providers own the same canonical model ID (e.g. `anthropic` and `anthropic-copilot` both expose `claude-sonnet-4.6`).

### Key changes

- **`ProviderRegistry.detectProviderForModel(modelId, providerId)`** — new deterministic method; does a direct `registry.get(providerId)` lookup, logs an error if the provider is not registered, never falls back to scanning
- **`ProviderRegistry.detectProvider(modelId)`** — marked `@deprecated`; retained only for legacy call sites (CLI, old integration tests) with a visible deprecation warning
- **`ModelSwitchHandler.switchModel(newModel, newProvider?)`** — threaded `newProvider` through; resolves to `modelInfo?.provider` as a secondary source; falls back to deprecated `detectProvider` as a last resort with an explicit `logger.warn`; returns an error (instead of silently no-oping) when no provider is found
- **`ProviderService.getEnvVarsForModel / applyEnvVarsToProcess`** — `providerId` is now a required explicit argument
- **`ContextManager.requiresQueryRestart`** — accepts explicit `newProviderId`
- **`QueryRunner`** — passes `explicitProviderId` through the same two-path approach
- **`session.model.switch` RPC** — destructures `provider` from payload and threads it to `handleModelSwitch`
- **`useModelSwitcher` hook** — `switchModel(modelId, providerId)` now requires both args; RPC payload always includes `provider`
- **`SessionStatusBar`** / `InputActionsMenu` / `ChatContainer` / `MessageInput` — all callback signatures updated to `(modelId, providerId)`

### Type fixes (iteration 4)

- Replaced stale `as 'anthropic' | 'glm'` / `as any` casts with `as Provider` (imported from `@neokai/shared`)
- Converted the null `newProviderInstance` path from a silent no-op to an explicit error return
- Added `logger.warn` when no `newProvider` is supplied (deprecated heuristic path)

### Test coverage

- Unit: `provider-registry`, `context-manager`, `provider-service`, `agent-session`, `session-handlers` — all updated to pass explicit provider IDs
- Web: `SessionStatusBar`, `useModelSwitcher` — mocks include `provider` field; assertions verify `(modelId, providerId)` pairs
- Online: `rpc-model-handlers`, `rpc-model-switching`, `rpc-session-handlers-extended` — all `session.model.switch` calls now include `provider`