### PR TITLE
feat: replace copy toast with inline green check mark

### DIFF
--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -18,6 +18,7 @@ import {
 	isToolUseBlock,
 } from '@neokai/shared/sdk/type-guards';
 import { useEffect, useState } from 'preact/hooks';
+import { toast } from '../../lib/toast.ts';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
@@ -92,6 +93,8 @@ export function SDKAssistantMessage({
 		const success = await copyToClipboard(textContent);
 		if (success) {
 			setCopied(true);
+		} else {
+			toast.error('Failed to copy message');
 		}
 	};
 
@@ -144,7 +147,7 @@ export function SDKAssistantMessage({
 							<path
 								strokeLinecap="round"
 								strokeLinejoin="round"
-								stroke-width={2}
+								strokeWidth={2}
 								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
 							/>
 						</svg>
@@ -198,7 +201,7 @@ export function SDKAssistantMessage({
 							<path
 								strokeLinecap="round"
 								strokeLinejoin="round"
-								stroke-width={2}
+								strokeWidth={2}
 								d="M5 13l4 4L19 7"
 							/>
 						</svg>
@@ -207,7 +210,7 @@ export function SDKAssistantMessage({
 							<path
 								strokeLinecap="round"
 								strokeLinejoin="round"
-								stroke-width={2}
+								strokeWidth={2}
 								d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
 							/>
 						</svg>

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -17,7 +17,7 @@ import {
 	isThinkingBlock,
 	isToolUseBlock,
 } from '@neokai/shared/sdk/type-guards';
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
@@ -81,12 +81,17 @@ export function SDKAssistantMessage({
 
 	const [copied, setCopied] = useState(false);
 
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const textContent = getTextContent();
 		const success = await copyToClipboard(textContent);
 		if (success) {
 			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -17,8 +17,8 @@ import {
 	isThinkingBlock,
 	isToolUseBlock,
 } from '@neokai/shared/sdk/type-guards';
+import { useState } from 'preact/hooks';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
-import { toast } from '../../lib/toast.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import { QuestionPrompt } from '../QuestionPrompt.tsx';
@@ -79,13 +79,14 @@ export function SDKAssistantMessage({
 			.join('\n');
 	};
 
+	const [copied, setCopied] = useState(false);
+
 	const handleCopy = async () => {
 		const textContent = getTextContent();
 		const success = await copyToClipboard(textContent);
 		if (success) {
-			toast.success('Message copied to clipboard');
-		} else {
-			toast.error('Failed to copy message');
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 
@@ -181,15 +182,31 @@ export function SDKAssistantMessage({
 					<span class="text-xs text-gray-500">{getTimestamp()}</span>
 				</Tooltip>
 
-				<IconButton size="md" onClick={handleCopy} title="Copy message">
-					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							stroke-width={2}
-							d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-						/>
-					</svg>
+				<IconButton
+					size="md"
+					onClick={handleCopy}
+					title={copied ? 'Copied!' : 'Copy message'}
+					class={copied ? 'text-green-400' : ''}
+				>
+					{copied ? (
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								stroke-width={2}
+								d="M5 13l4 4L19 7"
+							/>
+						</svg>
+					) : (
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								stroke-width={2}
+								d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+							/>
+						</svg>
+					)}
 				</IconButton>
 			</div>
 		) : null;

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -343,19 +343,14 @@ export function SDKUserMessage({
 			>
 				{copied ? (
 					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M5 13l4 4L19 7"
-						/>
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
 					</svg>
 				) : (
 					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth={2}
 							d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
 						/>
 					</svg>

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { Dropdown } from '../ui/Dropdown.tsx';
@@ -148,11 +148,16 @@ export function SDKUserMessage({
 		return hasErrorOutput(textContent);
 	};
 
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(textContent);
 		if (success) {
 			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -316,9 +316,9 @@ export function SDKUserMessage({
 						<IconButton size="md" onClick={() => onRewind(message.uuid!)} title="Rewind to here">
 							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width={2}
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
 									d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
 								/>
 							</svg>

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -6,6 +6,7 @@
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useEffect, useState } from 'preact/hooks';
+import { toast } from '../../lib/toast.ts';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { Dropdown } from '../ui/Dropdown.tsx';
@@ -158,6 +159,8 @@ export function SDKUserMessage({
 		const success = await copyToClipboard(textContent);
 		if (success) {
 			setCopied(true);
+		} else {
+			toast.error('Failed to copy message');
 		}
 	};
 

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -5,8 +5,8 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import { useState } from 'preact/hooks';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
-import { toast } from '../../lib/toast.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { Dropdown } from '../ui/Dropdown.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
@@ -53,6 +53,7 @@ export function SDKUserMessage({
 	allMessages: _allMessages,
 }: Props) {
 	const { message: apiMessage } = message;
+	const [copied, setCopied] = useState(false);
 
 	// Check if this is a tool result message (should not be rendered as user message)
 	const isToolResultMessage = (): boolean => {
@@ -150,9 +151,8 @@ export function SDKUserMessage({
 	const handleCopy = async () => {
 		const success = await copyToClipboard(textContent);
 		if (success) {
-			toast.success('Message copied to clipboard');
-		} else {
-			toast.error('Failed to copy message');
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 
@@ -327,15 +327,31 @@ export function SDKUserMessage({
 				/>
 			)}
 
-			<IconButton size="md" onClick={handleCopy} title="Copy message">
-				<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width={2}
-						d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-					/>
-				</svg>
+			<IconButton
+				size="md"
+				onClick={handleCopy}
+				title={copied ? 'Copied!' : 'Copy message'}
+				class={copied ? 'text-green-400' : ''}
+			>
+				{copied ? (
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M5 13l4 4L19 7"
+						/>
+					</svg>
+				) : (
+					<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+						/>
+					</svg>
+				)}
 			</IconButton>
 		</div>
 	);

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useEffect, useState } from 'preact/hooks';
+import { toast } from '../../lib/toast.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { messageSpacing, borderRadius } from '../../lib/design-tokens.ts';
 import { Tooltip } from '../ui/Tooltip.tsx';
@@ -87,6 +88,8 @@ export function SyntheticMessageBlock({ content, timestamp, uuid }: Props) {
 		const success = await copyToClipboard(getTextContent());
 		if (success) {
 			setCopied(true);
+		} else {
+			toast.error('Failed to copy message');
 		}
 	};
 

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -11,11 +11,11 @@
  * - Timestamp and synthetic badge in footer
  */
 
+import { useEffect, useState } from 'preact/hooks';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { messageSpacing, borderRadius } from '../../lib/design-tokens.ts';
 import { Tooltip } from '../ui/Tooltip.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
-import { toast } from '../../lib/toast.ts';
 
 interface Props {
 	/** Content to display - can be a simple string or array of content blocks */
@@ -75,12 +75,18 @@ export function SyntheticMessageBlock({ content, timestamp, uuid }: Props) {
 			.join('\n');
 	};
 
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(getTextContent());
 		if (success) {
-			toast.success('Message copied to clipboard');
-		} else {
-			toast.error('Failed to copy message');
+			setCopied(true);
 		}
 	};
 
@@ -191,15 +197,31 @@ export function SyntheticMessageBlock({ content, timestamp, uuid }: Props) {
 						</span>
 					</Tooltip>
 
-					<IconButton size="md" onClick={handleCopy} title="Copy message">
-						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth={2}
-								d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-							/>
-						</svg>
+					<IconButton
+						size="md"
+						onClick={handleCopy}
+						title={copied ? 'Copied!' : 'Copy message'}
+						class={copied ? 'text-green-400' : ''}
+					>
+						{copied ? (
+							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M5 13l4 4L19 7"
+								/>
+							</svg>
+						) : (
+							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									strokeWidth={2}
+									d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+								/>
+							</svg>
+						)}
 					</IconButton>
 				</div>
 			</div>

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -374,6 +374,32 @@ describe('SDKAssistantMessage', () => {
 				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
 			});
 		});
+
+		it('should revert to copy icon after 1500ms', async () => {
+			vi.mocked(copyToClipboard).mockResolvedValue(true);
+			vi.useFakeTimers();
+
+			const message = createTextOnlyMessage('Hello world');
+			const { container } = render(<SDKAssistantMessage message={message} />);
+
+			const copyButton = container.querySelector('button[title="Copy message"]');
+			fireEvent.click(copyButton!);
+
+			// Should show Copied! state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+			});
+
+			// Advance timer past 1500ms
+			vi.advanceTimersByTime(1500);
+
+			// Should revert to copy state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			});
+
+			vi.useRealTimers();
+		});
 	});
 
 	describe('Question Handling (AskUserQuestion)', () => {

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -21,16 +21,7 @@ vi.mock('../../../lib/utils.ts', async (importOriginal) => {
 	};
 });
 
-// Mock the toast module
-vi.mock('../../../lib/toast.ts', () => ({
-	toast: {
-		success: vi.fn(),
-		error: vi.fn(),
-	},
-}));
-
 import { copyToClipboard } from '../../../lib/utils.ts';
-import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	cleanup();
@@ -327,7 +318,7 @@ describe('SDKAssistantMessage', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should show success toast when copy succeeds', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(true);
 
 			const message = createTextOnlyMessage('Hello world');
@@ -339,11 +330,14 @@ describe('SDKAssistantMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should now show "Copied!" title and green color
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextOnlyMessage('Hello world');
@@ -355,7 +349,8 @@ describe('SDKAssistantMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
+				// Button should remain showing "Copy message" (not switched to Copied!)
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
 			});
 		});
 
@@ -375,7 +370,8 @@ describe('SDKAssistantMessage', () => {
 				expect(copyToClipboard).toHaveBeenCalledWith(
 					'I will read the file.\nThe file has been read.'
 				);
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should switch to "Copied!" state
+				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
 			});
 		});
 	});

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -21,7 +21,16 @@ vi.mock('../../../lib/utils.ts', async (importOriginal) => {
 	};
 });
 
+// Mock the toast module
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
 import { copyToClipboard } from '../../../lib/utils.ts';
+import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	cleanup();
@@ -337,7 +346,7 @@ describe('SDKAssistantMessage', () => {
 			});
 		});
 
-		it('should not show green check when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextOnlyMessage('Hello world');
@@ -351,6 +360,8 @@ describe('SDKAssistantMessage', () => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
 				// Button should remain showing "Copy message" (not switched to Copied!)
 				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				// Error toast should be shown
+				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
 			});
 		});
 
@@ -375,30 +386,37 @@ describe('SDKAssistantMessage', () => {
 			});
 		});
 
-		it('should revert to copy icon after 1500ms', async () => {
-			vi.mocked(copyToClipboard).mockResolvedValue(true);
-			vi.useFakeTimers();
-
-			const message = createTextOnlyMessage('Hello world');
-			const { container } = render(<SDKAssistantMessage message={message} />);
-
-			const copyButton = container.querySelector('button[title="Copy message"]');
-			fireEvent.click(copyButton!);
-
-			// Should show Copied! state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
 			});
 
-			// Advance timer past 1500ms
-			vi.advanceTimersByTime(1500);
-
-			// Should revert to copy state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			afterEach(() => {
+				vi.useRealTimers();
 			});
 
-			vi.useRealTimers();
+			it('should revert to copy icon after 1500ms', async () => {
+				vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+				const message = createTextOnlyMessage('Hello world');
+				const { container } = render(<SDKAssistantMessage message={message} />);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
+			});
 		});
 	});
 

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -20,16 +20,7 @@ vi.mock('../../../lib/utils.ts', async (importOriginal) => {
 	};
 });
 
-// Mock the toast module
-vi.mock('../../../lib/toast.ts', () => ({
-	toast: {
-		success: vi.fn(),
-		error: vi.fn(),
-	},
-}));
-
 import { copyToClipboard } from '../../../lib/utils.ts';
-import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -390,7 +381,7 @@ describe('SDKUserMessage', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should show success toast when copy succeeds', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(true);
 
 			const message = createTextMessage('Hello world');
@@ -402,11 +393,14 @@ describe('SDKUserMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.success).toHaveBeenCalledWith('Message copied to clipboard');
+				// Button should now show "Copied!" title and green color
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextMessage('Hello world');
@@ -418,7 +412,8 @@ describe('SDKUserMessage', () => {
 			// Wait for the async handler to complete
 			await vi.waitFor(() => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
-				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
+				// Button should remain showing "Copy message" (not switched to Copied!)
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
 			});
 		});
 	});

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -20,7 +20,16 @@ vi.mock('../../../lib/utils.ts', async (importOriginal) => {
 	};
 });
 
+// Mock the toast module
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
 import { copyToClipboard } from '../../../lib/utils.ts';
+import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -400,7 +409,7 @@ describe('SDKUserMessage', () => {
 			});
 		});
 
-		it('should not show green check when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			vi.mocked(copyToClipboard).mockResolvedValue(false);
 
 			const message = createTextMessage('Hello world');
@@ -414,33 +423,42 @@ describe('SDKUserMessage', () => {
 				expect(copyToClipboard).toHaveBeenCalledWith('Hello world');
 				// Button should remain showing "Copy message" (not switched to Copied!)
 				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				// Error toast should be shown
+				expect(toast.error).toHaveBeenCalledWith('Failed to copy message');
 			});
 		});
 
