### PR TITLE
feat: UI terminology — rename Goal to Mission (Task 5)

### DIFF
--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -17,9 +17,7 @@ import { waitForWebSocketConnected } from '../helpers/wait-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-async function createRoom(
-	page: Parameters<typeof waitForWebSocketConnected>[0]
-): Promise<string> {
+async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0]): Promise<string> {
 	await waitForWebSocketConnected(page);
 	return page.evaluate(async () => {
 		const hub = window.__messageHub || window.appState?.messageHub;

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -1,0 +1,129 @@
+/**
+ * Mission Terminology E2E Tests
+ *
+ * Verifies that the UI displays "Mission" terminology (not "Goal") after the
+ * Task 5 copy rename. Tests cover:
+ * - "Missions" tab label in room page
+ * - Empty state heading "No missions yet"
+ * - Empty state call-to-action "Create Mission" button
+ * - No residual "Goal" text visible to users
+ *
+ * Setup: creates a room via RPC (infrastructure), then tests the UI.
+ * Cleanup: deletes the room via RPC in afterEach.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function createRoom(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<string> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(async () => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+		const res = await hub.request('room.create', {
+			name: 'E2E Mission Terminology Test Room',
+		});
+		return (res as { room: { id: string } }).room.id;
+	});
+}
+
+async function deleteRoom(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string
+): Promise<void> {
+	if (!roomId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('room.delete', { roomId: id });
+		}, roomId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Mission Terminology', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		roomId = await createRoom(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (roomId) {
+			await deleteRoom(page, roomId);
+			roomId = '';
+		}
+	});
+
+	test('should show "Missions" tab label in room page', async ({ page }) => {
+		await page.goto(`/rooms/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// The "Missions" tab button should be visible
+		const missionsTab = page.locator('button:has-text("Missions")');
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+	});
+
+	test('should not show "Goals" tab label in room page', async ({ page }) => {
+		await page.goto(`/rooms/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for tabs to render
+		await expect(page.locator('button:has-text("Missions")')).toBeVisible({ timeout: 10000 });
+
+		// There should be no user-visible "Goals" tab button
+		const goalsTab = page.locator('button:has-text("Goals")');
+		await expect(goalsTab).not.toBeVisible();
+	});
+
+	test('should show "No missions yet" in empty state after clicking Missions tab', async ({
+		page,
+	}) => {
+		await page.goto(`/rooms/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Click the Missions tab
+		const missionsTab = page.locator('button:has-text("Missions")');
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+		await missionsTab.click();
+
+		// Empty state heading should read "No missions yet"
+		await expect(page.locator('h3:has-text("No missions yet")')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('should show "Create Mission" button in empty state', async ({ page }) => {
+		await page.goto(`/rooms/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Click the Missions tab
+		const missionsTab = page.locator('button:has-text("Missions")');
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+		await missionsTab.click();
+
+		// Both the header button and the empty-state button should say "Create Mission"
+		const createMissionButtons = page.locator('button:has-text("Create Mission")');
+		await expect(createMissionButtons.first()).toBeVisible({ timeout: 5000 });
+	});
+
+	test('should show "Missions" heading inside the tab panel', async ({ page }) => {
+		await page.goto(`/rooms/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Click the Missions tab
+		const missionsTab = page.locator('button:has-text("Missions")');
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+		await missionsTab.click();
+
+		// The GoalsEditor renders an <h2>Missions</h2> heading
+		await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
+	});
+});

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -80,9 +80,9 @@ test.describe('Mission Terminology', () => {
 		// Wait for tabs to render
 		await expect(page.locator('button:has-text("Missions")')).toBeVisible({ timeout: 10000 });
 
-		// There should be no user-visible "Goals" tab button
+		// There should be no "Goals" tab button in the DOM at all
 		const goalsTab = page.locator('button:has-text("Goals")');
-		await expect(goalsTab).not.toBeVisible();
+		await expect(goalsTab).not.toBeAttached();
 	});
 
 	test('should show "No missions yet" in empty state after clicking Missions tab', async ({

--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -40,9 +40,9 @@ describe('GoalsEditor', () => {
 	};
 
 	describe('Rendering', () => {
-		it('should render the Goals header', () => {
+		it('should render the Missions header', () => {
 			const { container } = render(<GoalsEditor goals={[]} {...defaultHandlers} />);
-			expect(container.textContent).toContain('Goals');
+			expect(container.textContent).toContain('Missions');
 		});
 
 		it('should display goal count badge', () => {
@@ -52,10 +52,10 @@ describe('GoalsEditor', () => {
 			expect(badge?.textContent).toBe('2');
 		});
 
-		it('should render "Create Goal" button', () => {
+		it('should render "Create Mission" button', () => {
 			const { container } = render(<GoalsEditor goals={[]} {...defaultHandlers} />);
 			const buttons = container.querySelectorAll('button');
-			const hasCreateGoal = Array.from(buttons).some((btn) => btn.textContent === 'Create Goal');
+			const hasCreateGoal = Array.from(buttons).some((btn) => btn.textContent === 'Create Mission');
 			expect(hasCreateGoal).toBe(true);
 		});
 	});
@@ -63,14 +63,14 @@ describe('GoalsEditor', () => {
 	describe('Empty State', () => {
 		it('should show empty state when no goals', () => {
 			const { container } = render(<GoalsEditor goals={[]} {...defaultHandlers} />);
-			expect(container.textContent).toContain('No goals yet');
-			expect(container.textContent).toContain('Create your first goal to get started');
+			expect(container.textContent).toContain('No missions yet');
+			expect(container.textContent).toContain('Create your first mission to get started');
 		});
 
-		it('should have "Create Goal" button in empty state', () => {
+		it('should have "Create Mission" button in empty state', () => {
 			const { container } = render(<GoalsEditor goals={[]} {...defaultHandlers} />);
 			const buttons = container.querySelectorAll('button');
-			const hasCreateGoal = Array.from(buttons).some((btn) => btn.textContent === 'Create Goal');
+			const hasCreateGoal = Array.from(buttons).some((btn) => btn.textContent === 'Create Mission');
 			expect(hasCreateGoal).toBe(true);
 		});
 	});

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -166,7 +166,7 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 	);
 }
 
-// Create/Edit Goal Form
+// Create/Edit Mission Form
 interface GoalFormProps {
 	initialTitle?: string;
 	initialDescription?: string;
@@ -660,7 +660,7 @@ export function GoalsEditor({
 				</div>
 			)}
 
-			{/* Create Goal Modal */}
+			{/* Create Mission Modal */}
 			<Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title="Create Mission">
 				<GoalForm
 					onSubmit={onCreateGoal}

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -661,7 +661,11 @@ export function GoalsEditor({
 			)}
 
 			{/* Create Mission Modal */}
-			<Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title="Create Mission">
+			<Modal
+				isOpen={showCreateModal}
+				onClose={() => setShowCreateModal(false)}
+				title="Create Mission"
+			>
 				<GoalForm
 					onSubmit={onCreateGoal}
 					onCancel={() => setShowCreateModal(false)}

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -1,13 +1,13 @@
 /**
  * GoalsEditor Component
  *
- * Provides CRUD operations for room goals with progress tracking.
+ * Provides CRUD operations for room missions with progress tracking.
  * Features:
- * - Create, edit, and delete goals
+ * - Create, edit, and delete missions
  * - Status and priority badges with visual indicators
  * - Progress bar with color-coded completion
- * - Link/unlink tasks to goals
- * - Expandable goal details view
+ * - Link/unlink tasks to missions
+ * - Expandable mission details view
  */
 
 import { useState } from 'preact/hooks';
@@ -226,7 +226,7 @@ function GoalForm({
 					value={title}
 					onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
 					class="w-full px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-					placeholder="Enter goal title..."
+					placeholder="Enter mission title..."
 					required
 				/>
 			</div>
@@ -240,7 +240,7 @@ function GoalForm({
 					value={description}
 					onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
 					class="w-full px-3 py-2 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-					placeholder="Describe the goal..."
+					placeholder="Describe the mission..."
 					rows={3}
 				/>
 			</div>
@@ -530,7 +530,7 @@ function GoalItem({
 				isOpen={showDeleteConfirm}
 				onClose={() => setShowDeleteConfirm(false)}
 				onConfirm={handleDelete}
-				title="Delete Goal"
+				title="Delete Mission"
 				message={`Are you sure you want to delete "${goal.title}"? This action cannot be undone.`}
 				confirmText="Delete"
 				isLoading={isUpdating}
@@ -572,9 +572,9 @@ function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
 					/>
 				</svg>
 			</div>
-			<h3 class="text-lg font-medium text-gray-200 mb-2">No goals yet</h3>
-			<p class="text-sm text-gray-400 mb-4">Create your first goal to get started.</p>
-			<Button onClick={onCreateClick}>Create Goal</Button>
+			<h3 class="text-lg font-medium text-gray-200 mb-2">No missions yet</h3>
+			<p class="text-sm text-gray-400 mb-4">Create your first mission to get started.</p>
+			<Button onClick={onCreateClick}>Create Mission</Button>
 		</div>
 	);
 }
@@ -629,12 +629,12 @@ export function GoalsEditor({
 			{/* Header */}
 			<div class="flex items-center justify-between">
 				<div class="flex items-center gap-2">
-					<h2 class="text-lg font-semibold text-gray-100">Goals</h2>
+					<h2 class="text-lg font-semibold text-gray-100">Missions</h2>
 					<span class="px-2 py-0.5 text-xs font-medium bg-dark-700 text-gray-300 rounded">
 						{goals.length}
 					</span>
 				</div>
-				<Button onClick={() => setShowCreateModal(true)}>Create Goal</Button>
+				<Button onClick={() => setShowCreateModal(true)}>Create Mission</Button>
 			</div>
 
 			{/* Content */}
@@ -661,7 +661,7 @@ export function GoalsEditor({
 			)}
 
 			{/* Create Goal Modal */}
-			<Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title="Create Goal">
+			<Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title="Create Mission">
 				<GoalForm
 					onSubmit={onCreateGoal}
 					onCancel={() => setShowCreateModal(false)}

--- a/packages/web/src/components/room/RoomAgents.tsx
+++ b/packages/web/src/components/room/RoomAgents.tsx
@@ -64,7 +64,7 @@ interface AgentRole {
 }
 
 const BUILTIN_AGENTS: AgentRole[] = [
-	{ key: 'planner', label: 'Planner', description: 'Breaks goals into tasks' },
+	{ key: 'planner', label: 'Planner', description: 'Breaks missions into tasks' },
 	{ key: 'coder', label: 'Coder', description: 'Implements code changes' },
 	{ key: 'general', label: 'General', description: 'Non-coding tasks' },
 	{ key: 'leader', label: 'Leader', description: 'Reviews and routes' },

--- a/packages/web/src/components/room/RoomSettings.tsx
+++ b/packages/web/src/components/room/RoomSettings.tsx
@@ -255,7 +255,7 @@ export function RoomSettings({
 						Max Planning Retries
 					</label>
 					<p class="text-xs text-gray-500 mb-2">
-						How many times the room will retry planning a goal after failure before escalating to
+						How many times the room will retry planning a mission after failure before escalating to
 						human review. 0 means no automatic retries.
 					</p>
 					<input
@@ -507,7 +507,7 @@ export function RoomSettings({
 									<div class="min-w-0">
 										<p class="text-sm font-medium text-gray-200">Delete this room</p>
 										<p class="text-xs text-gray-500 mt-0.5">
-											Permanently remove this room and all sessions, tasks, goals, and messages.
+											Permanently remove this room and all sessions, tasks, missions, and messages.
 											Cannot be undone.
 										</p>
 									</div>

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -3,7 +3,7 @@
  *
  * Main room page component with:
  * - Room dashboard showing sessions and tasks
- * - Goals tab
+ * - Missions tab
  * - Real-time updates via state channels
  */
 
@@ -181,7 +181,7 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 								}`}
 								onClick={() => handleTabChange('goals')}
 							>
-								Goals
+								Missions
 							</button>
 							<button
 								class={`px-4 py-2 text-sm font-medium transition-colors ${


### PR DESCRIPTION
## Summary

- Renames all user-visible \"Goal\" text to \"Mission\" in the frontend (pure copy change, no logic changes)
- `GoalsEditor.tsx`: heading, buttons, empty state, modal titles, and form placeholders updated
- `Room.tsx`: \"Goals\" tab label → \"Missions\"
- `GoalsEditor.test.tsx`: unit test assertions updated to match new text (all 38 pass)
- `mission-terminology.e2e.ts`: new e2e test suite verifying mission terminology is displayed correctly in the room page

## What's unchanged

- Internal component names (`GoalsEditor`, `GoalItem`, etc.) — cosmetic rename deferred
- RoomStore signals (`goals`, `goalsLoading`, `createGoal`, etc.)
- Backend event subscriptions (`goal.*`)
- RPC handler names (`goal.create`, `goal.update`, etc.)

## Test plan

- [x] `packages/web` unit tests: `bunx vitest run src/components/room/GoalsEditor.test.tsx` — 38/38 pass
- [x] TypeScript build check passes (`bun run typecheck`)
- [ ] E2E: `make run-e2e TEST=tests/features/mission-terminology.e2e.ts` (requires full server build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)