### PR TITLE
feat: remove openai/google from PROVIDER_LABELS, add anthropic-codex

### DIFF
--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -142,9 +142,8 @@ describe('useModelSwitcher', () => {
 		it('should return correct label for known providers', () => {
 			expect(getProviderLabel('anthropic')).toBe('Anthropic');
 			expect(getProviderLabel('glm')).toBe('GLM');
-			expect(getProviderLabel('openai')).toBe('OpenAI');
 			expect(getProviderLabel('anthropic-copilot')).toBe('Copilot');
-			expect(getProviderLabel('google')).toBe('Google');
+			expect(getProviderLabel('anthropic-codex')).toBe('Codex');
 		});
 
 		it('should return the provider string for unknown providers', () => {
@@ -260,39 +259,6 @@ describe('useModelSwitcher', () => {
 			const glmModel = result.current.availableModels.find((m) => m.id === 'glm-4-plus');
 			expect(glmModel?.provider).toBe('glm');
 			expect(glmModel?.family).toBe('glm');
-		});
-
-		it('should detect gpt family and openai provider for OpenAI models', async () => {
-			const mockHub = {
-				request: vi
-					.fn()
-					.mockResolvedValueOnce({
-						currentModel: 'gpt-5.3-codex',
-						modelInfo: null,
-					})
-					.mockResolvedValueOnce({
-						models: [
-							{
-								id: 'gpt-5.3-codex',
-								display_name: 'GPT-5.3 Codex',
-								description: '',
-								provider: 'openai',
-							},
-							{ id: 'gpt-5-mini', display_name: 'GPT-5 Mini', description: '', provider: 'openai' },
-						],
-					}),
-			};
-			mockGetHubIfConnected.mockReturnValue(mockHub);
-
-			const { result } = renderHook(() => useModelSwitcher('session-1'));
-
-			await waitFor(() => {
-				expect(result.current.loading).toBe(false);
-			});
-
-			const gptModel = result.current.availableModels.find((m) => m.id === 'gpt-5.3-codex');
-			expect(gptModel?.provider).toBe('openai');
-			expect(gptModel?.family).toBe('gpt');
 		});
 
 		it('should detect gpt family and anthropic-copilot provider for Copilot GPT models', async () => {

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -75,9 +75,8 @@ export const PROVIDER_LABELS: Record<string, string> = {
 	anthropic: 'Anthropic',
 	glm: 'GLM',
 	minimax: 'MiniMax',
-	openai: 'OpenAI',
 	'anthropic-copilot': 'Copilot',
-	google: 'Google',
+	'anthropic-codex': 'Codex',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Remove `openai: 'OpenAI'` and `google: 'Google'` from `PROVIDER_LABELS` in `useModelSwitcher.ts`
- Add `'anthropic-codex': 'Codex'` (the only missing entry)
- Keep `gpt`/`gemini` in `FAMILY_ORDER` and `MODEL_FAMILY_ICONS` — both are used by `anthropic-copilot` bridge models, not exclusively OpenAI/Google
- Remove dead test assertions for `openai`/`google` labels and the OpenAI-specific family detection test

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings/errors
- [x] `cd packages/web && bunx vitest run` — 3709/3709 passed