-		it('should revert to copy icon after 1500ms', async () => {
-			vi.mocked(copyToClipboard).mockResolvedValue(true);
-			vi.useFakeTimers();
-
-			const message = createTextMessage('Hello world');
-			const { container } = render(<SDKUserMessage message={message} />);
-
-			const copyButton = container.querySelector('button[title="Copy message"]');
-			fireEvent.click(copyButton!);
-
-			// Should show Copied! state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
 			});
 
-			// Advance timer past 1500ms
-			vi.advanceTimersByTime(1500);
-
-			// Should revert to copy state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			afterEach(() => {
+				vi.useRealTimers();
 			});
 
-			vi.useRealTimers();
+			it('should revert to copy icon after 1500ms', async () => {
+				vi.mocked(copyToClipboard).mockResolvedValue(true);
+
+				const message = createTextMessage('Hello world');
+				const { container } = render(<SDKUserMessage message={message} />);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
+			});
 		});
 	});
 

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -416,6 +416,32 @@ describe('SDKUserMessage', () => {
 				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
 			});
 		});
+
+		it('should revert to copy icon after 1500ms', async () => {
+			vi.mocked(copyToClipboard).mockResolvedValue(true);
+			vi.useFakeTimers();
+
+			const message = createTextMessage('Hello world');
+			const { container } = render(<SDKUserMessage message={message} />);
+
+			const copyButton = container.querySelector('button[title="Copy message"]');
+			fireEvent.click(copyButton!);
+
+			// Should show Copied! state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+			});
+
+			// Advance timer past 1500ms
+			vi.advanceTimersByTime(1500);
+
+			// Should revert to copy state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			});
+
+			vi.useRealTimers();
+		});
 	});
 
 	describe('Rewind Mode', () => {

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -4,9 +4,9 @@
  *
  * Tests user message rendering including text, images, and special cases
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { render, fireEvent } from '@testing-library/preact';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { SDKUserMessage } from '../SDKUserMessage';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
@@ -33,6 +33,10 @@ import { toast } from '../../../lib/toast.ts';
 
 beforeEach(() => {
 	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	cleanup();
 });
 
 // Helper to create a valid UUID

--- a/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
@@ -20,10 +20,21 @@ vi.mock('../../../lib/utils.ts', async () => {
 	};
 });
 
+// Mock toast
+const mockToastError = vi.fn();
+
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		success: vi.fn(),
+		error: (msg: string) => mockToastError(msg),
+	},
+}));
+
 describe('SyntheticMessageBlock', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockCopyToClipboard.mockResolvedValue(true);
+		mockToastError.mockClear();
 	});
 
 	afterEach(() => {
@@ -294,7 +305,7 @@ describe('SyntheticMessageBlock', () => {
 			});
 		});
 
