### PR TITLE
feat: recurring missions — scheduling with execution identity and recovery (Task 3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.77",
         "@github/copilot-sdk": "^0.1.32",
         "@neokai/shared": "workspace:*",
+        "croner": "^10.0.1",
         "simple-git": "3.33.0",
         "zod": "4.3.6",
       },
@@ -602,6 +603,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookies": ["cookies@0.9.1", "", { "dependencies": { "depd": "~2.0.0", "keygrip": "~1.1.0" } }, "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw=="],
+
+    "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -22,6 +22,7 @@
 		"@anthropic-ai/claude-agent-sdk": "0.2.77",
 		"@github/copilot-sdk": "^0.1.32",
 		"@neokai/shared": "workspace:*",
+		"croner": "^10.0.1",
 		"simple-git": "3.33.0",
 		"zod": "4.3.6"
 	},

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -15,7 +15,7 @@ import {
 	type CreateGoalParams,
 } from '../../../storage/repositories/goal-repository';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
-import type { RoomGoal, GoalStatus, GoalPriority } from '@neokai/shared';
+import type { RoomGoal, GoalStatus, GoalPriority, MissionExecution } from '@neokai/shared';
 
 export class GoalManager {
 	private goalRepo: GoalRepository;
@@ -34,10 +34,8 @@ export class GoalManager {
 	 */
 	async createGoal(params: Omit<CreateGoalParams, 'roomId'>): Promise<RoomGoal> {
 		const goal = this.goalRepo.createGoal({
+			...params,
 			roomId: this.roomId,
-			title: params.title,
-			description: params.description,
-			priority: params.priority,
 		});
 
 		return goal;
@@ -58,6 +56,15 @@ export class GoalManager {
 	 * List goals with optional status filter
 	 */
 	async listGoals(status?: GoalStatus): Promise<RoomGoal[]> {
+		return this.goalRepo.listGoals(this.roomId, status);
+	}
+
+	/**
+	 * Synchronous version of listGoals. All bun:sqlite operations are synchronous;
+	 * this avoids the extra microtask yield from the async wrapper when callers
+	 * need to check for recurring goals without introducing async scheduling side-effects.
+	 */
+	listGoalsSync(status?: GoalStatus): RoomGoal[] {
 		return this.goalRepo.listGoals(this.roomId, status);
 	}
 
@@ -143,6 +150,40 @@ export class GoalManager {
 		const updatedGoal = this.goalRepo.linkTaskToGoal(goalId, taskId);
 		if (!updatedGoal) {
 			throw new Error(`Failed to link task to goal: ${goalId}`);
+		}
+
+		// Recalculate progress
+		await this.recalculateProgress(goalId);
+
+		return this.getGoal(goalId) as Promise<RoomGoal>;
+	}
+
+	/**
+	 * Atomically link a task to a recurring mission execution AND the parent goal.
+	 *
+	 * Use this for all recurring-mission task linkage. It writes to both
+	 * mission_executions.task_ids and goals.linked_task_ids in one transaction.
+	 * For non-recurring missions, use linkTaskToGoal() instead.
+	 */
+	async linkTaskToExecution(
+		goalId: string,
+		executionId: string,
+		taskId: string
+	): Promise<RoomGoal> {
+		const goal = await this.getGoal(goalId);
+		if (!goal) {
+			throw new Error(`Goal not found: ${goalId}`);
+		}
+
+		// Verify task exists in this room
+		const task = this.taskRepo.getTask(taskId);
+		if (!task || task.roomId !== this.roomId) {
+			throw new Error(`Task not found in this room: ${taskId}`);
+		}
+
+		const updatedGoal = this.goalRepo.linkTaskToExecution(goalId, executionId, taskId);
+		if (!updatedGoal) {
+			throw new Error(`Failed to link task to execution: ${executionId}`);
 		}
 
 		// Recalculate progress
@@ -295,6 +336,86 @@ export class GoalManager {
 			throw new Error(`Failed to update planning_attempts for goal: ${goalId}`);
 		}
 		return updatedGoal;
+	}
+
+	// =========================================================================
+	// Mission Execution management (recurring missions)
+	// =========================================================================
+
+	/**
+	 * Get the currently running execution for a recurring mission.
+	 * Returns null if no execution is running (or if this is not a recurring mission).
+	 */
+	getActiveExecution(goalId: string): MissionExecution | null {
+		return this.goalRepo.getActiveExecution(goalId);
+	}
+
+	/**
+	 * Start a new execution for a recurring mission.
+	 * Atomically:
+	 *   1. Clears goals.linked_task_ids (so this execution starts fresh)
+	 *   2. Inserts a new mission_executions row with the next execution_number
+	 *
+	 * Returns the new MissionExecution record.
+	 * Throws if the goal does not exist.
+	 */
+	startExecution(goalId: string): MissionExecution {
+		const goal = this.goalRepo.getGoal(goalId);
+		if (!goal) {
+			throw new Error(`Goal not found: ${goalId}`);
+		}
+		const executionNumber = this.goalRepo.getNextExecutionNumber(goalId);
+		// Clear linked_task_ids so the new execution starts with an empty task list
+		this.goalRepo.clearLinkedTaskIds(goalId);
+		return this.goalRepo.insertExecution({ goalId, executionNumber });
+	}
+
+	/**
+	 * Mark an execution as completed and optionally record a result summary.
+	 * Returns the updated MissionExecution or null if not found.
+	 */
+	completeExecution(executionId: string, resultSummary?: string): MissionExecution | null {
+		const now = Math.floor(Date.now() / 1000);
+		return this.goalRepo.updateExecution(executionId, {
+			status: 'completed',
+			completedAt: now,
+			resultSummary,
+		});
+	}
+
+	/**
+	 * Mark an execution as failed.
+	 * Returns the updated MissionExecution or null if not found.
+	 */
+	failExecution(executionId: string, resultSummary?: string): MissionExecution | null {
+		const now = Math.floor(Date.now() / 1000);
+		return this.goalRepo.updateExecution(executionId, {
+			status: 'failed',
+			completedAt: now,
+			resultSummary,
+		});
+	}
+
+	/**
+	 * Update the next_run_at timestamp for a recurring mission.
+	 */
+	async updateNextRunAt(goalId: string, nextRunAt: number | null): Promise<RoomGoal> {
+		const goal = await this.getGoal(goalId);
+		if (!goal) {
+			throw new Error(`Goal not found: ${goalId}`);
+		}
+		const updated = this.goalRepo.updateGoal(goalId, { nextRunAt });
+		if (!updated) {
+			throw new Error(`Failed to update nextRunAt for goal: ${goalId}`);
+		}
+		return updated;
+	}
+
+	/**
+	 * List executions for a goal (most recent first).
+	 */
+	listExecutions(goalId: string, limit?: number): MissionExecution[] {
+		return this.goalRepo.listExecutions(goalId, limit);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -351,23 +351,26 @@ export class GoalManager {
 	}
 
 	/**
-	 * Start a new execution for a recurring mission.
-	 * Atomically:
-	 *   1. Clears goals.linked_task_ids (so this execution starts fresh)
-	 *   2. Inserts a new mission_executions row with the next execution_number
+	 * Atomically start a new execution for a recurring mission.
+	 * In a single SQLite transaction:
+	 *   1. Clears goals.linked_task_ids (fresh task list per execution)
+	 *   2. Resets goals.planning_attempts to 0 (per-execution counter)
+	 *   3. Inserts mission_executions row with the next execution_number
+	 *   4. Advances goals.next_run_at (optional — avoids a separate updateNextRunAt call)
+	 *
+	 * Passing nextRunAt here prevents the window between insertExecution and a
+	 * subsequent updateNextRunAt where a crash could leave an execution running
+	 * with an expired next_run_at (which would be stuck due to overlap prevention).
 	 *
 	 * Returns the new MissionExecution record.
 	 * Throws if the goal does not exist.
 	 */
-	startExecution(goalId: string): MissionExecution {
+	startExecution(goalId: string, nextRunAt?: number): MissionExecution {
 		const goal = this.goalRepo.getGoal(goalId);
 		if (!goal) {
 			throw new Error(`Goal not found: ${goalId}`);
 		}
-		const executionNumber = this.goalRepo.getNextExecutionNumber(goalId);
-		// Clear linked_task_ids so the new execution starts with an empty task list
-		this.goalRepo.clearLinkedTaskIds(goalId);
-		return this.goalRepo.insertExecution({ goalId, executionNumber });
+		return this.goalRepo.atomicStartExecution(goalId, nextRunAt);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/cron-utils.ts
+++ b/packages/daemon/src/lib/room/runtime/cron-utils.ts
@@ -16,7 +16,7 @@ import { Cron } from 'croner';
  * Parse and validate a cron expression (including presets).
  * Returns null if the expression is invalid.
  */
-export function parseCronExpression(expression: string): boolean {
+export function isValidCronExpression(expression: string): boolean {
 	// Normalize presets before passing to croner
 	const normalized = normalizePreset(expression);
 	try {

--- a/packages/daemon/src/lib/room/runtime/cron-utils.ts
+++ b/packages/daemon/src/lib/room/runtime/cron-utils.ts
@@ -1,0 +1,91 @@
+/**
+ * Cron utilities for recurring mission scheduling.
+ *
+ * Thin wrapper around the `croner` library with timezone support.
+ * Precision note: up to 30s jitter from the scheduler tick interval (acceptable for @hourly+).
+ *
+ * Supported formats:
+ * - 5-field cron: `0 9 * * *` (minute hour dom month dow)
+ * - Presets: `@hourly`, `@daily`, `@weekly`, `@monthly`, `@yearly`/`@annually`
+ * - `@midnight` (alias for `@daily`)
+ */
+
+import { Cron } from 'croner';
+
+/**
+ * Parse and validate a cron expression (including presets).
+ * Returns null if the expression is invalid.
+ */
+export function parseCronExpression(expression: string): boolean {
+	// Normalize presets before passing to croner
+	const normalized = normalizePreset(expression);
+	try {
+		// Attempt to construct a Cron to validate — catch invalid expressions
+		const cron = new Cron(normalized, { paused: true });
+		// Check if at least one next run is calculable
+		const next = cron.nextRun();
+		return next !== null;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Calculate the next run timestamp (Unix seconds) after a given base time.
+ * Honors timezone.
+ *
+ * @param expression Cron expression or preset
+ * @param timezone IANA timezone string (e.g. "America/New_York") or "UTC"
+ * @param afterMs Epoch millis to compute next run after (default: now)
+ * @returns Unix seconds of next run, or null if the expression produces no future run
+ */
+export function getNextRunAt(
+	expression: string,
+	timezone: string,
+	afterMs?: number
+): number | null {
+	const normalized = normalizePreset(expression);
+	const startAt = afterMs !== undefined ? new Date(afterMs) : new Date();
+
+	try {
+		const cron = new Cron(normalized, {
+			timezone,
+			startAt,
+			paused: true,
+		});
+		const next = cron.nextRun();
+		if (!next) return null;
+		return Math.floor(next.getTime() / 1000);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Return the system's local IANA timezone name.
+ * Falls back to "UTC" if unavailable.
+ */
+export function getSystemTimezone(): string {
+	try {
+		return Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
+	} catch {
+		return 'UTC';
+	}
+}
+
+// ---- Preset normalization ----
+
+const PRESET_MAP: Record<string, string> = {
+	'@hourly': '0 * * * *',
+	'@daily': '0 0 * * *',
+	'@midnight': '0 0 * * *',
+	'@weekly': '0 0 * * 0',
+	'@monthly': '0 0 1 * *',
+	'@yearly': '0 0 1 1 *',
+	'@annually': '0 0 1 1 *',
+};
+
+function normalizePreset(expression: string): string {
+	const lower = expression.trim().toLowerCase();
+	return PRESET_MAP[lower] ?? expression.trim();
+}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2119,8 +2119,7 @@ export class RoomRuntime {
 	 * advance from current time (skipping missed intervals).
 	 *
 	 * Precision: up to 30s jitter from tick interval (acceptable for @hourly+).
-	 */
-	/**
+	 *
 	 * Returns void synchronously when there are no recurring goals (to preserve microtask ordering),
 	 * or a Promise<void> when async work is needed.
 	 * Call site must conditionally await: `const p = this.tickRecurringMissions(); if (p) await p;`
@@ -2148,7 +2147,23 @@ export class RoomRuntime {
 
 			// Check if all tasks for this execution are in terminal state
 			const taskIds = activeExecution.taskIds;
-			if (taskIds.length === 0) continue;
+			if (taskIds.length === 0) {
+				// Orphan guard: execution has been running with no tasks for > 5 minutes.
+				// This happens if planning failed before any tasks were created (e.g. a crash
+				// between startExecution and spawnPlanningGroup). Fail it so Phase 2 can fire again.
+				const ORPHAN_THRESHOLD_SEC = 5 * 60; // 5 minutes
+				if (nowSec - activeExecution.startedAt > ORPHAN_THRESHOLD_SEC) {
+					log.warn(
+						`Recurring mission ${goal.id}: orphan execution ${activeExecution.id} ` +
+						`has no tasks after ${ORPHAN_THRESHOLD_SEC}s — failing it`
+					);
+					this.goalManager.failExecution(
+						activeExecution.id,
+						`Orphan: execution started but no tasks were created within ${ORPHAN_THRESHOLD_SEC}s.`
+					);
+				}
+				continue;
+			}
 
 			const tasks = await Promise.all(taskIds.map((id) => this.taskManager.getTask(id)));
 			const validTasks = tasks.filter(Boolean) as NonNullable<(typeof tasks)[number]>[];
@@ -2211,6 +2226,12 @@ export class RoomRuntime {
 			if (goal.nextRunAt === undefined || goal.nextRunAt === null) continue;
 			if (goal.nextRunAt > nowSec) continue; // not due yet
 
+			// Calculate next_run_at BEFORE startExecution so it is written atomically
+			// in the same transaction — prevents a crash leaving an execution running
+			// with an expired next_run_at.
+			const tz = goal.schedule.timezone ?? 'UTC';
+			const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+
 			// Check for active execution (overlap prevention — app level)
 			const activeExecution = this.goalManager.getActiveExecution(goal.id);
 			if (activeExecution) {
@@ -2219,18 +2240,17 @@ export class RoomRuntime {
 				log.warn(
 					`Recurring mission ${goal.id} (${goal.title}) due but execution ${activeExecution.id} still running — skipping trigger, advancing next_run_at`
 				);
-				const tz = goal.schedule.timezone ?? 'UTC';
-				const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
 				if (nextRunAt !== null) {
 					await this.goalManager.updateNextRunAt(goal.id, nextRunAt);
 				}
 				continue;
 			}
 
-			// Trigger a new execution (wrapped in try/catch to handle DB unique constraint)
+			// Trigger a new execution — nextRunAt is set atomically in the same transaction.
+			// try/catch handles the DB unique-constraint guard against concurrent inserts.
 			let execution;
 			try {
-				execution = this.goalManager.startExecution(goal.id);
+				execution = this.goalManager.startExecution(goal.id, nextRunAt ?? undefined);
 				log.info(
 					`Recurring mission ${goal.id} (${goal.title}) triggered execution ${execution.executionNumber}`
 				);
@@ -2241,13 +2261,6 @@ export class RoomRuntime {
 					`Recurring mission ${goal.id}: failed to start execution (possible race) — ${err}`
 				);
 				continue;
-			}
-
-			// Advance next_run_at immediately (catch-up: skip missed intervals by computing from now)
-			const tz = goal.schedule.timezone ?? 'UTC';
-			const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
-			if (nextRunAt !== null) {
-				await this.goalManager.updateNextRunAt(goal.id, nextRunAt);
 			}
 
 			// Fetch previous execution result for context
@@ -2499,8 +2512,9 @@ export class RoomRuntime {
 		// Wire up the mutable ref so isPlanApproved can query the group
 		spawnedGroupId = group.id;
 
-		// For recurring missions, persist the execution ID in group metadata so
-		// recoverZombieGroups() can correlate the group back to mission_executions after restart.
+		// For recurring missions, persist the execution ID in group metadata.
+		// recoverZombieGroups() stores it for auditability; the actual execution state
+		// is recovered via getActiveExecution() which reads mission_executions directly.
 		if (isRecurringExecution) {
 			this.groupRepo.setExecutionId(group.id, executionId);
 		}
@@ -2763,7 +2777,14 @@ export class RoomRuntime {
 			attempt: attempts + 1,
 		};
 
-		await this.spawnPlanningGroup(goal, replanContext);
+		// For recurring missions, pass the active executionId so task-linking uses
+		// linkTaskToExecution instead of linkTaskToGoal (execution identity preserved).
+		const activeExecution =
+			goal.missionType === 'recurring'
+				? this.goalManager.getActiveExecution(goal.id)
+				: null;
+
+		await this.spawnPlanningGroup(goal, replanContext, activeExecution?.id);
 		this.scheduleTick();
 
 		return jsonResult({

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2137,9 +2137,9 @@ export class RoomRuntime {
 	private tickRecurringMissions(): void | Promise<void> {
 		// Synchronous pre-check — goalRepo.listGoals is a bun:sqlite synchronous call.
 		// Avoids an extra microtask yield when there are no recurring goals.
-		const recurringGoals = this.goalManager.listGoalsSync('active').filter(
-			(g) => g.missionType === 'recurring'
-		);
+		const recurringGoals = this.goalManager
+			.listGoalsSync('active')
+			.filter((g) => g.missionType === 'recurring');
 
 		if (recurringGoals.length === 0) return; // synchronous return — no microtask added
 
@@ -2147,7 +2147,6 @@ export class RoomRuntime {
 	}
 
 	private async _doTickRecurringMissions(recurringGoals: RoomGoal[]): Promise<void> {
-
 		const nowSec = Math.floor(Date.now() / 1000);
 
 		// Phase 1: Complete finished executions
@@ -2165,7 +2164,7 @@ export class RoomRuntime {
 				if (nowSec - activeExecution.startedAt > ORPHAN_THRESHOLD_SEC) {
 					log.warn(
 						`Recurring mission ${goal.id}: orphan execution ${activeExecution.id} ` +
-						`has no tasks after ${ORPHAN_THRESHOLD_SEC}s — failing it`
+							`has no tasks after ${ORPHAN_THRESHOLD_SEC}s — failing it`
 					);
 					this.goalManager.failExecution(
 						activeExecution.id,
@@ -2192,10 +2191,14 @@ export class RoomRuntime {
 
 			if (anyCompleted) {
 				this.goalManager.completeExecution(activeExecution.id, resultSummary);
-				log.info(`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} completed`);
+				log.info(
+					`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} completed`
+				);
 			} else {
 				this.goalManager.failExecution(activeExecution.id, resultSummary);
-				log.warn(`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} failed`);
+				log.warn(
+					`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} failed`
+				);
 			}
 
 			// Advance next_run_at from current time
@@ -2678,9 +2681,7 @@ export class RoomRuntime {
 			// For recurring missions look up the active execution so that
 			// mission_executions.task_ids is also populated (same as the primary path).
 			const activeExecution =
-				goal.missionType === 'recurring'
-					? this.goalManager.getActiveExecution(goal.id)
-					: null;
+				goal.missionType === 'recurring' ? this.goalManager.getActiveExecution(goal.id) : null;
 			const drafts = await this.taskManager.getDraftTasksByCreator(taskId);
 			const linked = new Set(goal.linkedTaskIds ?? []);
 			for (const draft of drafts) {
@@ -2801,9 +2802,7 @@ export class RoomRuntime {
 		// For recurring missions, pass the active executionId so task-linking uses
 		// linkTaskToExecution instead of linkTaskToGoal (execution identity preserved).
 		const activeExecution =
-			goal.missionType === 'recurring'
-				? this.goalManager.getActiveExecution(goal.id)
-				: null;
+			goal.missionType === 'recurring' ? this.goalManager.getActiveExecution(goal.id) : null;
 
 		await this.spawnPlanningGroup(goal, replanContext, activeExecution?.id);
 		this.scheduleTick();

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1589,7 +1589,17 @@ export class RoomRuntime {
 						assignedAgent: params.agent,
 					});
 					if (goal) {
-						await this.goalManager.linkTaskToGoal(goal.id, newTask.id);
+						// For recurring missions, use the atomic dual-write path so that
+						// mission_executions.task_ids stays in sync after a daemon restart.
+						const activeExecution =
+							goal.missionType === 'recurring'
+								? this.goalManager.getActiveExecution(goal.id)
+								: null;
+						if (activeExecution) {
+							await this.goalManager.linkTaskToExecution(goal.id, activeExecution.id, newTask.id);
+						} else {
+							await this.goalManager.linkTaskToGoal(goal.id, newTask.id);
+						}
 					}
 					log.info(`Planning (restored) created draft task: ${newTask.id} (${newTask.title})`);
 					return { id: newTask.id, title: newTask.title };
@@ -2659,16 +2669,27 @@ export class RoomRuntime {
 		if (!task || task.taskType !== 'planning') return;
 
 		// Safety net: ensure all draft children are linked to the same goal
-		// as the planning task. MCP server closures may have been lost on
-		// daemon restart, so linkTaskToGoal may not have been called.
+		// (and execution for recurring missions) as the planning task.
+		// MCP server closures may have been lost on daemon restart, so the
+		// link call may not have fired during the original planning session.
 		const goals = await this.goalManager.getGoalsForTask(taskId);
 		const goal = goals[0];
 		if (goal) {
+			// For recurring missions look up the active execution so that
+			// mission_executions.task_ids is also populated (same as the primary path).
+			const activeExecution =
+				goal.missionType === 'recurring'
+					? this.goalManager.getActiveExecution(goal.id)
+					: null;
 			const drafts = await this.taskManager.getDraftTasksByCreator(taskId);
 			const linked = new Set(goal.linkedTaskIds ?? []);
 			for (const draft of drafts) {
 				if (!linked.has(draft.id)) {
-					await this.goalManager.linkTaskToGoal(goal.id, draft.id);
+					if (activeExecution) {
+						await this.goalManager.linkTaskToExecution(goal.id, activeExecution.id, draft.id);
+					} else {
+						await this.goalManager.linkTaskToGoal(goal.id, draft.id);
+					}
 					log.info(`Linked draft task ${draft.id} to goal ${goal.id} (safety net)`);
 				}
 			}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -66,6 +66,7 @@ import {
 	type LeaderCompleteHookContext,
 } from './lifecycle-hooks';
 import { checkDeadLoop, DEFAULT_DEAD_LOOP_CONFIG, type DeadLoopConfig } from './dead-loop-detector';
+import { getNextRunAt } from './cron-utils';
 
 const log = new Logger('room-runtime');
 
@@ -2020,7 +2021,9 @@ export class RoomRuntime {
 
 	private async executeTick(): Promise<void> {
 		// Safety net: detect and recover zombie groups (sessions missing from cache).
-		// Sync detection avoids unnecessary microtask checkpoints in the common case.
+		// Ordering: zombie recovery runs BEFORE tickRecurringMissions so that any
+		// in-flight execution from a prior restart is recovered first, preventing a
+		// duplicate catch-up trigger from the scheduler.
 		const zombies = this.findZombieGroups();
 		if (zombies.length > 0) {
 			await this.recoverZombieGroups(zombies);
@@ -2030,6 +2033,19 @@ export class RoomRuntime {
 		// This recovers cases where the observer callback fired but the routing failed silently.
 		// Note: synchronous scan, only fires async work as fire-and-forget if stuck workers are found.
 		this.recoverStuckWorkers();
+
+		// Recurring mission scheduler: check for due missions and trigger new executions.
+		// Also checks for completed executions to advance next_run_at.
+		// Runs only when runtime is in 'running' state (enforced by tick() guard above).
+		// tickRecurringMissions() returns void (synchronously) when there are no recurring goals,
+		// or Promise<void> when async work is needed — only await in the latter case to preserve
+		// the microtask-ordering behaviour that existing tests depend on.
+		const recurringWork = this.tickRecurringMissions();
+		if (recurringWork !== undefined) {
+			await recurringWork;
+			// Bail out early if the runtime was stopped during the async recurring mission work.
+			if (this.state !== 'running') return;
+		}
 
 		// Check capacity — groups awaiting human review don't consume slots
 		const activeGroups = this.groupRepo
@@ -2086,6 +2102,167 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Scheduler tick for recurring missions.
+	 *
+	 * Two phases per tick:
+	 * Phase 1 — Completion check: for each recurring goal with a running execution,
+	 *   check whether all of its tasks have reached a terminal state. If so, mark
+	 *   the execution as completed and advance next_run_at.
+	 * Phase 2 — Trigger check: for each recurring goal where next_run_at <= now
+	 *   AND schedule_paused = false AND no active execution, start a new execution.
+	 *
+	 * Overlap prevention: enforced at two levels —
+	 *   (1) DB partial unique index on mission_executions(goal_id) WHERE status='running'
+	 *   (2) App-level check via getActiveExecution() before insert
+	 *
+	 * Catch-up: if next_run_at is in the past, fire once immediately, then
+	 * advance from current time (skipping missed intervals).
+	 *
+	 * Precision: up to 30s jitter from tick interval (acceptable for @hourly+).
+	 */
+	/**
+	 * Returns void synchronously when there are no recurring goals (to preserve microtask ordering),
+	 * or a Promise<void> when async work is needed.
+	 * Call site must conditionally await: `const p = this.tickRecurringMissions(); if (p) await p;`
+	 */
+	private tickRecurringMissions(): void | Promise<void> {
+		// Synchronous pre-check — goalRepo.listGoals is a bun:sqlite synchronous call.
+		// Avoids an extra microtask yield when there are no recurring goals.
+		const recurringGoals = this.goalManager.listGoalsSync('active').filter(
+			(g) => g.missionType === 'recurring'
+		);
+
+		if (recurringGoals.length === 0) return; // synchronous return — no microtask added
+
+		return this._doTickRecurringMissions(recurringGoals);
+	}
+
+	private async _doTickRecurringMissions(recurringGoals: RoomGoal[]): Promise<void> {
+
+		const nowSec = Math.floor(Date.now() / 1000);
+
+		// Phase 1: Complete finished executions
+		for (const goal of recurringGoals) {
+			const activeExecution = this.goalManager.getActiveExecution(goal.id);
+			if (!activeExecution) continue;
+
+			// Check if all tasks for this execution are in terminal state
+			const taskIds = activeExecution.taskIds;
+			if (taskIds.length === 0) continue;
+
+			const tasks = await Promise.all(taskIds.map((id) => this.taskManager.getTask(id)));
+			const validTasks = tasks.filter(Boolean) as NonNullable<(typeof tasks)[number]>[];
+			if (validTasks.length === 0) continue;
+
+			const isTerminal = (status: string) =>
+				status === 'completed' || status === 'needs_attention' || status === 'cancelled';
+			const allTerminal = validTasks.every((t) => isTerminal(t.status));
+			if (!allTerminal) continue;
+
+			// All tasks are terminal: mark execution as completed (or failed)
+			const anyCompleted = validTasks.some((t) => t.status === 'completed');
+			const resultSummary = anyCompleted
+				? `Execution ${activeExecution.executionNumber} completed: ${validTasks.filter((t) => t.status === 'completed').length}/${validTasks.length} tasks succeeded.`
+				: `Execution ${activeExecution.executionNumber} failed: all tasks reached terminal state without completion.`;
+
+			if (anyCompleted) {
+				this.goalManager.completeExecution(activeExecution.id, resultSummary);
+				log.info(`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} completed`);
+			} else {
+				this.goalManager.failExecution(activeExecution.id, resultSummary);
+				log.warn(`Recurring mission ${goal.id} execution ${activeExecution.executionNumber} failed`);
+			}
+
+			// Advance next_run_at from current time
+			if (goal.schedule) {
+				const tz = goal.schedule.timezone ?? 'UTC';
+				const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+				if (nextRunAt !== null) {
+					await this.goalManager.updateNextRunAt(goal.id, nextRunAt);
+					log.info(
+						`Recurring mission ${goal.id} next run scheduled at ${new Date(nextRunAt * 1000).toISOString()}`
+					);
+				}
+			}
+
+			// Emit goal progress update
+			if (this.daemonHub) {
+				const updatedGoal = await this.goalManager.getGoal(goal.id);
+				if (updatedGoal) {
+					void this.daemonHub.emit('goal.progressUpdated', {
+						sessionId: `room:${this.roomId}`,
+						roomId: this.roomId,
+						goalId: goal.id,
+						progress: updatedGoal.progress,
+					});
+				}
+			}
+		}
+
+		// Phase 2: Trigger new executions for due missions
+		// Refresh goal list after Phase 1 mutations
+		const refreshedGoals = (await this.goalManager.listGoals('active')).filter(
+			(g) => g.missionType === 'recurring'
+		);
+
+		for (const goal of refreshedGoals) {
+			if (goal.schedulePaused) continue;
+			if (!goal.schedule) continue;
+			if (goal.nextRunAt === undefined || goal.nextRunAt === null) continue;
+			if (goal.nextRunAt > nowSec) continue; // not due yet
+
+			// Check for active execution (overlap prevention — app level)
+			const activeExecution = this.goalManager.getActiveExecution(goal.id);
+			if (activeExecution) {
+				// Overlap: execution still running but next_run_at is past
+				// Advance next_run_at to prevent repeated log spam on every tick
+				log.warn(
+					`Recurring mission ${goal.id} (${goal.title}) due but execution ${activeExecution.id} still running — skipping trigger, advancing next_run_at`
+				);
+				const tz = goal.schedule.timezone ?? 'UTC';
+				const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+				if (nextRunAt !== null) {
+					await this.goalManager.updateNextRunAt(goal.id, nextRunAt);
+				}
+				continue;
+			}
+
+			// Trigger a new execution (wrapped in try/catch to handle DB unique constraint)
+			let execution;
+			try {
+				execution = this.goalManager.startExecution(goal.id);
+				log.info(
+					`Recurring mission ${goal.id} (${goal.title}) triggered execution ${execution.executionNumber}`
+				);
+			} catch (err) {
+				// Unique constraint violation from DB index: another process already inserted a row.
+				// Idempotent — log and skip.
+				log.warn(
+					`Recurring mission ${goal.id}: failed to start execution (possible race) — ${err}`
+				);
+				continue;
+			}
+
+			// Advance next_run_at immediately (catch-up: skip missed intervals by computing from now)
+			const tz = goal.schedule.timezone ?? 'UTC';
+			const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+			if (nextRunAt !== null) {
+				await this.goalManager.updateNextRunAt(goal.id, nextRunAt);
+			}
+
+			// Fetch previous execution result for context
+			const prevExecutions = this.goalManager.listExecutions(goal.id, 2);
+			const prevCompleted = prevExecutions.find(
+				(e) => e.id !== execution.id && e.status === 'completed'
+			);
+			const previousResultSummary = prevCompleted?.resultSummary;
+
+			// Spawn planning group with executionId
+			await this.spawnPlanningGroup(goal, undefined, execution.id, previousResultSummary);
+		}
+	}
+
+	/**
 	 * Find the highest-priority active goal that needs planning.
 	 *
 	 * A goal needs planning when:
@@ -2100,6 +2277,9 @@ export class RoomRuntime {
 		const activeGoals = await this.goalManager.listGoals('active');
 
 		for (const goal of activeGoals) {
+			// Recurring missions are ONLY planned through the scheduler path (tickRecurringMissions).
+			// Never let the standard selector pick them up.
+			if (goal.missionType === 'recurring') continue;
 			const linkedTaskIds = goal.linkedTaskIds ?? [];
 
 			let needsPlanning: boolean;
@@ -2159,21 +2339,40 @@ export class RoomRuntime {
 	/**
 	 * Spawn a planning (Planner, Leader) group for a goal that has no tasks yet.
 	 * Creates a planning task, increments planning_attempts, and starts the group.
+	 *
+	 * For recurring missions, pass executionId to correlate the group with the
+	 * mission_executions row. Pass previousResultSummary for continuity context.
 	 */
-	private async spawnPlanningGroup(goal: RoomGoal, replanContext?: ReplanContext): Promise<void> {
+	private async spawnPlanningGroup(
+		goal: RoomGoal,
+		replanContext?: ReplanContext,
+		executionId?: string,
+		previousResultSummary?: string
+	): Promise<void> {
 		const isReplan = !!replanContext;
+		const isRecurringExecution = !!executionId;
+
 		// Create the planning task itself
 		const planningTask = await this.taskManager.createTask({
 			title: isReplan ? `Replan: ${goal.title}` : `Plan: ${goal.title}`,
 			description: isReplan
 				? `Replan the goal "${goal.title}" after task failure. Build on completed work.`
-				: `Examine the codebase and break down the goal "${goal.title}" into concrete, executable tasks.`,
+				: isRecurringExecution
+					? `Scheduled execution of "${goal.title}".` +
+						(previousResultSummary
+							? ` Previous run result: ${previousResultSummary}`
+							: ' (first execution)')
+					: `Examine the codebase and break down the goal "${goal.title}" into concrete, executable tasks.`,
 			taskType: 'planning',
 			status: 'pending',
 		});
 
-		// Link planning task to the goal
-		await this.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+		// Link planning task to the goal (or execution for recurring missions)
+		if (isRecurringExecution) {
+			await this.goalManager.linkTaskToExecution(goal.id, executionId, planningTask.id);
+		} else {
+			await this.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+		}
 
 		// Increment planning attempts BEFORE spawning (counts attempts, not outcomes)
 		await this.goalManager.incrementPlanningAttempts(goal.id);
@@ -2192,8 +2391,12 @@ export class RoomRuntime {
 				createdByTaskId: planningTask.id,
 				assignedAgent: params.agent,
 			});
-			// Link the draft task to the goal so it appears in the room
-			await this.goalManager.linkTaskToGoal(goal.id, task.id);
+			// Link the draft task to the goal (or execution for recurring missions)
+			if (isRecurringExecution) {
+				await this.goalManager.linkTaskToExecution(goal.id, executionId, task.id);
+			} else {
+				await this.goalManager.linkTaskToGoal(goal.id, task.id);
+			}
 			log.info(`Planning created draft task: ${task.id} (${task.title})`);
 			return { id: task.id, title: task.title };
 		};
@@ -2296,12 +2499,19 @@ export class RoomRuntime {
 		// Wire up the mutable ref so isPlanApproved can query the group
 		spawnedGroupId = group.id;
 
+		// For recurring missions, persist the execution ID in group metadata so
+		// recoverZombieGroups() can correlate the group back to mission_executions after restart.
+		if (isRecurringExecution) {
+			this.groupRepo.setExecutionId(group.id, executionId);
+		}
+
 		// Notify UI: planning task is now in_progress
 		await this.emitTaskUpdateById(planningTask.id);
 		this.setupMirroring(group);
 
 		log.info(
-			`Spawned planning group for goal ${goal.id} (${goal.title}), attempt ${(goal.planning_attempts ?? 0) + 1}`
+			`Spawned planning group for goal ${goal.id} (${goal.title}), attempt ${(goal.planning_attempts ?? 0) + 1}` +
+				(isRecurringExecution ? ` [execution ${executionId}]` : '')
 		);
 	}
 

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -76,6 +76,11 @@ interface TaskGroupMetadata {
 	 * because bypass tasks have no PR.
 	 */
 	workerBypassed?: boolean;
+	/**
+	 * Links this session group to a specific mission_executions row for recurring missions.
+	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
+	 */
+	executionId?: string;
 }
 
 function defaultMetadata(): TaskGroupMetadata {
@@ -137,6 +142,11 @@ export interface SessionGroup {
 	 * When true, checkLeaderPrMerged fails open even with approved=true (no PR exists).
 	 */
 	workerBypassed: boolean;
+	/**
+	 * Links this session group to a specific mission_executions row for recurring missions.
+	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
+	 */
+	executionId?: string;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -499,6 +509,24 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Set executionId in group metadata without version check.
+	 * Links this group to a mission_executions row for recurring mission correlation.
+	 */
+	setExecutionId(groupId: string, executionId: string): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		const merged = { ...currentMeta, executionId };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
 	 * Set waitingForQuestion flag without version check.
 	 * When set, the group is paused waiting for a human answer to an agent question.
 	 */
@@ -741,6 +769,7 @@ export class SessionGroupRepository {
 			waitingForQuestion: meta.waitingForQuestion ?? false,
 			waitingSession: meta.waitingSession ?? null,
 			workerBypassed: meta.workerBypassed === true,
+			executionId: meta.executionId,
 			createdAt: row.created_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
 		};

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -866,9 +866,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 				timezone: z
 					.string()
 					.optional()
-					.describe(
-						'IANA timezone string (e.g. "America/New_York"). Defaults to system timezone.'
-					),
+					.describe('IANA timezone string (e.g. "America/New_York"). Defaults to system timezone.'),
 			},
 			(args) => handlers.set_schedule(args)
 		),

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -20,7 +20,7 @@ import type { SessionGroupRepository } from '../state/session-group-repository';
 import type { DaemonHub } from '../../daemon-hub';
 import type { RoomRuntime } from '../runtime/room-runtime';
 import { routeHumanMessageToGroup } from '../runtime/human-message-routing';
-import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../runtime/cron-utils';
+import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../runtime/cron-utils';
 
 export interface RoomAgentToolsConfig {
 	roomId: string;
@@ -569,7 +569,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					error: `Goal ${args.goal_id} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'}). Only recurring missions can have a schedule.`,
 				});
 			}
-			if (!parseCronExpression(args.cron_expression)) {
+			if (!isValidCronExpression(args.cron_expression)) {
 				return jsonResult({
 					success: false,
 					error: `Invalid cron expression: "${args.cron_expression}". Use 5-field cron (e.g. "0 9 * * *") or presets (@daily, @weekly, @hourly, @monthly).`,

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -20,6 +20,7 @@ import type { SessionGroupRepository } from '../state/session-group-repository';
 import type { DaemonHub } from '../../daemon-hub';
 import type { RoomRuntime } from '../runtime/room-runtime';
 import { routeHumanMessageToGroup } from '../runtime/human-message-routing';
+import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../runtime/cron-utils';
 
 export interface RoomAgentToolsConfig {
 	roomId: string;
@@ -127,7 +128,19 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 			if (args.goal_id) {
-				await goalManager.linkTaskToGoal(args.goal_id, task.id);
+				// For recurring missions with an active execution, use the atomic dual-write path.
+				// For all other goals, use the standard linkTaskToGoal path.
+				const linkedGoal = await goalManager.getGoal(args.goal_id);
+				if (linkedGoal?.missionType === 'recurring') {
+					const activeExecution = goalManager.getActiveExecution(args.goal_id);
+					if (activeExecution) {
+						await goalManager.linkTaskToExecution(args.goal_id, activeExecution.id, task.id);
+					} else {
+						await goalManager.linkTaskToGoal(args.goal_id, task.id);
+					}
+				} else {
+					await goalManager.linkTaskToGoal(args.goal_id, task.id);
+				}
 			}
 			// Notify runtime so it schedules a tick immediately
 			if (daemonHub) {
@@ -541,6 +554,98 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			});
 		},
 
+		async set_schedule(args: {
+			goal_id: string;
+			cron_expression: string;
+			timezone?: string;
+		}): Promise<ToolResult> {
+			const goal = await goalManager.getGoal(args.goal_id);
+			if (!goal) {
+				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+			}
+			if (goal.missionType !== 'recurring') {
+				return jsonResult({
+					success: false,
+					error: `Goal ${args.goal_id} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'}). Only recurring missions can have a schedule.`,
+				});
+			}
+			if (!parseCronExpression(args.cron_expression)) {
+				return jsonResult({
+					success: false,
+					error: `Invalid cron expression: "${args.cron_expression}". Use 5-field cron (e.g. "0 9 * * *") or presets (@daily, @weekly, @hourly, @monthly).`,
+				});
+			}
+			const tz = args.timezone ?? goal.schedule?.timezone ?? getSystemTimezone();
+			const nextRunAt = getNextRunAt(args.cron_expression, tz);
+			if (nextRunAt === null) {
+				return jsonResult({
+					success: false,
+					error: `Cron expression "${args.cron_expression}" produces no future run times.`,
+				});
+			}
+			const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
+				schedule: { expression: args.cron_expression, timezone: tz },
+				nextRunAt,
+				missionType: 'recurring',
+			});
+			return jsonResult({
+				success: true,
+				goal: updated,
+				nextRunAt,
+				nextRunAtISO: new Date(nextRunAt * 1000).toISOString(),
+			});
+		},
+
+		async pause_schedule(args: { goal_id: string }): Promise<ToolResult> {
+			const goal = await goalManager.getGoal(args.goal_id);
+			if (!goal) {
+				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+			}
+			if (goal.missionType !== 'recurring') {
+				return jsonResult({
+					success: false,
+					error: `Goal ${args.goal_id} is not a recurring mission.`,
+				});
+			}
+			const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
+				schedulePaused: true,
+			});
+			return jsonResult({ success: true, goal: updated, message: 'Schedule paused.' });
+		},
+
+		async resume_schedule(args: { goal_id: string }): Promise<ToolResult> {
+			const goal = await goalManager.getGoal(args.goal_id);
+			if (!goal) {
+				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+			}
+			if (goal.missionType !== 'recurring') {
+				return jsonResult({
+					success: false,
+					error: `Goal ${args.goal_id} is not a recurring mission.`,
+				});
+			}
+			if (!goal.schedule) {
+				return jsonResult({
+					success: false,
+					error: `Goal ${args.goal_id} has no schedule set. Use set_schedule first.`,
+				});
+			}
+			// Recalculate next_run_at from current time on resume
+			const tz = goal.schedule.timezone ?? getSystemTimezone();
+			const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+			const updated = await goalManager.updateGoalStatus(args.goal_id, goal.status, {
+				schedulePaused: false,
+				nextRunAt: nextRunAt ?? undefined,
+			});
+			return jsonResult({
+				success: true,
+				goal: updated,
+				message: 'Schedule resumed.',
+				nextRunAt,
+				nextRunAtISO: nextRunAt !== null ? new Date(nextRunAt * 1000).toISOString() : null,
+			});
+		},
+
 		async get_room_status(): Promise<ToolResult> {
 			const goals = await goalManager.listGoals();
 			const tasks = await taskManager.listTasks();
@@ -747,6 +852,37 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			'Get full details for a task including group session IDs and whether it is awaiting human review',
 			{ task_id: z.string().describe('ID of the task to get details for') },
 			(args) => handlers.get_task_detail(args)
+		),
+		tool(
+			'set_schedule',
+			'Set or update the cron schedule for a recurring mission. Supports 5-field cron expressions (e.g. "0 9 * * *") and presets: @hourly, @daily, @weekly, @monthly.',
+			{
+				goal_id: z.string().describe('ID of the recurring mission goal'),
+				cron_expression: z
+					.string()
+					.describe(
+						'Cron expression (e.g. "0 9 * * *" = 9am daily) or preset (@hourly, @daily, @weekly, @monthly)'
+					),
+				timezone: z
+					.string()
+					.optional()
+					.describe(
+						'IANA timezone string (e.g. "America/New_York"). Defaults to system timezone.'
+					),
+			},
+			(args) => handlers.set_schedule(args)
+		),
+		tool(
+			'pause_schedule',
+			'Pause the schedule for a recurring mission. While paused, the mission will not trigger automatically.',
+			{ goal_id: z.string().describe('ID of the recurring mission goal') },
+			(args) => handlers.pause_schedule(args)
+		),
+		tool(
+			'resume_schedule',
+			'Resume a paused recurring mission schedule. Recalculates next_run_at from the current time.',
+			{ goal_id: z.string().describe('ID of the recurring mission goal') },
+			(args) => handlers.resume_schedule(args)
 		),
 		tool(
 			'get_room_status',

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -19,6 +19,7 @@ import type { GoalManager } from '../room/managers/goal-manager';
 import type { TaskManager } from '../room/managers/task-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
+import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../room/runtime/cron-utils';
 
 const log = new Logger('goal-handlers');
 
@@ -33,7 +34,10 @@ export type GoalManagerLike = Pick<
 	| 'needsHumanGoal'
 	| 'reactivateGoal'
 	| 'linkTaskToGoal'
+	| 'linkTaskToExecution'
 	| 'deleteGoal'
+	| 'getActiveExecution'
+	| 'updateNextRunAt'
 >;
 
 export type GoalManagerFactory = (roomId: string) => GoalManagerLike;
@@ -258,7 +262,24 @@ export function setupGoalHandlers(
 		}
 
 		const goalManager = goalManagerFactory(params.roomId);
-		const goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
+
+		// For recurring missions with an active execution, use the atomic dual-write path.
+		let goal;
+		const linkedGoal = await goalManager.getGoal(params.goalId);
+		if (linkedGoal?.missionType === 'recurring') {
+			const activeExecution = goalManager.getActiveExecution(params.goalId);
+			if (activeExecution) {
+				goal = await goalManager.linkTaskToExecution(
+					params.goalId,
+					activeExecution.id,
+					params.taskId
+				);
+			} else {
+				goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
+			}
+		} else {
+			goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
+		}
 
 		// Emit goal.updated event (task linked and progress recalculated)
 		emitGoalUpdated(params.roomId, params.goalId, goal);
@@ -285,6 +306,102 @@ export function setupGoalHandlers(
 		emitGoalUpdated(params.roomId, params.goalId);
 
 		return { success };
+	});
+
+	// goal.setSchedule - Set or update cron schedule for a recurring mission
+	messageHub.onRequest('goal.setSchedule', async (data) => {
+		const params = data as {
+			roomId: string;
+			goalId: string;
+			cronExpression: string;
+			timezone?: string;
+		};
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+		if (!params.cronExpression) throw new Error('Cron expression is required');
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goal = await goalManager.getGoal(params.goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+		if (goal.missionType !== 'recurring') {
+			throw new Error(
+				`Goal ${params.goalId} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'})`
+			);
+		}
+		if (!parseCronExpression(params.cronExpression)) {
+			throw new Error(
+				`Invalid cron expression: "${params.cronExpression}". Use 5-field cron or presets (@daily, @weekly, @hourly, @monthly).`
+			);
+		}
+
+		const tz = params.timezone ?? goal.schedule?.timezone ?? getSystemTimezone();
+		const nextRunAt = getNextRunAt(params.cronExpression, tz);
+		if (nextRunAt === null) {
+			throw new Error(
+				`Cron expression "${params.cronExpression}" produces no future run times.`
+			);
+		}
+
+		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+			schedule: { expression: params.cronExpression, timezone: tz },
+			nextRunAt,
+			missionType: 'recurring',
+		});
+
+		emitGoalUpdated(params.roomId, params.goalId, updated);
+		return { goal: updated, nextRunAt };
+	});
+
+	// goal.pauseSchedule - Pause the schedule for a recurring mission
+	messageHub.onRequest('goal.pauseSchedule', async (data) => {
+		const params = data as { roomId: string; goalId: string };
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goal = await goalManager.getGoal(params.goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+		if (goal.missionType !== 'recurring') {
+			throw new Error(`Goal ${params.goalId} is not a recurring mission.`);
+		}
+
+		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+			schedulePaused: true,
+		});
+		emitGoalUpdated(params.roomId, params.goalId, updated);
+		return { goal: updated };
+	});
+
+	// goal.resumeSchedule - Resume a paused recurring mission schedule
+	messageHub.onRequest('goal.resumeSchedule', async (data) => {
+		const params = data as { roomId: string; goalId: string };
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goal = await goalManager.getGoal(params.goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+		if (goal.missionType !== 'recurring') {
+			throw new Error(`Goal ${params.goalId} is not a recurring mission.`);
+		}
+		if (!goal.schedule) {
+			throw new Error(
+				`Goal ${params.goalId} has no schedule set. Set a schedule first.`
+			);
+		}
+
+		// Recalculate next_run_at from current time
+		const tz = goal.schedule.timezone ?? getSystemTimezone();
+		const nextRunAt = getNextRunAt(goal.schedule.expression, tz);
+		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
+			schedulePaused: false,
+			nextRunAt: nextRunAt ?? undefined,
+		});
+		emitGoalUpdated(params.roomId, params.goalId, updated);
+		return { goal: updated, nextRunAt };
 	});
 
 	// task.approve - Human approves the PR; resume leader to complete task flow

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -19,7 +19,7 @@ import type { GoalManager } from '../room/managers/goal-manager';
 import type { TaskManager } from '../room/managers/task-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
-import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../room/runtime/cron-utils';
+import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../room/runtime/cron-utils';
 
 const log = new Logger('goal-handlers');
 
@@ -329,7 +329,7 @@ export function setupGoalHandlers(
 				`Goal ${params.goalId} is not a recurring mission (missionType=${goal.missionType ?? 'one_shot'})`
 			);
 		}
-		if (!parseCronExpression(params.cronExpression)) {
+		if (!isValidCronExpression(params.cronExpression)) {
 			throw new Error(
 				`Invalid cron expression: "${params.cronExpression}". Use 5-field cron or presets (@daily, @weekly, @hourly, @monthly).`
 			);

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -338,9 +338,7 @@ export function setupGoalHandlers(
 		const tz = params.timezone ?? goal.schedule?.timezone ?? getSystemTimezone();
 		const nextRunAt = getNextRunAt(params.cronExpression, tz);
 		if (nextRunAt === null) {
-			throw new Error(
-				`Cron expression "${params.cronExpression}" produces no future run times.`
-			);
+			throw new Error(`Cron expression "${params.cronExpression}" produces no future run times.`);
 		}
 
 		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
@@ -388,9 +386,7 @@ export function setupGoalHandlers(
 			throw new Error(`Goal ${params.goalId} is not a recurring mission.`);
 		}
 		if (!goal.schedule) {
-			throw new Error(
-				`Goal ${params.goalId} has no schedule set. Set a schedule first.`
-			);
+			throw new Error(`Goal ${params.goalId} has no schedule set. Set a schedule first.`);
 		}
 
 		// Recalculate next_run_at from current time

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -277,6 +277,40 @@ export class GoalRepository {
 	}
 
 	/**
+	 * Atomically link a task to both a mission execution and the parent goal.
+	 *
+	 * This is the single write path for recurring-mission task linkage:
+	 * - Appends taskId to mission_executions.task_ids (execution-scoped history)
+	 * - Appends taskId to goals.linked_task_ids (current execution snapshot for progress)
+	 *
+	 * For non-recurring missions use linkTaskToGoal() instead.
+	 * Returns null if the execution or goal does not exist.
+	 */
+	linkTaskToExecution(goalId: string, executionId: string, taskId: string): RoomGoal | null {
+		return this.db.transaction(() => {
+			// 1. Update mission_executions.task_ids
+			const execRow = this.db
+				.prepare(`SELECT task_ids FROM mission_executions WHERE id = ? AND goal_id = ?`)
+				.get(executionId, goalId) as { task_ids: string } | undefined;
+			if (!execRow) return null;
+
+			const execTaskIds: string[] = JSON.parse(execRow.task_ids);
+			if (!execTaskIds.includes(taskId)) {
+				execTaskIds.push(taskId);
+			}
+			this.db
+				.prepare(`UPDATE mission_executions SET task_ids = ? WHERE id = ?`)
+				.run(JSON.stringify(execTaskIds), executionId);
+
+			// 2. Update goals.linked_task_ids
+			const goal = this.getGoal(goalId);
+			if (!goal) return null;
+			const goalTaskIds = [...new Set([...goal.linkedTaskIds, taskId])];
+			return this.updateGoal(goalId, { linkedTaskIds: goalTaskIds });
+		})();
+	}
+
+	/**
 	 * Unlink a task from a goal
 	 */
 	unlinkTaskFromGoal(goalId: string, taskId: string): RoomGoal | null {
@@ -386,6 +420,27 @@ export class GoalRepository {
 	// =========================================================================
 	// Mission Executions
 	// =========================================================================
+
+	/**
+	 * Return the next execution number for a goal (max existing + 1, or 1 if none).
+	 */
+	getNextExecutionNumber(goalId: string): number {
+		const row = this.db
+			.prepare(
+				`SELECT MAX(execution_number) as max_num FROM mission_executions WHERE goal_id = ?`
+			)
+			.get(goalId) as { max_num: number | null } | undefined;
+		const maxNum = row?.max_num ?? 0;
+		return maxNum + 1;
+	}
+
+	/**
+	 * Clear linked_task_ids on a goal (used when a new recurring execution starts).
+	 * Returns updated goal or null if not found.
+	 */
+	clearLinkedTaskIds(goalId: string): RoomGoal | null {
+		return this.updateGoal(goalId, { linkedTaskIds: [] });
+	}
 
 	/**
 	 * Insert a new mission execution record

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -443,6 +443,38 @@ export class GoalRepository {
 	}
 
 	/**
+	 * Atomically start a new execution for a recurring mission.
+	 *
+	 * Wraps four mutations in a single SQLite transaction so a crash between any
+	 * two steps cannot leave the goal in an inconsistent state:
+	 *   1. Determine the next execution_number
+	 *   2. Clear goals.linked_task_ids (fresh task list for this execution)
+	 *   3. Reset goals.planning_attempts to 0 (per-execution counter)
+	 *   4. Insert the mission_executions row (status = 'running')
+	 *   5. Advance goals.next_run_at (optional — pass undefined to skip)
+	 *
+	 * The DB partial unique index on mission_executions(goal_id) WHERE status='running'
+	 * provides an additional guard against duplicate concurrent executions.
+	 */
+	atomicStartExecution(goalId: string, nextRunAt?: number): MissionExecution {
+		return this.db.transaction(() => {
+			const executionNumber = this.getNextExecutionNumber(goalId);
+
+			// Atomically clear task list, reset planning counter, and advance schedule
+			const goalUpdates: UpdateGoalParams = {
+				linkedTaskIds: [],
+				planning_attempts: 0,
+			};
+			if (nextRunAt !== undefined) {
+				goalUpdates.nextRunAt = nextRunAt;
+			}
+			this.updateGoal(goalId, goalUpdates);
+
+			return this.insertExecution({ goalId, executionNumber });
+		})();
+	}
+
+	/**
 	 * Insert a new mission execution record
 	 */
 	insertExecution(params: CreateExecutionParams): MissionExecution {

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -445,13 +445,11 @@ export class GoalRepository {
 	/**
 	 * Atomically start a new execution for a recurring mission.
 	 *
-	 * Wraps four mutations in a single SQLite transaction so a crash between any
-	 * two steps cannot leave the goal in an inconsistent state:
-	 *   1. Determine the next execution_number
-	 *   2. Clear goals.linked_task_ids (fresh task list for this execution)
-	 *   3. Reset goals.planning_attempts to 0 (per-execution counter)
-	 *   4. Insert the mission_executions row (status = 'running')
-	 *   5. Advance goals.next_run_at (optional — pass undefined to skip)
+	 * Wraps three mutations (plus one read) in a single SQLite transaction so a
+	 * crash between any two steps cannot leave the goal in an inconsistent state:
+	 *   1. Read: determine the next execution_number
+	 *   2. Write: clear goals.linked_task_ids + reset planning_attempts (+ optional next_run_at)
+	 *   3. Write: insert the mission_executions row (status = 'running')
 	 *
 	 * The DB partial unique index on mission_executions(goal_id) WHERE status='running'
 	 * provides an additional guard against duplicate concurrent executions.

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -426,9 +426,7 @@ export class GoalRepository {
 	 */
 	getNextExecutionNumber(goalId: string): number {
 		const row = this.db
-			.prepare(
-				`SELECT MAX(execution_number) as max_num FROM mission_executions WHERE goal_id = ?`
-			)
+			.prepare(`SELECT MAX(execution_number) as max_num FROM mission_executions WHERE goal_id = ?`)
 			.get(goalId) as { max_num: number | null } | undefined;
 		const maxNum = row?.max_num ?? 0;
 		return maxNum + 1;

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Recurring Missions Tests
+ *
+ * Tests for Task 3: Recurring Missions — Scheduling with Execution Identity and Recovery.
+ *
+ * Covers:
+ * - getNextGoalForPlanning() skips recurring missions
+ * - tickRecurringMissions() triggers planning when next_run_at <= now
+ * - Overlap prevention: no double-trigger if execution is running
+ * - schedule_paused prevents firing
+ * - next_run_at advances after execution completes
+ * - executionId stored in session group metadata
+ * - linkTaskToExecution atomic dual-write
+ * - GoalManager.startExecution / completeExecution / failExecution
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+	createRuntimeTestContext,
+	makeRoom,
+	type RuntimeTestContext,
+} from './room-runtime-test-helpers';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+
+// ============================================================
+// Schema extension: add mission_executions table to test DB
+// ============================================================
+
+function addMissionExecutionsTable(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mission_executions (
+			id TEXT PRIMARY KEY,
+			goal_id TEXT NOT NULL,
+			execution_number INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			status TEXT NOT NULL DEFAULT 'running',
+			result_summary TEXT,
+			task_ids TEXT NOT NULL DEFAULT '[]',
+			planning_attempts INTEGER NOT NULL DEFAULT 0,
+			FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE,
+			UNIQUE(goal_id, execution_number)
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running
+			ON mission_executions(goal_id) WHERE status = 'running';
+	`);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('Recurring Missions: getNextGoalForPlanning skips recurring', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('recurring mission is not returned by getNextGoalForPlanning', async () => {
+		// Create a recurring mission with next_run_at far in the future (not due)
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Daily standup',
+			description: 'Run daily at 9am',
+			missionType: 'recurring',
+			schedule: { expression: '0 9 * * *', timezone: 'UTC' },
+			nextRunAt: Math.floor(Date.now() / 1000) + 3600, // 1 hour in future
+		});
+
+		// Also create a regular one-shot goal needing planning
+		const oneShot = await ctx.goalManager.createGoal({
+			title: 'One-shot work',
+			description: 'Regular task',
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// The runtime should have spawned planning for the one-shot, not the recurring
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		// Only one planning group should spawn (for one-shot, not recurring)
+		expect(workerCalls.length).toBeGreaterThanOrEqual(1);
+
+		// Verify recurring goal status is unchanged (still active, no planning attempts)
+		const recurringGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(recurringGoal?.planning_attempts).toBe(0);
+
+		// Verify one-shot goal got planning attempts
+		const oneShotGoal = await ctx.goalManager.getGoal(oneShot.id);
+		expect((oneShotGoal?.planning_attempts ?? 0)).toBeGreaterThan(0);
+	});
+
+	test('recurring mission with zero linked tasks is NOT selected by standard planning', async () => {
+		await ctx.goalManager.createGoal({
+			title: 'Recurring — no tasks',
+			description: 'Should never be planned by standard selector',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// No worker sessions should be spawned (no one-shot goals, and recurring is skipped)
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(workerCalls).toHaveLength(0);
+	});
+});
+
+describe('Recurring Missions: tickRecurringMissions triggers execution', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('triggers planning when next_run_at <= now and not paused', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60; // 60s in past
+		await ctx.goalManager.createGoal({
+			title: 'Daily report',
+			description: 'Run every day',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Should have spawned a planning group
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(workerCalls.length).toBeGreaterThan(0);
+	});
+
+	test('does NOT trigger when schedule_paused is true', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		await ctx.goalManager.createGoal({
+			title: 'Paused mission',
+			description: 'Should not fire',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+			schedulePaused: true,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(workerCalls).toHaveLength(0);
+	});
+
+	test('does NOT trigger when next_run_at is in the future', async () => {
+		const futureTime = Math.floor(Date.now() / 1000) + 3600;
+		await ctx.goalManager.createGoal({
+			title: 'Future mission',
+			description: 'Not yet',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: futureTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(workerCalls).toHaveLength(0);
+	});
+
+	test('does NOT trigger when an execution is already running (overlap prevention)', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Overlap test',
+			description: 'No double trigger',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		// Manually start an execution (simulate already-running)
+		ctx.goalManager.startExecution(goal.id);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Should NOT spawn another planning group (execution already running)
+		const workerCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'createAndStartSession'
+		);
+		expect(workerCalls).toHaveLength(0);
+	});
+
+	test('advances next_run_at after triggering', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Catchup test',
+			description: 'next_run_at advances',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// next_run_at should have been advanced to a future time
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.nextRunAt).not.toBeNull();
+		expect(updatedGoal!.nextRunAt!).toBeGreaterThan(Math.floor(Date.now() / 1000));
+	});
+
+	test('creates mission_executions row on trigger', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Execution row test',
+			description: 'should create execution',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+		expect(activeExecution?.status).toBe('running');
+		expect(activeExecution?.executionNumber).toBe(1);
+	});
+
+	test('clears linked_task_ids when new execution starts', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Clear tasks test',
+			description: 'linked_task_ids should be cleared',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		// Simulate a task from a previous execution
+		const oldTask = await ctx.taskManager.createTask({
+			title: 'Old task',
+			description: 'From previous execution',
+			status: 'completed',
+		});
+		const goalRepo = new GoalRepository(ctx.db as never);
+		goalRepo.linkTaskToGoal(goal.id, oldTask.id);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// After the new execution starts, linked_task_ids should be cleared
+		// (it may contain the new planning task, but not the old task)
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		const linkedIds = updatedGoal?.linkedTaskIds ?? [];
+		expect(linkedIds).not.toContain(oldTask.id);
+	});
+});
+
+describe('GoalManager execution methods', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('startExecution creates execution row with execution_number=1 for first run', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		const execution = ctx.goalManager.startExecution(goal.id);
+		expect(execution.executionNumber).toBe(1);
+		expect(execution.status).toBe('running');
+		expect(execution.goalId).toBe(goal.id);
+	});
+
+	test('startExecution increments execution_number monotonically', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		const exec1 = ctx.goalManager.startExecution(goal.id);
+		ctx.goalManager.completeExecution(exec1.id);
+
+		const exec2 = ctx.goalManager.startExecution(goal.id);
+		expect(exec2.executionNumber).toBe(2);
+	});
+
+	test('completeExecution sets status to completed', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		const execution = ctx.goalManager.startExecution(goal.id);
+		const completed = ctx.goalManager.completeExecution(execution.id, 'All done');
+		expect(completed?.status).toBe('completed');
+		expect(completed?.resultSummary).toBe('All done');
+		expect(completed?.completedAt).toBeDefined();
+	});
+
+	test('failExecution sets status to failed', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		const execution = ctx.goalManager.startExecution(goal.id);
+		const failed = ctx.goalManager.failExecution(execution.id, 'Something went wrong');
+		expect(failed?.status).toBe('failed');
+		expect(failed?.resultSummary).toBe('Something went wrong');
+	});
+
+	test('DB partial unique index prevents two running executions', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		ctx.goalManager.startExecution(goal.id); // first execution (running)
+
+		// Attempting a second execution should throw (UNIQUE constraint on running)
+		expect(() => {
+			ctx.goalManager.startExecution(goal.id);
+		}).toThrow();
+	});
+
+	test('getActiveExecution returns null after completion', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		const execution = ctx.goalManager.startExecution(goal.id);
+		ctx.goalManager.completeExecution(execution.id);
+
+		const active = ctx.goalManager.getActiveExecution(goal.id);
+		expect(active).toBeNull();
+	});
+});
+
+describe('linkTaskToExecution atomic dual-write', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('appends task to both mission_executions.task_ids and goals.linked_task_ids', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+		const execution = ctx.goalManager.startExecution(goal.id);
+
+		const task = await ctx.taskManager.createTask({
+			title: 'Test task',
+			description: 'For execution',
+		});
+
+		await ctx.goalManager.linkTaskToExecution(goal.id, execution.id, task.id);
+
+		// Check goals.linked_task_ids
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal?.linkedTaskIds).toContain(task.id);
+
+		// Check mission_executions.task_ids
+		const updatedExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(updatedExecution?.taskIds).toContain(task.id);
+	});
+
+	test('is idempotent — linking same task twice does not duplicate', async () => {
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+		const execution = ctx.goalManager.startExecution(goal.id);
+
+		const task = await ctx.taskManager.createTask({
+			title: 'Test task',
+			description: 'For execution',
+		});
+
+		await ctx.goalManager.linkTaskToExecution(goal.id, execution.id, task.id);
+		await ctx.goalManager.linkTaskToExecution(goal.id, execution.id, task.id);
+
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		const count = updatedGoal!.linkedTaskIds.filter((id) => id === task.id).length;
+		expect(count).toBe(1);
+	});
+
+	test('throws if goal does not exist', async () => {
+		const task = await ctx.taskManager.createTask({
+			title: 'Test task',
+			description: 'No goal',
+		});
+		await expect(
+			ctx.goalManager.linkTaskToExecution('non-existent-goal', 'exec-1', task.id)
+		).rejects.toThrow();
+	});
+});
+
+describe('executionId in session group metadata', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('spawned planning group has executionId set in metadata', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Execution identity test',
+			description: 'executionId in metadata',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+
+		// Find the planning group and check its executionId metadata
+		const activeGroups = ctx.groupRepo.getActiveGroups('room-1');
+		expect(activeGroups.length).toBeGreaterThan(0);
+
+		const planningGroup = activeGroups[0];
+		expect(planningGroup.executionId).toBe(activeExecution!.id);
+	});
+});

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -96,7 +96,7 @@ describe('Recurring Missions: getNextGoalForPlanning skips recurring', () => {
 
 		// Verify one-shot goal got planning attempts
 		const oneShotGoal = await ctx.goalManager.getGoal(oneShot.id);
-		expect((oneShotGoal?.planning_attempts ?? 0)).toBeGreaterThan(0);
+		expect(oneShotGoal?.planning_attempts ?? 0).toBeGreaterThan(0);
 	});
 
 	test('recurring mission with zero linked tasks is NOT selected by standard planning', async () => {

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -484,3 +484,106 @@ describe('executionId in session group metadata', () => {
 		expect(planningGroup.executionId).toBe(activeExecution!.id);
 	});
 });
+
+describe('replan_goal + recurring mission interaction', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+		addMissionExecutionsTable(ctx.db as Database);
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	test('getActiveExecution returns running execution for handleReplanGoal to consume', async () => {
+		// Simulate what handleReplanGoal checks: is there an active execution for a recurring mission?
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Daily digest',
+			description: 'recurring',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		});
+		const execution = ctx.goalManager.startExecution(goal.id);
+
+		// handleReplanGoal calls getActiveExecution to get the executionId
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+		expect(activeExecution!.id).toBe(execution.id);
+		expect(activeExecution!.status).toBe('running');
+	});
+
+	test('atomicStartExecution resets planning_attempts to 0', async () => {
+		// Verifies that per-execution planning_attempts counter is reset atomically on
+		// each new execution (important for replan budget tracking).
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Recurring goal',
+			description: 'test',
+			missionType: 'recurring',
+		});
+
+		// Simulate two planning attempts during the first execution
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+		const afterAttempts = await ctx.goalManager.getGoal(goal.id);
+		expect(afterAttempts?.planning_attempts).toBe(2);
+
+		// Complete the execution so we can start a second one
+		const execution = ctx.goalManager.startExecution(goal.id);
+		ctx.goalManager.completeExecution(execution.id);
+
+		// New execution: planning_attempts must reset to 0 atomically
+		ctx.goalManager.startExecution(goal.id);
+		const afterRestart = await ctx.goalManager.getGoal(goal.id);
+		expect(afterRestart?.planning_attempts).toBe(0);
+	});
+
+	test('atomicStartExecution sets nextRunAt in the same transaction', async () => {
+		// Verifies that nextRunAt is advanced atomically with execution start —
+		// crash between startExecution and a separate updateNextRunAt cannot leave
+		// an expired next_run_at paired with a running execution.
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const futureTime = Math.floor(Date.now() / 1000) + 3600;
+
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Atomic schedule test',
+			description: 'test',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.goalManager.startExecution(goal.id, futureTime);
+
+		const updated = await ctx.goalManager.getGoal(goal.id);
+		expect(updated?.nextRunAt).toBe(futureTime);
+	});
+
+	test('tick triggers execution and spawns planning group for due recurring mission', async () => {
+		const pastTime = Math.floor(Date.now() / 1000) - 60;
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Due recurring mission',
+			description: 'test',
+			missionType: 'recurring',
+			schedule: { expression: '@daily', timezone: 'UTC' },
+			nextRunAt: pastTime,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const activeExecution = ctx.goalManager.getActiveExecution(goal.id);
+		expect(activeExecution).not.toBeNull();
+
+		// Planning group executionId must match the running execution
+		const activeGroups = ctx.groupRepo.getActiveGroups('room-1');
+		expect(activeGroups.length).toBeGreaterThan(0);
+		expect(activeGroups[0].executionId).toBe(activeExecution!.id);
+
+		// next_run_at must be advanced past now (atomic with execution start)
+		const updatedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(updatedGoal!.nextRunAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+	});
+});

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1637,12 +1637,15 @@ describe('Room Agent Tools', () => {
 			expect(fullServer.name).toBe('room-agent');
 		});
 
-		it('full server exposes all 14 tools', () => {
+		it('full server exposes all 17 tools', () => {
 			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(fullServer as never);
-			expect(names).toHaveLength(14);
+			expect(names).toHaveLength(17);
 			expect(names).toContain('approve_task');
 			expect(names).toContain('reject_task');
+			expect(names).toContain('set_schedule');
+			expect(names).toContain('pause_schedule');
+			expect(names).toContain('resume_schedule');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
@@ -2,45 +2,45 @@
  * cron-utils Tests
  *
  * Tests for cron expression parsing and next-run calculation:
- * - parseCronExpression: valid/invalid expressions
+ * - isValidCronExpression: valid/invalid expressions
  * - getNextRunAt: 5-field cron and preset expansion
  * - Timezone-aware scheduling
  * - getSystemTimezone fallback
  */
 
 import { describe, test, expect } from 'bun:test';
-import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../../../../src/lib/room/runtime/cron-utils';
+import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../../../../src/lib/room/runtime/cron-utils';
 
-describe('parseCronExpression', () => {
+describe('isValidCronExpression', () => {
 	test('accepts valid 5-field cron expressions', () => {
-		expect(parseCronExpression('0 9 * * *')).toBe(true);    // 9am daily
-		expect(parseCronExpression('0 0 * * *')).toBe(true);    // midnight daily
-		expect(parseCronExpression('0 0 * * 0')).toBe(true);    // weekly Sunday
-		expect(parseCronExpression('30 14 1 * *')).toBe(true);  // 2:30pm on 1st of month
-		expect(parseCronExpression('*/5 * * * *')).toBe(true);  // every 5 minutes
+		expect(isValidCronExpression('0 9 * * *')).toBe(true);    // 9am daily
+		expect(isValidCronExpression('0 0 * * *')).toBe(true);    // midnight daily
+		expect(isValidCronExpression('0 0 * * 0')).toBe(true);    // weekly Sunday
+		expect(isValidCronExpression('30 14 1 * *')).toBe(true);  // 2:30pm on 1st of month
+		expect(isValidCronExpression('*/5 * * * *')).toBe(true);  // every 5 minutes
 	});
 
 	test('accepts preset aliases', () => {
-		expect(parseCronExpression('@hourly')).toBe(true);
-		expect(parseCronExpression('@daily')).toBe(true);
-		expect(parseCronExpression('@midnight')).toBe(true);
-		expect(parseCronExpression('@weekly')).toBe(true);
-		expect(parseCronExpression('@monthly')).toBe(true);
-		expect(parseCronExpression('@yearly')).toBe(true);
-		expect(parseCronExpression('@annually')).toBe(true);
+		expect(isValidCronExpression('@hourly')).toBe(true);
+		expect(isValidCronExpression('@daily')).toBe(true);
+		expect(isValidCronExpression('@midnight')).toBe(true);
+		expect(isValidCronExpression('@weekly')).toBe(true);
+		expect(isValidCronExpression('@monthly')).toBe(true);
+		expect(isValidCronExpression('@yearly')).toBe(true);
+		expect(isValidCronExpression('@annually')).toBe(true);
 	});
 
 	test('accepts case-insensitive presets', () => {
-		expect(parseCronExpression('@DAILY')).toBe(true);
-		expect(parseCronExpression('@Daily')).toBe(true);
-		expect(parseCronExpression('@HOURLY')).toBe(true);
+		expect(isValidCronExpression('@DAILY')).toBe(true);
+		expect(isValidCronExpression('@Daily')).toBe(true);
+		expect(isValidCronExpression('@HOURLY')).toBe(true);
 	});
 
 	test('rejects invalid expressions', () => {
-		expect(parseCronExpression('')).toBe(false);
-		expect(parseCronExpression('not-a-cron')).toBe(false);
-		expect(parseCronExpression('0 25 * * *')).toBe(false);  // hour 25 is invalid
-		expect(parseCronExpression('60 * * * *')).toBe(false);  // minute 60 is invalid
+		expect(isValidCronExpression('')).toBe(false);
+		expect(isValidCronExpression('not-a-cron')).toBe(false);
+		expect(isValidCronExpression('0 25 * * *')).toBe(false);  // hour 25 is invalid
+		expect(isValidCronExpression('60 * * * *')).toBe(false);  // minute 60 is invalid
 	});
 });
 

--- a/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
@@ -1,0 +1,113 @@
+/**
+ * cron-utils Tests
+ *
+ * Tests for cron expression parsing and next-run calculation:
+ * - parseCronExpression: valid/invalid expressions
+ * - getNextRunAt: 5-field cron and preset expansion
+ * - Timezone-aware scheduling
+ * - getSystemTimezone fallback
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parseCronExpression, getNextRunAt, getSystemTimezone } from '../../../../src/lib/room/runtime/cron-utils';
+
+describe('parseCronExpression', () => {
+	test('accepts valid 5-field cron expressions', () => {
+		expect(parseCronExpression('0 9 * * *')).toBe(true);    // 9am daily
+		expect(parseCronExpression('0 0 * * *')).toBe(true);    // midnight daily
+		expect(parseCronExpression('0 0 * * 0')).toBe(true);    // weekly Sunday
+		expect(parseCronExpression('30 14 1 * *')).toBe(true);  // 2:30pm on 1st of month
+		expect(parseCronExpression('*/5 * * * *')).toBe(true);  // every 5 minutes
+	});
+
+	test('accepts preset aliases', () => {
+		expect(parseCronExpression('@hourly')).toBe(true);
+		expect(parseCronExpression('@daily')).toBe(true);
+		expect(parseCronExpression('@midnight')).toBe(true);
+		expect(parseCronExpression('@weekly')).toBe(true);
+		expect(parseCronExpression('@monthly')).toBe(true);
+		expect(parseCronExpression('@yearly')).toBe(true);
+		expect(parseCronExpression('@annually')).toBe(true);
+	});
+
+	test('accepts case-insensitive presets', () => {
+		expect(parseCronExpression('@DAILY')).toBe(true);
+		expect(parseCronExpression('@Daily')).toBe(true);
+		expect(parseCronExpression('@HOURLY')).toBe(true);
+	});
+
+	test('rejects invalid expressions', () => {
+		expect(parseCronExpression('')).toBe(false);
+		expect(parseCronExpression('not-a-cron')).toBe(false);
+		expect(parseCronExpression('0 25 * * *')).toBe(false);  // hour 25 is invalid
+		expect(parseCronExpression('60 * * * *')).toBe(false);  // minute 60 is invalid
+	});
+});
+
+describe('getNextRunAt', () => {
+	test('returns a unix timestamp in seconds for a valid cron', () => {
+		const next = getNextRunAt('0 9 * * *', 'UTC');
+		expect(next).not.toBeNull();
+		// Should be a reasonable future timestamp (within a day or just over)
+		const nowSec = Math.floor(Date.now() / 1000);
+		expect(next).toBeGreaterThan(nowSec);
+		expect(next).toBeLessThan(nowSec + 2 * 24 * 3600); // within 2 days
+	});
+
+	test('respects afterMs parameter', () => {
+		// "0 9 * * *" at 9am UTC
+		// If we are at 8:59am UTC, next should be 1 minute away
+		const now = new Date();
+		const todayAt9am = new Date(
+			Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 9, 0, 0)
+		);
+
+		// Get next run starting from 1 minute before 9am today
+		const oneMinBefore = todayAt9am.getTime() - 60_000;
+		const next = getNextRunAt('0 9 * * *', 'UTC', oneMinBefore);
+		expect(next).not.toBeNull();
+		// next should be exactly todayAt9am (or tomorrow if already past 9am today)
+		const nextDate = new Date(next! * 1000);
+		expect(nextDate.getUTCHours()).toBe(9);
+		expect(nextDate.getUTCMinutes()).toBe(0);
+	});
+
+	test('expands @daily preset', () => {
+		const next = getNextRunAt('@daily', 'UTC');
+		expect(next).not.toBeNull();
+		const nextDate = new Date(next! * 1000);
+		expect(nextDate.getUTCHours()).toBe(0);
+		expect(nextDate.getUTCMinutes()).toBe(0);
+	});
+
+	test('expands @weekly preset', () => {
+		const next = getNextRunAt('@weekly', 'UTC');
+		expect(next).not.toBeNull();
+		const nextDate = new Date(next! * 1000);
+		// @weekly = every Sunday at midnight
+		expect(nextDate.getUTCDay()).toBe(0); // Sunday
+		expect(nextDate.getUTCHours()).toBe(0);
+	});
+
+	test('returns null for invalid expression', () => {
+		const next = getNextRunAt('not-valid', 'UTC');
+		expect(next).toBeNull();
+	});
+
+	test('two successive calls give different (sequential) timestamps', () => {
+		const nowMs = Date.now();
+		const next1 = getNextRunAt('@hourly', 'UTC', nowMs);
+		const next2 = getNextRunAt('@hourly', 'UTC', next1! * 1000 + 1000); // start from after next1
+		expect(next1).not.toBeNull();
+		expect(next2).not.toBeNull();
+		expect(next2).toBeGreaterThan(next1!);
+	});
+});
+
+describe('getSystemTimezone', () => {
+	test('returns a non-empty string', () => {
+		const tz = getSystemTimezone();
+		expect(typeof tz).toBe('string');
+		expect(tz.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/cron-utils.test.ts
@@ -9,15 +9,19 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { isValidCronExpression, getNextRunAt, getSystemTimezone } from '../../../../src/lib/room/runtime/cron-utils';
+import {
+	isValidCronExpression,
+	getNextRunAt,
+	getSystemTimezone,
+} from '../../../../src/lib/room/runtime/cron-utils';
 
 describe('isValidCronExpression', () => {
 	test('accepts valid 5-field cron expressions', () => {
-		expect(isValidCronExpression('0 9 * * *')).toBe(true);    // 9am daily
-		expect(isValidCronExpression('0 0 * * *')).toBe(true);    // midnight daily
-		expect(isValidCronExpression('0 0 * * 0')).toBe(true);    // weekly Sunday
-		expect(isValidCronExpression('30 14 1 * *')).toBe(true);  // 2:30pm on 1st of month
-		expect(isValidCronExpression('*/5 * * * *')).toBe(true);  // every 5 minutes
+		expect(isValidCronExpression('0 9 * * *')).toBe(true); // 9am daily
+		expect(isValidCronExpression('0 0 * * *')).toBe(true); // midnight daily
+		expect(isValidCronExpression('0 0 * * 0')).toBe(true); // weekly Sunday
+		expect(isValidCronExpression('30 14 1 * *')).toBe(true); // 2:30pm on 1st of month
+		expect(isValidCronExpression('*/5 * * * *')).toBe(true); // every 5 minutes
 	});
 
 	test('accepts preset aliases', () => {
@@ -39,8 +43,8 @@ describe('isValidCronExpression', () => {
 	test('rejects invalid expressions', () => {
 		expect(isValidCronExpression('')).toBe(false);
 		expect(isValidCronExpression('not-a-cron')).toBe(false);
-		expect(isValidCronExpression('0 25 * * *')).toBe(false);  // hour 25 is invalid
-		expect(isValidCronExpression('60 * * * *')).toBe(false);  // minute 60 is invalid
+		expect(isValidCronExpression('0 25 * * *')).toBe(false); // hour 25 is invalid
+		expect(isValidCronExpression('60 * * * *')).toBe(false); // minute 60 is invalid
 	});
 });
 

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -712,6 +712,261 @@ describe('Goal RPC Handlers', () => {
 		});
 	});
 
+	// ---- recurring mission schedule handlers ----
+
+	const recurringGoal: RoomGoal = {
+		id: 'goal-123',
+		roomId: 'room-123',
+		title: 'Daily Backup',
+		description: 'Run daily backup',
+		status: 'active' as GoalStatus,
+		priority: 'normal' as GoalPriority,
+		progress: 0,
+		linkedTaskIds: [],
+		missionType: 'recurring',
+		schedule: { expression: '@daily', timezone: 'UTC' },
+		nextRunAt: Math.floor(Date.now() / 1000) + 3600,
+		schedulePaused: false,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+
+	describe('goal.setSchedule', () => {
+		it('registers the handler', () => {
+			expect(messageHubData.handlers.get('goal.setSchedule')).toBeDefined();
+		});
+
+		it('sets a valid cron schedule and returns updated goal and nextRunAt', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
+				...recurringGoal,
+				schedule: { expression: '0 9 * * *', timezone: 'UTC' },
+			});
+
+			const result = (await handler!(
+				{ roomId: 'room-123', goalId: 'goal-123', cronExpression: '0 9 * * *' },
+				{}
+			)) as { goal: RoomGoal; nextRunAt: number };
+
+			expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith(
+				'goal-123',
+				'active',
+				expect.objectContaining({
+					schedule: expect.objectContaining({ expression: '0 9 * * *' }),
+					missionType: 'recurring',
+				})
+			);
+			expect(typeof result.nextRunAt).toBe('number');
+			expect(result.goal).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			await expect(
+				handler!({ goalId: 'goal-123', cronExpression: '@daily' }, {})
+			).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			await expect(
+				handler!({ roomId: 'room-123', cronExpression: '@daily' }, {})
+			).rejects.toThrow('Goal ID is required');
+		});
+
+		it('throws when cronExpression is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
+			).rejects.toThrow('Cron expression is required');
+		});
+
+		it('throws when goal is not found', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(null);
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-missing', cronExpression: '@daily' }, {})
+			).rejects.toThrow('Goal not found');
+		});
+
+		it('throws when goal is not a recurring mission', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				missionType: 'one_shot',
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', cronExpression: '@daily' }, {})
+			).rejects.toThrow('not a recurring mission');
+		});
+
+		it('throws when cron expression is invalid', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			await expect(
+				handler!(
+					{ roomId: 'room-123', goalId: 'goal-123', cronExpression: 'not-valid-cron' },
+					{}
+				)
+			).rejects.toThrow('Invalid cron expression');
+		});
+
+		it('emits goal.updated event on success', async () => {
+			const handler = messageHubData.handlers.get('goal.setSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce(recurringGoal);
+
+			await handler!({ roomId: 'room-123', goalId: 'goal-123', cronExpression: '@weekly' }, {});
+
+			expect(daemonHubData.emit).toHaveBeenCalledWith(
+				'goal.updated',
+				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
+			);
+		});
+	});
+
+	describe('goal.pauseSchedule', () => {
+		it('registers the handler', () => {
+			expect(messageHubData.handlers.get('goal.pauseSchedule')).toBeDefined();
+		});
+
+		it('sets schedulePaused=true and returns updated goal', async () => {
+			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
+				...recurringGoal,
+				schedulePaused: true,
+			});
+
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				goal: RoomGoal;
+			};
+
+			expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith(
+				'goal-123',
+				'active',
+				expect.objectContaining({ schedulePaused: true })
+			);
+			expect(result.goal).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
+			await expect(handler!({ goalId: 'goal-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
+		});
+
+		it('throws when goal is not a recurring mission', async () => {
+			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				missionType: 'one_shot',
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
+			).rejects.toThrow('not a recurring mission');
+		});
+
+		it('emits goal.updated event on success', async () => {
+			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
+				...recurringGoal,
+				schedulePaused: true,
+			});
+
+			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
+
+			expect(daemonHubData.emit).toHaveBeenCalledWith(
+				'goal.updated',
+				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
+			);
+		});
+	});
+
+	describe('goal.resumeSchedule', () => {
+		const pausedGoal: RoomGoal = { ...recurringGoal, schedulePaused: true };
+
+		it('registers the handler', () => {
+			expect(messageHubData.handlers.get('goal.resumeSchedule')).toBeDefined();
+		});
+
+		it('sets schedulePaused=false and returns updated goal with nextRunAt', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(pausedGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
+				...pausedGoal,
+				schedulePaused: false,
+			});
+
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				goal: RoomGoal;
+				nextRunAt: number | null;
+			};
+
+			expect(mockGoalManager.updateGoalStatus).toHaveBeenCalledWith(
+				'goal-123',
+				'active',
+				expect.objectContaining({ schedulePaused: false })
+			);
+			expect(result.goal).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			await expect(handler!({ goalId: 'goal-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
+		});
+
+		it('throws when goal is not a recurring mission', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				missionType: 'one_shot',
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
+			).rejects.toThrow('not a recurring mission');
+		});
+
+		it('throws when goal has no schedule', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				...recurringGoal,
+				schedule: undefined,
+				schedulePaused: true,
+			});
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
+			).rejects.toThrow('no schedule set');
+		});
+
+		it('emits goal.updated event on success', async () => {
+			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
+			mockGoalManager.getGoal.mockResolvedValueOnce(pausedGoal);
+			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
+				...pausedGoal,
+				schedulePaused: false,
+			});
+
+			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
+
+			expect(daemonHubData.emit).toHaveBeenCalledWith(
+				'goal.updated',
+				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
+			);
+		});
+	});
+
 	describe('task approval handlers', () => {
 		function setupApprovalHandlers(task: NeoTask | null, resumeResult = true) {
 			const taskManager = {

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -849,23 +849,23 @@ describe('Goal RPC Handlers', () => {
 
 		it('throws when roomId is missing', async () => {
 			const handler = messageHubData.handlers.get('goal.setSchedule')!;
-			await expect(
-				handler!({ goalId: 'goal-123', cronExpression: '@daily' }, {})
-			).rejects.toThrow('Room ID is required');
+			await expect(handler!({ goalId: 'goal-123', cronExpression: '@daily' }, {})).rejects.toThrow(
+				'Room ID is required'
+			);
 		});
 
 		it('throws when goalId is missing', async () => {
 			const handler = messageHubData.handlers.get('goal.setSchedule')!;
-			await expect(
-				handler!({ roomId: 'room-123', cronExpression: '@daily' }, {})
-			).rejects.toThrow('Goal ID is required');
+			await expect(handler!({ roomId: 'room-123', cronExpression: '@daily' }, {})).rejects.toThrow(
+				'Goal ID is required'
+			);
 		});
 
 		it('throws when cronExpression is missing', async () => {
 			const handler = messageHubData.handlers.get('goal.setSchedule')!;
-			await expect(
-				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
-			).rejects.toThrow('Cron expression is required');
+			await expect(handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'Cron expression is required'
+			);
 		});
 
 		it('throws when goal is not found', async () => {
@@ -891,10 +891,7 @@ describe('Goal RPC Handlers', () => {
 			const handler = messageHubData.handlers.get('goal.setSchedule')!;
 			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
 			await expect(
-				handler!(
-					{ roomId: 'room-123', goalId: 'goal-123', cronExpression: 'not-valid-cron' },
-					{}
-				)
+				handler!({ roomId: 'room-123', goalId: 'goal-123', cronExpression: 'not-valid-cron' }, {})
 			).rejects.toThrow('Invalid cron expression');
 		});
 
@@ -953,9 +950,9 @@ describe('Goal RPC Handlers', () => {
 				...recurringGoal,
 				missionType: 'one_shot',
 			});
-			await expect(
-				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
-			).rejects.toThrow('not a recurring mission');
+			await expect(handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'not a recurring mission'
+			);
 		});
 
 		it('emits goal.updated event on success', async () => {
@@ -1019,9 +1016,9 @@ describe('Goal RPC Handlers', () => {
 				...recurringGoal,
 				missionType: 'one_shot',
 			});
-			await expect(
-				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
-			).rejects.toThrow('not a recurring mission');
+			await expect(handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'not a recurring mission'
+			);
 		});
 
 		it('throws when goal has no schedule', async () => {
@@ -1031,9 +1028,9 @@ describe('Goal RPC Handlers', () => {
 				schedule: undefined,
 				schedulePaused: true,
 			});
-			await expect(
-				handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})
-			).rejects.toThrow('no schedule set');
+			await expect(handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})).rejects.toThrow(
+				'no schedule set'
+			);
 		});
 
 		it('emits goal.updated event on success', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -21,6 +21,7 @@ import {
 	type GoalStatus,
 	type GoalPriority,
 	type NeoTask,
+	type MissionExecution,
 } from '@neokai/shared';
 import {
 	setupGoalHandlers,
@@ -149,6 +150,22 @@ const mockGoalManager = {
 		})
 	),
 	deleteGoal: mock(async (): Promise<boolean> => true),
+	getActiveExecution: mock((): MissionExecution | null => null),
+	linkTaskToExecution: mock(
+		async (): Promise<RoomGoal> => ({
+			id: 'goal-123',
+			roomId: 'room-123',
+			title: 'Test Goal',
+			description: 'Test description',
+			status: 'active' as GoalStatus,
+			priority: 'normal' as GoalPriority,
+			progress: 0,
+			linkedTaskIds: ['task-456'],
+			missionType: 'recurring',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})
+	),
 };
 
 const createMockGoalManager = (): GoalManagerLike => mockGoalManager as unknown as GoalManagerLike;
@@ -219,6 +236,8 @@ describe('Goal RPC Handlers', () => {
 		mockGoalManager.reactivateGoal.mockClear();
 		mockGoalManager.linkTaskToGoal.mockClear();
 		mockGoalManager.deleteGoal.mockClear();
+		mockGoalManager.getActiveExecution.mockClear();
+		mockGoalManager.linkTaskToExecution.mockClear();
 
 		// Setup handlers with mocked dependencies
 		setupGoalHandlers(messageHubData.hub, daemonHubData.daemonHub, createMockGoalManager);
@@ -648,6 +667,73 @@ describe('Goal RPC Handlers', () => {
 					goalId: 'goal-123',
 				})
 			);
+		});
+
+		it('uses linkTaskToExecution for recurring mission with active execution', async () => {
+			const handler = messageHubData.handlers.get('goal.linkTask')!;
+
+			// Mock: goal is a recurring mission
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Recurring Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				missionType: 'recurring',
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as RoomGoal);
+
+			// Mock: active execution exists
+			const fakeExecution: MissionExecution = {
+				id: 'exec-1',
+				goalId: 'goal-123',
+				executionNumber: 1,
+				startedAt: Math.floor(Date.now() / 1000),
+				completedAt: null,
+				status: 'running',
+				resultSummary: null,
+				taskIds: [],
+			};
+			mockGoalManager.getActiveExecution.mockReturnValueOnce(fakeExecution);
+
+			await handler!({ roomId: 'room-123', goalId: 'goal-123', taskId: 'task-456' }, {});
+
+			expect(mockGoalManager.linkTaskToExecution).toHaveBeenCalledWith(
+				'goal-123',
+				'exec-1',
+				'task-456'
+			);
+			expect(mockGoalManager.linkTaskToGoal).not.toHaveBeenCalled();
+		});
+
+		it('falls back to linkTaskToGoal for recurring mission without active execution', async () => {
+			const handler = messageHubData.handlers.get('goal.linkTask')!;
+
+			mockGoalManager.getGoal.mockResolvedValueOnce({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Recurring Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				missionType: 'recurring',
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			} as RoomGoal);
+
+			// No active execution
+			mockGoalManager.getActiveExecution.mockReturnValueOnce(null);
+
+			await handler!({ roomId: 'room-123', goalId: 'goal-123', taskId: 'task-456' }, {});
+
+			expect(mockGoalManager.linkTaskToGoal).toHaveBeenCalledWith('goal-123', 'task-456');
+			expect(mockGoalManager.linkTaskToExecution).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
Implements cron-based scheduling for recurring missions with execution identity,
overlap prevention, per-execution task isolation, and daemon-restart recovery.

Key changes:
- croner package for 5-field cron + preset (@daily/@weekly/@hourly etc.) parsing
- cron-utils.ts: parseCronExpression / getNextRunAt / getSystemTimezone helpers
- GoalRepository: linkTaskToExecution (atomic dual-write), getNextExecutionNumber,
  clearLinkedTaskIds, getActiveExecution, insertExecution, updateExecution,
  listExecutions — backed by mission_executions table from Migration 28
- GoalManager: startExecution / completeExecution / failExecution / getActiveExecution /
  linkTaskToExecution / updateNextRunAt / listExecutions / listGoalsSync
  createGoal now forwards all V2 params (missionType, schedule, nextRunAt, etc.)
- SessionGroup / TaskGroupMetadata: executionId field for restart recovery
- RoomRuntime: getNextGoalForPlanning skips recurring missions; tickRecurringMissions
  two-phase scheduler (completion check → trigger check); spawnPlanningGroup accepts
  executionId and previousResultSummary for recurring mission context
- room-agent-tools: set_schedule / pause_schedule / resume_schedule MCP tools;
  create_task uses linkTaskToExecution for recurring missions with active execution
- goal-handlers: goal.setSchedule / goal.pauseSchedule / goal.resumeSchedule RPC handlers

Scheduling behaviour:
- Overlap prevention: DB partial unique index + app-level getActiveExecution check
- Catch-up: if next_run_at is past, fire once and advance from current time
- tickRecurringMissions returns void synchronously (no microtask yield) when there
  are no recurring goals, preserving existing tests' microtask ordering

Tests: 30 new unit tests (11 cron-utils + 19 recurring-missions); updated
room-agent-tools test to reflect 17 total tools (3 new schedule tools added).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
