### PR TITLE
fix: render leader questions as interactive forms in task conversation

### DIFF
--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -820,8 +820,9 @@ describe('TaskConversationRenderer — session question state props', () => {
 		});
 
 		await waitFor(() => {
-			const leaderProps = capturedSDKProps.find((p) => p.uuid === 'uuid-leader');
-			const workerProps = capturedSDKProps.find((p) => p.uuid === 'uuid-worker');
+			// Use the last captured render for each uuid to avoid stale intermediate snapshots
+			const leaderProps = [...capturedSDKProps].reverse().find((p) => p.uuid === 'uuid-leader');
+			const workerProps = [...capturedSDKProps].reverse().find((p) => p.uuid === 'uuid-worker');
 			// Leader message should receive the pending question
 			expect(leaderProps?.pendingQuestion).toEqual(leaderPendingQuestion);
 			// Worker message should NOT receive the leader's pending question (no cross-session contamination)

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -628,3 +628,111 @@ describe('TaskConversationRenderer — pagination', () => {
 		expect(getByText('Load older messages')).toBeDefined();
 	});
 });
+
+describe('TaskConversationRenderer — session question state props', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockClear();
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		deltaHandler = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('accepts leaderSessionId and workerSessionId props without errors', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+
+		let threw = false;
+		try {
+			const { container } = render(
+				<TaskConversationRenderer
+					groupId="group-1"
+					leaderSessionId="leader-session-123"
+					workerSessionId="worker-session-456"
+					onMessageCountChange={vi.fn()}
+				/>
+			);
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
+			});
+		} catch {
+			threw = true;
+		}
+
+		expect(threw).toBe(false);
+	});
+
+	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+
+		let threw = false;
+		try {
+			const { container } = render(
+				<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+			);
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
+			});
+		} catch {
+			threw = true;
+		}
+
+		expect(threw).toBe(false);
+	});
+
+	it('joins session channels for leader and worker when both session IDs provided', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+
+		render(
+			<TaskConversationRenderer
+				groupId="group-1"
+				leaderSessionId="leader-session-123"
+				workerSessionId="worker-session-456"
+				onMessageCountChange={vi.fn()}
+			/>
+		);
+
+		await waitFor(() => {
+			// TaskConversationRenderer joins group channel; useSessionQuestionState joins session channels
+			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
+			expect(joinedRooms).toContain('group:group-1');
+			expect(joinedRooms).toContain('session:leader-session-123');
+			expect(joinedRooms).toContain('session:worker-session-456');
+		});
+	});
+
+	it('renders messages with _taskMeta.authorSessionId set correctly', async () => {
+		// Craft a message with _taskMeta.authorSessionId set to a leader session
+		const leaderMsg = makeRawMessage(1, 'assistant', 'uuid-leader');
+		const parsed = JSON.parse(leaderMsg.content);
+		parsed._taskMeta = {
+			authorRole: 'leader',
+			authorSessionId: 'leader-session-123',
+			turnId: 'turn-1',
+			iteration: 0,
+		};
+		leaderMsg.content = JSON.stringify(parsed);
+
+		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
+
+		const { container } = render(
+			<TaskConversationRenderer
+				groupId="group-1"
+				leaderSessionId="leader-session-123"
+				workerSessionId="worker-session-456"
+				onMessageCountChange={vi.fn()}
+			/>
+		);
+
+		await waitFor(() => {
+			// The message renders — the SDKMessageRenderer mock renders a div with the uuid
+			expect(container.querySelector('[data-testid="msg-uuid-leader"]')).not.toBeNull();
+		});
+	});
+});

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -20,12 +20,22 @@ import { TaskConversationRenderer } from './TaskConversationRenderer';
 
 const mockRequest = vi.fn();
 let deltaHandler: ((event: { added: unknown[]; timestamp: number }) => void) | null = null;
-const mockOnEvent = vi.fn((eventName: string, handler: (event: unknown) => void) => {
-	if (eventName === 'state.groupMessages.delta') {
-		deltaHandler = handler;
+
+// state.session handlers keyed by the channel passed when the handler fires,
+// allowing tests to fire session-state events scoped to a specific session channel.
+type SessionStateHandler = (data: unknown, context: { channel?: string }) => void;
+const sessionStateHandlers: SessionStateHandler[] = [];
+
+const mockOnEvent = vi.fn(
+	(eventName: string, handler: (data: unknown, context?: { channel?: string }) => void) => {
+		if (eventName === 'state.groupMessages.delta') {
+			deltaHandler = handler as (event: { added: unknown[]; timestamp: number }) => void;
+		} else if (eventName === 'state.session') {
+			sessionStateHandlers.push(handler as SessionStateHandler);
+		}
+		return () => {};
 	}
-	return () => {};
-});
+);
 const mockJoinRoom = vi.fn();
 const mockLeaveRoom = vi.fn();
 
@@ -38,12 +48,38 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 	}),
 }));
 
