### PR TITLE
fix: inject room chat system prompt to prevent premature task creation

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -648,7 +648,7 @@ export class AgentSession
 	 * Used to inject context-specific instructions (e.g. room workflow guidance)
 	 * without persisting them to the database.
 	 */
-	setRuntimeSystemPrompt(systemPrompt: string): void {
+	setRuntimeSystemPrompt(systemPrompt: SystemPromptConfig): void {
 		this.session.config = {
 			...this.session.config,
 			systemPrompt,

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -643,6 +643,18 @@ export class AgentSession
 		};
 	}
 
+	/**
+	 * Apply a runtime system prompt to in-memory session config only.
+	 * Used to inject context-specific instructions (e.g. room workflow guidance)
+	 * without persisting them to the database.
+	 */
+	setRuntimeSystemPrompt(systemPrompt: string): void {
+		this.session.config = {
+			...this.session.config,
+			systemPrompt,
+		};
+	}
+
 	updateMetadata(updates: Partial<Session>): void {
 		this.sessionConfigHandler.updateMetadata(updates);
 	}

--- a/packages/daemon/src/lib/room/agents/room-chat-agent.ts
+++ b/packages/daemon/src/lib/room/agents/room-chat-agent.ts
@@ -30,60 +30,16 @@ export function buildRoomChatSystemPrompt(context?: RoomChatAgentContext): strin
 		: '';
 
 	return `\
-You are the Room Agent — a conversational coordinator for autonomous software development in this room.
+You are the Room Agent — a conversational coordinator for autonomous software development.
 
 ${backgroundSection}${instructionsSection}\
-## Your Role
+## Goal Creation — CRITICAL RULE
 
-You help the human user manage goals and monitor the autonomous development workflow.
-You have access to tools for creating goals, managing tasks, reviewing progress, and communicating with active agents.
+When the user asks you to create a goal, call \`create_goal\` and STOP. Do NOT call \`create_task\`.
+The system automatically handles the rest: planning → human approval → task creation → execution.
 
-## Goal Creation Workflow — CRITICAL
+After creating a goal, tell the user it was created and that the planning phase has started automatically — they will be asked to review and approve the plan before any tasks are created.
 
-When the user asks you to create a goal, you MUST follow this strict workflow:
-
-**Step 1 — Create the goal only:**
-Call \`create_goal\` with the title and description. That is all you do.
-
-**Do NOT call \`create_task\` after \`create_goal\`.** The remaining steps happen automatically:
-
-**Step 2 — Planning (automatic):**
-The system automatically spawns a Planner agent that explores the codebase and writes a plan document in a PR.
-
-**Step 3 — Plan review (automatic + human):**
-A Leader agent reviews the plan. The human will be presented with the plan and asked to approve or reject it.
-
-**Step 4 — Task creation (automatic, after approval):**
-Once the plan is approved, tasks are automatically created from the approved plan by the Planner agent.
-
-**Step 5 — Execution (automatic):**
-Coder and General agents execute each task; a Leader agent reviews the code.
-
-### After creating a goal, tell the user:
-- The goal has been created successfully.
-- The system has started the planning phase automatically.
-- They will be asked to review and approve the plan before any tasks are created.
-- Once approved, implementation tasks will be created and execution begins autonomously.
-
-## When to use \`create_task\` directly
-
-Only use \`create_task\` without a prior goal when the user explicitly requests a standalone task that:
-- Does not need planning (it's simple and self-contained)
-- Should not be tracked as part of a larger goal
-
-If a task is associated with a goal, do NOT create it manually — the planner will create tasks automatically from the approved plan.
-
-## Reviewing and Approving Work
-
-Use \`get_room_status\` or \`list_tasks\` to check what is awaiting review.
-Use \`approve_task\` to approve a plan or code that is ready.
-Use \`reject_task\` to send feedback if something needs to be changed.
-Use \`send_message_to_task\` to communicate with an active agent.
-
-## Reading the Codebase
-
-You have read-only access to the codebase via \`Read\`, \`Glob\`, \`Grep\`, and \`WebFetch\`.
-Use these to answer questions about the code, verify implementation, or understand context.
-Do NOT use file-modification tools — code changes are done by Coder/General agents.
+Only use \`create_task\` directly for explicit standalone tasks that have no associated goal and need no planning.
 `;
 }

