### PR TITLE
feat: log warning when tool_choice is provided but not honored in both bridges

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -198,6 +198,12 @@ async function handleMessages(
 		return;
 	}
 
+	if (body.tool_choice !== undefined) {
+		logger.warn(
+			`tool_choice is not supported by the Copilot SDK and will be ignored (received: ${JSON.stringify(body.tool_choice)})`
+		);
+	}
+
 	const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
 	const hasToolResults = extractToolResultIds(body.messages).length > 0;
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -255,6 +255,12 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				'X-Accel-Buffering': 'no',
 			};
 
+			if (body.tool_choice !== undefined) {
+				logger.warn(
+					`tool_choice is not supported by the Codex bridge and will be ignored (received: ${JSON.stringify(body.tool_choice)})`
+				);
+			}
+
 			// ------------------------------------------------------------------
 			// Tool-continuation: resume a suspended generator
 			// ------------------------------------------------------------------

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -43,7 +43,7 @@ export type AnthropicTool = {
 	input_schema: Record<string, unknown>;
 };
 
-export type AnthropicToolChoice =
+export type ToolChoice =
 	| { type: 'auto' }
 	| { type: 'none' }
 	| { type: 'any' }
@@ -61,7 +61,7 @@ export type AnthropicRequest = {
 	 * the Codex app-server does not expose tool-choice control.
 	 * A warning is logged when this field is present.
 	 */
-	tool_choice?: AnthropicToolChoice;
+	tool_choice?: ToolChoice;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -43,6 +43,12 @@ export type AnthropicTool = {
 	input_schema: Record<string, unknown>;
 };
 
+export type AnthropicToolChoice =
+	| { type: 'auto' }
+	| { type: 'none' }
+	| { type: 'any' }
+	| { type: 'tool'; name: string };
+
 export type AnthropicRequest = {
 	model: string;
 	messages: AnthropicMessage[];
@@ -50,6 +56,12 @@ export type AnthropicRequest = {
 	tools?: AnthropicTool[];
 	max_tokens?: number;
 	stream?: boolean;
+	/**
+	 * Accepted for API compatibility but not forwarded to Codex —
+	 * the Codex app-server does not expose tool-choice control.
+	 * A warning is logged when this field is present.
+	 */
+	tool_choice?: AnthropicToolChoice;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../src/lib/providers/anthropic-copilot/index';
 import { initializeProviders, resetProviderFactory } from '../../../../src/lib/providers/factory';
 import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
+import { Logger } from '../../../../src/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Mock CopilotSession
@@ -952,5 +953,75 @@ describe('factory registration', () => {
 		const p = registry.get('anthropic-copilot');
 		expect(p).toBeDefined();
 		expect(p?.id).toBe('anthropic-copilot');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// tool_choice pass-through — Copilot bridge
+// ---------------------------------------------------------------------------
+
+describe('tool_choice warning — copilot bridge', () => {
+	let session: MockCopilotSession;
+	let client: CopilotClient & { lastSession?: MockCopilotSession };
+	let serverUrl: string;
+	let stopServer: () => Promise<void>;
+
+	beforeEach(async () => {
+		session = new MockCopilotSession();
+		client = makeMockClient(() => session);
+		const server = await startEmbeddedServer(client, '/tmp');
+		serverUrl = server.url;
+		stopServer = server.stop;
+	});
+
+	afterEach(async () => {
+		await stopServer();
+	});
+
+	it('logs a warning when tool_choice is provided', async () => {
+		const warnSpy = spyOn(Logger.prototype, 'warn');
+
+		const r = await postMessages(serverUrl, {
+			model: 'claude-sonnet-4.6',
+			max_tokens: 100,
+			messages: [{ role: 'user', content: 'hello' }],
+			tool_choice: { type: 'auto' },
+		});
+
+		expect(r.status).toBe(200);
+		const warnMessages = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
+		expect(warnMessages.some((m) => m.includes('tool_choice'))).toBe(true);
+
+		warnSpy.mockRestore();
+	});
+
+	it('processes the request successfully even when tool_choice is provided', async () => {
+		const r = await postMessages(serverUrl, {
+			model: 'claude-sonnet-4.6',
+			max_tokens: 100,
+			messages: [{ role: 'user', content: 'hello' }],
+			tool_choice: { type: 'none' },
+		});
+
+		expect(r.status).toBe(200);
+		const types = r.events.map((e) => e.type);
+		expect(types).toContain('message_stop');
+	});
+
+	it('does NOT log a warning when tool_choice is absent', async () => {
+		const warnSpy = spyOn(Logger.prototype, 'warn');
+
+		await postMessages(serverUrl, {
+			model: 'claude-sonnet-4.6',
+			max_tokens: 100,
+			messages: [{ role: 'user', content: 'hello' }],
+		});
+
+		const toolChoiceWarns = warnSpy.mock.calls.filter((args) =>
+			args.map(String).join(' ').includes('tool_choice')
+		);
+		expect(toolChoiceWarns.length).toBe(0);
+
+		warnSpy.mockRestore();
 	});
 });

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -22,7 +22,11 @@ import {
 	type BridgeServer,
 	type ToolSession,
 } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
-import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
+import {
+	AppServerConn,
+	BridgeSession,
+	type BridgeEvent,
+} from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 import { Logger } from '../../../../src/lib/logger';
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -14,7 +14,7 @@
  * the exported `ToolSession` type from `server.ts` — both share the same named type.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import {
 	createBridgeServer,
 	createAnthropicError,
@@ -23,6 +23,7 @@ import {
 	type ToolSession,
 } from '../../../../src/lib/providers/codex-anthropic-bridge/server';
 import type { BridgeEvent } from '../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
+import { Logger } from '../../../../src/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helper: parse SSE response body into an array of events
@@ -1098,5 +1099,105 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
 		expect(body.type).toBe('error');
 		expect(body.error.type).toBe('api_error');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// tool_choice pass-through — Codex bridge (production createBridgeServer)
+// ---------------------------------------------------------------------------
+
+describe('tool_choice warning — codex bridge', () => {
+	let server: BridgeServer & { port: number };
+
+	beforeEach(() => {
+		// Stub AppServerConn.create so no real subprocess is spawned.
+		spyOn(AppServerConn, 'create').mockReturnValue({
+			closed: new Promise<void>(() => {}),
+			request: () => Promise.resolve({}),
+			notify: () => {},
+			kill: () => {},
+		} as unknown as AppServerConn);
+
+		// Stub BridgeSession methods to avoid real I/O.
+		spyOn(BridgeSession.prototype, 'initialize').mockResolvedValue(undefined);
+		spyOn(BridgeSession.prototype, 'kill').mockImplementation(() => {});
+		spyOn(BridgeSession.prototype, 'startTurn').mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (): AsyncGenerator<BridgeEvent> {
+				yield { type: 'turn_done', inputTokens: 0, outputTokens: 1 };
+			}
+		);
+
+		server = createBridgeServer({
+			codexBinaryPath: '/fake/codex',
+			cwd: '/tmp',
+		}) as BridgeServer & { port: number };
+	});
+
+	afterEach(() => {
+		server.stop();
+	});
+
+	it('logs a warning when tool_choice is provided', async () => {
+		const warnSpy = spyOn(Logger.prototype, 'warn');
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'hello' }],
+				tool_choice: { type: 'auto' },
+				stream: true,
+			}),
+		});
+
+		await readSSEEvents(resp.body);
+
+		const warnMessages = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
+		expect(warnMessages.some((m) => m.includes('tool_choice'))).toBe(true);
+
+		warnSpy.mockRestore();
+	});
+
+	it('processes the request successfully even when tool_choice is provided', async () => {
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'hello' }],
+				tool_choice: { type: 'none' },
+				stream: true,
+			}),
+		});
+
+		expect(resp.ok).toBe(true);
+		const events = await readSSEEvents(resp.body);
+		const types = events.map((e) => e.event);
+		expect(types).toContain('message_stop');
+	});
+
+	it('does NOT log a tool_choice warning when tool_choice is absent', async () => {
+		const warnSpy = spyOn(Logger.prototype, 'warn');
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'hello' }],
+				stream: true,
+			}),
+		});
+
+		await readSSEEvents(resp.body);
+
+		const toolChoiceWarns = warnSpy.mock.calls.filter((args) =>
+			args.map(String).join(' ').includes('tool_choice')
+		);
+		expect(toolChoiceWarns.length).toBe(0);
+
+		warnSpy.mockRestore();
 	});
 });

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -1108,10 +1108,14 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 
 describe('tool_choice warning — codex bridge', () => {
 	let server: BridgeServer & { port: number };
+	let connCreateSpy: ReturnType<typeof spyOn>;
+	let initializeSpy: ReturnType<typeof spyOn>;
+	let killSpy: ReturnType<typeof spyOn>;
+	let startTurnSpy: ReturnType<typeof spyOn>;
 
 	beforeEach(() => {
 		// Stub AppServerConn.create so no real subprocess is spawned.
-		spyOn(AppServerConn, 'create').mockReturnValue({
+		connCreateSpy = spyOn(AppServerConn, 'create').mockReturnValue({
 			closed: new Promise<void>(() => {}),
 			request: () => Promise.resolve({}),
 			notify: () => {},
@@ -1119,9 +1123,9 @@ describe('tool_choice warning — codex bridge', () => {
 		} as unknown as AppServerConn);
 
 		// Stub BridgeSession methods to avoid real I/O.
-		spyOn(BridgeSession.prototype, 'initialize').mockResolvedValue(undefined);
-		spyOn(BridgeSession.prototype, 'kill').mockImplementation(() => {});
-		spyOn(BridgeSession.prototype, 'startTurn').mockImplementation(
+		initializeSpy = spyOn(BridgeSession.prototype, 'initialize').mockResolvedValue(undefined);
+		killSpy = spyOn(BridgeSession.prototype, 'kill').mockImplementation(() => {});
+		startTurnSpy = spyOn(BridgeSession.prototype, 'startTurn').mockImplementation(
 			// eslint-disable-next-line @typescript-eslint/require-await
 			async function* (): AsyncGenerator<BridgeEvent> {
 				yield { type: 'turn_done', inputTokens: 0, outputTokens: 1 };
@@ -1136,6 +1140,10 @@ describe('tool_choice warning — codex bridge', () => {
 
 	afterEach(() => {
 		server.stop();
+		connCreateSpy.mockRestore();
+		initializeSpy.mockRestore();
+		killSpy.mockRestore();
+		startTurnSpy.mockRestore();
 	});
 
 	it('logs a warning when tool_choice is provided', async () => {


### PR DESCRIPTION
- anthropic-copilot/server.ts: warn when tool_choice is present (Copilot SDK
  does not expose tool-choice control)
- codex-anthropic-bridge/server.ts: warn when tool_choice is present (Codex
  app-server does not expose tool-choice control)
- codex-anthropic-bridge/translator.ts: add tool_choice field to AnthropicRequest
  type (AnthropicToolChoice union) for API completeness
- Add unit tests verifying warning is logged and request succeeds regardless