-		it('should not show green check when copy fails', async () => {
+		it('should not show green check and show error toast when copy fails', async () => {
 			mockCopyToClipboard.mockResolvedValue(false);
 
 			const { container } = render(
@@ -307,33 +318,40 @@ describe('SyntheticMessageBlock', () => {
 			await waitFor(() => {
 				expect(mockCopyToClipboard).toHaveBeenCalledWith('Content to copy');
 				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				expect(mockToastError).toHaveBeenCalledWith('Failed to copy message');
 			});
 		});
 
-		it('should revert to copy icon after 1500ms', async () => {
-			vi.useFakeTimers();
-
-			const { container } = render(
-				<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
-			);
-
-			const copyButton = container.querySelector('button[title="Copy message"]');
-			fireEvent.click(copyButton!);
-
-			// Should show Copied! state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+		describe('auto-revert behavior', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
 			});
 
-			// Advance timer past 1500ms
-			vi.advanceTimersByTime(1500);
-
-			// Should revert to copy state
-			await vi.waitFor(() => {
-				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			afterEach(() => {
+				vi.useRealTimers();
 			});
 
-			vi.useRealTimers();
+			it('should revert to copy icon after 1500ms', async () => {
+				const { container } = render(
+					<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
+				);
+
+				const copyButton = container.querySelector('button[title="Copy message"]');
+				fireEvent.click(copyButton!);
+
+				// Should show Copied! state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+				});
+
+				// Advance timer past 1500ms
+				vi.advanceTimersByTime(1500);
+
+				// Should revert to copy state
+				await vi.waitFor(() => {
+					expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+				});
+			});
 		});
 
 		it('should extract and copy text from array content blocks', async () => {

--- a/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SyntheticMessageBlock.test.tsx
@@ -20,17 +20,6 @@ vi.mock('../../../lib/utils.ts', async () => {
 	};
 });
 
-// Mock toast
-const mockToastSuccess = vi.fn();
-const mockToastError = vi.fn();
-
-vi.mock('../../../lib/toast.ts', () => ({
-	toast: {
-		success: (msg: string) => mockToastSuccess(msg),
-		error: (msg: string) => mockToastError(msg),
-	},
-}));
-
 describe('SyntheticMessageBlock', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -289,7 +278,7 @@ describe('SyntheticMessageBlock', () => {
 			expect(copyButton).toBeTruthy();
 		});
 
-		it('should copy string content on button click', async () => {
+		it('should show inline green check when copy succeeds', async () => {
 			const { container } = render(
 				<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
 			);
@@ -299,11 +288,13 @@ describe('SyntheticMessageBlock', () => {
 
 			await waitFor(() => {
 				expect(mockCopyToClipboard).toHaveBeenCalledWith('Content to copy');
-				expect(mockToastSuccess).toHaveBeenCalledWith('Message copied to clipboard');
+				const copiedButton = container.querySelector('button[title="Copied!"]');
+				expect(copiedButton).toBeTruthy();
+				expect(copiedButton?.className).toContain('text-green-400');
 			});
 		});
 
-		it('should show error toast when copy fails', async () => {
+		it('should not show green check when copy fails', async () => {
 			mockCopyToClipboard.mockResolvedValue(false);
 
 			const { container } = render(
@@ -314,8 +305,35 @@ describe('SyntheticMessageBlock', () => {
 			fireEvent.click(copyButton!);
 
 			await waitFor(() => {
-				expect(mockToastError).toHaveBeenCalledWith('Failed to copy message');
+				expect(mockCopyToClipboard).toHaveBeenCalledWith('Content to copy');
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
 			});
+		});
+
+		it('should revert to copy icon after 1500ms', async () => {
+			vi.useFakeTimers();
+
+			const { container } = render(
+				<SyntheticMessageBlock content="Content to copy" timestamp={Date.now()} />
+			);
+
+			const copyButton = container.querySelector('button[title="Copy message"]');
+			fireEvent.click(copyButton!);
+
+			// Should show Copied! state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copied!"]')).toBeTruthy();
+			});
+
+			// Advance timer past 1500ms
+			vi.advanceTimersByTime(1500);
+
+			// Should revert to copy state
+			await vi.waitFor(() => {
+				expect(container.querySelector('button[title="Copy message"]')).toBeTruthy();
+			});
+
+			vi.useRealTimers();
 		});
 
 		it('should extract and copy text from array content blocks', async () => {

--- a/packages/web/src/components/ui/CopyButton.tsx
+++ b/packages/web/src/components/ui/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { copyToClipboard } from '../../lib/utils.ts';
 
 interface CopyButtonProps {
@@ -9,11 +9,16 @@ interface CopyButtonProps {
 export function CopyButton({ text, label = 'Copy to clipboard' }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
 
+	useEffect(() => {
+		if (!copied) return;
+		const timer = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(timer);
+	}, [copied]);
+
 	const handleCopy = async () => {
 		const success = await copyToClipboard(text);
 		if (success) {
 			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
 		}
 	};
 


### PR DESCRIPTION
Replace toast.success notification on copy button success with an
inline green checkmark icon that reverts after 1.5s, matching the
existing CopyButton component pattern.
