### PR TITLE
feat: improve error mapping in copilot bridge (Task 5.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "@neokai/daemon",
       "version": "0.7.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.76",
+        "@anthropic-ai/claude-agent-sdk": "0.2.77",
         "@github/copilot-sdk": "^0.1.32",
         "@neokai/shared": "workspace:*",
         "simple-git": "3.33.0",
@@ -105,7 +105,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.76", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.77", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-t+R1BW3ahCFMNM7/8WJq7+Gw9KPA9Cl7UUK8fWPokJZ75cf/xwEd9MqB+MVNoQT45dJiom/wxybT7tqYPkCqyg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,7 +19,7 @@
 		"test:online": "bun test --coverage --coverage-reporter=text ./tests/online"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.76",
+		"@anthropic-ai/claude-agent-sdk": "0.2.77",
 		"@github/copilot-sdk": "^0.1.32",
 		"@neokai/shared": "workspace:*",
 		"simple-git": "3.33.0",

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -593,9 +593,10 @@ export class AgentSession
 	// ============================================================================
 
 	async handleModelSwitch(
-		newModel: string
+		newModel: string,
+		newProvider: string
 	): Promise<{ success: boolean; model: string; error?: string }> {
-		return this.modelSwitchHandler.switchModel(newModel);
+		return this.modelSwitchHandler.switchModel(newModel, newProvider);
 	}
 
 	getCurrentModel(): CurrentModelInfo {
@@ -640,6 +641,18 @@ export class AgentSession
 		this.session.config = {
 			...this.session.config,
 			mcpServers,
+		};
+	}
+
+	/**
+	 * Apply a runtime system prompt to in-memory session config only.
+	 * Used to inject context-specific instructions (e.g. room workflow guidance)
+	 * without persisting them to the database.
+	 */
+	setRuntimeSystemPrompt(systemPrompt: SystemPromptConfig): void {
+		this.session.config = {
+			...this.session.config,
+			systemPrompt,
 		};
 	}
 

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -9,8 +9,16 @@
  * - Free space
  * - Autocompact buffer
  *
- * The /context command returns a user message with isReplay=true containing
- * markdown-formatted breakdown in <local-command-stdout> tags.
+ * The /context command response format depends on the claude binary version:
+ *
+ * OLD format (claude binary < ~1.0.53):
+ *   A user message with isReplay=true containing markdown-formatted breakdown
+ *   wrapped in <local-command-stdout> tags.
+ *
+ * NEW format (claude binary >= ~1.0.53):
+ *   An assistant message where the SDK's sc8() function strips the
+ *   <local-command-stdout> wrapper and converts the output to an assistant
+ *   message with raw markdown content.
  */
 
 import type { ContextInfo, ContextCategoryBreakdown } from '@neokai/shared';
@@ -33,25 +41,74 @@ export class ContextFetcher {
 	}
 
 	/**
-	 * Check if an SDK message is a /context response
+	 * Extract text content from a message's content field.
+	 * Handles both string content and array of text blocks (BetaContentBlock[]).
+	 */
+	private extractTextContent(content: unknown): string {
+		if (typeof content === 'string') return content;
+		if (Array.isArray(content)) {
+			return content
+				.filter((block): block is { type: 'text'; text: string } => {
+					return (
+						typeof block === 'object' &&
+						block !== null &&
+						(block as { type?: string }).type === 'text'
+					);
+				})
+				.map((block) => block.text)
+				.join('');
+		}
+		return '';
+	}
+
+	/**
+	 * Check if an SDK message is a /context response.
+	 *
+	 * Handles two SDK message formats:
+	 * 1. OLD: user message with isReplay=true, content wrapped in <local-command-stdout> tags
+	 * 2. NEW: assistant message with raw markdown content (no wrapper tags)
+	 *
 	 * Returns true if the message contains context breakdown
 	 */
 	isContextResponse(message: SDKMessage): boolean {
-		if (message.type !== 'user') return false;
+		if (message.type === 'user') {
+			const userMsg = message as {
+				isReplay?: boolean;
+				message?: { content?: unknown };
+			};
 
-		const userMsg = message as {
-			isReplay?: boolean;
-			message?: { content?: string };
-		};
+			if (!userMsg.isReplay) return false;
 
-		if (!userMsg.isReplay) return false;
+			const content = this.extractTextContent(userMsg.message?.content);
+			if (!content.includes('<local-command-stdout>')) return false;
 
-		const content = userMsg.message?.content || '';
-		if (!content.includes('<local-command-stdout>')) return false;
+			// SDK output headers can drift by version/provider, but /context output always
+			// includes a "**Tokens:**" line in local-command stdout.
+			return content.includes('Context Usage') || content.includes('**Tokens:**');
+		}
 
-		// SDK output headers can drift by version/provider, but /context output always
-		// includes a "**Tokens:**" line in local-command stdout.
-		return content.includes('Context Usage') || content.includes('**Tokens:**');
+		if (message.type === 'assistant') {
+			// New SDK format: assistant message produced by sc8() in the claude binary.
+			// The <local-command-stdout> wrapper is stripped; content is raw markdown.
+			//
+			// NOTE: Unlike the old user/isReplay format (which is protected by both
+			// the isReplay flag and UUID matching), this path relies solely on content
+			// heuristics with no UUID correlation. The dual-signal guard below
+			// (**Tokens:** + | Category |) reduces false-positive risk, but a real
+			// assistant response that happens to contain both patterns would be silently
+			// consumed and not shown in the UI. This is an acceptable trade-off because
+			// the pattern combination is highly specific to /context output.
+			const assistantMsg = message as {
+				message?: { content?: unknown };
+			};
+
+			const content = this.extractTextContent(assistantMsg.message?.content);
+			// Must contain the tokens line AND at least one category table row to avoid
+			// false-positives on regular assistant messages that mention token counts.
+			return content.includes('**Tokens:**') && content.includes('| Category |');
+		}
+
+		return false;
 	}
 
 	/**
@@ -59,34 +116,53 @@ export class ContextFetcher {
 	 * Returns null if message is not a context response
 	 */
 	parseContextResponse(message: SDKMessage): ParsedContextInfo | null {
-		if (message.type !== 'user') {
-			return null;
+		if (message.type === 'user') {
+			const userMsg = message as {
+				isReplay?: boolean;
+				message?: { content?: unknown };
+			};
+
+			if (!userMsg.isReplay) {
+				return null;
+			}
+
+			const content = this.extractTextContent(userMsg.message?.content);
+			if (!content.includes('<local-command-stdout>')) {
+				return null;
+			}
+
+			try {
+				return this.parseMarkdownContext(content);
+			} catch (error) {
+				this.logger.warn('Failed to parse context response (user/isReplay):', error);
+				return null;
+			}
 		}
 
-		const userMsg = message as {
-			isReplay?: boolean;
-			message?: { content?: string };
-		};
+		if (message.type === 'assistant') {
+			// New SDK format: raw markdown content without <local-command-stdout> wrapper
+			const assistantMsg = message as {
+				message?: { content?: unknown };
+			};
 
-		if (!userMsg.isReplay) {
-			return null;
+			const content = this.extractTextContent(assistantMsg.message?.content);
+			if (!content.includes('**Tokens:**') || !content.includes('| Category |')) {
+				return null;
+			}
+
+			try {
+				return this.parseMarkdownTokensAndBreakdown(content);
+			} catch (error) {
+				this.logger.warn('Failed to parse context response (assistant):', error);
+				return null;
+			}
 		}
 
-		const content = userMsg.message?.content || '';
-		if (!content.includes('<local-command-stdout>')) {
-			return null;
-		}
-
-		try {
-			return this.parseMarkdownContext(content);
-		} catch (error) {
-			this.logger.warn('Failed to parse context response:', error);
-			return null;
-		}
+		return null;
 	}
 
 	/**
-	 * Parse markdown content from <local-command-stdout> tags
+	 * Parse markdown content from <local-command-stdout> tags (old SDK format).
 	 */
 	private parseMarkdownContext(content: string): ParsedContextInfo {
 		// Extract content from <local-command-stdout> tags
@@ -95,8 +171,15 @@ export class ContextFetcher {
 			throw new Error('No <local-command-stdout> tags found');
 		}
 
-		const markdown = match[1];
+		return this.parseMarkdownTokensAndBreakdown(match[1]);
+	}
 
+	/**
+	 * Parse model, token counts, and category breakdown from raw markdown.
+	 * Used by both old format (after stripping <local-command-stdout> tags)
+	 * and new format (assistant message with no tags).
+	 */
+	private parseMarkdownTokensAndBreakdown(markdown: string): ParsedContextInfo {
 		// Parse model and capacity from tokens line
 		// Example: **Model:** claude-sonnet-4-5-20250929
 		// Example: **Tokens:** 62.5k / 200.0k (31%) - when tokens > 0, SDK uses 'k' suffix

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -61,8 +61,11 @@ export class EventSubscriptionSetup {
 		// Model switch request handler
 		const unsubModelSwitch = daemonHub.on(
 			'model.switchRequest',
-			async ({ sessionId: sid, model }) => {
-				const result = await modelSwitchHandler.switchModel(model);
+			async ({ sessionId: sid, model, provider }) => {
+				if (!provider) {
+					throw new Error('model.switchRequest event is missing required field: provider');
+				}
+				const result = await modelSwitchHandler.switchModel(model, provider);
 
 				// Emit result
 				await daemonHub.emit('model.switched', {

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -17,7 +17,13 @@
  */
 
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
-import type { Session, SessionConfig, CurrentModelInfo, MessageHub } from '@neokai/shared';
+import type {
+	Provider,
+	Session,
+	SessionConfig,
+	CurrentModelInfo,
+	MessageHub,
+} from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { ErrorManager } from '../error-manager';
@@ -75,13 +81,16 @@ export class ModelSwitchHandler {
 	}
 
 	/**
-	 * Switch to a different model mid-session
+	 * Switch to a different model mid-session.
 	 *
 	 * Always restarts the query to ensure SDK emits a fresh system:init message
 	 * with the correct model. This is necessary because SDK's setModel() doesn't
 	 * update the cached system:init, causing stale model info in the UI.
+	 *
+	 * @param newModel - Model ID or alias to switch to
+	 * @param newProvider - Provider ID for the new model (required)
 	 */
-	async switchModel(newModel: string): Promise<ModelSwitchResult> {
+	async switchModel(newModel: string, newProvider: string): Promise<ModelSwitchResult> {
 		const {
 			session,
 			db,
@@ -97,8 +106,12 @@ export class ModelSwitchHandler {
 		} = this.ctx;
 
 		try {
-			// Validate the model
-			const isValid = await isValidModel(newModel);
+			if (!session.config.provider) {
+				throw new Error('Session has no provider configured');
+			}
+
+			// Validate the new model against the new provider
+			const isValid = await isValidModel(newModel, 'global', newProvider);
 			if (!isValid) {
 				const error = `Invalid model: ${newModel}. Use a valid model ID or alias.`;
 				logger.error(`${error}`);
@@ -110,14 +123,25 @@ export class ModelSwitchHandler {
 			// and then calling getModelInfo loses the provider — two providers can share
 			// the same canonical ID (e.g., Anthropic and anthropic-copilot both have
 			// 'claude-sonnet-4.6').
-			const modelInfo = await getModelInfo(newModel);
-			const resolvedModel = modelInfo?.id ?? (await resolveModelAlias(newModel));
+			// Use newProvider to correctly disambiguate same-ID models across providers.
+			const modelInfo = await getModelInfo(newModel, 'global', newProvider);
+			// modelInfo is non-null here because isValidModel passed above;
+			// fall back to newModel as-is for defensive safety (unreachable in practice).
+			const resolvedModel = modelInfo?.id ?? newModel;
 
-			// Resolve the current model in case it's also an alias
-			const currentResolvedModel = await resolveModelAlias(session.config.model);
+			// Resolve the current model in case it's also an alias.
+			// Use session.config.provider (the current provider) for the current model.
+			const currentResolvedModel = await resolveModelAlias(
+				session.config.model,
+				'global',
+				session.config.provider
+			);
 
-			// Check if already using this model (compare resolved IDs)
-			if (currentResolvedModel === resolvedModel) {
+			// Check if already using this model (compare resolved IDs and provider).
+			// Must check provider too: two providers can share the same canonical ID
+			// (e.g., anthropic and anthropic-copilot both have claude-sonnet-4.6),
+			// so switching providers on the same model ID is a meaningful operation.
+			if (currentResolvedModel === resolvedModel && session.config.provider === newProvider) {
 				return {
 					success: true,
 					model: resolvedModel,
@@ -140,34 +164,33 @@ export class ModelSwitchHandler {
 			// Check if query is running AND ProcessTransport is ready
 			const transportReady = firstMessageReceived;
 
-			// Detect new provider instance to keep provider config aligned with the model
+			// Locate the provider instance for the new model.
+			// newProvider is a required string, so detectProviderForModel always receives
+			// an explicit provider — no heuristic fallback is needed.
 			const providerRegistry = getProviderRegistry();
-			// Use provider from model info to correctly handle shared canonical IDs
-			// (e.g., 'claude-sonnet-4.6' is owned by both Anthropic and anthropic-copilot).
-			// detectProvider() would otherwise return Anthropic for 'claude-sonnet-4.6'.
-			const newProviderInstance = modelInfo?.provider
-				? (providerRegistry.get(modelInfo.provider) ??
-					providerRegistry.detectProvider(resolvedModel))
-				: providerRegistry.detectProvider(resolvedModel);
+			const newProviderInstance = providerRegistry.detectProviderForModel(
+				resolvedModel,
+				newProvider
+			);
+
+			if (!newProviderInstance) {
+				const errMsg = `Cannot switch to model '${resolvedModel}': provider '${newProvider}' is not registered.`;
+				logger.error(errMsg);
+				return { success: false, model: session.config.model, error: errMsg };
+			}
 
 			if (!queryObject || !transportReady) {
 				// Query not started yet OR transport not ready - just update config
 				session.config.model = resolvedModel;
-				// Keep provider aligned with model for pre-query switches too.
-				// Without this, a stale explicit provider can force wrong model routing.
-				if (newProviderInstance?.id) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					session.config.provider = newProviderInstance.id as any;
-				}
+				// newProviderInstance is guaranteed non-null here (we returned early above).
+				session.config.provider = newProviderInstance.id as Provider;
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
 					config: {
 						model: resolvedModel,
-						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as 'anthropic' | 'glm',
-						}),
+						provider: newProviderInstance.id as Provider,
 					} as SessionConfig,
 				});
 
@@ -188,21 +211,15 @@ export class ModelSwitchHandler {
 
 				// Update session config first (will be used when query restarts)
 				session.config.model = resolvedModel;
-				// Keep provider aligned with model (same as the pre-query branch —
-				// unconditionally update so same-provider switches don’t leave stale state).
-				if (newProviderInstance?.id) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					session.config.provider = newProviderInstance.id as any;
-				}
+				// newProviderInstance is guaranteed non-null here (we returned early above).
+				session.config.provider = newProviderInstance.id as Provider;
 				// Only pass serializable fields — session.config may contain runtime-only
 				// objects (mcpServers with closures, agents, spawnClaudeCodeProcess) that
 				// cannot be JSON-stringified and would cause a cyclic structure error.
 				db.updateSession(session.id, {
 					config: {
 						model: resolvedModel,
-						...(newProviderInstance?.id && {
-							provider: newProviderInstance.id as 'anthropic' | 'glm',
-						}),
+						provider: newProviderInstance.id as Provider,
 					} as SessionConfig,
 				});
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -124,12 +124,12 @@ export class QueryRunner {
 			const { initializeProviders } = await import('../providers/factory.js');
 			const providerRegistry = initializeProviders();
 			const modelId = session.config.model || 'sonnet';
-			// Check explicit provider first (stored during session creation when model alias is resolved).
-			// This is critical when canonical model IDs are shared across providers
-			// (e.g., claude-sonnet-4.6), which would be misrouted if we only used detectProvider().
+			// Routing is deterministic: session.config.provider is always set by the model
+			// picker and stored on every model switch. Legacy sessions without a stored
+			// provider fall back to heuristic detection (@deprecated path).
 			const explicitProviderId = session.config.provider as string | undefined;
 			const provider = explicitProviderId
-				? (providerRegistry.get(explicitProviderId) ?? providerRegistry.detectProvider(modelId))
+				? providerRegistry.detectProviderForModel(modelId, explicitProviderId)
 				: providerRegistry.detectProvider(modelId);
 
 			// Check if the provider supports getAuthStatus (OAuth-style providers)
@@ -193,10 +193,9 @@ export class QueryRunner {
 			{
 				const { getProviderService } = await import('../provider-service');
 				const providerService = getProviderService();
-				// Pass explicitProviderId so providers whose model IDs are also claimed by
-				// Anthropic (e.g. AnthropicToCopilotBridgeProvider uses claude-opus-4.6) are not
-				// incorrectly routed to Anthropic by detectProvider().
-				const originalEnvVars = providerService.applyEnvVarsToProcess(modelId, explicitProviderId);
+				// Use the resolved provider ID (falls back to 'anthropic' for legacy sessions)
+				const resolvedProviderId = explicitProviderId ?? provider?.id ?? 'anthropic';
+				const originalEnvVars = providerService.applyEnvVarsToProcess(modelId, resolvedProviderId);
 				this.ctx.originalEnvVars = originalEnvVars;
 			}
 

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -21,6 +21,7 @@ import { generateUUID } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SDKMessage, SDKUserMessage } from '@neokai/shared/sdk';
 import {
+	isSDKAPIRetryMessage,
 	isSDKAssistantMessage,
 	isSDKCompactBoundary,
 	isSDKResultSuccess,
@@ -467,39 +468,72 @@ export class SDKMessageHandler {
 			return;
 		}
 
+		// Suppress API retry messages: log at daemon level but do not save to DB or broadcast.
+		// These carry operational metadata (attempt count, delay, error) that is useful for
+		// debugging but should not appear in the transcript or accumulate in the database.
+		if (isSDKAPIRetryMessage(message)) {
+			this.logger.warn(
+				`API retry: attempt ${message.attempt}/${message.max_retries}, ` +
+					`delay ${message.retry_delay_ms}ms, status ${message.error_status ?? 'n/a'}, ` +
+					`error ${message.error}`
+			);
+			return;
+		}
+
 		// Automatically update phase based on message type
 		await stateManager.detectPhaseFromMessage(message);
 
 		// First, correlate internal /context replay by message UUID.
 		// This avoids relying on brittle content markers that may change across SDK versions.
 		if (this.isInternalContextResponse(message)) {
-			await this.handleContextResponse(message);
-			// Skip:
-			// 1. Queuing another /context for the paired result
-			// 2. Saving/broadcasting this internal replay message
-			this.lastMessageWasContextResponse = true;
+			// UUID matches an internally queued /context command.
+			// Try to parse the context data from this message.
+			//
+			// NEW SDK behaviour (claude binary >= ~1.0.53): the user replay message
+			// contains only the original '/context' text (not the output). The actual
+			// context output arrives as a SEPARATE assistant message via sc8(). In that
+			// case parseContextResponse returns null here and the content-based check
+			// below catches the assistant message on the next iteration.
+			//
+			// OLD SDK behaviour: the user replay message itself contains the context
+			// output wrapped in <local-command-stdout> tags.
+			const parsed = await this.handleContextResponseIfParseable(message);
 
-			const userMsg = message as { uuid?: string };
-			if (userMsg.uuid) {
-				this.internalContextCommandIds.delete(userMsg.uuid);
+			if (parsed) {
+				// Successfully parsed: this message IS the context output.
+				this.lastMessageWasContextResponse = true;
+				const userMsg = message as { uuid?: string };
+				if (userMsg.uuid) {
+					this.internalContextCommandIds.delete(userMsg.uuid);
+				}
 			}
+			// Whether parsed or not, suppress saving/broadcasting this internal message
 			return;
 		}
 
-		// Check if this is a /context response BEFORE saving/emitting
+		// Check if this is a /context response BEFORE saving/emitting.
+		// Handles both:
+		//   - Old format: user message with isReplay=true + <local-command-stdout>
+		//   - New format: assistant message (from sc8()) with raw markdown content
 		// /context responses should be processed for context tracking but NOT saved to DB or shown in UI
 		const isContextResponse = this.contextFetcher.isContextResponse(message);
 		if (isContextResponse) {
-			await this.handleContextResponse(message);
+			const parsed = await this.handleContextResponseIfParseable(message);
+			if (!parsed) {
+				// Content-based detection said it looks like context data, but parsing
+				// failed — log a warning so the failure is visible.
+				this.logger.warn('Failed to parse /context response');
+			}
 			// Set flag to skip:
 			// 1. Queuing another /context for the next result
 			// 2. Saving the result message that follows this context response
 			this.lastMessageWasContextResponse = true;
 
-			// Clean up the tracked ID if this is the response
-			const userMsg = message as { uuid?: string };
-			if (userMsg.uuid && this.internalContextCommandIds.has(userMsg.uuid)) {
-				this.internalContextCommandIds.delete(userMsg.uuid);
+			// Clean up the tracked ID if this message carries the same UUID
+			// (only possible in old format where the replay IS the output)
+			const msg = message as { uuid?: string };
+			if (msg.uuid && this.internalContextCommandIds.has(msg.uuid)) {
+				this.internalContextCommandIds.delete(msg.uuid);
 			}
 
 			// IMPORTANT: Return early to skip saving and emitting this message
@@ -521,6 +555,11 @@ export class SDKMessageHandler {
 		if (message.type === 'result' && this.lastMessageWasContextResponse) {
 			// Reset the flag - we've now handled both the context response AND its result
 			this.lastMessageWasContextResponse = false;
+			// Clear any pending internal context command IDs. In the new SDK format the
+			// assistant message that carries context data does NOT match the enqueued UUID,
+			// so the UUID stays in the set after the user-replay is processed. Without this
+			// clear the stale UUID would prevent auto-queuing /context on subsequent turns.
+			this.internalContextCommandIds.clear();
 			// Return early - don't save or broadcast this result
 			return;
 		}
@@ -595,7 +634,9 @@ export class SDKMessageHandler {
 
 		// Capture SDK's internal session ID if we don't have it yet
 		// This enables session resumption after daemon restart
-		if (!session.sdkSessionId && message.session_id) {
+		// Guard on isSDKSystemInit so that other system subtypes (api_retry, status, etc.)
+		// that also carry session_id cannot accidentally overwrite this field.
+		if (isSDKSystemInit(message) && !session.sdkSessionId && message.session_id) {
 			// Update in-memory session
 			session.sdkSessionId = message.session_id;
 
@@ -803,21 +844,25 @@ export class SDKMessageHandler {
 	}
 
 	/**
-	 * Handle /context response
-	 * Parse the detailed breakdown and update context tracker
+	 * Attempt to parse and handle a /context response.
+	 *
+	 * Returns true if the message was successfully parsed as context data.
+	 * Returns false if the message did not contain parseable context data
+	 * (e.g. it is a plain user acknowledgment of the /context command rather
+	 * than the actual output — which happens in the new SDK format where a
+	 * user replay carries the original '/context' text, not the output).
 	 */
-	private async handleContextResponse(message: SDKMessage): Promise<void> {
+	private async handleContextResponseIfParseable(message: SDKMessage): Promise<boolean> {
 		const { session, daemonHub, contextTracker } = this.ctx;
 
 		const parsedContext = this.contextFetcher.parseContextResponse(message);
 		if (!parsedContext) {
-			this.logger.warn('Failed to parse /context response');
-			return;
+			return false;
 		}
 
 		const contextInfo = this.contextFetcher.toContextInfo(parsedContext);
 
-		// Update ContextTracker - persists to session metadata
+		// Persist to session metadata
 		contextTracker.updateWithDetailedBreakdown(contextInfo);
 
 		// Emit context update event via DaemonHub
@@ -826,5 +871,6 @@ export class SDKMessageHandler {
 			sessionId: session.id,
 			contextInfo,
 		});
+		return true;
 	}
 }

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -115,7 +115,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	};
 
 	// Model switch events
-	'model.switchRequest': { sessionId: string; model: string };
+	'model.switchRequest': { sessionId: string; model: string; provider: string };
 	'model.switched': {
 		sessionId: string;
 		success: boolean;

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -102,19 +102,25 @@ const FALLBACK_MODELS: ModelInfo[] = [
  * are always available for resolution, even when only non-Anthropic
  * providers are configured.
  *
- * Provider models take precedence over fallback models with same ID.
+ * Provider models take precedence over fallback models with the same
+ * (provider, id) pair. Models with the same id but different providers
+ * are kept as separate entries so that provider-filtered lookup in
+ * getModelInfo can distinguish them (e.g. both 'anthropic' and
+ * 'anthropic-copilot' may expose 'claude-sonnet-4.6').
  */
 function mergeWithFallbackModels(providerModels: ModelInfo[]): ModelInfo[] {
+	// Key by "provider:id" so same-id models from different providers
+	// are preserved as distinct entries rather than last-writer-wins.
 	const modelMap = new Map<string, ModelInfo>();
 
 	// Add fallback models first
 	for (const model of FALLBACK_MODELS) {
-		modelMap.set(model.id, model);
+		modelMap.set(`${model.provider}:${model.id}`, model);
 	}
 
-	// Provider models override fallbacks with same ID
+	// Provider models override fallbacks with same (provider, id)
 	for (const model of providerModels) {
-		modelMap.set(model.id, model);
+		modelMap.set(`${model.provider}:${model.id}`, model);
 	}
 
 	return Array.from(modelMap.values());
@@ -338,60 +344,129 @@ export function setModelsCache(cache: Map<string, ModelInfo[]>, timestamp?: numb
 }
 
 /**
- * Get model info by ID or alias
- * Searches available models with support for legacy model IDs
+ * Three-step search helper for a given model list.
+ * 1. Exact ID match
+ * 2. Alias field match
+ * 3. Legacy model mapping
+ */
+function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undefined {
+	// 1. Exact ID match (works for SDK's short IDs like 'opus', 'default')
+	let found = models.find((m) => m.id === idOrAlias);
+
+	// 2. Alias field match
+	if (!found) {
+		found = models.find((m) => m.alias === idOrAlias);
+	}
+
+	// 3. Legacy model mapping (maps old full IDs to SDK short IDs)
+	if (!found) {
+		const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
+		if (legacyMappedId) {
+			found = models.find((m) => m.id === legacyMappedId);
+		}
+	}
+
+	return found;
+}
+
+/**
+ * Get model info by ID or alias, filtered to the specified provider.
+ * All three parameters are required — no fallback to unfiltered search.
+ * Returns null if no model matching both idOrAlias and providerId is found.
+ *
+ * @param idOrAlias - Model ID or alias to look up
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Provider ID to filter by (required)
  */
 export async function getModelInfo(
+	idOrAlias: string,
+	cacheKey: string,
+	providerId: string
+): Promise<ModelInfo | null> {
+	const availableModels = getAvailableModels(cacheKey);
+	const providerModels = availableModels.filter((m) => m.provider === providerId);
+	return findInModels(providerModels, idOrAlias) ?? null;
+}
+
+/**
+ * Get model info by ID or alias without filtering by provider.
+ * Use this ONLY for callers that genuinely lack provider context (e.g., legacy
+ * config paths, manual test utilities). For all new code, prefer `getModelInfo`
+ * with an explicit `providerId`.
+ *
+ * WARNING: If the same model ID exists in multiple providers (e.g., `claude-sonnet-4.6`
+ * in both `anthropic` and `anthropic-copilot`), this function returns whichever entry
+ * appears first in the cache — the result is ambiguous and provider-dependent.
+ *
+ * @param idOrAlias - Model ID or alias to look up
+ * @param cacheKey - Cache key to look up models (defaults to 'global')
+ */
+export async function getModelInfoUnfiltered(
 	idOrAlias: string,
 	cacheKey: string = 'global'
 ): Promise<ModelInfo | null> {
 	const availableModels = getAvailableModels(cacheKey);
-
-	// 1. Try exact ID match first (works for SDK's short IDs like 'opus', 'default')
-	let model = availableModels.find((m) => m.id === idOrAlias);
-
-	// 2. Try alias match in model's alias field
-	if (!model) {
-		model = availableModels.find((m) => m.alias === idOrAlias);
-	}
-
-	// 3. Try legacy model mapping (maps old full IDs to SDK short IDs)
-	// This handles existing sessions with legacy model IDs like 'claude-sonnet-4-5-20250929'
-	if (!model) {
-		const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
-		if (legacyMappedId) {
-			model = availableModels.find((m) => m.id === legacyMappedId);
-		}
-	}
-
-	return model || null;
+	return findInModels(availableModels, idOrAlias) ?? null;
 }
 
 /**
- * Validate if a model ID or alias is valid
+ * Validate if a model ID or alias is valid for the specified provider.
+ * All three parameters are required — validation is strict, no unfiltered fallback.
+ *
+ * @param idOrAlias - Model ID or alias to validate
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Provider ID to filter by (required)
  */
 export async function isValidModel(
 	idOrAlias: string,
-	cacheKey: string = 'global'
+	cacheKey: string,
+	providerId: string
 ): Promise<boolean> {
-	const modelInfo = await getModelInfo(idOrAlias, cacheKey);
+	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	return modelInfo !== null;
 }
 
 /**
- * Resolve a model alias to its actual ID in the available models
- * Returns the model ID as it exists in the SDK/cache
+ * Resolve a model alias to its actual ID, filtered to the specified provider.
+ * All three parameters are required.
+ * Returns the original idOrAlias if no match is found.
+ *
+ * @param idOrAlias - Model ID or alias to resolve
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Provider ID to filter by (required)
  */
 export async function resolveModelAlias(
 	idOrAlias: string,
-	cacheKey: string = 'global'
+	cacheKey: string,
+	providerId: string
 ): Promise<string> {
-	// Try to find the model directly
-	const modelInfo = await getModelInfo(idOrAlias, cacheKey);
+	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	if (modelInfo) {
 		return modelInfo.id;
 	}
+	// Return as-is if nothing found
+	return idOrAlias;
+}
 
+/**
+ * Resolve a model alias to its actual ID without filtering by provider.
+ * Use this ONLY for callers that genuinely lack provider context.
+ * For all new code, prefer `resolveModelAlias` with an explicit `providerId`.
+ *
+ * WARNING: Same ambiguity caveat as `getModelInfoUnfiltered` — if the same alias
+ * resolves to different IDs in different providers, the result is non-deterministic.
+ *
+ * @param idOrAlias - Model ID or alias to resolve
+ * @param cacheKey - Cache key to look up models (defaults to 'global')
+ */
+export async function resolveModelAliasUnfiltered(
+	idOrAlias: string,
+	cacheKey: string = 'global'
+): Promise<string> {
+	const modelInfo = await getModelInfoUnfiltered(idOrAlias, cacheKey);
+	if (modelInfo) {
+		return modelInfo.id;
+	}
 	// Return as-is if nothing found
 	return idOrAlias;
 }

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -334,9 +334,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Detect if a model ID belongs to GLM provider
+	 * Detect if a model ID belongs to GLM provider.
 	 *
-	 * Delegates to registry.detectProvider()
+	 * @deprecated Use explicit `providerId` comparison instead. GLM model IDs are currently
+	 *   unique (no collision), but prefer routing by provider ID for consistency.
 	 */
 	isGlmModel(modelId: string): boolean {
 		const registry = this.getRegistry();
@@ -345,9 +346,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Detect provider from model ID
+	 * Detect provider from model ID alone.
 	 *
-	 * Delegates to registry.detectProvider()
+	 * @deprecated Use `detectProviderForModel(modelId, providerId)` with an explicit provider ID.
+	 *   This method is ambiguous when multiple providers claim the same model ID.
 	 */
 	detectProviderFromModel(modelId: string): Provider {
 		const registry = this.getRegistry();
@@ -356,9 +358,10 @@ export class ProviderService {
 	}
 
 	/**
-	 * Translate a model ID to an SDK-recognized model ID
+	 * Translate a model ID to an SDK-recognized model ID.
 	 *
-	 * Delegates to provider.translateModelIdForSdk()
+	 * @deprecated Pass explicit `providerId` to resolve which provider's translation to apply.
+	 *   Delegates to provider.translateModelIdForSdk()
 	 */
 	translateModelIdForSdk(modelId: string): string {
 		const registry = this.getRegistry();
@@ -373,20 +376,17 @@ export class ProviderService {
 	}
 
 	/**
-	 * Get environment variables for SDK subprocess based on model ID
+	 * Get environment variables for SDK subprocess based on explicit (modelId, providerId) pair.
 	 *
-	 * Delegates to provider.buildSdkConfig()
+	 * Both the model ID and provider ID must be known at the call site. Use
+	 * `getProviderEnvVars(session)` when you have a full session object.
 	 *
-	 * @param modelId - The model ID to get env vars for
-	 * @param providerId - When supplied, look up provider by ID instead of auto-detecting from
-	 *   modelId. Required when model IDs are shared across providers (e.g. claude-opus-4.6 is
-	 *   claimed by both Anthropic and AnthropicCopilot).
+	 * @param modelId - The model ID (used for SDK config building)
+	 * @param providerId - The provider ID — must be explicit; routing is deterministic
 	 */
-	getEnvVarsForModel(modelId: string, providerId?: string): ProviderEnvVars {
+	getEnvVarsForModel(modelId: string, providerId: string): ProviderEnvVars {
 		const registry = this.getRegistry();
-		const provider = providerId
-			? (registry.get(providerId) ?? registry.detectProvider(modelId))
-			: registry.detectProvider(modelId);
+		const provider = registry.detectProviderForModel(modelId, providerId);
 
 		if (!provider || provider.id === 'anthropic') {
 			// When Dev Proxy is enabled, route Anthropic API calls through the proxy
@@ -447,19 +447,18 @@ export class ProviderService {
 	}
 
 	/**
-	 * Apply provider environment variables to process.env
+	 * Apply provider environment variables to process.env.
 	 *
 	 * IMPORTANT: These must be set in the parent process before SDK query creation.
 	 * The SDK subprocess inherits these environment variables when spawned.
 	 *
 	 * This method saves the original values and returns them for restoration.
 	 *
-	 * @param modelId - The model ID to get env vars for
-	 * @param providerId - When supplied, look up provider by ID instead of auto-detecting from
-	 *   modelId. Required when model IDs are shared across providers.
+	 * @param modelId - The model ID (used for SDK config building)
+	 * @param providerId - The provider ID — must be explicit; routing is deterministic
 	 * @returns Original env vars that should be restored after SDK query
 	 */
-	applyEnvVarsToProcess(modelId: string, providerId?: string): OriginalEnvVars {
+	applyEnvVarsToProcess(modelId: string, providerId: string): OriginalEnvVars {
 		const envVars = this.getEnvVarsForModel(modelId, providerId);
 
 		// For Anthropic (or any non-overriding provider), explicitly clear routing

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -169,7 +169,7 @@ async function handleMessages(
 		sendJsonError(
 			res,
 			status,
-			'invalid_request_error',
+			status === 413 ? 'request_too_large' : 'invalid_request_error',
 			status === 413 ? 'Request body exceeds 10 MB limit' : 'Failed to read request body'
 		);
 		return;
@@ -431,8 +431,7 @@ export function startEmbeddedServer(
 			return;
 		}
 
-		res.writeHead(404, { 'Content-Type': 'application/json' });
-		res.end(JSON.stringify({ type: 'error', error: { type: 'api_error', message: 'Not found' } }));
+		sendJsonError(res, 404, 'not_found_error', 'Not found');
 	});
 
 	return new Promise((resolve, reject) => {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -38,6 +38,7 @@ import { formatAnthropicPrompt, extractSystemText, extractToolResultIds } from '
 import { ConversationManager } from './conversation.js';
 import { runSessionStreaming, resumeSessionStreaming } from './streaming.js';
 import { Logger } from '../../logger.js';
+import { type AnthropicErrorType, createAnthropicErrorBody } from '../shared/error-envelope.js';
 
 const logger = new Logger('anthropic-copilot-server');
 
@@ -75,12 +76,11 @@ function readBody(req: IncomingMessage): Promise<string> {
 function sendJsonError(
 	res: ServerResponse,
 	status: number,
-	type: 'invalid_request_error' | 'api_error',
+	type: AnthropicErrorType,
 	message: string
 ): void {
-	const body = JSON.stringify({ type: 'error', error: { type, message } });
 	res.writeHead(status, { 'Content-Type': 'application/json' });
-	res.end(body);
+	res.end(createAnthropicErrorBody(type, message));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
@@ -10,6 +10,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { ServerResponse } from 'node:http';
+import type { AnthropicErrorType } from '../shared/error-envelope.js';
 
 // ---------------------------------------------------------------------------
 // Headers & low-level helper
@@ -169,14 +170,25 @@ export class AnthropicStreamWriter {
 		this.sendEpilogue(res, 'end_turn');
 	}
 
-	/** Emit an `end_turn` epilogue (best-effort — called on error paths). */
-	sendFailed(res: ServerResponse): void {
+	/**
+	 * Emit an Anthropic-format `error` SSE event (called on error paths).
+	 *
+	 * Closes the open text block (if any) then emits an `error` event that the
+	 * Claude Agent SDK interprets as an `APIError`.  Does NOT emit `message_stop`
+	 * — the stream ends after the error event per the Anthropic streaming spec.
+	 */
+	sendFailed(
+		res: ServerResponse,
+		errorType: AnthropicErrorType = 'api_error',
+		message = 'Internal server error'
+	): void {
 		if (this.textBlockStarted) {
 			sendEvent(res, 'content_block_stop', {
 				type: 'content_block_stop',
 				index: this.textBlockIndex,
 			});
+			this.textBlockStarted = false;
 		}
-		this.sendEpilogue(res, 'end_turn');
+		sendEvent(res, 'error', { type: 'error', error: { type: errorType, message } });
 	}
 }

--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -148,7 +148,7 @@ function streamSession(
 			case 'session.error':
 				logger.warn(`Copilot session error: ${String(event.data.message)}`);
 				flushDeltas();
-				writer.sendFailed(res);
+				writer.sendFailed(res, 'api_error', String(event.data.message) || 'Session error');
 				res.end();
 				finishCompleted();
 				break;
@@ -170,7 +170,7 @@ function streamSession(
 			onDone();
 			session.abort().catch(() => {});
 			session.disconnect().catch(() => {});
-			writer.sendFailed(res);
+			writer.sendFailed(res, 'api_error', 'Streaming timeout');
 			res.end();
 			resolve({ kind: 'completed' });
 		}
@@ -207,7 +207,7 @@ function streamSession(
 	// fire between them.
 	startFn(finishCompleted, () => {
 		if (!sessionDone) {
-			writer.sendFailed(res);
+			writer.sendFailed(res, 'api_error', 'Internal streaming error');
 			res.end();
 		}
 	});

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -91,11 +91,6 @@ async function drainToSSE(
 		const { value: event, done } = await gen.next();
 		if (done) break;
 
-		// DIAGNOSTIC: log each BridgeEvent type to stderr for CI debugging
-		process.stderr.write(
-			`[codex-bridge-server] drainToSSE event: ${event.type}${event.type === 'text_delta' ? ` text=${JSON.stringify((event as { text: string }).text)}` : ''}\n`
-		);
-
 		if (event.type === 'text_delta') {
 			if (!textBlockOpen) {
 				send(contentBlockStartTextSSE(blockIndex));

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -12,7 +12,7 @@
  */
 
 import { BridgeSession, AppServerConn, type AppServerAuth } from './process-manager.js';
-import { createAnthropicErrorBody } from '../shared/error-envelope.js';
+import { createAnthropicErrorBody, anthropicErrorSSELine } from '../shared/error-envelope.js';
 
 export type { AppServerAuth } from './process-manager.js';
 import {
@@ -151,14 +151,14 @@ async function drainToSSE(
 			return;
 		} else if (event.type === 'error') {
 			logger.error('codex-bridge: BridgeSession error:', event.message);
-			// Emit a minimal error text block so the SDK gets a response
-			if (!textBlockOpen) {
-				send(contentBlockStartTextSSE(blockIndex));
+			// Close any open text block before emitting the error event
+			if (textBlockOpen) {
+				send(contentBlockStopSSE(blockIndex));
+				textBlockOpen = false;
 			}
-			send(textDeltaSSE(blockIndex, `[Codex error: ${event.message}]`));
-			send(contentBlockStopSSE(blockIndex));
-			send(messageDeltaSSE('end_turn', outputTokens));
-			send(messageStopSSE());
+			// Emit an Anthropic-format error SSE event so the Claude Agent SDK
+			// surfaces this as an APIError instead of silently completing.
+			send(anthropicErrorSSELine('api_error', String(event.message) || 'Codex session error'));
 			session.kill();
 			controller.close();
 			return;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -12,6 +12,7 @@
  */
 
 import { BridgeSession, AppServerConn, type AppServerAuth } from './process-manager.js';
+import { createAnthropicErrorBody } from '../shared/error-envelope.js';
 
 export type { AppServerAuth } from './process-manager.js';
 import {
@@ -210,14 +211,23 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			}
 
 			if (url.pathname !== '/v1/messages' || req.method !== 'POST') {
-				return new Response('Not Found', { status: 404 });
+				return new Response(createAnthropicErrorBody('not_found_error', 'Not found'), {
+					status: 404,
+					headers: { 'Content-Type': 'application/json' },
+				});
 			}
 
 			let body: AnthropicRequest;
 			try {
 				body = (await req.json()) as AnthropicRequest;
 			} catch {
-				return new Response('Bad Request', { status: 400 });
+				return new Response(
+					createAnthropicErrorBody('invalid_request_error', 'Request body must be valid JSON'),
+					{
+						status: 400,
+						headers: { 'Content-Type': 'application/json' },
+					}
+				);
 			}
 
 			const sseHeaders = {
@@ -233,7 +243,10 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			if (isToolResultContinuation(body.messages)) {
 				const toolResults = extractToolResults(body.messages);
 				if (toolResults.length === 0) {
-					return new Response('Bad Request: no tool_result found', { status: 400 });
+					return new Response(
+						createAnthropicErrorBody('invalid_request_error', 'No tool_result found in messages'),
+						{ status: 400, headers: { 'Content-Type': 'application/json' } }
+					);
 				}
 
 				// For simplicity handle one tool result at a time (Codex sends one at a time)
@@ -241,7 +254,13 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				const stored = toolSessions.get(tr.toolUseId);
 				if (!stored) {
 					logger.error(`codex-bridge: no active session for tool_use_id=${tr.toolUseId}`);
-					return new Response('Session not found', { status: 404 });
+					return new Response(
+						createAnthropicErrorBody(
+							'not_found_error',
+							`No active session for tool_use_id=${tr.toolUseId}`
+						),
+						{ status: 404, headers: { 'Content-Type': 'application/json' } }
+					);
 				}
 				toolSessions.delete(tr.toolUseId);
 
@@ -284,7 +303,13 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				await session.initialize();
 			} catch (err) {
 				logger.error('codex-bridge: failed to start BridgeSession:', err);
-				return new Response(`Internal Server Error: ${String(err)}`, { status: 500 });
+				return new Response(
+					createAnthropicErrorBody(
+						'api_error',
+						`Failed to start session: ${err instanceof Error ? err.message : String(err)}`
+					),
+					{ status: 500, headers: { 'Content-Type': 'application/json' } }
+				);
 			}
 
 			const gen = session.startTurn(userText);

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -12,11 +12,11 @@
  */
 
 import { BridgeSession, AppServerConn, type AppServerAuth } from './process-manager.js';
-import { createAnthropicErrorBody, anthropicErrorSSELine } from '../shared/error-envelope.js';
 
 export type { AppServerAuth } from './process-manager.js';
 import {
 	type AnthropicRequest,
+	type AnthropicErrorType,
 	buildDynamicTools,
 	buildConversationText,
 	extractSystemText,
@@ -31,10 +31,30 @@ import {
 	contentBlockStopSSE,
 	messageDeltaSSE,
 	messageStopSSE,
+	errorSSE,
 } from './translator.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('codex-bridge-server');
+
+// ---------------------------------------------------------------------------
+// Anthropic JSON error envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a JSON Response with an Anthropic-format error envelope body.
+ * Shape: {"type":"error","error":{"type":"<errorType>","message":"<message>"}}
+ */
+export function createAnthropicError(
+	httpStatus: number,
+	type: AnthropicErrorType,
+	message: string
+): Response {
+	return new Response(JSON.stringify({ type: 'error', error: { type, message } }), {
+		status: httpStatus,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
 
 /** Default TTL before an unresolved tool-call session is abandoned (5 min). */
 export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
@@ -43,7 +63,7 @@ export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
 // Session state for tool-call round-trips
 // ---------------------------------------------------------------------------
 
-type ToolSession = {
+export type ToolSession = {
 	/** The suspended generator — resume with provideResult then continue polling. */
 	gen: AsyncGenerator<import('./process-manager.js').BridgeEvent>;
 	/** The underlying BridgeSession — needed to kill the subprocess when done. */
@@ -64,7 +84,7 @@ function generateMsgId(): string {
 // SSE drain loop — shared between new turns and tool continuations
 // ---------------------------------------------------------------------------
 
-async function drainToSSE(
+export async function drainToSSE(
 	gen: AsyncGenerator<import('./process-manager.js').BridgeEvent>,
 	session: BridgeSession,
 	model: string,
@@ -90,6 +110,10 @@ async function drainToSSE(
 	while (true) {
 		const { value: event, done } = await gen.next();
 		if (done) break;
+
+		logger.debug(
+			`drainToSSE event: ${event.type}${event.type === 'text_delta' ? ` text=${JSON.stringify((event as { text: string }).text)}` : ''}`
+		);
 
 		if (event.type === 'text_delta') {
 			if (!textBlockOpen) {
@@ -151,9 +175,8 @@ async function drainToSSE(
 				send(contentBlockStopSSE(blockIndex));
 				textBlockOpen = false;
 			}
-			// Emit an Anthropic-format error SSE event so the Claude Agent SDK
-			// surfaces this as an APIError instead of silently completing.
-			send(anthropicErrorSSELine('api_error', String(event.message) || 'Codex session error'));
+			// Emit an Anthropic-format error SSE event then close the stream
+			send(errorSSE('api_error', event.message));
 			session.kill();
 			controller.close();
 			return;
@@ -206,23 +229,14 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			}
 
 			if (url.pathname !== '/v1/messages' || req.method !== 'POST') {
-				return new Response(createAnthropicErrorBody('not_found_error', 'Not found'), {
-					status: 404,
-					headers: { 'Content-Type': 'application/json' },
-				});
+				return createAnthropicError(404, 'not_found_error', 'Not found');
 			}
 
 			let body: AnthropicRequest;
 			try {
 				body = (await req.json()) as AnthropicRequest;
 			} catch {
-				return new Response(
-					createAnthropicErrorBody('invalid_request_error', 'Request body must be valid JSON'),
-					{
-						status: 400,
-						headers: { 'Content-Type': 'application/json' },
-					}
-				);
+				return createAnthropicError(400, 'invalid_request_error', 'Bad Request: invalid JSON');
 			}
 
 			const sseHeaders = {
@@ -238,34 +252,59 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			if (isToolResultContinuation(body.messages)) {
 				const toolResults = extractToolResults(body.messages);
 				if (toolResults.length === 0) {
-					return new Response(
-						createAnthropicErrorBody('invalid_request_error', 'No tool_result found in messages'),
-						{ status: 400, headers: { 'Content-Type': 'application/json' } }
+					return createAnthropicError(
+						400,
+						'invalid_request_error',
+						'Bad Request: no tool_result found'
 					);
 				}
 
-				// For simplicity handle one tool result at a time (Codex sends one at a time)
-				const tr = toolResults[0];
-				const stored = toolSessions.get(tr.toolUseId);
-				if (!stored) {
-					logger.error(`codex-bridge: no active session for tool_use_id=${tr.toolUseId}`);
-					return new Response(
-						createAnthropicErrorBody(
-							'not_found_error',
-							`No active session for tool_use_id=${tr.toolUseId}`
-						),
-						{ status: 404, headers: { 'Content-Type': 'application/json' } }
+				// Iterate ALL tool results — the Anthropic API allows multiple tool_result
+				// blocks in a single continuation request (one per parallel tool call).
+				//
+				// NOTE: The Codex app-server only ever emits one tool call per turn, because
+				// each item/tool/call RPC handler blocks until its result is provided before
+				// Codex can proceed to the next tool call. In practice there is therefore
+				// always exactly one suspended ToolSession at continuation time. We still
+				// handle the multi-result path correctly here for forward compatibility: if
+				// Codex ever gains parallel tool-call support, this code will work without
+				// changes.
+				//
+				// The first matched session's generator drives the resumed SSE stream.
+				// All matched sessions have their Deferreds resolved. Unmatched tool_use_ids
+				// produce a warning and are skipped (not silently dropped).
+				let primaryStored: ToolSession | null = null;
+
+				for (const tr of toolResults) {
+					const stored = toolSessions.get(tr.toolUseId);
+					if (!stored) {
+						logger.warn(
+							`codex-bridge: orphaned tool_result — no active session for tool_use_id=${tr.toolUseId}, skipping`
+						);
+						continue;
+					}
+					toolSessions.delete(tr.toolUseId);
+					// Cancel the TTL timer — session is being resumed normally
+					clearTimeout(stored.cleanupTimer);
+					// Provide the tool result — this unblocks the Codex read loop for this call
+					stored.provideResult(tr.text);
+					if (!primaryStored) {
+						primaryStored = stored;
+					}
+				}
+
+				if (!primaryStored) {
+					logger.error(
+						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
+					);
+					return createAnthropicError(
+						404,
+						'not_found_error',
+						'Session not found for all tool_use_ids in this continuation'
 					);
 				}
-				toolSessions.delete(tr.toolUseId);
 
-				// Cancel the TTL timer — session is being resumed normally
-				clearTimeout(stored.cleanupTimer);
-
-				const { gen, session, provideResult, model: sessionModel } = stored;
-				// Provide the tool result — this unblocks the Codex read loop
-				provideResult(tr.text);
-
+				const { gen, session, model: sessionModel } = primaryStored;
 				const stream = new ReadableStream<Uint8Array>({
 					start(controller) {
 						void drainToSSE(gen, session, sessionModel, toolSessions, controller, ttlMs);
@@ -298,13 +337,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				await session.initialize();
 			} catch (err) {
 				logger.error('codex-bridge: failed to start BridgeSession:', err);
-				return new Response(
-					createAnthropicErrorBody(
-						'api_error',
-						`Failed to start session: ${err instanceof Error ? err.message : String(err)}`
-					),
-					{ status: 500, headers: { 'Content-Type': 'application/json' } }
-				);
+				return createAnthropicError(500, 'api_error', `Internal Server Error: ${String(err)}`);
 			}
 
 			const gen = session.startTurn(userText);

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -286,3 +286,15 @@ export function messageDeltaSSE(
 export function messageStopSSE(): string {
 	return sseEvent('message_stop', { type: 'message_stop' });
 }
+
+/** Anthropic-standard error types used in both HTTP envelopes and SSE error events. */
+export type AnthropicErrorType =
+	| 'invalid_request_error'
+	| 'authentication_error'
+	| 'not_found_error'
+	| 'api_error'
+	| 'overloaded_error';
+
+export function errorSSE(errorType: AnthropicErrorType, message: string): string {
+	return sseEvent('error', { type: 'error', error: { type: errorType, message } });
+}

--- a/packages/daemon/src/lib/providers/context-manager.ts
+++ b/packages/daemon/src/lib/providers/context-manager.ts
@@ -100,7 +100,7 @@ export class ProviderContextManager {
 	 * Resolve the provider for a session
 	 */
 	private resolveProvider(session: Session): Provider {
-		// 1. Try explicit provider first
+		// 1. Prefer explicit provider stored in session config (always set for new sessions)
 		if (session.config.provider) {
 			const provider = this.registry.get(session.config.provider);
 			if (provider) {
@@ -108,7 +108,8 @@ export class ProviderContextManager {
 			}
 		}
 
-		// 2. Detect provider from model ID
+		// 2. Legacy fallback: detect from model ID for old sessions that pre-date explicit routing.
+		// @deprecated — new sessions always store session.config.provider.
 		const modelId = session.config.model || 'default';
 		const detected = this.registry.detectProvider(modelId);
 		if (detected) {
@@ -125,21 +126,24 @@ export class ProviderContextManager {
 	}
 
 	/**
-	 * Check if a model switch requires a query restart
+	 * Check if a model switch requires a query restart.
 	 *
 	 * Cross-provider switches require restart because the SDK subprocess
 	 * needs different environment variables.
+	 *
+	 * @param session - Current session (used to resolve the current provider)
+	 * @param newModelId - Target model ID (informational)
+	 * @param newProviderId - Target provider ID (explicit — must be known by the caller)
 	 */
-	requiresQueryRestart(session: Session, newModelId: string): boolean {
+	requiresQueryRestart(session: Session, newModelId: string, newProviderId: string): boolean {
 		const currentProvider = this.resolveProvider(session);
-		const newProvider = this.registry.detectProvider(newModelId);
+		const newProvider = this.registry.get(newProviderId);
 
-		// If we can't detect the new provider, assume it's different
+		// If the new provider is unknown, assume a different one — safer to restart
 		if (!newProvider) {
 			return true;
 		}
 
-		// Restart if providers are different
 		return currentProvider.id !== newProvider.id;
 	}
 
@@ -151,7 +155,8 @@ export class ProviderContextManager {
 	}
 
 	/**
-	 * Detect provider from model ID
+	 * @deprecated Use `getProvider(providerId)` or `registry.detectProviderForModel(modelId, providerId)`.
+	 *   Heuristic model-ID-only detection is ambiguous when providers share model IDs.
 	 */
 	detectProvider(modelId: string): Provider | undefined {
 		return this.registry.detectProvider(modelId);

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -10,7 +10,10 @@
  * - Provider auto-detection from model IDs
  */
 
+import { createLogger } from '@neokai/shared/logger';
 import type { Provider, ProviderId, ProviderInfo } from '@neokai/shared/provider';
+
+const log = createLogger('kai:providers:registry');
 
 /**
  * Provider Registry class
@@ -74,10 +77,29 @@ export class ProviderRegistry {
 	}
 
 	/**
-	 * Detect provider from model ID
-	 * Asks each provider if it owns the model
+	 * Resolve provider by explicit (modelId, providerId) pair — fully deterministic.
 	 *
-	 * Returns undefined if no provider claims the model
+	 * Both the model ID and provider ID must be known at the call site. This is the
+	 * preferred routing method: when the UI selects a model it always has the associated
+	 * provider ID, so there is never any ambiguity.
+	 *
+	 * Logs an error and returns `undefined` if the provider is not registered.
+	 */
+	detectProviderForModel(modelId: string, providerId: string): Provider | undefined {
+		const provider = this.providers.get(providerId);
+		if (!provider) {
+			log.error(`[routing] Unknown provider '${providerId}' for model '${modelId}'`);
+		}
+		return provider;
+	}
+
+	/**
+	 * Heuristic provider detection from model ID alone.
+	 *
+	 * @deprecated Use `detectProviderForModel(modelId, providerId)` with an explicit provider ID.
+	 *   This method is ambiguous when multiple providers claim the same model ID
+	 *   (e.g. 'claude-sonnet-4.6' is owned by both Anthropic and anthropic-copilot).
+	 *   It is retained only for legacy paths (e.g. old sessions without a stored provider).
 	 */
 	detectProvider(modelId: string): Provider | undefined {
 		for (const provider of this.getAll()) {

--- a/packages/daemon/src/lib/providers/shared/error-envelope.ts
+++ b/packages/daemon/src/lib/providers/shared/error-envelope.ts
@@ -34,14 +34,3 @@ export type AnthropicErrorType =
 export function createAnthropicErrorBody(errorType: AnthropicErrorType, message: string): string {
 	return JSON.stringify({ type: 'error', error: { type: errorType, message } });
 }
-
-/**
- * Format an Anthropic-format `error` SSE event string.
- *
- * Emitted mid-stream (after SSE headers and `message_start` have been sent)
- * when a streaming error occurs.  The Claude Agent SDK interprets this event
- * as an `APIError` and surfaces it to the caller.
- */
-export function anthropicErrorSSELine(errorType: AnthropicErrorType, message: string): string {
-	return `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type: errorType, message } })}\n\n`;
-}

--- a/packages/daemon/src/lib/providers/shared/error-envelope.ts
+++ b/packages/daemon/src/lib/providers/shared/error-envelope.ts
@@ -34,3 +34,14 @@ export type AnthropicErrorType =
 export function createAnthropicErrorBody(errorType: AnthropicErrorType, message: string): string {
 	return JSON.stringify({ type: 'error', error: { type: errorType, message } });
 }
+
+/**
+ * Format an Anthropic-format `error` SSE event string.
+ *
+ * Emitted mid-stream (after SSE headers and `message_start` have been sent)
+ * when a streaming error occurs.  The Claude Agent SDK interprets this event
+ * as an `APIError` and surfaces it to the caller.
+ */
+export function anthropicErrorSSELine(errorType: AnthropicErrorType, message: string): string {
+	return `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type: errorType, message } })}\n\n`;
+}

--- a/packages/daemon/src/lib/providers/shared/error-envelope.ts
+++ b/packages/daemon/src/lib/providers/shared/error-envelope.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared Anthropic-format error helpers for bridge HTTP servers.
+ *
+ * Both the copilot bridge and codex bridge servers must return errors in the
+ * same format as the real Anthropic Messages API so the Claude Agent SDK can
+ * surface them correctly.
+ *
+ * ## HTTP error format
+ *
+ *   { "type": "error", "error": { "type": "<errorType>", "message": "..." } }
+ *
+ * ## SSE error format (streaming responses)
+ *
+ *   event: error
+ *   data: {"type":"error","error":{"type":"<errorType>","message":"..."}}
+ */
+
+/** Anthropic API error type discriminators. */
+export type AnthropicErrorType =
+	| 'invalid_request_error'
+	| 'authentication_error'
+	| 'permission_error'
+	| 'not_found_error'
+	| 'request_too_large'
+	| 'rate_limit_error'
+	| 'api_error'
+	| 'overloaded_error';
+
+/**
+ * Serialize an Anthropic-format error envelope as a JSON string.
+ *
+ * Use as the body of HTTP non-2xx responses from bridge servers.
+ */
+export function createAnthropicErrorBody(errorType: AnthropicErrorType, message: string): string {
+	return JSON.stringify({ type: 'error', error: { type: errorType, message } });
+}

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -234,9 +234,14 @@ export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 	sections.push(`3. Add or update tests to cover the new/changed behavior — tests are mandatory`);
 	sections.push(`4. Push your branch: \`git push -u origin HEAD\``);
 	sections.push(
-		`5. Create a pull request — detect the default branch inside the subshell (no persistent variable needed):\n` +
+		`5. Ensure a pull request exists — check first to avoid creating a duplicate:\n` +
 			`   \`\`\`bash\n` +
-			`   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
+			`   EXISTING_PR=$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json url --jq '.[0].url // empty' 2>/dev/null)\n` +
+			`   if [ -z "$EXISTING_PR" ]; then\n` +
+			`     gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
+			`   else\n` +
+			`     echo "PR already exists: $EXISTING_PR (updated with latest push)"\n` +
+			`   fi\n` +
 			`   \`\`\``
 	);
 	sections.push(`6. Finish your response`);
@@ -374,6 +379,13 @@ export function buildCoderTaskMessage(config: CoderAgentConfig): string {
 	if (room.instructions) {
 		sections.push(`\n## Instructions\n`);
 		sections.push(room.instructions);
+	}
+
+	// Existing PR context (when task already has a PR from a previous iteration)
+	if (task.prUrl) {
+		sections.push(`\n## Existing Pull Request\n`);
+		sections.push(`This task already has an existing pull request: ${task.prUrl}`);
+		sections.push(`Push your changes to update this PR — do NOT create a new one.`);
 	}
 
 	// Previous task summaries

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -169,7 +169,7 @@ For planning tasks the planner must run a second phase to create tasks.
 
 1. **Send the planner back** — Call \`send_to_worker\` (mode: "queue") with:
    "The plan is approved. Please:
-   1. Merge the plan PR: \`gh pr merge <PR_NUMBER> --merge\`
+   1. Merge the plan PR: \`gh pr merge <PR_NUMBER>\`
    2. Read the plan file under docs/plans/
    3. Create all tasks 1:1 from the plan using the \`create_task\` tool
    4. Finish your response after all tasks are created"
@@ -185,7 +185,7 @@ When the human message indicates approval (e.g., "approved", "merge it", "looks 
 
 1. **Merge the PR** — Use \`gh pr merge\` to merge the approved PR:
    \`\`\`bash
-   gh pr merge <PR_NUMBER> --squash --delete-branch
+   gh pr merge <PR_NUMBER>
    \`\`\`
 2. **Sync the root repo** — Pull the merged changes into the root workspace:
    \`\`\`bash

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -294,7 +294,7 @@ Finish your response after the plan-writer completes — the Leader will dispatc
 When the Leader sends you an approval message, you are in Phase 2.
 **IMPORTANT**: Do NOT skip straight to \`create_task\` — you MUST merge the plan PR first.
 
-1. Merge the plan PR: run \`gh pr merge <PR_NUMBER> --merge\` (use the pr_number from the Phase 1 plan-writer result)
+1. Merge the plan PR: run \`gh pr merge <PR_NUMBER>\` (use the pr_number from the Phase 1 plan-writer result)
 2. Read the plan files (use the \`plan_files\` list from Phase 1, or find them under \`${planDir}/\` or at \`${planPath}\`)
 3. Create tasks 1:1 from the plan sections using the \`create_task\` tool
 4. Each task title and description should match the plan exactly

--- a/packages/daemon/src/lib/room/agents/room-chat-agent.ts
+++ b/packages/daemon/src/lib/room/agents/room-chat-agent.ts
@@ -1,0 +1,48 @@
+/**
+ * Room Chat Agent - System prompt for the room's conversational coordinator.
+ *
+ * The room chat session (room:chat:${roomId}) is a persistent session where
+ * the human user interacts with an AI coordinator that manages goals and tasks.
+ *
+ * Key responsibility: enforce the proper goal → plan → approval → task workflow
+ * so that tasks are never created prematurely (before the plan is approved).
+ */
+
+export interface RoomChatAgentContext {
+	background?: string;
+	instructions?: string;
+}
+
+/**
+ * Build the system prompt for the room chat agent.
+ *
+ * Provides workflow instructions that prevent the agent from creating tasks
+ * immediately when a goal is created. Tasks must only be created after the
+ * planner agent has produced a plan and the human has approved it.
+ */
+export function buildRoomChatSystemPrompt(context?: RoomChatAgentContext): string {
+	// Trust assumption: background and instructions are operator-controlled fields.
+	// They are interpolated directly into the system prompt without sanitization.
+	// This is acceptable for a self-hosted tool where the operator sets these values.
+	const backgroundSection = context?.background
+		? `## Room Background\n\n${context.background}\n\n`
+		: '';
+
+	const instructionsSection = context?.instructions
+		? `## Room Instructions\n\n${context.instructions}\n\n`
+		: '';
+
+	return `\
+You are the Room Agent — a conversational coordinator for autonomous software development.
+
+${backgroundSection}${instructionsSection}\
+## Goal Creation — CRITICAL RULE
+
+When the user asks you to create a goal, call \`create_goal\` and STOP. Do NOT call \`create_task\`.
+The system automatically handles the rest: planning → human approval → task creation → execution.
+
+After creating a goal, tell the user it was created and that the planning phase has started automatically — they will be asked to review and approve the plan before any tasks are created.
+
+Only use \`create_task\` directly for explicit standalone tasks that have no associated goal and need no planning.
+`;
+}

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -300,7 +300,7 @@ export async function checkWorkerPrMerged(
 				`The PR for branch "${branch}" is CLOSED — it was closed without merging.\n\n` +
 				`A closed PR cannot be merged directly. To fix this:\n` +
 				`1. Reopen the PR: \`gh pr reopen ${branch}\`\n` +
-				`2. Then merge: \`gh pr merge ${branch} --merge\`\n` +
+				`2. Then merge: \`gh pr merge ${branch}\`\n` +
 				`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
 				`4. Then finish your response.`,
 		};
@@ -312,10 +312,9 @@ export async function checkWorkerPrMerged(
 		bounceMessage:
 			`The PR for branch "${branch}" is not merged yet (state: ${prState}).\n\n` +
 			`You were asked to merge the PR. Please complete this step:\n` +
-			`1. Run: \`gh pr merge ${branch} --merge\`\n` +
-			`2. If that fails, try: \`gh pr merge ${branch} --squash\`\n` +
-			`3. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
-			`4. Then finish your response.`,
+			`1. Run: \`gh pr merge ${branch}\`\n` +
+			`2. Verify: \`gh pr view ${branch} --json state --jq .state\` (must return "MERGED")\n` +
+			`3. Then finish your response.`,
 	};
 }
 
@@ -380,7 +379,7 @@ export async function checkLeaderPrMerged(
 				`The PR for this task is CLOSED — it was closed without merging.\n\n` +
 				'A closed PR cannot be merged directly. To fix this:\n' +
 				'1. Use `send_to_worker` with: "The PR was closed without merging. ' +
-				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch} --merge\`, ` +
+				`Reopen it with \`gh pr reopen ${branch}\`, then merge with \`gh pr merge ${branch}\`, ` +
 				`and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 				'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 		};
@@ -393,7 +392,7 @@ export async function checkLeaderPrMerged(
 			`The PR for this task is not merged (state: ${prState}). You cannot mark the task complete until the PR is actually merged.\n\n` +
 			'To fix this:\n' +
 			'1. Use `send_to_worker` to ask the worker: "The PR merge did not complete. ' +
-			`Please run \`gh pr merge ${branch} --merge\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
+			`Please run \`gh pr merge ${branch}\` and verify with \`gh pr view ${branch} --json state --jq .state\`"\n` +
 			'2. After the worker confirms the merge (state: MERGED), call `complete_task` again.',
 	};
 }
@@ -591,12 +590,60 @@ export async function checkLeaderDraftsExist(
 			'No draft tasks were created by the planner yet. The planner must run Phase 2 to create tasks.\n\n' +
 			'To fix this:\n' +
 			'1. Call `send_to_worker` (mode: "queue") with: "The plan is approved. Please:\n' +
-			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER> --merge`\n' +
+			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER>`\n' +
 			'   2. Read the plan file under docs/plans/\n' +
 			'   3. Create all tasks 1:1 from the plan using the `create_task` tool\n' +
 			'   4. Finish your response after all tasks are created"\n' +
 			'2. After the planner exits with tasks created, call `complete_task` again.',
 	};
+}
+
+// --- PR URL Utility ---
+
+/**
+ * Close a stale PR when a new PR has been created to replace it.
+ *
+ * Called when submit_for_review is invoked with a PR URL that differs from the
+ * task's existing prUrl. Closes the old PR with a comment pointing to the new one.
+ *
+ * Fails open: if the close command fails (e.g., PR already closed, gh unavailable),
+ * the error is logged but does not block the submit_for_review flow.
+ *
+ * Uses the PR URL directly with `gh pr close` — gh accepts both numbers and URLs,
+ * and URLs are unambiguous across multi-remote/forked repo setups.
+ *
+ * @param oldPrUrl - The existing PR URL stored in the task
+ * @param newPrUrl - The new PR URL being submitted for review
+ * @param workspacePath - The workspace path to run gh commands from
+ * @param opts - Optional hook options (for testing)
+ * @returns true if closed successfully, false otherwise
+ */
+export async function closeStalePr(
+	oldPrUrl: string,
+	newPrUrl: string,
+	workspacePath: string,
+	opts?: HookOptions
+): Promise<boolean> {
+	const run = getRunner(opts);
+
+	if (!oldPrUrl || !oldPrUrl.includes('/pull/')) {
+		log.warn(`closeStalePr: invalid old PR URL: ${oldPrUrl}`);
+		return false;
+	}
+
+	const comment = `Superseded by ${newPrUrl}`;
+	const { exitCode } = await run(
+		['gh', 'pr', 'close', oldPrUrl, '--comment', comment],
+		workspacePath
+	);
+
+	if (exitCode !== 0) {
+		log.warn(`closeStalePr: failed to close PR ${oldPrUrl} (exit ${exitCode})`);
+		return false;
+	}
+
+	log.info(`closeStalePr: closed stale PR ${oldPrUrl}, superseded by ${newPrUrl}`);
+	return true;
 }
 
 // --- Gate Runners ---

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -24,6 +24,7 @@ import { TaskManager } from '../managers/task-manager';
 import { GoalManager } from '../managers/goal-manager';
 import { AgentSession } from '../../agent/agent-session';
 import { createRoomAgentMcpServer } from '../tools/room-agent-tools';
+import { buildRoomChatSystemPrompt } from '../agents/room-chat-agent';
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { recoverRuntime, type SessionStateChecker } from './runtime-recovery';
 import type { RoomManager } from '../managers/room-manager';
@@ -434,10 +435,21 @@ export class RoomRuntimeService {
 				roomChatSession.setRuntimeMcpServers({
 					'room-agent-tools': roomAgentMcpServer,
 				});
+				// Inject the room chat system prompt so the agent knows the proper
+				// goal → plan → approval → task workflow and never creates tasks
+				// prematurely when a goal is created.
+				roomChatSession.setRuntimeSystemPrompt(this.buildRoomSystemPrompt(room));
 			})
 			.catch((error) => {
 				log.error(`Failed to attach room MCP tools for room ${room.id}:`, error);
 			});
+	}
+
+	private buildRoomSystemPrompt(room: Room): string {
+		return buildRoomChatSystemPrompt({
+			background: room.background,
+			instructions: room.instructions,
+		});
 	}
 
 	private subscribeToEvents(): void {
@@ -460,6 +472,19 @@ export class RoomRuntimeService {
 					const room = this.ctx.roomManager.getRoom(event.roomId);
 					if (room) {
 						runtime.updateRoom(room);
+						// Re-apply the room chat system prompt so it reflects the latest
+						// room background/instructions (e.g. after room.update changes them).
+						const roomChatSessionId = `room:chat:${room.id}`;
+						void this.ctx.sessionManager
+							.getSessionAsync(roomChatSessionId)
+							.then((session) => {
+								if (session) {
+									session.setRuntimeSystemPrompt(this.buildRoomSystemPrompt(room));
+								}
+							})
+							.catch((error) => {
+								log.warn(`Failed to update room chat system prompt for room ${room.id}:`, error);
+							});
 					}
 				}
 			},

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -60,6 +60,7 @@ import {
 	runWorkerExitGate,
 	runLeaderCompleteGate,
 	runLeaderSubmitGate,
+	closeStalePr,
 	type HookOptions,
 	type HookResult,
 	type WorkerExitHookContext,
@@ -1093,6 +1094,22 @@ export class RoomRuntime {
 								action_required: gateResult.bounceMessage,
 							});
 						}
+					}
+				}
+
+				// If the task already has a different PR URL (e.g., agent created a new PR
+				// instead of updating the existing one), close the stale PR before proceeding.
+				{
+					const existingTask = await this.taskManager.getTask(group.taskId);
+					if (existingTask?.prUrl && existingTask.prUrl !== prUrl) {
+						const groupWorkspace = group.workspacePath ?? this.taskGroupManager.workspacePath;
+						log.info(
+							`submit_for_review: new PR ${prUrl} differs from existing ${existingTask.prUrl} — closing stale PR`
+						);
+						this.appendGroupEvent(groupId, 'status', {
+							text: `Closing stale PR ${existingTask.prUrl}, superseded by ${prUrl}.`,
+						});
+						await closeStalePr(existingTask.prUrl, prUrl, groupWorkspace, this.hookOptions);
 					}
 				}
 

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -40,6 +40,7 @@ import type {
 	UpdateBulkConfigRequest,
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
+import { Logger } from '../logger';
 import type { SessionManager } from '../session-manager';
 import {
 	validateSystemPromptConfig,
@@ -52,6 +53,8 @@ import {
 	validateBetasConfig,
 	validateEnvConfig,
 } from '../config-validators';
+
+const log = new Logger('config-handlers');
 
 /**
  * Setup SDK config RPC handlers
@@ -93,14 +96,26 @@ export function setupConfigHandlers(
 
 		// Handle model change (runtime native via existing handleModelSwitch)
 		if (settings.model) {
-			const result = await agentSession.handleModelSwitch(settings.model);
-			if (result.success) {
-				results.applied.push('model');
-			} else {
+			const provider = agentSession.getSessionData().config.provider;
+			if (!provider) {
+				// Session has no provider — cannot route the model switch.
+				// This is a misconfigured session; surface the error rather than
+				// silently falling back to 'anthropic' (which switchModel rejects anyway).
+				log.warn('config.model.update: session has no provider configured — skipping model switch');
 				results.errors.push({
 					field: 'model',
-					error: result.error || 'Failed to switch model',
+					error: 'Session has no provider configured',
 				});
+			} else {
+				const result = await agentSession.handleModelSwitch(settings.model, provider);
+				if (result.success) {
+					results.applied.push('model');
+				} else {
+					results.errors.push({
+						field: 'model',
+						error: result.error || 'Failed to switch model',
+					});
+				}
 			}
 		}
 
@@ -705,14 +720,25 @@ export function setupConfigHandlers(
 		const runtimeConfig = { ...config };
 
 		if (runtimeConfig.model) {
-			const result = await agentSession.handleModelSwitch(runtimeConfig.model);
-			if (result.success) {
-				results.applied.push('model');
-			} else {
+			const provider = agentSession.getSessionData().config.provider;
+			if (!provider) {
+				// Session has no provider — surface the error instead of silently
+				// falling back (switchModel rejects missing provider internally anyway).
+				log.warn('config.updateBulk: session has no provider configured — skipping model switch');
 				results.errors.push({
 					field: 'model',
-					error: result.error || 'Failed',
+					error: 'Session has no provider configured',
 				});
+			} else {
+				const result = await agentSession.handleModelSwitch(runtimeConfig.model, provider);
+				if (result.success) {
+					results.applied.push('model');
+				} else {
+					results.errors.push({
+						field: 'model',
+						error: result.error || 'Failed',
+					});
+				}
 			}
 			delete runtimeConfig.model;
 		}

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -320,10 +320,10 @@ export function setupGoalHandlers(
 		const message =
 			task.taskType === 'planning'
 				? 'Your plan has been approved by AI reviewers and the human reviewer. ' +
-					'Now merge the plan PR (run `gh pr merge --merge` or merge the branch manually), ' +
+					'Now merge the plan PR (run `gh pr merge` or merge the branch manually), ' +
 					'then read the plan file under `docs/plans/` and create tasks 1:1 from the approved plan using `create_task`. ' +
 					'Each task title and description should match the plan exactly.'
-				: 'Human has approved the PR. Merge it now by running `gh pr merge --merge`. ' +
+				: 'Human has approved the PR. Merge it now by running `gh pr merge`. ' +
 					'After the merge completes, your work is done.';
 
 		const resumed = await runtime.resumeWorkerFromHuman(params.taskId, message, {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -356,11 +356,17 @@ export function setupSessionHandlers(
 
 		// Get current model ID (may be an alias like "default")
 		const rawModelId = agentSession.getCurrentModel().id;
+		const sessionProvider = agentSession.getSessionData().config.provider;
+
+		if (!sessionProvider) {
+			throw new Error('Session has no provider configured');
+		}
 
 		// Resolve alias to full model ID for consistency with session.model.switch
+		// Pass provider so same-ID models are disambiguated by provider context
 		const { resolveModelAlias, getModelInfo } = await import('../model-service');
-		const currentModelId = await resolveModelAlias(rawModelId);
-		const modelInfo = await getModelInfo(currentModelId);
+		const currentModelId = await resolveModelAlias(rawModelId, 'global', sessionProvider);
+		const modelInfo = await getModelInfo(currentModelId, 'global', sessionProvider);
 
 		return {
 			currentModel: currentModelId,
@@ -371,10 +377,20 @@ export function setupSessionHandlers(
 	// Handle model switching
 	// Returns synchronous result for test compatibility and immediate feedback
 	messageHub.onRequest('session.model.switch', async (data) => {
-		const { sessionId: targetSessionId, model } = data as {
+		const {
+			sessionId: targetSessionId,
+			model,
+			provider,
+		} = data as {
 			sessionId: string;
 			model: string;
+			/** Explicit provider ID — always supply this from the UI model picker. */
+			provider?: string;
 		};
+
+		if (!provider) {
+			throw new Error('Missing required field: provider');
+		}
 
 		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
 		if (!agentSession) {
@@ -382,7 +398,7 @@ export function setupSessionHandlers(
 		}
 
 		// Call handleModelSwitch directly - returns {success, model, error}
-		const result = await agentSession.handleModelSwitch(model);
+		const result = await agentSession.handleModelSwitch(model, provider);
 
 		// Broadcast model switch result via state channels for UI updates
 		if (result.success) {

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -9,7 +9,7 @@
  * - Title generation and branch renaming
  */
 
-import type { Session, WorktreeMetadata, MessageHub } from '@neokai/shared';
+import type { Provider, Session, WorktreeMetadata, MessageHub } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
@@ -178,8 +178,7 @@ export class SessionLifecycle {
 				// Provider: Allow explicit override; fall back to resolved provider from model alias.
 				// Critical when providers share canonical IDs (e.g., Anthropic and
 				// anthropic-copilot both owning claude-sonnet-4.6).
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				provider: (params.config?.provider ?? resolvedProvider) as any,
+				provider: (params.config?.provider ?? resolvedProvider) as Provider,
 				// Tools config: Use global defaults for new sessions
 				// SDK built-in tools are always enabled (not configurable)
 				// MCP and NeoKai tools are configurable based on global settings
@@ -730,7 +729,7 @@ export class SessionLifecycle {
 		// provider's own isAvailable() implementation.
 		const legacyKeyProviders: string[] = ['anthropic', 'glm', 'minimax'];
 		if (legacyKeyProviders.includes(provider)) {
-			const apiKey = providerService.getProviderApiKey(provider as 'anthropic' | 'glm' | 'minimax');
+			const apiKey = providerService.getProviderApiKey(provider as Provider);
 			if (!apiKey) {
 				this.logger.warn(
 					`[SessionLifecycle] No API key for provider ${provider}, using fallback title`

--- a/packages/daemon/tests/manual/test-model-cache.ts
+++ b/packages/daemon/tests/manual/test-model-cache.ts
@@ -7,7 +7,7 @@
 import {
 	initializeModels,
 	getAvailableModels,
-	getModelInfo,
+	getModelInfoUnfiltered,
 	clearModelsCache,
 } from '../../src/lib/model-service';
 
@@ -27,8 +27,8 @@ async function testModelCache() {
 	console.log('\n=== Test 3: Legacy model ID lookup ===');
 	const legacyIds = ['sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101'];
 	for (const id of legacyIds) {
-		const info = await getModelInfo(id, 'global');
-		console.log(`  getModelInfo('${id}') → ${info ? `Found: ${info.name}` : 'NULL'}`);
+		const info = await getModelInfoUnfiltered(id, 'global');
+		console.log(`  getModelInfoUnfiltered('${id}') → ${info ? `Found: ${info.name}` : 'NULL'}`);
 	}
 
 	console.log('\n=== Test 4: Clear cache (should return empty - no static fallback) ===');

--- a/packages/daemon/tests/online/agent/context-command.test.ts
+++ b/packages/daemon/tests/online/agent/context-command.test.ts
@@ -48,22 +48,12 @@ interface SDKMessageResult {
 describe('Context Command Online Tests', () => {
 	let daemon: DaemonServerContext;
 
-	// Skip all tests if no Anthropic credentials (or not using Dev Proxy mock)
-	const hasAnthropicCredentials =
-		IS_MOCK || process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN;
-
 	beforeEach(async () => {
-		if (!hasAnthropicCredentials) {
-			return; // Skip setup if no credentials
-		}
 		daemon = await createDaemonServer();
 	}, SETUP_TIMEOUT);
 
 	afterEach(
 		async () => {
-			if (!hasAnthropicCredentials) {
-				return; // Skip cleanup if no credentials
-			}
 			if (daemon) {
 				daemon.kill('SIGTERM');
 				await daemon.waitForExit();
@@ -74,11 +64,6 @@ describe('Context Command Online Tests', () => {
 
 	describe('Automatic /context at turn end', () => {
 		test('should parse /context replay and produce source=context-command with SDK categories', async () => {
-			if (!hasAnthropicCredentials) {
-				console.log('Skipping - no Anthropic API credentials');
-				return;
-			}
-
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: process.cwd(),
 				title: 'Context Command Test',
@@ -161,10 +146,6 @@ describe('Context Command Online Tests', () => {
 		}, 60000);
 
 		test('should not produce repeated zero-token result messages after one turn', async () => {
-			if (!hasAnthropicCredentials) {
-				console.log('Skipping - no Anthropic API credentials');
-				return;
-			}
 			// In mock mode, the test checks for zero-token result patterns which may
 			// not behave the same way with mocked responses. Do a basic check only.
 			if (IS_MOCK) {

--- a/packages/daemon/tests/online/glm/model-switching.test.ts
+++ b/packages/daemon/tests/online/glm/model-switching.test.ts
@@ -55,6 +55,7 @@ describe('GLM Model Switching', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			})) as { success: boolean; model: string; error?: string };
 
 			expect(result.success).toBe(true);
@@ -98,6 +99,7 @@ describe('GLM Model Switching', () => {
 			await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			});
 
 			// Get state after switch
@@ -142,12 +144,19 @@ describe('GLM Model Switching', () => {
 			daemon.trackSession(sessionId);
 
 			// Perform rapid switches between Claude and GLM
-			const switches = ['glm-5', 'haiku', 'glm-5', 'sonnet', 'glm-5'];
+			const switches: Array<{ model: string; provider: string }> = [
+				{ model: 'glm-5', provider: 'glm' },
+				{ model: 'haiku', provider: 'anthropic' },
+				{ model: 'glm-5', provider: 'glm' },
+				{ model: 'sonnet', provider: 'anthropic' },
+				{ model: 'glm-5', provider: 'glm' },
+			];
 
-			for (const model of switches) {
+			for (const { model, provider } of switches) {
 				const result = (await daemon.messageHub.request('session.model.switch', {
 					sessionId,
 					model,
+					provider,
 				})) as { success: boolean };
 				expect(result.success).toBe(true);
 			}
@@ -176,6 +185,7 @@ describe('GLM Model Switching', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'glm-5',
+				provider: 'glm',
 			})) as { success: boolean; model: string };
 
 			expect(result.success).toBe(true);

--- a/packages/daemon/tests/online/rpc/rpc-model-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-model-handlers.test.ts
@@ -78,6 +78,7 @@ describe('Model RPC Handlers', () => {
 				daemon.messageHub.request('session.model.switch', {
 					sessionId: 'non-existent',
 					model: 'claude-opus-4-20250514',
+					provider: 'anthropic',
 				})
 			).rejects.toThrow();
 		});
@@ -88,6 +89,7 @@ describe('Model RPC Handlers', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'invalid-model-name',
+				provider: 'anthropic',
 			})) as { success: boolean; error?: string };
 
 			expect(result.success).toBe(false);
@@ -104,6 +106,7 @@ describe('Model RPC Handlers', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: currentModel,
+				provider: 'anthropic',
 			})) as { success: boolean; model: string };
 
 			expect(result.success).toBe(true);

--- a/packages/daemon/tests/online/rpc/rpc-model-switching.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-model-switching.test.ts
@@ -80,6 +80,7 @@ describe('Model Switching', () => {
 				daemon.messageHub.request('session.model.switch', {
 					sessionId: 'non-existent-session',
 					model: 'sonnet',
+					provider: 'anthropic',
 				})
 			).rejects.toThrow();
 		});

--- a/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
@@ -149,6 +149,7 @@ describe('Session RPC Handlers - Extended', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'haiku',
+				provider: 'anthropic',
 			})) as { success: boolean };
 
 			expect(result.success).toBe(true);
@@ -166,6 +167,7 @@ describe('Session RPC Handlers - Extended', () => {
 			const result = (await daemon.messageHub.request('session.model.switch', {
 				sessionId,
 				model: 'invalid-model-id',
+				provider: 'anthropic',
 			})) as { success: boolean; error?: string };
 
 			expect(result.success).toBe(false);

--- a/packages/daemon/tests/unit/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/agent/agent-session.test.ts
@@ -536,9 +536,9 @@ describe('AgentSession', () => {
 				switchModel: switchModelSpy,
 			};
 
-			const result = await agentSession.handleModelSwitch('claude-opus-4-20250514');
+			const result = await agentSession.handleModelSwitch('claude-opus-4-20250514', 'anthropic');
 
-			expect(switchModelSpy).toHaveBeenCalledWith('claude-opus-4-20250514');
+			expect(switchModelSpy).toHaveBeenCalledWith('claude-opus-4-20250514', 'anthropic');
 			expect(result).toEqual(mockResult);
 		});
 
@@ -2070,6 +2070,121 @@ describe('AgentSession', () => {
 			expect(agentSession.getSessionData().worktree).toBeUndefined();
 			expect(agentSession.getSessionData().workspacePath).toBe('/new/workspace');
 			expect(agentSession.getSessionData().type).toBe('room');
+		});
+	});
+
+	describe('setRuntimeSystemPrompt', () => {
+		it('should update the in-memory system prompt without persisting it', () => {
+			const mockSession: Session = {
+				id: 'room:chat:test',
+				title: 'Room Chat',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1.0,
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+				type: 'room_chat',
+			};
+
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			// Initially no system prompt
+			expect(agentSession.getSessionData().config.systemPrompt).toBeUndefined();
+
+			// Set the runtime system prompt
+			agentSession.setRuntimeSystemPrompt('You are the Room Agent.');
+
+			// In-memory config should reflect the new prompt
+			expect(agentSession.getSessionData().config.systemPrompt).toBe('You are the Room Agent.');
+
+			// The DB update should NOT have been called (runtime-only, not persisted)
+			const updateSessionCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateSessionCalls.length).toBe(0);
+		});
+
+		it('should overwrite an existing runtime system prompt', () => {
+			const mockSession: Session = {
+				id: 'room:chat:test2',
+				title: 'Room Chat',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1.0,
+					systemPrompt: 'old prompt',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+				type: 'room_chat',
+			};
+
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			agentSession.setRuntimeSystemPrompt('new prompt');
+
+			expect(agentSession.getSessionData().config.systemPrompt).toBe('new prompt');
 		});
 	});
 

--- a/packages/daemon/tests/unit/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/agent/context-fetcher.test.ts
@@ -5,7 +5,9 @@ describe('ContextFetcher', () => {
 	const fetcher = new ContextFetcher('test-session');
 
 	describe('isContextResponse', () => {
-		it('should detect valid context response', () => {
+		// --- Old SDK format (user message with isReplay + <local-command-stdout>) ---
+
+		it('should detect valid context response (old format: user/isReplay)', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -17,15 +19,6 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(true);
 		});
 
-		it('should reject non-user messages', () => {
-			const message = {
-				type: 'assistant',
-				message: { content: 'test' },
-			};
-
-			expect(fetcher.isContextResponse(message as never)).toBe(false);
-		});
-
 		it('should reject user messages without isReplay', () => {
 			const message = {
 				type: 'user',
@@ -35,7 +28,7 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 
-		it('should reject messages without context stdout', () => {
+		it('should reject user isReplay messages without context stdout', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -45,7 +38,7 @@ describe('ContextFetcher', () => {
 			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 
-		it('should detect context response without explicit "Context Usage" header', () => {
+		it('should detect context response without explicit "Context Usage" header (old format)', () => {
 			const message = {
 				type: 'user',
 				isReplay: true,
@@ -56,6 +49,72 @@ describe('ContextFetcher', () => {
 			};
 
 			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		// --- New SDK format (assistant message with raw markdown, no wrapper tags) ---
+		// In the new claude binary, sc8() converts system/local_command messages to
+		// assistant messages and strips <local-command-stdout> tags.
+
+		it('should detect context response in new assistant message format', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [
+						{
+							type: 'text',
+							text: `## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n### Estimated usage by category\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |\n| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |`,
+						},
+					],
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		it('should detect context response in new format with string content', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content:
+						'## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |',
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(true);
+		});
+
+		it('should reject regular assistant messages that mention tokens but have no category table', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [
+						{
+							type: 'text',
+							text: 'Here is a summary. **Tokens:** 1k / 200k (1%). No table here.',
+						},
+					],
+				},
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
+		});
+
+		it('should reject regular assistant messages without tokens line', () => {
+			const message = {
+				type: 'assistant',
+				message: { content: 'This is just a regular assistant response.' },
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
+		});
+
+		it('should reject system messages', () => {
+			const message = {
+				type: 'system',
+				subtype: 'init',
+			};
+
+			expect(fetcher.isContextResponse(message as never)).toBe(false);
 		});
 	});
 
@@ -236,6 +295,84 @@ No table rows here.
 
 </local-command-stdout>`,
 				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
+		// --- New SDK format: assistant messages (sc8() strips <local-command-stdout> tags) ---
+
+		it('should parse new assistant message format with array content', () => {
+			// This is the format produced by sc8() in newer claude binaries:
+			// <local-command-stdout> tags are stripped, content is raw markdown in an array.
+			const rawMarkdown = `## Context Usage\n\n**Model:** claude-sonnet-4-6  \n**Tokens:** 20.3k / 200k (10%)\n\n### Estimated usage by category\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.6k | 1.8% |\n| System tools | 18k | 9.0% |\n| Skills | 61 | 0.0% |\n| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |\n| Autocompact buffer | 33k | 16.5% |`;
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [{ type: 'text', text: rawMarkdown }],
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+
+			expect(result).not.toBeNull();
+			expect(result?.model).toBe('claude-sonnet-4-6');
+			expect(result?.totalCapacity).toBe(200000);
+			// totalUsed = 3600 + 18000 + 61 + 108 + 33000 = 54769 (Free space excluded)
+			expect(result?.totalUsed).toBe(54769);
+			expect(result?.percentUsed).toBe(27);
+			expect(result?.breakdown['System tools']).toEqual({ tokens: 18000, percent: 9.0 });
+			expect(result?.breakdown['System prompt']).toEqual({ tokens: 3600, percent: 1.8 });
+			expect(result?.breakdown['Autocompact buffer']).toEqual({ tokens: 33000, percent: 16.5 });
+		});
+
+		it('should parse new assistant message format with string content', () => {
+			const rawMarkdown = `## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 62.5k / 200.0k (31%)\n\n| Category | Tokens | Percentage |\n|----------|--------|------------|\n| System prompt | 3.2k | 1.6% |\n| System tools | 14.3k | 7.1% |\n| Messages | 25 | 0.0% |\n| Free space | 137.5k | 68.7% |\n| Autocompact buffer | 45.0k | 22.5% |`;
+			const message = {
+				type: 'assistant',
+				message: { content: rawMarkdown },
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+
+			expect(result).not.toBeNull();
+			expect(result?.model).toBe('claude-sonnet-4-6');
+			expect(result?.totalCapacity).toBe(200000);
+			// totalUsed = 3200 + 14300 + 25 + 45000 = 62525
+			expect(result?.totalUsed).toBe(62525);
+			expect(result?.percentUsed).toBe(31);
+		});
+
+		it('should return null for assistant message without tokens line', () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					content: [{ type: 'text', text: 'Just a regular response without context data.' }],
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
+		it('should return null for assistant message with tokens line but no category table', () => {
+			// Guard is tighter than isContextResponse to prevent false-positive parse attempts
+			const message = {
+				type: 'assistant',
+				message: {
+					content: 'Here is your summary. **Tokens:** 5k / 200k (2%). No table follows.',
+				},
+			};
+
+			const result = fetcher.parseContextResponse(message as never);
+			expect(result).toBeNull();
+		});
+
+		it('should return null for non-user non-assistant messages', () => {
+			const message = {
+				type: 'system',
+				subtype: 'init',
 			};
 
 			const result = fetcher.parseContextResponse(message as never);

--- a/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
@@ -123,9 +123,9 @@ describe('EventSubscriptionSetup', () => {
 				setup.setup();
 
 				const callback = registeredCallbacks.get('model.switchRequest')!;
-				await callback({ sessionId: 'test-session-id', model: 'opus' });
+				await callback({ sessionId: 'test-session-id', model: 'opus', provider: 'anthropic' });
 
-				expect(mockModelSwitchHandler.switchModel).toHaveBeenCalledWith('opus');
+				expect(mockModelSwitchHandler.switchModel).toHaveBeenCalledWith('opus', 'anthropic');
 				expect(emitSpy).toHaveBeenCalledWith('model.switched', {
 					sessionId: 'test-session-id',
 					success: true,
@@ -144,7 +144,7 @@ describe('EventSubscriptionSetup', () => {
 				setup.setup();
 
 				const callback = registeredCallbacks.get('model.switchRequest')!;
-				await callback({ sessionId: 'test-session-id', model: 'opus' });
+				await callback({ sessionId: 'test-session-id', model: 'opus', provider: 'anthropic' });
 
 				expect(emitSpy).toHaveBeenCalledWith('model.switched', {
 					sessionId: 'test-session-id',
@@ -152,6 +152,15 @@ describe('EventSubscriptionSetup', () => {
 					model: 'opus',
 					error: 'Invalid model',
 				});
+			});
+
+			it('should throw when provider is missing from event', async () => {
+				setup.setup();
+
+				const callback = registeredCallbacks.get('model.switchRequest')!;
+				await expect(callback({ sessionId: 'test-session-id', model: 'opus' })).rejects.toThrow(
+					'model.switchRequest event is missing required field: provider'
+				);
 			});
 		});
 

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -72,6 +72,38 @@ const TEST_MODELS: ModelInfo[] = [
 		releaseDate: '2026-01-01',
 		available: true,
 	},
+	// Copilot models — intentionally share IDs with standard Anthropic models.
+	// isValidModel/getModelInfo now filter by provider, so 'claude-opus-4.6' under
+	// 'anthropic-copilot' and 'claude-opus-4.6' under 'anthropic' are distinct entries.
+	// There is no Anthropic entry for 'claude-sonnet-4.6' here because the cross-provider
+	// tests that start on 'anthropic' switch *to* 'anthropic-copilot' and only need the
+	// copilot entry to resolve. Callers that stay on 'anthropic' use 'default'/'opus'/etc.
+	{
+		id: 'claude-opus-4.6',
+		name: 'Claude Opus 4.6 (Copilot)',
+		alias: 'copilot-anthropic-opus',
+		family: 'opus',
+		provider: 'anthropic-copilot',
+		contextWindow: 200000,
+		description: 'Claude Opus via GitHub Copilot',
+		releaseDate: '2025-11-01',
+		available: true,
+	},
+	{
+		// 'claude-sonnet-4.6' registered only under 'anthropic-copilot' in this fixture.
+		// isValidModel('claude-sonnet-4.6', 'global', 'anthropic-copilot') → found.
+		// isValidModel('claude-sonnet-4.6', 'global', 'anthropic')         → not found
+		//   (tests that need an anthropic sonnet use 'default' which resolves to 'default').
+		id: 'claude-sonnet-4.6',
+		name: 'Claude Sonnet 4.6 (Copilot)',
+		alias: 'copilot-anthropic-sonnet',
+		family: 'sonnet',
+		provider: 'anthropic-copilot',
+		contextWindow: 200000,
+		description: 'Claude Sonnet 4.6 via Copilot',
+		releaseDate: '2025-11-01',
+		available: true,
+	},
 ];
 
 describe('ModelSwitchHandler', () => {
@@ -118,6 +150,7 @@ describe('ModelSwitchHandler', () => {
 			status: 'active',
 			config: {
 				model: 'default',
+				provider: 'anthropic',
 				maxTokens: 8192,
 				temperature: 1.0,
 			},
@@ -170,6 +203,8 @@ describe('ModelSwitchHandler', () => {
 		mockLogger = {
 			log: mock(() => {}),
 			error: mock(() => {}),
+			warn: mock(() => {}),
+			debug: mock(() => {}),
 		} as unknown as Logger;
 
 		mockLifecycleManager = {
@@ -267,7 +302,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when query not started', () => {
 			it('should update config only when query not started', async () => {
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalledWith(
@@ -287,7 +322,7 @@ describe('ModelSwitchHandler', () => {
 				(mockSession.config as Record<string, unknown>)['mcpServers'] = { 'room-tools': liveObj };
 
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				// The spy should have been called with only plain serializable fields
@@ -299,7 +334,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit session.updated event', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(emitSpy).toHaveBeenCalledWith(
 					'session.updated',
@@ -312,7 +347,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit model-switching event', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(publishSpy).toHaveBeenCalledWith(
 					'session.model-switching',
@@ -325,7 +360,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit model-switched event on success', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(publishSpy).toHaveBeenCalledWith(
 					'session.model-switched',
@@ -341,7 +376,7 @@ describe('ModelSwitchHandler', () => {
 				mockSession.config.provider = 'glm';
 
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(mockSession.config.provider).toBe('anthropic');
@@ -351,7 +386,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when transport not ready', () => {
 			it('should update config only when transport not ready', async () => {
 				handler = createHandler({ firstMessageReceived: false });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalled();
@@ -362,7 +397,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when query is running', () => {
 			it('should restart query when running', async () => {
 				handler = createHandler();
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(restartSpy).toHaveBeenCalled();
@@ -370,7 +405,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should update session config before restart', async () => {
 				handler = createHandler();
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(updateSessionSpy).toHaveBeenCalledWith(
 					mockSession.id,
@@ -384,7 +419,7 @@ describe('ModelSwitchHandler', () => {
 		describe('validation', () => {
 			it('should reject invalid model', async () => {
 				handler = createHandler();
-				const result = await handler.switchModel('invalid-model-12345');
+				const result = await handler.switchModel('invalid-model-12345', 'anthropic');
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Invalid model');
@@ -395,9 +430,9 @@ describe('ModelSwitchHandler', () => {
 				// No query running for simpler test
 				handler = createHandler({ queryObject: null });
 				// Switch to haiku first
-				await handler.switchModel('haiku');
+				await handler.switchModel('haiku', 'anthropic');
 				// Then try to switch to haiku again
-				const result = await handler.switchModel('haiku');
+				const result = await handler.switchModel('haiku', 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(result.error).toContain('Already using');
@@ -410,11 +445,22 @@ describe('ModelSwitchHandler', () => {
 				restartSpy.mockRejectedValue(new Error('Restart failed'));
 				handler = createHandler();
 
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Restart failed');
 				expect(handleErrorSpy).toHaveBeenCalled();
+			});
+
+			it('should return error when session has no provider configured', async () => {
+				// Remove provider from session config
+				(mockSession.config as Record<string, unknown>).provider = undefined;
+				handler = createHandler({ queryObject: null });
+
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
+
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Session has no provider configured');
 			});
 		});
 
@@ -423,9 +469,123 @@ describe('ModelSwitchHandler', () => {
 				// Set query to null so we don't need restart
 				handler = createHandler({ queryObject: null });
 				// Use haiku to ensure we're switching to a different model
-				await handler.switchModel('haiku');
+				await handler.switchModel('haiku', 'anthropic');
 
 				expect(setModelTrackerSpy).toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('provider routing', () => {
+		/**
+		 * Same-provider switch: copilot opus -> copilot sonnet (explicit provider)
+		 *
+		 * When a session is on anthropic-copilot and the caller explicitly passes
+		 * 'anthropic-copilot' as the provider, the switch stays within that provider.
+		 * Both copilot-opus and copilot-sonnet share canonical IDs with Anthropic models;
+		 * explicit provider routing (dev approach) means there is no ambiguity.
+		 */
+		describe('same-provider switch (copilot opus to copilot sonnet)', () => {
+			beforeEach(() => {
+				mockSession.config.model = 'claude-opus-4.6';
+				mockSession.config.provider = 'anthropic-copilot';
+			});
+
+			it('switches copilot opus to copilot sonnet with explicit provider', async () => {
+				handler = createHandler({ queryObject: null });
+				const result = await handler.switchModel('claude-sonnet-4.6', 'anthropic-copilot');
+
+				expect(result.success).toBe(true);
+				expect(result.model).toBe('claude-sonnet-4.6');
+				expect(mockSession.config.provider).toBe('anthropic-copilot');
+			});
+
+			it('stores anthropic-copilot in persisted config', async () => {
+				handler = createHandler({ queryObject: null });
+				await handler.switchModel('claude-sonnet-4.6', 'anthropic-copilot');
+
+				expect(updateSessionSpy).toHaveBeenCalledWith(
+					mockSession.id,
+					expect.objectContaining({
+						config: expect.objectContaining({ provider: 'anthropic-copilot' }),
+					})
+				);
+			});
+
+			it('already on copilot-opus via alias; no-op expected', async () => {
+				// copilot-anthropic-opus resolves to claude-opus-4.6 which is the current model.
+				// Provider also matches, so the handler takes the "already using" early-return path.
+				handler = createHandler({ queryObject: null });
+				const result = await handler.switchModel('copilot-anthropic-opus', 'anthropic-copilot');
+
+				expect(result.success).toBe(true);
+				expect(result.error).toContain('Already using');
+				// No-op: must not write to DB or restart query
+				expect(updateSessionSpy).not.toHaveBeenCalled();
+			});
+		});
+
+		/**
+		 * Cross-provider switch: anthropic -> copilot (explicit provider)
+		 *
+		 * Caller explicitly requests 'anthropic-copilot'; session was on 'anthropic'.
+		 * The explicit provider arg always wins.
+		 */
+		describe('cross-provider switch (anthropic to copilot, explicit provider)', () => {
+			beforeEach(() => {
+				mockSession.config.model = 'default';
+				mockSession.config.provider = 'anthropic';
+			});
+
+			it('switches to anthropic-copilot when explicitly requested', async () => {
+				handler = createHandler({ queryObject: null });
+				const result = await handler.switchModel('claude-sonnet-4.6', 'anthropic-copilot');
+
+				expect(result.success).toBe(true);
+				expect(result.model).toBe('claude-sonnet-4.6');
+				expect(mockSession.config.provider).toBe('anthropic-copilot');
+			});
+
+			it('persists the new provider in the database', async () => {
+				handler = createHandler({ queryObject: null });
+				await handler.switchModel('claude-sonnet-4.6', 'anthropic-copilot');
+
+				expect(updateSessionSpy).toHaveBeenCalledWith(
+					mockSession.id,
+					expect.objectContaining({
+						config: expect.objectContaining({
+							model: 'claude-sonnet-4.6',
+							provider: 'anthropic-copilot',
+						}),
+					})
+				);
+			});
+		});
+
+		/**
+		 * Cross-provider switch: GLM -> anthropic (explicit provider)
+		 *
+		 * Caller passes 'anthropic' explicitly when switching from GLM to an Anthropic model.
+		 */
+		describe('cross-provider switch (glm to anthropic, explicit provider)', () => {
+			it('switches from glm to anthropic when explicit provider given', async () => {
+				mockSession.config.model = 'glm-5';
+				mockSession.config.provider = 'glm';
+
+				handler = createHandler({ queryObject: null });
+				const result = await handler.switchModel('opus', 'anthropic');
+
+				expect(result.success).toBe(true);
+				expect(mockSession.config.provider).toBe('anthropic');
+				expect(updateSessionSpy).toHaveBeenCalledWith(
+					mockSession.id,
+					expect.objectContaining({
+						config: expect.objectContaining({
+							model: 'opus',
+							provider: 'anthropic',
+						}),
+					})
+				);
 			});
 		});
 	});

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -411,6 +411,13 @@ describe('QueryOptionsBuilder', () => {
 			const options = await builder.build();
 			expect(options.systemPrompt).toBeUndefined();
 		});
+
+		it('should preserve a custom string system prompt for room sessions', async () => {
+			mockSession.type = 'room_chat';
+			mockSession.config.systemPrompt = 'You are the Room Agent.';
+			const options = await builder.build();
+			expect(options.systemPrompt).toBe('You are the Room Agent.');
+		});
 	});
 
 	describe('additional directories configuration', () => {

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -377,6 +377,29 @@ describe('SDKMessageHandler', () => {
 
 			expect(mockSession.sdkSessionId).toBe('existing-session-id');
 		});
+
+		it('should not set sdkSessionId from api_retry message', async () => {
+			// api_retry has session_id but should not overwrite sdkSessionId
+			// — only system/init messages are the authoritative source
+			const message: SDKMessage = {
+				type: 'system',
+				subtype: 'api_retry',
+				uuid: 'retry-uuid',
+				session_id: 'retry-session-id',
+				attempt: 1,
+				max_retries: 3,
+				retry_delay_ms: 1000,
+				error_status: 429,
+				error: 'rate_limit',
+			} as unknown as SDKMessage;
+
+			await handler.handleMessage(message);
+
+			expect(mockSession.sdkSessionId).toBeUndefined();
+			// api_retry is suppressed before DB/broadcast — should not appear in transcript
+			expect(saveSDKMessageSpy).not.toHaveBeenCalled();
+			expect(publishSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('handleResultMessage', () => {
@@ -1122,6 +1145,108 @@ describe('SDKMessageHandler', () => {
 				'/context',
 				true
 			);
+		});
+
+		it('should clear internalContextCommandIds after new SDK format three-message sequence', async () => {
+			// New SDK format state machine:
+			// 1. Normal result → enqueues /context (UUID=X stored in internalContextCommandIds)
+			// 2. User replay (UUID=X, content='/context') → UUID matched, parse returns null, UUID stays in set
+			// 3. Assistant message (sc8() output, UUID≠X) → context parsed, lastMessageWasContextResponse=true
+			// 4. Result message → internalContextCommandIds.clear() fires
+			// 5. Next normal result → set is empty → queues /context again
+
+			const normalResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'normal-result-uuid',
+				usage: {
+					input_tokens: 100,
+					output_tokens: 50,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0.001,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+
+			// Step 1: normal result queues /context
+			await handler.handleMessage(normalResult);
+			const contextUuid = (mockMessageQueue.enqueueWithId as ReturnType<typeof mock>).mock
+				.calls[0][0] as string;
+			expect(contextUuid).toBeString();
+
+			// Step 2: user replay with the context UUID but only plain '/context' text (new SDK format)
+			const userReplay: SDKMessage = {
+				type: 'user',
+				uuid: contextUuid,
+				isReplay: true,
+				message: {
+					role: 'user',
+					content: '/context',
+				},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(userReplay);
+			// UUID-matched replay is suppressed — no save or broadcast
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1); // only the normal result
+
+			// Step 3: sc8() assistant message carrying actual context output (UUID differs from contextUuid)
+			const sc8AssistantContextMarkdown =
+				'## Context Usage\n\n**Model:** claude-sonnet-4-6\n**Tokens:** 20.3k / 200k (10%)\n\n' +
+				'### Estimated usage by category\n\n' +
+				'| Category | Tokens | Percentage |\n|----------|--------|------------|\n' +
+				'| System prompt | 3.6k | 1.8% |\n| System tools | 18k | 9.0% |\n' +
+				'| Messages | 108 | 0.1% |\n| Free space | 145.3k | 72.6% |';
+			const sc8AssistantMessage: SDKMessage = {
+				type: 'assistant',
+				uuid: 'sc8-assistant-uuid',
+				message: {
+					role: 'assistant',
+					content: [{ type: 'text', text: sc8AssistantContextMarkdown }],
+				},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(sc8AssistantMessage);
+			// Context data was parsed and tracker updated
+			expect(updateWithDetailedBreakdownSpy).toHaveBeenCalledTimes(1);
+			// sc8() assistant message is suppressed — still only 1 DB save
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1);
+
+			// Step 4: result message following the /context turn (zero tokens) — suppressed
+			const contextTurnResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'context-turn-result-uuid',
+				usage: {
+					input_tokens: 0,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(contextTurnResult);
+			// Result suppressed — still only 1 DB save and no new /context enqueue
+			expect(saveSDKMessageSpy).toHaveBeenCalledTimes(1);
+			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(1);
+
+			// Step 5: next normal result — internalContextCommandIds must be empty now
+			// so /context gets queued again
+			const nextNormalResult: SDKMessage = {
+				type: 'result',
+				subtype: 'success',
+				uuid: 'next-normal-result-uuid',
+				usage: {
+					input_tokens: 120,
+					output_tokens: 60,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				total_cost_usd: 0.001,
+				modelUsage: {},
+			} as unknown as SDKMessage;
+			await handler.handleMessage(nextNormalResult);
+			// internalContextCommandIds was cleared in step 4, so /context is queued again
+			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(2);
 		});
 
 		it('should suppress zero-token internal result when replay correlation fails', async () => {

--- a/packages/daemon/tests/unit/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/core/model-service.test.ts
@@ -9,8 +9,10 @@ import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
 import {
 	getAvailableModels,
 	getModelInfo,
+	getModelInfoUnfiltered,
 	isValidModel,
 	resolveModelAlias,
+	resolveModelAliasUnfiltered,
 	clearModelsCache,
 	getModelsCache,
 	setModelsCache,
@@ -169,40 +171,46 @@ describe('Model Service', () => {
 		});
 
 		it('should find model by exact ID', async () => {
-			const model = await getModelInfo('sonnet');
+			const model = await getModelInfo('sonnet', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should find model by alias', async () => {
-			const model = await getModelInfo('opus');
+			const model = await getModelInfo('opus', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should return null for unknown model', async () => {
-			const model = await getModelInfo('unknown-model');
+			const model = await getModelInfo('unknown-model', 'global', 'anthropic');
 			expect(model).toBeNull();
 		});
 
 		it('should handle legacy model IDs', async () => {
 			// Legacy full model IDs should map to SDK short IDs
 			// Note: 'claude-sonnet-4-5-20250929' maps to 'sonnet' via LEGACY_MODEL_MAPPINGS
-			const model = await getModelInfo('claude-sonnet-4-5-20250929');
+			const model = await getModelInfo('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle legacy opus model ID', async () => {
-			const model = await getModelInfo('claude-opus-4-5-20251101');
+			const model = await getModelInfo('claude-opus-4-5-20251101', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should handle legacy haiku model ID', async () => {
-			const model = await getModelInfo('claude-haiku-4-5-20251001');
+			const model = await getModelInfo('claude-haiku-4-5-20251001', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('haiku');
+		});
+
+		it('should return null when provider does not match (no fallback)', async () => {
+			// 'sonnet' exists for 'anthropic' but not for 'glm'
+			const model = await getModelInfo('sonnet', 'global', 'glm');
+			expect(model).toBeNull();
 		});
 	});
 
@@ -214,22 +222,22 @@ describe('Model Service', () => {
 		});
 
 		it('should return true for valid model ID', async () => {
-			const isValid = await isValidModel('sonnet');
+			const isValid = await isValidModel('sonnet', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should return true for valid alias', async () => {
-			const isValid = await isValidModel('opus');
+			const isValid = await isValidModel('opus', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should return false for invalid model', async () => {
-			const isValid = await isValidModel('invalid-model');
+			const isValid = await isValidModel('invalid-model', 'global', 'anthropic');
 			expect(isValid).toBe(false);
 		});
 
 		it('should return true for legacy model IDs', async () => {
-			const isValid = await isValidModel('claude-sonnet-4-5-20250929');
+			const isValid = await isValidModel('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 	});
@@ -242,23 +250,23 @@ describe('Model Service', () => {
 		});
 
 		it('should resolve existing model ID', async () => {
-			const resolved = await resolveModelAlias('sonnet');
+			const resolved = await resolveModelAlias('sonnet', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 
 		it('should resolve alias to model ID', async () => {
-			const resolved = await resolveModelAlias('opus');
+			const resolved = await resolveModelAlias('opus', 'global', 'anthropic');
 			expect(resolved).toBe('opus');
 		});
 
 		it('should return input as-is for unknown model', async () => {
-			const resolved = await resolveModelAlias('custom-model-id');
+			const resolved = await resolveModelAlias('custom-model-id', 'global', 'anthropic');
 			expect(resolved).toBe('custom-model-id');
 		});
 
 		it('should resolve legacy model ID', async () => {
 			// LEGACY_MODEL_MAPPINGS maps 'claude-sonnet-4-5-20250929' to 'sonnet'
-			const resolved = await resolveModelAlias('claude-sonnet-4-5-20250929');
+			const resolved = await resolveModelAlias('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 	});
@@ -371,6 +379,60 @@ describe('Model Service', () => {
 			const cache = getModelsCache();
 			expect(cache.get('global')).toEqual(mockModels);
 		});
+
+		it('should preserve both provider entries for shared model IDs after merge', async () => {
+			// Exercises the production mergeWithFallbackModels code path.
+			// Before the P0 fix, mergeWithFallbackModels keyed by model.id alone, so
+			// the second provider's entry silently overwrote the first (last-writer-wins).
+			//
+			// Use IDs that don't conflict with built-in providers so initializeProviders()
+			// can register them without collision after the registry is reset.
+			const { getProviderRegistry } = await import('../../../src/lib/providers/registry');
+			type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+
+			const registry = getProviderRegistry();
+			const sharedId = 'shared-model-xyz';
+
+			registry.register({
+				id: 'test-provider-a',
+				getModels: async () => [
+					{
+						id: sharedId,
+						name: 'Shared (A)',
+						family: 'test',
+						provider: 'test-provider-a',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			registry.register({
+				id: 'test-provider-b',
+				getModels: async () => [
+					{
+						id: sharedId,
+						name: 'Shared (B)',
+						family: 'test',
+						provider: 'test-provider-b',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			await initializeModels();
+
+			// Both entries must survive the merge — one per (provider, id) pair
+			const entryA = await getModelInfo(sharedId, 'global', 'test-provider-a');
+			const entryB = await getModelInfo(sharedId, 'global', 'test-provider-b');
+
+			expect(entryA).not.toBeNull();
+			expect(entryA?.provider).toBe('test-provider-a');
+
+			expect(entryB).not.toBeNull();
+			expect(entryB?.provider).toBe('test-provider-b');
+		});
 	});
 
 	describe('background refresh behavior', () => {
@@ -477,25 +539,25 @@ describe('Model Service', () => {
 		});
 
 		it('should handle claude-sonnet-4-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-sonnet-4-20241022');
+			const model = await getModelInfo('claude-sonnet-4-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle claude-3-5-sonnet-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-3-5-sonnet-20241022');
+			const model = await getModelInfo('claude-3-5-sonnet-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle claude-opus-4-20250514 legacy ID', async () => {
-			const model = await getModelInfo('claude-opus-4-20250514');
+			const model = await getModelInfo('claude-opus-4-20250514', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should handle claude-3-5-haiku-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-3-5-haiku-20241022');
+			const model = await getModelInfo('claude-3-5-haiku-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('haiku');
 		});
@@ -512,7 +574,7 @@ describe('Model Service', () => {
 			];
 
 			for (const { id, expected } of legacyIds) {
-				const resolved = await resolveModelAlias(id);
+				const resolved = await resolveModelAlias(id, 'global', 'anthropic');
 				expect(resolved).toBe(expected);
 			}
 		});
@@ -527,17 +589,17 @@ describe('Model Service', () => {
 
 		it('should resolve "default" alias to sonnet', async () => {
 			// LEGACY_MODEL_MAPPINGS maps 'default' to 'sonnet'
-			const resolved = await resolveModelAlias('default');
+			const resolved = await resolveModelAlias('default', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 
 		it('should validate "default" as a valid model', async () => {
-			const isValid = await isValidModel('default');
+			const isValid = await isValidModel('default', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should get model info for "default"', async () => {
-			const model = await getModelInfo('default');
+			const model = await getModelInfo('default', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
@@ -573,17 +635,17 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Should find in global cache
-			const globalModel = await getModelInfo('sonnet', 'global');
+			// Should find in global cache with correct provider
+			const globalModel = await getModelInfo('sonnet', 'global', 'anthropic');
 			expect(globalModel).not.toBeNull();
 
-			// Should find in custom cache
-			const customModel = await getModelInfo('custom-model', 'custom-cache');
+			// Should find in custom cache with correct provider
+			const customModel = await getModelInfo('custom-model', 'custom-cache', 'custom');
 			expect(customModel).not.toBeNull();
 			expect(customModel?.id).toBe('custom-model');
 
 			// Should not find custom model in global cache
-			const notFound = await getModelInfo('custom-model', 'global');
+			const notFound = await getModelInfo('custom-model', 'global', 'custom');
 			expect(notFound).toBeNull();
 		});
 	});
@@ -607,11 +669,11 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Custom model should be valid in custom cache
-			expect(await isValidModel('custom-only', 'custom-cache')).toBe(true);
+			// Custom model should be valid in custom cache with correct provider
+			expect(await isValidModel('custom-only', 'custom-cache', 'custom')).toBe(true);
 
-			// Custom model should not be valid in global cache
-			expect(await isValidModel('custom-only', 'global')).toBe(false);
+			// Custom model should not be valid in global cache (not present there)
+			expect(await isValidModel('custom-only', 'global', 'custom')).toBe(false);
 		});
 	});
 
@@ -634,13 +696,191 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Should resolve alias in custom cache
-			const resolved = await resolveModelAlias('my-custom-alias', 'custom-cache');
+			// Should resolve alias in custom cache with correct provider
+			const resolved = await resolveModelAlias('my-custom-alias', 'custom-cache', 'custom');
 			expect(resolved).toBe('custom-alias-model');
 
-			// Should return as-is when not found in global cache
-			const notResolved = await resolveModelAlias('my-custom-alias', 'global');
+			// Should return as-is when not found in global cache (wrong provider)
+			const notResolved = await resolveModelAlias('my-custom-alias', 'global', 'anthropic');
 			expect(notResolved).toBe('my-custom-alias');
+		});
+	});
+
+	describe('provider-filtered model resolution', () => {
+		// Two providers exposing the same canonical model ID
+		const sharedModels: ModelInfo[] = [
+			{
+				id: 'claude-sonnet-4.6',
+				name: 'Claude Sonnet 4.6 (Anthropic)',
+				alias: 'sonnet-4.6',
+				family: 'sonnet',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				description: 'Anthropic Sonnet',
+				available: true,
+			},
+			{
+				id: 'claude-sonnet-4.6',
+				name: 'Claude Sonnet 4.6 (Copilot)',
+				alias: 'sonnet-4.6',
+				family: 'sonnet',
+				provider: 'anthropic-copilot',
+				contextWindow: 200000,
+				description: 'Copilot Sonnet',
+				available: true,
+			},
+			{
+				id: 'haiku',
+				name: 'Haiku (Anthropic)',
+				alias: 'haiku',
+				family: 'haiku',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				available: true,
+			},
+		];
+
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', sharedModels);
+			setModelsCache(testCache);
+		});
+
+		it('should return provider-specific model when providerId matches anthropic-copilot', async () => {
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-copilot');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Copilot)');
+		});
+
+		it('should return anthropic model when providerId is anthropic', async () => {
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'anthropic');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Anthropic)');
+		});
+
+		it('should return null when provider does not have the model (no fallback)', async () => {
+			// 'glm' provider has no claude-sonnet-4.6 — no fallback, returns null
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'glm');
+			expect(model).toBeNull();
+		});
+
+		it('should resolve alias with provider filter', async () => {
+			const resolved = await resolveModelAlias('claude-sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(resolved).toBe('claude-sonnet-4.6');
+		});
+
+		it('should find model by alias with provider filter', async () => {
+			const model = await getModelInfo('sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-copilot');
+		});
+
+		it('should return null when model not found for the specified provider', async () => {
+			const model = await getModelInfo('nonexistent-model', 'global', 'anthropic-copilot');
+			expect(model).toBeNull();
+		});
+
+		it('should return null for model unique to one provider when wrong provider is requested', async () => {
+			// 'haiku' only exists for 'anthropic', not 'anthropic-copilot'
+			const model = await getModelInfo('haiku', 'global', 'anthropic-copilot');
+			expect(model).toBeNull();
+		});
+
+		it('should resolve legacy model ID to provider-specific entry when providerId is set', async () => {
+			// Add a copilot variant of the legacy-mapped target 'sonnet'
+			const modelsWithCopilotSonnet: ModelInfo[] = [
+				...sharedModels,
+				{
+					id: 'sonnet',
+					name: 'Sonnet (Copilot)',
+					alias: 'sonnet',
+					family: 'sonnet',
+					provider: 'anthropic-copilot',
+					contextWindow: 200000,
+					available: true,
+				},
+				{
+					id: 'sonnet',
+					name: 'Sonnet (Anthropic)',
+					alias: 'sonnet',
+					family: 'sonnet',
+					provider: 'anthropic',
+					contextWindow: 200000,
+					available: true,
+				},
+			];
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', modelsWithCopilotSonnet);
+			setModelsCache(cache);
+
+			// LEGACY_MODEL_MAPPINGS maps 'claude-sonnet-4-5-20250929' → 'sonnet'
+			// With copilot provider, should find the copilot sonnet entry
+			const model = await getModelInfo('claude-sonnet-4-5-20250929', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+			expect(model?.provider).toBe('anthropic-copilot');
+		});
+	});
+
+	describe('getModelInfoUnfiltered', () => {
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache);
+		});
+
+		it('should return a result without requiring provider', async () => {
+			const model = await getModelInfoUnfiltered('sonnet');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+			expect(model?.provider).toBe('anthropic');
+		});
+
+		it('should find model by alias without provider filter', async () => {
+			const model = await getModelInfoUnfiltered('opus');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('opus');
+		});
+
+		it('should return null for unknown model', async () => {
+			const model = await getModelInfoUnfiltered('nonexistent-model-xyz');
+			expect(model).toBeNull();
+		});
+
+		it('should handle legacy model IDs without provider', async () => {
+			const model = await getModelInfoUnfiltered('claude-sonnet-4-5-20250929');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+		});
+	});
+
+	describe('resolveModelAliasUnfiltered', () => {
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache);
+		});
+
+		it('should resolve correctly without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('sonnet');
+			expect(resolved).toBe('sonnet');
+		});
+
+		it('should resolve alias to model ID without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('opus');
+			expect(resolved).toBe('opus');
+		});
+
+		it('should return input as-is for unknown model', async () => {
+			const resolved = await resolveModelAliasUnfiltered('unknown-id-xyz');
+			expect(resolved).toBe('unknown-id-xyz');
+		});
+
+		it('should handle legacy model IDs without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('claude-sonnet-4-5-20250929');
+			expect(resolved).toBe('sonnet');
 		});
 	});
 

--- a/packages/daemon/tests/unit/core/provider-service.test.ts
+++ b/packages/daemon/tests/unit/core/provider-service.test.ts
@@ -508,12 +508,12 @@ describe('ProviderService', () => {
 
 	describe('getEnvVarsForModel', () => {
 		it('should return empty object for anthropic model', () => {
-			const envVars = service.getEnvVarsForModel('claude-3-opus');
+			const envVars = service.getEnvVarsForModel('claude-3-opus', 'anthropic');
 			expect(envVars).toEqual({});
 		});
 
 		it('should return env vars for GLM model', () => {
-			const envVars = service.getEnvVarsForModel('glm-4');
+			const envVars = service.getEnvVarsForModel('glm-4', 'glm');
 
 			expect(envVars.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 			expect(envVars.API_TIMEOUT_MS).toBe('120000');
@@ -669,7 +669,7 @@ describe('ProviderService', () => {
 
 	describe('applyEnvVarsToProcess', () => {
 		it('should return empty object for anthropic model', () => {
-			const original = service.applyEnvVarsToProcess('claude-3-opus');
+			const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 			expect(original).toEqual({});
 		});
 
@@ -678,7 +678,7 @@ describe('ProviderService', () => {
 			process.env.API_TIMEOUT_MS = '120000';
 			process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'glm-4';
 
-			const original = service.applyEnvVarsToProcess('claude-3-opus');
+			const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
 			expect(original.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 			expect(original.API_TIMEOUT_MS).toBe('120000');
@@ -692,7 +692,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_AUTH_TOKEN = 'original-token';
 			process.env.ANTHROPIC_BASE_URL = 'original-url';
 
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Check original values were saved
 			expect(original.ANTHROPIC_AUTH_TOKEN).toBe('original-token');
@@ -725,14 +725,14 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
 
 			// Apply GLM env vars
-			const originalFromGlm = service.applyEnvVarsToProcess('glm-4');
+			const originalFromGlm = service.applyEnvVarsToProcess('glm-4', 'glm');
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 
 			// Restore from GLM query
 			service.restoreEnvVars(originalFromGlm);
 
 			// Switch to anthropic - leaked GLM URL should be cleared
-			const originalFromAnthropic = service.applyEnvVarsToProcess('claude-3-opus');
+			const originalFromAnthropic = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
 			// The leaked GLM URL should be cleared
 			expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
@@ -776,7 +776,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_BASE_URL = 'original-url';
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Verify env vars changed
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -795,7 +795,7 @@ describe('ProviderService', () => {
 			delete process.env.ANTHROPIC_BASE_URL;
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Verify env vars were set
 			expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -838,7 +838,7 @@ describe('ProviderService', () => {
 			process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'opus-model';
 
 			// Apply GLM env vars
-			const original = service.applyEnvVarsToProcess('glm-4');
+			const original = service.applyEnvVarsToProcess('glm-4', 'glm');
 
 			// Restore
 			service.restoreEnvVars(original);

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
@@ -249,7 +249,8 @@ describe('startEmbeddedServer', () => {
 		const body = JSON.parse(text) as Record<string, unknown>;
 		expect(body['type']).toBe('error');
 		const err = body['error'] as Record<string, unknown>;
-		expect(err['type']).toBe('invalid_request_error');
+		// Anthropic API uses 'request_too_large' (not 'invalid_request_error') for 413
+		expect(err['type']).toBe('request_too_large');
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
@@ -187,6 +187,16 @@ describe('startEmbeddedServer', () => {
 		expect(r.status).toBe(400);
 	});
 
+	it('returns 400 JSON error envelope for missing required fields', async () => {
+		const r = await postMessages(serverUrl, { model: 'x' });
+		expect(r.status).toBe(400);
+		const body = JSON.parse(r.rawBody ?? '{}') as Record<string, unknown>;
+		expect(body['type']).toBe('error');
+		const err = body['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('invalid_request_error');
+		expect(typeof err['message']).toBe('string');
+	});
+
 	it('returns 400 for stream=false', async () => {
 		const r = await postMessages(serverUrl, {
 			model: 'x',
@@ -195,6 +205,20 @@ describe('startEmbeddedServer', () => {
 			stream: false,
 		});
 		expect(r.status).toBe(400);
+	});
+
+	it('returns 400 JSON error envelope for stream=false', async () => {
+		const r = await postMessages(serverUrl, {
+			model: 'x',
+			max_tokens: 100,
+			messages: [{ role: 'user', content: 'hi' }],
+			stream: false,
+		});
+		expect(r.status).toBe(400);
+		const body = JSON.parse(r.rawBody ?? '{}') as Record<string, unknown>;
+		expect(body['type']).toBe('error');
+		const err = body['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('invalid_request_error');
 	});
 
 	it('returns 413 when body exceeds 10 MB', async () => {
@@ -208,6 +232,24 @@ describe('startEmbeddedServer', () => {
 			}),
 		});
 		expect(resp.status).toBe(413);
+	});
+
+	it('returns 413 JSON error envelope for oversized body', async () => {
+		const resp = await fetch(`${serverUrl}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'x',
+				max_tokens: 100,
+				messages: [{ role: 'user', content: 'x'.repeat(11 * 1024 * 1024) }],
+			}),
+		});
+		expect(resp.status).toBe(413);
+		const text = await resp.text();
+		const body = JSON.parse(text) as Record<string, unknown>;
+		expect(body['type']).toBe('error');
+		const err = body['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('invalid_request_error');
 	});
 
 	// -------------------------------------------------------------------------
@@ -386,7 +428,29 @@ describe('startEmbeddedServer', () => {
 		}
 	});
 
-	it('sends complete SSE epilogue on session error', async () => {
+	it('returns 500 JSON error envelope when createSession throws', async () => {
+		const rejectClient = makeMockClient(() => {
+			throw new Error('internal error');
+		});
+		const rs = await startEmbeddedServer(rejectClient, '/tmp');
+		try {
+			const r = await postMessages(rs.url, {
+				model: 'some-model',
+				max_tokens: 100,
+				messages: [{ role: 'user', content: 'hi' }],
+			});
+			expect(r.status).toBe(500);
+			const body = JSON.parse(r.rawBody ?? '{}') as Record<string, unknown>;
+			expect(body['type']).toBe('error');
+			const err = body['error'] as Record<string, unknown>;
+			expect(err['type']).toBe('api_error');
+			expect(typeof err['message']).toBe('string');
+		} finally {
+			await rs.stop();
+		}
+	});
+
+	it('emits Anthropic error SSE event on session error', async () => {
 		session.shouldError = true;
 		const r = await postMessages(serverUrl, {
 			model: 'x',
@@ -394,10 +458,17 @@ describe('startEmbeddedServer', () => {
 			messages: [{ role: 'user', content: 'err' }],
 		});
 		expect(r.status).toBe(200);
-		expect(r.events.map((e) => e.type)).toContain('message_stop');
+		// Must emit an `error` SSE event (Anthropic streaming error format)
+		const errorEvent = r.events.find((e) => e.type === 'error');
+		expect(errorEvent).toBeDefined();
+		const data = errorEvent!.data as Record<string, unknown>;
+		expect(data['type']).toBe('error');
+		const err = data['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('api_error');
+		expect(typeof err['message']).toBe('string');
 	});
 
-	it('sends complete SSE epilogue when session.send() rejects', async () => {
+	it('emits Anthropic error SSE event when session.send() rejects', async () => {
 		session.shouldRejectSend = true;
 		const r = await postMessages(serverUrl, {
 			model: 'x',
@@ -405,7 +476,13 @@ describe('startEmbeddedServer', () => {
 			messages: [{ role: 'user', content: 'err' }],
 		});
 		expect(r.status).toBe(200);
-		expect(r.events.map((e) => e.type)).toContain('message_stop');
+		// Must emit an `error` SSE event (Anthropic streaming error format)
+		const errorEvent = r.events.find((e) => e.type === 'error');
+		expect(errorEvent).toBeDefined();
+		const data = errorEvent!.data as Record<string, unknown>;
+		expect(data['type']).toBe('error');
+		const err = data['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('api_error');
 	});
 
 	// -------------------------------------------------------------------------
@@ -422,7 +499,7 @@ describe('startEmbeddedServer', () => {
 		expect(session.disconnectCalled).toBe(true);
 	});
 
-	it('calls session.disconnect() after session error', async () => {
+	it('calls session.disconnect() after session.error event', async () => {
 		session.shouldError = true;
 		await postMessages(serverUrl, {
 			model: 'x',

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/sse.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/sse.test.ts
@@ -137,6 +137,71 @@ describe('AnthropicStreamWriter', () => {
 		});
 	});
 
+	describe('sendFailed()', () => {
+		it('emits error SSE event with default api_error type', () => {
+			const { written, res } = makeRes();
+			const writer = new AnthropicStreamWriter();
+			writer.start(res, 'model');
+			writer.sendFailed(res);
+			const events = parseEvents(written);
+			const errorEvent = events.find((e) => e.type === 'error');
+			expect(errorEvent).toBeDefined();
+			const data = errorEvent!.data as Record<string, unknown>;
+			expect(data['type']).toBe('error');
+			const err = data['error'] as Record<string, unknown>;
+			expect(err['type']).toBe('api_error');
+			expect(err['message']).toBe('Internal server error');
+		});
+
+		it('forwards custom errorType and message', () => {
+			const { written, res } = makeRes();
+			const writer = new AnthropicStreamWriter();
+			writer.start(res, 'model');
+			writer.sendFailed(res, 'authentication_error', 'Token expired');
+			const events = parseEvents(written);
+			const errorEvent = events.find((e) => e.type === 'error');
+			expect(errorEvent).toBeDefined();
+			const err = (errorEvent!.data as Record<string, unknown>)['error'] as Record<string, unknown>;
+			expect(err['type']).toBe('authentication_error');
+			expect(err['message']).toBe('Token expired');
+		});
+
+		it('closes open text block before emitting error event', () => {
+			const { written, res } = makeRes();
+			const writer = new AnthropicStreamWriter();
+			writer.start(res, 'model');
+			writer.flushDeltas(res, ['partial text']);
+			writer.sendFailed(res, 'api_error', 'Session error');
+			const events = parseEvents(written);
+			const types = events.map((e) => e.type);
+			// content_block_stop must appear before error
+			const stopIdx = types.lastIndexOf('content_block_stop');
+			const errorIdx = types.indexOf('error');
+			expect(stopIdx).toBeGreaterThanOrEqual(0);
+			expect(errorIdx).toBeGreaterThan(stopIdx);
+		});
+
+		it('emits error event without a preceding text block when no deltas were flushed', () => {
+			const { written, res } = makeRes();
+			const writer = new AnthropicStreamWriter();
+			writer.start(res, 'model');
+			writer.sendFailed(res);
+			const events = parseEvents(written);
+			const types = events.map((e) => e.type);
+			expect(types).not.toContain('content_block_stop');
+			expect(types).toContain('error');
+		});
+
+		it('does NOT emit message_stop after error event', () => {
+			const { written, res } = makeRes();
+			const writer = new AnthropicStreamWriter();
+			writer.start(res, 'model');
+			writer.sendFailed(res);
+			const events = parseEvents(written);
+			expect(events.some((e) => e.type === 'message_stop')).toBe(false);
+		});
+	});
+
 	describe('sendToolUse()', () => {
 		it('emits tool_use content_block_start with correct id/name', () => {
 			const { written, state, res } = makeRes();

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
@@ -104,7 +104,7 @@ describe('runSessionStreaming', () => {
 
 	it('resolves completed on session.error', async () => {
 		const session = new MockSession();
-		const { res } = makeMockRes();
+		const { written, res } = makeMockRes();
 		const { req } = makeMockReq();
 
 		const p = runSessionStreaming(
@@ -120,6 +120,9 @@ describe('runSessionStreaming', () => {
 		const outcome = await p;
 		expect(outcome.kind).toBe('completed');
 		expect(session.disconnectCalled).toBe(true);
+		// Must emit an Anthropic-format error SSE event (not a silent end_turn)
+		expect(written.some((c) => c.includes('event: error'))).toBe(true);
+		expect(written.some((c) => c.includes('"type":"api_error"'))).toBe(true);
 	});
 
 	it('resolves completed and aborts on client disconnect', async () => {
@@ -199,7 +202,7 @@ describe('runSessionStreaming', () => {
 		jest.useFakeTimers();
 		try {
 			const session = new MockSession();
-			const { res } = makeMockRes();
+			const { written, res } = makeMockRes();
 			const { req } = makeMockReq();
 
 			expect(STREAMING_TIMEOUT_MS).toBeGreaterThan(0);
@@ -214,6 +217,9 @@ describe('runSessionStreaming', () => {
 			// Timeout path must abort and disconnect the session.
 			expect(session.abortCalled).toBe(true);
 			expect(session.disconnectCalled).toBe(true);
+			// Must emit an Anthropic-format error SSE event (not a silent end_turn)
+			expect(written.some((c) => c.includes('event: error'))).toBe(true);
+			expect(written.some((c) => c.includes('"type":"api_error"'))).toBe(true);
 		} finally {
 			jest.useRealTimers();
 		}

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -15,6 +15,7 @@ import {
 	type BridgeServer,
 } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
+import { anthropicErrorSSELine } from '../../../../src/lib/providers/shared/error-envelope';
 
 // ---------------------------------------------------------------------------
 // Helper: parse SSE response body into an array of events
@@ -183,13 +184,28 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 						});
 						controller.close();
 						return;
-					} else if (event.type === 'turn_done' || event.type === 'error') {
+					} else if (event.type === 'turn_done') {
 						if (textOpen) {
 							controller.enqueue(enc.encode(contentBlockStopSSE(blockIndex)));
 							textOpen = false;
 						}
 						controller.enqueue(enc.encode(messageDeltaSSE('end_turn', outputTokens)));
 						controller.enqueue(enc.encode(messageStopSSE()));
+						sessionArg?.kill();
+						controller.close();
+						return;
+					} else if (event.type === 'error') {
+						// Mirror production drainToSSE: close open text block then emit
+						// Anthropic-format error SSE event (no message_stop epilogue).
+						if (textOpen) {
+							controller.enqueue(enc.encode(contentBlockStopSSE(blockIndex)));
+							textOpen = false;
+						}
+						controller.enqueue(
+							enc.encode(
+								anthropicErrorSSELine('api_error', String(event.message) || 'Codex session error')
+							)
+						);
 						sessionArg?.kill();
 						controller.close();
 						return;
@@ -444,6 +460,44 @@ describe('Bridge HTTP server', () => {
 			.map((d) => d.text ?? '')
 			.join('');
 		expect(text).toBe('file1.ts');
+	});
+
+	// -------------------------------------------------------------------------
+	// BridgeSession error — emits Anthropic error SSE event
+	// -------------------------------------------------------------------------
+
+	it('emits Anthropic error SSE event when BridgeSession yields an error event', async () => {
+		mockSessionFactory = () =>
+			new MockBridgeSession([
+				{ type: 'text_delta', text: 'partial' },
+				{ type: 'error', message: 'boom' },
+			]);
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'fail me' }],
+				stream: true,
+			}),
+		});
+
+		expect(resp.ok).toBe(true);
+		const events = await readSSEEvents(resp.body);
+		const types = events.map((e) => e.event);
+
+		// Must emit Anthropic error SSE event
+		expect(types).toContain('error');
+		// Must NOT emit message_stop after the error
+		expect(types).not.toContain('message_stop');
+
+		const errorEvent = events.find((e) => e.event === 'error');
+		const data = errorEvent!.data as Record<string, unknown>;
+		expect(data['type']).toBe('error');
+		const err = data['error'] as Record<string, unknown>;
+		expect(err['type']).toBe('api_error');
+		expect(err['message']).toBe('boom');
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -3,19 +3,26 @@
  *
  * These tests spin up a real Bun HTTP server backed by a MOCK BridgeSession.
  * The mock injects pre-scripted BridgeEvents so no real `codex` binary is needed.
+ *
+ * Why a mock server instead of the production `createBridgeServer`?
+ * `createBridgeServer` spawns a real `codex` subprocess via `AppServerConn.create()`.
+ * There is no session-factory injection point in the current API, so the production
+ * server cannot be exercised with a mock `BridgeSession` without starting a real process.
+ * The `createMockBridgeServer` helper below reimplements the same HTTP routing + SSE
+ * drain logic using `MockBridgeSession`, keeping all test coverage in-process and fast.
+ * Type drift between the mock and the production server is kept in check by importing
+ * the exported `ToolSession` type from `server.ts` — both share the same named type.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
-	BridgeSession,
-	AppServerConn,
-} from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
-import {
 	createBridgeServer,
+	createAnthropicError,
+	drainToSSE,
 	type BridgeServer,
+	type ToolSession,
 } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
-import { anthropicErrorSSELine } from '../../../../src/lib/providers/shared/error-envelope';
 
 // ---------------------------------------------------------------------------
 // Helper: parse SSE response body into an array of events
@@ -84,16 +91,7 @@ class MockBridgeSession {
 let mockSessionFactory: (() => MockBridgeSession) | null = null;
 
 /** Shared tool session map — reset in beforeEach. */
-const toolSessions = new Map<
-	string,
-	{
-		gen: AsyncGenerator<BridgeEvent>;
-		session: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
-		provideResult: (text: string) => void;
-		model: string;
-		cleanupTimer: ReturnType<typeof setTimeout>;
-	}
->();
+const toolSessions = new Map<string, ToolSession>();
 
 function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 	const bunServer = Bun.serve({
@@ -119,6 +117,7 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 				contentBlockStopSSE,
 				messageDeltaSSE,
 				messageStopSSE,
+				errorSSE,
 			} = await import('../../../../src/lib/providers/codex-anthropic-bridge/translator');
 
 			const body =
@@ -195,17 +194,11 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 						controller.close();
 						return;
 					} else if (event.type === 'error') {
-						// Mirror production drainToSSE: close open text block then emit
-						// Anthropic-format error SSE event (no message_stop epilogue).
 						if (textOpen) {
 							controller.enqueue(enc.encode(contentBlockStopSSE(blockIndex)));
 							textOpen = false;
 						}
-						controller.enqueue(
-							enc.encode(
-								anthropicErrorSSELine('api_error', String(event.message) || 'Codex session error')
-							)
-						);
+						controller.enqueue(enc.encode(errorSSE('api_error', event.message)));
 						sessionArg?.kill();
 						controller.close();
 						return;
@@ -219,17 +212,27 @@ function createMockBridgeServer(opts?: { ttlMs?: number }): BridgeServer {
 			}
 
 			if (isToolResultContinuation(body.messages)) {
-				const [tr] = extractToolResults(body.messages);
-				const stored = toolSessions.get(tr.toolUseId);
-				if (!stored) return new Response('Session not found', { status: 404 });
-				toolSessions.delete(tr.toolUseId);
-				clearTimeout(stored.cleanupTimer);
-				stored.provideResult(tr.text);
-				const resumeModel = stored.model; // preserve original model
+				const toolResults = extractToolResults(body.messages);
+				// Mirror production logic: iterate all tool results, warn on unmatched
+				let primaryStored: ToolSession | null = null;
+				for (const tr of toolResults) {
+					const stored = toolSessions.get(tr.toolUseId);
+					if (!stored) {
+						// warn — mirrors production logger.warn for orphaned results
+						continue;
+					}
+					toolSessions.delete(tr.toolUseId);
+					clearTimeout(stored.cleanupTimer);
+					stored.provideResult(tr.text);
+					if (!primaryStored) primaryStored = stored;
+				}
+				if (!primaryStored) return new Response('Session not found', { status: 404 });
+				const resumeModel = primaryStored.model;
+				const primaryGen = primaryStored.gen;
 				const stream = new ReadableStream<Uint8Array>({
 					async start(controller) {
 						controller.enqueue(enc.encode(messageStartSSE(`msg_${Date.now()}`, resumeModel, 0)));
-						await drainGen(stored.gen, null, resumeModel, controller);
+						await drainGen(primaryGen, null, resumeModel, controller);
 					},
 				});
 				return new Response(stream, { headers: sseHeaders });
@@ -463,44 +466,6 @@ describe('Bridge HTTP server', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// BridgeSession error — emits Anthropic error SSE event
-	// -------------------------------------------------------------------------
-
-	it('emits Anthropic error SSE event when BridgeSession yields an error event', async () => {
-		mockSessionFactory = () =>
-			new MockBridgeSession([
-				{ type: 'text_delta', text: 'partial' },
-				{ type: 'error', message: 'boom' },
-			]);
-
-		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				model: 'codex-1',
-				messages: [{ role: 'user', content: 'fail me' }],
-				stream: true,
-			}),
-		});
-
-		expect(resp.ok).toBe(true);
-		const events = await readSSEEvents(resp.body);
-		const types = events.map((e) => e.event);
-
-		// Must emit Anthropic error SSE event
-		expect(types).toContain('error');
-		// Must NOT emit message_stop after the error
-		expect(types).not.toContain('message_stop');
-
-		const errorEvent = events.find((e) => e.event === 'error');
-		const data = errorEvent!.data as Record<string, unknown>;
-		expect(data['type']).toBe('error');
-		const err = data['error'] as Record<string, unknown>;
-		expect(err['type']).toBe('api_error');
-		expect(err['message']).toBe('boom');
-	});
-
-	// -------------------------------------------------------------------------
 	// 404 for unknown tool_use_id
 	// -------------------------------------------------------------------------
 
@@ -638,6 +603,258 @@ describe('Bridge HTTP server', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Multiple tool results — all matched sessions resolved
+	// -------------------------------------------------------------------------
+
+	it('resolves all matched tool results when multiple tool_use_ids are sent', async () => {
+		const resolvedIds: string[] = [];
+
+		// The mock generator only emits one tool_call (call-multi-1) then turn_done.
+		// This reflects the real Codex constraint: Codex emits one tool call at a time
+		// because each item/tool/call RPC handler blocks until its result is provided.
+		//
+		// To test the multi-result server loop, a second ToolSession (call-multi-2)
+		// is injected directly into the toolSessions map after the first HTTP request.
+		// This simulates a hypothetical future scenario where the client sends two
+		// tool_result blocks in a single continuation (e.g. from parallel tool calls
+		// in a different upstream model). The server loop must resolve both Deferreds
+		// and treat the first matched entry as the primary gen to drain.
+		mockSessionFactory = () => {
+			const sess = new MockBridgeSession([
+				{
+					type: 'tool_call',
+					callId: 'call-multi-1',
+					toolName: 'bash',
+					toolInput: { command: 'ls' },
+					provideResult: (_text: string) => {
+						resolvedIds.push('call-multi-1');
+					},
+				},
+				{ type: 'turn_done', inputTokens: 5, outputTokens: 5 },
+			]);
+			return sess;
+		};
+
+		// First request — suspends on call-multi-1
+		const resp1 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'run' }],
+				stream: true,
+			}),
+		});
+		await readSSEEvents(resp1.body);
+		expect(toolSessions.has('call-multi-1')).toBe(true);
+
+		// Inject a second ToolSession sharing the same gen, representing a hypothetical
+		// parallel tool call from the same turn (see comment above for rationale).
+		const secondResolved: string[] = [];
+		const stored1 = toolSessions.get('call-multi-1')!;
+		toolSessions.set('call-multi-2', {
+			gen: stored1.gen,
+			session: stored1.session,
+			provideResult: (_text: string) => {
+				secondResolved.push('call-multi-2');
+			},
+			model: stored1.model,
+			cleanupTimer: setTimeout(() => {}, 60_000),
+		});
+
+		// Send a continuation with BOTH tool results
+		const resp2 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'run' },
+					{
+						role: 'assistant',
+						content: [
+							{ type: 'tool_use', id: 'call-multi-1', name: 'bash', input: {} },
+							{ type: 'tool_use', id: 'call-multi-2', name: 'bash', input: {} },
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'call-multi-1', content: 'result-1' },
+							{ type: 'tool_result', tool_use_id: 'call-multi-2', content: 'result-2' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		expect(resp2.ok).toBe(true);
+		await readSSEEvents(resp2.body);
+
+		// Both provideResult callbacks must have been called
+		expect(resolvedIds).toContain('call-multi-1');
+		expect(secondResolved).toContain('call-multi-2');
+
+		// Both sessions must be removed from the map
+		expect(toolSessions.has('call-multi-1')).toBe(false);
+		expect(toolSessions.has('call-multi-2')).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple tool results — some unmatched (orphaned) — warn, not crash
+	// -------------------------------------------------------------------------
+
+	it('warns on unmatched tool_use_ids and still resumes the matched session', async () => {
+		const resolvedIds: string[] = [];
+
+		mockSessionFactory = () =>
+			new MockBridgeSession([
+				{
+					type: 'tool_call',
+					callId: 'call-orphan-match',
+					toolName: 'bash',
+					toolInput: { command: 'pwd' },
+					provideResult: (_text: string) => {
+						resolvedIds.push('call-orphan-match');
+					},
+				},
+				{ type: 'text_delta', text: 'resumed' },
+				{ type: 'turn_done', inputTokens: 1, outputTokens: 1 },
+			]);
+
+		// First request — suspends on call-orphan-match
+		const resp1 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'pwd' }],
+				stream: true,
+			}),
+		});
+		await readSSEEvents(resp1.body);
+		expect(toolSessions.has('call-orphan-match')).toBe(true);
+
+		// Send continuation with the real call-id AND a nonexistent call-id
+		const resp2 = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'pwd' },
+					{
+						role: 'assistant',
+						content: [
+							{ type: 'tool_use', id: 'call-orphan-match', name: 'bash', input: {} },
+							{ type: 'tool_use', id: 'call-orphan-no-session', name: 'bash', input: {} },
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'call-orphan-match', content: 'dir' },
+							{ type: 'tool_result', tool_use_id: 'call-orphan-no-session', content: 'dir' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		// Must succeed (not 404) — the matched session is resumed normally
+		expect(resp2.ok).toBe(true);
+		const events2 = await readSSEEvents(resp2.body);
+
+		// The matched session resolved its Deferred
+		expect(resolvedIds).toContain('call-orphan-match');
+
+		// Resumed turn text should appear
+		const text = events2
+			.filter((e) => e.event === 'content_block_delta')
+			.map((e) => (e.data as { delta: { type: string; text?: string } }).delta)
+			.filter((d) => d.type === 'text_delta')
+			.map((d) => d.text ?? '')
+			.join('');
+		expect(text).toBe('resumed');
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple tool results — ALL unmatched — 404
+	// -------------------------------------------------------------------------
+
+	it('returns 404 when all tool_use_ids in the continuation are unmatched', async () => {
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'x' },
+					{
+						role: 'assistant',
+						content: [{ type: 'tool_use', id: 'bad-id-1', name: 'bash', input: {} }],
+					},
+					{
+						role: 'user',
+						content: [
+							{ type: 'tool_result', tool_use_id: 'bad-id-1', content: 'r1' },
+							{ type: 'tool_result', tool_use_id: 'bad-id-2', content: 'r2' },
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+		expect(resp.status).toBe(404);
+	});
+
+	// -------------------------------------------------------------------------
+	// Streaming error — drainToSSE emits Anthropic error SSE event (tests real code path)
+	// -------------------------------------------------------------------------
+
+	it('drainToSSE emits an Anthropic error SSE event on BridgeSession error', async () => {
+		async function* errorGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'text_delta', text: 'partial' };
+			yield { type: 'error', message: 'codex subprocess crashed' };
+		}
+
+		let killCalled = false;
+		const mockSession = {
+			kill: () => {
+				killCalled = true;
+			},
+		} as unknown as import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeSession;
+
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				void drainToSSE(errorGen(), mockSession, 'test-model', new Map(), controller, 5000);
+			},
+		});
+
+		const events = await readSSEEvents(stream);
+
+		// Must have exactly one error SSE event
+		const errorEvents = events.filter((e) => e.event === 'error');
+		expect(errorEvents).toHaveLength(1);
+		const data = errorEvents[0].data as { type: string; error: { type: string; message: string } };
+		expect(data.type).toBe('error');
+		expect(data.error.type).toBe('api_error');
+		expect(data.error.message).toBe('codex subprocess crashed');
+
+		// Must NOT contain [Codex error: ...] plain-text blocks
+		const textDeltas = events.filter((e) => e.event === 'content_block_delta');
+		const hasLegacyErrorText = textDeltas.some((e) =>
+			String((e.data as { delta?: { text?: string } }).delta?.text ?? '').includes('[Codex error:')
+		);
+		expect(hasLegacyErrorText).toBe(false);
+
+		// Session must be killed
+		expect(killCalled).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
 	// stop() cleanup — suspended sessions killed (regression: issue #3b)
 	// -------------------------------------------------------------------------
 
@@ -682,5 +899,122 @@ describe('Bridge HTTP server', () => {
 		// Prevent afterEach from calling stop() again on an already-stopped server
 		// by replacing server with a no-op
 		server = { port: 0, stop: () => {} } as BridgeServer & { port: number };
+	});
+});
+
+// ---------------------------------------------------------------------------
+// createAnthropicError helper unit tests
+// ---------------------------------------------------------------------------
+
+describe('createAnthropicError', () => {
+	it('returns the correct HTTP status and JSON envelope for 400', async () => {
+		const resp = createAnthropicError(400, 'invalid_request_error', 'bad input');
+		expect(resp.status).toBe(400);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('invalid_request_error');
+		expect(body.error.message).toBe('bad input');
+	});
+
+	it('returns the correct HTTP status and JSON envelope for 404', async () => {
+		const resp = createAnthropicError(404, 'not_found_error', 'not here');
+		expect(resp.status).toBe(404);
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+		expect(body.error.message).toBe('not here');
+	});
+
+	it('returns the correct HTTP status and JSON envelope for 500', async () => {
+		const resp = createAnthropicError(500, 'api_error', 'something exploded');
+		expect(resp.status).toBe(500);
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('api_error');
+		expect(body.error.message).toBe('something exploded');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Real createBridgeServer — HTTP error envelope integration tests
+// ---------------------------------------------------------------------------
+
+describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
+	let realServer: BridgeServer & { port: number };
+
+	beforeEach(() => {
+		// Use a nonexistent binary path; these tests only exercise paths that
+		// don't require a real Codex subprocess.
+		realServer = createBridgeServer({
+			codexBinaryPath: '/nonexistent/codex',
+			cwd: '/tmp',
+		}) as BridgeServer & { port: number };
+	});
+
+	afterEach(() => {
+		realServer.stop();
+	});
+
+	it('returns 404 JSON envelope for unknown URL paths', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/unknown/path`, {
+			method: 'GET',
+		});
+		expect(resp.status).toBe(404);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+	});
+
+	it('returns 400 JSON envelope for invalid JSON body', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'this is not json{{{',
+		});
+		expect(resp.status).toBe(400);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('invalid_request_error');
+	});
+
+	it('returns 404 JSON envelope when tool_use_id has no active session', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{
+						role: 'user',
+						content: [{ type: 'tool_result', tool_use_id: 'nonexistent-id', content: 'result' }],
+					},
+				],
+			}),
+		});
+		expect(resp.status).toBe(404);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('not_found_error');
+	});
+
+	it('returns 500 JSON envelope when BridgeSession fails to initialize', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'hello' }],
+				stream: true,
+			}),
+		});
+		expect(resp.status).toBe(500);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
+		expect(body.type).toBe('error');
+		expect(body.error.type).toBe('api_error');
 	});
 });

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -541,87 +541,49 @@ describe('ProviderContextManager', () => {
 	});
 
 	describe('requiresQueryRestart', () => {
-		it('should return true for cross-provider switch', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
+		const anthropicSession: Session = {
+			id: 'test-session',
+			title: 'Test',
+			workspacePath: '/test',
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'active',
+			config: {
+				model: 'claude-3-opus',
+				maxTokens: 8192,
+				temperature: 1.0,
+				provider: 'anthropic',
+			},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+			},
+		};
 
-			const requires = manager.requiresQueryRestart(session, 'glm-4');
+		it('should return true for cross-provider switch', () => {
+			const requires = manager.requiresQueryRestart(anthropicSession, 'glm-4', 'glm');
 			expect(requires).toBe(true);
 		});
 
 		it('should return false for same-provider switch', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
-
-			const requires = manager.requiresQueryRestart(session, 'claude-3-sonnet');
+			const requires = manager.requiresQueryRestart(
+				anthropicSession,
+				'claude-3-sonnet',
+				'anthropic'
+			);
 			expect(requires).toBe(false);
 		});
 
-		it('should return true when new provider cannot be detected', () => {
-			const session: Session = {
-				id: 'test-session',
-				title: 'Test',
-				workspacePath: '/test',
-				createdAt: new Date().toISOString(),
-				lastActiveAt: new Date().toISOString(),
-				status: 'active',
-				config: {
-					model: 'claude-3-opus',
-					maxTokens: 8192,
-					temperature: 1.0,
-					provider: 'anthropic',
-				},
-				metadata: {
-					messageCount: 0,
-					totalTokens: 0,
-					inputTokens: 0,
-					outputTokens: 0,
-					totalCost: 0,
-					toolCallCount: 0,
-				},
-			};
-
-			const requires = manager.requiresQueryRestart(session, 'unknown-model-xyz');
+		it('should return true when the new provider is not registered', () => {
+			const requires = manager.requiresQueryRestart(
+				anthropicSession,
+				'unknown-model-xyz',
+				'unknown-provider-xyz'
+			);
 			expect(requires).toBe(true);
 		});
 	});
@@ -639,7 +601,7 @@ describe('ProviderContextManager', () => {
 		});
 	});
 
-	describe('detectProvider', () => {
+	describe('detectProvider (deprecated legacy heuristic)', () => {
 		it('should detect provider from model ID', () => {
 			const provider = manager.detectProvider('claude-3-opus');
 			expect(provider?.id).toBe('anthropic');

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -2,8 +2,9 @@
  * Unit tests for Provider Registry
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import type { ModelInfo } from '@neokai/shared';
+import { Logger } from '@neokai/shared/logger';
 import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
 import { resetProviderFactory } from '../../../src/lib/providers/factory';
 import { ProviderRegistry, resetProviderRegistry } from '../../../src/lib/providers/registry';
@@ -59,6 +60,37 @@ class MockProvider implements Provider {
 			isAnthropicCompatible: true,
 		};
 	}
+}
+
+// Provider subclass factories for collision tests
+function makeAnthropicProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic' as const;
+		readonly displayName = 'Anthropic';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('claude-');
+		}
+	})();
+}
+
+function makeAnthropicCopilotProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic-copilot' as const;
+		readonly displayName = 'Anthropic Copilot';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('claude-');
+		}
+	})();
+}
+
+function makeAnthropicCodexProvider() {
+	return new (class extends MockProvider {
+		readonly id = 'anthropic-codex' as const;
+		readonly displayName = 'Anthropic Codex';
+		ownsModel(modelId: string): boolean {
+			return modelId.startsWith('gpt-') || modelId.startsWith('claude-');
+		}
+	})();
 }
 
 describe('ProviderRegistry', () => {
@@ -205,6 +237,69 @@ describe('ProviderRegistry', () => {
 
 		it('should return undefined when no providers registered', () => {
 			expect(registry.detectProvider('any-model')).toBeUndefined();
+		});
+
+		it('should return the first registered provider (legacy heuristic, no warning)', () => {
+			// detectProvider is deprecated — it does simple first-match, no collision warning
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProvider('claude-opus-4.6');
+			expect(result?.id).toBe('anthropic');
+		});
+	});
+
+	describe('detectProviderForModel', () => {
+		it('should return copilot provider when providerId is anthropic-copilot', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			// Deterministic: explicit providerId → always the right provider regardless of model
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic-copilot');
+			expect(result?.id).toBe('anthropic-copilot');
+		});
+
+		it('should return anthropic provider when providerId is anthropic', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProviderForModel('claude-opus-4.6', 'anthropic');
+			expect(result?.id).toBe('anthropic');
+		});
+
+		it('should return codex provider for gpt- model when providerId is anthropic-codex', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCodexProvider());
+
+			const result = registry.detectProviderForModel('gpt-5.3-codex', 'anthropic-codex');
+			expect(result?.id).toBe('anthropic-codex');
+		});
+
+		it('should return undefined and log an error when providerId is not registered', () => {
+			const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(mock(() => {}));
+
+			try {
+				registry.register(makeAnthropicProvider());
+
+				const result = registry.detectProviderForModel('claude-opus-4.6', 'nonexistent-provider');
+				expect(result).toBeUndefined();
+				// Error should be logged for the unknown provider
+				expect(errorSpy).toHaveBeenCalledTimes(1);
+				const errArg = errorSpy.mock.calls[0][0] as string;
+				expect(errArg).toContain('nonexistent-provider');
+				expect(errArg).toContain('claude-opus-4.6');
+			} finally {
+				errorSpy.mockRestore();
+			}
+		});
+
+		it('detectProvider (deprecated) still returns first-registered match for legacy paths', () => {
+			// anthropic registered first — heuristic fallback returns it
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			const result = registry.detectProvider('claude-opus-4.6');
+			expect(result?.id).toBe('anthropic');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -98,6 +98,20 @@ describe('Coder Agent', () => {
 			);
 		});
 
+		it('checks for existing PR before creating to avoid duplicates', () => {
+			const prompt = buildCoderSystemPrompt();
+			// Step 5 should check for an existing PR first
+			expect(prompt).toContain('EXISTING_PR=$(gh pr list --head');
+			expect(prompt).toContain('--state open --json url --jq');
+			// Uses `// empty` to convert jq null output to empty string (avoids the "null" string bug)
+			expect(prompt).toContain('// empty');
+			expect(prompt).toContain('if [ -z "$EXISTING_PR" ]');
+			// Only create PR when none exists
+			expect(prompt).toContain('gh pr create --fill --base');
+			// Acknowledge when PR already exists
+			expect(prompt).toContain('PR already exists');
+		});
+
 		it('combines sync commands in a single bash invocation using the empty-check fallback pattern', () => {
 			const prompt = buildCoderSystemPrompt();
 			// Two-step empty check: symbolic-ref first, then remote show if empty.
@@ -193,6 +207,25 @@ describe('Coder Agent', () => {
 		it('should omit previous work section when no summaries', () => {
 			const message = buildCoderTaskMessage(makeConfig());
 			expect(message).not.toContain('Previous Work');
+		});
+
+		it('should include existing PR URL when task has prUrl', () => {
+			const message = buildCoderTaskMessage(
+				makeConfig({
+					task: makeTask({ prUrl: 'https://github.com/org/repo/pull/42' }),
+				})
+			);
+			expect(message).toContain('https://github.com/org/repo/pull/42');
+			expect(message).toContain('Existing Pull Request');
+			// Should say "existing" not "open" — prUrl may be closed
+			expect(message).toContain('existing pull request');
+			expect(message).not.toContain('open pull request');
+			expect(message).toContain('do NOT create a new one');
+		});
+
+		it('should omit existing PR section when task has no prUrl', () => {
+			const message = buildCoderTaskMessage(makeConfig());
+			expect(message).not.toContain('Existing Pull Request');
 		});
 
 		it('should end with begin instruction', () => {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -204,14 +204,15 @@ describe('Leader Agent', () => {
 			// Should instruct leader to send planner back — NOT merge the PR itself
 			expect(prompt).toContain('send_to_worker');
 			expect(prompt).toContain('create_task');
-			// The "merge PR yourself" instructions should NOT be present
-			expect(prompt).not.toContain('gh pr merge <PR_NUMBER> --squash');
+			// The "merge PR yourself" instructions should NOT be present for plan_review
+			expect(prompt).not.toContain('Do NOT send the worker back to do the merge');
 		});
 
 		it('should use direct merge post-approval workflow for code review', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
-			// Leader merges the PR directly for coder/general tasks
-			expect(prompt).toContain('gh pr merge <PR_NUMBER> --squash');
+			// Leader merges the PR directly for coder/general tasks (no hardcoded merge method)
+			expect(prompt).toContain('gh pr merge <PR_NUMBER>');
+			expect(prompt).not.toContain('gh pr merge <PR_NUMBER> --');
 			expect(prompt).toContain('Do NOT send the worker back to do the merge');
 		});
 

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -15,6 +15,7 @@ import {
 	runLeaderSubmitGate,
 	detectBypassMarker,
 	BYPASS_GATES_MARKERS,
+	closeStalePr,
 	type WorkerExitHookContext,
 	type LeaderCompleteHookContext,
 	type HookOptions,
@@ -1487,5 +1488,84 @@ describe('runWorkerExitGate with bypass markers', () => {
 		expect(result.pass).toBe(true);
 		expect(result.bypassed).toBe(true);
 		expect(result.reason).toContain('Bypassed');
+	});
+});
+
+describe('closeStalePr', () => {
+	test('closes the old PR via URL with a superseded-by comment', async () => {
+		const calls: Array<{ args: string[]; cwd: string }> = [];
+		const opts: HookOptions = {
+			runCommand: async (args, cwd) => {
+				calls.push({ args, cwd });
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'https://github.com/org/repo/pull/10',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(true);
+		expect(calls.length).toBe(1);
+		// Uses the full URL, not just the PR number
+		expect(calls[0].args).toEqual([
+			'gh',
+			'pr',
+			'close',
+			'https://github.com/org/repo/pull/10',
+			'--comment',
+			'Superseded by https://github.com/org/repo/pull/20',
+		]);
+		expect(calls[0].cwd).toBe('/workspace');
+	});
+
+	test('returns false when gh command fails', async () => {
+		const opts: HookOptions = {
+			runCommand: async () => ({ stdout: '', exitCode: 1 }),
+		};
+		const result = await closeStalePr(
+			'https://github.com/org/repo/pull/10',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+	});
+
+	test('returns false for invalid old PR URL (not a PR path)', async () => {
+		const calls: Array<string[]> = [];
+		const opts: HookOptions = {
+			runCommand: async (args) => {
+				calls.push(args);
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'not-a-pr-url',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+		expect(calls.length).toBe(0);
+	});
+
+	test('returns false for empty old PR URL', async () => {
+		const calls: Array<string[]> = [];
+		const opts: HookOptions = {
+			runCommand: async (args) => {
+				calls.push(args);
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+		expect(calls.length).toBe(0);
 	});
 });

--- a/packages/daemon/tests/unit/room/room-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/room/room-chat-agent.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import { buildRoomChatSystemPrompt } from '../../../src/lib/room/agents/room-chat-agent';
+
+describe('buildRoomChatSystemPrompt', () => {
+	it('returns a non-empty string', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	it('includes the Room Agent role description', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('Room Agent');
+	});
+
+	it('instructs the agent NOT to call create_task when creating a goal', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('create_goal');
+		expect(prompt).toContain('create_task');
+		// Must explicitly say not to call create_task after create_goal
+		expect(prompt).toMatch(/do NOT call.*create_task|never call.*create_task/i);
+	});
+
+	it('describes the full goal creation workflow steps', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		// Planning phase
+		expect(prompt.toLowerCase()).toContain('plan');
+		// Approval step
+		expect(prompt.toLowerCase()).toContain('approv');
+		// Task creation only after approval
+		expect(prompt.toLowerCase()).toContain('task');
+	});
+
+	it('tells the agent to explain the workflow to the user after goal creation', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		expect(prompt).toContain('planning phase');
+	});
+
+	it('includes room background when provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ background: 'This is a trading platform.' });
+		expect(prompt).toContain('This is a trading platform.');
+		expect(prompt).toContain('Room Background');
+	});
+
+	it('includes room instructions when provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ instructions: 'Always prefer TypeScript.' });
+		expect(prompt).toContain('Always prefer TypeScript.');
+		expect(prompt).toContain('Room Instructions');
+	});
+
+	it('omits background section when not provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ instructions: 'Use bun.' });
+		expect(prompt).not.toContain('Room Background');
+	});
+
+	it('omits instructions section when not provided', () => {
+		const prompt = buildRoomChatSystemPrompt({ background: 'A fintech room.' });
+		expect(prompt).not.toContain('Room Instructions');
+	});
+
+	it('includes both sections when both are provided', () => {
+		const prompt = buildRoomChatSystemPrompt({
+			background: 'A fintech room.',
+			instructions: 'Always add tests.',
+		});
+		expect(prompt).toContain('Room Background');
+		expect(prompt).toContain('A fintech room.');
+		expect(prompt).toContain('Room Instructions');
+		expect(prompt).toContain('Always add tests.');
+	});
+
+	it('produces identical output when called with undefined context', () => {
+		const promptA = buildRoomChatSystemPrompt();
+		const promptB = buildRoomChatSystemPrompt(undefined);
+		expect(promptA).toBe(promptB);
+	});
+
+	it('mentions that tasks are created automatically after plan approval', () => {
+		const prompt = buildRoomChatSystemPrompt();
+		// Must mention that the system automatically handles planning, approval, and task creation
+		expect(prompt.toLowerCase()).toMatch(/automatically.*plan.*approv.*task/);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -580,4 +580,110 @@ describe('RoomRuntime leader tools', () => {
 			expect(planningTasks).toHaveLength(0);
 		});
 	});
+
+	describe('submit_for_review stale PR cleanup', () => {
+		it('closes stale PR when submit_for_review is called with a different PR URL', async () => {
+			const ghCalls: Array<string[]> = [];
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async (args) => {
+						ghCalls.push(args);
+						// Simulate successful gh pr close; fail everything else gracefully
+						if (args[0] === 'gh' && args[1] === 'pr' && args[2] === 'close') {
+							return { stdout: '', exitCode: 0 };
+						}
+						return { stdout: '', exitCode: 1 };
+					},
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set the task with an existing PR URL to simulate a second review cycle
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Leader calls submit_for_review with a NEW, different PR URL
+				const result = await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/20',
+				});
+
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.success).toBe(true);
+
+				// Should have called gh pr close with the old PR URL
+				const closeCalls = ghCalls.filter((a) => a[1] === 'pr' && a[2] === 'close');
+				expect(closeCalls.length).toBe(1);
+				expect(closeCalls[0]).toContain('https://github.com/org/repo/pull/10');
+				expect(closeCalls[0]).toContain('Superseded by https://github.com/org/repo/pull/20');
+
+				// Task should now have the new PR URL
+				const updatedTask = await ctx2.taskManager.getTask(task.id);
+				expect(updatedTask!.prUrl).toBe('https://github.com/org/repo/pull/20');
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+
+		it('does not call gh pr close when submit_for_review uses the same PR URL', async () => {
+			const ghCalls: Array<string[]> = [];
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async (args) => {
+						ghCalls.push(args);
+						return { stdout: '', exitCode: 1 };
+					},
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set the task with the same PR URL that will be submitted
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Leader calls submit_for_review with the SAME PR URL — no close needed
+				await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/10',
+				});
+
+				const closeCalls = ghCalls.filter((a) => a[1] === 'pr' && a[2] === 'close');
+				expect(closeCalls.length).toBe(0);
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+
+		it('proceeds with submit_for_review even when closeStalePr fails', async () => {
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async () => ({ stdout: '', exitCode: 1 }), // gh always fails
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set an existing PR URL
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Even though gh pr close will fail, submit_for_review should still succeed
+				const result = await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/20',
+				});
+
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.success).toBe(true);
+
+				// Task still updates to the new PR URL
+				const updatedTask = await ctx2.taskManager.getTask(task.id);
+				expect(updatedTask!.prUrl).toBe('https://github.com/org/repo/pull/20');
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+	});
 });

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -130,6 +130,7 @@ function createMockAgentSession(overrides: Partial<AgentSession> = {}): {
 		status: 'active',
 		config: {
 			model: 'claude-sonnet-4-20250514',
+			provider: 'anthropic',
 			coordinatorMode: false,
 			sandbox: { enabled: true },
 			thinkingLevel: 'auto',
@@ -701,24 +702,30 @@ describe('Session RPC Handlers', () => {
 			const params = {
 				sessionId: 'session-123',
 				model: 'claude-opus-4-6',
+				provider: 'anthropic',
 			};
 
-			const { mocks } = createMockAgentSession();
+			const { agentSession, mocks } = createMockAgentSession();
 			mocks.handleModelSwitch.mockResolvedValueOnce({
 				success: true,
 				model: 'claude-opus-4-6',
 			});
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
 
 			const result = await handler!(params, {});
 
 			expect(result).toHaveProperty('success');
+			expect(mocks.handleModelSwitch).toHaveBeenCalledWith('claude-opus-4-6', 'anthropic');
 		});
 
 		it('broadcasts session.updated on successful switch', async () => {
 			const handler = messageHubData.handlers.get('session.model.switch');
 			expect(handler).toBeDefined();
 
-			await handler!({ sessionId: 'session-123', model: 'claude-opus-4-6' }, {});
+			await handler!(
+				{ sessionId: 'session-123', model: 'claude-opus-4-6', provider: 'anthropic' },
+				{}
+			);
 
 			expect(messageHubData.hub.event).toHaveBeenCalledWith('session.updated', expect.any(Object), {
 				channel: 'session:session-123',
@@ -732,8 +739,35 @@ describe('Session RPC Handlers', () => {
 			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);
 
 			await expect(
-				handler!({ sessionId: 'non-existent', model: 'claude-opus' }, {})
+				handler!({ sessionId: 'non-existent', model: 'claude-opus', provider: 'anthropic' }, {})
 			).rejects.toThrow('Session not found');
+		});
+
+		it('throws error when provider is omitted', async () => {
+			const handler = messageHubData.handlers.get('session.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'session-123', model: 'claude-opus' }, {})
+			).rejects.toThrow('Missing required field: provider');
+		});
+	});
+
+	describe('session.model.get', () => {
+		it('throws error when session has no provider configured', async () => {
+			const handler = messageHubData.handlers.get('session.model.get');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession();
+			(agentSession.getSessionData as ReturnType<typeof mock>).mockReturnValue({
+				id: 'session-123',
+				config: { model: 'claude-sonnet-4-20250514' }, // no provider
+			});
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			await expect(handler!({ sessionId: 'session-123' }, {})).rejects.toThrow(
+				'Session has no provider configured'
+			);
 		});
 	});
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -181,6 +181,7 @@ export interface GetCurrentModelResponse {
 export interface SwitchModelRequest {
 	sessionId: string;
 	model: string; // Can be alias (e.g., "opus") or full ID
+	provider: string; // Required — identifies which provider owns this model
 }
 
 export interface SwitchModelResponse {
@@ -509,7 +510,7 @@ export interface APIClient {
 
 	// Models
 	getCurrentModel(sessionId: string): Promise<GetCurrentModelResponse>;
-	switchModel(sessionId: string, model: string): Promise<SwitchModelResponse>;
+	switchModel(sessionId: string, model: string, provider: string): Promise<SwitchModelResponse>;
 
 	// Providers
 	listProviders(): Promise<ListProvidersResponse>;

--- a/packages/shared/src/sdk/index.ts
+++ b/packages/shared/src/sdk/index.ts
@@ -16,6 +16,7 @@ export {
   isSDKCompactBoundary,
   isSDKStatusMessage,
   isSDKHookResponse,
+  isSDKAPIRetryMessage,
   isSDKStreamEvent,
   isSDKToolProgressMessage,
   isSDKAuthStatusMessage,

--- a/packages/shared/src/sdk/sdk.d.ts
+++ b/packages/shared/src/sdk/sdk.d.ts
@@ -236,6 +236,7 @@ declare namespace coreTypes {
         PromptRequest,
         PromptResponse,
         RewindFilesResult,
+        SDKAPIRetryMessage,
         SDKAssistantMessageError,
         SDKAssistantMessage,
         SDKAuthStatusMessage,
@@ -1994,7 +1995,7 @@ export declare type SdkMcpToolDefinition<Schema extends AnyZodRawShape = AnyZodR
     handler: (args: InferShape<Schema>, extra: unknown) => Promise<CallToolResult>;
 };
 
-export declare type SDKMessage = SDKAssistantMessage | SDKUserMessage | SDKUserMessageReplay | SDKResultMessage | SDKSystemMessage | SDKPartialAssistantMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKLocalCommandOutputMessage | SDKHookStartedMessage | SDKHookProgressMessage | SDKHookResponseMessage | SDKToolProgressMessage | SDKAuthStatusMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKToolUseSummaryMessage | SDKRateLimitEvent | SDKElicitationCompleteMessage | SDKPromptSuggestionMessage;
+export declare type SDKMessage = SDKAssistantMessage | SDKUserMessage | SDKUserMessageReplay | SDKResultMessage | SDKSystemMessage | SDKPartialAssistantMessage | SDKCompactBoundaryMessage | SDKStatusMessage | SDKAPIRetryMessage | SDKLocalCommandOutputMessage | SDKHookStartedMessage | SDKHookProgressMessage | SDKHookResponseMessage | SDKToolProgressMessage | SDKAuthStatusMessage | SDKTaskNotificationMessage | SDKTaskStartedMessage | SDKTaskProgressMessage | SDKFilesPersistedEvent | SDKToolUseSummaryMessage | SDKRateLimitEvent | SDKElicitationCompleteMessage | SDKPromptSuggestionMessage;
 
 export declare type SDKPartialAssistantMessage = {
     type: 'stream_event';
@@ -2230,6 +2231,18 @@ export declare type SDKStatusMessage = {
     subtype: 'status';
     status: SDKStatus;
     permissionMode?: PermissionMode;
+    uuid: UUID;
+    session_id: string;
+};
+
+export declare type SDKAPIRetryMessage = {
+    type: 'system';
+    subtype: 'api_retry';
+    attempt: number;
+    max_retries: number;
+    retry_delay_ms: number;
+    error_status: number | null;
+    error: SDKAssistantMessageError;
     uuid: UUID;
     session_id: string;
 };

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  SDKAPIRetryMessage,
   SDKMessage,
   SDKAssistantMessage,
   SDKAuthStatusMessage,
@@ -131,6 +132,15 @@ export function isSDKHookResponse(
   msg: SDKMessage,
 ): msg is SDKHookResponseMessage {
   return msg.type === "system" && (msg as SDKHookResponseMessage).subtype === "hook_response";
+}
+
+/**
+ * Check if message is an API retry message
+ */
+export function isSDKAPIRetryMessage(
+  msg: SDKMessage,
+): msg is SDKAPIRetryMessage {
+  return msg.type === "system" && (msg as SDKAPIRetryMessage).subtype === "api_retry";
 }
 
 /**
@@ -311,6 +321,10 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
     const hookMsg = msg as SDKHookResponseMessage;
     return `Hook Response: ${hookMsg.hook_name}`;
   }
+  if (isSDKAPIRetryMessage(msg)) {
+    const retryMsg = msg as SDKAPIRetryMessage;
+    return `API Retry: attempt ${retryMsg.attempt}/${retryMsg.max_retries}`;
+  }
   if (isSDKStreamEvent(msg)) {
     return "Streaming Event";
   }
@@ -330,8 +344,9 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
 export function isUserVisibleMessage(msg: SDKMessage): boolean {
   // User should see: assistant, user, result, tool_progress, auth_status, user replays,
   // compact_boundary, and compacting status messages
-  // User should NOT see: stream events only
+  // User should NOT see: stream events or API retry messages
   if (isSDKStreamEvent(msg)) return false;
+  if (isSDKAPIRetryMessage(msg)) return false;
 
   return true;
 }

--- a/packages/web/src/components/InputActionsMenu.tsx
+++ b/packages/web/src/components/InputActionsMenu.tsx
@@ -26,7 +26,7 @@ export interface InputActionsMenuProps {
 	availableModels?: ModelInfo[];
 	modelSwitching?: boolean;
 	modelLoading?: boolean;
-	onModelSwitch?: (modelId: string) => void;
+	onModelSwitch?: (model: ModelInfo) => void;
 	/** Auto-scroll state */
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'preact/hooks';
-import type { MessageDeliveryMode, MessageImage, SessionType } from '@neokai/shared';
+import type { MessageDeliveryMode, MessageImage, ModelInfo, SessionType } from '@neokai/shared';
 import { isAgentWorking } from '../lib/state.ts';
 import { connectionManager } from '../lib/connection-manager';
 import { AttachmentPreview } from './AttachmentPreview.tsx';
@@ -239,8 +239,8 @@ export default function MessageInput({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string) => {
-			await switchModel(modelId);
+		async (model: ModelInfo) => {
+			await switchModel(model);
 			actionsMenu.close();
 		},
 		[switchModel, actionsMenu]

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -15,12 +15,19 @@
 import { useSignalEffect } from '@preact/signals';
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import type { ContextInfo, ModelInfo, ThinkingLevel, SessionFeatures } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { DEFAULT_WORKER_FEATURES } from '@neokai/shared';
 import { connectionState, type ConnectionState } from '../lib/state.ts';
 import ConnectionStatus from './ConnectionStatus.tsx';
 import ContextUsageBar from './ContextUsageBar.tsx';
 import { ContentContainer } from './ui/ContentContainer.tsx';
-import { useModal, getModelFamilyIcon, getProviderLabel, useMessageHub } from '../hooks';
+import {
+	useModal,
+	getModelFamilyIcon,
+	getProviderLabel,
+	groupModelsByProvider,
+	useMessageHub,
+} from '../hooks';
 import { Spinner } from './ui/Spinner.tsx';
 import { Tooltip } from './ui/Tooltip.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -144,7 +151,7 @@ interface SessionStatusBarProps {
 	availableModels: ModelInfo[];
 	modelSwitching: boolean;
 	modelLoading: boolean;
-	onModelSwitch: (modelId: string) => void;
+	onModelSwitch: (model: ModelInfo) => void;
 	// Auto-scroll
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;
@@ -195,6 +202,29 @@ export default function SessionStatusBar({
 	// Get MessageHub for RPC calls
 	const { callIfConnected } = useMessageHub();
 
+	// Provider auth statuses for availability dots in model picker
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, boolean>>(new Map());
+
+	useEffect(() => {
+		let cancelled = false;
+		callIfConnected('auth.providers', {})
+			.then((res) => {
+				if (cancelled) return;
+				const result = res as { providers?: ProviderAuthStatus[] } | null;
+				const statusMap = new Map<string, boolean>();
+				for (const p of result?.providers ?? []) {
+					statusMap.set(p.id, p.isAuthenticated);
+				}
+				setProviderAuthStatuses(statusMap);
+			})
+			.catch(() => {
+				// Silently ignore — dots just stay gray
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [callIfConnected]);
+
 	// Dropdowns - only one can be open at a time
 	const modelDropdown = useModal();
 	const thinkingDropdown = useModal();
@@ -243,8 +273,8 @@ export default function SessionStatusBar({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string) => {
-			await onModelSwitch(modelId);
+		async (model: ModelInfo) => {
+			await onModelSwitch(model);
 			modelDropdown.close();
 		},
 		[onModelSwitch, modelDropdown]
@@ -372,30 +402,46 @@ export default function SessionStatusBar({
 					{/* Model Dropdown */}
 					{modelDropdown.isOpen && (
 						<div
-							class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-48 py-1 z-50 animate-slideIn`}
+							class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
 						>
 							<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
-							{availableModels.map((model) => (
-								<button
-									key={model.id}
-									class={`w-full text-left px-3 py-2 hover:bg-dark-700 text-xs flex items-center gap-2 ${
-										model.id === currentModelInfo?.id ? 'text-blue-400' : 'text-gray-200'
-									}`}
-									onClick={() => handleModelSwitch(model.alias)}
-									disabled={modelSwitching}
-								>
-									<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-									<span class="flex-1 truncate">{model.name}</span>
-									{model.provider !== 'anthropic' && (
-										<span class="text-gray-500 text-[10px]">
-											{getProviderLabel(model.provider)}
-										</span>
-									)}
-									{model.id === currentModelInfo?.id && (
-										<span class="text-blue-400 text-[10px]">(current)</span>
-									)}
-								</button>
-							))}
+							{Array.from(groupModelsByProvider(availableModels).entries()).map(
+								([provider, models], groupIndex) => {
+									const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
+									return (
+										<div key={provider}>
+											{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
+											<div class="px-3 py-1 flex items-center gap-1.5">
+												<span
+													class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
+												/>
+												<span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">
+													{getProviderLabel(provider)}
+												</span>
+											</div>
+											{models.map((model) => {
+												const isCurrent =
+													model.id === currentModelInfo?.id &&
+													model.provider === currentModelInfo?.provider;
+												return (
+													<button
+														key={`${model.provider}:${model.id}`}
+														class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
+															isCurrent ? 'text-blue-400' : 'text-gray-200'
+														}`}
+														onClick={() => handleModelSwitch(model)}
+														disabled={modelSwitching}
+													>
+														<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+														<span class="flex-1 truncate">{model.name}</span>
+														{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+													</button>
+												);
+											})}
+										</div>
+									);
+								}
+							)}
 						</div>
 					)}
 				</div>

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -9,9 +9,21 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { ContextInfo, ModelInfo } from '@neokai/shared';
 import SessionStatusBar from '../SessionStatusBar';
+
+// Configurable hub mock — defaults to null (no connection) so existing tests are unaffected.
+// Individual tests can call mockGetHubIfConnected.mockReturnValue({ request: ... }) to
+// simulate an authenticated connection.
+const mockGetHubIfConnected = vi.fn(() => null);
+
+vi.mock('../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => mockGetHubIfConnected(),
+		onConnection: vi.fn(() => () => {}),
+	},
+}));
 
 describe('SessionStatusBar', () => {
 	const mockOnModelSwitch = vi.fn(() => Promise.resolve());
@@ -22,6 +34,7 @@ describe('SessionStatusBar', () => {
 		id: 'sonnet',
 		name: 'Sonnet 4.5',
 		family: 'sonnet',
+		provider: 'anthropic',
 		isDefault: true,
 	};
 
@@ -31,6 +44,7 @@ describe('SessionStatusBar', () => {
 			alias: 'opus',
 			name: 'Opus 4.5',
 			family: 'opus',
+			provider: 'anthropic',
 			isDefault: false,
 		},
 		{
@@ -38,6 +52,7 @@ describe('SessionStatusBar', () => {
 			alias: 'sonnet',
 			name: 'Sonnet 4.5',
 			family: 'sonnet',
+			provider: 'anthropic',
 			isDefault: true,
 		},
 		{
@@ -45,6 +60,7 @@ describe('SessionStatusBar', () => {
 			alias: 'haiku',
 			name: 'Haiku 4.5',
 			family: 'haiku',
+			provider: 'anthropic',
 			isDefault: false,
 		},
 	];
@@ -82,6 +98,8 @@ describe('SessionStatusBar', () => {
 		mockOnModelSwitch.mockClear();
 		mockOnAutoScrollChange.mockClear();
 		mockOnCoordinatorModeChange.mockClear();
+		// Reset hub to null (no connection) between tests — individual tests can override
+		mockGetHubIfConnected.mockReturnValue(null);
 	});
 
 	afterEach(() => {
@@ -409,7 +427,7 @@ describe('SessionStatusBar', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(modelButton);
 
-			expect(container.textContent).toContain('(current)');
+			expect(container.textContent).toContain('✓');
 		});
 
 		it('should call onModelSwitch when a model is selected', async () => {
@@ -425,7 +443,9 @@ describe('SessionStatusBar', () => {
 			const opusButton = buttons.find((btn) => btn.textContent?.includes('Opus 4.5'));
 			fireEvent.click(opusButton!);
 
-			expect(mockOnModelSwitch).toHaveBeenCalledWith('opus');
+			expect(mockOnModelSwitch).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'opus', family: 'opus' })
+			);
 		});
 
 		it('should close model dropdown when clicking it again', () => {
@@ -763,6 +783,112 @@ describe('SessionStatusBar', () => {
 				(btn) => btn.getAttribute('title')?.includes('Coordinator Mode') || false
 			);
 			expect(coordinatorButton?.className).toContain('border-gray-600');
+		});
+	});
+
+	describe('Model Dropdown — provider group headers', () => {
+		it('should render provider group header label when dropdown is open', () => {
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			// All mock models belong to 'anthropic' → label "Anthropic" should appear
+			expect(container.textContent).toContain('Anthropic');
+		});
+
+		it('should render one provider group header per distinct provider', () => {
+			const multiProviderModels: ModelInfo[] = [
+				{ id: 'opus', alias: 'opus', name: 'Opus 4.5', family: 'opus', provider: 'anthropic' },
+				{
+					id: 'copilot-sonnet',
+					alias: 'copilot-sonnet',
+					name: 'Sonnet (Copilot)',
+					family: 'sonnet',
+					provider: 'anthropic-copilot',
+				},
+			];
+
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} availableModels={multiProviderModels} />
+			);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			expect(container.textContent).toContain('Anthropic');
+			expect(container.textContent).toContain('Copilot');
+		});
+
+		it('should render an availability dot for each provider group', () => {
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			// Provider availability dots have flex-shrink-0 to distinguish them from
+			// the connection status dot (which does not have that class)
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+		});
+
+		it('should show gray availability dot when provider is not authenticated', () => {
+			// No hub → auth.providers returns null → isAuthenticated defaults to false → gray dot
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+			expect(providerDots[0].className).toContain('bg-gray-500');
+		});
+
+		it('should show green availability dot when provider is authenticated', async () => {
+			// Configure hub to return authenticated status for 'anthropic'
+			mockGetHubIfConnected.mockReturnValue({
+				request: vi.fn().mockImplementation((method: string) => {
+					if (method === 'auth.providers') {
+						return Promise.resolve({
+							providers: [{ id: 'anthropic', displayName: 'Anthropic', isAuthenticated: true }],
+						});
+					}
+					return Promise.resolve(null);
+				}),
+				onEvent: vi.fn(() => () => {}),
+				onConnection: vi.fn(() => () => {}),
+				isConnected: vi.fn(() => true),
+			});
+
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			// Wait for the auth.providers effect to resolve
+			await act(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			});
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+			expect(providerDots[0].className).toContain('bg-green-500');
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -119,10 +119,12 @@ vi.mock('../ScrollToBottomButton.tsx', () => ({
 
 // Mock InputTextarea so we don't need its full dependencies.
 // Forwards maxChars as maxLength so tests can verify the 50000 limit is passed.
+// Forwards onKeyDown so keyboard-shortcut tests can exercise Enter/Shift+Enter/Cmd+Enter.
 vi.mock('../InputTextarea.tsx', () => ({
 	InputTextarea: ({
 		content,
 		onContentChange,
+		onKeyDown,
 		onSubmit,
 		disabled,
 		placeholder,
@@ -131,6 +133,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 	}: {
 		content: string;
 		onContentChange: (v: string) => void;
+		onKeyDown?: (e: KeyboardEvent) => void;
 		onSubmit: () => void;
 		disabled?: boolean;
 		placeholder?: string;
@@ -143,6 +146,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 				data-testid="input-textarea-field"
 				value={content}
 				onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
+				onKeyDown={onKeyDown}
 				disabled={disabled}
 				placeholder={placeholder}
 				maxLength={maxChars}
@@ -406,7 +410,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		expect(queryByTestId('task-target-button')).not.toBeNull();
 	});
 
-	it('sends feedback via task.sendHumanMessage in awaiting_human state', async () => {
+	it('sends feedback via task.sendHumanMessage in awaiting_human state (default target: leader)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
@@ -430,7 +434,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 				roomId: 'room-1',
 				taskId: 'task-1',
 				message: 'Nice work!',
-				target: 'worker',
+				target: 'leader',
 			});
 		});
 	});
@@ -504,7 +508,9 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Please focus on auth first' } });
 
-		// Explicitly target leader in the dropdown.
+		// Explicitly select leader in the dropdown.
+		// Note: 'leader' is the default since the default target changed, so this selection
+		// is redundant but kept to make the intent of this test explicit.
 		fireEvent.click(getByTestId('task-target-button'));
 		fireEvent.click(getByTestId('task-target-option-leader'));
 		fireEvent.click(getByTestId('input-textarea-send'));
@@ -519,7 +525,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		});
 	});
 
-	it('sends message to worker in awaiting_worker state', async () => {
+	it('sends message to worker in awaiting_worker state when worker is explicitly selected', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -535,6 +541,11 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Add benchmarks too' } });
+
+		// Explicitly select worker (default is now leader)
+		fireEvent.click(getByTestId('task-target-button'));
+		fireEvent.click(getByTestId('task-target-option-worker'));
+
 		fireEvent.click(getByTestId('input-textarea-send'));
 
 		await waitFor(() => {
@@ -565,6 +576,160 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const leaderOption = getByTestId('task-target-option-leader') as HTMLButtonElement;
 		expect(workerOption.disabled).toBe(false);
 		expect(leaderOption.disabled).toBe(false);
+	});
+
+	it('default target is leader', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		// Default target button label should be "Leader"
+		expect(getByTestId('task-target-button').textContent).toContain('Leader');
+	});
+
+	it('sends message when Enter is pressed (desktop)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Hello leader' } });
+
+		// Plain Enter on desktop — should send
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: false, ctrlKey: false });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Hello leader',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('does NOT send when Shift+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Hello\nworld' } });
+
+		// Shift+Enter — should NOT send (used for newlines)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true, metaKey: false, ctrlKey: false });
+
+		// sendMessage is async, but the RPC call should not have been invoked synchronously
+		// Verify immediately that no send was triggered (the handler does not send for Shift+Enter)
+		expect(mockRequest).not.toHaveBeenCalledWith(
+			'task.sendHumanMessage',
+			expect.objectContaining({ message: expect.any(String) })
+		);
+	});
+
+	it('sends message when Cmd+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Cmd enter works' } });
+
+		// Cmd+Enter — should also send (backward compat, macOS)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: true, ctrlKey: false });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Cmd enter works',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('sends message when Ctrl+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Ctrl enter works' } });
+
+		// Ctrl+Enter — should send (backward compat, Windows/Linux)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: false, ctrlKey: true });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Ctrl enter works',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('placeholder text reflects Enter-to-send UX', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.placeholder).toContain('Enter to send');
+		expect(textarea.placeholder).toContain('Shift+Enter');
 	});
 });
 

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -291,9 +291,16 @@ function HumanInputArea({
 	} = useTaskInputDraft(roomId, taskId);
 	const [sending, setSending] = useState(false);
 	const [inputError, setInputError] = useState<string | null>(null);
-	const [target, setTarget] = useState<HumanMessageTarget>('worker');
+	const [target, setTarget] = useState<HumanMessageTarget>('leader');
 	const [menuOpen, setMenuOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
+	const isTouchDeviceRef = useRef(false);
+
+	useEffect(() => {
+		isTouchDeviceRef.current =
+			window.matchMedia('(pointer: coarse)').matches ||
+			('ontouchstart' in window && window.innerWidth < 768);
+	}, []);
 
 	useEffect(() => {
 		if (!menuOpen) return;
@@ -329,11 +336,12 @@ function HumanInputArea({
 		}
 	};
 
+	const targetLabel = target === 'leader' ? 'leader' : 'worker';
 	const placeholder = !hasGroup
 		? 'No active agent group yet — input will activate once a group starts.'
-		: target === 'leader'
-			? 'Send a message to the leader… (⌘↵ to send)'
-			: 'Send a message to the worker… (⌘↵ to send)';
+		: isTouchDeviceRef.current
+			? `Send a message to the ${targetLabel}…`
+			: `Send a message to the ${targetLabel}… (Enter to send, Shift+Enter for newline)`;
 
 	return (
 		<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
@@ -357,9 +365,11 @@ function HumanInputArea({
 				content={messageText}
 				onContentChange={setMessageText}
 				onKeyDown={(e) => {
-					if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-						e.preventDefault();
-						void sendMessage();
+					if (e.key === 'Enter') {
+						if (e.metaKey || e.ctrlKey || (!e.shiftKey && !isTouchDeviceRef.current)) {
+							e.preventDefault();
+							void sendMessage();
+						}
 					}
 				}}
 				onSubmit={() => void sendMessage()}

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -17,8 +17,9 @@ import {
 	isThinkingBlock,
 	isToolUseBlock,
 } from '@neokai/shared/sdk/type-guards';
-import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
+import { useEffect, useState } from 'preact/hooks';
 import { toast } from '../../lib/toast.ts';
+import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import { QuestionPrompt } from '../QuestionPrompt.tsx';
@@ -79,11 +80,19 @@ export function SDKAssistantMessage({
 			.join('\n');
 	};
 
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const textContent = getTextContent();
 		const success = await copyToClipboard(textContent);
 		if (success) {
-			toast.success('Message copied to clipboard');
+			setCopied(true);
 		} else {
 			toast.error('Failed to copy message');
 		}
@@ -138,7 +147,7 @@ export function SDKAssistantMessage({
 							<path
 								strokeLinecap="round"
 								strokeLinejoin="round"
-								stroke-width={2}
+								strokeWidth={2}
 								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
 							/>
 						</svg>
@@ -181,15 +190,31 @@ export function SDKAssistantMessage({
 					<span class="text-xs text-gray-500">{getTimestamp()}</span>
 				</Tooltip>
 
-				<IconButton size="md" onClick={handleCopy} title="Copy message">
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							stroke-width={2}
-							d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-						/>
-					</svg>
+				<IconButton
+					size="md"
+					onClick={handleCopy}
+					title={copied ? 'Copied!' : 'Copy message'}
+					class={copied ? 'text-green-400' : ''}
+				>
+					{copied ? (
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M5 13l4 4L19 7"
+							/>
+						</svg>
+					) : (
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+							/>
+						</svg>
+					)}
 				</IconButton>
 			</div>
 		) : null;

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -5,8 +5,9 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
+import { useEffect, useState } from 'preact/hooks';
 import { toast } from '../../lib/toast.ts';
+import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { Dropdown } from '../ui/Dropdown.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
@@ -53,6 +54,7 @@ export function SDKUserMessage({
 	allMessages: _allMessages,
 }: Props) {
 	const { message: apiMessage } = message;
+	const [copied, setCopied] = useState(false);
 
 	// Check if this is a tool result message (should not be rendered as user message)
 	const isToolResultMessage = (): boolean => {
@@ -147,10 +149,16 @@ export function SDKUserMessage({
 		return hasErrorOutput(textContent);
 	};
 
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(textContent);
 		if (success) {
-			toast.success('Message copied to clipboard');
+			setCopied(true);
 		} else {
 			toast.error('Failed to copy message');
 		}
@@ -308,9 +316,9 @@ export function SDKUserMessage({
 						<IconButton size="md" onClick={() => onRewind(message.uuid!)} title="Rewind to here">
 							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
 									d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
 								/>
 							</svg>
@@ -327,15 +335,26 @@ export function SDKUserMessage({
 				/>
 			)}
 
-			<IconButton size="md" onClick={handleCopy} title="Copy message">
-				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width={2}
-						d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-					/>
-				</svg>
+			<IconButton
+				size="md"
+				onClick={handleCopy}
+				title={copied ? 'Copied!' : 'Copy message'}
+				class={copied ? 'text-green-400' : ''}
+			>
+				{copied ? (
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+					</svg>
+				) : (
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth={2}
+							d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+						/>
+					</svg>
+				)}
 			</IconButton>
 		</div>
 	);

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -11,11 +11,12 @@
  * - Timestamp and synthetic badge in footer
  */
 
+import { useEffect, useState } from 'preact/hooks';
+import { toast } from '../../lib/toast.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { messageSpacing, borderRadius } from '../../lib/design-tokens.ts';
 import { Tooltip } from '../ui/Tooltip.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
-import { toast } from '../../lib/toast.ts';
 
 interface Props {
 	/** Content to display - can be a simple string or array of content blocks */
@@ -75,10 +76,18 @@ export function SyntheticMessageBlock({ content, timestamp, uuid }: Props) {
 			.join('\n');
 	};
 
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(getTextContent());
 		if (success) {
-			toast.success('Message copied to clipboard');
+			setCopied(true);
 		} else {
 			toast.error('Failed to copy message');
 		}
@@ -191,15 +200,31 @@ export function SyntheticMessageBlock({ content, timestamp, uuid }: Props) {
 						</span>
 					</Tooltip>
 
-					<IconButton size="md" onClick={handleCopy} title="Copy message">
-						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth={2}
-								d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-							/>
-						</svg>
+					<IconButton
+						size="md"
+						onClick={handleCopy}
+						title={copied ? 'Copied!' : 'Copy message'}
+						class={copied ? 'text-green-400' : ''}
+					>
+						{copied ? (
+							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M5 13l4 4L19 7"
+								/>
+							</svg>
+						) : (
+							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+								/>
+							</svg>
+						)}
 					</IconButton>
 				</div>
 			</div>

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -327,7 +327,7 @@ describe('SDKAssistantMessage', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should show success toast when copy succeeds', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(true);
 
 			const message = createTextOnlyMessage('Hello world');
@@ -339,11 +339,14 @@ describe('SDKAssistantMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should now show "Copied!" title and green color
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextOnlyMessage('Hello world');
@@ -355,6 +358,9 @@ describe('SDKAssistantMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
+				// Button should remain showing "Copy message" (not switched to Copied!)
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				// Error toast should be shown
 				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
 			});
 		});
@@ -375,7 +381,41 @@ describe('SDKAssistantMessage', () => {
 				expect(copyToClipboard).toHaveBeenCalledWith(
 					'I will read the file.\nThe file has been read.'
 				);
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should switch to "Copied!" state
+				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+			});
+		});
+
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			it('should revert to copy icon after 1500ms', async () => {
+				vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+				const message = createTextOnlyMessage('Hello world');
+				const { container } = render(<SDKAssistantMessage message={message} />);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
 			});
 		});
 	});

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -4,9 +4,9 @@
  *
  * Tests user message rendering including text, images, and special cases
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { render, fireEvent } from '@testing-library/preact';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { SDKUserMessage } from '../SDKUserMessage';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
@@ -33,6 +33,10 @@ import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	cleanup();
 });
 
 // Helper to create a valid UUID
@@ -390,7 +394,7 @@ describe('SDKUserMessage', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should show success toast when copy succeeds', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(true);
 
 			const message = createTextMessage('Hello world');
@@ -402,11 +406,14 @@ describe('SDKUserMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should now show "Copied!" title and green color
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextMessage('Hello world');
@@ -418,7 +425,43 @@ describe('SDKUserMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
+				// Button should remain showing "Copy message" (not switched to Copied!)
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				// Error toast should be shown
 				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
+			});
+		});
+
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			it('should revert to copy icon after 1500ms', async () => {
+				vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+				const message = createTextMessage('Hello world');
+				const { container } = render(<SDKUserMessage message={message} />);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
 			});
 		});
 	});

--- a/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
@@ -21,12 +21,11 @@ vi.mock('../../../lib/utils.ts', async () => {
 });
 
 // Mock toast
-const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 
 vi.mock('../../../lib/toast.ts', () => ({
 	toast: {
-		success: (msg: string) => mockToastSuccess(msg),
+		success: vi.fn(),
 		error: (msg: string) => mockToastError(msg),
 	},
 }));
@@ -35,6 +34,7 @@ describe('SyntheticMessageBlock', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockCopyToClipboard.mockResolvedValue(true);
+		mockToastError.mockClear();
 	});
 
 	afterEach(() => {
@@ -289,7 +289,7 @@ describe('SyntheticMessageBlock', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should copy string content on button click', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			const { container } = render(
 				<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
 			);
@@ -299,11 +299,13 @@ describe('SyntheticMessageBlock', () => {
 
 			await waitFor(() => {
 				expect(mockCopyToClipboard).toHaveBeenCalledWith('Content to copy');
-				expect(mockToastSuccess).toHaveBeenCalledWith('Message copied to clipboard');
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			mockCopyToClipboard.mockResolvedValue(false);
 
 			const { container } = render(
@@ -314,7 +316,41 @@ describe('SyntheticMessageBlock', () => {
 			fireEvent.click(copyButton!);
 
 			await waitFor(() => {
+				expect(mockCopyToClipboard).toHaveBeenCalledWith('Content to copy');
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
 				expect(mockToastError).toHaveBeenCalledWith('Failed to copy message');
+			});
+		});
+
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			it('should revert to copy icon after 1500ms', async () => {
+				const { container } = render(
+					<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
+				);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
 			});
 		});
 

--- a/packages/web/src/components/ui/CopyButton.tsx
+++ b/packages/web/src/components/ui/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { copyToClipboard } from '../../lib/utils.ts';
 
 interface CopyButtonProps {
@@ -9,11 +9,16 @@ interface CopyButtonProps {
 export function CopyButton({ text, label = 'Copy to clipboard' }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
 
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(text);
 		if (success) {
 			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -12,6 +12,7 @@ import {
 	MODEL_FAMILY_ICONS,
 	getModelFamilyIcon,
 	getProviderLabel,
+	groupModelsByProvider,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -142,9 +143,9 @@ describe('useModelSwitcher', () => {
 		it('should return correct label for known providers', () => {
 			expect(getProviderLabel('anthropic')).toBe('Anthropic');
 			expect(getProviderLabel('glm')).toBe('GLM');
-			expect(getProviderLabel('openai')).toBe('OpenAI');
+			expect(getProviderLabel('minimax')).toBe('MiniMax');
 			expect(getProviderLabel('anthropic-copilot')).toBe('Copilot');
-			expect(getProviderLabel('google')).toBe('Google');
+			expect(getProviderLabel('anthropic-codex')).toBe('Codex');
 		});
 
 		it('should return the provider string for unknown providers', () => {
@@ -260,39 +261,6 @@ describe('useModelSwitcher', () => {
 			const glmModel = result.current.availableModels.find((m) => m.id === 'glm-4-plus');
 			expect(glmModel?.provider).toBe('glm');
 			expect(glmModel?.family).toBe('glm');
-		});
-
-		it('should detect gpt family and openai provider for OpenAI models', async () => {
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockResolvedValueOnce({
-						currentModel: 'gpt-5.3-codex',
-						modelInfo: null,
-					})
-					.mockResolvedValueOnce({
-						models: [
-							{
-								id: 'gpt-5.3-codex',
-								display_name: 'GPT-5.3 Codex',
-								description: '',
-								provider: 'openai',
-							},
-							{ id: 'gpt-5-mini', display_name: 'GPT-5 Mini', description: '', provider: 'openai' },
-						],
-					}),
-			};
-			mockGetHubIfConnected.mockReturnValue(mockHub);
-
-			const { result } = renderHook(() => useModelSwitcher('session-1'));
-
-			await waitFor(() => {
-				expect(result.current.loading).toBe(false);
-			});
-
-			const gptModel = result.current.availableModels.find((m) => m.id === 'gpt-5.3-codex');
-			expect(gptModel?.provider).toBe('openai');
-			expect(gptModel?.family).toBe('gpt');
 		});
 
 		it('should detect gpt family and anthropic-copilot provider for Copilot GPT models', async () => {
@@ -463,7 +431,7 @@ describe('useModelSwitcher', () => {
 					.fn()
 					.mockResolvedValueOnce({
 						currentModel: 'claude-sonnet-4-20250514',
-						modelInfo: { id: 'claude-sonnet-4-20250514', name: 'Sonnet' },
+						modelInfo: { id: 'claude-sonnet-4-20250514', name: 'Sonnet', provider: 'anthropic' },
 					})
 					.mockResolvedValueOnce({ models: [] }),
 			};
@@ -476,7 +444,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-sonnet-4-20250514');
+				await result.current.switchModel({ id: 'claude-sonnet-4-20250514', provider: 'anthropic' });
 			});
 
 			expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Already using'));
@@ -510,7 +478,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(result.current.currentModel).toBe('claude-opus-4-5-20251101');
@@ -540,7 +508,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Model not available');
@@ -568,7 +536,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Failed to switch model');
@@ -596,7 +564,7 @@ describe('useModelSwitcher', () => {
 			mockGetHubIfConnected.mockReturnValue(null);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Not connected to server');
@@ -632,7 +600,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Connection lost');
@@ -668,7 +636,7 @@ describe('useModelSwitcher', () => {
 			switchingStates.push(result.current.switching);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			// After switch completes, should not be switching
@@ -679,6 +647,7 @@ describe('useModelSwitcher', () => {
 			expect(mockHub.request).toHaveBeenCalledWith('session.model.switch', {
 				sessionId: 'session-1',
 				model: 'claude-opus-4-5-20251101',
+				provider: 'anthropic',
 			});
 		});
 
@@ -710,10 +679,93 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(result.current.currentModelInfo?.id).toBe('claude-opus-4-5-20251101');
+		});
+	});
+
+	describe('switchModel - cross-provider', () => {
+		it('should match currentModelInfo by provider after cross-provider switch', async () => {
+			// Two providers both expose claude-sonnet-4-20250514; the post-switch find must
+			// prefer the entry for the provider that was actually switched to.
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockResolvedValueOnce({
+						currentModel: 'claude-sonnet-4-20250514',
+						modelInfo: null,
+					})
+					.mockResolvedValueOnce({
+						models: [
+							{
+								id: 'claude-sonnet-4-20250514',
+								display_name: 'Sonnet (Anthropic)',
+								description: '',
+								provider: 'anthropic',
+							},
+							{
+								id: 'claude-sonnet-4-20250514',
+								display_name: 'Sonnet (Copilot)',
+								description: '',
+								provider: 'anthropic-copilot',
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						model: 'claude-sonnet-4-20250514',
+					}),
+			};
+			mockGetHubIfConnected.mockReturnValue(mockHub);
+
+			const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			await act(async () => {
+				// Switch to the copilot variant
+				await result.current.switchModel({
+					id: 'claude-sonnet-4-20250514',
+					provider: 'anthropic-copilot',
+				});
+			});
+
+			// Should resolve to the copilot entry, not the anthropic one
+			expect(result.current.currentModelInfo?.provider).toBe('anthropic-copilot');
+			expect(result.current.currentModelInfo?.name).toBe('Sonnet (Copilot)');
+		});
+	});
+
+	describe('switchModel - provider validation', () => {
+		it('should show error when provider is missing from model', async () => {
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockResolvedValueOnce({
+						currentModel: 'claude-sonnet-4-20250514',
+						modelInfo: null,
+					})
+					.mockResolvedValueOnce({ models: [] }),
+			};
+			mockGetHubIfConnected.mockReturnValue(mockHub);
+
+			const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			await act(async () => {
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101' });
+			});
+
+			expect(mockToastError).toHaveBeenCalledWith('Model provider information is missing');
+			// Should not have made an RPC call for the switch
+			expect(mockHub.request).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
 		});
 	});
 
@@ -815,6 +867,78 @@ describe('useModelSwitcher', () => {
 			rerender();
 
 			expect(result.current.reload).toBe(firstReload);
+		});
+	});
+
+	describe('groupModelsByProvider', () => {
+		it('should return an empty map for empty input', () => {
+			const result = groupModelsByProvider([]);
+			expect(result.size).toBe(0);
+		});
+
+		it('should group models by provider', () => {
+			const models = [
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+				{ id: 'claude-opus-4', provider: 'anthropic', family: 'opus', name: 'Opus' },
+				{
+					id: 'claude-sonnet-4',
+					provider: 'anthropic-copilot',
+					family: 'sonnet',
+					name: 'Sonnet (Copilot)',
+				},
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.size).toBe(2);
+			expect(result.get('anthropic')).toHaveLength(2);
+			expect(result.get('anthropic-copilot')).toHaveLength(1);
+		});
+
+		it('should default to anthropic provider when model has no provider', () => {
+			const models = [{ id: 'claude-sonnet-4', family: 'sonnet', name: 'Sonnet' }];
+			const result = groupModelsByProvider(models as any);
+			expect(result.has('anthropic')).toBe(true);
+			expect(result.get('anthropic')).toHaveLength(1);
+		});
+
+		it('should preserve all models within each group', () => {
+			const models = [
+				{ id: 'glm-4-plus', provider: 'glm', family: 'glm', name: 'GLM 4 Plus' },
+				{ id: 'glm-4-flash', provider: 'glm', family: 'glm', name: 'GLM 4 Flash' },
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.get('glm')).toHaveLength(2);
+			expect(result.get('anthropic')).toHaveLength(1);
+		});
+
+		it('should maintain insertion order of models within each group', () => {
+			const models = [
+				{ id: 'claude-opus-4', provider: 'anthropic', family: 'opus', name: 'Opus' },
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+				{ id: 'claude-haiku-4', provider: 'anthropic', family: 'haiku', name: 'Haiku' },
+			];
+			const result = groupModelsByProvider(models as any);
+			const anthropicModels = result.get('anthropic')!;
+			expect(anthropicModels[0].id).toBe('claude-opus-4');
+			expect(anthropicModels[1].id).toBe('claude-sonnet-4');
+			expect(anthropicModels[2].id).toBe('claude-haiku-4');
+		});
+
+		it('should handle all supported providers', () => {
+			const models = [
+				{ id: 'm1', provider: 'anthropic', family: 'sonnet', name: 'M1' },
+				{ id: 'm2', provider: 'anthropic-copilot', family: 'sonnet', name: 'M2' },
+				{ id: 'm3', provider: 'anthropic-codex', family: 'sonnet', name: 'M3' },
+				{ id: 'm4', provider: 'glm', family: 'glm', name: 'M4' },
+				{ id: 'm5', provider: 'minimax', family: 'minimax', name: 'M5' },
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.size).toBe(5);
+			expect(result.has('anthropic')).toBe(true);
+			expect(result.has('anthropic-copilot')).toBe(true);
+			expect(result.has('anthropic-codex')).toBe(true);
+			expect(result.has('glm')).toBe(true);
+			expect(result.has('minimax')).toBe(true);
 		});
 	});
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -18,6 +18,7 @@ export {
 	getModelFamilyIcon,
 	PROVIDER_LABELS,
 	getProviderLabel,
+	groupModelsByProvider,
 } from './useModelSwitcher';
 export {
 	useMessageHub,

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -34,7 +34,7 @@ export interface UseModelSwitcherResult {
 	/** Whether models are being loaded */
 	loading: boolean;
 	/** Switch to a different model */
-	switchModel: (modelId: string) => Promise<void>;
+	switchModel: (model: ModelInfo) => Promise<void>;
 	/** Reload model info */
 	reload: () => Promise<void>;
 }
@@ -70,14 +70,43 @@ const FAMILY_ORDER: Record<string, number> = {
 	gemini: 6,
 };
 
+/** Provider sort order for model picker grouping */
+const PROVIDER_ORDER: Record<string, number> = {
+	anthropic: 0,
+	'anthropic-copilot': 1,
+	'anthropic-codex': 2,
+	glm: 3,
+	minimax: 4,
+};
+
+/**
+ * Group models by their provider, preserving insertion order of the input array.
+ * Provider group ordering depends on the caller supplying a pre-sorted array —
+ * `loadModelInfo` sorts by PROVIDER_ORDER before calling this function.
+ * Models within each group retain their input order (family-sorted by the caller).
+ */
+export function groupModelsByProvider(models: ModelInfo[]): Map<string, ModelInfo[]> {
+	const groups = new Map<string, ModelInfo[]>();
+	for (const model of models) {
+		const provider = model.provider || 'anthropic';
+		const existing = groups.get(provider);
+		if (existing) {
+			existing.push(model);
+		} else {
+			groups.set(provider, [model]);
+		}
+	}
+	return groups;
+}
+
 /** Provider display labels for UI */
 export const PROVIDER_LABELS: Record<string, string> = {
 	anthropic: 'Anthropic',
 	glm: 'GLM',
 	minimax: 'MiniMax',
-	openai: 'OpenAI',
 	'anthropic-copilot': 'Copilot',
-	google: 'Google',
+	'anthropic-codex': 'Codex',
+	// Note: keep in sync with PROVIDER_ORDER above
 };
 
 /**
@@ -162,8 +191,17 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 				};
 			});
 
-			// Sort by family order
-			modelInfos.sort((a, b) => FAMILY_ORDER[a.family] - FAMILY_ORDER[b.family]);
+			// Sort by provider first, then by family order within each provider group.
+			// This pre-sort is required so that groupModelsByProvider() preserves
+			// the intended provider order via Map insertion order.
+			modelInfos.sort((a, b) => {
+				const providerA = PROVIDER_ORDER[a.provider || 'anthropic'] ?? 99;
+				const providerB = PROVIDER_ORDER[b.provider || 'anthropic'] ?? 99;
+				if (providerA !== providerB) return providerA - providerB;
+				const familyA = FAMILY_ORDER[a.family] ?? 99;
+				const familyB = FAMILY_ORDER[b.family] ?? 99;
+				return familyA - familyB;
+			});
 			setAvailableModels(modelInfos);
 		} catch {
 			// Error handled silently - loading state will be cleared
@@ -178,8 +216,13 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 	}, [loadModelInfo]);
 
 	const switchModel = useCallback(
-		async (newModelId: string) => {
-			if (newModelId === currentModel) {
+		async (model: ModelInfo) => {
+			if (!model.provider) {
+				toast.error('Model provider information is missing');
+				return;
+			}
+
+			if (model.id === currentModel && model.provider === currentModelInfo?.provider) {
 				toast.info(`Already using ${currentModelInfo?.name || currentModel}`);
 				return;
 			}
@@ -194,7 +237,8 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 
 				const result = (await hub.request('session.model.switch', {
 					sessionId,
-					model: newModelId,
+					model: model.id,
+					provider: model.provider,
 				})) as {
 					success: boolean;
 					model: string;
@@ -203,7 +247,12 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 
 				if (result.success) {
 					setCurrentModel(result.model);
-					const newModelInfo = availableModels.find((m) => m.id === result.model);
+					// Match by both id AND provider to avoid returning the wrong entry when
+					// two providers share the same canonical model ID (e.g. anthropic and
+					// anthropic-copilot both expose claude-sonnet-4.6).
+					const newModelInfo =
+						availableModels.find((m) => m.id === result.model && m.provider === model.provider) ??
+						availableModels.find((m) => m.id === result.model);
 					setCurrentModelInfo(newModelInfo || null);
 					toast.success(`Switched to ${newModelInfo?.name || result.model}`);
 				} else {

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -19,6 +19,7 @@
 import type {
 	MessageDeliveryMode,
 	MessageImage,
+	ModelInfo,
 	ResolvedQuestion,
 	SessionFeatures,
 } from '@neokai/shared';
@@ -403,14 +404,14 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 
 	// Model switch with processing confirmation
 	const handleModelSwitchWithConfirmation = useCallback(
-		async (modelId: string) => {
+		async (model: ModelInfo) => {
 			if (isProcessing) {
 				const confirmed = confirm(
 					'The agent is currently processing. Switching the model will interrupt the current operation. Continue?'
 				);
 				if (!confirmed) return;
 			}
-			await switchModel(modelId);
+			await switchModel(model);
 		},
 		[switchModel, isProcessing]
 	);


### PR DESCRIPTION
## Summary

- Create `packages/daemon/src/lib/providers/shared/error-envelope.ts` with `AnthropicErrorType` union type and `createAnthropicErrorBody()` helper, shared by both bridge servers
- Update `sendJsonError()` in the copilot server to use the widened `AnthropicErrorType` (now includes `authentication_error`, `request_too_large`, etc.) via the shared helper
- Change `AnthropicStreamWriter.sendFailed()` to emit a proper Anthropic-format `error` SSE event (`event: error\ndata: {...}`) instead of a silent `end_turn` epilogue — the Claude Agent SDK will now surface streaming failures as `APIError` instead of silently succeeding
- Pass error type and message to `sendFailed()` from all error paths in `streaming.ts`: `session.error` event, streaming timeout, and `session.send()` rejection

## Test plan

- [x] `bun run typecheck` passes (0 errors)
- [x] `bun run lint` passes (0 warnings/errors)
- [x] All 56 tests in `server.test.ts`, `sse.test.ts`, `streaming.test.ts` pass
- [x] HTTP 400 returns Anthropic JSON error envelope (`{ type: 'error', error: { type: 'invalid_request_error', message: '...' } }`)
- [x] HTTP 413 returns Anthropic JSON error envelope
- [x] HTTP 500 returns Anthropic JSON error envelope with `api_error` type
- [x] `session.error` event emits Anthropic `error` SSE event with `api_error` type
- [x] `session.send()` rejection emits Anthropic `error` SSE event with `api_error` type