### PR TITLE
feat: add provider badge in session status bar next to model icon

### DIFF
--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -33,6 +33,38 @@ import { Tooltip } from './ui/Tooltip.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 
 /**
+ * Per-provider dot color.
+ * Keep in sync with PROVIDER_LABELS in packages/web/src/hooks/useModelSwitcher.ts —
+ * when a new provider is added there, add a matching entry here.
+ */
+const PROVIDER_DOT_COLORS: Record<string, string> = {
+	'anthropic-copilot': 'bg-green-400',
+	'anthropic-codex': 'bg-teal-400',
+	glm: 'bg-blue-400',
+	minimax: 'bg-purple-400',
+};
+
+/**
+ * ProviderBadge - Small colored dot indicating the provider next to the model name.
+ * Returns null for the Anthropic default provider (no dot needed).
+ * The dot's title/aria-label provide the provider name for accessibility.
+ */
+function ProviderBadge({ provider }: { provider: string | undefined }) {
+	if (!provider || provider === 'anthropic') return null;
+	const color = PROVIDER_DOT_COLORS[provider] ?? 'bg-gray-400';
+	const label = getProviderLabel(provider);
+	return (
+		<span
+			class={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${color}`}
+			title={label}
+			aria-label={label}
+			role="img"
+			data-testid="provider-badge"
+		/>
+	);
+}
+
+/**
  * Thinking level display labels
  */
 const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
@@ -382,68 +414,73 @@ export default function SessionStatusBar({
 					</Tooltip>
 				)}
 
-				{/* Model Switcher */}
-				<div class="relative">
-					<Tooltip
-						content={currentModelInfo ? `Model: ${currentModelInfo.name}` : 'Switch Model'}
-						position="top"
-						delay={300}
-					>
-						<button
-							class="control-btn w-8 h-8 flex items-center justify-center bg-dark-700 hover:bg-dark-600 border border-gray-600 sm:border-gray-600 rounded-full transition-colors text-lg disabled:opacity-50 disabled:cursor-not-allowed"
-							onClick={toggleModelDropdown}
-							disabled={modelLoading || modelSwitching || coordinatorSwitching}
-							title={currentModelInfo ? `Switch Model (${currentModelInfo.name})` : 'Switch Model'}
+				{/* Model Switcher + Provider Badge */}
+				<div class="flex items-center gap-1.5">
+					<div class="relative">
+						<Tooltip
+							content={currentModelInfo ? `Model: ${currentModelInfo.name}` : 'Switch Model'}
+							position="top"
+							delay={300}
 						>
-							{modelSwitching ? <Spinner size="sm" /> : currentModelIcon}
-						</button>
-					</Tooltip>
-
-					{/* Model Dropdown */}
-					{modelDropdown.isOpen && (
-						<div
-							class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
-						>
-							<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
-							{Array.from(groupModelsByProvider(availableModels).entries()).map(
-								([provider, models], groupIndex) => {
-									const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
-									return (
-										<div key={provider}>
-											{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
-											<div class="px-3 py-1 flex items-center gap-1.5">
-												<span
-													class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
-												/>
-												<span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">
-													{getProviderLabel(provider)}
-												</span>
-											</div>
-											{models.map((model) => {
-												const isCurrent =
-													model.id === currentModelInfo?.id &&
-													model.provider === currentModelInfo?.provider;
-												return (
-													<button
-														key={`${model.provider}:${model.id}`}
-														class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
-															isCurrent ? 'text-blue-400' : 'text-gray-200'
-														}`}
-														onClick={() => handleModelSwitch(model)}
-														disabled={modelSwitching}
-													>
-														<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-														<span class="flex-1 truncate">{model.name}</span>
-														{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
-													</button>
-												);
-											})}
-										</div>
-									);
+							<button
+								class="control-btn w-8 h-8 flex items-center justify-center bg-dark-700 hover:bg-dark-600 border border-gray-600 sm:border-gray-600 rounded-full transition-colors text-lg disabled:opacity-50 disabled:cursor-not-allowed"
+								onClick={toggleModelDropdown}
+								disabled={modelLoading || modelSwitching || coordinatorSwitching}
+								title={
+									currentModelInfo ? `Switch Model (${currentModelInfo.name})` : 'Switch Model'
 								}