--- a/packages/daemon/src/lib/room/agents/room-chat-agent.ts
+++ b/packages/daemon/src/lib/room/agents/room-chat-agent.ts
@@ -21,6 +21,9 @@ export interface RoomChatAgentContext {
  * planner agent has produced a plan and the human has approved it.
  */
 export function buildRoomChatSystemPrompt(context?: RoomChatAgentContext): string {
+	// Trust assumption: background and instructions are operator-controlled fields.
+	// They are interpolated directly into the system prompt without sanitization.
+	// This is acceptable for a self-hosted tool where the operator sets these values.
 	const backgroundSection = context?.background
 		? `## Room Background\n\n${context.background}\n\n`
 		: '';

--- a/packages/daemon/src/lib/room/agents/room-chat-agent.ts
+++ b/packages/daemon/src/lib/room/agents/room-chat-agent.ts
@@ -1,0 +1,89 @@
+/**
+ * Room Chat Agent - System prompt for the room's conversational coordinator.
+ *
+ * The room chat session (room:chat:${roomId}) is a persistent session where
+ * the human user interacts with an AI coordinator that manages goals and tasks.
+ *
+ * Key responsibility: enforce the proper goal → plan → approval → task workflow
+ * so that tasks are never created prematurely (before the plan is approved).
+ */
+
+export interface RoomChatAgentContext {
+	background?: string;
+	instructions?: string;
+}
+
+/**
+ * Build the system prompt for the room chat agent.
+ *
+ * Provides workflow instructions that prevent the agent from creating tasks
+ * immediately when a goal is created. Tasks must only be created after the
+ * planner agent has produced a plan and the human has approved it.
+ */
+export function buildRoomChatSystemPrompt(context?: RoomChatAgentContext): string {
+	const backgroundSection = context?.background
+		? `## Room Background\n\n${context.background}\n\n`
+		: '';
+
+	const instructionsSection = context?.instructions
+		? `## Room Instructions\n\n${context.instructions}\n\n`
+		: '';
+
+	return `\
+You are the Room Agent — a conversational coordinator for autonomous software development in this room.
+
+${backgroundSection}${instructionsSection}\
+## Your Role
+
+You help the human user manage goals and monitor the autonomous development workflow.
+You have access to tools for creating goals, managing tasks, reviewing progress, and communicating with active agents.
+
+## Goal Creation Workflow — CRITICAL
+
+When the user asks you to create a goal, you MUST follow this strict workflow:
+
+**Step 1 — Create the goal only:**
+Call \`create_goal\` with the title and description. That is all you do.
+
+**Do NOT call \`create_task\` after \`create_goal\`.** The remaining steps happen automatically:
+
+**Step 2 — Planning (automatic):**
+The system automatically spawns a Planner agent that explores the codebase and writes a plan document in a PR.
+
+**Step 3 — Plan review (automatic + human):**
+A Leader agent reviews the plan. The human user (you) will be presented with the plan and asked to approve or reject it.
+
+**Step 4 — Task creation (automatic, after approval):**
+Once the plan is approved, tasks are automatically created from the approved plan by the Planner agent.
+
+**Step 5 — Execution (automatic):**
+Coder and General agents execute each task; a Leader agent reviews the code.
+
+### After creating a goal, tell the user:
+- The goal has been created successfully.
+- The system has started the planning phase automatically.
+- They will be asked to review and approve the plan before any tasks are created.
+- Once approved, implementation tasks will be created and execution begins autonomously.
+
+## When to use \`create_task\` directly
+
+Only use \`create_task\` without a prior goal when the user explicitly requests a standalone task that:
+- Does not need planning (it's simple and self-contained)
+- Should not be tracked as part of a larger goal
+
+If a task is associated with a goal, do NOT create it manually — the planner will create tasks automatically from the approved plan.
+
+## Reviewing and Approving Work
+
+Use \`get_room_status\` or \`list_tasks\` to check what is awaiting review.
+Use \`approve_task\` to approve a plan or code that is ready.
+Use \`reject_task\` to send feedback if something needs to be changed.
+Use \`send_message_to_task\` to communicate with an active agent.
+
+## Reading the Codebase
+
+You have read-only access to the codebase via \`Read\`, \`Glob\`, \`Grep\`, and \`WebFetch\`.
+Use these to answer questions about the code, verify implementation, or understand context.
+Do NOT use file-modification tools — code changes are done by Coder/General agents.
+`;
+}

--- a/packages/daemon/src/lib/room/agents/room-chat-agent.ts
+++ b/packages/daemon/src/lib/room/agents/room-chat-agent.ts
@@ -51,7 +51,7 @@ Call \`create_goal\` with the title and description. That is all you do.
 The system automatically spawns a Planner agent that explores the codebase and writes a plan document in a PR.
 
 **Step 3 — Plan review (automatic + human):**
-A Leader agent reviews the plan. The human user (you) will be presented with the plan and asked to approve or reject it.
+A Leader agent reviews the plan. The human will be presented with the plan and asked to approve or reject it.
 
 **Step 4 — Task creation (automatic, after approval):**
 Once the plan is approved, tasks are automatically created from the approved plan by the Planner agent.

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -438,16 +438,18 @@ export class RoomRuntimeService {
 				// Inject the room chat system prompt so the agent knows the proper
 				// goal → plan → approval → task workflow and never creates tasks
 				// prematurely when a goal is created.
-				roomChatSession.setRuntimeSystemPrompt(
-					buildRoomChatSystemPrompt({
-						background: room.background,
-						instructions: room.instructions,
-					})
-				);
+				roomChatSession.setRuntimeSystemPrompt(this.buildRoomSystemPrompt(room));
 			})
 			.catch((error) => {
 				log.error(`Failed to attach room MCP tools for room ${room.id}:`, error);
 			});
+	}
+
+	private buildRoomSystemPrompt(room: Room): string {
+		return buildRoomChatSystemPrompt({
+			background: room.background,
+			instructions: room.instructions,
+		});
 	}
 
 	private subscribeToEvents(): void {
@@ -477,12 +479,7 @@ export class RoomRuntimeService {
 							.getSessionAsync(roomChatSessionId)
 							.then((session) => {
 								if (session) {
-									session.setRuntimeSystemPrompt(
-										buildRoomChatSystemPrompt({
-											background: room.background,
-											instructions: room.instructions,
-										})
-									);
+									session.setRuntimeSystemPrompt(this.buildRoomSystemPrompt(room));
 								}
 							})
 							.catch((error) => {

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -24,6 +24,7 @@ import { TaskManager } from '../managers/task-manager';
 import { GoalManager } from '../managers/goal-manager';
 import { AgentSession } from '../../agent/agent-session';
 import { createRoomAgentMcpServer } from '../tools/room-agent-tools';
+import { buildRoomChatSystemPrompt } from '../agents/room-chat-agent';
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { recoverRuntime, type SessionStateChecker } from './runtime-recovery';
 import type { RoomManager } from '../managers/room-manager';
@@ -434,6 +435,15 @@ export class RoomRuntimeService {
 				roomChatSession.setRuntimeMcpServers({
 					'room-agent-tools': roomAgentMcpServer,
 				});
+				// Inject the room chat system prompt so the agent knows the proper
+				// goal → plan → approval → task workflow and never creates tasks
+				// prematurely when a goal is created.
+				roomChatSession.setRuntimeSystemPrompt(
+					buildRoomChatSystemPrompt({
+						background: room.background,
+						instructions: room.instructions,
+					})
+				);
 			})
 			.catch((error) => {
 				log.error(`Failed to attach room MCP tools for room ${room.id}:`, error);
@@ -460,6 +470,24 @@ export class RoomRuntimeService {
 					const room = this.ctx.roomManager.getRoom(event.roomId);
 					if (room) {
 						runtime.updateRoom(room);
+						// Re-apply the room chat system prompt so it reflects the latest
+						// room background/instructions (e.g. after room.update changes them).
+						const roomChatSessionId = `room:chat:${room.id}`;
+						void this.ctx.sessionManager
+							.getSessionAsync(roomChatSessionId)
+							.then((session) => {
+								if (session) {
+									session.setRuntimeSystemPrompt(
+										buildRoomChatSystemPrompt({
+											background: room.background,
+											instructions: room.instructions,
+										})
+									);
+								}
+							})
+							.catch((error) => {
+								log.warn(`Failed to update room chat system prompt for room ${room.id}:`, error);
+							});
 					}
 				}
 			},

--- a/packages/daemon/tests/unit/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/agent/agent-session.test.ts
@@ -2073,6 +2073,121 @@ describe('AgentSession', () => {
 		});
 	});
 
+	describe('setRuntimeSystemPrompt', () => {
+		it('should update the in-memory system prompt without persisting it', () => {
+			const mockSession: Session = {
+				id: 'room:chat:test',
+				title: 'Room Chat',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1.0,
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+				type: 'room_chat',
+			};
+
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			// Initially no system prompt
+			expect(agentSession.getSessionData().config.systemPrompt).toBeUndefined();
+
+			// Set the runtime system prompt
+			agentSession.setRuntimeSystemPrompt('You are the Room Agent.');
+
+			// In-memory config should reflect the new prompt
+			expect(agentSession.getSessionData().config.systemPrompt).toBe('You are the Room Agent.');
+
+			// The DB update should NOT have been called (runtime-only, not persisted)
+			const updateSessionCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateSessionCalls.length).toBe(0);
+		});
+
+		it('should overwrite an existing runtime system prompt', () => {
+			const mockSession: Session = {
+				id: 'room:chat:test2',
+				title: 'Room Chat',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1.0,
+					systemPrompt: 'old prompt',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+				type: 'room_chat',
+			};
+
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			agentSession.setRuntimeSystemPrompt('new prompt');
+
+			expect(agentSession.getSessionData().config.systemPrompt).toBe('new prompt');
+		});
+	});
+
 	describe('startupTimeoutTimer', () => {
 		let mockSession: Session;
 		let mockDb: Database;

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -411,6 +411,13 @@ describe('QueryOptionsBuilder', () => {
 			const options = await builder.build();
 			expect(options.systemPrompt).toBeUndefined();
 		});
+
+		it('should preserve a custom string system prompt for room sessions', async () => {
+			mockSession.type = 'room_chat';
+			mockSession.config.systemPrompt = 'You are the Room Agent.';
+			const options = await builder.build();
+			expect(options.systemPrompt).toBe('You are the Room Agent.');
+		});
 	});
 
 	describe('additional directories configuration', () => {

--- a/packages/daemon/tests/unit/room/room-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/room/room-chat-agent.test.ts
@@ -77,9 +77,7 @@ describe('buildRoomChatSystemPrompt', () => {
 
 	it('mentions that tasks are created automatically after plan approval', () => {
 		const prompt = buildRoomChatSystemPrompt();
-		// Should mention that tasks come from an approved plan
-		expect(prompt.toLowerCase()).toMatch(
-			/tasks.*automatically|automatically.*created.*plan|tasks.*approved plan/
-		);
+		// Should mention automatic handling including planning, approval, and task creation
+		expect(prompt.toLowerCase()).toMatch(/automatically.*plan.*approv.*task|approv.*task/);
 	});
 });

--- a/packages/daemon/tests/unit/room/room-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/room/room-chat-agent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import { buildRoomChatSystemPrompt } from '../../../src/lib/room/agents/room-chat-agent';
+
+describe('buildRoomChatSystemPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('includes the Room Agent role description', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('Room Agent');
+	});
+
+	it('instructs the agent NOT to call create_task when creating a goal', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('create_goal');
+		expect(prompt).toContain('create_task');
+		// Must explicitly say not to call create_task after create_goal
+		expect(prompt).toMatch(/do NOT call.*create_task|never call.*create_task/i);
+	});
+
+	it('describes the full goal creation workflow steps', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		// Planning phase
+		expect(prompt.toLowerCase()).toContain('plan');
+		// Approval step
+		expect(prompt.toLowerCase()).toContain('approv');
+		// Task creation only after approval
+		expect(prompt.toLowerCase()).toContain('task');
+	});
+
+	it('tells the agent to explain the workflow to the user after goal creation', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('planning phase');
+	});
+
+	it('includes room background when provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ background: 'This is a trading platform.' });
+		expect(prompt).toContain('This is a trading platform.');
+		expect(prompt).toContain('Room Background');
+	});
+
+	it('includes room instructions when provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ instructions: 'Always prefer TypeScript.' });
+		expect(prompt).toContain('Always prefer TypeScript.');
+		expect(prompt).toContain('Room Instructions');
+	});
+
+	it('omits background section when not provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ instructions: 'Use bun.' });
+		expect(prompt).not.toContain('Room Background');
+	});
+
+	it('omits instructions section when not provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ background: 'A fintech room.' });
+		expect(prompt).not.toContain('Room Instructions');
+	});
+
+	it('includes both sections when both are provided', () => {
+		const prompt = buildRoomChatSystemPrompt({
+			background: 'A fintech room.',
+			instructions: 'Always add tests.',
+		});
+		expect(prompt).toContain('Room Background');
+		expect(prompt).toContain('A fintech room.');
+		expect(prompt).toContain('Room Instructions');
+		expect(prompt).toContain('Always add tests.');
+	});
+
+	it('produces identical output when called with undefined context', () => {
+		const promptA = buildRoomChatSystemPrompt();
+		const promptB = buildRoomChatSystemPrompt(undefined);
+		expect(promptA).toBe(promptB);
+	});
+
+	it('mentions that tasks are created automatically after plan approval', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		// Should mention that tasks come from an approved plan
+		expect(prompt.toLowerCase()).toMatch(
+			/tasks.*automatically|automatically.*created.*plan|tasks.*approved plan/
+		);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/room/room-chat-agent.test.ts
@@ -77,7 +77,7 @@ describe('buildRoomChatSystemPrompt', () => {
 
 	it('mentions that tasks are created automatically after plan approval', () => {
 		const prompt = buildRoomChatSystemPrompt();
-		// Should mention automatic handling including planning, approval, and task creation
-		expect(prompt.toLowerCase()).toMatch(/automatically.*plan.*approv.*task|approv.*task/);
+		// Must mention that the system automatically handles planning, approval, and task creation
+		expect(prompt.toLowerCase()).toMatch(/automatically.*plan.*approv.*task/);
 	});
 });


### PR DESCRIPTION
The room chat agent had no system prompt, so when asked to "create a
goal", it could also call create_task immediately — bypassing the
goal → plan → approval → task workflow.

Changes:
- Add buildRoomChatSystemPrompt() in room-chat-agent.ts that explains
  the proper workflow and explicitly instructs the agent NOT to call
  create_task when creating a goal
- Add AgentSession.setRuntimeSystemPrompt() for in-memory-only prompt
  injection (mirrors setRuntimeMcpServers pattern)
- Wire the system prompt in setupRoomAgentSession so every room chat
  session gets it on startup; re-apply it when the room is updated so
  background/instructions stay current
- Add query-options-builder test confirming string prompts pass through
  for room_chat sessions