-// SDKMessageRenderer minimal mock
+// SDKMessageRenderer mock that captures rendered props for inspection
+type CapturedRendererProps = {
+	uuid: string;
+	sessionId: string | undefined;
+	pendingQuestion: unknown;
+	resolvedQuestions: unknown;
+};
+const capturedSDKProps: CapturedRendererProps[] = [];
+
 vi.mock('../sdk/SDKMessageRenderer.tsx', () => ({
-	SDKMessageRenderer: ({ message }: { message: { uuid?: string } }) => (
-		<div data-testid={`msg-${message.uuid ?? 'unknown'}`} />
-	),
+	SDKMessageRenderer: (props: {
+		message: { uuid?: string };
+		sessionId?: string;
+		pendingQuestion?: unknown;
+		resolvedQuestions?: unknown;
+	}) => {
+		capturedSDKProps.push({
+			uuid: props.message?.uuid ?? 'unknown',
+			sessionId: props.sessionId,
+			pendingQuestion: props.pendingQuestion,
+			resolvedQuestions: props.resolvedQuestions,
+		});
+		return <div data-testid={`msg-${props.message?.uuid ?? 'unknown'}`} />;
+	},
 }));
+
+/** Fire a state.session event on the given channel to all registered handlers */
+function fireSessionStateEvent(channel: string, data: unknown): void {
+	for (const handler of sessionStateHandlers) {
+		handler(data, { channel });
+	}
+}
 
 // -------------------------------------------------------
 // Helpers
