### PR TITLE
feat: heuristic token accounting for copilot bridge

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -230,7 +230,11 @@ async function handleMessages(
 						// next HTTP request will route correctly without any help here.
 						// Cleanup (cleanupConversation / releaseConversation) is handled
 						// below based on the StreamingOutcome kind.
-					}
+					},
+					// Heuristic input_tokens for the continuation turn: the full
+					// conversation history (system + all messages including tool results)
+					// is re-serialised on every request, so we use that as the input text.
+					(extractSystemText(body.system) ?? '') + formatAnthropicPrompt(body.messages)
 				);
 				if (outcome.kind === 'completed') {
 					// streamSession already called session.disconnect() — use

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -323,7 +323,9 @@ async function handleNewToolConversation(
 			body.model,
 			req,
 			res,
-			conv.registry
+			conv.registry,
+			() => {},
+			(systemMessage ?? '') + prompt
 		);
 		if (outcome.kind === 'completed') {
 			// streamSession already called session.disconnect() — use
@@ -372,7 +374,16 @@ async function handlePlainRequest(
 	}
 
 	try {
-		await runSessionStreaming(session, prompt, body.model, req, res);
+		await runSessionStreaming(
+			session,
+			prompt,
+			body.model,
+			req,
+			res,
+			undefined,
+			() => {},
+			(systemMessage ?? '') + prompt
+		);
 	} catch (err) {
 		logger.error('Streaming failed:', err);
 		// Disconnect the session in case runSessionStreaming threw before its

--- a/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
@@ -13,6 +13,22 @@ import type { ServerResponse } from 'node:http';
 import type { AnthropicErrorType } from '../shared/error-envelope.js';
 
 // ---------------------------------------------------------------------------
+// Token estimation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate token count from a character count using the rough 4-chars-per-token
+ * heuristic.
+ *
+ * NOTE: These are NOT actual model-reported values — the Copilot SDK does not
+ * expose per-request token counts.  The estimate provides a non-zero
+ * approximation for UI display purposes only.
+ */
+export function estimateTokens(charCount: number): number {
+	return Math.ceil(charCount / 4);
+}
+
+// ---------------------------------------------------------------------------
 // Headers & low-level helper
 // ---------------------------------------------------------------------------
 
@@ -41,6 +57,8 @@ export class AnthropicStreamWriter {
 	private textBlockStarted = false;
 	private nextBlockIndex = 0;
 	private textBlockIndex = 0;
+	/** Accumulated output character count, used for heuristic output_tokens estimate. */
+	private outputCharCount = 0;
 	readonly messageId = `msg_${randomUUID()}`;
 
 	private closeTextBlock(res: ServerResponse): void {
@@ -67,19 +85,24 @@ export class AnthropicStreamWriter {
 	}
 
 	private sendEpilogue(res: ServerResponse, stopReason: string): void {
-		// output_tokens is always 0 because the Copilot SDK does not expose token
-		// counts.  Any NeoKai UI elements that display token usage will show 0 for
-		// Copilot-backed sessions — this is a known limitation of the bridge layer.
+		// Heuristic estimate: ceil(outputTextLength / 4).
+		// NOT actual model-reported values — the Copilot SDK does not expose
+		// per-request token counts.  Approximation for UI display purposes only.
 		sendEvent(res, 'message_delta', {
 			type: 'message_delta',
 			delta: { stop_reason: stopReason, stop_sequence: null },
-			usage: { output_tokens: 0 },
+			usage: { output_tokens: estimateTokens(this.outputCharCount) },
 		});
 		sendEvent(res, 'message_stop', { type: 'message_stop' });
 	}
 
-	/** Write the `message_start` preamble and set SSE response headers. */
-	start(res: ServerResponse, model: string): void {
+	/**
+	 * Write the `message_start` preamble and set SSE response headers.
+	 *
+	 * @param inputTokens Heuristic estimate of input tokens — caller should pass
+	 *   `estimateTokens(inputText.length)`.  NOT actual model-reported values.
+	 */
+	start(res: ServerResponse, model: string, inputTokens = 0): void {
 		res.writeHead(200, SSE_HEADERS);
 		sendEvent(res, 'message_start', {
 			type: 'message_start',
@@ -90,9 +113,10 @@ export class AnthropicStreamWriter {
 				content: [],
 				model,
 				stop_reason: null,
-				// TODO: input_tokens is always 0 — the Copilot SDK does not expose
-				// per-request token counts on the prompt side.
-				usage: { input_tokens: 0, output_tokens: 0 },
+				// Heuristic estimate: ceil(inputTextLength / 4).
+				// NOT actual model-reported values — the Copilot SDK does not expose
+				// per-request token counts.  Approximation for UI display purposes only.
+				usage: { input_tokens: inputTokens, output_tokens: 0 },
 			},
 		});
 	}
@@ -102,6 +126,7 @@ export class AnthropicStreamWriter {
 		if (deltas.length === 0) return;
 		this.ensureTextBlock(res);
 		for (const text of deltas) {
+			this.outputCharCount += text.length;
 			sendEvent(res, 'content_block_delta', {
 				type: 'content_block_delta',
 				index: this.textBlockIndex,

--- a/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
@@ -139,6 +139,10 @@ export class AnthropicStreamWriter {
 	 * Write one `tool_use` content block WITHOUT writing the epilogue or ending
 	 * the response.  Use this when multiple parallel tool calls need to be
 	 * emitted in the same response — call `sendToolUseEpilogue()` afterward.
+	 *
+	 * NOTE: Tool JSON bytes are NOT counted in `outputCharCount`.  The heuristic
+	 * `output_tokens` estimate in `message_delta` covers only text delta
+	 * characters accumulated via `flushDeltas()`.
 	 */
 	writeToolUseBlock(
 		res: ServerResponse,

--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -273,7 +273,9 @@ export function resumeSessionStreaming(
 	res: ServerResponse,
 	registry: ToolBridgeRegistry,
 	toolResults: ToolResult[],
-	onDone: () => void = () => {}
+	onDone: () => void = () => {},
+	/** Raw input text (system prompt + full message history) for heuristic token estimation. */
+	inputText = ''
 ): Promise<StreamingOutcome> {
 	return streamSession(
 		session,
@@ -288,6 +290,7 @@ export function resumeSessionStreaming(
 				registry.resolveToolResult(toolUseId, result, isError);
 			}
 		},
-		onDone
+		onDone,
+		inputText
 	);
 }

--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -32,7 +32,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { CopilotSession, SessionEvent } from '@github/copilot-sdk';
 import type { ToolBridgeRegistry } from './tool-bridge.js';
 import type { ToolResult } from './conversation.js';
-import { AnthropicStreamWriter } from './sse.js';
+import { AnthropicStreamWriter, estimateTokens } from './sse.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('anthropic-copilot-streaming');
@@ -84,10 +84,12 @@ function streamSession(
 	res: ServerResponse,
 	registry: ToolBridgeRegistry | undefined,
 	startFn: (finish: () => void, writeFailed: () => void) => void,
-	onDone: () => void
+	onDone: () => void,
+	/** Raw input text used for heuristic token estimation (system prompt + formatted messages). */
+	inputText = ''
 ): Promise<StreamingOutcome> {
 	const writer = new AnthropicStreamWriter();
-	writer.start(res, model);
+	writer.start(res, model, estimateTokens(inputText.length));
 
 	let sessionDone = false;
 	let pendingDeltas: string[] = [];
@@ -232,7 +234,9 @@ export function runSessionStreaming(
 	req: IncomingMessage,
 	res: ServerResponse,
 	registry?: ToolBridgeRegistry,
-	onDone: () => void = () => {}
+	onDone: () => void = () => {},
+	/** Raw input text (system prompt + formatted messages) for heuristic token estimation. */
+	inputText = ''
 ): Promise<StreamingOutcome> {
 	return streamSession(
 		session,
@@ -251,7 +255,8 @@ export function runSessionStreaming(
 				finish();
 			});
 		},
-		onDone
+		onDone,
+		inputText
 	);
 }
 

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
@@ -15,6 +15,7 @@ import {
 	resumeSessionStreaming,
 	STREAMING_TIMEOUT_MS,
 } from '../../../../src/lib/providers/anthropic-copilot/streaming';
+import { estimateTokens } from '../../../../src/lib/providers/anthropic-copilot/sse';
 import { ToolBridgeRegistry } from '../../../../src/lib/providers/anthropic-copilot/tool-bridge';
 
 // ---------------------------------------------------------------------------
@@ -226,6 +227,84 @@ describe('runSessionStreaming', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// SSE parse helper (shared with token accounting assertions below)
+// ---------------------------------------------------------------------------
+
+function parseEvents(written: string[]): Array<{ type: string; data: unknown }> {
+	const events: Array<{ type: string; data: unknown }> = [];
+	let currentType = '';
+	for (const chunk of written) {
+		for (const line of chunk.split('\n')) {
+			if (line.startsWith('event: ')) {
+				currentType = line.slice(7).trim();
+			} else if (line.startsWith('data: ')) {
+				events.push({ type: currentType, data: JSON.parse(line.slice(6)) });
+				currentType = '';
+			}
+		}
+	}
+	return events;
+}
+
+// ---------------------------------------------------------------------------
+// Token accounting via inputText parameter
+// ---------------------------------------------------------------------------
+
+describe('runSessionStreaming — inputText / input_tokens', () => {
+	it('message_start carries non-zero input_tokens when inputText is provided', async () => {
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+
+		const inputText = 'hello world'; // 11 chars → ceil(11/4) = 3
+		const p = runSessionStreaming(
+			session as unknown as CopilotSession,
+			'prompt',
+			'model',
+			req,
+			res,
+			undefined,
+			() => {},
+			inputText
+		);
+		await Promise.resolve();
+		session.emit('session.idle');
+		await p;
+
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(estimateTokens(inputText.length));
+	});
+
+	it('message_start carries 0 input_tokens when inputText is empty (default)', async () => {
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+
+		const p = runSessionStreaming(
+			session as unknown as CopilotSession,
+			'prompt',
+			'model',
+			req,
+			res
+		);
+		await Promise.resolve();
+		session.emit('session.idle');
+		await p;
+
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(0);
+	});
+});
+
 describe('resumeSessionStreaming', () => {
 	it('resolves completed after tool results resume and session idles', async () => {
 		const session = new MockSession();
@@ -268,6 +347,48 @@ describe('resumeSessionStreaming', () => {
 		const outcome = await p;
 		expect(outcome.kind).toBe('completed');
 		expect(session.disconnectCalled).toBe(true);
+		clearTimeout(fakeTimer);
+	});
+
+	it('message_start carries non-zero input_tokens when inputText is provided', async () => {
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+		const registry = new ToolBridgeRegistry();
+
+		const fakeTimer = setTimeout(() => {}, 100_000);
+		(registry as unknown as Record<string, unknown>)['pending'] = new Map([
+			[
+				'tc_1',
+				{
+					resolve: () => {},
+					reject: () => {},
+					timer: fakeTimer,
+				},
+			],
+		]);
+
+		const inputText = 'system context\nuser: run the tool'; // 34 chars → ceil(34/4) = 9
+		const p = resumeSessionStreaming(
+			session as unknown as CopilotSession,
+			'model',
+			req,
+			res,
+			registry,
+			[{ toolUseId: 'tc_1', result: 'ok' }],
+			() => {},
+			inputText
+		);
+		await Promise.resolve();
+		session.emit('session.idle');
+		await p;
+
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(estimateTokens(inputText.length));
 		clearTimeout(fakeTimer);
 	});
 });

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/token-accounting.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/token-accounting.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for heuristic token accounting in the anthropic-copilot bridge.
+ *
+ * The Copilot SDK does not expose real token counts, so we use a 4-chars-per-token
+ * heuristic.  These tests verify the formula and its integration with SSE events.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ServerResponse } from 'node:http';
+import {
+	estimateTokens,
+	AnthropicStreamWriter,
+} from '../../../../src/lib/providers/anthropic-copilot/sse';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRes(): { written: string[]; res: ServerResponse } {
+	const written: string[] = [];
+	const res = {
+		writeHead: (_status: number, _headers: unknown) => {},
+		write: (chunk: string) => {
+			written.push(chunk);
+			return true;
+		},
+		end: () => {},
+	} as unknown as ServerResponse;
+	return { written, res };
+}
+
+function parseEvents(written: string[]): Array<{ type: string; data: unknown }> {
+	const events: Array<{ type: string; data: unknown }> = [];
+	let currentType = '';
+	for (const chunk of written) {
+		for (const line of chunk.split('\n')) {
+			if (line.startsWith('event: ')) {
+				currentType = line.slice(7).trim();
+			} else if (line.startsWith('data: ')) {
+				events.push({ type: currentType, data: JSON.parse(line.slice(6)) });
+				currentType = '';
+			}
+		}
+	}
+	return events;
+}
+
+// ---------------------------------------------------------------------------
+// estimateTokens()
+// ---------------------------------------------------------------------------
+
+describe('estimateTokens()', () => {
+	it('returns 0 for empty input', () => {
+		expect(estimateTokens(0)).toBe(0);
+	});
+
+	it('returns 1 for 1-4 chars', () => {
+		expect(estimateTokens(1)).toBe(1);
+		expect(estimateTokens(4)).toBe(1);
+	});
+
+	it('returns 2 for 5-8 chars', () => {
+		expect(estimateTokens(5)).toBe(2);
+		expect(estimateTokens(8)).toBe(2);
+	});
+
+	it('applies ceil for non-divisible lengths', () => {
+		// 7 chars → ceil(7/4) = 2
+		expect(estimateTokens(7)).toBe(2);
+		// 9 chars → ceil(9/4) = 3
+		expect(estimateTokens(9)).toBe(3);
+	});
+
+	it('exact multiple of 4 → no rounding', () => {
+		expect(estimateTokens(12)).toBe(3);
+		expect(estimateTokens(400)).toBe(100);
+	});
+
+	it('known inputs produce expected values', () => {
+		// "hello world" = 11 chars → ceil(11/4) = 3
+		expect(estimateTokens('hello world'.length)).toBe(3);
+		// 100-char string → ceil(100/4) = 25
+		expect(estimateTokens(100)).toBe(25);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// message_start: input_tokens estimate
+// ---------------------------------------------------------------------------
+
+describe('message_start input_tokens', () => {
+	it('is 0 when no inputTokens are provided', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(0);
+	});
+
+	it('is non-zero for a non-empty inputTokens value', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		// 40-char input → ceil(40/4) = 10
+		writer.start(res, 'model', estimateTokens(40));
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(10);
+	});
+
+	it('reflects exact formula: ceil(charCount / 4)', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		// "system: do stuff\nuser: hello" = 29 chars → ceil(29/4) = 8
+		const inputText = 'system: do stuff\nuser: hello';
+		writer.start(res, 'model', estimateTokens(inputText.length));
+		const events = parseEvents(written);
+		const start = events.find((e) => e.type === 'message_start');
+		const usage = ((start!.data as Record<string, unknown>)['message'] as Record<string, unknown>)[
+			'usage'
+		] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(Math.ceil(inputText.length / 4));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// message_delta: output_tokens estimate
+// ---------------------------------------------------------------------------
+
+describe('message_delta output_tokens', () => {
+	it('is 0 when no text was flushed', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['output_tokens']).toBe(0);
+	});
+
+	it('is non-zero after text deltas are flushed', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		writer.flushDeltas(res, ['hello world']); // 11 chars
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		// ceil(11/4) = 3
+		expect(usage['output_tokens']).toBe(3);
+	});
+
+	it('accumulates across multiple flushDeltas calls', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		// 4 chars + 8 chars = 12 chars total → ceil(12/4) = 3
+		writer.flushDeltas(res, ['abcd']);
+		writer.flushDeltas(res, ['efghijkl']);
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['output_tokens']).toBe(3);
+	});
+
+	it('accumulates across multiple deltas in a single flush', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		// ['abc', 'de'] = 3 + 2 = 5 chars → ceil(5/4) = 2
+		writer.flushDeltas(res, ['abc', 'de']);
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['output_tokens']).toBe(2);
+	});
+
+	it('reflects exact formula: ceil(totalOutputChars / 4)', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		const outputText = 'The answer is 42, and the universe is vast.'; // 43 chars
+		writer.flushDeltas(res, [outputText]);
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['output_tokens']).toBe(Math.ceil(outputText.length / 4));
+	});
+
+	it('output_tokens is correct in tool_use epilogue too', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model');
+		// Emit some text before tool call
+		writer.flushDeltas(res, ['thinking...']); // 11 chars
+		writer.sendToolUse(res, 'tc_1', 'bash', { command: 'ls' });
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		// ceil(11/4) = 3
+		expect(usage['output_tokens']).toBe(3);
+	});
+});


### PR DESCRIPTION
The Copilot SDK does not expose per-request token counts. Use a
4-chars-per-token heuristic to produce non-zero estimates so the NeoKai
UI can display meaningful usage figures for Copilot-backed sessions.

- Export `estimateTokens(charCount)` helper in sse.ts (ceil / 4)
- `AnthropicStreamWriter.start()` accepts `inputTokens` and emits it
  in `message_start.usage.input_tokens`
- `AnthropicStreamWriter.flushDeltas()` accumulates output char count;
  `message_delta.usage.output_tokens` is set to the heuristic estimate
- `streamSession()` accepts `inputText` and forwards the estimate to
  `writer.start()`; `runSessionStreaming()` propagates the caller's
  input text; `server.ts` passes `systemMessage + prompt` as input text
- Comments throughout document that these are heuristic estimates, NOT
  actual model-reported values
- New unit tests in token-accounting.test.ts verify formula correctness
  and SSE event payloads
