### PR TITLE
fix: Enter to send in task HumanInputArea, default target to leader

### DIFF
--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -119,10 +119,12 @@ vi.mock('../ScrollToBottomButton.tsx', () => ({
 
 // Mock InputTextarea so we don't need its full dependencies.
 // Forwards maxChars as maxLength so tests can verify the 50000 limit is passed.
+// Forwards onKeyDown so keyboard-shortcut tests can exercise Enter/Shift+Enter/Cmd+Enter.
 vi.mock('../InputTextarea.tsx', () => ({
 	InputTextarea: ({
 		content,
 		onContentChange,
+		onKeyDown,
 		onSubmit,
 		disabled,
 		placeholder,
@@ -131,6 +133,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 	}: {
 		content: string;
 		onContentChange: (v: string) => void;
+		onKeyDown?: (e: KeyboardEvent) => void;
 		onSubmit: () => void;
 		disabled?: boolean;
 		placeholder?: string;
@@ -143,6 +146,7 @@ vi.mock('../InputTextarea.tsx', () => ({
 				data-testid="input-textarea-field"
 				value={content}
 				onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
+				onKeyDown={onKeyDown}
 				disabled={disabled}
 				placeholder={placeholder}
 				maxLength={maxChars}
@@ -406,7 +410,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		expect(queryByTestId('task-target-button')).not.toBeNull();
 	});
 
-	it('sends feedback via task.sendHumanMessage in awaiting_human state', async () => {
+	it('sends feedback via task.sendHumanMessage in awaiting_human state (default target: leader)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
@@ -430,7 +434,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 				roomId: 'room-1',
 				taskId: 'task-1',
 				message: 'Nice work!',
-				target: 'worker',
+				target: 'leader',
 			});
 		});
 	});
@@ -519,7 +523,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		});
 	});
 
-	it('sends message to worker in awaiting_worker state', async () => {
+	it('sends message to worker in awaiting_worker state when worker is explicitly selected', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -535,6 +539,11 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Add benchmarks too' } });
+
+		// Explicitly select worker (default is now leader)
+		fireEvent.click(getByTestId('task-target-button'));
+		fireEvent.click(getByTestId('task-target-option-worker'));
+
 		fireEvent.click(getByTestId('input-textarea-send'));
 
 		await waitFor(() => {
@@ -565,6 +574,131 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const leaderOption = getByTestId('task-target-option-leader') as HTMLButtonElement;
 		expect(workerOption.disabled).toBe(false);
 		expect(leaderOption.disabled).toBe(false);
+	});
+
+	it('default target is leader', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		// Default target button label should be "Leader"
+		expect(getByTestId('task-target-button').textContent).toContain('Leader');
+	});
+
+	it('sends message when Enter is pressed (desktop)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Hello leader' } });
+
+		// Plain Enter on desktop — should send
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: false, ctrlKey: false });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Hello leader',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('does NOT send when Shift+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Hello\nworld' } });
+
+		// Shift+Enter — should NOT send (used for newlines)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true, metaKey: false, ctrlKey: false });
+
+		// Give some time to ensure no send is triggered
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(mockRequest).not.toHaveBeenCalledWith(
+			'task.sendHumanMessage',
+			expect.objectContaining({ message: expect.any(String) })
+		);
+	});
+
+	it('sends message when Cmd+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Cmd enter works' } });
+
+		// Cmd+Enter — should also send (backward compat)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: true, ctrlKey: false });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Cmd enter works',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('placeholder text reflects Enter-to-send UX', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.placeholder).toContain('Enter to send');
+		expect(textarea.placeholder).toContain('Shift+Enter');
 	});
 });
 

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -508,7 +508,9 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Please focus on auth first' } });
 
-		// Explicitly target leader in the dropdown.
+		// Explicitly select leader in the dropdown.
+		// Note: 'leader' is the default since the default target changed, so this selection
+		// is redundant but kept to make the intent of this test explicit.
 		fireEvent.click(getByTestId('task-target-button'));
 		fireEvent.click(getByTestId('task-target-option-leader'));
 		fireEvent.click(getByTestId('input-textarea-send'));
@@ -644,9 +646,8 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		// Shift+Enter — should NOT send (used for newlines)
 		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true, metaKey: false, ctrlKey: false });
 