@@ -100,6 +136,8 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		deltaHandler = null;
+		sessionStateHandlers.length = 0;
+		capturedSDKProps.length = 0;
 	});
 
 	afterEach(() => {
@@ -403,6 +441,8 @@ describe('TaskConversationRenderer — pagination', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		deltaHandler = null;
+		sessionStateHandlers.length = 0;
+		capturedSDKProps.length = 0;
 	});
 
 	afterEach(() => {
@@ -636,6 +676,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
 		deltaHandler = null;
+		sessionStateHandlers.length = 0;
+		capturedSDKProps.length = 0;
 	});
 
 	afterEach(() => {
@@ -646,43 +688,29 @@ describe('TaskConversationRenderer — session question state props', () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
-		let threw = false;
-		try {
-			const { container } = render(
-				<TaskConversationRenderer
-					groupId="group-1"
-					leaderSessionId="leader-session-123"
-					workerSessionId="worker-session-456"
-					onMessageCountChange={vi.fn()}
-				/>
-			);
-			await waitFor(() => {
-				expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
-			});
-		} catch {
-			threw = true;
-		}
-
-		expect(threw).toBe(false);
+		const { container } = render(
+			<TaskConversationRenderer
+				groupId="group-1"
+				leaderSessionId="leader-session-123"
+				workerSessionId="worker-session-456"
+				onMessageCountChange={vi.fn()}
+			/>
+		);
+		await waitFor(() => {
+			expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
+		});
 	});
 
 	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
-		let threw = false;
-		try {
-			const { container } = render(
-				<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-			);
-			await waitFor(() => {
-				expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
-			});
-		} catch {
-			threw = true;
-		}
-
-		expect(threw).toBe(false);
+		const { container } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+		await waitFor(() => {
+			expect(container.querySelector('[data-testid^="msg-"]')).not.toBeNull();
+		});
 	});
 
 	it('joins session channels for leader and worker when both session IDs provided', async () => {
@@ -699,7 +727,6 @@ describe('TaskConversationRenderer — session question state props', () => {
 		);
 
 		await waitFor(() => {
-			// TaskConversationRenderer joins group channel; useSessionQuestionState joins session channels
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
 			expect(joinedRooms).toContain('group:group-1');
 			expect(joinedRooms).toContain('session:leader-session-123');
@@ -707,8 +734,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		});
 	});
 
-	it('renders messages with _taskMeta.authorSessionId set correctly', async () => {
-		// Craft a message with _taskMeta.authorSessionId set to a leader session
+	it('passes sessionId from authorSessionId to SDKMessageRenderer', async () => {
 		const leaderMsg = makeRawMessage(1, 'assistant', 'uuid-leader');
 		const parsed = JSON.parse(leaderMsg.content);
 		parsed._taskMeta = {
@@ -721,7 +747,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
 
-		const { container } = render(
+		render(
 			<TaskConversationRenderer
 				groupId="group-1"
 				leaderSessionId="leader-session-123"
@@ -731,8 +757,106 @@ describe('TaskConversationRenderer — session question state props', () => {
 		);
 
 		await waitFor(() => {
-			// The message renders — the SDKMessageRenderer mock renders a div with the uuid
-			expect(container.querySelector('[data-testid="msg-uuid-leader"]')).not.toBeNull();
+			const leaderProps = capturedSDKProps.find((p) => p.uuid === 'uuid-leader');
+			expect(leaderProps).toBeDefined();
+			expect(leaderProps?.sessionId).toBe('leader-session-123');
+		});
+	});
+
+	it('passes pendingQuestion to SDKMessageRenderer for the correct session after state.session event', async () => {
+		// Leader message
+		const leaderMsg = makeRawMessage(1, 'assistant', 'uuid-leader');
+		const parsedLeader = JSON.parse(leaderMsg.content);
+		parsedLeader._taskMeta = {
+			authorRole: 'leader',
+			authorSessionId: 'leader-session-123',
+			turnId: 'turn-1',
+			iteration: 0,
+		};
+		leaderMsg.content = JSON.stringify(parsedLeader);
+
+		// Worker message
+		const workerMsg = makeRawMessage(2, 'assistant', 'uuid-worker');
+		const parsedWorker = JSON.parse(workerMsg.content);
+		parsedWorker._taskMeta = {
+			authorRole: 'coder',
+			authorSessionId: 'worker-session-456',
+			turnId: 'turn-2',
+			iteration: 0,
+		};
+		workerMsg.content = JSON.stringify(parsedWorker);
+
+		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg, workerMsg]));
+
+		render(
+			<TaskConversationRenderer
+				groupId="group-1"
+				leaderSessionId="leader-session-123"
+				workerSessionId="worker-session-456"
+				onMessageCountChange={vi.fn()}
+			/>
+		);
+
+		// Wait for initial render
+		await waitFor(() => {
+			expect(capturedSDKProps.length).toBeGreaterThanOrEqual(2);
+		});
+
+		capturedSDKProps.length = 0; // Reset to capture fresh render
+
+		// Fire a state.session event for the LEADER session with waiting_for_input
+		const leaderPendingQuestion = {
+			toolUseId: 'tool-123',
+			questions: [
+				{ question: 'How should I proceed?', header: 'Decision', options: [], multiSelect: false },
+			],
+			askedAt: Date.now(),
+		};
+		await act(async () => {
+			fireSessionStateEvent('session:leader-session-123', {
+				agentState: { status: 'waiting_for_input', pendingQuestion: leaderPendingQuestion },
+				sessionInfo: null,
+			});
+		});
+
+		await waitFor(() => {
+			const leaderProps = capturedSDKProps.find((p) => p.uuid === 'uuid-leader');
+			const workerProps = capturedSDKProps.find((p) => p.uuid === 'uuid-worker');
+			// Leader message should receive the pending question
+			expect(leaderProps?.pendingQuestion).toEqual(leaderPendingQuestion);
+			// Worker message should NOT receive the leader's pending question (no cross-session contamination)
+			expect(workerProps?.pendingQuestion).toBeNull();
+		});
+	});
+
+	it('uses no-op question state for messages with unknown authorSessionId', async () => {
+		const unknownMsg = makeRawMessage(1, 'assistant', 'uuid-unknown');
+		const parsedUnknown = JSON.parse(unknownMsg.content);
+		parsedUnknown._taskMeta = {
+			authorRole: 'general',
+			authorSessionId: 'unknown-session-xyz',
+			turnId: 'turn-1',
+			iteration: 0,
+		};
+		unknownMsg.content = JSON.stringify(parsedUnknown);
+
+		mockRequest.mockImplementation(async () => makeApiResponse([unknownMsg]));
+
+		render(
+			<TaskConversationRenderer
+				groupId="group-1"
+				leaderSessionId="leader-session-123"
+				workerSessionId="worker-session-456"
+				onMessageCountChange={vi.fn()}
+			/>
+		);
+
+		await waitFor(() => {
+			const props = capturedSDKProps.find((p) => p.uuid === 'uuid-unknown');
+			expect(props).toBeDefined();
+			// Unknown session should get no-op state: no sessionId from question state but
+			// authorSessionId is still passed as sessionId prop to allow form rendering for known tools
+			expect(props?.pendingQuestion).toBeNull();
 		});
 	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useMessageHub } from '../../hooks/useMessageHub';
+import { useSessionQuestionState } from '../../hooks/useSessionQuestionState';
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 
@@ -39,6 +40,10 @@ interface GroupMessage {
 
 interface TaskConversationRendererProps {
 	groupId: string;
+	/** Session ID of the leader agent (used to render AskUserQuestion as interactive forms) */
+	leaderSessionId?: string;
+	/** Session ID of the worker agent (used to render AskUserQuestion as interactive forms) */
+	workerSessionId?: string;
 	/** Called whenever the message list length changes, so the parent can drive autoscroll */
 	onMessageCountChange?: (count: number) => void;
 }
@@ -95,9 +100,16 @@ const PAGE_SIZE = 50;
 
 export function TaskConversationRenderer({
 	groupId,
+	leaderSessionId,
+	workerSessionId,
 	onMessageCountChange,
 }: TaskConversationRendererProps) {
 	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
+
+	// Subscribe to question state for each agent session so AskUserQuestion
+	// renders as an interactive form rather than a plain message
+	const leaderQuestionState = useSessionQuestionState(leaderSessionId);
+	const workerQuestionState = useSessionQuestionState(workerSessionId);
 	const [messages, setMessages] = useState<SDKMessage[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [loadingOlder, setLoadingOlder] = useState(false);
@@ -367,6 +379,15 @@ export function TaskConversationRenderer({
 				// Insert a role transition divider when the agent changes
 				const showTransition = roleTransitions.has(i);
 
+				// Look up the question state for the session that authored this message
+				const authorSessionId = meta?.authorSessionId;
+				let questionState = leaderQuestionState;
+				if (authorSessionId && workerSessionId && authorSessionId === workerSessionId) {
+					questionState = workerQuestionState;
+				} else if (authorSessionId && leaderSessionId && authorSessionId === leaderSessionId) {
+					questionState = leaderQuestionState;
+				}
+
 				return (
 					<div key={key}>
 						{showTransition && (
@@ -386,6 +407,10 @@ export function TaskConversationRenderer({
 								toolResultsMap={maps.toolResultsMap}
 								toolInputsMap={maps.toolInputsMap}
 								subagentMessagesMap={maps.subagentMessagesMap}
+								sessionId={authorSessionId || undefined}
+								pendingQuestion={questionState.pendingQuestion}
+								resolvedQuestions={questionState.resolvedQuestions}
+								onQuestionResolved={questionState.onQuestionResolved}
 								taskContext
 							/>
 						</div>

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -17,9 +17,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useMessageHub } from '../../hooks/useMessageHub';
-import { useSessionQuestionState } from '../../hooks/useSessionQuestionState';
+import {
+	useSessionQuestionState,
+	type SessionQuestionState,
+} from '../../hooks/useSessionQuestionState';
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
+
+/** Empty question state used as a safe fallback for messages with unknown session IDs */
+const NO_OP_QUESTION_STATE: SessionQuestionState = {
+	pendingQuestion: null,
+	resolvedQuestions: new Map(),
+	onQuestionResolved: () => {},
+};
 
 interface TaskMeta {
 	authorRole: 'planner' | 'coder' | 'general' | 'leader' | 'craft' | 'lead' | 'human' | 'system';
@@ -379,13 +389,15 @@ export function TaskConversationRenderer({
 				// Insert a role transition divider when the agent changes
 				const showTransition = roleTransitions.has(i);
 
-				// Look up the question state for the session that authored this message
+				// Look up the question state for the session that authored this message.
+				// Fall back to a no-op state for messages whose authorSessionId does not
+				// match either known session, to avoid rendering incorrect question forms.
 				const authorSessionId = meta?.authorSessionId;
-				let questionState = leaderQuestionState;
-				if (authorSessionId && workerSessionId && authorSessionId === workerSessionId) {
-					questionState = workerQuestionState;
-				} else if (authorSessionId && leaderSessionId && authorSessionId === leaderSessionId) {
+				let questionState: SessionQuestionState = NO_OP_QUESTION_STATE;
+				if (authorSessionId && leaderSessionId && authorSessionId === leaderSessionId) {
 					questionState = leaderQuestionState;
+				} else if (authorSessionId && workerSessionId && authorSessionId === workerSessionId) {
+					questionState = workerQuestionState;
 				}
 
 				return (

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -1112,6 +1112,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						<TaskConversationRenderer
 							key={`${group.id}-${conversationKey}`}
 							groupId={group.id}
+							leaderSessionId={group.leaderSessionId}
+							workerSessionId={group.workerSessionId}
 							onMessageCountChange={setMessageCount}
 						/>
 					) : (

--- a/packages/web/src/hooks/__tests__/useSessionQuestionState.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionQuestionState.test.ts
@@ -257,4 +257,37 @@ describe('useSessionQuestionState', () => {
 
 		expect(result.current.resolvedQuestions.size).toBe(0);
 	});
+
+	it('preserves resolvedQuestions when a state event arrives with null sessionInfo (optimistic update not erased)', async () => {
+		mockRequest.mockResolvedValue(makeWaitingSessionState('tool-001'));
+
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		// Optimistically resolve the question
+		await act(async () => {
+			result.current.onQuestionResolved('submitted', [
+				{ questionIndex: 0, selectedLabels: ['Yes'], customText: undefined },
+			]);
+		});
+
+		expect(result.current.resolvedQuestions.size).toBe(1);
+
+		// Server sends a state event without sessionInfo (no metadata/resolvedQuestions)
+		act(() => {
+			fireSessionEvent('session:session-abc', makeIdleSessionState());
+		});
+
+		await waitFor(() => {
+			// pendingQuestion cleared by the server event
+			expect(result.current.pendingQuestion).toBeNull();
+		});
+
+		// Optimistic resolved entry must NOT be erased by the null-metadata event
+		expect(result.current.resolvedQuestions.size).toBe(1);
+		expect(result.current.resolvedQuestions.get('tool-001')?.state).toBe('submitted');
+	});
 });

--- a/packages/web/src/hooks/__tests__/useSessionQuestionState.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionQuestionState.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for useSessionQuestionState hook
+ *
+ * Verifies that:
+ * - Returns empty state when sessionId is undefined
+ * - Joins/leaves the session channel correctly
+ * - Extracts pendingQuestion from waiting_for_input agentState
+ * - Syncs resolvedQuestions from session metadata
+ * - Filters state.session events by channel (no cross-session contamination)
+ * - onQuestionResolved provides an optimistic local update
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/preact';
+import type { SessionState } from '@neokai/shared';
+import { useSessionQuestionState } from '../useSessionQuestionState';
+
+// -------------------------------------------------------
+// Mocks
+// -------------------------------------------------------
+
+const mockRequest = vi.fn();
+const mockJoinRoom = vi.fn();
+const mockLeaveRoom = vi.fn();
+
+// Capture registered state.session handlers so tests can fire them
+type HandlerWithContext = (data: unknown, context: { channel?: string }) => void;
+const sessionStateHandlers: HandlerWithContext[] = [];
+
+const mockOnEvent = vi.fn(
+	(eventName: string, handler: (data: unknown, context?: { channel?: string }) => void) => {
+		if (eventName === 'state.session') {
+			sessionStateHandlers.push(handler as HandlerWithContext);
+		}
+		return () => {};
+	}
+);
+
+vi.mock('../useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		joinRoom: mockJoinRoom,
+		leaveRoom: mockLeaveRoom,
+	}),
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeIdleSessionState(): SessionState {
+	return {
+		agentState: { status: 'idle' },
+		sessionInfo: null,
+		commandsData: { availableCommands: [] },
+		error: null,
+	} as unknown as SessionState;
+}
+
+function makeWaitingSessionState(toolUseId: string): SessionState {
+	return {
+		agentState: {
+			status: 'waiting_for_input',
+			pendingQuestion: {
+				toolUseId,
+				questions: [
+					{
+						question: 'What should I do?',
+						header: 'Decision needed',
+						options: [],
+						multiSelect: false,
+					},
+				],
+				askedAt: 1000,
+			},
+		},
+		sessionInfo: null,
+		commandsData: { availableCommands: [] },
+		error: null,
+	} as unknown as SessionState;
+}
+
+function fireSessionEvent(channel: string, data: unknown): void {
+	for (const handler of sessionStateHandlers) {
+		handler(data, { channel });
+	}
+}
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+describe('useSessionQuestionState', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockClear();
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		sessionStateHandlers.length = 0;
+		// Default: fetch returns idle state
+		mockRequest.mockResolvedValue(makeIdleSessionState());
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('returns empty state when sessionId is undefined', () => {
+		const { result } = renderHook(() => useSessionQuestionState(undefined));
+
+		expect(result.current.pendingQuestion).toBeNull();
+		expect(result.current.resolvedQuestions.size).toBe(0);
+		expect(typeof result.current.onQuestionResolved).toBe('function');
+
+		// Should not join any channel
+		expect(mockJoinRoom).not.toHaveBeenCalled();
+	});
+
+	it('joins the session channel when sessionId is provided', () => {
+		renderHook(() => useSessionQuestionState('session-abc'));
+
+		expect(mockJoinRoom).toHaveBeenCalledWith('session:session-abc');
+	});
+
+	it('leaves the channel on unmount', () => {
+		const { unmount } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		unmount();
+
+		expect(mockLeaveRoom).toHaveBeenCalledWith('session:session-abc');
+	});
+
+	it('fetches initial state and sets pendingQuestion when waiting_for_input', async () => {
+		mockRequest.mockResolvedValue(makeWaitingSessionState('tool-001'));
+
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.pendingQuestion).not.toBeNull();
+		expect(result.current.pendingQuestion?.toolUseId).toBe('tool-001');
+	});
+
+	it('fetches initial state and resolvedQuestions from session metadata', async () => {
+		const resolvedQuestion = {
+			question: { toolUseId: 'tool-old', questions: [], askedAt: 500 },
+			state: 'submitted' as const,
+			responses: [{ questionIndex: 0, selectedLabels: ['Yes'], customText: undefined }],
+			resolvedAt: 600,
+		};
+
+		mockRequest.mockResolvedValue({
+			...makeIdleSessionState(),
+			sessionInfo: {
+				metadata: {
+					resolvedQuestions: {
+						'tool-old': resolvedQuestion,
+					},
+				},
+			},
+		} as unknown as SessionState);
+
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.resolvedQuestions.size).toBe(1);
+		expect(result.current.resolvedQuestions.get('tool-old')).toEqual(resolvedQuestion);
+	});
+
+	it('updates pendingQuestion on state.session event from the correct channel', async () => {
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		act(() => {
+			fireSessionEvent('session:session-abc', makeWaitingSessionState('tool-abc'));
+		});
+
+		await waitFor(() => {
+			expect(result.current.pendingQuestion?.toolUseId).toBe('tool-abc');
+		});
+	});
+
+	it('ignores state.session events from OTHER channels (cross-session contamination fix)', async () => {
+		// Two hooks for different sessions
+		const { result: leaderResult } = renderHook(() => useSessionQuestionState('leader-session'));
+		const { result: workerResult } = renderHook(() => useSessionQuestionState('worker-session'));
+
+		act(() => {
+			// Fire an event only on the worker's channel
+			fireSessionEvent('session:worker-session', makeWaitingSessionState('tool-worker'));
+		});
+
+		// Worker should have the pending question (channel matches)
+		await waitFor(() => {
+			expect(workerResult.current.pendingQuestion?.toolUseId).toBe('tool-worker');
+		});
+		// Leader should NOT have received the worker's event (cross-session contamination fix)
+		expect(leaderResult.current.pendingQuestion).toBeNull();
+	});
+
+	it('clears pendingQuestion when session transitions out of waiting_for_input', async () => {
+		mockRequest.mockResolvedValue(makeWaitingSessionState('tool-001'));
+
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.pendingQuestion).not.toBeNull();
+
+		await act(async () => {
+			fireSessionEvent('session:session-abc', makeIdleSessionState());
+		});
+
+		expect(result.current.pendingQuestion).toBeNull();
+	});
+
+	it('onQuestionResolved moves pendingQuestion to resolvedQuestions optimistically', async () => {
+		mockRequest.mockResolvedValue(makeWaitingSessionState('tool-001'));
+
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 0));
+		});
+
+		expect(result.current.pendingQuestion).not.toBeNull();
+
+		await act(async () => {
+			result.current.onQuestionResolved('submitted', [
+				{ questionIndex: 0, selectedLabels: ['Option A'], customText: undefined },
+			]);
+		});
+
+		// pendingQuestion should be cleared
+		expect(result.current.pendingQuestion).toBeNull();
+		// resolvedQuestions should have the entry
+		expect(result.current.resolvedQuestions.size).toBe(1);
+		const resolved = result.current.resolvedQuestions.get('tool-001');
+		expect(resolved?.state).toBe('submitted');
+		expect(resolved?.question.toolUseId).toBe('tool-001');
+	});
+
+	it('onQuestionResolved is a no-op when no pendingQuestion exists', () => {
+		const { result } = renderHook(() => useSessionQuestionState('session-abc'));
+
+		// Should not throw
+		act(() => {
+			result.current.onQuestionResolved('cancelled', []);
+		});
+
+		expect(result.current.resolvedQuestions.size).toBe(0);
+	});
+});

--- a/packages/web/src/hooks/useSessionQuestionState.ts
+++ b/packages/web/src/hooks/useSessionQuestionState.ts
@@ -26,6 +26,31 @@ export interface SessionQuestionState {
 }
 
 /**
+ * Extracts pending question and resolved questions from a SessionState snapshot.
+ * Shared between the real-time event handler and the initial fetch to avoid duplication.
+ */
+function applySessionState(
+	sessionState: SessionState,
+	setPendingQuestion: (q: PendingUserQuestion | null) => void,
+	setResolvedQuestions: (map: Map<string, ResolvedQuestion>) => void
+): void {
+	if (sessionState.agentState.status === 'waiting_for_input') {
+		setPendingQuestion(sessionState.agentState.pendingQuestion);
+	} else {
+		setPendingQuestion(null);
+	}
+
+	const resolvedRaw = sessionState.sessionInfo?.metadata?.resolvedQuestions;
+	if (resolvedRaw) {
+		const map = new Map<string, ResolvedQuestion>();
+		for (const [toolUseId, resolved] of Object.entries(resolvedRaw)) {
+			map.set(toolUseId, resolved as ResolvedQuestion);
+		}
+		setResolvedQuestions(map);
+	}
+}
+
+/**
  * Subscribes to session:{sessionId} channel and tracks question state.
  * Returns pendingQuestion, resolvedQuestions, and onQuestionResolved callback.
  * When sessionId is undefined, returns empty/no-op state.
@@ -49,26 +74,14 @@ export function useSessionQuestionState(sessionId: string | undefined): SessionQ
 		joinRoom(channel);
 		let cancelled = false;
 
-		// Subscribe to state.session events for real-time updates
-		const unsub = onEvent<SessionState>('state.session', (event) => {
+		// Subscribe to state.session events for real-time updates.
+		// Filter by context.channel to avoid cross-session contamination: both the
+		// leader and worker hooks subscribe to the same 'state.session' method name,
+		// but only process events that originated from their own session's channel.
+		const unsub = onEvent<SessionState>('state.session', (event, context) => {
 			if (cancelled) return;
-
-			// Update pending question from agent state
-			if (event.agentState.status === 'waiting_for_input') {
-				setPendingQuestion(event.agentState.pendingQuestion);
-			} else {
-				setPendingQuestion(null);
-			}
-
-			// Sync resolved questions from session metadata
-			const resolvedRaw = event.sessionInfo?.metadata?.resolvedQuestions;
-			if (resolvedRaw) {
-				const map = new Map<string, ResolvedQuestion>();
-				for (const [toolUseId, resolved] of Object.entries(resolvedRaw)) {
-					map.set(toolUseId, resolved as ResolvedQuestion);
-				}
-				setResolvedQuestions(map);
-			}
+			if (context.channel !== channel) return;
+			applySessionState(event, setPendingQuestion, setResolvedQuestions);
 		});
 
 		// Fetch initial state — state.session RPC returns SessionState directly
@@ -76,20 +89,7 @@ export function useSessionQuestionState(sessionId: string | undefined): SessionQ
 			try {
 				const sessionState = await request<SessionState>('state.session', { sessionId });
 				if (!cancelled && sessionState) {
-					if (sessionState.agentState.status === 'waiting_for_input') {
-						setPendingQuestion(sessionState.agentState.pendingQuestion);
-					} else {
-						setPendingQuestion(null);
-					}
-
-					const resolvedRaw = sessionState.sessionInfo?.metadata?.resolvedQuestions;
-					if (resolvedRaw) {
-						const map = new Map<string, ResolvedQuestion>();
-						for (const [toolUseId, resolved] of Object.entries(resolvedRaw)) {
-							map.set(toolUseId, resolved as ResolvedQuestion);
-						}
-						setResolvedQuestions(map);
-					}
+					applySessionState(sessionState, setPendingQuestion, setResolvedQuestions);
 				}
 			} catch {
 				// Fetch failure is non-fatal — question state will be empty until next event

--- a/packages/web/src/hooks/useSessionQuestionState.ts
+++ b/packages/web/src/hooks/useSessionQuestionState.ts
@@ -48,6 +48,12 @@ function applySessionState(
 		}
 		setResolvedQuestions(map);
 	}
+	// When resolvedRaw is absent (e.g. sessionInfo: null), we intentionally do NOT
+	// call setResolvedQuestions. Resolved questions are append-only: once a question
+	// has been resolved it should remain visible, and optimistic updates from
+	// onQuestionResolved must not be erased by a subsequent server event that lacks
+	// metadata. The server will include resolvedQuestions in metadata once it
+	// persists the resolution, at which point we will apply the authoritative map.
 }
 
 /**

--- a/packages/web/src/hooks/useSessionQuestionState.ts
+++ b/packages/web/src/hooks/useSessionQuestionState.ts
@@ -1,0 +1,130 @@
+/**
+ * useSessionQuestionState Hook
+ *
+ * Subscribes to a session's state channel and tracks question state
+ * (pending question and resolved questions). Used by TaskConversationRenderer
+ * to pass the correct question state to SDKMessageRenderer for each agent session
+ * in a task group, so that AskUserQuestion tool calls render as interactive forms.
+ */
+
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import type {
+	PendingUserQuestion,
+	QuestionDraftResponse,
+	ResolvedQuestion,
+	SessionState,
+} from '@neokai/shared';
+import { useMessageHub } from './useMessageHub';
+
+export interface SessionQuestionState {
+	pendingQuestion: PendingUserQuestion | null;
+	resolvedQuestions: Map<string, ResolvedQuestion>;
+	onQuestionResolved: (
+		state: 'submitted' | 'cancelled',
+		responses: QuestionDraftResponse[]
+	) => void;
+}
+
+/**
+ * Subscribes to session:{sessionId} channel and tracks question state.
+ * Returns pendingQuestion, resolvedQuestions, and onQuestionResolved callback.
+ * When sessionId is undefined, returns empty/no-op state.
+ */
+export function useSessionQuestionState(sessionId: string | undefined): SessionQuestionState {
+	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
+
+	const [pendingQuestion, setPendingQuestion] = useState<PendingUserQuestion | null>(null);
+	const [resolvedQuestions, setResolvedQuestions] = useState<Map<string, ResolvedQuestion>>(
+		new Map()
+	);
+
+	useEffect(() => {
+		if (!sessionId) {
+			setPendingQuestion(null);
+			setResolvedQuestions(new Map());
+			return;
+		}
+
+		const channel = `session:${sessionId}`;
+		joinRoom(channel);
+		let cancelled = false;
+
+		// Subscribe to state.session events for real-time updates
+		const unsub = onEvent<SessionState>('state.session', (event) => {
+			if (cancelled) return;
+
+			// Update pending question from agent state
+			if (event.agentState.status === 'waiting_for_input') {
+				setPendingQuestion(event.agentState.pendingQuestion);
+			} else {
+				setPendingQuestion(null);
+			}
+
+			// Sync resolved questions from session metadata
+			const resolvedRaw = event.sessionInfo?.metadata?.resolvedQuestions;
+			if (resolvedRaw) {
+				const map = new Map<string, ResolvedQuestion>();
+				for (const [toolUseId, resolved] of Object.entries(resolvedRaw)) {
+					map.set(toolUseId, resolved as ResolvedQuestion);
+				}
+				setResolvedQuestions(map);
+			}
+		});
+
+		// Fetch initial state — state.session RPC returns SessionState directly
+		const fetchInitial = async () => {
+			try {
+				const sessionState = await request<SessionState>('state.session', { sessionId });
+				if (!cancelled && sessionState) {
+					if (sessionState.agentState.status === 'waiting_for_input') {
+						setPendingQuestion(sessionState.agentState.pendingQuestion);
+					} else {
+						setPendingQuestion(null);
+					}
+
+					const resolvedRaw = sessionState.sessionInfo?.metadata?.resolvedQuestions;
+					if (resolvedRaw) {
+						const map = new Map<string, ResolvedQuestion>();
+						for (const [toolUseId, resolved] of Object.entries(resolvedRaw)) {
+							map.set(toolUseId, resolved as ResolvedQuestion);
+						}
+						setResolvedQuestions(map);
+					}
+				}
+			} catch {
+				// Fetch failure is non-fatal — question state will be empty until next event
+			}
+		};
+
+		void fetchInitial();
+
+		return () => {
+			cancelled = true;
+			unsub();
+			leaveRoom(channel);
+		};
+	}, [sessionId, joinRoom, leaveRoom, onEvent, request]);
+
+	// Optimistic update: move question to resolved state locally for immediate UI feedback
+	// (The actual RPC calls are handled by QuestionPrompt)
+	const onQuestionResolved = useCallback(
+		(resolvedState: 'submitted' | 'cancelled', responses: QuestionDraftResponse[]) => {
+			if (!pendingQuestion) return;
+			const resolved: ResolvedQuestion = {
+				question: pendingQuestion,
+				state: resolvedState,
+				responses,
+				resolvedAt: Date.now(),
+			};
+			setResolvedQuestions((prev) => {
+				const next = new Map(prev);
+				next.set(pendingQuestion.toolUseId, resolved);
+				return next;
+			});
+			setPendingQuestion(null);
+		},
+		[pendingQuestion]
+	);
+
+	return { pendingQuestion, resolvedQuestions, onQuestionResolved };
+}


### PR DESCRIPTION
TaskConversationRenderer was calling SDKMessageRenderer without sessionId,
so the AskUserQuestion condition in SDKAssistantMessage always failed and
the form was never rendered.

- Add useSessionQuestionState hook that subscribes to session:${id} channel
  and tracks pendingQuestion/resolvedQuestions from state.session events
- Pass leaderSessionId/workerSessionId to TaskConversationRenderer
- Look up per-message question state by _taskMeta.authorSessionId
- Pass sessionId, pendingQuestion, resolvedQuestions, onQuestionResolved
  to SDKMessageRenderer for each message
