### PR TITLE
fix: remove unsafe provider casts in daemon, use widened Provider type

### DIFF
--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -17,7 +17,13 @@
  */
 
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
-import type { Session, SessionConfig, CurrentModelInfo, MessageHub } from '@neokai/shared';
+import type {
+	Provider,
+	Session,
+	SessionConfig,
+	CurrentModelInfo,
+	MessageHub,
+} from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ErrorManager } from '../error-manager';
@@ -156,8 +162,7 @@ export class ModelSwitchHandler {
 				// Keep provider aligned with model for pre-query switches too.
 				// Without this, a stale explicit provider can force wrong model routing.
 				if (newProviderInstance?.id) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					session.config.provider = newProviderInstance.id as any;
+					session.config.provider = newProviderInstance.id as Provider;
 				}
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
@@ -166,7 +171,7 @@ export class ModelSwitchHandler {
 					config: {
 						model: resolvedModel,
 						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as 'anthropic' | 'glm',
+							provider: newProviderInstance.id as Provider,
 						}),
 					} as SessionConfig,
 				});
@@ -191,8 +196,7 @@ export class ModelSwitchHandler {
 				// Keep provider aligned with model (same as the pre-query branch —
 				// unconditionally update so same-provider switches don’t leave stale state).
 				if (newProviderInstance?.id) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					session.config.provider = newProviderInstance.id as any;
+					session.config.provider = newProviderInstance.id as Provider;
 				}
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
@@ -201,7 +205,7 @@ export class ModelSwitchHandler {
 					config: {
 						model: resolvedModel,
 						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as 'anthropic' | 'glm',
+							provider: newProviderInstance.id as Provider,
 						}),
 					} as SessionConfig,
 				});

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -9,7 +9,7 @@
  * - Title generation and branch renaming
  */
 
-import type { Session, WorktreeMetadata, MessageHub } from '@neokai/shared';
+import type { Provider, Session, WorktreeMetadata, MessageHub } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
@@ -178,8 +178,7 @@ export class SessionLifecycle {
 				// Provider: Allow explicit override; fall back to resolved provider from model alias.
 				// Critical when providers share canonical IDs (e.g., Anthropic and
 				// anthropic-copilot both owning claude-sonnet-4.6).
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				provider: (params.config?.provider ?? resolvedProvider) as any,
+				provider: (params.config?.provider ?? resolvedProvider) as Provider,
 				// Tools config: Use global defaults for new sessions
 				// SDK built-in tools are always enabled (not configurable)
 				// MCP and NeoKai tools are configurable based on global settings
@@ -730,7 +729,7 @@ export class SessionLifecycle {
 		// provider's own isAvailable() implementation.
 		const legacyKeyProviders: string[] = ['anthropic', 'glm', 'minimax'];
 		if (legacyKeyProviders.includes(provider)) {
-			const apiKey = providerService.getProviderApiKey(provider as 'anthropic' | 'glm' | 'minimax');
+			const apiKey = providerService.getProviderApiKey(provider as Provider);
 			if (!apiKey) {
 				this.logger.warn(
 					`[SessionLifecycle] No API key for provider ${provider}, using fallback title`


### PR DESCRIPTION
Replace `as any` and `as 'anthropic' | 'glm'` casts with `as Provider`
throughout model-switch-handler.ts and session-lifecycle.ts. The Provider
type now includes all five providers, making the narrow casts unnecessary
and the any-casts unsafe.
