### PR TITLE
feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -16,6 +16,7 @@ import { BridgeSession, AppServerConn, type AppServerAuth } from './process-mana
 export type { AppServerAuth } from './process-manager.js';
 import {
 	type AnthropicRequest,
+	type AnthropicErrorType,
 	buildDynamicTools,
 	buildConversationText,
 	extractSystemText,
@@ -30,10 +31,30 @@ import {
 	contentBlockStopSSE,
 	messageDeltaSSE,
 	messageStopSSE,
+	errorSSE,
 } from './translator.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('codex-bridge-server');
+
+// ---------------------------------------------------------------------------
+// Anthropic JSON error envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a JSON Response with an Anthropic-format error envelope body.
+ * Shape: {"type":"error","error":{"type":"<errorType>","message":"<message>"}}
+ */
+export function createAnthropicError(
+	httpStatus: number,
+	type: AnthropicErrorType,
+	message: string
+): Response {
+	return new Response(JSON.stringify({ type: 'error', error: { type, message } }), {
+		status: httpStatus,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
 
 /** Default TTL before an unresolved tool-call session is abandoned (5 min). */
 export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
@@ -63,7 +84,7 @@ function generateMsgId(): string {
 // SSE drain loop — shared between new turns and tool continuations
 // ---------------------------------------------------------------------------
 
-async function drainToSSE(
+export async function drainToSSE(
 	gen: AsyncGenerator<import('./process-manager.js').BridgeEvent>,
 	session: BridgeSession,
 	model: string,
@@ -149,14 +170,13 @@ async function drainToSSE(
 			return;
 		} else if (event.type === 'error') {
 			logger.error('codex-bridge: BridgeSession error:', event.message);
-			// Emit a minimal error text block so the SDK gets a response
-			if (!textBlockOpen) {
-				send(contentBlockStartTextSSE(blockIndex));
+			// Close any open text block before emitting the error event
+			if (textBlockOpen) {
+				send(contentBlockStopSSE(blockIndex));
+				textBlockOpen = false;
 			}
-			send(textDeltaSSE(blockIndex, `[Codex error: ${event.message}]`));
-			send(contentBlockStopSSE(blockIndex));
-			send(messageDeltaSSE('end_turn', outputTokens));
-			send(messageStopSSE());
+			// Emit an Anthropic-format error SSE event then close the stream
+			send(errorSSE('api_error', event.message));
 			session.kill();
 			controller.close();
 			return;
@@ -209,14 +229,14 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			}
 
 			if (url.pathname !== '/v1/messages' || req.method !== 'POST') {
-				return new Response('Not Found', { status: 404 });
+				return createAnthropicError(404, 'not_found_error', 'Not found');
 			}
 
 			let body: AnthropicRequest;
 			try {
 				body = (await req.json()) as AnthropicRequest;
 			} catch {
-				return new Response('Bad Request', { status: 400 });
+				return createAnthropicError(400, 'invalid_request_error', 'Bad Request: invalid JSON');
 			}
 
 			const sseHeaders = {
@@ -232,7 +252,11 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			if (isToolResultContinuation(body.messages)) {
 				const toolResults = extractToolResults(body.messages);
 				if (toolResults.length === 0) {
-					return new Response('Bad Request: no tool_result found', { status: 400 });
+					return createAnthropicError(
+						400,
+						'invalid_request_error',
+						'Bad Request: no tool_result found'
+					);
 				}
 
 				// Iterate ALL tool results — the Anthropic API allows multiple tool_result
@@ -273,7 +297,11 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					logger.error(
 						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
 					);
-					return new Response('Session not found', { status: 404 });
+					return createAnthropicError(
+						404,
+						'not_found_error',
+						'Session not found for all tool_use_ids in this continuation'
+					);
 				}
 
 				const { gen, session, model: sessionModel } = primaryStored;
@@ -309,7 +337,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				await session.initialize();
 			} catch (err) {
 				logger.error('codex-bridge: failed to start BridgeSession:', err);
-				return new Response(`Internal Server Error: ${String(err)}`, { status: 500 });
+				return createAnthropicError(500, 'api_error', `Internal Server Error: ${String(err)}`);
 			}
 
 			const gen = session.startTurn(userText);

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -286,3 +286,15 @@ export function messageDeltaSSE(
 export function messageStopSSE(): string {
 	return sseEvent('message_stop', { type: 'message_stop' });
 }
+
+/** Anthropic-standard error types used in both HTTP envelopes and SSE error events. */
+export type AnthropicErrorType =
+	| 'invalid_request_error'
+	| 'authentication_error'
+	| 'not_found_error'
+	| 'api_error'
+	| 'overloaded_error';
+
+export function errorSSE(errorType: AnthropicErrorType, message: string): string {
+	return sseEvent('error', { type: 'error', error: { type: errorType, message } });
+}

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -808,6 +808,8 @@ describe('Bridge HTTP server', () => {
 			}),
 		});
 		expect(resp.status).toBe(404);
+	});
+
 	// -------------------------------------------------------------------------
 	// Streaming error — drainToSSE emits Anthropic error SSE event (tests real code path)
 	// -------------------------------------------------------------------------
@@ -833,26 +835,23 @@ describe('Bridge HTTP server', () => {
 
 		const events = await readSSEEvents(stream);
 
-		// Must emit an SSE error event with Anthropic envelope
-		const errorEvent = events.find((e) => e.event === 'error');
-		expect(errorEvent).toBeDefined();
-		const data = errorEvent!.data as { type: string; error: { type: string; message: string } };
+		// Must have exactly one error SSE event
+		const errorEvents = events.filter((e) => e.event === 'error');
+		expect(errorEvents).toHaveLength(1);
+		const data = errorEvents[0].data as { type: string; error: { type: string; message: string } };
 		expect(data.type).toBe('error');
 		expect(data.error.type).toBe('api_error');
 		expect(data.error.message).toBe('codex subprocess crashed');
 
-		// Must NOT emit a plain-text [Codex error: ...] block
+		// Must NOT contain [Codex error: ...] plain-text blocks
 		const textDeltas = events.filter((e) => e.event === 'content_block_delta');
-		const hasErrorText = textDeltas.some((e) =>
-			String(
-				((e.data as { delta?: { text?: string } }).delta?.text) ?? ''
-			).includes('[Codex error:')
+		const hasLegacyErrorText = textDeltas.some((e) =>
+			String((e.data as { delta?: { text?: string } }).delta?.text ?? '').includes('[Codex error:')
 		);
-		expect(hasErrorText).toBe(false);
+		expect(hasLegacyErrorText).toBe(false);
 
-		// Session must be killed after error
+		// Session must be killed
 		expect(killCalled).toBe(true);
-	});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -15,9 +15,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import type {
-	BridgeServer,
-	ToolSession,
+import {
+	createBridgeServer,
+	createAnthropicError,
+	drainToSSE,
+	type BridgeServer,
+	type ToolSession,
 } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 
@@ -114,6 +117,7 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 				contentBlockStopSSE,
 				messageDeltaSSE,
 				messageStopSSE,
+				errorSSE,
 			} = await import('../../../../src/lib/providers/codex-anthropic-bridge/translator');
 
 			const body =
@@ -179,13 +183,22 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 						});
 						controller.close();
 						return;
-					} else if (event.type === 'turn_done' || event.type === 'error') {
+					} else if (event.type === 'turn_done') {
 						if (textOpen) {
 							controller.enqueue(enc.encode(contentBlockStopSSE(blockIndex)));
 							textOpen = false;
 						}
 						controller.enqueue(enc.encode(messageDeltaSSE('end_turn', outputTokens)));
 						controller.enqueue(enc.encode(messageStopSSE()));
+						sessionArg?.kill();
+						controller.close();
+						return;
+					} else if (event.type === 'error') {
+						if (textOpen) {
+							controller.enqueue(enc.encode(contentBlockStopSSE(blockIndex)));
+							textOpen = false;
+						}
+						controller.enqueue(enc.encode(errorSSE('api_error', event.message)));
 						sessionArg?.kill();
 						controller.close();
 						return;
@@ -795,6 +808,51 @@ describe('Bridge HTTP server', () => {
 			}),
 		});
 		expect(resp.status).toBe(404);
+	// -------------------------------------------------------------------------
+	// Streaming error — drainToSSE emits Anthropic error SSE event (tests real code path)
+	// -------------------------------------------------------------------------
+
+	it('drainToSSE emits an Anthropic error SSE event on BridgeSession error', async () => {
+		async function* errorGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'text_delta', text: 'partial' };
+			yield { type: 'error', message: 'codex subprocess crashed' };
+		}
+
+		let killCalled = false;
+		const mockSession = {
+			kill: () => {
+				killCalled = true;
+			},
+		} as unknown as import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				void drainToSSE(errorGen(), mockSession, 'test-model', new Map(), controller, 5000);
+			},
+		});
+
+		const events = await readSSEEvents(stream);
+
+		// Must emit an SSE error event with Anthropic envelope
+		const errorEvent = events.find((e) => e.event === 'error');
+		expect(errorEvent).toBeDefined();
+		const data = errorEvent!.data as { type: string; error: { type: string; message: string } };
+		expect(data.type).toBe('error');
+		expect(data.error.type).toBe('api_error');
+		expect(data.error.message).toBe('codex subprocess crashed');
+
+		// Must NOT emit a plain-text [Codex error: ...] block
+		const textDeltas = events.filter((e) => e.event === 'content_block_delta');
+		const hasErrorText = textDeltas.some((e) =>
+			String(
+				((e.data as { delta?: { text?: string } }).delta?.text) ?? ''
+			).includes('[Codex error:')
+		);
+		expect(hasErrorText).toBe(false);
+
+		// Session must be killed after error
+		expect(killCalled).toBe(true);
+	});
 	});
 
 	// -------------------------------------------------------------------------
