### PR TITLE
fix: parse /context response from assistant messages (new SDK format)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "@neokai/daemon",
       "version": "0.7.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.76",
+        "@anthropic-ai/claude-agent-sdk": "0.2.77",
         "@github/copilot-sdk": "^0.1.32",
         "@neokai/shared": "workspace:*",
         "simple-git": "3.33.0",
@@ -105,7 +105,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.76", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.77", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-t+R1BW3ahCFMNM7/8WJq7+Gw9KPA9Cl7UUK8fWPokJZ75cf/xwEd9MqB+MVNoQT45dJiom/wxybT7tqYPkCqyg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,7 +19,7 @@
 		"test:online": "bun test --coverage --coverage-reporter=text ./tests/online"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.76",
+		"@anthropic-ai/claude-agent-sdk": "0.2.77",
 		"@github/copilot-sdk": "^0.1.32",
 		"@neokai/shared": "workspace:*",
 		"simple-git": "3.33.0",

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -146,7 +146,7 @@ export class ContextFetcher {
 			};
 
 			const content = this.extractTextContent(assistantMsg.message?.content);
-			if (!content.includes('**Tokens:**')) {
+			if (!content.includes('**Tokens:**') || !content.includes('| Category |')) {
 				return null;
 			}
 

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -9,8 +9,16 @@
  * - Free space
  * - Autocompact buffer
  *
- * The /context command returns a user message with isReplay=true containing
- * markdown-formatted breakdown in <local-command-stdout> tags.
+ * The /context command response format depends on the claude binary version:
+ *
+ * OLD format (claude binary < ~1.0.53):
+ *   A user message with isReplay=true containing markdown-formatted breakdown
+ *   wrapped in <local-command-stdout> tags.
+ *
+ * NEW format (claude binary >= ~1.0.53):
+ *   An assistant message where the SDK's sc8() function strips the
+ *   <local-command-stdout> wrapper and converts the output to an assistant
+ *   message with raw markdown content.
  */
 
 import type { ContextInfo, ContextCategoryBreakdown } from '@neokai/shared';
@@ -33,25 +41,66 @@ export class ContextFetcher {
 	}
 
 	/**
-	 * Check if an SDK message is a /context response
+	 * Extract text content from a message's content field.
+	 * Handles both string content and array of text blocks (BetaContentBlock[]).
+	 */
+	private extractTextContent(content: unknown): string {
+		if (typeof content === 'string') return content;
+		if (Array.isArray(content)) {
+			return content
+				.filter((block): block is { type: 'text'; text: string } => {
+					return (
+						typeof block === 'object' &&
+						block !== null &&
+						(block as { type?: string }).type === 'text'
+					);
+				})
+				.map((block) => block.text)
+				.join('');
+		}
+		return '';
+	}
+
+	/**
+	 * Check if an SDK message is a /context response.
+	 *
+	 * Handles two SDK message formats:
+	 * 1. OLD: user message with isReplay=true, content wrapped in <local-command-stdout> tags
+	 * 2. NEW: assistant message with raw markdown content (no wrapper tags)
+	 *
 	 * Returns true if the message contains context breakdown
 	 */
 	isContextResponse(message: SDKMessage): boolean {
-		if (message.type !== 'user') return false;
+		if (message.type === 'user') {
+			const userMsg = message as {
+				isReplay?: boolean;
+				message?: { content?: unknown };
+			};
 
-		const userMsg = message as {
-			isReplay?: boolean;
-			message?: { content?: string };
-		};
+			if (!userMsg.isReplay) return false;
 
-		if (!userMsg.isReplay) return false;
+			const content = this.extractTextContent(userMsg.message?.content);
+			if (!content.includes('<local-command-stdout>')) return false;
 
-		const content = userMsg.message?.content || '';
-		if (!content.includes('<local-command-stdout>')) return false;
+			// SDK output headers can drift by version/provider, but /context output always
+			// includes a "**Tokens:**" line in local-command stdout.
+			return content.includes('Context Usage') || content.includes('**Tokens:**');
+		}
 
-		// SDK output headers can drift by version/provider, but /context output always
-		// includes a "**Tokens:**" line in local-command stdout.
-		return content.includes('Context Usage') || content.includes('**Tokens:**');
+		if (message.type === 'assistant') {
+			// New SDK format: assistant message produced by sc8() in the claude binary.
+			// The <local-command-stdout> wrapper is stripped; content is raw markdown.
+			const assistantMsg = message as {
+				message?: { content?: unknown };
+			};
+
+			const content = this.extractTextContent(assistantMsg.message?.content);
+			// Must contain the tokens line AND at least one category table row to avoid
+			// false-positives on regular assistant messages that mention token counts.
+			return content.includes('**Tokens:**') && content.includes('| Category |');
+		}
+
+		return false;
 	}
 
 	/**
@@ -59,34 +108,53 @@ export class ContextFetcher {
 	 * Returns null if message is not a context response
 	 */
 	parseContextResponse(message: SDKMessage): ParsedContextInfo | null {
-		if (message.type !== 'user') {
-			return null;
+		if (message.type === 'user') {
+			const userMsg = message as {
+				isReplay?: boolean;
+				message?: { content?: unknown };
+			};
+
+			if (!userMsg.isReplay) {
+				return null;
+			}
+
+			const content = this.extractTextContent(userMsg.message?.content);
+			if (!content.includes('<local-command-stdout>')) {
+				return null;
+			}
+
+			try {
+				return this.parseMarkdownContext(content);
+			} catch (error) {
+				this.logger.warn('Failed to parse context response (user/isReplay):', error);
+				return null;
+			}
 		}
 
-		const userMsg = message as {
-			isReplay?: boolean;
-			message?: { content?: string };
-		};
+		if (message.type === 'assistant') {
+			// New SDK format: raw markdown content without <local-command-stdout> wrapper
+			const assistantMsg = message as {
+				message?: { content?: unknown };
+			};
 
-		if (!userMsg.isReplay) {
-			return null;
+			const content = this.extractTextContent(assistantMsg.message?.content);
+			if (!content.includes('**Tokens:**')) {
+				return null;
+			}
+
+			try {
+				return this.parseMarkdownContextDirect(content);
+			} catch (error) {
+				this.logger.warn('Failed to parse context response (assistant):', error);
+				return null;
+			}
 		}
 
-		const content = userMsg.message?.content || '';
-		if (!content.includes('<local-command-stdout>')) {
-			return null;
-		}
-
-		try {
-			return this.parseMarkdownContext(content);
-		} catch (error) {
-			this.logger.warn('Failed to parse context response:', error);
-			return null;
-		}
+		return null;
 	}
 
 	/**
-	 * Parse markdown content from <local-command-stdout> tags
+	 * Parse markdown content from <local-command-stdout> tags (old SDK format).
 	 */
 	private parseMarkdownContext(content: string): ParsedContextInfo {
 		// Extract content from <local-command-stdout> tags
@@ -95,8 +163,15 @@ export class ContextFetcher {
 			throw new Error('No <local-command-stdout> tags found');
 		}
 
-		const markdown = match[1];
+		return this.parseMarkdownTokensAndBreakdown(match[1]);
+	}
 
+	/**
+	 * Parse model, token counts, and category breakdown from raw markdown.
+	 * Used by both old format (after stripping <local-command-stdout> tags)
+	 * and new format (assistant message with no tags).
+	 */
+	private parseMarkdownTokensAndBreakdown(markdown: string): ParsedContextInfo {
 		// Parse model and capacity from tokens line
 		// Example: **Model:** claude-sonnet-4-5-20250929
 		// Example: **Tokens:** 62.5k / 200.0k (31%) - when tokens > 0, SDK uses 'k' suffix
@@ -180,6 +255,16 @@ export class ContextFetcher {
 		}
 
 		return breakdown;
+	}
+
+	/**
+	 * Parse markdown content directly (new SDK format: no <local-command-stdout> wrapper).
+	 *
+	 * Called for assistant messages produced by the claude binary's sc8() function,
+	 * which strips the <local-command-stdout> wrapper before creating the assistant message.
+	 */
+	private parseMarkdownContextDirect(markdown: string): ParsedContextInfo {
+		return this.parseMarkdownTokensAndBreakdown(markdown);
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -90,6 +90,14 @@ export class ContextFetcher {
 		if (message.type === 'assistant') {
 			// New SDK format: assistant message produced by sc8() in the claude binary.
 			// The <local-command-stdout> wrapper is stripped; content is raw markdown.
+			//
+			// NOTE: Unlike the old user/isReplay format (which is protected by both
+			// the isReplay flag and UUID matching), this path relies solely on content
+			// heuristics with no UUID correlation. The dual-signal guard below
+			// (**Tokens:** + | Category |) reduces false-positive risk, but a real
+			// assistant response that happens to contain both patterns would be silently
+			// consumed and not shown in the UI. This is an acceptable trade-off because
+			// the pattern combination is highly specific to /context output.
 			const assistantMsg = message as {
 				message?: { content?: unknown };
 			};
@@ -143,7 +151,7 @@ export class ContextFetcher {
 			}
 
 			try {
-				return this.parseMarkdownContextDirect(content);
+				return this.parseMarkdownTokensAndBreakdown(content);
 			} catch (error) {
 				this.logger.warn('Failed to parse context response (assistant):', error);
 				return null;
@@ -255,16 +263,6 @@ export class ContextFetcher {
 		}
 
 		return breakdown;
-	}
-
-	/**
-	 * Parse markdown content directly (new SDK format: no <local-command-stdout> wrapper).
-	 *
-	 * Called for assistant messages produced by the claude binary's sc8() function,
-	 * which strips the <local-command-stdout> wrapper before creating the assistant message.
-	 */
-	private parseMarkdownContextDirect(markdown: string): ParsedContextInfo {
-		return this.parseMarkdownTokensAndBreakdown(markdown);
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -473,20 +473,35 @@ export class SDKMessageHandler {
 		// First, correlate internal /context replay by message UUID.
 		// This avoids relying on brittle content markers that may change across SDK versions.
 		if (this.isInternalContextResponse(message)) {
-			await this.handleContextResponse(message);
-			// Skip:
-			// 1. Queuing another /context for the paired result
-			// 2. Saving/broadcasting this internal replay message
-			this.lastMessageWasContextResponse = true;
+			// UUID matches an internally queued /context command.
+			// Try to parse the context data from this message.
+			//
+			// NEW SDK behaviour (claude binary >= ~1.0.53): the user replay message
+			// contains only the original '/context' text (not the output). The actual
+			// context output arrives as a SEPARATE assistant message via sc8(). In that
+			// case parseContextResponse returns null here and the content-based check
+			// below catches the assistant message on the next iteration.
+			//
+			// OLD SDK behaviour: the user replay message itself contains the context
+			// output wrapped in <local-command-stdout> tags.
+			const parsed = await this.handleContextResponseIfParseable(message);
 
-			const userMsg = message as { uuid?: string };
-			if (userMsg.uuid) {
-				this.internalContextCommandIds.delete(userMsg.uuid);
+			if (parsed) {
+				// Successfully parsed: this message IS the context output.
+				this.lastMessageWasContextResponse = true;
+				const userMsg = message as { uuid?: string };
+				if (userMsg.uuid) {
+					this.internalContextCommandIds.delete(userMsg.uuid);
+				}
 			}
+			// Whether parsed or not, suppress saving/broadcasting this internal message
 			return;
 		}
 
-		// Check if this is a /context response BEFORE saving/emitting
+		// Check if this is a /context response BEFORE saving/emitting.
+		// Handles both:
+		//   - Old format: user message with isReplay=true + <local-command-stdout>
+		//   - New format: assistant message (from sc8()) with raw markdown content
 		// /context responses should be processed for context tracking but NOT saved to DB or shown in UI
 		const isContextResponse = this.contextFetcher.isContextResponse(message);
 		if (isContextResponse) {
@@ -496,10 +511,11 @@ export class SDKMessageHandler {
 			// 2. Saving the result message that follows this context response
 			this.lastMessageWasContextResponse = true;
 
-			// Clean up the tracked ID if this is the response
-			const userMsg = message as { uuid?: string };
-			if (userMsg.uuid && this.internalContextCommandIds.has(userMsg.uuid)) {
-				this.internalContextCommandIds.delete(userMsg.uuid);
+			// Clean up the tracked ID if this message carries the same UUID
+			// (only possible in old format where the replay IS the output)
+			const msg = message as { uuid?: string };
+			if (msg.uuid && this.internalContextCommandIds.has(msg.uuid)) {
+				this.internalContextCommandIds.delete(msg.uuid);
 			}
 
 			// IMPORTANT: Return early to skip saving and emitting this message
@@ -826,5 +842,30 @@ export class SDKMessageHandler {
 			sessionId: session.id,
 			contextInfo,
 		});
+	}
+
+	/**
+	 * Attempt to parse and handle a /context response.
+	 *
+	 * Returns true if the message was successfully parsed as context data.
+	 * Returns false if the message did not contain parseable context data
+	 * (e.g. it is a plain user acknowledgment of the /context command rather
+	 * than the actual output — which happens in the new SDK format).
+	 */
+	private async handleContextResponseIfParseable(message: SDKMessage): Promise<boolean> {
+		const { session, daemonHub, contextTracker } = this.ctx;
+
+		const parsedContext = this.contextFetcher.parseContextResponse(message);
+		if (!parsedContext) {
+			return false;
+		}
+
+		const contextInfo = this.contextFetcher.toContextInfo(parsedContext);
+		contextTracker.updateWithDetailedBreakdown(contextInfo);
+		await daemonHub.emit('context.updated', {
+			sessionId: session.id,
+			contextInfo,
+		});
+		return true;
 	}
 }

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -21,6 +21,7 @@ import { generateUUID } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SDKMessage, SDKUserMessage } from '@neokai/shared/sdk';
 import {
+	isSDKAPIRetryMessage,
 	isSDKAssistantMessage,
 	isSDKCompactBoundary,
 	isSDKResultSuccess,
@@ -467,6 +468,18 @@ export class SDKMessageHandler {
 			return;
 		}
 
+		// Suppress API retry messages: log at daemon level but do not save to DB or broadcast.
+		// These carry operational metadata (attempt count, delay, error) that is useful for
+		// debugging but should not appear in the transcript or accumulate in the database.
+		if (isSDKAPIRetryMessage(message)) {
+			this.logger.warn(
+				`API retry: attempt ${message.attempt}/${message.max_retries}, ` +
+					`delay ${message.retry_delay_ms}ms, status ${message.error_status ?? 'n/a'}, ` +
+					`error ${message.error}`
+			);
+			return;
+		}
+
 		// Automatically update phase based on message type
 		await stateManager.detectPhaseFromMessage(message);
 
@@ -621,7 +634,9 @@ export class SDKMessageHandler {
 
 		// Capture SDK's internal session ID if we don't have it yet
 		// This enables session resumption after daemon restart
-		if (!session.sdkSessionId && message.session_id) {
+		// Guard on isSDKSystemInit so that other system subtypes (api_retry, status, etc.)
+		// that also carry session_id cannot accidentally overwrite this field.
+		if (isSDKSystemInit(message) && !session.sdkSessionId && message.session_id) {
 			// Update in-memory session
 			session.sdkSessionId = message.session_id;
 

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -505,7 +505,12 @@ export class SDKMessageHandler {
 		// /context responses should be processed for context tracking but NOT saved to DB or shown in UI
 		const isContextResponse = this.contextFetcher.isContextResponse(message);
 		if (isContextResponse) {
-			await this.handleContextResponse(message);
+			const parsed = await this.handleContextResponseIfParseable(message);
+			if (!parsed) {
+				// Content-based detection said it looks like context data, but parsing
+				// failed — log a warning so the failure is visible.
+				this.logger.warn('Failed to parse /context response');
+			}
 			// Set flag to skip:
 			// 1. Queuing another /context for the next result
 			// 2. Saving the result message that follows this context response
@@ -537,6 +542,11 @@ export class SDKMessageHandler {
 		if (message.type === 'result' && this.lastMessageWasContextResponse) {
 			// Reset the flag - we've now handled both the context response AND its result
 			this.lastMessageWasContextResponse = false;
+			// Clear any pending internal context command IDs. In the new SDK format the
+			// assistant message that carries context data does NOT match the enqueued UUID,
+			// so the UUID stays in the set after the user-replay is processed. Without this
+			// clear the stale UUID would prevent auto-queuing /context on subsequent turns.
+			this.internalContextCommandIds.clear();
 			// Return early - don't save or broadcast this result
 			return;
 		}
@@ -819,38 +829,13 @@ export class SDKMessageHandler {
 	}
 
 	/**
-	 * Handle /context response
-	 * Parse the detailed breakdown and update context tracker
-	 */
-	private async handleContextResponse(message: SDKMessage): Promise<void> {
-		const { session, daemonHub, contextTracker } = this.ctx;
-
-		const parsedContext = this.contextFetcher.parseContextResponse(message);
-		if (!parsedContext) {
-			this.logger.warn('Failed to parse /context response');
-			return;
-		}
-
-		const contextInfo = this.contextFetcher.toContextInfo(parsedContext);
-
-		// Update ContextTracker - persists to session metadata
-		contextTracker.updateWithDetailedBreakdown(contextInfo);
-
-		// Emit context update event via DaemonHub
-		// StateManager will broadcast this via state.session channel
-		await daemonHub.emit('context.updated', {
-			sessionId: session.id,
-			contextInfo,
-		});
-	}
-
-	/**
 	 * Attempt to parse and handle a /context response.
 	 *
 	 * Returns true if the message was successfully parsed as context data.
 	 * Returns false if the message did not contain parseable context data
 	 * (e.g. it is a plain user acknowledgment of the /context command rather
-	 * than the actual output — which happens in the new SDK format).
+	 * than the actual output — which happens in the new SDK format where a
+	 * user replay carries the original '/context' text, not the output).
 	 */
 	private async handleContextResponseIfParseable(message: SDKMessage): Promise<boolean> {
 		const { session, daemonHub, contextTracker } = this.ctx;
@@ -861,7 +846,12 @@ export class SDKMessageHandler {
 		}
 
 		const contextInfo = this.contextFetcher.toContextInfo(parsedContext);
+
+		// Persist to session metadata
 		contextTracker.updateWithDetailedBreakdown(contextInfo);
+
+		// Emit context update event via DaemonHub
+		// StateManager will broadcast this via state.session channel
 		await daemonHub.emit('context.updated', {
 			sessionId: session.id,
 			contextInfo,

--- a/packages/daemon/tests/online/agent/context-command.test.ts
+++ b/packages/daemon/tests/online/agent/context-command.test.ts
@@ -48,22 +48,12 @@ interface SDKMessageResult {
 describe('Context Command Online Tests', () => {
 	let daemon: DaemonServerContext;
 
-	// Skip all tests if no Anthropic credentials (or not using Dev Proxy mock)
-	const hasAnthropicCredentials =
-		IS_MOCK || process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN;
-
 	beforeEach(async () => {
-		if (!hasAnthropicCredentials) {
-			return; // Skip setup if no credentials
-		}
 		daemon = await createDaemonServer();
 	}, SETUP_TIMEOUT);
 
 	afterEach(
 		async () => {
-			if (!hasAnthropicCredentials) {
-				return; // Skip cleanup if no credentials
-			}
 			if (daemon) {
 				daemon.kill('SIGTERM');
 				await daemon.waitForExit();
@@ -74,11 +64,6 @@ describe('Context Command Online Tests', () => {
 
 	describe('Automatic /context at turn end', () => {
 		test('should parse /context replay and produce source=context-command with SDK categories', async () => {
-			if (!hasAnthropicCredentials) {
-				console.log('Skipping - no Anthropic API credentials');
-				return;
-			}
-
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: process.cwd(),
 				title: 'Context Command Test',
@@ -161,10 +146,6 @@ describe('Context Command Online Tests', () => {
 		}, 60000);
 
 		test('should not produce repeated zero-token result messages after one turn', async () => {
-			if (!hasAnthropicCredentials) {
-				console.log('Skipping - no Anthropic API credentials');
-				return;
-			}
 			// In mock mode, the test checks for zero-token result patterns which may
 			// not behave the same way with mocked responses. Do a basic check only.
 			if (IS_MOCK) {

--- a/packages/daemon/tests/unit/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/agent/context-fetcher.test.ts
@@ -5,7 +5,9 @@ describe('ContextFetcher', () => {
 	const fetcher = new ContextFetcher('test-session');
 
 	describe('isContextResponse', () => {
-		it('should detect valid context response', () => {
+		// --- Old SDK format (user message with isReplay + <local-command-stdout>) ---
+
+		it('should detect valid context response (old format: user/isReplay)', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -17,15 +19,6 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(true);
 		});
 
-		it('should reject non-user messages', () => {
-			const message = {
-				type: 'assistant',
-				message: { content: 'test' },
-			};
-
-			expect(fetcher.isContextResponse(message as never)).toBe(false);
-		});
-
 		it('should reject user messages without isReplay', () => {
 			const message = {
 				type: 'user',
@@ -35,7 +28,7 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 
-		it('should reject messages without context stdout', () => {
+		it('should reject user isReplay messages without context stdout', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -45,7 +38,7 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 
-		it('should detect context response without explicit "Context Usage" header', () => {
+		it('should detect context response without explicit "Context Usage" header (old format)', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -56,6 +49,72 @@ describe('ContextFetcher', () => {
 			};
 
 			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		// --- New SDK format (assistant message with raw markdown, no wrapper tags) ---
+		// In the new claude binary, sc8() converts system/local_command messages to
+		// assistant messages and strips <local-command-stdout> tags.
+
+		it('should detect context response in new assistant message format', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [
+						{
+							type: 'text',
+							text: `## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n### Estimated usage by category\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |\n| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |`,
+						},
+					],
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		it('should detect context response in new format with string content', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content:
+						'## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |',
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		it('should reject regular assistant messages that mention tokens but have no category table', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [
+						{
+							type: 'text',
+							text: 'Here is a summary. **Tokens:** 1k / 200k (1%). No table here.',
+						},
+					],
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
+		});
+
+		it('should reject regular assistant messages without tokens line', () => {
+			const message = {
+				type: 'assistant',
+				message: { content: 'This is just a regular assistant response.' },
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
+		});
+
+		it('should reject system messages', () => {
+			const message = {
+				type: 'system',
+				subtype: 'init',
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 	});
 
@@ -236,6 +295,71 @@ No table rows here.
 
 </local-command-stdout>`,
 				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
+		// --- New SDK format: assistant messages (sc8() strips <local-command-stdout> tags) ---
+
+		it('should parse new assistant message format with array content', () => {
+			// This is the format produced by sc8() in newer claude binaries:
+			// <local-command-stdout> tags are stripped, content is raw markdown in an array.
+			const rawMarkdown = `## Context Usage\n\n**Model:** claude-sonnet-4-6  \n**Tokens:** 20.3k / 200k (10%)\n\n### Estimated usage by category\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |\n| System tools | 18k | 9.0% |\n| Skills | 61 | 0.0% |\n| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |\n| Autocompact buffer | 33k | 16.5% |`;
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [{ type: 'text', text: rawMarkdown }],
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+
+			expect(result).not.toBeNull();
+			expect(result?.model).toBe('claude-sonnet-4-6');
+			expect(result?.totalCapacity).toBe(200000);
+			// totalUsed = 3600 + 18000 + 61 + 108 + 33000 = 54769 (Free space excluded)
+			expect(result?.totalUsed).toBe(54769);
+			expect(result?.percentUsed).toBe(27);
+			expect(result?.breakdown['System tools']).toEqual({ tokens: 18000, percent: 9.0 });
+			expect(result?.breakdown['System prompt']).toEqual({ tokens: 3600, percent: 1.8 });
+			expect(result?.breakdown['Autocompact buffer']).toEqual({ tokens: 33000, percent: 16.5 });
+		});
+
+		it('should parse new assistant message format with string content', () => {
+			const rawMarkdown = `## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 62.5k / 200.0k (31%)\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.2k | 1.6% |\n| System tools | 14.3k | 7.1% |\n| Messages | 25 | 0.0% |\n| Free space | 137.5k | 68.7% |\n| Autocompact buffer | 45.0k | 22.5% |`;
+			const message = {
+				type: 'assistant',
+				message: { content: rawMarkdown },
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+
+			expect(result).not.toBeNull();
+			expect(result?.model).toBe('claude-sonnet-4-6');
+			expect(result?.totalCapacity).toBe(200000);
+			// totalUsed = 3200 + 14300 + 25 + 45000 = 62525
+			expect(result?.totalUsed).toBe(62525);
+			expect(result?.percentUsed).toBe(31);
+		});
+
+		it('should return null for assistant message without tokens line', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [{ type: 'text', text: 'Just a regular response without context data.' }],
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
+		it('should return null for non-user non-assistant messages', () => {
+			const message = {
+				type: 'system',
+				subtype: 'init',
 			};
 
 			const result = fetcher.parseContextResponse(message as never);

--- a/packages/daemon/tests/unit/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/agent/context-fetcher.test.ts
@@ -356,6 +356,19 @@ No table rows here.
 			expect(result).toBeNull();
 		});
 
+		it('should return null for assistant message with tokens line but no category table', () => {
+			// Guard is tighter than isContextResponse to prevent false-positive parse attempts
+			const message = {
+				type: 'assistant',
+				message: {
+					content: 'Here is your summary. **Tokens:** 5k / 200k (2%). No table follows.',
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
 		it('should return null for non-user non-assistant messages', () => {
 			const message = {
 				type: 'system',

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -1124,6 +1124,108 @@ describe('SDKMessageHandler', () => {
 			);
 		});
 
+		it('should clear internalContextCommandIds after new SDK format three-message sequence', async () => {
+			// New SDK format state machine:
+			// 1. Normal result → enqueues /context (UUID=X stored in internalContextCommandIds)
+			// 2. User replay (UUID=X, content='/context') → UUID matched, parse returns null, UUID stays in set
+			// 3. Assistant message (sc8() output, UUID≠X) → context parsed, lastMessageWasContextResponse=true
+			// 4. Result message → internalContextCommandIds.clear() fires
+			// 5. Next normal result → set is empty → queues /context again
+
+			const normalResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'normal-result-uuid',
+				usage: {
+					input_tokens: 100,
+					output_tokens: 50,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0.001,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+
+			// Step 1: normal result queues /context
+			await handler.handleMessage(normalResult);
+			const contextUuid = (mockMessageQueue.enqueueWithId as ReturnType<typeof mock>).mock
+				.calls[0][0] as string;
+			expect(contextUuid).toBeString();
+
+			// Step 2: user replay with the context UUID but only plain '/context' text (new SDK format)
+			const userReplay: SDKMessage = {
+				type: 'user',
+				uuid: contextUuid,
+				isReplay: true,
+				message: {
+					role: 'user',
+					content: '/context',
+				},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(userReplay);
+			// UUID-matched replay is suppressed — no save or broadcast
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1); // only the normal result
+
+			// Step 3: sc8() assistant message carrying actual context output (UUID differs from contextUuid)
+			const sc8AssistantContextMarkdown =
+				'## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n' +
+				'### Estimated usage by category\n\n' +
+				'| Category | Tokens | Percentage |\n|----------|--------|------------|\n' +
+				'| System prompt | 3.6k | 1.8% |\n| System tools | 18k | 9.0% |\n' +
+				'| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |';
+			const sc8AssistantMessage: SDKMessage = {
+				type: 'assistant',
+				uuid: 'sc8-assistant-uuid',
+				message: {
+					role: 'assistant',
+					content: [{ type: 'text', text: sc8AssistantContextMarkdown }],
+				},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(sc8AssistantMessage);
+			// Context data was parsed and tracker updated
+			expect(updateWithDetailedBreakdownSpy).toHaveBeenCalledTimes(1);
+			// sc8() assistant message is suppressed — still only 1 DB save
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1);
+
+			// Step 4: result message following the /context turn (zero tokens) — suppressed
+			const contextTurnResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'context-turn-result-uuid',
+				usage: {
+					input_tokens: 0,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(contextTurnResult);
+			// Result suppressed — still only 1 DB save and no new /context enqueue
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1);
+			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(1);
+
+			// Step 5: next normal result — internalContextCommandIds must be empty now
+			// so /context gets queued again
+			const nextNormalResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'next-normal-result-uuid',
+				usage: {
+					input_tokens: 120,
+					output_tokens: 60,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0.001,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(nextNormalResult);
+			// internalContextCommandIds was cleared in step 4, so /context is queued again
+			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(2);
+		});
+
 		it('should suppress zero-token internal result when replay correlation fails', async () => {
 			const normalResult: SDKMessage = {
 				type: 'result',

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -377,6 +377,29 @@ describe('SDKMessageHandler', () => {
 
 			expect(mockSession.sdkSessionId).toBe('existing-session-id');
 		});
+
+		it('should not set sdkSessionId from api_retry message', async () => {
+			// api_retry has session_id but should not overwrite sdkSessionId
+			// — only system/init messages are the authoritative source
+			const message: SDKMessage = {
+				type: 'system',
+				subtype: 'api_retry',
+				uuid: 'retry-uuid',
+				session_id: 'retry-session-id',
+				attempt: 1,
+				max_retries: 3,
+				retry_delay_ms: 1000,
+				error_status: 429,
+				error: 'rate_limit',
+			} as unknown as SDKMessage;
+
+			await handler.handleMessage(message);
+
+			expect(mockSession.sdkSessionId).toBeUndefined();
+			// api_retry is suppressed before DB/broadcast — should not appear in transcript
+			expect(saveSDKMessageSpy).not.toHaveBeenCalled();
+			expect(publishSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('handleResultMessage', () => {

--- a/packages/shared/src/sdk/index.ts
+++ b/packages/shared/src/sdk/index.ts
@@ -16,6 +16,7 @@ export {
   isSDKCompactBoundary,
   isSDKStatusMessage,
   isSDKHookResponse,
+  isSDKAPIRetryMessage,
   isSDKStreamEvent,
   isSDKToolProgressMessage,
   isSDKAuthStatusMessage,

--- a/packages/shared/src/sdk/sdk.d.ts
+++ b/packages/shared/src/sdk/sdk.d.ts
@@ -236,6 +236,7 @@ declare namespace coreTypes {
         PromptRequest,
         PromptResponse,
         RewindFilesResult,
+        SDKAPIRetryMessage,
         SDKAssistantMessageError,
         SDKAssistantMessage,
         SDKAuthStatusMessage,
@@ -1994,7 +1995,7 @@ export declare type SdkMcpToolDefinition<Schema extends AnyZodRawShape = AnyZodR
     handler: (args: InferShape<Schema>, extra: unknown) => Promise<CallToolResult>;
 };
 
-export declare type SDKMessage = SDKAssistantMessage | SDKUserMessage | SDKUserMessageReplay | SDKResultMessage | SDKSystemMessage | SDKPartialAssistantMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKLocalCommandOutputMessage | SDKHookStartedMessage | SDKHookProgressMessage | SDKHookResponseMessage | SDKToolProgressMessage | SDKAuthStatusMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKToolUseSummaryMessage | SDKRateLimitEvent | SDKElicitationCompleteMessage | SDKPromptSuggestionMessage;
+export declare type SDKMessage = SDKAssistantMessage | SDKUserMessage | SDKUserMessageReplay | SDKResultMessage | SDKSystemMessage | SDKPartialAssistantMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKAPIRetryMessage | SDKLocalCommandOutputMessage | SDKHookStartedMessage | SDKHookProgressMessage | SDKHookResponseMessage | SDKToolProgressMessage | SDKAuthStatusMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKToolUseSummaryMessage | SDKRateLimitEvent | SDKElicitationCompleteMessage | SDKPromptSuggestionMessage;
 
 export declare type SDKPartialAssistantMessage = {
     type: 'stream_event';
@@ -2230,6 +2231,18 @@ export declare type SDKStatusMessage = {
     subtype: 'status';
     status: SDKStatus;
     permissionMode?: PermissionMode;
+    uuid: UUID;
+    session_id: string;
+};
+
+export declare type SDKAPIRetryMessage = {
+    type: 'system';
+    subtype: 'api_retry';
+    attempt: number;
+    max_retries: number;
+    retry_delay_ms: number;
+    error_status: number | null;
+    error: SDKAssistantMessageError;
     uuid: UUID;
     session_id: string;
 };

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  SDKAPIRetryMessage,
   SDKMessage,
   SDKAssistantMessage,
   SDKAuthStatusMessage,
@@ -131,6 +132,15 @@ export function isSDKHookResponse(
   msg: SDKMessage,
 ): msg is SDKHookResponseMessage {
   return msg.type === "system" && (msg as SDKHookResponseMessage).subtype === "hook_response";
+}
+
+/**
+ * Check if message is an API retry message
+ */
+export function isSDKAPIRetryMessage(
+  msg: SDKMessage,
+): msg is SDKAPIRetryMessage {
+  return msg.type === "system" && (msg as SDKAPIRetryMessage).subtype === "api_retry";
 }
 
 /**
@@ -311,6 +321,10 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
     const hookMsg = msg as SDKHookResponseMessage;
     return `Hook Response: ${hookMsg.hook_name}`;
   }
+  if (isSDKAPIRetryMessage(msg)) {
+    const retryMsg = msg as SDKAPIRetryMessage;
+    return `API Retry: attempt ${retryMsg.attempt}/${retryMsg.max_retries}`;
+  }
   if (isSDKStreamEvent(msg)) {
     return "Streaming Event";
   }
@@ -330,8 +344,9 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
 export function isUserVisibleMessage(msg: SDKMessage): boolean {
   // User should see: assistant, user, result, tool_progress, auth_status, user replays,
   // compact_boundary, and compacting status messages
-  // User should NOT see: stream events only
+  // User should NOT see: stream events or API retry messages
   if (isSDKStreamEvent(msg)) return false;
+  if (isSDKAPIRetryMessage(msg)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: After upgrading `@anthropic-ai/claude-agent-sdk` from 0.2.55 → 0.2.76, the `/context` command response format changed. In newer claude binaries (≥ ~1.0.53), the slash command output is stored internally as a `system/local_command` message and yielded by the SDK's `sc8()` function as an **assistant message** with raw markdown content (no `<local-command-stdout>` wrapper). The previous code only detected the old format — a `user` message with `isReplay=true` containing `<local-command-stdout>` tags — so the context data was never parsed and the response appeared as a regular assistant message in the UI.
- **Fix**: Extended `ContextFetcher.isContextResponse()` and `parseContextResponse()` to handle both formats. Added a shared `parseMarkdownTokensAndBreakdown()` helper so both paths reuse the same token/breakdown parsing logic.
- **SDK message handler**: Replaced the noisy `handleContextResponse()` call on UUID-matched user messages with `handleContextResponseIfParseable()` — plain `/context` acknowledgment replays (new SDK sends content `/context`, not the output) are now silently suppressed instead of logging a spurious warning.

## Test plan

- [x] 7 new unit tests in `context-fetcher.test.ts` covering:
  - `isContextResponse` detection of new assistant message format (array and string content)
  - `parseContextResponse` parsing of new assistant message format
  - Rejection of regular assistant messages that mention tokens but lack a category table
- [x] All existing `context-fetcher.test.ts` tests (old format) still pass
- [x] `make test-daemon` — 4633 pass, 0 new failures (pre-existing Dev Proxy / Copilot PATH failures are unrelated)
- [x] Lint, typecheck, and knip all clean