### PR TITLE
feat: iterate all tool results in codex bridge continuation

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -90,9 +90,8 @@ async function drainToSSE(
 		const { value: event, done } = await gen.next();
 		if (done) break;
 
-		// DIAGNOSTIC: log each BridgeEvent type to stderr for CI debugging
-		process.stderr.write(
-			`[codex-bridge-server] drainToSSE event: ${event.type}${event.type === 'text_delta' ? ` text=${JSON.stringify((event as { text: string }).text)}` : ''}\n`
+		logger.debug(
+			`drainToSSE event: ${event.type}${event.type === 'text_delta' ? ` text=${JSON.stringify((event as { text: string }).text)}` : ''}`
 		);
 
 		if (event.type === 'text_delta') {

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -42,7 +42,7 @@ export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
 // Session state for tool-call round-trips
 // ---------------------------------------------------------------------------
 
-type ToolSession = {
+export type ToolSession = {
 	/** The suspended generator — resume with provideResult then continue polling. */
 	gen: AsyncGenerator<import('./process-manager.js').BridgeEvent>;
 	/** The underlying BridgeSession — needed to kill the subprocess when done. */

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -236,22 +236,48 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					return new Response('Bad Request: no tool_result found', { status: 400 });
 				}
 
-				// For simplicity handle one tool result at a time (Codex sends one at a time)
-				const tr = toolResults[0];
-				const stored = toolSessions.get(tr.toolUseId);
-				if (!stored) {
-					logger.error(`codex-bridge: no active session for tool_use_id=${tr.toolUseId}`);
+				// Iterate ALL tool results — the Anthropic API allows multiple tool_result
+				// blocks in a single continuation request (one per parallel tool call).
+				//
+				// NOTE: The Codex app-server only ever emits one tool call per turn, because
+				// each item/tool/call RPC handler blocks until its result is provided before
+				// Codex can proceed to the next tool call. In practice there is therefore
+				// always exactly one suspended ToolSession at continuation time. We still
+				// handle the multi-result path correctly here for forward compatibility: if
+				// Codex ever gains parallel tool-call support, this code will work without
+				// changes.
+				//
+				// The first matched session's generator drives the resumed SSE stream.
+				// All matched sessions have their Deferreds resolved. Unmatched tool_use_ids
+				// produce a warning and are skipped (not silently dropped).
+				let primaryStored: ToolSession | null = null;
+
+				for (const tr of toolResults) {
+					const stored = toolSessions.get(tr.toolUseId);
+					if (!stored) {
+						logger.warn(
+							`codex-bridge: orphaned tool_result — no active session for tool_use_id=${tr.toolUseId}, skipping`
+						);
+						continue;
+					}
+					toolSessions.delete(tr.toolUseId);
+					// Cancel the TTL timer — session is being resumed normally
+					clearTimeout(stored.cleanupTimer);
+					// Provide the tool result — this unblocks the Codex read loop for this call
+					stored.provideResult(tr.text);
+					if (!primaryStored) {
+						primaryStored = stored;
+					}
+				}
+
+				if (!primaryStored) {
+					logger.error(
+						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
+					);
 					return new Response('Session not found', { status: 404 });
 				}
-				toolSessions.delete(tr.toolUseId);
 
-				// Cancel the TTL timer — session is being resumed normally
-				clearTimeout(stored.cleanupTimer);
-
-				const { gen, session, provideResult, model: sessionModel } = stored;
-				// Provide the tool result — this unblocks the Codex read loop
-				provideResult(tr.text);
-
+				const { gen, session, model: sessionModel } = primaryStored;
 				const stream = new ReadableStream<Uint8Array>({
 					start(controller) {
 						void drainToSSE(gen, session, sessionModel, toolSessions, controller, ttlMs);

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -3,17 +3,20 @@
  *
  * These tests spin up a real Bun HTTP server backed by a MOCK BridgeSession.
  * The mock injects pre-scripted BridgeEvents so no real `codex` binary is needed.
+ *
+ * Why a mock server instead of the production `createBridgeServer`?
+ * `createBridgeServer` spawns a real `codex` subprocess via `AppServerConn.create()`.
+ * There is no session-factory injection point in the current API, so the production
+ * server cannot be exercised with a mock `BridgeSession` without starting a real process.
+ * The `createMockBridgeServer` helper below reimplements the same HTTP routing + SSE
+ * drain logic using `MockBridgeSession`, keeping all test coverage in-process and fast.
+ * The production server's multi-result loop is covered by the same code path exercised
+ * through the mock — any logic drift would be caught by a type error at the shared
+ * `ToolSession` type boundary.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import {
-	BridgeSession,
-	AppServerConn,
-} from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
-import {
-	createBridgeServer,
-	type BridgeServer,
-} from '../../../../src/lib/providers/codex-anthropic-bridge/server';
+import type { BridgeServer } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 
 // ---------------------------------------------------------------------------
@@ -205,8 +208,14 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 			if (isToolResultContinuation(body.messages)) {
 				const toolResults = extractToolResults(body.messages);
 				// Mirror production logic: iterate all tool results, warn on unmatched
-				let primaryStored: (typeof toolSessions extends Map<string, infer V> ? V : never) | null =
-					null;
+				type ToolSessionEntry = {
+					gen: AsyncGenerator<BridgeEvent>;
+					session: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
+					provideResult: (text: string) => void;
+					model: string;
+					cleanupTimer: ReturnType<typeof setTimeout>;
+				};
+				let primaryStored: ToolSessionEntry | null = null;
 				for (const tr of toolResults) {
 					const stored = toolSessions.get(tr.toolUseId);
 					if (!stored) {
@@ -601,10 +610,16 @@ describe('Bridge HTTP server', () => {
 	it('resolves all matched tool results when multiple tool_use_ids are sent', async () => {
 		const resolvedIds: string[] = [];
 
-		// Simulate two sequential tool calls sharing the same generator.
-		// In the mock, both tool_call events are yielded before turn_done.
-		// The second tool_call's provideResult is pre-resolved (no-op) since
-		// the mock generator doesn't actually block — it just records calls.
+		// The mock generator only emits one tool_call (call-multi-1) then turn_done.
+		// This reflects the real Codex constraint: Codex emits one tool call at a time
+		// because each item/tool/call RPC handler blocks until its result is provided.
+		//
+		// To test the multi-result server loop, a second ToolSession (call-multi-2)
+		// is injected directly into the toolSessions map after the first HTTP request.
+		// This simulates a hypothetical future scenario where the client sends two
+		// tool_result blocks in a single continuation (e.g. from parallel tool calls
+		// in a different upstream model). The server loop must resolve both Deferreds
+		// and treat the first matched entry as the primary gen to drain.
 		mockSessionFactory = () => {
 			const sess = new MockBridgeSession([
 				{
@@ -634,8 +649,8 @@ describe('Bridge HTTP server', () => {
 		await readSSEEvents(resp1.body);
 		expect(toolSessions.has('call-multi-1')).toBe(true);
 
-		// Manually inject a second suspended session with a different callId but
-		// the SAME gen (simulating a second tool call from the same turn).
+		// Inject a second ToolSession sharing the same gen, representing a hypothetical
+		// parallel tool call from the same turn (see comment above for rationale).
 		const secondResolved: string[] = [];
 		const stored1 = toolSessions.get('call-multi-1')!;
 		toolSessions.set('call-multi-2', {

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -10,13 +10,15 @@
  * server cannot be exercised with a mock `BridgeSession` without starting a real process.
  * The `createMockBridgeServer` helper below reimplements the same HTTP routing + SSE
  * drain logic using `MockBridgeSession`, keeping all test coverage in-process and fast.
- * The production server's multi-result loop is covered by the same code path exercised
- * through the mock — any logic drift would be caught by a type error at the shared
- * `ToolSession` type boundary.
+ * Type drift between the mock and the production server is kept in check by importing
+ * the exported `ToolSession` type from `server.ts` — both share the same named type.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import type { BridgeServer } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
+import type {
+	BridgeServer,
+	ToolSession,
+} from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 
 // ---------------------------------------------------------------------------
@@ -86,16 +88,7 @@ class MockBridgeSession {
 let mockSessionFactory: (() => MockBridgeSession) | null = null;
 
 /** Shared tool session map — reset in beforeEach. */
-const toolSessions = new Map<
-	string,
-	{
-		gen: AsyncGenerator<BridgeEvent>;
-		session: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
-		provideResult: (text: string) => void;
-		model: string;
-		cleanupTimer: ReturnType<typeof setTimeout>;
-	}
->();
+const toolSessions = new Map<string, ToolSession>();
 
 function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 	const bunServer = Bun.serve({
@@ -208,14 +201,7 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 			if (isToolResultContinuation(body.messages)) {
 				const toolResults = extractToolResults(body.messages);
 				// Mirror production logic: iterate all tool results, warn on unmatched
-				type ToolSessionEntry = {
-					gen: AsyncGenerator<BridgeEvent>;
-					session: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
-					provideResult: (text: string) => void;
-					model: string;
-					cleanupTimer: ReturnType<typeof setTimeout>;
-				};
-				let primaryStored: ToolSessionEntry | null = null;
+				let primaryStored: ToolSession | null = null;
 				for (const tr of toolResults) {
 					const stored = toolSessions.get(tr.toolUseId);
 					if (!stored) {

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -203,17 +203,28 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 			}
 
 			if (isToolResultContinuation(body.messages)) {
-				const [tr] = extractToolResults(body.messages);
-				const stored = toolSessions.get(tr.toolUseId);
-				if (!stored) return new Response('Session not found', { status: 404 });
-				toolSessions.delete(tr.toolUseId);
-				clearTimeout(stored.cleanupTimer);
-				stored.provideResult(tr.text);
-				const resumeModel = stored.model; // preserve original model
+				const toolResults = extractToolResults(body.messages);
+				// Mirror production logic: iterate all tool results, warn on unmatched
+				let primaryStored: (typeof toolSessions extends Map<string, infer V> ? V : never) | null =
+					null;
+				for (const tr of toolResults) {
+					const stored = toolSessions.get(tr.toolUseId);
+					if (!stored) {
+						// warn — mirrors production logger.warn for orphaned results
+						continue;
+					}
+					toolSessions.delete(tr.toolUseId);
+					clearTimeout(stored.cleanupTimer);
+					stored.provideResult(tr.text);
+					if (!primaryStored) primaryStored = stored;
+				}
+				if (!primaryStored) return new Response('Session not found', { status: 404 });
+				const resumeModel = primaryStored.model;
+				const primaryGen = primaryStored.gen;
 				const stream = new ReadableStream<Uint8Array>({
 					async start(controller) {
 						controller.enqueue(enc.encode(messageStartSSE(`msg_${Date.now()}`, resumeModel, 0)));
-						await drainGen(stored.gen, null, resumeModel, controller);
+						await drainGen(primaryGen, null, resumeModel, controller);
 					},
 				});
 				return new Response(stream, { headers: sseHeaders });
@@ -581,6 +592,208 @@ describe('Bridge HTTP server', () => {
 		} finally {
 			ttlServer.stop();
 		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple tool results — all matched sessions resolved
+	// -------------------------------------------------------------------------
+
+	it('resolves all matched tool results when multiple tool_use_ids are sent', async () => {
+		const resolvedIds: string[] = [];
+
+		// Simulate two sequential tool calls sharing the same generator.
+		// In the mock, both tool_call events are yielded before turn_done.
+		// The second tool_call's provideResult is pre-resolved (no-op) since
+		// the mock generator doesn't actually block — it just records calls.
+		mockSessionFactory = () => {
+			const sess = new MockBridgeSession([
+				{
+					type: 'tool_call',
+					callId: 'call-multi-1',
+					toolName: 'bash',
+					toolInput: { command: 'ls' },
+					provideResult: (_text: string) => {
+						resolvedIds.push('call-multi-1');
+					},
+				},
+				{ type: 'turn_done', inputTokens: 5, outputTokens: 5 },
+			]);
+			return sess;
+		};
+
+		// First request — suspends on call-multi-1
+		const resp1 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'run' }],
+				stream: true,
+			}),
+		});
+		await readSSEEvents(resp1.body);
+		expect(toolSessions.has('call-multi-1')).toBe(true);
+
+		// Manually inject a second suspended session with a different callId but
+		// the SAME gen (simulating a second tool call from the same turn).
+		const secondResolved: string[] = [];
+		const stored1 = toolSessions.get('call-multi-1')!;
+		toolSessions.set('call-multi-2', {
+			gen: stored1.gen,
+			session: stored1.session,
+			provideResult: (_text: string) => {
+				secondResolved.push('call-multi-2');
+			},
+			model: stored1.model,
+			cleanupTimer: setTimeout(() => {}, 60_000),
+		});
+
+		// Send a continuation with BOTH tool results
+		const resp2 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'run' },
+					{
+						role: 'assistant',
+						content: [
+							{ type: 'tool_use', id: 'call-multi-1', name: 'bash', input: {} },
+							{ type: 'tool_use', id: 'call-multi-2', name: 'bash', input: {} },
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'call-multi-1', content: 'result-1' },
+							{ type: 'tool_result', tool_use_id: 'call-multi-2', content: 'result-2' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		expect(resp2.ok).toBe(true);
+		await readSSEEvents(resp2.body);
+
+		// Both provideResult callbacks must have been called
+		expect(resolvedIds).toContain('call-multi-1');
+		expect(secondResolved).toContain('call-multi-2');
+
+		// Both sessions must be removed from the map
+		expect(toolSessions.has('call-multi-1')).toBe(false);
+		expect(toolSessions.has('call-multi-2')).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple tool results — some unmatched (orphaned) — warn, not crash
+	// -------------------------------------------------------------------------
+
+	it('warns on unmatched tool_use_ids and still resumes the matched session', async () => {
+		const resolvedIds: string[] = [];
+
+		mockSessionFactory = () =>
+			new MockBridgeSession([
+				{
+					type: 'tool_call',
+					callId: 'call-orphan-match',
+					toolName: 'bash',
+					toolInput: { command: 'pwd' },
+					provideResult: (_text: string) => {
+						resolvedIds.push('call-orphan-match');
+					},
+				},
+				{ type: 'text_delta', text: 'resumed' },
+				{ type: 'turn_done', inputTokens: 1, outputTokens: 1 },
+			]);
+
+		// First request — suspends on call-orphan-match
+		const resp1 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'pwd' }],
+				stream: true,
+			}),
+		});
+		await readSSEEvents(resp1.body);
+		expect(toolSessions.has('call-orphan-match')).toBe(true);
+
+		// Send continuation with the real call-id AND a nonexistent call-id
+		const resp2 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'pwd' },
+					{
+						role: 'assistant',
+						content: [
+							{ type: 'tool_use', id: 'call-orphan-match', name: 'bash', input: {} },
+							{ type: 'tool_use', id: 'call-orphan-no-session', name: 'bash', input: {} },
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'call-orphan-match', content: 'dir' },
+							{ type: 'tool_result', tool_use_id: 'call-orphan-no-session', content: 'dir' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		// Must succeed (not 404) — the matched session is resumed normally
+		expect(resp2.ok).toBe(true);
+		const events2 = await readSSEEvents(resp2.body);
+
+		// The matched session resolved its Deferred
+		expect(resolvedIds).toContain('call-orphan-match');
+
+		// Resumed turn text should appear
+		const text = events2
+			.filter((e) => e.event === 'content_block_delta')
+			.map((e) => (e.data as { delta: { type: string; text?: string } }).delta)
+			.filter((d) => d.type === 'text_delta')
+			.map((d) => d.text ?? '')
+			.join('');
+		expect(text).toBe('resumed');
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple tool results — ALL unmatched — 404
+	// -------------------------------------------------------------------------
+
+	it('returns 404 when all tool_use_ids in the continuation are unmatched', async () => {
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'x' },
+					{
+						role: 'assistant',
+						content: [{ type: 'tool_use', id: 'bad-id-1', name: 'bash', input: {} }],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'bad-id-1', content: 'r1' },
+							{ type: 'tool_result', tool_use_id: 'bad-id-2', content: 'r2' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+		expect(resp.status).toBe(404);
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Previously the bridge only resolved toolResults[0] when resuming a
suspended session, silently dropping any additional tool_result blocks.
Now it iterates every tool_result, resolves each matching ToolSession by
tool_use_id, warns on unmatched (orphaned) IDs, and returns 404 only
when no IDs match at all.

Adds three new unit-test cases: multiple results all matched, partial
match with orphaned ID, and all-unmatched 404 path.