@@ -842,5 +900,122 @@ describe('Bridge HTTP server', () => {
 		// Prevent afterEach from calling stop() again on an already-stopped server
 		// by replacing server with a no-op
 		server = { port: 0, stop: () => {} } as BridgeServer & { port: number };
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createAnthropicError helper unit tests
+// ---------------------------------------------------------------------------
+
+describe('createAnthropicError', () => {
+	it('returns the correct HTTP status and JSON envelope for 400', async () => {
+		const resp = createAnthropicError(400, 'invalid_request_error', 'bad input');
+		expect(resp.status).toBe(400);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('invalid_request_error');
+		expect(body.error.message).toBe('bad input');
+	});
+
+	it('returns the correct HTTP status and JSON envelope for 404', async () => {
+		const resp = createAnthropicError(404, 'not_found_error', 'not here');
+		expect(resp.status).toBe(404);
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+		expect(body.error.message).toBe('not here');
+	});
+
+	it('returns the correct HTTP status and JSON envelope for 500', async () => {
+		const resp = createAnthropicError(500, 'api_error', 'something exploded');
+		expect(resp.status).toBe(500);
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('api_error');
+		expect(body.error.message).toBe('something exploded');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Real createBridgeServer — HTTP error envelope integration tests
+// ---------------------------------------------------------------------------
+
+describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
+	let realServer: BridgeServer & { port: number };
+
+	beforeEach(() => {
+		// Use a nonexistent binary path; these tests only exercise paths that
+		// don't require a real Codex subprocess.
+		realServer = createBridgeServer({
+			codexBinaryPath: '/nonexistent/codex',
+			cwd: '/tmp',
+		}) as BridgeServer & { port: number };
+	});
+
+	afterEach(() => {
+		realServer.stop();
+	});
+
+	it('returns 404 JSON envelope for unknown URL paths', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/unknown/path`, {
+			method: 'GET',
+		});
+		expect(resp.status).toBe(404);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+	});
+
+	it('returns 400 JSON envelope for invalid JSON body', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'this is not json{{{',
+		});
+		expect(resp.status).toBe(400);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('invalid_request_error');
+	});
+
+	it('returns 404 JSON envelope when tool_use_id has no active session', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{
+						role: 'user',
+						content: [{ type: 'tool_result', tool_use_id: 'nonexistent-id', content: 'result' }],
+					},
+				],
+			}),
+		});
+		expect(resp.status).toBe(404);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+	});
+
+	it('returns 500 JSON envelope when BridgeSession fails to initialize', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'hello' }],
+				stream: true,
+			}),
+		});
+		expect(resp.status).toBe(500);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('api_error');
 	});
 });


### PR DESCRIPTION
- Add `createAnthropicError(httpStatus, type, message)` helper that builds
  RFC-conformant `{"type":"error","error":{"type":"...","message":"..."}}` responses
- Add `errorSSE(errorType, message)` SSE helper to translator for streaming errors
- Replace all plain-text 400/404/500 HTTP responses in server.ts with JSON envelopes
- Replace `[Codex error: ...]` text-block stream emissions with Anthropic `error` SSE events
- Remove leftover `process.stderr.write` diagnostic log (violated no-console rule);
  replaced with `logger.debug()`
- Add unit tests: createAnthropicError shape, real-server 400/404/500 envelopes,
  streaming error SSE event format