-							)}
-						</div>
-					)}
+							>
+								{modelSwitching ? <Spinner size="sm" /> : currentModelIcon}
+							</button>
+						</Tooltip>
+
+						{/* Model Dropdown */}
+						{modelDropdown.isOpen && (
+							<div
+								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
+							>
+								<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
+								{Array.from(groupModelsByProvider(availableModels).entries()).map(
+									([provider, models], groupIndex) => {
+										const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
+										return (
+											<div key={provider}>
+												{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
+												<div class="px-3 py-1 flex items-center gap-1.5">
+													<span
+														class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
+													/>
+													<span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">
+														{getProviderLabel(provider)}
+													</span>
+												</div>
+												{models.map((model) => {
+													const isCurrent =
+														model.id === currentModelInfo?.id &&
+														model.provider === currentModelInfo?.provider;
+													return (
+														<button
+															key={`${model.provider}:${model.id}`}
+															class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
+																isCurrent ? 'text-blue-400' : 'text-gray-200'
+															}`}
+															onClick={() => handleModelSwitch(model)}
+															disabled={modelSwitching}
+														>
+															<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+															<span class="flex-1 truncate">{model.name}</span>
+															{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+														</button>
+													);
+												})}
+											</div>
+										);
+									}
+								)}
+							</div>
+						)}
+					</div>
+					<ProviderBadge provider={currentModelInfo?.provider} />
 				</div>
 
 				{/* Thinking Level */}

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -33,29 +33,33 @@ import { Tooltip } from './ui/Tooltip.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 
 /**
- * Per-provider dot color.
+ * Brand-accurate provider dot colors (hex values outside Tailwind's palette).
  * Keep in sync with PROVIDER_LABELS in packages/web/src/hooks/useModelSwitcher.ts —
  * when a new provider is added there, add a matching entry here.
  */
-const PROVIDER_DOT_COLORS: Record<string, string> = {
-	'anthropic-copilot': 'bg-green-400',
-	'anthropic-codex': 'bg-teal-400',
-	glm: 'bg-blue-400',
-	minimax: 'bg-purple-400',
+const PROVIDER_DOT_COLORS: Record<string, { color: string; ring?: boolean }> = {
+	anthropic: { color: '#D97757' }, // Anthropic brand orange
+	'anthropic-copilot': { color: '#8957E5' }, // GitHub Copilot purple
+	'anthropic-codex': { color: '#FFFFFF', ring: true }, // OpenAI white (ring for visibility)
+	glm: { color: '#7DD3FC' }, // ChatGLM light blue
+	minimax: { color: '#FCA5A5' }, // MiniMax light red
 };
 
 /**
  * ProviderBadge - Small colored dot indicating the provider next to the model name.
- * Returns null for the Anthropic default provider (no dot needed).
+ * Shows for all providers including Anthropic (orange dot).
+ * Returns null only when provider is undefined/unknown.
  * The dot's title/aria-label provide the provider name for accessibility.
  */
 function ProviderBadge({ provider }: { provider: string | undefined }) {
-	if (!provider || provider === 'anthropic') return null;
-	const color = PROVIDER_DOT_COLORS[provider] ?? 'bg-gray-400';
+	if (!provider) return null;
+	const config = PROVIDER_DOT_COLORS[provider];
+	const backgroundColor = config?.color ?? '#9CA3AF'; // gray-400 fallback
 	const label = getProviderLabel(provider);
 	return (
 		<span
-			class={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${color}`}
+			class={`inline-block w-2 h-2 rounded-full flex-shrink-0${config?.ring ? ' ring-1 ring-gray-300' : ''}`}
+			style={{ backgroundColor }}
 			title={label}
 			aria-label={label}
 			role="img"

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -794,7 +794,7 @@ describe('SessionStatusBar', () => {
 	});
 
 	describe('Provider Badge (colored dot)', () => {
-		it('should not show provider badge for Anthropic provider', () => {
+		it('should show orange dot for Anthropic provider', () => {
 			const anthropicModelInfo: ModelInfo = {
 				...mockModelInfo,
 				provider: 'anthropic',
@@ -803,7 +803,10 @@ describe('SessionStatusBar', () => {
 				<SessionStatusBar {...defaultProps} currentModelInfo={anthropicModelInfo} />
 			);
 			const badge = container.querySelector('[data-testid="provider-badge"]');
-			expect(badge).toBeNull();
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe('Anthropic');
+			expect(badge?.getAttribute('aria-label')).toBe('Anthropic');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#D97757');
 		});
 
 		it('should not show provider badge when provider is undefined', () => {
@@ -818,7 +821,7 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeNull();
 		});
 
-		it('should show green dot for anthropic-copilot provider', () => {
+		it('should show purple dot for anthropic-copilot provider', () => {
 			const copilotModelInfo: ModelInfo = {
 				...mockModelInfo,
 				provider: 'anthropic-copilot',
@@ -830,10 +833,10 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeTruthy();
 			expect(badge?.getAttribute('title')).toBe('Copilot');
 			expect(badge?.getAttribute('aria-label')).toBe('Copilot');
-			expect(badge?.className).toContain('bg-green-400');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#8957E5');
 		});
 
-		it('should show teal dot for anthropic-codex provider', () => {
+		it('should show white dot with ring for anthropic-codex provider', () => {
 			const codexModelInfo: ModelInfo = {
 				...mockModelInfo,
 				provider: 'anthropic-codex',
@@ -845,10 +848,11 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeTruthy();
 			expect(badge?.getAttribute('title')).toBe('Codex');
 			expect(badge?.getAttribute('aria-label')).toBe('Codex');
-			expect(badge?.className).toContain('bg-teal-400');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#FFFFFF');
+			expect(badge?.className).toContain('ring-1');
 		});
 
-		it('should show blue dot for glm provider', () => {
+		it('should show light blue dot for glm provider', () => {
 			const glmModelInfo: ModelInfo = {
 				...mockModelInfo,
 				provider: 'glm',
@@ -860,10 +864,10 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeTruthy();
 			expect(badge?.getAttribute('title')).toBe('GLM');
 			expect(badge?.getAttribute('aria-label')).toBe('GLM');
-			expect(badge?.className).toContain('bg-blue-400');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#7DD3FC');
 		});
 
-		it('should show purple dot for minimax provider', () => {
+		it('should show light red dot for minimax provider', () => {
 			const minimaxModelInfo: ModelInfo = {
 				...mockModelInfo,
 				provider: 'minimax',
@@ -875,7 +879,7 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeTruthy();
 			expect(badge?.getAttribute('title')).toBe('MiniMax');
 			expect(badge?.getAttribute('aria-label')).toBe('MiniMax');
-			expect(badge?.className).toContain('bg-purple-400');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#FCA5A5');
 		});
 
 		it('should show gray dot for unknown provider using getProviderLabel fallback', () => {
@@ -892,11 +896,17 @@ describe('SessionStatusBar', () => {
 			expect(badge).toBeTruthy();
 			expect(badge?.getAttribute('title')).toBe(expectedLabel);
 			expect(badge?.getAttribute('aria-label')).toBe(expectedLabel);
-			expect(badge?.className).toContain('bg-gray-400');
+			expect((badge as HTMLElement)?.style.backgroundColor).toBe('#9CA3AF');
 		});
 
-		it('should have explicit dot color for every known non-anthropic provider', () => {
-			const knownProviders = ['anthropic-copilot', 'anthropic-codex', 'glm', 'minimax'];
+		it('should have explicit dot color for every known provider', () => {
+			const knownProviders = [
+				'anthropic',
+				'anthropic-copilot',
+				'anthropic-codex',
+				'glm',
+				'minimax',
+			];
 			for (const provider of knownProviders) {
 				const modelInfo: ModelInfo = { ...mockModelInfo, provider };
 				const { container, unmount } = render(
@@ -904,9 +914,9 @@ describe('SessionStatusBar', () => {
 				);
 				const badge = container.querySelector('[data-testid="provider-badge"]');
 				expect(
-					badge?.className,
-					`${provider} should have explicit color, not fallback gray`
-				).not.toContain('bg-gray-400');
+					(badge as HTMLElement)?.style.backgroundColor,
+					`${provider} should have explicit brand color, not fallback gray`
+				).not.toBe('#9CA3AF');
 				unmount();
 			}
 		});

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { ContextInfo, ModelInfo } from '@neokai/shared';
 import SessionStatusBar from '../SessionStatusBar';
+import { getProviderLabel } from '../../hooks';
 
 // Configurable hub mock — defaults to null (no connection) so existing tests are unaffected.
 // Individual tests can call mockGetHubIfConnected.mockReturnValue({ request: ... }) to
@@ -29,6 +30,7 @@ describe('SessionStatusBar', () => {
 	const mockOnModelSwitch = vi.fn(() => Promise.resolve());
 	const mockOnAutoScrollChange = vi.fn(() => {});
 	const mockOnCoordinatorModeChange = vi.fn(() => {});
+	const mockOnSandboxModeChange = vi.fn(() => {});
 
 	const mockModelInfo: ModelInfo = {
 		id: 'sonnet',
@@ -91,6 +93,8 @@ describe('SessionStatusBar', () => {
 		coordinatorMode: true,
 		coordinatorSwitching: false,
 		onCoordinatorModeChange: mockOnCoordinatorModeChange,
+		sandboxEnabled: false,
+		onSandboxModeChange: mockOnSandboxModeChange,
 	};
 
 	beforeEach(() => {
@@ -98,6 +102,7 @@ describe('SessionStatusBar', () => {
 		mockOnModelSwitch.mockClear();
 		mockOnAutoScrollChange.mockClear();
 		mockOnCoordinatorModeChange.mockClear();
+		mockOnSandboxModeChange.mockClear();
 		// Reset hub to null (no connection) between tests — individual tests can override
 		mockGetHubIfConnected.mockReturnValue(null);
 	});
@@ -682,6 +687,7 @@ describe('SessionStatusBar', () => {
 				name: 'Claude Opus 4',
 				family: 'opus',
 				isDefault: false,
+				provider: 'anthropic',
 			};
 			const { container } = render(
 				<SessionStatusBar {...defaultProps} currentModelInfo={opusModelInfo} />
@@ -697,6 +703,7 @@ describe('SessionStatusBar', () => {
 				name: 'Claude Haiku 3',
 				family: 'haiku',
 				isDefault: false,
+				provider: 'anthropic',
 			};
 			const { container } = render(
 				<SessionStatusBar {...defaultProps} currentModelInfo={haikuModelInfo} />
@@ -783,6 +790,138 @@ describe('SessionStatusBar', () => {
 				(btn) => btn.getAttribute('title')?.includes('Coordinator Mode') || false
 			);
 			expect(coordinatorButton?.className).toContain('border-gray-600');
+		});
+	});
+
+	describe('Provider Badge (colored dot)', () => {
+		it('should not show provider badge for Anthropic provider', () => {
+			const anthropicModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={anthropicModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeNull();
+		});
+
+		it('should not show provider badge when provider is undefined', () => {
+			const noProviderModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: undefined,
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={noProviderModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeNull();
+		});
+
+		it('should show green dot for anthropic-copilot provider', () => {
+			const copilotModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic-copilot',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={copilotModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe('Copilot');
+			expect(badge?.getAttribute('aria-label')).toBe('Copilot');
+			expect(badge?.className).toContain('bg-green-400');
+		});
+
+		it('should show teal dot for anthropic-codex provider', () => {
+			const codexModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic-codex',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={codexModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe('Codex');
+			expect(badge?.getAttribute('aria-label')).toBe('Codex');
+			expect(badge?.className).toContain('bg-teal-400');
+		});
+
+		it('should show blue dot for glm provider', () => {
+			const glmModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'glm',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={glmModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe('GLM');
+			expect(badge?.getAttribute('aria-label')).toBe('GLM');
+			expect(badge?.className).toContain('bg-blue-400');
+		});
+
+		it('should show purple dot for minimax provider', () => {
+			const minimaxModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'minimax',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={minimaxModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe('MiniMax');
+			expect(badge?.getAttribute('aria-label')).toBe('MiniMax');
+			expect(badge?.className).toContain('bg-purple-400');
+		});
+
+		it('should show gray dot for unknown provider using getProviderLabel fallback', () => {
+			const unknownProvider = 'some-unknown-provider';
+			const unknownModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: unknownProvider,
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={unknownModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			const expectedLabel = getProviderLabel(unknownProvider);
+			expect(badge).toBeTruthy();
+			expect(badge?.getAttribute('title')).toBe(expectedLabel);
+			expect(badge?.getAttribute('aria-label')).toBe(expectedLabel);
+			expect(badge?.className).toContain('bg-gray-400');
+		});
+
+		it('should have explicit dot color for every known non-anthropic provider', () => {
+			const knownProviders = ['anthropic-copilot', 'anthropic-codex', 'glm', 'minimax'];
+			for (const provider of knownProviders) {
+				const modelInfo: ModelInfo = { ...mockModelInfo, provider };
+				const { container, unmount } = render(
+					<SessionStatusBar {...defaultProps} currentModelInfo={modelInfo} />
+				);
+				const badge = container.querySelector('[data-testid="provider-badge"]');
+				expect(
+					badge?.className,
+					`${provider} should have explicit color, not fallback gray`
+				).not.toContain('bg-gray-400');
+				unmount();
+			}
+		});
+
+		it('should render as a dot with no text content', () => {
+			const copilotModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic-copilot',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={copilotModelInfo} />
+			);
+			const badge = container.querySelector('[data-testid="provider-badge"]');
+			expect(badge?.textContent).toBe('');
+			expect(badge?.className).toContain('rounded-full');
 		});
 	});
 


### PR DESCRIPTION
Show a colored chip/badge for non-Anthropic providers (Copilot, Codex,
GLM, MiniMax) next to the model icon in the status bar. Anthropic
(default) shows no badge to keep the UI clean.
