### PR TITLE
feat: provider-grouped model picker with availability dots

### DIFF
--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -15,12 +15,19 @@
 import { useSignalEffect } from '@preact/signals';
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import type { ContextInfo, ModelInfo, ThinkingLevel, SessionFeatures } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { DEFAULT_WORKER_FEATURES } from '@neokai/shared';
 import { connectionState, type ConnectionState } from '../lib/state.ts';
 import ConnectionStatus from './ConnectionStatus.tsx';
 import ContextUsageBar from './ContextUsageBar.tsx';
 import { ContentContainer } from './ui/ContentContainer.tsx';
-import { useModal, getModelFamilyIcon, getProviderLabel, useMessageHub } from '../hooks';
+import {
+	useModal,
+	getModelFamilyIcon,
+	getProviderLabel,
+	groupModelsByProvider,
+	useMessageHub,
+} from '../hooks';
 import { Spinner } from './ui/Spinner.tsx';
 import { Tooltip } from './ui/Tooltip.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -194,6 +201,29 @@ export default function SessionStatusBar({
 
 	// Get MessageHub for RPC calls
 	const { callIfConnected } = useMessageHub();
+
+	// Provider auth statuses for availability dots in model picker
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, boolean>>(new Map());
+
+	useEffect(() => {
+		let cancelled = false;
+		callIfConnected('auth.providers', {})
+			.then((res) => {
+				if (cancelled) return;
+				const result = res as { providers?: ProviderAuthStatus[] } | null;
+				const statusMap = new Map<string, boolean>();
+				for (const p of result?.providers ?? []) {
+					statusMap.set(p.id, p.isAuthenticated);
+				}
+				setProviderAuthStatuses(statusMap);
+			})
+			.catch(() => {
+				// Silently ignore — dots just stay gray
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [callIfConnected]);
 
 	// Dropdowns - only one can be open at a time
 	const modelDropdown = useModal();
@@ -372,30 +402,46 @@ export default function SessionStatusBar({
 					{/* Model Dropdown */}
 					{modelDropdown.isOpen && (
 						<div
-							class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-48 py-1 z-50 animate-slideIn`}
+							class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
 						>
 							<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
-							{availableModels.map((model) => (
-								<button
-									key={model.id}
-									class={`w-full text-left px-3 py-2 hover:bg-dark-700 text-xs flex items-center gap-2 ${
-										model.id === currentModelInfo?.id ? 'text-blue-400' : 'text-gray-200'
-									}`}
-									onClick={() => handleModelSwitch(model)}
-									disabled={modelSwitching}
-								>
-									<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-									<span class="flex-1 truncate">{model.name}</span>
-									{model.provider !== 'anthropic' && (
-										<span class="text-gray-500 text-[10px]">
-											{getProviderLabel(model.provider)}
-										</span>
-									)}
-									{model.id === currentModelInfo?.id && (
-										<span class="text-blue-400 text-[10px]">(current)</span>
-									)}
-								</button>
-							))}
+							{Array.from(groupModelsByProvider(availableModels).entries()).map(
+								([provider, models], groupIndex) => {
+									const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
+									return (
+										<div key={provider}>
+											{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
+											<div class="px-3 py-1 flex items-center gap-1.5">
+												<span
+													class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
+												/>
+												<span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">
+													{getProviderLabel(provider)}
+												</span>
+											</div>
+											{models.map((model) => {
+												const isCurrent =
+													model.id === currentModelInfo?.id &&
+													model.provider === currentModelInfo?.provider;
+												return (
+													<button
+														key={`${model.provider}:${model.id}`}
+														class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
+															isCurrent ? 'text-blue-400' : 'text-gray-200'
+														}`}
+														onClick={() => handleModelSwitch(model)}
+														disabled={modelSwitching}
+													>
+														<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+														<span class="flex-1 truncate">{model.name}</span>
+														{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+													</button>
+												);
+											})}
+										</div>
+									);
+								}
+							)}
 						</div>
 					)}
 				</div>

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -22,6 +22,7 @@ describe('SessionStatusBar', () => {
 		id: 'sonnet',
 		name: 'Sonnet 4.5',
 		family: 'sonnet',
+		provider: 'anthropic',
 		isDefault: true,
 	};
 
@@ -412,7 +413,7 @@ describe('SessionStatusBar', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(modelButton);
 
-			expect(container.textContent).toContain('(current)');
+			expect(container.textContent).toContain('✓');
 		});
 
 		it('should call onModelSwitch when a model is selected', async () => {

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -9,9 +9,21 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { ContextInfo, ModelInfo } from '@neokai/shared';
 import SessionStatusBar from '../SessionStatusBar';
+
+// Configurable hub mock — defaults to null (no connection) so existing tests are unaffected.
+// Individual tests can call mockGetHubIfConnected.mockReturnValue({ request: ... }) to
+// simulate an authenticated connection.
+const mockGetHubIfConnected = vi.fn(() => null);
+
+vi.mock('../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => mockGetHubIfConnected(),
+		onConnection: vi.fn(() => () => {}),
+	},
+}));
 
 describe('SessionStatusBar', () => {
 	const mockOnModelSwitch = vi.fn(() => Promise.resolve());
@@ -86,6 +98,8 @@ describe('SessionStatusBar', () => {
 		mockOnModelSwitch.mockClear();
 		mockOnAutoScrollChange.mockClear();
 		mockOnCoordinatorModeChange.mockClear();
+		// Reset hub to null (no connection) between tests — individual tests can override
+		mockGetHubIfConnected.mockReturnValue(null);
 	});
 
 	afterEach(() => {
@@ -769,6 +783,112 @@ describe('SessionStatusBar', () => {
 				(btn) => btn.getAttribute('title')?.includes('Coordinator Mode') || false
 			);
 			expect(coordinatorButton?.className).toContain('border-gray-600');
+		});
+	});
+
+	describe('Model Dropdown — provider group headers', () => {
+		it('should render provider group header label when dropdown is open', () => {
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			// All mock models belong to 'anthropic' → label "Anthropic" should appear
+			expect(container.textContent).toContain('Anthropic');
+		});
+
+		it('should render one provider group header per distinct provider', () => {
+			const multiProviderModels: ModelInfo[] = [
+				{ id: 'opus', alias: 'opus', name: 'Opus 4.5', family: 'opus', provider: 'anthropic' },
+				{
+					id: 'copilot-sonnet',
+					alias: 'copilot-sonnet',
+					name: 'Sonnet (Copilot)',
+					family: 'sonnet',
+					provider: 'anthropic-copilot',
+				},
+			];
+
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} availableModels={multiProviderModels} />
+			);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			expect(container.textContent).toContain('Anthropic');
+			expect(container.textContent).toContain('Copilot');
+		});
+
+		it('should render an availability dot for each provider group', () => {
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			// Provider availability dots have flex-shrink-0 to distinguish them from
+			// the connection status dot (which does not have that class)
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+		});
+
+		it('should show gray availability dot when provider is not authenticated', () => {
+			// No hub → auth.providers returns null → isAuthenticated defaults to false → gray dot
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+			expect(providerDots[0].className).toContain('bg-gray-500');
+		});
+
+		it('should show green availability dot when provider is authenticated', async () => {
+			// Configure hub to return authenticated status for 'anthropic'
+			mockGetHubIfConnected.mockReturnValue({
+				request: vi.fn().mockImplementation((method: string) => {
+					if (method === 'auth.providers') {
+						return Promise.resolve({
+							providers: [{ id: 'anthropic', displayName: 'Anthropic', isAuthenticated: true }],
+						});
+					}
+					return Promise.resolve(null);
+				}),
+				onEvent: vi.fn(() => () => {}),
+				onConnection: vi.fn(() => () => {}),
+				isConnected: vi.fn(() => true),
+			});
+
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			// Wait for the auth.providers effect to resolve
+			await act(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			});
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			const providerDots = Array.from(
+				container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+			);
+			expect(providerDots.length).toBeGreaterThan(0);
+			expect(providerDots[0].className).toContain('bg-green-500');
 		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -143,6 +143,7 @@ describe('useModelSwitcher', () => {
 		it('should return correct label for known providers', () => {
 			expect(getProviderLabel('anthropic')).toBe('Anthropic');
 			expect(getProviderLabel('glm')).toBe('GLM');
+			expect(getProviderLabel('minimax')).toBe('MiniMax');
 			expect(getProviderLabel('anthropic-copilot')).toBe('Copilot');
 			expect(getProviderLabel('anthropic-codex')).toBe('Codex');
 		});

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -12,6 +12,7 @@ import {
 	MODEL_FAMILY_ICONS,
 	getModelFamilyIcon,
 	getProviderLabel,
+	groupModelsByProvider,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -865,6 +866,78 @@ describe('useModelSwitcher', () => {
 			rerender();
 
 			expect(result.current.reload).toBe(firstReload);
+		});
+	});
+
+	describe('groupModelsByProvider', () => {
+		it('should return an empty map for empty input', () => {
+			const result = groupModelsByProvider([]);
+			expect(result.size).toBe(0);
+		});
+
+		it('should group models by provider', () => {
+			const models = [
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+				{ id: 'claude-opus-4', provider: 'anthropic', family: 'opus', name: 'Opus' },
+				{
+					id: 'claude-sonnet-4',
+					provider: 'anthropic-copilot',
+					family: 'sonnet',
+					name: 'Sonnet (Copilot)',
+				},
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.size).toBe(2);
+			expect(result.get('anthropic')).toHaveLength(2);
+			expect(result.get('anthropic-copilot')).toHaveLength(1);
+		});
+
+		it('should default to anthropic provider when model has no provider', () => {
+			const models = [{ id: 'claude-sonnet-4', family: 'sonnet', name: 'Sonnet' }];
+			const result = groupModelsByProvider(models as any);
+			expect(result.has('anthropic')).toBe(true);
+			expect(result.get('anthropic')).toHaveLength(1);
+		});
+
+		it('should preserve all models within each group', () => {
+			const models = [
+				{ id: 'glm-4-plus', provider: 'glm', family: 'glm', name: 'GLM 4 Plus' },
+				{ id: 'glm-4-flash', provider: 'glm', family: 'glm', name: 'GLM 4 Flash' },
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.get('glm')).toHaveLength(2);
+			expect(result.get('anthropic')).toHaveLength(1);
+		});
+
+		it('should maintain insertion order of models within each group', () => {
+			const models = [
+				{ id: 'claude-opus-4', provider: 'anthropic', family: 'opus', name: 'Opus' },
+				{ id: 'claude-sonnet-4', provider: 'anthropic', family: 'sonnet', name: 'Sonnet' },
+				{ id: 'claude-haiku-4', provider: 'anthropic', family: 'haiku', name: 'Haiku' },
+			];
+			const result = groupModelsByProvider(models as any);
+			const anthropicModels = result.get('anthropic')!;
+			expect(anthropicModels[0].id).toBe('claude-opus-4');
+			expect(anthropicModels[1].id).toBe('claude-sonnet-4');
+			expect(anthropicModels[2].id).toBe('claude-haiku-4');
+		});
+
+		it('should handle all supported providers', () => {
+			const models = [
+				{ id: 'm1', provider: 'anthropic', family: 'sonnet', name: 'M1' },
+				{ id: 'm2', provider: 'anthropic-copilot', family: 'sonnet', name: 'M2' },
+				{ id: 'm3', provider: 'anthropic-codex', family: 'sonnet', name: 'M3' },
+				{ id: 'm4', provider: 'glm', family: 'glm', name: 'M4' },
+				{ id: 'm5', provider: 'minimax', family: 'minimax', name: 'M5' },
+			];
+			const result = groupModelsByProvider(models as any);
+			expect(result.size).toBe(5);
+			expect(result.has('anthropic')).toBe(true);
+			expect(result.has('anthropic-copilot')).toBe(true);
+			expect(result.has('anthropic-codex')).toBe(true);
+			expect(result.has('glm')).toBe(true);
+			expect(result.has('minimax')).toBe(true);
 		});
 	});
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -18,6 +18,7 @@ export {
 	getModelFamilyIcon,
 	PROVIDER_LABELS,
 	getProviderLabel,
+	groupModelsByProvider,
 } from './useModelSwitcher';
 export {
 	useMessageHub,

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -80,8 +80,10 @@ const PROVIDER_ORDER: Record<string, number> = {
 };
 
 /**
- * Group models by their provider, maintaining family sort order within each group.
- * Provider groups are ordered by PROVIDER_ORDER.
+ * Group models by their provider, preserving insertion order of the input array.
+ * Provider group ordering depends on the caller supplying a pre-sorted array —
+ * `loadModelInfo` sorts by PROVIDER_ORDER before calling this function.
+ * Models within each group retain their input order (family-sorted by the caller).
  */
 export function groupModelsByProvider(models: ModelInfo[]): Map<string, ModelInfo[]> {
 	const groups = new Map<string, ModelInfo[]>();
@@ -104,6 +106,7 @@ export const PROVIDER_LABELS: Record<string, string> = {
 	minimax: 'MiniMax',
 	'anthropic-copilot': 'Copilot',
 	'anthropic-codex': 'Codex',
+	// Note: keep in sync with PROVIDER_ORDER above
 };
 
 /**
@@ -188,7 +191,9 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 				};
 			});
 
-			// Sort by provider first, then by family order within each provider group
+			// Sort by provider first, then by family order within each provider group.
+			// This pre-sort is required so that groupModelsByProvider() preserves
+			// the intended provider order via Map insertion order.
 			modelInfos.sort((a, b) => {
 				const providerA = PROVIDER_ORDER[a.provider || 'anthropic'] ?? 99;
 				const providerB = PROVIDER_ORDER[b.provider || 'anthropic'] ?? 99;

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -70,6 +70,33 @@ const FAMILY_ORDER: Record<string, number> = {
 	gemini: 6,
 };
 
+/** Provider sort order for model picker grouping */
+const PROVIDER_ORDER: Record<string, number> = {
+	anthropic: 0,
+	'anthropic-copilot': 1,
+	'anthropic-codex': 2,
+	glm: 3,
+	minimax: 4,
+};
+
+/**
+ * Group models by their provider, maintaining family sort order within each group.
+ * Provider groups are ordered by PROVIDER_ORDER.
+ */
+export function groupModelsByProvider(models: ModelInfo[]): Map<string, ModelInfo[]> {
+	const groups = new Map<string, ModelInfo[]>();
+	for (const model of models) {
+		const provider = model.provider || 'anthropic';
+		const existing = groups.get(provider);
+		if (existing) {
+			existing.push(model);
+		} else {
+			groups.set(provider, [model]);
+		}
+	}
+	return groups;
+}
+
 /** Provider display labels for UI */
 export const PROVIDER_LABELS: Record<string, string> = {
 	anthropic: 'Anthropic',
@@ -161,8 +188,15 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 				};
 			});
 
-			// Sort by family order
-			modelInfos.sort((a, b) => FAMILY_ORDER[a.family] - FAMILY_ORDER[b.family]);
+			// Sort by provider first, then by family order within each provider group
+			modelInfos.sort((a, b) => {
+				const providerA = PROVIDER_ORDER[a.provider || 'anthropic'] ?? 99;
+				const providerB = PROVIDER_ORDER[b.provider || 'anthropic'] ?? 99;
+				if (providerA !== providerB) return providerA - providerB;
+				const familyA = FAMILY_ORDER[a.family] ?? 99;
+				const familyB = FAMILY_ORDER[b.family] ?? 99;
+				return familyA - familyB;
+			});
 			setAvailableModels(modelInfos);
 		} catch {
 			// Error handled silently - loading state will be cleared


### PR DESCRIPTION
## Summary

- Add `groupModelsByProvider(models: ModelInfo[]): Map<string, ModelInfo[]>` helper that groups models by provider, preserving family sort order within each group. Export from hooks index.
- Update model list sort to group by provider first (PROVIDER_ORDER: anthropic → copilot → codex → glm → minimax), then by family within each group.
- SessionStatusBar model dropdown now renders **provider group headers** with a green/gray availability dot (fetched via `auth.providers` RPC) and a separator between groups.
- Current model indicator changed from text `(current)` to checkmark `✓`, matching by both `id` and `provider` to handle cross-provider cases.
- Cross-provider switching already sends `provider` field via Task 2.3.

## Test plan

- [ ] 6 new unit tests for `groupModelsByProvider` (empty, grouping, default provider, order preservation, all providers)
- [ ] Updated `SessionStatusBar` test: `mockModelInfo` gains `provider: 'anthropic'`, indicator assertion updated to `✓`
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] All 3720 web tests pass