### PR TITLE
fix: scope message locator in persistence e2e test to avoid strict mode violation

### DIFF
--- a/packages/e2e/tests/core/persistence.e2e.ts
+++ b/packages/e2e/tests/core/persistence.e2e.ts
@@ -186,8 +186,12 @@ test.describe('Page Refresh - Session State Persistence', () => {
 		const messageCountAfter = await page.locator('[data-message-role]').count();
 		expect(messageCountAfter).toBe(messageCountBefore);
 
-		// Verify original message is still visible
-		await expect(page.locator('text=What is React and why is it popular?')).toBeVisible();
+		// Verify original message is still visible in the chat area
+		await expect(
+			page
+				.locator('[data-message-role="user"]')
+				.filter({ hasText: 'What is React and why is it popular?' })
+		).toBeVisible();
 
 		// Verify session title is restored in sidebar
 		await expect(sessionItem).toBeVisible();

--- a/packages/e2e/tests/helpers/wait-helpers.ts
+++ b/packages/e2e/tests/helpers/wait-helpers.ts
@@ -137,12 +137,16 @@ export async function waitForSessionCreated(page: Page): Promise<string> {
  * Wait for user message to be sent
  */
 export async function waitForMessageSent(page: Page, messageText: string): Promise<void> {
-	// Wait for user message to appear in the UI
-	// Use getByText which handles special characters better than text= selector
-	await page.getByText(messageText, { exact: false }).first().waitFor({
-		state: 'visible',
-		timeout: 10000,
-	});
+	// Wait for user message to appear in the chat area specifically
+	// Scoping to [data-message-role="user"] avoids false positives from sidebar titles
+	await page
+		.locator('[data-message-role="user"]')
+		.filter({ hasText: messageText })
+		.first()
+		.waitFor({
+			state: 'visible',
+			timeout: 10000,
+		});
 }
 
 /**

--- a/packages/e2e/tests/serial/multi-session-concurrent-pages.e2e.ts
+++ b/packages/e2e/tests/serial/multi-session-concurrent-pages.e2e.ts
@@ -200,11 +200,19 @@ test.describe('Multi-Session Concurrent Pages (Skipped - Flaky)', () => {
 			await Promise.all([message1Promise, message2Promise]);
 
 			// Each session should only have its own message
-			await expect(page1.locator('text="Concurrent message 1"')).toBeVisible();
-			await expect(page1.locator('text="Concurrent message 2"')).not.toBeVisible();
+			await expect(
+				page1.locator('[data-message-role="user"]').filter({ hasText: 'Concurrent message 1' })
+			).toBeVisible();
+			await expect(
+				page1.locator('[data-message-role="user"]').filter({ hasText: 'Concurrent message 2' })
+			).not.toBeVisible();
 
-			await expect(page2.locator('text="Concurrent message 2"')).toBeVisible();
-			await expect(page2.locator('text="Concurrent message 1"')).not.toBeVisible();
+			await expect(
+				page2.locator('[data-message-role="user"]').filter({ hasText: 'Concurrent message 2' })
+			).toBeVisible();
+			await expect(
+				page2.locator('[data-message-role="user"]').filter({ hasText: 'Concurrent message 1' })
+			).not.toBeVisible();
 
 			// Cleanup
 			await cleanupTestSession(page1, session1);

--- a/packages/e2e/tests/serial/recovery-scenarios.e2e.ts
+++ b/packages/e2e/tests/serial/recovery-scenarios.e2e.ts
@@ -83,7 +83,8 @@ test.describe('Recovery Mechanisms', () => {
 
 		// Should see the message that was being processed
 		const hasMessage = await page
-			.locator('text="Message before refresh"')
+			.locator('[data-message-role="user"]')
+			.filter({ hasText: 'Message before refresh' })
 			.isVisible({ timeout: 5000 })
 			.catch(() => false);
 

--- a/packages/e2e/tests/settings/auto-title.e2e.ts
+++ b/packages/e2e/tests/settings/auto-title.e2e.ts
@@ -117,7 +117,9 @@ test.describe('Auto Title Generation', () => {
 		await messageInput.press('Enter');
 
 		// Wait for second message to appear in the chat (don't need full response)
-		await expect(page.locator('text=What are its benefits?')).toBeVisible({ timeout: 5000 });
+		await expect(
+			page.locator('[data-message-role="user"]').filter({ hasText: 'What are its benefits?' })
+		).toBeVisible({ timeout: 5000 });
 
 		// Wait enough time for title regeneration to trigger (if it were going to)
 		// IS_MOCK: Reduced timeout in mock mode since title won't regenerate anyway


### PR DESCRIPTION
## Summary
- The `core-persistence` E2E test was failing with a Playwright strict mode violation
- `locator('text=What is React and why is it popular?')` resolved to 3 elements (user message bubble, sidebar session title, and possibly page title)
- Fixed by scoping the locator to `[data-message-role="user"]` elements filtered by the text, ensuring only the message in the chat area is matched

## Test plan
- [ ] `E2E No-LLM (core-persistence)` should pass in CI