### PR TITLE
feat: provider-aware session creation (#399)

### DIFF
--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -15,7 +15,12 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import type { Room, ModelInfo } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
-import { groupModelsByProvider, getProviderLabel } from '../../hooks/useModelSwitcher';
+import {
+	groupModelsByProvider,
+	getProviderLabel,
+	mapRawModelsToModelInfos,
+} from '../../hooks/useModelSwitcher';
+import type { RawModelEntry } from '../../hooks/useModelSwitcher';
 
 interface RecentPath {
 	path: string;
@@ -23,46 +28,14 @@ interface RecentPath {
 	absoluteTime: Date;
 }
 
-/** Fetch available models from the server and map to ModelInfo */
-async function fetchAvailableModels(): Promise<ModelInfo[]> {
+/** Fetch available models from the server, mapped and sorted via shared utility */
+async function fetchAvailableModels(): Promise<import('@neokai/shared').ModelInfo[]> {
 	const hub = connectionManager.getHubIfConnected();
 	if (!hub) return [];
-
 	const { models } = (await hub.request('models.list', { useCache: true })) as {
-		models: Array<{
-			id: string;
-			display_name: string;
-			description: string;
-			alias?: string;
-			provider?: string;
-		}>;
+		models: RawModelEntry[];
 	};
-
-	return models.map((m) => {
-		let family = 'sonnet';
-		const mid = m.id.toLowerCase();
-		if (mid.includes('opus')) {
-			family = 'opus';
-		} else if (mid.includes('haiku')) {
-			family = 'haiku';
-		} else if (mid.startsWith('glm-')) {
-			family = 'glm';
-		} else if (mid.startsWith('minimax-')) {
-			family = 'minimax';
-		}
-
-		return {
-			id: m.id,
-			name: m.display_name,
-			alias: m.alias || m.id,
-			family,
-			provider: m.provider || 'anthropic',
-			contextWindow: 200000,
-			description: m.description || '',
-			releaseDate: '',
-			available: true,
-		};
-	});
+	return mapRawModelsToModelInfos(models);
 }
 
 interface NewSessionModalProps {
@@ -192,6 +165,7 @@ export function NewSessionModal({
 		setSelectedPath('');
 		setSelectedRoomId(undefined);
 		setSelectedModelKey('');
+		setAvailableModels([]);
 		setShowCreateRoom(false);
 		setNewRoomName('');
 		setNewRoomDescription('');

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -6,13 +6,16 @@
  * - Optional room assignment dropdown (shows room name + allowedPaths count)
  * - "Create new room" option that opens inline form
  * - "Browse for folder" button
+ * - Optional model selector (provider-grouped)
  * - Form validation and error handling
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
-import type { Room } from '@neokai/shared';
+import type { Room, ModelInfo } from '@neokai/shared';
+import { connectionManager } from '../../lib/connection-manager';
+import { groupModelsByProvider, getProviderLabel } from '../../hooks/useModelSwitcher';
 
 interface RecentPath {
 	path: string;
@@ -20,10 +23,56 @@ interface RecentPath {
 	absoluteTime: Date;
 }
 
+/** Fetch available models from the server and map to ModelInfo */
+async function fetchAvailableModels(): Promise<ModelInfo[]> {
+	const hub = connectionManager.getHubIfConnected();
+	if (!hub) return [];
+
+	const { models } = (await hub.request('models.list', { useCache: true })) as {
+		models: Array<{
+			id: string;
+			display_name: string;
+			description: string;
+			alias?: string;
+			provider?: string;
+		}>;
+	};
+
+	return models.map((m) => {
+		let family = 'sonnet';
+		const mid = m.id.toLowerCase();
+		if (mid.includes('opus')) {
+			family = 'opus';
+		} else if (mid.includes('haiku')) {
+			family = 'haiku';
+		} else if (mid.startsWith('glm-')) {
+			family = 'glm';
+		} else if (mid.startsWith('minimax-')) {
+			family = 'minimax';
+		}
+
+		return {
+			id: m.id,
+			name: m.display_name,
+			alias: m.alias || m.id,
+			family,
+			provider: m.provider || 'anthropic',
+			contextWindow: 200000,
+			description: m.description || '',
+			releaseDate: '',
+			available: true,
+		};
+	});
+}
+
 interface NewSessionModalProps {
 	isOpen: boolean;
 	onClose: () => void;
-	onSubmit: (params: { workspacePath: string; roomId?: string }) => Promise<void>;
+	onSubmit: (params: {
+		workspacePath: string;
+		roomId?: string;
+		model?: ModelInfo;
+	}) => Promise<void>;
 	recentPaths: RecentPath[];
 	rooms: Room[];
 	onCreateRoom?: (params: {
@@ -49,6 +98,27 @@ export function NewSessionModal({
 	const [showCreateRoom, setShowCreateRoom] = useState(false);
 	const [newRoomName, setNewRoomName] = useState('');
 	const [newRoomDescription, setNewRoomDescription] = useState('');
+	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+	// Empty string = "Default (server setting)"; non-empty = "provider:id"
+	const [selectedModelKey, setSelectedModelKey] = useState<string>('');
+
+	useEffect(() => {
+		if (!isOpen) return;
+		fetchAvailableModels()
+			.then((models) => setAvailableModels(models))
+			.catch(() => {
+				// silently ignore — model picker remains hidden
+			});
+	}, [isOpen]);
+
+	/** Resolve the selected model by composite key `provider:id` */
+	function resolveSelectedModel(): ModelInfo | undefined {
+		if (!selectedModelKey) return undefined;
+		const colonIdx = selectedModelKey.indexOf(':');
+		const provider = selectedModelKey.slice(0, colonIdx);
+		const id = selectedModelKey.slice(colonIdx + 1);
+		return availableModels.find((m) => m.provider === provider && m.id === id);
+	}
 
 	const handleSubmit = async (e: Event) => {
 		e.preventDefault();
@@ -66,11 +136,13 @@ export function NewSessionModal({
 			await onSubmit({
 				workspacePath,
 				roomId: selectedRoomId || undefined,
+				model: resolveSelectedModel(),
 			});
 
 			// Reset form on success
 			setSelectedPath('');
 			setSelectedRoomId(undefined);
+			setSelectedModelKey('');
 			setShowCreateRoom(false);
 			setNewRoomName('');
 			setNewRoomDescription('');
@@ -119,12 +191,15 @@ export function NewSessionModal({
 	const handleClose = () => {
 		setSelectedPath('');
 		setSelectedRoomId(undefined);
+		setSelectedModelKey('');
 		setShowCreateRoom(false);
 		setNewRoomName('');
 		setNewRoomDescription('');
 		setError(null);
 		onClose();
 	};
+
+	const groupedModels = groupModelsByProvider(availableModels);
 
 	const handleBrowseFolder = () => {
 		// Trigger file browser dialog
@@ -194,6 +269,32 @@ export function NewSessionModal({
 						Browse for folder...
 					</button>
 				</div>
+
+				{/* Model Selection Section */}
+				{availableModels.length > 0 && (
+					<div>
+						<label class="block text-sm font-medium text-gray-300 mb-1.5">Model (optional)</label>
+						<select
+							value={selectedModelKey}
+							onChange={(e) => setSelectedModelKey((e.target as HTMLSelectElement).value)}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100 focus:outline-none focus:border-blue-500 cursor-pointer"
+						>
+							<option value="">Default (server setting)</option>
+							{Array.from(groupedModels.entries()).map(([provider, models]) => (
+								<optgroup key={provider} label={getProviderLabel(provider)}>
+									{models.map((model) => (
+										<option
+											key={`${model.provider}:${model.id}`}
+											value={`${model.provider}:${model.id}`}
+										>
+											{model.name}
+										</option>
+									))}
+								</optgroup>
+							))}
+						</select>
+					</div>
+				)}
 
 				{/* Room Assignment Section */}
 				{!showCreateRoom && (

--- a/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
@@ -1,0 +1,280 @@
+// @ts-nocheck
+/**
+ * Tests for NewSessionModal — provider-aware session creation
+ */
+
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NewSessionModal } from '../NewSessionModal';
+
+// Mock Portal to render inline
+vi.mock('../../ui/Portal.tsx', () => ({
+	Portal: ({ children }) => <div data-portal="true">{children}</div>,
+}));
+
+// Mock connection manager — controls what models.list returns
+const mockRequest = vi.fn();
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => ({ request: mockRequest }),
+	},
+}));
+
+const DEFAULT_PROPS = {
+	isOpen: true,
+	onClose: vi.fn(),
+	onSubmit: vi.fn().mockResolvedValue(undefined),
+	recentPaths: [],
+	rooms: [],
+};
+
+const MOCK_MODELS = [
+	{ id: 'claude-opus-4-6', display_name: 'Claude Opus', description: '', provider: 'anthropic' },
+	{
+		id: 'claude-sonnet-4-6',
+		display_name: 'Claude Sonnet',
+		description: '',
+		provider: 'anthropic',
+	},
+	{
+		id: 'copilot-claude-sonnet',
+		display_name: 'Copilot Sonnet',
+		description: '',
+		provider: 'anthropic-copilot',
+	},
+	{
+		id: 'codex-claude-sonnet',
+		display_name: 'Codex Sonnet',
+		description: '',
+		provider: 'anthropic-codex',
+	},
+];
+
+describe('NewSessionModal — provider-aware session creation', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		mockRequest.mockResolvedValue({ models: MOCK_MODELS });
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.resetAllMocks();
+	});
+
+	describe('model picker rendering', () => {
+		it('shows model selector when models are available', async () => {
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const select = document.querySelector('select[class*="cursor-pointer"]');
+				expect(select).toBeTruthy();
+			});
+			// Should have optgroups for each provider
+			const optgroups = document.querySelectorAll('optgroup');
+			expect(optgroups.length).toBeGreaterThan(0);
+		});
+
+		it('renders provider optgroup labels for anthropic, copilot, and codex', async () => {
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				const labels = Array.from(optgroups).map((g) => g.getAttribute('label'));
+				expect(labels).toContain('Anthropic');
+				expect(labels).toContain('Copilot');
+				expect(labels).toContain('Codex');
+			});
+		});
+
+		it('has "Default (server setting)" as the first option', async () => {
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const modelSelect = Array.from(document.querySelectorAll('select')).find((s) =>
+					s.querySelector('option[value=""]')
+				);
+				expect(modelSelect).toBeTruthy();
+				const defaultOption = modelSelect?.querySelector('option[value=""]');
+				expect(defaultOption?.textContent).toBe('Default (server setting)');
+			});
+		});
+
+		it('does not show model selector when no models returned', async () => {
+			mockRequest.mockResolvedValue({ models: [] });
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			// Wait for the fetch attempt to complete
+			await new Promise((r) => setTimeout(r, 50));
+			// No optgroup means no model picker rendered
+			const optgroups = document.querySelectorAll('optgroup');
+			expect(optgroups.length).toBe(0);
+		});
+	});
+
+	describe('onSubmit with model selection', () => {
+		it('calls onSubmit without model when default is selected', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<NewSessionModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			// Set workspace path
+			const pathInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/home/user/project' } });
+
+			// Submit without changing model selection
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workspacePath: '/home/user/project',
+						model: undefined,
+					})
+				);
+			});
+		});
+
+		it('calls onSubmit with copilot model and provider when copilot model selected', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<NewSessionModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			// Wait for models to load
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				expect(optgroups.length).toBeGreaterThan(0);
+			});
+
+			// Select copilot model
+			const modelSelects = Array.from(document.querySelectorAll('select'));
+			const modelSelect = modelSelects.find((s) =>
+				Array.from(s.options).some((o) => o.value.includes('anthropic-copilot'))
+			);
+			expect(modelSelect).toBeTruthy();
+			fireEvent.change(modelSelect!, {
+				target: { value: 'anthropic-copilot:copilot-claude-sonnet' },
+			});
+
+			// Set workspace path
+			const pathInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/home/user/project' } });
+
+			// Submit
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workspacePath: '/home/user/project',
+						model: expect.objectContaining({
+							id: 'copilot-claude-sonnet',
+							provider: 'anthropic-copilot',
+						}),
+					})
+				);
+			});
+		});
+
+		it('calls onSubmit with codex model and provider when codex model selected', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<NewSessionModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				expect(optgroups.length).toBeGreaterThan(0);
+			});
+
+			const modelSelects = Array.from(document.querySelectorAll('select'));
+			const modelSelect = modelSelects.find((s) =>
+				Array.from(s.options).some((o) => o.value.includes('anthropic-codex'))
+			);
+			fireEvent.change(modelSelect!, {
+				target: { value: 'anthropic-codex:codex-claude-sonnet' },
+			});
+
+			const pathInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/home/user/project' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith(
+					expect.objectContaining({
+						workspacePath: '/home/user/project',
+						model: expect.objectContaining({
+							id: 'codex-claude-sonnet',
+							provider: 'anthropic-codex',
+						}),
+					})
+				);
+			});
+		});
+
+		it('calls onSubmit with anthropic model when anthropic model selected', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<NewSessionModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				expect(optgroups.length).toBeGreaterThan(0);
+			});
+
+			const modelSelects = Array.from(document.querySelectorAll('select'));
+			const modelSelect = modelSelects.find((s) =>
+				Array.from(s.options).some((o) => o.value === 'anthropic:claude-opus-4-6')
+			);
+			fireEvent.change(modelSelect!, {
+				target: { value: 'anthropic:claude-opus-4-6' },
+			});
+
+			const pathInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/home/user/project' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect(onSubmit).toHaveBeenCalledWith(
+					expect.objectContaining({
+						model: expect.objectContaining({
+							id: 'claude-opus-4-6',
+							provider: 'anthropic',
+						}),
+					})
+				);
+			});
+		});
+	});
+
+	describe('form reset', () => {
+		it('resets model selection after successful submit', async () => {
+			const onSubmit = vi.fn().mockResolvedValue(undefined);
+			render(<NewSessionModal {...DEFAULT_PROPS} onSubmit={onSubmit} />);
+
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				expect(optgroups.length).toBeGreaterThan(0);
+			});
+
+			const modelSelects = Array.from(document.querySelectorAll('select'));
+			const modelSelect = modelSelects.find((s) =>
+				Array.from(s.options).some((o) => o.value.includes('anthropic-copilot'))
+			);
+			fireEvent.change(modelSelect!, {
+				target: { value: 'anthropic-copilot:copilot-claude-sonnet' },
+			});
+
+			expect((modelSelect as HTMLSelectElement).value).toBe(
+				'anthropic-copilot:copilot-claude-sonnet'
+			);
+
+			const pathInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+			fireEvent.input(pathInput, { target: { value: '/home/user/project' } });
+
+			const form = document.querySelector('form') as HTMLFormElement;
+			fireEvent.submit(form);
+
+			await waitFor(() => {
+				expect((modelSelect as HTMLSelectElement).value).toBe('');
+			});
+		});
+	});
+});

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -13,6 +13,7 @@ import {
 	getModelFamilyIcon,
 	getProviderLabel,
 	groupModelsByProvider,
+	mapRawModelsToModelInfos,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -974,5 +975,70 @@ describe('useModelSwitcher', () => {
 			// Server-provided alias is used directly
 			expect(result.current.availableModels[0].alias).toBe('copilot-anthropic-opus');
 		});
+	});
+});
+
+describe('mapRawModelsToModelInfos', () => {
+	it('maps display_name to name and falls back alias to id', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'claude-sonnet-4-6', display_name: 'Claude Sonnet', description: '' },
+		]);
+		expect(result[0].name).toBe('Claude Sonnet');
+		expect(result[0].alias).toBe('claude-sonnet-4-6');
+	});
+
+	it('detects opus family', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'claude-opus-4-6', display_name: 'Opus', description: '' },
+		]);
+		expect(result[0].family).toBe('opus');
+	});
+
+	it('detects gpt family', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'gpt-4o', display_name: 'GPT-4o', description: '' },
+		]);
+		expect(result[0].family).toBe('gpt');
+	});
+
+	it('detects gemini family', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'gemini-1-5-pro', display_name: 'Gemini', description: '' },
+		]);
+		expect(result[0].family).toBe('gemini');
+	});
+
+	it('defaults provider to anthropic when not provided', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'claude-sonnet-4-6', display_name: 'Sonnet', description: '' },
+		]);
+		expect(result[0].provider).toBe('anthropic');
+	});
+
+	it('sorts by PROVIDER_ORDER: anthropic before copilot before codex', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'codex-sonnet', display_name: 'Codex', description: '', provider: 'anthropic-codex' },
+			{ id: 'claude-sonnet', display_name: 'Sonnet', description: '', provider: 'anthropic' },
+			{
+				id: 'copilot-sonnet',
+				display_name: 'Copilot',
+				description: '',
+				provider: 'anthropic-copilot',
+			},
+		]);
+		expect(result[0].provider).toBe('anthropic');
+		expect(result[1].provider).toBe('anthropic-copilot');
+		expect(result[2].provider).toBe('anthropic-codex');
+	});
+
+	it('sorts within provider by family: opus before sonnet before haiku', () => {
+		const result = mapRawModelsToModelInfos([
+			{ id: 'claude-haiku-3', display_name: 'Haiku', description: '', provider: 'anthropic' },
+			{ id: 'claude-opus-4', display_name: 'Opus', description: '', provider: 'anthropic' },
+			{ id: 'claude-sonnet-4', display_name: 'Sonnet', description: '', provider: 'anthropic' },
+		]);
+		expect(result[0].family).toBe('opus');
+		expect(result[1].family).toBe('sonnet');
+		expect(result[2].family).toBe('haiku');
 	});
 });

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -59,8 +59,17 @@ export function getModelFamilyIcon(family: string): string {
 	return MODEL_FAMILY_ICONS[family] || MODEL_FAMILY_ICONS.__default__;
 }
 
