### PR TITLE
test: unit tests for provider routing and type safety (Task 7.1)

### DIFF
--- a/packages/daemon/tests/unit/model-service-provider-routing.test.ts
+++ b/packages/daemon/tests/unit/model-service-provider-routing.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import type { ModelInfo } from '@neokai/shared';
-import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
+import type { Provider, ProviderCapabilities, ProviderSdkConfig } from '@neokai/shared/provider';
 import {
 	getModelInfo,
 	resolveModelAlias,
@@ -20,28 +20,30 @@ import {
 	initializeModels,
 } from '../../src/lib/model-service';
 import { getProviderRegistry, resetProviderRegistry } from '../../src/lib/providers/registry';
-import { resetProviderFactory } from '../../src/lib/providers/factory';
+import { initializeProviders, resetProviderFactory } from '../../src/lib/providers/factory';
 
 // ---------------------------------------------------------------------------
-// Minimal provider stub
+// Minimal provider stub — implements the full Provider interface structurally
 // ---------------------------------------------------------------------------
 function makeStubProvider(id: string, models: ModelInfo[], available: boolean = true): Provider {
-	return {
+	const capabilities: ProviderCapabilities = {
+		streaming: true,
+		extendedThinking: false,
+		maxContextWindow: 200000,
+		functionCalling: true,
+		vision: false,
+	};
+	const stub: Provider = {
 		id,
 		displayName: id,
-		capabilities: {
-			streaming: true,
-			extendedThinking: false,
-			maxContextWindow: 200000,
-			functionCalling: true,
-			vision: false,
-		},
+		capabilities,
 		isAvailable: async () => available,
 		getModels: async () => models,
 		ownsModel: (modelId: string) => models.some((m) => m.id === modelId),
 		getModelForTier: () => undefined,
 		buildSdkConfig: (): ProviderSdkConfig => ({ envVars: {}, isAnthropicCompatible: true }),
-	} as unknown as Provider;
+	};
+	return stub;
 }
 
 // Shared model IDs that appear in more than one provider
@@ -256,10 +258,12 @@ describe('Model Service — provider routing', () => {
 	// -------------------------------------------------------------------------
 	// Global cache populated from all available providers via initializeModels
 	// -------------------------------------------------------------------------
-	// NOTE: initializeModels() calls initializeProviders() internally, which
-	// registers the 5 built-in providers (anthropic, glm, etc.). To avoid
-	// ID collisions we use unique stub IDs that don't shadow built-ins.
-	// The model .provider fields match those stub IDs so getModelInfo filtering works.
+	// Strategy: call initializeProviders() first so the 5 built-in providers are
+	// registered and initialized=true. Then add stub providers. When initializeModels()
+	// runs it calls initializeProviders() again, but because initialized=true and
+	// registry.size > 0, it returns early without touching the registry.
+	// All 5 real providers are unavailable in the test environment (no credentials),
+	// so only stub models make it into the cache — giving us deterministic assertions.
 	// -------------------------------------------------------------------------
 	describe('initializeModels — global cache contains models from all providers', () => {
 		const STUB_A = 'stub-provider-alpha';
@@ -304,6 +308,8 @@ describe('Model Service — provider routing', () => {
 		];
 
 		it('populates cache with models from all registered stub providers', async () => {
+			// Register real providers first (all unavailable); then add stubs.
+			initializeProviders();
 			const registry = getProviderRegistry();
 			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
 			registry.register(makeStubProvider(STUB_B, stubModelsB, true));
@@ -326,6 +332,7 @@ describe('Model Service — provider routing', () => {
 		});
 
 		it('keeps both provider entries when two providers share the same model ID', async () => {
+			initializeProviders();
 			const registry = getProviderRegistry();
 			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
 			registry.register(makeStubProvider(STUB_B, stubModelsB, true));
@@ -343,6 +350,7 @@ describe('Model Service — provider routing', () => {
 		});
 
 		it('skips unavailable providers when populating cache', async () => {
+			initializeProviders();
 			const registry = getProviderRegistry();
 			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
 			registry.register(makeStubProvider(STUB_B, stubModelsB, false)); // unavailable
@@ -359,6 +367,7 @@ describe('Model Service — provider routing', () => {
 		});
 
 		it('uses fallback models when all stub providers are unavailable', async () => {
+			initializeProviders();
 			const registry = getProviderRegistry();
 			registry.register(makeStubProvider(STUB_A, stubModelsA, false));
 			registry.register(makeStubProvider(STUB_B, stubModelsB, false));

--- a/packages/daemon/tests/unit/model-service-provider-routing.test.ts
+++ b/packages/daemon/tests/unit/model-service-provider-routing.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Model Service — Provider-Routing Unit Tests
+ *
+ * Focused tests for:
+ * - getModelInfo disambiguation when multiple providers share a model ID
+ * - resolveModelAlias with explicit providerId
+ * - Global cache populated from all available providers via initializeModels
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import type { ModelInfo } from '@neokai/shared';
+import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
+import {
+	getModelInfo,
+	resolveModelAlias,
+	isValidModel,
+	clearModelsCache,
+	setModelsCache,
+	getAvailableModels,
+	initializeModels,
+} from '../../src/lib/model-service';
+import { getProviderRegistry, resetProviderRegistry } from '../../src/lib/providers/registry';
+import { resetProviderFactory } from '../../src/lib/providers/factory';
+
+// ---------------------------------------------------------------------------
+// Minimal provider stub
+// ---------------------------------------------------------------------------
+function makeStubProvider(id: string, models: ModelInfo[], available: boolean = true): Provider {
+	return {
+		id,
+		displayName: id,
+		capabilities: {
+			streaming: true,
+			extendedThinking: false,
+			maxContextWindow: 200000,
+			functionCalling: true,
+			vision: false,
+		},
+		isAvailable: async () => available,
+		getModels: async () => models,
+		ownsModel: (modelId: string) => models.some((m) => m.id === modelId),
+		getModelForTier: () => undefined,
+		buildSdkConfig: (): ProviderSdkConfig => ({ envVars: {}, isAnthropicCompatible: true }),
+	} as unknown as Provider;
+}
+
+// Shared model IDs that appear in more than one provider
+const SHARED_MODEL_ID = 'claude-sonnet-4.6';
+
+const anthropicModels: ModelInfo[] = [
+	{
+		id: SHARED_MODEL_ID,
+		name: 'Claude Sonnet 4.6 (Anthropic)',
+		alias: 'sonnet-4.6',
+		family: 'sonnet',
+		provider: 'anthropic',
+		contextWindow: 200000,
+		available: true,
+	},
+	{
+		id: 'opus',
+		name: 'Claude Opus',
+		alias: 'opus',
+		family: 'opus',
+		provider: 'anthropic',
+		contextWindow: 200000,
+		available: true,
+	},
+];
+
+const copilotModels: ModelInfo[] = [
+	{
+		id: SHARED_MODEL_ID,
+		name: 'Claude Sonnet 4.6 (Copilot)',
+		alias: 'sonnet-4.6',
+		family: 'sonnet',
+		provider: 'anthropic-copilot',
+		contextWindow: 200000,
+		available: true,
+	},
+];
+
+const codexModels: ModelInfo[] = [
+	{
+		id: 'gpt-5.3-codex',
+		name: 'GPT-5.3 Codex',
+		alias: 'codex',
+		family: 'gpt',
+		provider: 'anthropic-codex',
+		contextWindow: 200000,
+		available: true,
+	},
+];
+
+// All models from all three providers in one flat list (simulates populated cache)
+const allModels: ModelInfo[] = [...anthropicModels, ...copilotModels, ...codexModels];
+
+describe('Model Service — provider routing', () => {
+	beforeEach(() => {
+		clearModelsCache();
+		resetProviderRegistry();
+		resetProviderFactory();
+	});
+
+	afterEach(() => {
+		clearModelsCache();
+		resetProviderRegistry();
+		resetProviderFactory();
+	});
+
+	// -------------------------------------------------------------------------
+	// getModelInfo with providerId disambiguation
+	// -------------------------------------------------------------------------
+	describe('getModelInfo — collision disambiguation', () => {
+		beforeEach(() => {
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', allModels);
+			setModelsCache(cache);
+		});
+
+		it('returns anthropic entry when providerId is anthropic', async () => {
+			const model = await getModelInfo(SHARED_MODEL_ID, 'global', 'anthropic');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Anthropic)');
+		});
+
+		it('returns anthropic-copilot entry when providerId is anthropic-copilot', async () => {
+			const model = await getModelInfo(SHARED_MODEL_ID, 'global', 'anthropic-copilot');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-copilot');
+			expect(model?.name).toBe('Claude Sonnet 4.6 (Copilot)');
+		});
+
+		it('returns null for anthropic-copilot when requesting a model only in anthropic', async () => {
+			const model = await getModelInfo('opus', 'global', 'anthropic-copilot');
+			expect(model).toBeNull();
+		});
+
+		it('returns anthropic-codex entry for gpt-5.3-codex', async () => {
+			const model = await getModelInfo('gpt-5.3-codex', 'global', 'anthropic-codex');
+			expect(model).not.toBeNull();
+			expect(model?.provider).toBe('anthropic-codex');
+		});
+
+		it('returns null when providerId is anthropic but model only exists in anthropic-codex', async () => {
+			const model = await getModelInfo('gpt-5.3-codex', 'global', 'anthropic');
+			expect(model).toBeNull();
+		});
+
+		it('returns null for an entirely unknown model regardless of provider', async () => {
+			const model = await getModelInfo('no-such-model-xyz', 'global', 'anthropic');
+			expect(model).toBeNull();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// resolveModelAlias with providerId
+	// -------------------------------------------------------------------------
+	describe('resolveModelAlias — provider-aware', () => {
+		beforeEach(() => {
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', allModels);
+			setModelsCache(cache);
+		});
+
+		it('resolves alias sonnet-4.6 to model ID for anthropic', async () => {
+			const resolved = await resolveModelAlias('sonnet-4.6', 'global', 'anthropic');
+			expect(resolved).toBe(SHARED_MODEL_ID);
+		});
+
+		it('resolves alias sonnet-4.6 to model ID for anthropic-copilot', async () => {
+			const resolved = await resolveModelAlias('sonnet-4.6', 'global', 'anthropic-copilot');
+			expect(resolved).toBe(SHARED_MODEL_ID);
+		});
+
+		it('resolves codex alias to gpt-5.3-codex for anthropic-codex', async () => {
+			const resolved = await resolveModelAlias('codex', 'global', 'anthropic-codex');
+			expect(resolved).toBe('gpt-5.3-codex');
+		});
+
+		it('returns alias as-is when no matching model found for the specified provider', async () => {
+			// codex alias does not exist in the anthropic provider
+			const resolved = await resolveModelAlias('codex', 'global', 'anthropic');
+			expect(resolved).toBe('codex');
+		});
+
+		it('resolves legacy model ID scoped to anthropic', async () => {
+			// Add a sonnet entry for anthropic so legacy mapping resolves correctly
+			const modelsWithSonnet: ModelInfo[] = [
+				...allModels,
+				{
+					id: 'sonnet',
+					name: 'Sonnet (Anthropic)',
+					alias: 'sonnet',
+					family: 'sonnet',
+					provider: 'anthropic',
+					contextWindow: 200000,
+					available: true,
+				},
+			];
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', modelsWithSonnet);
+			setModelsCache(cache);
+
+			// LEGACY_MODEL_MAPPINGS: 'claude-sonnet-4-5-20250929' → 'sonnet'
+			const resolved = await resolveModelAlias('claude-sonnet-4-5-20250929', 'global', 'anthropic');
+			expect(resolved).toBe('sonnet');
+		});
+
+		it('returns legacy model ID as-is when provider has no matching target', async () => {
+			// anthropic-codex has no 'sonnet' model — legacy mapping finds no match
+			const resolved = await resolveModelAlias(
+				'claude-sonnet-4-5-20250929',
+				'global',
+				'anthropic-codex'
+			);
+			// Falls back to the original input since there's no 'sonnet' in codex
+			expect(resolved).toBe('claude-sonnet-4-5-20250929');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// isValidModel with providerId
+	// -------------------------------------------------------------------------
+	describe('isValidModel — provider-scoped validation', () => {
+		beforeEach(() => {
+			const cache = new Map<string, ModelInfo[]>();
+			cache.set('global', allModels);
+			setModelsCache(cache);
+		});
+
+		it('validates claude-sonnet-4.6 as valid for anthropic', async () => {
+			expect(await isValidModel(SHARED_MODEL_ID, 'global', 'anthropic')).toBe(true);
+		});
+
+		it('validates claude-sonnet-4.6 as valid for anthropic-copilot', async () => {
+			expect(await isValidModel(SHARED_MODEL_ID, 'global', 'anthropic-copilot')).toBe(true);
+		});
+
+		it('rejects gpt-5.3-codex as invalid for anthropic', async () => {
+			expect(await isValidModel('gpt-5.3-codex', 'global', 'anthropic')).toBe(false);
+		});
+
+		it('validates gpt-5.3-codex as valid for anthropic-codex', async () => {
+			expect(await isValidModel('gpt-5.3-codex', 'global', 'anthropic-codex')).toBe(true);
+		});
+
+		it('rejects unknown model for any provider', async () => {
+			expect(await isValidModel('nonexistent-model', 'global', 'anthropic')).toBe(false);
+			expect(await isValidModel('nonexistent-model', 'global', 'anthropic-copilot')).toBe(false);
+			expect(await isValidModel('nonexistent-model', 'global', 'anthropic-codex')).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Global cache populated from all available providers via initializeModels
+	// -------------------------------------------------------------------------
+	// NOTE: initializeModels() calls initializeProviders() internally, which
+	// registers the 5 built-in providers (anthropic, glm, etc.). To avoid
+	// ID collisions we use unique stub IDs that don't shadow built-ins.
+	// The model .provider fields match those stub IDs so getModelInfo filtering works.
+	// -------------------------------------------------------------------------
+	describe('initializeModels — global cache contains models from all providers', () => {
+		const STUB_A = 'stub-provider-alpha';
+		const STUB_B = 'stub-provider-beta';
+		const STUB_C = 'stub-provider-gamma';
+		const STUB_SHARED_ID = 'shared-model-stub-xyz';
+
+		const stubModelsA: ModelInfo[] = [
+			{
+				id: STUB_SHARED_ID,
+				name: 'Shared Model (A)',
+				alias: 'shared-a',
+				family: 'test',
+				provider: STUB_A,
+				contextWindow: 100000,
+				available: true,
+			},
+		];
+
+		const stubModelsB: ModelInfo[] = [
+			{
+				id: STUB_SHARED_ID,
+				name: 'Shared Model (B)',
+				alias: 'shared-b',
+				family: 'test',
+				provider: STUB_B,
+				contextWindow: 100000,
+				available: true,
+			},
+		];
+
+		const stubModelsC: ModelInfo[] = [
+			{
+				id: 'unique-model-stub-xyz',
+				name: 'Unique Model (C)',
+				alias: 'unique-c',
+				family: 'test',
+				provider: STUB_C,
+				contextWindow: 100000,
+				available: true,
+			},
+		];
+
+		it('populates cache with models from all registered stub providers', async () => {
+			const registry = getProviderRegistry();
+			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
+			registry.register(makeStubProvider(STUB_B, stubModelsB, true));
+			registry.register(makeStubProvider(STUB_C, stubModelsC, true));
+
+			await initializeModels();
+
+			const entryA = await getModelInfo(STUB_SHARED_ID, 'global', STUB_A);
+			const entryB = await getModelInfo(STUB_SHARED_ID, 'global', STUB_B);
+			const entryC = await getModelInfo('unique-model-stub-xyz', 'global', STUB_C);
+
+			expect(entryA).not.toBeNull();
+			expect(entryA?.provider).toBe(STUB_A);
+
+			expect(entryB).not.toBeNull();
+			expect(entryB?.provider).toBe(STUB_B);
+
+			expect(entryC).not.toBeNull();
+			expect(entryC?.provider).toBe(STUB_C);
+		});
+
+		it('keeps both provider entries when two providers share the same model ID', async () => {
+			const registry = getProviderRegistry();
+			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
+			registry.register(makeStubProvider(STUB_B, stubModelsB, true));
+
+			await initializeModels();
+
+			const models = getAvailableModels('global');
+			const entriesForSharedId = models.filter((m) => m.id === STUB_SHARED_ID);
+
+			// Both provider entries must survive the merge — no last-writer-wins
+			expect(entriesForSharedId.length).toBeGreaterThanOrEqual(2);
+			const providers = entriesForSharedId.map((m) => m.provider);
+			expect(providers).toContain(STUB_A);
+			expect(providers).toContain(STUB_B);
+		});
+
+		it('skips unavailable providers when populating cache', async () => {
+			const registry = getProviderRegistry();
+			registry.register(makeStubProvider(STUB_A, stubModelsA, true));
+			registry.register(makeStubProvider(STUB_B, stubModelsB, false)); // unavailable
+
+			await initializeModels();
+
+			// STUB_B was unavailable — its models must not appear
+			const entryB = await getModelInfo(STUB_SHARED_ID, 'global', STUB_B);
+			expect(entryB).toBeNull();
+
+			// But STUB_A models are still present
+			const entryA = await getModelInfo(STUB_SHARED_ID, 'global', STUB_A);
+			expect(entryA).not.toBeNull();
+		});
+
+		it('uses fallback models when all stub providers are unavailable', async () => {
+			const registry = getProviderRegistry();
+			registry.register(makeStubProvider(STUB_A, stubModelsA, false));
+			registry.register(makeStubProvider(STUB_B, stubModelsB, false));
+
+			await initializeModels();
+
+			// FALLBACK_MODELS always include 'sonnet' for 'anthropic'
+			const fallback = await getModelInfo('sonnet', 'global', 'anthropic');
+			expect(fallback).not.toBeNull();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -805,6 +805,7 @@ describe('ProviderContextManager', () => {
 
 			expect(options.env).toBeDefined();
 			expect(options.env?.ANTHROPIC_BASE_URL).toBe('https://copilot.api.com');
+			expect(options.env?.ANTHROPIC_AUTH_TOKEN).toBe('copilot-token');
 		});
 
 		it('should return false for requiresQueryRestart within anthropic-copilot', () => {
@@ -962,6 +963,7 @@ describe('ProviderContextManager', () => {
 			const options = await context.buildSdkOptions({ maxTokens: 4096 });
 
 			expect(options.env?.ANTHROPIC_BASE_URL).toBe('https://codex.api.com');
+			expect(options.env?.ANTHROPIC_AUTH_TOKEN).toBe('codex-token');
 		});
 
 		it('should return true for requiresQueryRestart when switching from codex to anthropic', () => {

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -123,6 +123,60 @@ class AnthropicMockProvider extends MockProvider {
 	translateModelIdForSdk = undefined;
 }
 
+// Anthropic Copilot provider mock (same model IDs as anthropic)
+class AnthropicCopilotMockProvider extends MockProvider {
+	readonly id = 'anthropic-copilot' as const;
+	readonly displayName = 'Anthropic Copilot';
+
+	constructor(available: boolean = true) {
+		super('anthropic-copilot', 'Anthropic Copilot', available, 'claude-');
+	}
+
+	ownsModel(modelId: string): boolean {
+		return modelId.toLowerCase().startsWith('claude-');
+	}
+
+	buildSdkConfig(
+		_modelId: string,
+		sessionConfig?: { apiKey?: string; baseUrl?: string }
+	): ProviderSdkConfig {
+		return {
+			envVars: {
+				ANTHROPIC_BASE_URL: sessionConfig?.baseUrl || 'https://copilot.api.com',
+				ANTHROPIC_AUTH_TOKEN: sessionConfig?.apiKey || 'copilot-token',
+			},
+			isAnthropicCompatible: true,
+		};
+	}
+}
+
+// Anthropic Codex provider mock (gpt- and claude- models)
+class AnthropicCodexMockProvider extends MockProvider {
+	readonly id = 'anthropic-codex' as const;
+	readonly displayName = 'Anthropic Codex';
+
+	constructor(available: boolean = true) {
+		super('anthropic-codex', 'Anthropic Codex', available, 'gpt-');
+	}
+
+	ownsModel(modelId: string): boolean {
+		return modelId.toLowerCase().startsWith('gpt-') || modelId.toLowerCase().startsWith('claude-');
+	}
+
+	buildSdkConfig(
+		_modelId: string,
+		sessionConfig?: { apiKey?: string; baseUrl?: string }
+	): ProviderSdkConfig {
+		return {
+			envVars: {
+				ANTHROPIC_BASE_URL: sessionConfig?.baseUrl || 'https://codex.api.com',
+				ANTHROPIC_AUTH_TOKEN: sessionConfig?.apiKey || 'codex-token',
+			},
+			isAnthropicCompatible: true,
+		};
+	}
+}
+
 // GLM-like provider
 class GlmMockProvider extends MockProvider {
 	readonly id = 'glm' as const;
@@ -645,6 +699,326 @@ describe('ProviderContextManager', () => {
 			const result = await manager.validateProviderSwitch('unknown' as unknown as ProviderId);
 			expect(result.valid).toBe(false);
 			expect(result.error).toContain('Unknown provider');
+		});
+	});
+
+	describe('createContext — anthropic-copilot provider', () => {
+		beforeEach(() => {
+			resetProviderRegistry();
+			resetProviderFactory();
+			registry = new ProviderRegistry();
+			registry.register(new AnthropicMockProvider(true));
+			registry.register(new AnthropicCopilotMockProvider(true));
+			manager = new ProviderContextManager(registry);
+		});
+
+		it('should create context for session with explicit anthropic-copilot provider', () => {
+			const session: Session = {
+				id: 'copilot-session',
+				title: 'Copilot Session',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-copilot',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			const context = manager.createContext(session);
+
+			expect(context.provider.id).toBe('anthropic-copilot');
+			expect(context.modelId).toBe('claude-sonnet-4.6');
+		});
+
+		it('should select anthropic-copilot over anthropic when provider explicitly set', () => {
+			// Both anthropic and anthropic-copilot own claude- models.
+			// With explicit provider set, the copilot should be selected.
+			const copilotSession: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-opus-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-copilot',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+			const anthropicSession: Session = {
+				...copilotSession,
+				config: { ...copilotSession.config, provider: 'anthropic' },
+			};
+
+			expect(manager.createContext(copilotSession).provider.id).toBe('anthropic-copilot');
+			expect(manager.createContext(anthropicSession).provider.id).toBe('anthropic');
+		});
+
+		it('should build sdk options with copilot env vars', async () => {
+			const session: Session = {
+				id: 'copilot-sdk',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-copilot',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			const context = manager.createContext(session);
+			const options = await context.buildSdkOptions({ maxTokens: 4096 });
+
+			expect(options.env).toBeDefined();
+			expect(options.env?.ANTHROPIC_BASE_URL).toBe('https://copilot.api.com');
+		});
+
+		it('should return false for requiresQueryRestart within anthropic-copilot', () => {
+			const session: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-copilot',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			// Same provider → no restart needed
+			expect(manager.requiresQueryRestart(session, 'claude-opus-4.6', 'anthropic-copilot')).toBe(
+				false
+			);
+		});
+
+		it('should return true for requiresQueryRestart when switching from copilot to anthropic', () => {
+			const session: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-copilot',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			// Cross-provider switch → restart required
+			expect(manager.requiresQueryRestart(session, 'claude-opus-4.6', 'anthropic')).toBe(true);
+		});
+	});
+
+	describe('createContext — anthropic-codex provider', () => {
+		beforeEach(() => {
+			resetProviderRegistry();
+			resetProviderFactory();
+			registry = new ProviderRegistry();
+			registry.register(new AnthropicMockProvider(true));
+			registry.register(new AnthropicCodexMockProvider(true));
+			manager = new ProviderContextManager(registry);
+		});
+
+		it('should create context for session with explicit anthropic-codex provider', () => {
+			const session: Session = {
+				id: 'codex-session',
+				title: 'Codex Session',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'gpt-5.3-codex',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-codex',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			const context = manager.createContext(session);
+
+			expect(context.provider.id).toBe('anthropic-codex');
+			expect(context.modelId).toBe('gpt-5.3-codex');
+		});
+
+		it('should select anthropic-codex over anthropic for claude- models when explicitly set', () => {
+			// anthropic-codex also owns claude- models but explicit provider wins
+			const session: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-opus-4.6',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-codex',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			expect(manager.createContext(session).provider.id).toBe('anthropic-codex');
+		});
+
+		it('should build sdk options with codex env vars', async () => {
+			const session: Session = {
+				id: 'codex-sdk',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'gpt-5.3-codex',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-codex',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			const context = manager.createContext(session);
+			const options = await context.buildSdkOptions({ maxTokens: 4096 });
+
+			expect(options.env?.ANTHROPIC_BASE_URL).toBe('https://codex.api.com');
+		});
+
+		it('should return true for requiresQueryRestart when switching from codex to anthropic', () => {
+			const session: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'gpt-5.3-codex',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-codex',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			expect(manager.requiresQueryRestart(session, 'claude-opus-4.6', 'anthropic')).toBe(true);
+		});
+
+		it('should return false for requiresQueryRestart within anthropic-codex', () => {
+			const session: Session = {
+				id: 'test',
+				title: 'Test',
+				workspacePath: '/test',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'gpt-5.3-codex',
+					maxTokens: 8192,
+					temperature: 1.0,
+					provider: 'anthropic-codex',
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			};
+
+			// Same provider → no restart
+			expect(manager.requiresQueryRestart(session, 'gpt-5.3-codex-mini', 'anthropic-codex')).toBe(
+				false
+			);
 		});
 	});
 

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -296,15 +296,6 @@ describe('ProviderRegistry', () => {
 				errorSpy.mockRestore();
 			}
 		});
-
-		it('detectProvider (deprecated) still returns first-registered match for legacy paths', () => {
-			// anthropic registered first — heuristic fallback returns it
-			registry.register(makeAnthropicProvider());
-			registry.register(makeAnthropicCopilotProvider());
-
-			const result = registry.detectProvider('claude-opus-4.6');
-			expect(result?.id).toBe('anthropic');
-		});
 	});
 
 	describe('validateProviderSwitch', () => {
@@ -355,10 +346,9 @@ describe('ProviderRegistry', () => {
 	});
 
 	describe('initializeProviders — all five providers registered', () => {
-		it('should register exactly five built-in providers', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
+		// Outer beforeEach already resets registry+factory; no per-test resets needed.
 
+		it('should register exactly five built-in providers', () => {
 			const reg = initializeProviders();
 
 			const ids = reg
@@ -371,60 +361,39 @@ describe('ProviderRegistry', () => {
 		});
 
 		it('should include anthropic provider', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			const reg = initializeProviders();
 			expect(reg.has('anthropic')).toBe(true);
 		});
 
 		it('should include glm provider', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			const reg = initializeProviders();
 			expect(reg.has('glm')).toBe(true);
 		});
 
 		it('should include minimax provider', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			const reg = initializeProviders();
 			expect(reg.has('minimax')).toBe(true);
 		});
 
 		it('should include anthropic-codex provider', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			const reg = initializeProviders();
 			expect(reg.has('anthropic-codex')).toBe(true);
 		});
 
 		it('should include anthropic-copilot provider', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			const reg = initializeProviders();
 			expect(reg.has('anthropic-copilot')).toBe(true);
 		});
 
-		it('should return the same registry on repeated calls without reset', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
+		it('should return the same singleton registry on repeated calls without reset', () => {
 			const reg1 = initializeProviders();
 			const reg2 = initializeProviders();
-			// Both should be the same global registry with the same providers
-			expect(reg1.size).toBe(reg2.size);
+			// The global singleton must be the same reference — not a new instance
+			expect(reg1).toBe(reg2);
 			expect(reg2.size).toBe(5);
 		});
 
 		it('should use the global registry singleton', () => {
-			resetProviderRegistry();
-			resetProviderFactory();
-
 			initializeProviders();
 			const globalReg = getProviderRegistry();
 			expect(globalReg.size).toBe(5);
@@ -476,8 +445,14 @@ describe('ProviderRegistry', () => {
 		it('detectProviderForModel returns undefined for unknown provider regardless of model', () => {
 			registry.register(makeAnthropicProvider());
 
-			const result = registry.detectProviderForModel('claude-sonnet-4.6', 'unknown-provider');
-			expect(result).toBeUndefined();
+			// Suppress the expected error log produced by detectProviderForModel
+			const errorSpy = spyOn(Logger.prototype, 'error').mockImplementation(mock(() => {}));
+			try {
+				const result = registry.detectProviderForModel('claude-sonnet-4.6', 'unknown-provider');
+				expect(result).toBeUndefined();
+			} finally {
+				errorSpy.mockRestore();
+			}
 		});
 	});
 

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -6,8 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:te
 import type { ModelInfo } from '@neokai/shared';
 import { Logger } from '@neokai/shared/logger';
 import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
-import { resetProviderFactory } from '../../../src/lib/providers/factory';
-import { ProviderRegistry, resetProviderRegistry } from '../../../src/lib/providers/registry';
+import { initializeProviders, resetProviderFactory } from '../../../src/lib/providers/factory';
+import {
+	ProviderRegistry,
+	getProviderRegistry,
+	resetProviderRegistry,
+} from '../../../src/lib/providers/registry';
 
 // Mock provider for testing
 class MockProvider implements Provider {
@@ -347,6 +351,133 @@ describe('ProviderRegistry', () => {
 
 			registry.clear();
 			expect(registry.size).toBe(0);
+		});
+	});
+
+	describe('initializeProviders — all five providers registered', () => {
+		it('should register exactly five built-in providers', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+
+			const ids = reg
+				.getAll()
+				.map((p) => p.id)
+				.sort();
+			expect(ids).toEqual(
+				['anthropic', 'anthropic-codex', 'anthropic-copilot', 'glm', 'minimax'].sort()
+			);
+		});
+
+		it('should include anthropic provider', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+			expect(reg.has('anthropic')).toBe(true);
+		});
+
+		it('should include glm provider', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+			expect(reg.has('glm')).toBe(true);
+		});
+
+		it('should include minimax provider', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+			expect(reg.has('minimax')).toBe(true);
+		});
+
+		it('should include anthropic-codex provider', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+			expect(reg.has('anthropic-codex')).toBe(true);
+		});
+
+		it('should include anthropic-copilot provider', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg = initializeProviders();
+			expect(reg.has('anthropic-copilot')).toBe(true);
+		});
+
+		it('should return the same registry on repeated calls without reset', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			const reg1 = initializeProviders();
+			const reg2 = initializeProviders();
+			// Both should be the same global registry with the same providers
+			expect(reg1.size).toBe(reg2.size);
+			expect(reg2.size).toBe(5);
+		});
+
+		it('should use the global registry singleton', () => {
+			resetProviderRegistry();
+			resetProviderFactory();
+
+			initializeProviders();
+			const globalReg = getProviderRegistry();
+			expect(globalReg.size).toBe(5);
+		});
+	});
+
+	describe('ownsModel collision — anthropic vs anthropic-copilot vs anthropic-codex', () => {
+		it('anthropic and anthropic-copilot both claim claude- models', () => {
+			const anthropic = makeAnthropicProvider();
+			const copilot = makeAnthropicCopilotProvider();
+
+			expect(anthropic.ownsModel('claude-sonnet-4.6')).toBe(true);
+			expect(copilot.ownsModel('claude-sonnet-4.6')).toBe(true);
+		});
+
+		it('anthropic-codex additionally claims gpt- models', () => {
+			const codex = makeAnthropicCodexProvider();
+
+			expect(codex.ownsModel('gpt-5.3-codex')).toBe(true);
+			expect(codex.ownsModel('claude-opus-4.6')).toBe(true);
+		});
+
+		it('detectProvider (deprecated heuristic) is ambiguous — returns first registered for claude- models', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+
+			// Heuristic returns first match — non-deterministic when collision exists
+			const result = registry.detectProvider('claude-sonnet-4.6');
+			expect(result?.id).toBe('anthropic'); // First registered wins
+		});
+
+		it('detectProviderForModel is deterministic for colliding model IDs', () => {
+			registry.register(makeAnthropicProvider());
+			registry.register(makeAnthropicCopilotProvider());
+			registry.register(makeAnthropicCodexProvider());
+
+			// Explicit routing — no ambiguity regardless of registration order
+			expect(registry.detectProviderForModel('claude-sonnet-4.6', 'anthropic')?.id).toBe(
+				'anthropic'
+			);
+			expect(registry.detectProviderForModel('claude-sonnet-4.6', 'anthropic-copilot')?.id).toBe(
+				'anthropic-copilot'
+			);
+			expect(registry.detectProviderForModel('claude-opus-4.6', 'anthropic-codex')?.id).toBe(
+				'anthropic-codex'
+			);
+		});
+
+		it('detectProviderForModel returns undefined for unknown provider regardless of model', () => {
+			registry.register(makeAnthropicProvider());
+
+			const result = registry.detectProviderForModel('claude-sonnet-4.6', 'unknown-provider');
+			expect(result).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

- **`provider-registry.test.ts`**: Added `initializeProviders` describe block verifying all 5 built-in providers (`anthropic`, `glm`, `minimax`, `anthropic-codex`, `anthropic-copilot`) are registered; added `ownsModel collision` block testing deterministic `detectProviderForModel` vs ambiguous deprecated `detectProvider`
- **`context-manager.test.ts`**: Added `anthropic-copilot` and `anthropic-codex` mock providers plus two new describe blocks covering: explicit provider selection over collision detection, `buildSdkOptions` env vars, and `requiresQueryRestart` same/cross-provider logic
- **`model-service-provider-routing.test.ts`** (new file): Focused tests for `getModelInfo` disambiguation (same model ID in both `anthropic` and `anthropic-copilot`), `resolveModelAlias` with `providerId`, `isValidModel` provider-scoped validation, and `initializeModels` global cache population from all registered providers

## Test plan

- [x] All 100 new/modified tests pass
- [x] All 4370 unit tests pass (8 pre-existing failures in dev-proxy and buildCopilotEnv are unrelated)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Biome format check passes