### PR TITLE
feat: require explicit provider ID for all model resolution

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -594,7 +594,7 @@ export class AgentSession
 
 	async handleModelSwitch(
 		newModel: string,
-		newProvider?: string
+		newProvider: string
 	): Promise<{ success: boolean; model: string; error?: string }> {
 		return this.modelSwitchHandler.switchModel(newModel, newProvider);
 	}

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -62,8 +62,10 @@ export class EventSubscriptionSetup {
 		const unsubModelSwitch = daemonHub.on(
 			'model.switchRequest',
 			async ({ sessionId: sid, model, provider }) => {
-				const resolvedProvider = provider || session.config.provider || 'anthropic';
-				const result = await modelSwitchHandler.switchModel(model, resolvedProvider);
+				if (!provider) {
+					throw new Error('model.switchRequest event is missing required field: provider');
+				}
+				const result = await modelSwitchHandler.switchModel(model, provider);
 
 				// Emit result
 				await daemonHub.emit('model.switched', {

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -61,8 +61,9 @@ export class EventSubscriptionSetup {
 		// Model switch request handler
 		const unsubModelSwitch = daemonHub.on(
 			'model.switchRequest',
-			async ({ sessionId: sid, model }) => {
-				const result = await modelSwitchHandler.switchModel(model);
+			async ({ sessionId: sid, model, provider }) => {
+				const resolvedProvider = provider || session.config.provider || 'anthropic';
+				const result = await modelSwitchHandler.switchModel(model, resolvedProvider);
 
 				// Emit result
 				await daemonHub.emit('model.switched', {

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -164,29 +164,17 @@ export class ModelSwitchHandler {
 			// Check if query is running AND ProcessTransport is ready
 			const transportReady = firstMessageReceived;
 
-			// Resolve the target provider — deterministic when caller supplies newProvider.
-			// modelInfo?.provider is a secondary source (model registry metadata).
-			// detectProvider is a last-resort deprecated heuristic for callers that pre-date
-			// explicit routing (e.g. CLI, old integration tests). Log a warning so these
-			// paths are visible in production.
+			// Locate the provider instance for the new model.
+			// newProvider is a required string, so detectProviderForModel always receives
+			// an explicit provider — no heuristic fallback is needed.
 			const providerRegistry = getProviderRegistry();
-			const targetProviderId = newProvider ?? modelInfo?.provider;
-			let newProviderInstance: ReturnType<typeof providerRegistry.detectProvider>;
-			if (targetProviderId) {
-				newProviderInstance = providerRegistry.detectProviderForModel(
-					resolvedModel,
-					targetProviderId
-				);
-			} else {
-				logger.warn(
-					`[model-switch] No provider supplied for model '${resolvedModel}' — ` +
-						'falling back to heuristic detection. Update callers to pass an explicit providerId.'
-				);
-				newProviderInstance = providerRegistry.detectProvider(resolvedModel);
-			}
+			const newProviderInstance = providerRegistry.detectProviderForModel(
+				resolvedModel,
+				newProvider
+			);
 
 			if (!newProviderInstance) {
-				const errMsg = `Cannot switch to model '${resolvedModel}': provider '${targetProviderId ?? '(unknown)'}' is not registered.`;
+				const errMsg = `Cannot switch to model '${resolvedModel}': provider '${newProvider}' is not registered.`;
 				logger.error(errMsg);
 				return { success: false, model: session.config.model, error: errMsg };
 			}

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -125,8 +125,9 @@ export class ModelSwitchHandler {
 			// 'claude-sonnet-4.6').
 			// Use newProvider to correctly disambiguate same-ID models across providers.
 			const modelInfo = await getModelInfo(newModel, 'global', newProvider);
-			const resolvedModel =
-				modelInfo?.id ?? (await resolveModelAlias(newModel, 'global', newProvider));
+			// modelInfo is non-null here because isValidModel passed above;
+			// fall back to newModel as-is for defensive safety (unreachable in practice).
+			const resolvedModel = modelInfo?.id ?? newModel;
 
 			// Resolve the current model in case it's also an alias.
 			// Use session.config.provider (the current provider) for the current model.
@@ -136,8 +137,11 @@ export class ModelSwitchHandler {
 				session.config.provider
 			);
 
-			// Check if already using this model (compare resolved IDs)
-			if (currentResolvedModel === resolvedModel) {
+			// Check if already using this model (compare resolved IDs and provider).
+			// Must check provider too: two providers can share the same canonical ID
+			// (e.g., anthropic and anthropic-copilot both have claude-sonnet-4.6),
+			// so switching providers on the same model ID is a meaningful operation.
+			if (currentResolvedModel === resolvedModel && session.config.provider === newProvider) {
 				return {
 					success: true,
 					model: resolvedModel,

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -87,11 +87,10 @@ export class ModelSwitchHandler {
 	 * with the correct model. This is necessary because SDK's setModel() doesn't
 	 * update the cached system:init, causing stale model info in the UI.
 	 *
-	 * @param newModel - Target model ID or alias
-	 * @param newProvider - Explicit provider ID. When provided, routing is deterministic.
-	 *   If omitted, the provider is inferred from the model's metadata (legacy path).
+	 * @param newModel - Model ID or alias to switch to
+	 * @param newProvider - Provider ID for the new model (required)
 	 */
-	async switchModel(newModel: string, newProvider?: string): Promise<ModelSwitchResult> {
+	async switchModel(newModel: string, newProvider: string): Promise<ModelSwitchResult> {
 		const {
 			session,
 			db,
@@ -107,8 +106,12 @@ export class ModelSwitchHandler {
 		} = this.ctx;
 
 		try {
-			// Validate the model, preferring session provider for disambiguation
-			const isValid = await isValidModel(newModel, 'global', session.config.provider);
+			if (!session.config.provider) {
+				throw new Error('Session has no provider configured');
+			}
+
+			// Validate the new model against the new provider
+			const isValid = await isValidModel(newModel, 'global', newProvider);
 			if (!isValid) {
 				const error = `Invalid model: ${newModel}. Use a valid model ID or alias.`;
 				logger.error(`${error}`);
@@ -120,12 +123,13 @@ export class ModelSwitchHandler {
 			// and then calling getModelInfo loses the provider — two providers can share
 			// the same canonical ID (e.g., Anthropic and anthropic-copilot both have
 			// 'claude-sonnet-4.6').
-			// Pass session provider so same-ID models are disambiguated by provider.
-			const modelInfo = await getModelInfo(newModel, 'global', session.config.provider);
+			// Use newProvider to correctly disambiguate same-ID models across providers.
+			const modelInfo = await getModelInfo(newModel, 'global', newProvider);
 			const resolvedModel =
-				modelInfo?.id ?? (await resolveModelAlias(newModel, 'global', session.config.provider));
+				modelInfo?.id ?? (await resolveModelAlias(newModel, 'global', newProvider));
 
-			// Resolve the current model in case it's also an alias
+			// Resolve the current model in case it's also an alias.
+			// Use session.config.provider (the current provider) for the current model.
 			const currentResolvedModel = await resolveModelAlias(
 				session.config.model,
 				'global',

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -107,8 +107,8 @@ export class ModelSwitchHandler {
 		} = this.ctx;
 
 		try {
-			// Validate the model
-			const isValid = await isValidModel(newModel);
+			// Validate the model, preferring session provider for disambiguation
+			const isValid = await isValidModel(newModel, 'global', session.config.provider);
 			if (!isValid) {
 				const error = `Invalid model: ${newModel}. Use a valid model ID or alias.`;
 				logger.error(`${error}`);

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -120,11 +120,17 @@ export class ModelSwitchHandler {
 			// and then calling getModelInfo loses the provider — two providers can share
 			// the same canonical ID (e.g., Anthropic and anthropic-copilot both have
 			// 'claude-sonnet-4.6').
-			const modelInfo = await getModelInfo(newModel);
-			const resolvedModel = modelInfo?.id ?? (await resolveModelAlias(newModel));
+			// Pass session provider so same-ID models are disambiguated by provider.
+			const modelInfo = await getModelInfo(newModel, 'global', session.config.provider);
+			const resolvedModel =
+				modelInfo?.id ?? (await resolveModelAlias(newModel, 'global', session.config.provider));
 
 			// Resolve the current model in case it's also an alias
-			const currentResolvedModel = await resolveModelAlias(session.config.model);
+			const currentResolvedModel = await resolveModelAlias(
+				session.config.model,
+				'global',
+				session.config.provider
+			);
 
 			// Check if already using this model (compare resolved IDs)
 			if (currentResolvedModel === resolvedModel) {

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -115,7 +115,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	};
 
 	// Model switch events
-	'model.switchRequest': { sessionId: string; model: string };
+	'model.switchRequest': { sessionId: string; model: string; provider: string };
 	'model.switched': {
 		sessionId: string;
 		success: boolean;

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -390,8 +390,13 @@ export async function getModelInfo(
 
 /**
  * Get model info by ID or alias without filtering by provider.
- * Use this for internal/backward-compat callers that don't have provider context.
- * Searches all available models using the three-step search.
+ * Use this ONLY for callers that genuinely lack provider context (e.g., legacy
+ * config paths, manual test utilities). For all new code, prefer `getModelInfo`
+ * with an explicit `providerId`.
+ *
+ * WARNING: If the same model ID exists in multiple providers (e.g., `claude-sonnet-4.6`
+ * in both `anthropic` and `anthropic-copilot`), this function returns whichever entry
+ * appears first in the cache — the result is ambiguous and provider-dependent.
  *
  * @param idOrAlias - Model ID or alias to look up
  * @param cacheKey - Cache key to look up models (defaults to 'global')
@@ -445,8 +450,11 @@ export async function resolveModelAlias(
 
 /**
  * Resolve a model alias to its actual ID without filtering by provider.
- * Use this for internal/backward-compat callers that don't have provider context.
- * Returns the original idOrAlias if no match is found.
+ * Use this ONLY for callers that genuinely lack provider context.
+ * For all new code, prefer `resolveModelAlias` with an explicit `providerId`.
+ *
+ * WARNING: Same ambiguity caveat as `getModelInfoUnfiltered` — if the same alias
+ * resolves to different IDs in different providers, the result is non-deterministic.
  *
  * @param idOrAlias - Model ID or alias to resolve
  * @param cacheKey - Cache key to look up models (defaults to 'global')

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -340,31 +340,52 @@ export function setModelsCache(cache: Map<string, ModelInfo[]>, timestamp?: numb
 /**
  * Get model info by ID or alias
  * Searches available models with support for legacy model IDs
+ *
+ * @param idOrAlias - Model ID or alias to look up
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Optional provider ID to prefer when multiple models share the same ID/alias.
+ *   When specified, models from this provider are returned first. Falls back to unfiltered
+ *   search if no provider-matching model is found (backward compatible).
  */
 export async function getModelInfo(
 	idOrAlias: string,
-	cacheKey: string = 'global'
+	cacheKey: string = 'global',
+	providerId?: string
 ): Promise<ModelInfo | null> {
 	const availableModels = getAvailableModels(cacheKey);
 
-	// 1. Try exact ID match first (works for SDK's short IDs like 'opus', 'default')
-	let model = availableModels.find((m) => m.id === idOrAlias);
+	// Helper: run the three-step search on a subset of models
+	function findIn(models: ModelInfo[]): ModelInfo | undefined {
+		// 1. Exact ID match (works for SDK's short IDs like 'opus', 'default')
+		let found = models.find((m) => m.id === idOrAlias);
 
-	// 2. Try alias match in model's alias field
-	if (!model) {
-		model = availableModels.find((m) => m.alias === idOrAlias);
-	}
-
-	// 3. Try legacy model mapping (maps old full IDs to SDK short IDs)
-	// This handles existing sessions with legacy model IDs like 'claude-sonnet-4-5-20250929'
-	if (!model) {
-		const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
-		if (legacyMappedId) {
-			model = availableModels.find((m) => m.id === legacyMappedId);
+		// 2. Alias field match
+		if (!found) {
+			found = models.find((m) => m.alias === idOrAlias);
 		}
+
+		// 3. Legacy model mapping (maps old full IDs to SDK short IDs)
+		if (!found) {
+			const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
+			if (legacyMappedId) {
+				found = models.find((m) => m.id === legacyMappedId);
+			}
+		}
+
+		return found;
 	}
 
-	return model || null;
+	// When a provider is specified, prefer models from that provider first
+	if (providerId) {
+		const providerModels = availableModels.filter((m) => m.provider === providerId);
+		const match = findIn(providerModels);
+		if (match) {
+			return match;
+		}
+		// Fall through to unfiltered search for backward compatibility
+	}
+
+	return findIn(availableModels) ?? null;
 }
 
 /**
@@ -381,13 +402,18 @@ export async function isValidModel(
 /**
  * Resolve a model alias to its actual ID in the available models
  * Returns the model ID as it exists in the SDK/cache
+ *
+ * @param idOrAlias - Model ID or alias to resolve
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Optional provider ID to prefer for disambiguation (see getModelInfo)
  */
 export async function resolveModelAlias(
 	idOrAlias: string,
-	cacheKey: string = 'global'
+	cacheKey: string = 'global',
+	providerId?: string
 ): Promise<string> {
 	// Try to find the model directly
-	const modelInfo = await getModelInfo(idOrAlias, cacheKey);
+	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	if (modelInfo) {
 		return modelInfo.id;
 	}

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -344,91 +344,121 @@ export function setModelsCache(cache: Map<string, ModelInfo[]>, timestamp?: numb
 }
 
 /**
- * Get model info by ID or alias
- * Searches available models with support for legacy model IDs
- *
- * @param idOrAlias - Model ID or alias to look up
- * @param cacheKey - Cache key to look up models
- * @param providerId - Optional provider ID to prefer when multiple models share the same ID/alias.
- *   When specified, models from this provider are returned first. Falls back to unfiltered
- *   search if no provider-matching model is found (backward compatible).
+ * Three-step search helper for a given model list.
+ * 1. Exact ID match
+ * 2. Alias field match
+ * 3. Legacy model mapping
  */
-export async function getModelInfo(
-	idOrAlias: string,
-	cacheKey: string = 'global',
-	providerId?: string
-): Promise<ModelInfo | null> {
-	const availableModels = getAvailableModels(cacheKey);
+function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undefined {
+	// 1. Exact ID match (works for SDK's short IDs like 'opus', 'default')
+	let found = models.find((m) => m.id === idOrAlias);
 
-	// Helper: run the three-step search on a subset of models
-	function findIn(models: ModelInfo[]): ModelInfo | undefined {
-		// 1. Exact ID match (works for SDK's short IDs like 'opus', 'default')
-		let found = models.find((m) => m.id === idOrAlias);
-
-		// 2. Alias field match
-		if (!found) {
-			found = models.find((m) => m.alias === idOrAlias);
-		}
-
-		// 3. Legacy model mapping (maps old full IDs to SDK short IDs)
-		if (!found) {
-			const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
-			if (legacyMappedId) {
-				found = models.find((m) => m.id === legacyMappedId);
-			}
-		}
-
-		return found;
+	// 2. Alias field match
+	if (!found) {
+		found = models.find((m) => m.alias === idOrAlias);
 	}
 
-	// When a provider is specified, prefer models from that provider first
-	if (providerId) {
-		const providerModels = availableModels.filter((m) => m.provider === providerId);
-		const match = findIn(providerModels);
-		if (match) {
-			return match;
+	// 3. Legacy model mapping (maps old full IDs to SDK short IDs)
+	if (!found) {
+		const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
+		if (legacyMappedId) {
+			found = models.find((m) => m.id === legacyMappedId);
 		}
-		// Fall through to unfiltered search for backward compatibility
 	}
 
-	return findIn(availableModels) ?? null;
+	return found;
 }
 
 /**
- * Validate if a model ID or alias is valid
+ * Get model info by ID or alias, filtered to the specified provider.
+ * All three parameters are required — no fallback to unfiltered search.
+ * Returns null if no model matching both idOrAlias and providerId is found.
  *
- * @param providerId - Optional provider ID to prefer for disambiguation (see getModelInfo).
- *   Validation uses an unfiltered fallback, so a model is considered valid if it exists
- *   in *any* provider, but provider-specific models are preferred when `providerId` is set.
+ * @param idOrAlias - Model ID or alias to look up
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Provider ID to filter by (required)
+ */
+export async function getModelInfo(
+	idOrAlias: string,
+	cacheKey: string,
+	providerId: string
+): Promise<ModelInfo | null> {
+	const availableModels = getAvailableModels(cacheKey);
+	const providerModels = availableModels.filter((m) => m.provider === providerId);
+	return findInModels(providerModels, idOrAlias) ?? null;
+}
+
+/**
+ * Get model info by ID or alias without filtering by provider.
+ * Use this for internal/backward-compat callers that don't have provider context.
+ * Searches all available models using the three-step search.
+ *
+ * @param idOrAlias - Model ID or alias to look up
+ * @param cacheKey - Cache key to look up models (defaults to 'global')
+ */
+export async function getModelInfoUnfiltered(
+	idOrAlias: string,
+	cacheKey: string = 'global'
+): Promise<ModelInfo | null> {
+	const availableModels = getAvailableModels(cacheKey);
+	return findInModels(availableModels, idOrAlias) ?? null;
+}
+
+/**
+ * Validate if a model ID or alias is valid for the specified provider.
+ * All three parameters are required — validation is strict, no unfiltered fallback.
+ *
+ * @param idOrAlias - Model ID or alias to validate
+ * @param cacheKey - Cache key to look up models
+ * @param providerId - Provider ID to filter by (required)
  */
 export async function isValidModel(
 	idOrAlias: string,
-	cacheKey: string = 'global',
-	providerId?: string
+	cacheKey: string,
+	providerId: string
 ): Promise<boolean> {
 	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	return modelInfo !== null;
 }
 
 /**
- * Resolve a model alias to its actual ID in the available models
- * Returns the model ID as it exists in the SDK/cache
+ * Resolve a model alias to its actual ID, filtered to the specified provider.
+ * All three parameters are required.
+ * Returns the original idOrAlias if no match is found.
  *
  * @param idOrAlias - Model ID or alias to resolve
  * @param cacheKey - Cache key to look up models
- * @param providerId - Optional provider ID to prefer for disambiguation (see getModelInfo)
+ * @param providerId - Provider ID to filter by (required)
  */
 export async function resolveModelAlias(
 	idOrAlias: string,
-	cacheKey: string = 'global',
-	providerId?: string
+	cacheKey: string,
+	providerId: string
 ): Promise<string> {
-	// Try to find the model directly
 	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	if (modelInfo) {
 		return modelInfo.id;
 	}
+	// Return as-is if nothing found
+	return idOrAlias;
+}
 
+/**
+ * Resolve a model alias to its actual ID without filtering by provider.
+ * Use this for internal/backward-compat callers that don't have provider context.
+ * Returns the original idOrAlias if no match is found.
+ *
+ * @param idOrAlias - Model ID or alias to resolve
+ * @param cacheKey - Cache key to look up models (defaults to 'global')
+ */
+export async function resolveModelAliasUnfiltered(
+	idOrAlias: string,
+	cacheKey: string = 'global'
+): Promise<string> {
+	const modelInfo = await getModelInfoUnfiltered(idOrAlias, cacheKey);
+	if (modelInfo) {
+		return modelInfo.id;
+	}
 	// Return as-is if nothing found
 	return idOrAlias;
 }

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -102,19 +102,25 @@ const FALLBACK_MODELS: ModelInfo[] = [
  * are always available for resolution, even when only non-Anthropic
  * providers are configured.
  *
- * Provider models take precedence over fallback models with same ID.
+ * Provider models take precedence over fallback models with the same
+ * (provider, id) pair. Models with the same id but different providers
+ * are kept as separate entries so that provider-filtered lookup in
+ * getModelInfo can distinguish them (e.g. both 'anthropic' and
+ * 'anthropic-copilot' may expose 'claude-sonnet-4.6').
  */
 function mergeWithFallbackModels(providerModels: ModelInfo[]): ModelInfo[] {
+	// Key by "provider:id" so same-id models from different providers
+	// are preserved as distinct entries rather than last-writer-wins.
 	const modelMap = new Map<string, ModelInfo>();
 
 	// Add fallback models first
 	for (const model of FALLBACK_MODELS) {
-		modelMap.set(model.id, model);
+		modelMap.set(`${model.provider}:${model.id}`, model);
 	}
 
-	// Provider models override fallbacks with same ID
+	// Provider models override fallbacks with same (provider, id)
 	for (const model of providerModels) {
-		modelMap.set(model.id, model);
+		modelMap.set(`${model.provider}:${model.id}`, model);
 	}
 
 	return Array.from(modelMap.values());
@@ -390,12 +396,17 @@ export async function getModelInfo(
 
 /**
  * Validate if a model ID or alias is valid
+ *
+ * @param providerId - Optional provider ID to prefer for disambiguation (see getModelInfo).
+ *   Validation uses an unfiltered fallback, so a model is considered valid if it exists
+ *   in *any* provider, but provider-specific models are preferred when `providerId` is set.
  */
 export async function isValidModel(
 	idOrAlias: string,
-	cacheKey: string = 'global'
+	cacheKey: string = 'global',
+	providerId?: string
 ): Promise<boolean> {
-	const modelInfo = await getModelInfo(idOrAlias, cacheKey);
+	const modelInfo = await getModelInfo(idOrAlias, cacheKey, providerId);
 	return modelInfo !== null;
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -42,8 +42,6 @@ import type {
 import type { DaemonHub } from '../daemon-hub';
 import { Logger } from '../logger';
 import type { SessionManager } from '../session-manager';
-
-const log = new Logger('config-handlers');
 import {
 	validateSystemPromptConfig,
 	validateToolsConfig,
@@ -55,6 +53,8 @@ import {
 	validateBetasConfig,
 	validateEnvConfig,
 } from '../config-validators';
+
+const log = new Logger('config-handlers');
 
 /**
  * Setup SDK config RPC handlers
@@ -96,21 +96,26 @@ export function setupConfigHandlers(
 
 		// Handle model change (runtime native via existing handleModelSwitch)
 		if (settings.model) {
-			const sessionConfig = agentSession.getSessionData().config;
-			if (!sessionConfig.provider) {
-				log.warn(
-					'config.model.update: session has no provider configured — using anthropic as legacy fallback'
-				);
-			}
-			const provider = sessionConfig.provider ?? 'anthropic';
-			const result = await agentSession.handleModelSwitch(settings.model, provider);
-			if (result.success) {
-				results.applied.push('model');
-			} else {
+			const provider = agentSession.getSessionData().config.provider;
+			if (!provider) {
+				// Session has no provider — cannot route the model switch.
+				// This is a misconfigured session; surface the error rather than
+				// silently falling back to 'anthropic' (which switchModel rejects anyway).
+				log.warn('config.model.update: session has no provider configured — skipping model switch');
 				results.errors.push({
 					field: 'model',
-					error: result.error || 'Failed to switch model',
+					error: 'Session has no provider configured',
 				});
+			} else {
+				const result = await agentSession.handleModelSwitch(settings.model, provider);
+				if (result.success) {
+					results.applied.push('model');
+				} else {
+					results.errors.push({
+						field: 'model',
+						error: result.error || 'Failed to switch model',
+					});
+				}
 			}
 		}
 
@@ -715,21 +720,25 @@ export function setupConfigHandlers(
 		const runtimeConfig = { ...config };
 
 		if (runtimeConfig.model) {
-			const sessionCfg = agentSession.getSessionData().config;
-			if (!sessionCfg.provider) {
-				log.warn(
-					'config.updateBulk: session has no provider configured — using anthropic as legacy fallback'
-				);
-			}
-			const provider = sessionCfg.provider ?? 'anthropic';
-			const result = await agentSession.handleModelSwitch(runtimeConfig.model, provider);
-			if (result.success) {
-				results.applied.push('model');
-			} else {
+			const provider = agentSession.getSessionData().config.provider;
+			if (!provider) {
+				// Session has no provider — surface the error instead of silently
+				// falling back (switchModel rejects missing provider internally anyway).
+				log.warn('config.updateBulk: session has no provider configured — skipping model switch');
 				results.errors.push({
 					field: 'model',
-					error: result.error || 'Failed',
+					error: 'Session has no provider configured',
 				});
+			} else {
+				const result = await agentSession.handleModelSwitch(runtimeConfig.model, provider);
+				if (result.success) {
+					results.applied.push('model');
+				} else {
+					results.errors.push({
+						field: 'model',
+						error: result.error || 'Failed',
+					});
+				}
 			}
 			delete runtimeConfig.model;
 		}

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -40,7 +40,10 @@ import type {
 	UpdateBulkConfigRequest,
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
+import { Logger } from '../logger';
 import type { SessionManager } from '../session-manager';
+
+const log = new Logger('config-handlers');
 import {
 	validateSystemPromptConfig,
 	validateToolsConfig,
@@ -93,7 +96,13 @@ export function setupConfigHandlers(
 
 		// Handle model change (runtime native via existing handleModelSwitch)
 		if (settings.model) {
-			const provider = agentSession.getSessionData().config.provider ?? 'anthropic';
+			const sessionConfig = agentSession.getSessionData().config;
+			if (!sessionConfig.provider) {
+				log.warn(
+					'config.model.update: session has no provider configured — using anthropic as legacy fallback'
+				);
+			}
+			const provider = sessionConfig.provider ?? 'anthropic';
 			const result = await agentSession.handleModelSwitch(settings.model, provider);
 			if (result.success) {
 				results.applied.push('model');
@@ -706,7 +715,13 @@ export function setupConfigHandlers(
 		const runtimeConfig = { ...config };
 
 		if (runtimeConfig.model) {
-			const provider = agentSession.getSessionData().config.provider ?? 'anthropic';
+			const sessionCfg = agentSession.getSessionData().config;
+			if (!sessionCfg.provider) {
+				log.warn(
+					'config.updateBulk: session has no provider configured — using anthropic as legacy fallback'
+				);
+			}
+			const provider = sessionCfg.provider ?? 'anthropic';
 			const result = await agentSession.handleModelSwitch(runtimeConfig.model, provider);
 			if (result.success) {
 				results.applied.push('model');

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -93,7 +93,8 @@ export function setupConfigHandlers(
 
 		// Handle model change (runtime native via existing handleModelSwitch)
 		if (settings.model) {
-			const result = await agentSession.handleModelSwitch(settings.model);
+			const provider = agentSession.getSessionData().config.provider ?? 'anthropic';
+			const result = await agentSession.handleModelSwitch(settings.model, provider);
 			if (result.success) {
 				results.applied.push('model');
 			} else {
@@ -705,7 +706,8 @@ export function setupConfigHandlers(
 		const runtimeConfig = { ...config };
 
 		if (runtimeConfig.model) {
-			const result = await agentSession.handleModelSwitch(runtimeConfig.model);
+			const provider = agentSession.getSessionData().config.provider ?? 'anthropic';
+			const result = await agentSession.handleModelSwitch(runtimeConfig.model, provider);
 			if (result.success) {
 				results.applied.push('model');
 			} else {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -356,11 +356,13 @@ export function setupSessionHandlers(
 
 		// Get current model ID (may be an alias like "default")
 		const rawModelId = agentSession.getCurrentModel().id;
+		const sessionProvider = agentSession.getSessionData().config.provider;
 
 		// Resolve alias to full model ID for consistency with session.model.switch
+		// Pass provider so same-ID models are disambiguated by provider context
 		const { resolveModelAlias, getModelInfo } = await import('../model-service');
-		const currentModelId = await resolveModelAlias(rawModelId);
-		const modelInfo = await getModelInfo(currentModelId);
+		const currentModelId = await resolveModelAlias(rawModelId, 'global', sessionProvider);
+		const modelInfo = await getModelInfo(currentModelId, 'global', sessionProvider);
 
 		return {
 			currentModel: currentModelId,

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -358,6 +358,10 @@ export function setupSessionHandlers(
 		const rawModelId = agentSession.getCurrentModel().id;
 		const sessionProvider = agentSession.getSessionData().config.provider;
 
+		if (!sessionProvider) {
+			throw new Error('Session has no provider configured');
+		}
+
 		// Resolve alias to full model ID for consistency with session.model.switch
 		// Pass provider so same-ID models are disambiguated by provider context
 		const { resolveModelAlias, getModelInfo } = await import('../model-service');
@@ -383,6 +387,10 @@ export function setupSessionHandlers(
 			/** Explicit provider ID — always supply this from the UI model picker. */
 			provider?: string;
 		};
+
+		if (!provider) {
+			throw new Error('Missing required field: provider');
+		}
 
 		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
 		if (!agentSession) {

--- a/packages/daemon/tests/manual/test-model-cache.ts
+++ b/packages/daemon/tests/manual/test-model-cache.ts
@@ -7,7 +7,7 @@
 import {
 	initializeModels,
 	getAvailableModels,
-	getModelInfo,
+	getModelInfoUnfiltered,
 	clearModelsCache,
 } from '../../src/lib/model-service';
 
@@ -27,8 +27,8 @@ async function testModelCache() {
 	console.log('\n=== Test 3: Legacy model ID lookup ===');
 	const legacyIds = ['sonnet', 'claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101'];
 	for (const id of legacyIds) {
-		const info = await getModelInfo(id, 'global');
-		console.log(`  getModelInfo('${id}') → ${info ? `Found: ${info.name}` : 'NULL'}`);
+		const info = await getModelInfoUnfiltered(id, 'global');
+		console.log(`  getModelInfoUnfiltered('${id}') → ${info ? `Found: ${info.name}` : 'NULL'}`);
 	}
 
 	console.log('\n=== Test 4: Clear cache (should return empty - no static fallback) ===');

--- a/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
@@ -153,6 +153,15 @@ describe('EventSubscriptionSetup', () => {
 					error: 'Invalid model',
 				});
 			});
+
+			it('should throw when provider is missing from event', async () => {
+				setup.setup();
+
+				const callback = registeredCallbacks.get('model.switchRequest')!;
+				await expect(callback({ sessionId: 'test-session-id', model: 'opus' })).rejects.toThrow(
+					'model.switchRequest event is missing required field: provider'
+				);
+			});
 		});
 
 		describe('agent.interruptRequest handler', () => {

--- a/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
@@ -123,9 +123,9 @@ describe('EventSubscriptionSetup', () => {
 				setup.setup();
 
 				const callback = registeredCallbacks.get('model.switchRequest')!;
-				await callback({ sessionId: 'test-session-id', model: 'opus' });
+				await callback({ sessionId: 'test-session-id', model: 'opus', provider: 'anthropic' });
 
-				expect(mockModelSwitchHandler.switchModel).toHaveBeenCalledWith('opus');
+				expect(mockModelSwitchHandler.switchModel).toHaveBeenCalledWith('opus', 'anthropic');
 				expect(emitSpy).toHaveBeenCalledWith('model.switched', {
 					sessionId: 'test-session-id',
 					success: true,
@@ -144,7 +144,7 @@ describe('EventSubscriptionSetup', () => {
 				setup.setup();
 
 				const callback = registeredCallbacks.get('model.switchRequest')!;
-				await callback({ sessionId: 'test-session-id', model: 'opus' });
+				await callback({ sessionId: 'test-session-id', model: 'opus', provider: 'anthropic' });
 
 				expect(emitSpy).toHaveBeenCalledWith('model.switched', {
 					sessionId: 'test-session-id',

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -417,6 +417,17 @@ describe('ModelSwitchHandler', () => {
 				expect(result.error).toContain('Restart failed');
 				expect(handleErrorSpy).toHaveBeenCalled();
 			});
+
+			it('should return error when session has no provider configured', async () => {
+				// Remove provider from session config
+				(mockSession.config as Record<string, unknown>).provider = undefined;
+				handler = createHandler({ queryObject: null });
+
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
+
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Session has no provider configured');
+			});
 		});
 
 		describe('context tracker update', () => {

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -118,6 +118,7 @@ describe('ModelSwitchHandler', () => {
 			status: 'active',
 			config: {
 				model: 'default',
+				provider: 'anthropic',
 				maxTokens: 8192,
 				temperature: 1.0,
 			},
@@ -267,7 +268,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when query not started', () => {
 			it('should update config only when query not started', async () => {
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalledWith(
@@ -287,7 +288,7 @@ describe('ModelSwitchHandler', () => {
 				(mockSession.config as Record<string, unknown>)['mcpServers'] = { 'room-tools': liveObj };
 
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				// The spy should have been called with only plain serializable fields
@@ -299,7 +300,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit session.updated event', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(emitSpy).toHaveBeenCalledWith(
 					'session.updated',
@@ -312,7 +313,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit model-switching event', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(publishSpy).toHaveBeenCalledWith(
 					'session.model-switching',
@@ -325,7 +326,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should emit model-switched event on success', async () => {
 				handler = createHandler({ queryObject: null });
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(publishSpy).toHaveBeenCalledWith(
 					'session.model-switched',
@@ -341,7 +342,7 @@ describe('ModelSwitchHandler', () => {
 				mockSession.config.provider = 'glm';
 
 				handler = createHandler({ queryObject: null });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(mockSession.config.provider).toBe('anthropic');
@@ -351,7 +352,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when transport not ready', () => {
 			it('should update config only when transport not ready', async () => {
 				handler = createHandler({ firstMessageReceived: false });
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalled();
@@ -362,7 +363,7 @@ describe('ModelSwitchHandler', () => {
 		describe('when query is running', () => {
 			it('should restart query when running', async () => {
 				handler = createHandler();
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(restartSpy).toHaveBeenCalled();
@@ -370,7 +371,7 @@ describe('ModelSwitchHandler', () => {
 
 			it('should update session config before restart', async () => {
 				handler = createHandler();
-				await handler.switchModel(VALID_MODEL);
+				await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(updateSessionSpy).toHaveBeenCalledWith(
 					mockSession.id,
@@ -384,7 +385,7 @@ describe('ModelSwitchHandler', () => {
 		describe('validation', () => {
 			it('should reject invalid model', async () => {
 				handler = createHandler();
-				const result = await handler.switchModel('invalid-model-12345');
+				const result = await handler.switchModel('invalid-model-12345', 'anthropic');
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Invalid model');
@@ -395,9 +396,9 @@ describe('ModelSwitchHandler', () => {
 				// No query running for simpler test
 				handler = createHandler({ queryObject: null });
 				// Switch to haiku first
-				await handler.switchModel('haiku');
+				await handler.switchModel('haiku', 'anthropic');
 				// Then try to switch to haiku again
-				const result = await handler.switchModel('haiku');
+				const result = await handler.switchModel('haiku', 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(result.error).toContain('Already using');
@@ -410,7 +411,7 @@ describe('ModelSwitchHandler', () => {
 				restartSpy.mockRejectedValue(new Error('Restart failed'));
 				handler = createHandler();
 
-				const result = await handler.switchModel(VALID_MODEL);
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Restart failed');
@@ -423,7 +424,7 @@ describe('ModelSwitchHandler', () => {
 				// Set query to null so we don't need restart
 				handler = createHandler({ queryObject: null });
 				// Use haiku to ensure we're switching to a different model
-				await handler.switchModel('haiku');
+				await handler.switchModel('haiku', 'anthropic');
 
 				expect(setModelTrackerSpy).toHaveBeenCalled();
 			});

--- a/packages/daemon/tests/unit/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/core/model-service.test.ts
@@ -9,8 +9,10 @@ import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
 import {
 	getAvailableModels,
 	getModelInfo,
+	getModelInfoUnfiltered,
 	isValidModel,
 	resolveModelAlias,
+	resolveModelAliasUnfiltered,
 	clearModelsCache,
 	getModelsCache,
 	setModelsCache,
@@ -169,40 +171,46 @@ describe('Model Service', () => {
 		});
 
 		it('should find model by exact ID', async () => {
-			const model = await getModelInfo('sonnet');
+			const model = await getModelInfo('sonnet', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should find model by alias', async () => {
-			const model = await getModelInfo('opus');
+			const model = await getModelInfo('opus', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should return null for unknown model', async () => {
-			const model = await getModelInfo('unknown-model');
+			const model = await getModelInfo('unknown-model', 'global', 'anthropic');
 			expect(model).toBeNull();
 		});
 
 		it('should handle legacy model IDs', async () => {
 			// Legacy full model IDs should map to SDK short IDs
 			// Note: 'claude-sonnet-4-5-20250929' maps to 'sonnet' via LEGACY_MODEL_MAPPINGS
-			const model = await getModelInfo('claude-sonnet-4-5-20250929');
+			const model = await getModelInfo('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle legacy opus model ID', async () => {
-			const model = await getModelInfo('claude-opus-4-5-20251101');
+			const model = await getModelInfo('claude-opus-4-5-20251101', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should handle legacy haiku model ID', async () => {
-			const model = await getModelInfo('claude-haiku-4-5-20251001');
+			const model = await getModelInfo('claude-haiku-4-5-20251001', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('haiku');
+		});
+
+		it('should return null when provider does not match (no fallback)', async () => {
+			// 'sonnet' exists for 'anthropic' but not for 'glm'
+			const model = await getModelInfo('sonnet', 'global', 'glm');
+			expect(model).toBeNull();
 		});
 	});
 
@@ -214,22 +222,22 @@ describe('Model Service', () => {
 		});
 
 		it('should return true for valid model ID', async () => {
-			const isValid = await isValidModel('sonnet');
+			const isValid = await isValidModel('sonnet', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should return true for valid alias', async () => {
-			const isValid = await isValidModel('opus');
+			const isValid = await isValidModel('opus', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should return false for invalid model', async () => {
-			const isValid = await isValidModel('invalid-model');
+			const isValid = await isValidModel('invalid-model', 'global', 'anthropic');
 			expect(isValid).toBe(false);
 		});
 
 		it('should return true for legacy model IDs', async () => {
-			const isValid = await isValidModel('claude-sonnet-4-5-20250929');
+			const isValid = await isValidModel('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 	});
@@ -242,23 +250,23 @@ describe('Model Service', () => {
 		});
 
 		it('should resolve existing model ID', async () => {
-			const resolved = await resolveModelAlias('sonnet');
+			const resolved = await resolveModelAlias('sonnet', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 
 		it('should resolve alias to model ID', async () => {
-			const resolved = await resolveModelAlias('opus');
+			const resolved = await resolveModelAlias('opus', 'global', 'anthropic');
 			expect(resolved).toBe('opus');
 		});
 
 		it('should return input as-is for unknown model', async () => {
-			const resolved = await resolveModelAlias('custom-model-id');
+			const resolved = await resolveModelAlias('custom-model-id', 'global', 'anthropic');
 			expect(resolved).toBe('custom-model-id');
 		});
 
 		it('should resolve legacy model ID', async () => {
 			// LEGACY_MODEL_MAPPINGS maps 'claude-sonnet-4-5-20250929' to 'sonnet'
-			const resolved = await resolveModelAlias('claude-sonnet-4-5-20250929');
+			const resolved = await resolveModelAlias('claude-sonnet-4-5-20250929', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 	});
@@ -531,25 +539,25 @@ describe('Model Service', () => {
 		});
 
 		it('should handle claude-sonnet-4-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-sonnet-4-20241022');
+			const model = await getModelInfo('claude-sonnet-4-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle claude-3-5-sonnet-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-3-5-sonnet-20241022');
+			const model = await getModelInfo('claude-3-5-sonnet-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
 
 		it('should handle claude-opus-4-20250514 legacy ID', async () => {
-			const model = await getModelInfo('claude-opus-4-20250514');
+			const model = await getModelInfo('claude-opus-4-20250514', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('opus');
 		});
 
 		it('should handle claude-3-5-haiku-20241022 legacy ID', async () => {
-			const model = await getModelInfo('claude-3-5-haiku-20241022');
+			const model = await getModelInfo('claude-3-5-haiku-20241022', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('haiku');
 		});
@@ -566,7 +574,7 @@ describe('Model Service', () => {
 			];
 
 			for (const { id, expected } of legacyIds) {
-				const resolved = await resolveModelAlias(id);
+				const resolved = await resolveModelAlias(id, 'global', 'anthropic');
 				expect(resolved).toBe(expected);
 			}
 		});
@@ -581,17 +589,17 @@ describe('Model Service', () => {
 
 		it('should resolve "default" alias to sonnet', async () => {
 			// LEGACY_MODEL_MAPPINGS maps 'default' to 'sonnet'
-			const resolved = await resolveModelAlias('default');
+			const resolved = await resolveModelAlias('default', 'global', 'anthropic');
 			expect(resolved).toBe('sonnet');
 		});
 
 		it('should validate "default" as a valid model', async () => {
-			const isValid = await isValidModel('default');
+			const isValid = await isValidModel('default', 'global', 'anthropic');
 			expect(isValid).toBe(true);
 		});
 
 		it('should get model info for "default"', async () => {
-			const model = await getModelInfo('default');
+			const model = await getModelInfo('default', 'global', 'anthropic');
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 		});
@@ -627,17 +635,17 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Should find in global cache
-			const globalModel = await getModelInfo('sonnet', 'global');
+			// Should find in global cache with correct provider
+			const globalModel = await getModelInfo('sonnet', 'global', 'anthropic');
 			expect(globalModel).not.toBeNull();
 
-			// Should find in custom cache
-			const customModel = await getModelInfo('custom-model', 'custom-cache');
+			// Should find in custom cache with correct provider
+			const customModel = await getModelInfo('custom-model', 'custom-cache', 'custom');
 			expect(customModel).not.toBeNull();
 			expect(customModel?.id).toBe('custom-model');
 
 			// Should not find custom model in global cache
-			const notFound = await getModelInfo('custom-model', 'global');
+			const notFound = await getModelInfo('custom-model', 'global', 'custom');
 			expect(notFound).toBeNull();
 		});
 	});
@@ -661,11 +669,11 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Custom model should be valid in custom cache
-			expect(await isValidModel('custom-only', 'custom-cache')).toBe(true);
+			// Custom model should be valid in custom cache with correct provider
+			expect(await isValidModel('custom-only', 'custom-cache', 'custom')).toBe(true);
 
-			// Custom model should not be valid in global cache
-			expect(await isValidModel('custom-only', 'global')).toBe(false);
+			// Custom model should not be valid in global cache (not present there)
+			expect(await isValidModel('custom-only', 'global', 'custom')).toBe(false);
 		});
 	});
 
@@ -688,12 +696,12 @@ describe('Model Service', () => {
 			testCache.set('custom-cache', customModels);
 			setModelsCache(testCache);
 
-			// Should resolve alias in custom cache
-			const resolved = await resolveModelAlias('my-custom-alias', 'custom-cache');
+			// Should resolve alias in custom cache with correct provider
+			const resolved = await resolveModelAlias('my-custom-alias', 'custom-cache', 'custom');
 			expect(resolved).toBe('custom-alias-model');
 
-			// Should return as-is when not found in global cache
-			const notResolved = await resolveModelAlias('my-custom-alias', 'global');
+			// Should return as-is when not found in global cache (wrong provider)
+			const notResolved = await resolveModelAlias('my-custom-alias', 'global', 'anthropic');
 			expect(notResolved).toBe('my-custom-alias');
 		});
 	});
@@ -738,14 +746,7 @@ describe('Model Service', () => {
 			setModelsCache(testCache);
 		});
 
-		it('should return a match when no providerId specified (backward compat)', async () => {
-			const model = await getModelInfo('claude-sonnet-4.6', 'global');
-			expect(model).not.toBeNull();
-			// Some model with the correct ID is returned; provider is unspecified
-			expect(model?.id).toBe('claude-sonnet-4.6');
-		});
-
-		it('should return provider-specific model when providerId matches', async () => {
+		it('should return provider-specific model when providerId matches anthropic-copilot', async () => {
 			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'anthropic-copilot');
 			expect(model).not.toBeNull();
 			expect(model?.provider).toBe('anthropic-copilot');
@@ -759,11 +760,10 @@ describe('Model Service', () => {
 			expect(model?.name).toBe('Claude Sonnet 4.6 (Anthropic)');
 		});
 
-		it('should fall back to unfiltered search when providerId has no matching model', async () => {
-			// 'glm' provider has no claude-sonnet-4.6 — should fall back to anthropic entry
+		it('should return null when provider does not have the model (no fallback)', async () => {
+			// 'glm' provider has no claude-sonnet-4.6 — no fallback, returns null
 			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'glm');
-			expect(model).not.toBeNull();
-			expect(model?.id).toBe('claude-sonnet-4.6');
+			expect(model).toBeNull();
 		});
 
 		it('should resolve alias with provider filter', async () => {
@@ -777,16 +777,15 @@ describe('Model Service', () => {
 			expect(model?.provider).toBe('anthropic-copilot');
 		});
 
-		it('should return null when model not found even with provider filter (and no unfiltered match)', async () => {
+		it('should return null when model not found for the specified provider', async () => {
 			const model = await getModelInfo('nonexistent-model', 'global', 'anthropic-copilot');
 			expect(model).toBeNull();
 		});
 
-		it('should return model without provider filter for model unique to one provider', async () => {
+		it('should return null for model unique to one provider when wrong provider is requested', async () => {
+			// 'haiku' only exists for 'anthropic', not 'anthropic-copilot'
 			const model = await getModelInfo('haiku', 'global', 'anthropic-copilot');
-			expect(model).not.toBeNull();
-			// Not in copilot, falls back to unfiltered → finds anthropic haiku
-			expect(model?.provider).toBe('anthropic');
+			expect(model).toBeNull();
 		});
 
 		it('should resolve legacy model ID to provider-specific entry when providerId is set', async () => {
@@ -822,6 +821,66 @@ describe('Model Service', () => {
 			expect(model).not.toBeNull();
 			expect(model?.id).toBe('sonnet');
 			expect(model?.provider).toBe('anthropic-copilot');
+		});
+	});
+
+	describe('getModelInfoUnfiltered', () => {
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache);
+		});
+
+		it('should return a result without requiring provider', async () => {
+			const model = await getModelInfoUnfiltered('sonnet');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+			expect(model?.provider).toBe('anthropic');
+		});
+
+		it('should find model by alias without provider filter', async () => {
+			const model = await getModelInfoUnfiltered('opus');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('opus');
+		});
+
+		it('should return null for unknown model', async () => {
+			const model = await getModelInfoUnfiltered('nonexistent-model-xyz');
+			expect(model).toBeNull();
+		});
+
+		it('should handle legacy model IDs without provider', async () => {
+			const model = await getModelInfoUnfiltered('claude-sonnet-4-5-20250929');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+		});
+	});
+
+	describe('resolveModelAliasUnfiltered', () => {
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache);
+		});
+
+		it('should resolve correctly without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('sonnet');
+			expect(resolved).toBe('sonnet');
+		});
+
+		it('should resolve alias to model ID without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('opus');
+			expect(resolved).toBe('opus');
+		});
+
+		it('should return input as-is for unknown model', async () => {
+			const resolved = await resolveModelAliasUnfiltered('unknown-id-xyz');
+			expect(resolved).toBe('unknown-id-xyz');
+		});
+
+		it('should handle legacy model IDs without provider', async () => {
+			const resolved = await resolveModelAliasUnfiltered('claude-sonnet-4-5-20250929');
+			expect(resolved).toBe('sonnet');
 		});
 	});
 

--- a/packages/daemon/tests/unit/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/core/model-service.test.ts
@@ -371,6 +371,60 @@ describe('Model Service', () => {
 			const cache = getModelsCache();
 			expect(cache.get('global')).toEqual(mockModels);
 		});
+
+		it('should preserve both provider entries for shared model IDs after merge', async () => {
+			// Exercises the production mergeWithFallbackModels code path.
+			// Before the P0 fix, mergeWithFallbackModels keyed by model.id alone, so
+			// the second provider's entry silently overwrote the first (last-writer-wins).
+			//
+			// Use IDs that don't conflict with built-in providers so initializeProviders()
+			// can register them without collision after the registry is reset.
+			const { getProviderRegistry } = await import('../../../src/lib/providers/registry');
+			type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+
+			const registry = getProviderRegistry();
+			const sharedId = 'shared-model-xyz';
+
+			registry.register({
+				id: 'test-provider-a',
+				getModels: async () => [
+					{
+						id: sharedId,
+						name: 'Shared (A)',
+						family: 'test',
+						provider: 'test-provider-a',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			registry.register({
+				id: 'test-provider-b',
+				getModels: async () => [
+					{
+						id: sharedId,
+						name: 'Shared (B)',
+						family: 'test',
+						provider: 'test-provider-b',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			await initializeModels();
+
+			// Both entries must survive the merge — one per (provider, id) pair
+			const entryA = await getModelInfo(sharedId, 'global', 'test-provider-a');
+			const entryB = await getModelInfo(sharedId, 'global', 'test-provider-b');
+
+			expect(entryA).not.toBeNull();
+			expect(entryA?.provider).toBe('test-provider-a');
+
+			expect(entryB).not.toBeNull();
+			expect(entryB?.provider).toBe('test-provider-b');
+		});
 	});
 
 	describe('background refresh behavior', () => {
@@ -684,11 +738,11 @@ describe('Model Service', () => {
 			setModelsCache(testCache);
 		});
 
-		it('should return first match when no providerId specified (backward compat)', async () => {
+		it('should return a match when no providerId specified (backward compat)', async () => {
 			const model = await getModelInfo('claude-sonnet-4.6', 'global');
 			expect(model).not.toBeNull();
-			// First match is the anthropic one (insertion order)
-			expect(model?.provider).toBe('anthropic');
+			// Some model with the correct ID is returned; provider is unspecified
+			expect(model?.id).toBe('claude-sonnet-4.6');
 		});
 
 		it('should return provider-specific model when providerId matches', async () => {
@@ -733,6 +787,41 @@ describe('Model Service', () => {
 			expect(model).not.toBeNull();
 			// Not in copilot, falls back to unfiltered → finds anthropic haiku
 			expect(model?.provider).toBe('anthropic');
+		});
+
+		it('should resolve legacy model ID to provider-specific entry when providerId is set', async () => {
+			// Add a copilot variant of the legacy-mapped target 'sonnet'
+			const modelsWithCopilotSonnet: ModelInfo[] = [
+				...sharedModels,
+				{
+					id: 'sonnet',
+					name: 'Sonnet (Copilot)',
+					alias: 'sonnet',
+					family: 'sonnet',
+					provider: 'anthropic-copilot',
+					contextWindow: 200000,
+					available: true,
+				},
+				{
+					id: 'sonnet',
+					name: 'Sonnet (Anthropic)',
+					alias: 'sonnet',
+					family: 'sonnet',
+					provider: 'anthropic',
+					contextWindow: 200000,
+					available: true,
+				},
+			];
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', modelsWithCopilotSonnet);
+			setModelsCache(cache);
+
+			// LEGACY_MODEL_MAPPINGS maps 'claude-sonnet-4-5-20250929' → 'sonnet'
+			// With copilot provider, should find the copilot sonnet entry
+			const model = await getModelInfo('claude-sonnet-4-5-20250929', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('sonnet');
+			expect(model?.provider).toBe('anthropic-copilot');
 		});
 	});
 

--- a/packages/daemon/tests/unit/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/core/model-service.test.ts
@@ -644,6 +644,98 @@ describe('Model Service', () => {
 		});
 	});
 
+	describe('provider-filtered model resolution', () => {
+		// Two providers exposing the same canonical model ID
+		const sharedModels: ModelInfo[] = [
+			{
+				id: 'claude-sonnet-4.6',
+				name: 'Claude Sonnet 4.6 (Anthropic)',
+				alias: 'sonnet-4.6',
+				family: 'sonnet',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				description: 'Anthropic Sonnet',
+				available: true,
+			},
+			{
+				id: 'claude-sonnet-4.6',
+				name: 'Claude Sonnet 4.6 (Copilot)',
+				alias: 'sonnet-4.6',
+				family: 'sonnet',
+				provider: 'anthropic-copilot',
+				contextWindow: 200000,
+				description: 'Copilot Sonnet',
+				available: true,
+			},
+			{
+				id: 'haiku',
+				name: 'Haiku (Anthropic)',
+				alias: 'haiku',
+				family: 'haiku',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				available: true,
+			},
+		];
+
+		beforeEach(() => {
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', sharedModels);
+			setModelsCache(testCache);
+		});
+
+		it('should return first match when no providerId specified (backward compat)', async () => {
+			const model = await getModelInfo('claude-sonnet-4.6', 'global');
+			expect(model).not.toBeNull();
+			// First match is the anthropic one (insertion order)
+			expect(model?.provider).toBe('anthropic');
+		});
+
+		it('should return provider-specific model when providerId matches', async () => {
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-copilot');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Copilot)');
+		});
+
+		it('should return anthropic model when providerId is anthropic', async () => {
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'anthropic');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Anthropic)');
+		});
+
+		it('should fall back to unfiltered search when providerId has no matching model', async () => {
+			// 'glm' provider has no claude-sonnet-4.6 — should fall back to anthropic entry
+			const model = await getModelInfo('claude-sonnet-4.6', 'global', 'glm');
+			expect(model).not.toBeNull();
+			expect(model?.id).toBe('claude-sonnet-4.6');
+		});
+
+		it('should resolve alias with provider filter', async () => {
+			const resolved = await resolveModelAlias('claude-sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(resolved).toBe('claude-sonnet-4.6');
+		});
+
+		it('should find model by alias with provider filter', async () => {
+			const model = await getModelInfo('sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-copilot');
+		});
+
+		it('should return null when model not found even with provider filter (and no unfiltered match)', async () => {
+			const model = await getModelInfo('nonexistent-model', 'global', 'anthropic-copilot');
+			expect(model).toBeNull();
+		});
+
+		it('should return model without provider filter for model unique to one provider', async () => {
+			const model = await getModelInfo('haiku', 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			// Not in copilot, falls back to unfiltered → finds anthropic haiku
+			expect(model?.provider).toBe('anthropic');
+		});
+	});
+
 	describe('ModelInfo optional fields', () => {
 		it('should handle models with minimal fields', async () => {
 			const minimalModels: ModelInfo[] = [

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -130,6 +130,7 @@ function createMockAgentSession(overrides: Partial<AgentSession> = {}): {
 		status: 'active',
 		config: {
 			model: 'claude-sonnet-4-20250514',
+			provider: 'anthropic',
 			coordinatorMode: false,
 			sandbox: { enabled: true },
 			thinkingLevel: 'auto',
@@ -738,7 +739,7 @@ describe('Session RPC Handlers', () => {
 			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);
 
 			await expect(
-				handler!({ sessionId: 'non-existent', model: 'claude-opus' }, {})
+				handler!({ sessionId: 'non-existent', model: 'claude-opus', provider: 'anthropic' }, {})
 			).rejects.toThrow('Session not found');
 		});
 	});

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -742,6 +742,33 @@ describe('Session RPC Handlers', () => {
 				handler!({ sessionId: 'non-existent', model: 'claude-opus', provider: 'anthropic' }, {})
 			).rejects.toThrow('Session not found');
 		});
+
+		it('throws error when provider is omitted', async () => {
+			const handler = messageHubData.handlers.get('session.model.switch');
+			expect(handler).toBeDefined();
+
+			await expect(
+				handler!({ sessionId: 'session-123', model: 'claude-opus' }, {})
+			).rejects.toThrow('Missing required field: provider');
+		});
+	});
+
+	describe('session.model.get', () => {
+		it('throws error when session has no provider configured', async () => {
+			const handler = messageHubData.handlers.get('session.model.get');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession();
+			(agentSession.getSessionData as ReturnType<typeof mock>).mockReturnValue({
+				id: 'session-123',
+				config: { model: 'claude-sonnet-4-20250514' }, // no provider
+			});
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			await expect(handler!({ sessionId: 'session-123' }, {})).rejects.toThrow(
+				'Session has no provider configured'
+			);
+		});
 	});
 
 	describe('session.coordinator.switch', () => {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -181,6 +181,7 @@ export interface GetCurrentModelResponse {
 export interface SwitchModelRequest {
 	sessionId: string;
 	model: string; // Can be alias (e.g., "opus") or full ID
+	provider: string; // Required — identifies which provider owns this model
 }
 
 export interface SwitchModelResponse {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -509,7 +509,7 @@ export interface APIClient {
 
 	// Models
 	getCurrentModel(sessionId: string): Promise<GetCurrentModelResponse>;
-	switchModel(sessionId: string, model: string): Promise<SwitchModelResponse>;
+	switchModel(sessionId: string, model: string, provider: string): Promise<SwitchModelResponse>;
 
 	// Providers
 	listProviders(): Promise<ListProvidersResponse>;

--- a/packages/web/src/components/InputActionsMenu.tsx
+++ b/packages/web/src/components/InputActionsMenu.tsx
@@ -26,7 +26,7 @@ export interface InputActionsMenuProps {
 	availableModels?: ModelInfo[];
 	modelSwitching?: boolean;
 	modelLoading?: boolean;
-	onModelSwitch?: (modelId: string, providerId: string) => void;
+	onModelSwitch?: (model: ModelInfo) => void;
 	/** Auto-scroll state */
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'preact/hooks';
-import type { MessageDeliveryMode, MessageImage, SessionType } from '@neokai/shared';
+import type { MessageDeliveryMode, MessageImage, ModelInfo, SessionType } from '@neokai/shared';
 import { isAgentWorking } from '../lib/state.ts';
 import { connectionManager } from '../lib/connection-manager';
 import { AttachmentPreview } from './AttachmentPreview.tsx';
@@ -239,8 +239,8 @@ export default function MessageInput({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string, providerId: string) => {
-			await switchModel(modelId, providerId);
+		async (model: ModelInfo) => {
+			await switchModel(model);
 			actionsMenu.close();
 		},
 		[switchModel, actionsMenu]

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -144,7 +144,7 @@ interface SessionStatusBarProps {
 	availableModels: ModelInfo[];
 	modelSwitching: boolean;
 	modelLoading: boolean;
-	onModelSwitch: (modelId: string, providerId: string) => void;
+	onModelSwitch: (model: ModelInfo) => void;
 	// Auto-scroll
 	autoScroll: boolean;
 	onAutoScrollChange: (enabled: boolean) => void;
@@ -243,8 +243,8 @@ export default function SessionStatusBar({
 
 	// Model switch handler
 	const handleModelSwitch = useCallback(
-		async (modelId: string, providerId: string) => {
-			await onModelSwitch(modelId, providerId);
+		async (model: ModelInfo) => {
+			await onModelSwitch(model);
 			modelDropdown.close();
 		},
 		[onModelSwitch, modelDropdown]
@@ -381,7 +381,7 @@ export default function SessionStatusBar({
 									class={`w-full text-left px-3 py-2 hover:bg-dark-700 text-xs flex items-center gap-2 ${
 										model.id === currentModelInfo?.id ? 'text-blue-400' : 'text-gray-200'
 									}`}
-									onClick={() => handleModelSwitch(model.alias, model.provider)}
+									onClick={() => handleModelSwitch(model)}
 									disabled={modelSwitching}
 								>
 									<span class="text-base">{getModelFamilyIcon(model.family)}</span>

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -428,7 +428,9 @@ describe('SessionStatusBar', () => {
 			const opusButton = buttons.find((btn) => btn.textContent?.includes('Opus 4.5'));
 			fireEvent.click(opusButton!);
 
-			expect(mockOnModelSwitch).toHaveBeenCalledWith('opus', 'anthropic');
+			expect(mockOnModelSwitch).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'opus', family: 'opus' })
+			);
 		});
 
 		it('should close model dropdown when clicking it again', () => {

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -684,6 +684,60 @@ describe('useModelSwitcher', () => {
 		});
 	});
 
+	describe('switchModel - cross-provider', () => {
+		it('should match currentModelInfo by provider after cross-provider switch', async () => {
+			// Two providers both expose claude-sonnet-4-20250514; the post-switch find must
+			// prefer the entry for the provider that was actually switched to.
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockResolvedValueOnce({
+						currentModel: 'claude-sonnet-4-20250514',
+						modelInfo: null,
+					})
+					.mockResolvedValueOnce({
+						models: [
+							{
+								id: 'claude-sonnet-4-20250514',
+								display_name: 'Sonnet (Anthropic)',
+								description: '',
+								provider: 'anthropic',
+							},
+							{
+								id: 'claude-sonnet-4-20250514',
+								display_name: 'Sonnet (Copilot)',
+								description: '',
+								provider: 'anthropic-copilot',
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						model: 'claude-sonnet-4-20250514',
+					}),
+			};
+			mockGetHubIfConnected.mockReturnValue(mockHub);
+
+			const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			await act(async () => {
+				// Switch to the copilot variant
+				await result.current.switchModel({
+					id: 'claude-sonnet-4-20250514',
+					provider: 'anthropic-copilot',
+				});
+			});
+
+			// Should resolve to the copilot entry, not the anthropic one
+			expect(result.current.currentModelInfo?.provider).toBe('anthropic-copilot');
+			expect(result.current.currentModelInfo?.name).toBe('Sonnet (Copilot)');
+		});
+	});
+
 	describe('switchModel - provider validation', () => {
 		it('should show error when provider is missing from model', async () => {
 			const mockHub = {

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -429,7 +429,7 @@ describe('useModelSwitcher', () => {
 					.fn()
 					.mockResolvedValueOnce({
 						currentModel: 'claude-sonnet-4-20250514',
-						modelInfo: { id: 'claude-sonnet-4-20250514', name: 'Sonnet' },
+						modelInfo: { id: 'claude-sonnet-4-20250514', name: 'Sonnet', provider: 'anthropic' },
 					})
 					.mockResolvedValueOnce({ models: [] }),
 			};
@@ -442,7 +442,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-sonnet-4-20250514', 'anthropic');
+				await result.current.switchModel({ id: 'claude-sonnet-4-20250514', provider: 'anthropic' });
 			});
 
 			expect(mockToastInfo).toHaveBeenCalledWith(expect.stringContaining('Already using'));
@@ -476,7 +476,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(result.current.currentModel).toBe('claude-opus-4-5-20251101');
@@ -506,7 +506,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Model not available');
@@ -534,7 +534,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Failed to switch model');
@@ -562,7 +562,7 @@ describe('useModelSwitcher', () => {
 			mockGetHubIfConnected.mockReturnValue(null);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Not connected to server');
@@ -598,7 +598,7 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(mockToastError).toHaveBeenCalledWith('Connection lost');
@@ -634,7 +634,7 @@ describe('useModelSwitcher', () => {
 			switchingStates.push(result.current.switching);
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			// After switch completes, should not be switching
@@ -677,10 +677,39 @@ describe('useModelSwitcher', () => {
 			});
 
 			await act(async () => {
-				await result.current.switchModel('claude-opus-4-5-20251101', 'anthropic');
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101', provider: 'anthropic' });
 			});
 
 			expect(result.current.currentModelInfo?.id).toBe('claude-opus-4-5-20251101');
+		});
+	});
+
+	describe('switchModel - provider validation', () => {
+		it('should show error when provider is missing from model', async () => {
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockResolvedValueOnce({
+						currentModel: 'claude-sonnet-4-20250514',
+						modelInfo: null,
+					})
+					.mockResolvedValueOnce({ models: [] }),
+			};
+			mockGetHubIfConnected.mockReturnValue(mockHub);
+
+			const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			await act(async () => {
+				await result.current.switchModel({ id: 'claude-opus-4-5-20251101' });
+			});
+
+			expect(mockToastError).toHaveBeenCalledWith('Model provider information is missing');
+			// Should not have made an RPC call for the switch
+			expect(mockHub.request).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
 		});
 	});
 

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -208,7 +208,12 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 
 				if (result.success) {
 					setCurrentModel(result.model);
-					const newModelInfo = availableModels.find((m) => m.id === result.model);
+					// Match by both id AND provider to avoid returning the wrong entry when
+					// two providers share the same canonical model ID (e.g. anthropic and
+					// anthropic-copilot both expose claude-sonnet-4.6).
+					const newModelInfo =
+						availableModels.find((m) => m.id === result.model && m.provider === model.provider) ??
+						availableModels.find((m) => m.id === result.model);
 					setCurrentModelInfo(newModelInfo || null);
 					toast.success(`Switched to ${newModelInfo?.name || result.model}`);
 				} else {

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -33,8 +33,8 @@ export interface UseModelSwitcherResult {
 	switching: boolean;
 	/** Whether models are being loaded */
 	loading: boolean;
-	/** Switch to a different model. Both model ID and provider ID must be supplied. */
-	switchModel: (modelId: string, providerId: string) => Promise<void>;
+	/** Switch to a different model */
+	switchModel: (model: ModelInfo) => Promise<void>;
 	/** Reload model info */
 	reload: () => Promise<void>;
 }
@@ -177,8 +177,13 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 	}, [loadModelInfo]);
 
 	const switchModel = useCallback(
-		async (newModelId: string, newProviderId: string) => {
-			if (newModelId === currentModel) {
+		async (model: ModelInfo) => {
+			if (!model.provider) {
+				toast.error('Model provider information is missing');
+				return;
+			}
+
+			if (model.id === currentModel && model.provider === currentModelInfo?.provider) {
 				toast.info(`Already using ${currentModelInfo?.name || currentModel}`);
 				return;
 			}
@@ -193,8 +198,8 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 
 				const result = (await hub.request('session.model.switch', {
 					sessionId,
-					model: newModelId,
-					provider: newProviderId,
+					model: model.id,
+					provider: model.provider,
 				})) as {
 					success: boolean;
 					model: string;

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -19,6 +19,7 @@
 import type {
 	MessageDeliveryMode,
 	MessageImage,
+	ModelInfo,
 	ResolvedQuestion,
 	SessionFeatures,
 } from '@neokai/shared';
@@ -403,14 +404,14 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 
 	// Model switch with processing confirmation
 	const handleModelSwitchWithConfirmation = useCallback(
-		async (modelId: string, providerId: string) => {
+		async (model: ModelInfo) => {
 			if (isProcessing) {
 				const confirmed = confirm(
 					'The agent is currently processing. Switching the model will interrupt the current operation. Continue?'
 				);
 				if (!confirmed) return;
 			}
-			await switchModel(modelId, providerId);
+			await switchModel(model);
 		},
 		[switchModel, isProcessing]
 	);


### PR DESCRIPTION
## Summary

Enforce strict provider-aware model resolution across the full stack. Previously, `getModelInfo` / `resolveModelAlias` accepted an optional provider hint and silently fell back to a first-match when it was absent — making resolution non-deterministic when multiple providers (e.g. `anthropic` and `anthropic-copilot`) expose the same canonical model ID like `claude-sonnet-4.6`.

## Changes

### `packages/daemon/src/lib/model-service.ts`
- `getModelInfo(id, cacheKey, providerId)`, `resolveModelAlias`, `isValidModel` — `providerId` is now **required**; no silent fallback to unfiltered search
- Cache keyed by `provider:id` (not `id` alone) so same-model-ID entries from different providers both survive
- `getModelInfoUnfiltered` / `resolveModelAliasUnfiltered` — explicit escape hatches for the handful of internal callers that genuinely lack provider context (documented with JSDoc)

### `packages/daemon/src/lib/agent/model-switch-handler.ts`
- `switchModel(model, provider)` — both params required
- "Already using this model" early-exit now compares **both** model ID and provider
- Removed unreachable heuristic-fallback branch; simplified to direct `detectProviderForModel` call

### `packages/daemon/src/lib/rpc-handlers/session-handlers.ts`
- `session.model.switch` RPC — throws `"Missing required field: provider"` if omitted
- `session.model.get` RPC — throws `"Session has no provider configured"` if session is misconfigured

### `packages/daemon/src/lib/rpc-handlers/config-handlers.ts`
- Removed `?? 'anthropic'` silent fallback; logs a warning and records an error when session has no provider

### `packages/daemon/src/lib/agent/event-subscription-setup.ts`
- Removed silent two-level fallback chain; errors propagate correctly

### `packages/shared/src/api.ts`
- `SwitchModelRequest` interface updated to include `provider: string`

### Web UI
- `useModelSwitcher` — `switchModel` now accepts `ModelInfo` (not a bare string ID) so provider is structurally guaranteed at the call site; post-switch state lookup matches by both `id` and `provider` to prevent stale cross-provider entries
- `SessionStatusBar`, `ChatContainer`, `MessageInput`, `InputActionsMenu` updated accordingly

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] `cd packages/daemon && bun test tests/unit/` — all tests pass (includes new cases for provider-filtered lookup, alias resolution, missing-provider error paths, cross-provider "already using" check, and `initializeModels` cache deduplication)
- [ ] `cd packages/web && bunx vitest run` — all tests pass (includes new cross-provider `currentModelInfo` stale-entry test)
- [ ] Manual: switching models between `anthropic` and `anthropic-copilot` sessions resolves to the correct provider's model entry