-		// Give some time to ensure no send is triggered
-		await new Promise((r) => setTimeout(r, 50));
-
+		// sendMessage is async, but the RPC call should not have been invoked synchronously
+		// Verify immediately that no send was triggered (the handler does not send for Shift+Enter)
 		expect(mockRequest).not.toHaveBeenCalledWith(
 			'task.sendHumanMessage',
 			expect.objectContaining({ message: expect.any(String) })
@@ -670,7 +671,7 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
 		fireEvent.input(textarea, { target: { value: 'Cmd enter works' } });
 
-		// Cmd+Enter — should also send (backward compat)
+		// Cmd+Enter — should also send (backward compat, macOS)
 		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: true, ctrlKey: false });
 
 		await waitFor(() => {
@@ -678,6 +679,36 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 				roomId: 'room-1',
 				taskId: 'task-1',
 				message: 'Cmd enter works',
+				target: 'leader',
+			});
+		});
+	});
+
+	it('sends message when Ctrl+Enter is pressed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Ctrl enter works' } });
+
+		// Ctrl+Enter — should send (backward compat, Windows/Linux)
+		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, metaKey: false, ctrlKey: true });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				message: 'Ctrl enter works',
 				target: 'leader',
 			});
 		});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -291,7 +291,7 @@ function HumanInputArea({
 	} = useTaskInputDraft(roomId, taskId);
 	const [sending, setSending] = useState(false);
 	const [inputError, setInputError] = useState<string | null>(null);
-	const [target, setTarget] = useState<HumanMessageTarget>('worker');
+	const [target, setTarget] = useState<HumanMessageTarget>('leader');
 	const [menuOpen, setMenuOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 
@@ -332,8 +332,8 @@ function HumanInputArea({
 	const placeholder = !hasGroup
 		? 'No active agent group yet — input will activate once a group starts.'
 		: target === 'leader'
-			? 'Send a message to the leader… (⌘↵ to send)'
-			: 'Send a message to the worker… (⌘↵ to send)';
+			? 'Send a message to the leader… (Enter to send, Shift+Enter for newline)'
+			: 'Send a message to the worker… (Enter to send, Shift+Enter for newline)';
 
 	return (
 		<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
@@ -357,9 +357,14 @@ function HumanInputArea({
 				content={messageText}
 				onContentChange={setMessageText}
 				onKeyDown={(e) => {
-					if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-						e.preventDefault();
-						void sendMessage();
+					if (e.key === 'Enter') {
+						const isTouchDevice =
+							window.matchMedia('(pointer: coarse)').matches ||
+							('ontouchstart' in window && window.innerWidth < 768);
+						if (e.metaKey || e.ctrlKey || (!e.shiftKey && !isTouchDevice)) {
+							e.preventDefault();
+							void sendMessage();
+						}
 					}
 				}}
 				onSubmit={() => void sendMessage()}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -294,6 +294,13 @@ function HumanInputArea({
 	const [target, setTarget] = useState<HumanMessageTarget>('leader');
 	const [menuOpen, setMenuOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
+	const isTouchDeviceRef = useRef(false);
+
+	useEffect(() => {
+		isTouchDeviceRef.current =
+			window.matchMedia('(pointer: coarse)').matches ||
+			('ontouchstart' in window && window.innerWidth < 768);
+	}, []);
 
 	useEffect(() => {
 		if (!menuOpen) return;
@@ -329,11 +336,12 @@ function HumanInputArea({
 		}
 	};
 
+	const targetLabel = target === 'leader' ? 'leader' : 'worker';
 	const placeholder = !hasGroup
 		? 'No active agent group yet — input will activate once a group starts.'
-		: target === 'leader'
-			? 'Send a message to the leader… (Enter to send, Shift+Enter for newline)'
-			: 'Send a message to the worker… (Enter to send, Shift+Enter for newline)';
+		: isTouchDeviceRef.current
+			? `Send a message to the ${targetLabel}…`
+			: `Send a message to the ${targetLabel}… (Enter to send, Shift+Enter for newline)`;
 
 	return (
 		<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
@@ -358,10 +366,7 @@ function HumanInputArea({
 				onContentChange={setMessageText}
 				onKeyDown={(e) => {
 					if (e.key === 'Enter') {
-						const isTouchDevice =
-							window.matchMedia('(pointer: coarse)').matches ||
-							('ontouchstart' in window && window.innerWidth < 768);
-						if (e.metaKey || e.ctrlKey || (!e.shiftKey && !isTouchDevice)) {
+						if (e.metaKey || e.ctrlKey || (!e.shiftKey && !isTouchDeviceRef.current)) {
 							e.preventDefault();
 							void sendMessage();
 						}


### PR DESCRIPTION
- Change Enter key behavior: plain Enter sends message on desktop,
  Shift+Enter creates newlines (was Cmd+Enter only)
- Update placeholder text to reflect new UX (Enter to send, Shift+Enter for newline)
- Change default message target from 'worker' to 'leader' so human
  messages go directly to the coordinating agent by default
- Update tests: fix expected default target, add keyboard shortcut tests
