### PR TITLE
fix: prevent agent from creating duplicate PRs on re-dispatch

### DIFF
--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -234,9 +234,14 @@ export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 	sections.push(`3. Add or update tests to cover the new/changed behavior — tests are mandatory`);
 	sections.push(`4. Push your branch: \`git push -u origin HEAD\``);
 	sections.push(
-		`5. Create a pull request — detect the default branch inside the subshell (no persistent variable needed):\n` +
+		`5. Ensure a pull request exists — check first to avoid creating a duplicate:\n` +
 			`   \`\`\`bash\n` +
-			`   gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
+			`   EXISTING_PR=$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json url --jq '.[0].url' 2>/dev/null)\n` +
+			`   if [ -z "$EXISTING_PR" ]; then\n` +
+			`     gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
+			`   else\n` +
+			`     echo "PR already exists: $EXISTING_PR (updated with latest push)"\n` +
+			`   fi\n` +
 			`   \`\`\``
 	);
 	sections.push(`6. Finish your response`);
@@ -374,6 +379,13 @@ export function buildCoderTaskMessage(config: CoderAgentConfig): string {
 	if (room.instructions) {
 		sections.push(`\n## Instructions\n`);
 		sections.push(room.instructions);
+	}
+
+	// Existing PR context (when task already has a PR from a previous iteration)
+	if (task.prUrl) {
+		sections.push(`\n## Existing Pull Request\n`);
+		sections.push(`This task already has an open pull request: ${task.prUrl}`);
+		sections.push(`Push your changes to update this PR — do NOT create a new one.`);
 	}
 
 	// Previous task summaries

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -236,7 +236,7 @@ export function buildCoderSystemPrompt(helperAgentNames?: string[]): string {
 	sections.push(
 		`5. Ensure a pull request exists — check first to avoid creating a duplicate:\n` +
 			`   \`\`\`bash\n` +
-			`   EXISTING_PR=$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json url --jq '.[0].url' 2>/dev/null)\n` +
+			`   EXISTING_PR=$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json url --jq '.[0].url // empty' 2>/dev/null)\n` +
 			`   if [ -z "$EXISTING_PR" ]; then\n` +
 			`     gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
 			`   else\n` +
@@ -384,7 +384,7 @@ export function buildCoderTaskMessage(config: CoderAgentConfig): string {
 	// Existing PR context (when task already has a PR from a previous iteration)
 	if (task.prUrl) {
 		sections.push(`\n## Existing Pull Request\n`);
-		sections.push(`This task already has an open pull request: ${task.prUrl}`);
+		sections.push(`This task already has an existing pull request: ${task.prUrl}`);
 		sections.push(`Push your changes to update this PR — do NOT create a new one.`);
 	}
 

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -602,15 +602,6 @@ export async function checkLeaderDraftsExist(
 // --- PR URL Utility ---
 
 /**
- * Extract a PR number from a GitHub PR URL.
- * Returns null if the URL is not a valid GitHub PR URL.
- */
-export function extractPrNumberFromUrl(prUrl: string): number | null {
-	const match = prUrl.match(/\/pull\/(\d+)/);
-	return match ? parseInt(match[1], 10) : null;
-}
-
-/**
  * Close a stale PR when a new PR has been created to replace it.
  *
  * Called when submit_for_review is invoked with a PR URL that differs from the
@@ -618,6 +609,9 @@ export function extractPrNumberFromUrl(prUrl: string): number | null {
  *
  * Fails open: if the close command fails (e.g., PR already closed, gh unavailable),
  * the error is logged but does not block the submit_for_review flow.
+ *
+ * Uses the PR URL directly with `gh pr close` — gh accepts both numbers and URLs,
+ * and URLs are unambiguous across multi-remote/forked repo setups.
  *
  * @param oldPrUrl - The existing PR URL stored in the task
  * @param newPrUrl - The new PR URL being submitted for review
@@ -633,24 +627,23 @@ export async function closeStalePr(
 ): Promise<boolean> {
 	const run = getRunner(opts);
 
-	const oldPrNumber = extractPrNumberFromUrl(oldPrUrl);
-	if (!oldPrNumber) {
-		log.warn(`closeStalePr: could not extract PR number from URL: ${oldPrUrl}`);
+	if (!oldPrUrl || !oldPrUrl.includes('/pull/')) {
+		log.warn(`closeStalePr: invalid old PR URL: ${oldPrUrl}`);
 		return false;
 	}
 
 	const comment = `Superseded by ${newPrUrl}`;
 	const { exitCode } = await run(
-		['gh', 'pr', 'close', String(oldPrNumber), '--comment', comment],
+		['gh', 'pr', 'close', oldPrUrl, '--comment', comment],
 		workspacePath
 	);
 
 	if (exitCode !== 0) {
-		log.warn(`closeStalePr: failed to close PR #${oldPrNumber} (exit ${exitCode})`);
+		log.warn(`closeStalePr: failed to close PR ${oldPrUrl} (exit ${exitCode})`);
 		return false;
 	}
 
-	log.info(`closeStalePr: closed stale PR #${oldPrNumber}, superseded by ${newPrUrl}`);
+	log.info(`closeStalePr: closed stale PR ${oldPrUrl}, superseded by ${newPrUrl}`);
 	return true;
 }
 

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -599,6 +599,61 @@ export async function checkLeaderDraftsExist(
 	};
 }
 
+// --- PR URL Utility ---
+
+/**
+ * Extract a PR number from a GitHub PR URL.
+ * Returns null if the URL is not a valid GitHub PR URL.
+ */
+export function extractPrNumberFromUrl(prUrl: string): number | null {
+	const match = prUrl.match(/\/pull\/(\d+)/);
+	return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Close a stale PR when a new PR has been created to replace it.
+ *
+ * Called when submit_for_review is invoked with a PR URL that differs from the
+ * task's existing prUrl. Closes the old PR with a comment pointing to the new one.
+ *
+ * Fails open: if the close command fails (e.g., PR already closed, gh unavailable),
+ * the error is logged but does not block the submit_for_review flow.
+ *
+ * @param oldPrUrl - The existing PR URL stored in the task
+ * @param newPrUrl - The new PR URL being submitted for review
+ * @param workspacePath - The workspace path to run gh commands from
+ * @param opts - Optional hook options (for testing)
+ * @returns true if closed successfully, false otherwise
+ */
+export async function closeStalePr(
+	oldPrUrl: string,
+	newPrUrl: string,
+	workspacePath: string,
+	opts?: HookOptions
+): Promise<boolean> {
+	const run = getRunner(opts);
+
+	const oldPrNumber = extractPrNumberFromUrl(oldPrUrl);
+	if (!oldPrNumber) {
+		log.warn(`closeStalePr: could not extract PR number from URL: ${oldPrUrl}`);
+		return false;
+	}
+
+	const comment = `Superseded by ${newPrUrl}`;
+	const { exitCode } = await run(
+		['gh', 'pr', 'close', String(oldPrNumber), '--comment', comment],
+		workspacePath
+	);
+
+	if (exitCode !== 0) {
+		log.warn(`closeStalePr: failed to close PR #${oldPrNumber} (exit ${exitCode})`);
+		return false;
+	}
+
+	log.info(`closeStalePr: closed stale PR #${oldPrNumber}, superseded by ${newPrUrl}`);
+	return true;
+}
+
 // --- Gate Runners ---
 
 /**

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -60,6 +60,7 @@ import {
 	runWorkerExitGate,
 	runLeaderCompleteGate,
 	runLeaderSubmitGate,
+	closeStalePr,
 	type HookOptions,
 	type HookResult,
 	type WorkerExitHookContext,
@@ -1093,6 +1094,22 @@ export class RoomRuntime {
 								action_required: gateResult.bounceMessage,
 							});
 						}
+					}
+				}
+
+				// If the task already has a different PR URL (e.g., agent created a new PR
+				// instead of updating the existing one), close the stale PR before proceeding.
+				{
+					const existingTask = await this.taskManager.getTask(group.taskId);
+					if (existingTask?.prUrl && existingTask.prUrl !== prUrl) {
+						const groupWorkspace = group.workspacePath ?? this.taskGroupManager.workspacePath;
+						log.info(
+							`submit_for_review: new PR ${prUrl} differs from existing ${existingTask.prUrl} — closing stale PR`
+						);
+						this.appendGroupEvent(groupId, 'status', {
+							text: `Closing stale PR ${existingTask.prUrl}, superseded by ${prUrl}.`,
+						});
+						await closeStalePr(existingTask.prUrl, prUrl, groupWorkspace, this.hookOptions);
 					}
 				}
 

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -98,6 +98,18 @@ describe('Coder Agent', () => {
 			);
 		});
 
+		it('checks for existing PR before creating to avoid duplicates', () => {
+			const prompt = buildCoderSystemPrompt();
+			// Step 5 should check for an existing PR first
+			expect(prompt).toContain('EXISTING_PR=$(gh pr list --head');
+			expect(prompt).toContain('--state open --json url --jq');
+			expect(prompt).toContain('if [ -z "$EXISTING_PR" ]');
+			// Only create PR when none exists
+			expect(prompt).toContain('gh pr create --fill --base');
+			// Acknowledge when PR already exists
+			expect(prompt).toContain('PR already exists');
+		});
+
 		it('combines sync commands in a single bash invocation using the empty-check fallback pattern', () => {
 			const prompt = buildCoderSystemPrompt();
 			// Two-step empty check: symbolic-ref first, then remote show if empty.
@@ -193,6 +205,22 @@ describe('Coder Agent', () => {
 		it('should omit previous work section when no summaries', () => {
 			const message = buildCoderTaskMessage(makeConfig());
 			expect(message).not.toContain('Previous Work');
+		});
+
+		it('should include existing PR URL when task has prUrl', () => {
+			const message = buildCoderTaskMessage(
+				makeConfig({
+					task: makeTask({ prUrl: 'https://github.com/org/repo/pull/42' }),
+				})
+			);
+			expect(message).toContain('https://github.com/org/repo/pull/42');
+			expect(message).toContain('Existing Pull Request');
+			expect(message).toContain('do NOT create a new one');
+		});
+
+		it('should omit existing PR section when task has no prUrl', () => {
+			const message = buildCoderTaskMessage(makeConfig());
+			expect(message).not.toContain('Existing Pull Request');
 		});
 
 		it('should end with begin instruction', () => {

--- a/packages/daemon/tests/unit/room/coder-agent.test.ts
+++ b/packages/daemon/tests/unit/room/coder-agent.test.ts
@@ -103,6 +103,8 @@ describe('Coder Agent', () => {
 			// Step 5 should check for an existing PR first
 			expect(prompt).toContain('EXISTING_PR=$(gh pr list --head');
 			expect(prompt).toContain('--state open --json url --jq');
+			// Uses `// empty` to convert jq null output to empty string (avoids the "null" string bug)
+			expect(prompt).toContain('// empty');
 			expect(prompt).toContain('if [ -z "$EXISTING_PR" ]');
 			// Only create PR when none exists
 			expect(prompt).toContain('gh pr create --fill --base');
@@ -215,6 +217,9 @@ describe('Coder Agent', () => {
 			);
 			expect(message).toContain('https://github.com/org/repo/pull/42');
 			expect(message).toContain('Existing Pull Request');
+			// Should say "existing" not "open" — prUrl may be closed
+			expect(message).toContain('existing pull request');
+			expect(message).not.toContain('open pull request');
 			expect(message).toContain('do NOT create a new one');
 		});
 

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -15,6 +15,8 @@ import {
 	runLeaderSubmitGate,
 	detectBypassMarker,
 	BYPASS_GATES_MARKERS,
+	extractPrNumberFromUrl,
+	closeStalePr,
 	type WorkerExitHookContext,
 	type LeaderCompleteHookContext,
 	type HookOptions,
@@ -1487,5 +1489,87 @@ describe('runWorkerExitGate with bypass markers', () => {
 		expect(result.pass).toBe(true);
 		expect(result.bypassed).toBe(true);
 		expect(result.reason).toContain('Bypassed');
+	});
+});
+
+describe('extractPrNumberFromUrl', () => {
+	test('extracts PR number from a valid GitHub PR URL', () => {
+		expect(extractPrNumberFromUrl('https://github.com/org/repo/pull/42')).toBe(42);
+	});
+
+	test('extracts PR number from a URL with trailing segments', () => {
+		expect(extractPrNumberFromUrl('https://github.com/org/repo/pull/123/files')).toBe(123);
+	});
+
+	test('returns null for a non-PR URL', () => {
+		expect(extractPrNumberFromUrl('https://github.com/org/repo/issues/42')).toBeNull();
+	});
+
+	test('returns null for an empty string', () => {
+		expect(extractPrNumberFromUrl('')).toBeNull();
+	});
+
+	test('returns null for a malformed URL', () => {
+		expect(extractPrNumberFromUrl('not-a-url')).toBeNull();
+	});
+});
+
+describe('closeStalePr', () => {
+	test('closes the old PR with a superseded-by comment', async () => {
+		const calls: Array<{ args: string[]; cwd: string }> = [];
+		const opts: HookOptions = {
+			runCommand: async (args, cwd) => {
+				calls.push({ args, cwd });
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'https://github.com/org/repo/pull/10',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(true);
+		expect(calls.length).toBe(1);
+		expect(calls[0].args).toEqual([
+			'gh',
+			'pr',
+			'close',
+			'10',
+			'--comment',
+			'Superseded by https://github.com/org/repo/pull/20',
+		]);
+		expect(calls[0].cwd).toBe('/workspace');
+	});
+
+	test('returns false when gh command fails', async () => {
+		const opts: HookOptions = {
+			runCommand: async () => ({ stdout: '', exitCode: 1 }),
+		};
+		const result = await closeStalePr(
+			'https://github.com/org/repo/pull/10',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+	});
+
+	test('returns false for invalid old PR URL', async () => {
+		const calls: Array<string[]> = [];
+		const opts: HookOptions = {
+			runCommand: async (args) => {
+				calls.push(args);
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'not-a-pr-url',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+		expect(calls.length).toBe(0);
 	});
 });

--- a/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
+++ b/packages/daemon/tests/unit/room/lifecycle-hooks.test.ts
@@ -15,7 +15,6 @@ import {
 	runLeaderSubmitGate,
 	detectBypassMarker,
 	BYPASS_GATES_MARKERS,
-	extractPrNumberFromUrl,
 	closeStalePr,
 	type WorkerExitHookContext,
 	type LeaderCompleteHookContext,
@@ -1492,30 +1491,8 @@ describe('runWorkerExitGate with bypass markers', () => {
 	});
 });
 
-describe('extractPrNumberFromUrl', () => {
-	test('extracts PR number from a valid GitHub PR URL', () => {
-		expect(extractPrNumberFromUrl('https://github.com/org/repo/pull/42')).toBe(42);
-	});
-
-	test('extracts PR number from a URL with trailing segments', () => {
-		expect(extractPrNumberFromUrl('https://github.com/org/repo/pull/123/files')).toBe(123);
-	});
-
-	test('returns null for a non-PR URL', () => {
-		expect(extractPrNumberFromUrl('https://github.com/org/repo/issues/42')).toBeNull();
-	});
-
-	test('returns null for an empty string', () => {
-		expect(extractPrNumberFromUrl('')).toBeNull();
-	});
-
-	test('returns null for a malformed URL', () => {
-		expect(extractPrNumberFromUrl('not-a-url')).toBeNull();
-	});
-});
-
 describe('closeStalePr', () => {
-	test('closes the old PR with a superseded-by comment', async () => {
+	test('closes the old PR via URL with a superseded-by comment', async () => {
 		const calls: Array<{ args: string[]; cwd: string }> = [];
 		const opts: HookOptions = {
 			runCommand: async (args, cwd) => {
@@ -1531,11 +1508,12 @@ describe('closeStalePr', () => {
 		);
 		expect(result).toBe(true);
 		expect(calls.length).toBe(1);
+		// Uses the full URL, not just the PR number
 		expect(calls[0].args).toEqual([
 			'gh',
 			'pr',
 			'close',
-			'10',
+			'https://github.com/org/repo/pull/10',
 			'--comment',
 			'Superseded by https://github.com/org/repo/pull/20',
 		]);
@@ -1555,7 +1533,7 @@ describe('closeStalePr', () => {
 		expect(result).toBe(false);
 	});
 
-	test('returns false for invalid old PR URL', async () => {
+	test('returns false for invalid old PR URL (not a PR path)', async () => {
 		const calls: Array<string[]> = [];
 		const opts: HookOptions = {
 			runCommand: async (args) => {
@@ -1565,6 +1543,24 @@ describe('closeStalePr', () => {
 		};
 		const result = await closeStalePr(
 			'not-a-pr-url',
+			'https://github.com/org/repo/pull/20',
+			'/workspace',
+			opts
+		);
+		expect(result).toBe(false);
+		expect(calls.length).toBe(0);
+	});
+
+	test('returns false for empty old PR URL', async () => {
+		const calls: Array<string[]> = [];
+		const opts: HookOptions = {
+			runCommand: async (args) => {
+				calls.push(args);
+				return { stdout: '', exitCode: 0 };
+			},
+		};
+		const result = await closeStalePr(
+			'',
 			'https://github.com/org/repo/pull/20',
 			'/workspace',
 			opts

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -580,4 +580,110 @@ describe('RoomRuntime leader tools', () => {
 			expect(planningTasks).toHaveLength(0);
 		});
 	});
+
+	describe('submit_for_review stale PR cleanup', () => {
+		it('closes stale PR when submit_for_review is called with a different PR URL', async () => {
+			const ghCalls: Array<string[]> = [];
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async (args) => {
+						ghCalls.push(args);
+						// Simulate successful gh pr close; fail everything else gracefully
+						if (args[0] === 'gh' && args[1] === 'pr' && args[2] === 'close') {
+							return { stdout: '', exitCode: 0 };
+						}
+						return { stdout: '', exitCode: 1 };
+					},
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set the task with an existing PR URL to simulate a second review cycle
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Leader calls submit_for_review with a NEW, different PR URL
+				const result = await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/20',
+				});
+
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.success).toBe(true);
+
+				// Should have called gh pr close with the old PR URL
+				const closeCalls = ghCalls.filter((a) => a[1] === 'pr' && a[2] === 'close');
+				expect(closeCalls.length).toBe(1);
+				expect(closeCalls[0]).toContain('https://github.com/org/repo/pull/10');
+				expect(closeCalls[0]).toContain('Superseded by https://github.com/org/repo/pull/20');
+
+				// Task should now have the new PR URL
+				const updatedTask = await ctx2.taskManager.getTask(task.id);
+				expect(updatedTask!.prUrl).toBe('https://github.com/org/repo/pull/20');
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+
+		it('does not call gh pr close when submit_for_review uses the same PR URL', async () => {
+			const ghCalls: Array<string[]> = [];
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async (args) => {
+						ghCalls.push(args);
+						return { stdout: '', exitCode: 1 };
+					},
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set the task with the same PR URL that will be submitted
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Leader calls submit_for_review with the SAME PR URL — no close needed
+				await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/10',
+				});
+
+				const closeCalls = ghCalls.filter((a) => a[1] === 'pr' && a[2] === 'close');
+				expect(closeCalls.length).toBe(0);
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+
+		it('proceeds with submit_for_review even when closeStalePr fails', async () => {
+			const ctx2 = createRuntimeTestContext({
+				hookOptions: {
+					runCommand: async () => ({ stdout: '', exitCode: 1 }), // gh always fails
+				},
+			});
+
+			try {
+				const { task, group } = await spawnAndRouteToLeader(ctx2, { assignedAgent: 'coder' });
+
+				// Pre-set an existing PR URL
+				await ctx2.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/10');
+
+				// Even though gh pr close will fail, submit_for_review should still succeed
+				const result = await ctx2.runtime.handleLeaderTool(group.id, 'submit_for_review', {
+					pr_url: 'https://github.com/org/repo/pull/20',
+				});
+
+				const parsed = JSON.parse(result.content[0].text);
+				expect(parsed.success).toBe(true);
+
+				// Task still updates to the new PR URL
+				const updatedTask = await ctx2.taskManager.getTask(task.id);
+				expect(updatedTask!.prUrl).toBe('https://github.com/org/repo/pull/20');
+			} finally {
+				ctx2.runtime.stop();
+				ctx2.db.close();
+			}
+		});
+	});
 });


### PR DESCRIPTION
- Modify coder agent git workflow step 5 to check for an existing open PR
  before creating a new one (EXISTING_PR check via gh pr list --head).
  This prevents duplicate PRs when the agent is sent back for review feedback.

- Add existing PR URL to the coder task message context so the agent
  explicitly knows to push to update the PR rather than create a new one.

- Add closeStalePr() to lifecycle-hooks.ts: when submit_for_review is called
  with a PR URL that differs from the task's existing prUrl (i.e. agent created
  a new PR instead of updating the old one), automatically close the old PR
  with a superseded-by comment before updating the task link.

- Add extractPrNumberFromUrl() utility to lifecycle-hooks.ts.

- Add unit tests for all new logic (extractPrNumberFromUrl, closeStalePr,
  coder task message PR context, and system prompt PR-deduplication).