-/** Model family sort order */
-const FAMILY_ORDER: Record<string, number> = {
+/** Provider sort order for model picker grouping */
+export const PROVIDER_ORDER: Record<string, number> = {
+	anthropic: 0,
+	'anthropic-copilot': 1,
+	'anthropic-codex': 2,
+	glm: 3,
+	minimax: 4,
+};
+
+/** Model family sort order (exported for shared use) */
+export const FAMILY_ORDER: Record<string, number> = {
 	opus: 0,
 	sonnet: 1,
 	haiku: 2,
@@ -70,14 +79,63 @@ const FAMILY_ORDER: Record<string, number> = {
 	gemini: 6,
 };
 
-/** Provider sort order for model picker grouping */
-const PROVIDER_ORDER: Record<string, number> = {
-	anthropic: 0,
-	'anthropic-copilot': 1,
-	'anthropic-codex': 2,
-	glm: 3,
-	minimax: 4,
-};
+/** Raw model shape returned by the `models.list` RPC */
+export interface RawModelEntry {
+	id: string;
+	display_name: string;
+	description: string;
+	alias?: string;
+	provider?: string;
+}
+
+/**
+ * Map raw `models.list` RPC entries to `ModelInfo` objects and sort them
+ * by provider (PROVIDER_ORDER) then family (FAMILY_ORDER).
+ *
+ * This is the canonical mapping used by both `useModelSwitcher` and
+ * `NewSessionModal` so that family detection and sort order stay in sync.
+ */
+export function mapRawModelsToModelInfos(models: RawModelEntry[]): ModelInfo[] {
+	const modelInfos = models.map((m) => {
+		let family = 'sonnet';
+		const mid = m.id.toLowerCase();
+		if (mid.includes('opus')) {
+			family = 'opus';
+		} else if (mid.includes('haiku')) {
+			family = 'haiku';
+		} else if (mid.startsWith('glm-')) {
+			family = 'glm';
+		} else if (mid.startsWith('minimax-')) {
+			family = 'minimax';
+		} else if (mid.startsWith('gpt-')) {
+			family = 'gpt';
+		} else if (mid.startsWith('gemini-')) {
+			family = 'gemini';
+		}
+		return {
+			id: m.id,
+			name: m.display_name,
+			alias: m.alias || m.id,
+			family,
+			provider: m.provider || 'anthropic',
+			contextWindow: 200000,
+			description: m.description || '',
+			releaseDate: '',
+			available: true,
+		};
+	});
+
+	modelInfos.sort((a, b) => {
+		const providerA = PROVIDER_ORDER[a.provider || 'anthropic'] ?? 99;
+		const providerB = PROVIDER_ORDER[b.provider || 'anthropic'] ?? 99;
+		if (providerA !== providerB) return providerA - providerB;
+		const familyA = FAMILY_ORDER[a.family] ?? 99;
+		const familyB = FAMILY_ORDER[b.family] ?? 99;
+		return familyA - familyB;
+	});
+
+	return modelInfos;
+}
 
 /**
  * Group models by their provider, preserving insertion order of the input array.
@@ -148,61 +206,9 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 			// Fetch available models (includes all providers for cross-provider switching)
 			const { models } = (await hub.request('models.list', {
 				useCache: true,
-			})) as {
-				models: Array<{
-					id: string;
-					display_name: string;
-					description: string;
-					alias?: string;
-					provider?: string;
-				}>;
-			};
+			})) as { models: RawModelEntry[] };
 
-			const modelInfos: ModelInfo[] = models.map((m) => {
-				// Determine family from model ID
-				let family: string = 'sonnet';
-				const modelId = m.id.toLowerCase();
-				if (modelId.includes('opus')) {
-					family = 'opus';
-				} else if (modelId.includes('haiku')) {
-					family = 'haiku';
-				} else if (modelId.startsWith('glm-')) {
-					family = 'glm';
-				} else if (modelId.startsWith('minimax-')) {
-					family = 'minimax';
-				} else if (modelId.startsWith('gpt-')) {
-					family = 'gpt';
-				} else if (modelId.startsWith('gemini-')) {
-					family = 'gemini';
-				}
-
-				return {
-					id: m.id,
-					name: m.display_name,
-					// Use server-provided alias (unique per provider, e.g. 'copilot-anthropic-sonnet' for Copilot bridge)
-					alias: m.alias || m.id,
-					family,
-					// Use server-provided provider for correct routing
-					provider: m.provider || 'anthropic',
-					contextWindow: 200000,
-					description: m.description || '',
-					releaseDate: '',
-					available: true,
-				};
-			});
-
-			// Sort by provider first, then by family order within each provider group.
-			// This pre-sort is required so that groupModelsByProvider() preserves
-			// the intended provider order via Map insertion order.
-			modelInfos.sort((a, b) => {
-				const providerA = PROVIDER_ORDER[a.provider || 'anthropic'] ?? 99;
-				const providerB = PROVIDER_ORDER[b.provider || 'anthropic'] ?? 99;
-				if (providerA !== providerB) return providerA - providerB;
-				const familyA = FAMILY_ORDER[a.family] ?? 99;
-				const familyB = FAMILY_ORDER[b.family] ?? 99;
-				return familyA - familyB;
-			});
-			setAvailableModels(modelInfos);
+			setAvailableModels(mapRawModelsToModelInfos(models));
 		} catch {
 			// Error handled silently - loading state will be cleared
 		} finally {

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -61,12 +61,22 @@ export default function Lobby() {
 		absoluteTime: p.usedAt,
 	}));
 
-	async function handleCreateSession(params: { workspacePath: string; roomId?: string }) {
+	async function handleCreateSession(params: {
+		workspacePath: string;
+		roomId?: string;
+		model?: import('@neokai/shared').ModelInfo;
+	}) {
 		try {
 			const { sessionId } = await createSession({
 				workspacePath: params.workspacePath,
 				roomId: params.roomId,
 				createdBy: 'human',
+				...(params.model && {
+					config: {
+						model: params.model.id,
+						provider: params.model.provider as import('@neokai/shared').Provider,
+					},
+				}),
 			});
 
 			// Add to recent paths

--- a/packages/web/src/islands/Lobby.tsx
+++ b/packages/web/src/islands/Lobby.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useEffect, useState } from 'preact/hooks';
+import type { ModelInfo, Provider } from '@neokai/shared';
 import { lobbyStore } from '../lib/lobby-store';
 import { globalStore } from '../lib/global-store';
 import { navigateToRoom, navigateToSession } from '../lib/router';
@@ -64,7 +65,7 @@ export default function Lobby() {
 	async function handleCreateSession(params: {
 		workspacePath: string;
 		roomId?: string;
-		model?: import('@neokai/shared').ModelInfo;
+		model?: ModelInfo;
 	}) {
 		try {
 			const { sessionId } = await createSession({
@@ -74,7 +75,7 @@ export default function Lobby() {
 				...(params.model && {
 					config: {
 						model: params.model.id,
-						provider: params.model.provider as import('@neokai/shared').Provider,
+						provider: params.model.provider as Provider,
 					},
 				}),
 			});


### PR DESCRIPTION
## Summary

- **NewSessionModal**: Added an optional provider-grouped model picker that fetches available models on open via `models.list` RPC. Models are grouped using `groupModelsByProvider()` and rendered as `<optgroup>` elements (Anthropic / Copilot / Codex / etc.). Default selection is "Default (server setting)" which leaves model/provider unset.
- **NewSessionModal `onSubmit`**: Signature updated to include `model?: ModelInfo`. The selected model's `id` and `provider` are passed to the caller.
- **Lobby.tsx `handleCreateSession`**: Now passes `config.model` and `config.provider` to `createSession` when a model is explicitly selected, ensuring sessions created with a Copilot model get `config.provider: 'anthropic-copilot'`, Codex models get `config.provider: 'anthropic-codex'`, and default creation still uses `'anthropic'`.

## Test plan

- [x] 9 new unit tests in `NewSessionModal.test.tsx`:
  - Model picker visible when models available
  - Provider optgroup labels rendered (Anthropic / Copilot / Codex)
  - "Default (server setting)" is first option
  - No model picker when no models returned
  - `onSubmit` called without `model` when default selected
  - `onSubmit` called with `{ id, provider: 'anthropic-copilot' }` when Copilot model selected
  - `onSubmit` called with `{ id, provider: 'anthropic-codex' }` when Codex model selected
  - `onSubmit` called with `{ id, provider: 'anthropic' }` when Anthropic model selected
  - Model selection resets to default after successful submit
- [x] All 3734 web tests pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean