### PR TITLE
fix: call queryObject.close() before clearing transport reference

### DIFF
--- a/packages/daemon/src/lib/agent/interrupt-handler.ts
+++ b/packages/daemon/src/lib/agent/interrupt-handler.ts
@@ -88,10 +88,14 @@ export class InterruptHandler {
 				this.ctx.queryAbortController = null;
 			}
 
+			// Capture snapshot before any await so interrupt() always targets the
+			// right object even if ctx.queryObject changes during async operations.
+			const queryObjectSnapshot = this.ctx.queryObject;
+
 			// STEP 2: Call SDK interrupt()
-			if (this.ctx.queryObject && typeof this.ctx.queryObject.interrupt === 'function') {
+			if (queryObjectSnapshot && typeof queryObjectSnapshot.interrupt === 'function') {
 				try {
-					await this.ctx.queryObject.interrupt();
+					await queryObjectSnapshot.interrupt();
 				} catch (error) {
 					const errorMessage = error instanceof Error ? error.message : String(error);
 					logger.warn('SDK interrupt() failed (may be expected):', errorMessage);
@@ -110,8 +114,10 @@ export class InterruptHandler {
 				}
 			}
 
-			// STEP 4: Close query to terminate subprocess and MCP transports.
-			// Prevents "Already connected to a transport" errors on next query start.
+			// STEP 4: Close query — use live reference to avoid double-close.
+			// If runQuery()'s finally block ran during the STEP 3 await, it already
+			// called close() and nulled ctx.queryObject; skip close() in that case.
+			// Only close when the promise timed out and the subprocess is still alive.
 			if (this.ctx.queryObject) {
 				try {
 					this.ctx.queryObject.close();

--- a/packages/daemon/src/lib/agent/interrupt-handler.ts
+++ b/packages/daemon/src/lib/agent/interrupt-handler.ts
@@ -110,10 +110,21 @@ export class InterruptHandler {
 				}
 			}
 
-			// STEP 4: Clear queryObject
+			// STEP 4: Close query to terminate subprocess and MCP transports.
+			// Prevents "Already connected to a transport" errors on next query start.
+			if (this.ctx.queryObject) {
+				try {
+					this.ctx.queryObject.close();
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : String(error);
+					logger.warn('SDK close() failed (may be expected):', errorMessage);
+				}
+			}
+
+			// STEP 5: Clear queryObject
 			this.ctx.queryObject = null;
 
-			// STEP 5: Stop the message queue
+			// STEP 6: Stop the message queue
 			messageQueue.stop();
 
 			// Publish interrupt event

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -121,10 +121,10 @@ export class QueryLifecycleManager {
 		// 4. Close query to terminate subprocess and MCP transports.
 		// This prevents "Already connected to a transport" errors when a new
 		// query is started before the old subprocess has fully exited.
-		const queryObjectToClose = this.ctx.queryObject;
-		if (queryObjectToClose) {
+		// Uses the same local reference captured in step 2 for consistency.
+		if (queryObject) {
 			try {
-				queryObjectToClose.close();
+				queryObject.close();
 			} catch {
 				// Ignore close errors — subprocess may already be terminated
 			}

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -118,11 +118,13 @@ export class QueryLifecycleManager {
 			}
 		}
 
-		// 4. Close query to terminate subprocess and MCP transports.
-		// This prevents "Already connected to a transport" errors when a new
-		// query is started before the old subprocess has fully exited.
-		// Uses the same local reference captured in step 2 for consistency.
-		if (queryObject) {
+		// 4. Close query only if runQuery()'s finally block has not already done so.
+		// When queryPromise resolves normally, the finally block ran during the await
+		// above: it called close() and nulled ctx.queryObject. Check the live reference
+		// against our local snapshot — if they differ (null or new query), skip close()
+		// to avoid a redundant double-call. Only close when the promise timed out
+		// (finally block has not run yet, subprocess is still alive).
+		if (queryObject && this.ctx.queryObject === queryObject) {
 			try {
 				queryObject.close();
 			} catch {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -118,7 +118,19 @@ export class QueryLifecycleManager {
 			}
 		}
 
-		// 4. Clear references
+		// 4. Close query to terminate subprocess and MCP transports.
+		// This prevents "Already connected to a transport" errors when a new
+		// query is started before the old subprocess has fully exited.
+		const queryObjectToClose = this.ctx.queryObject;
+		if (queryObjectToClose) {
+			try {
+				queryObjectToClose.close();
+			} catch {
+				// Ignore close errors — subprocess may already be terminated
+			}
+		}
+
+		// 5. Clear references
 		this.ctx.queryObject = null;
 		this.ctx.queryPromise = null;
 	}

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -384,6 +384,7 @@ export class QueryRunner {
 
 				messageQueue.stop();
 				this.ctx.queryPromise = null;
+				this.ctx.queryObject = null;
 
 				// Restore original env vars
 				const originalEnvVars = this.ctx.originalEnvVars;

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -383,20 +383,21 @@ export class QueryRunner {
 				}
 
 				messageQueue.stop();
-				this.ctx.queryPromise = null;
 
-				// Close query to terminate subprocess and MCP transports before
-				// clearing the reference. This prevents "Already connected to a
-				// transport" errors when a new query starts before the old
-				// subprocess exits (natural completion path).
+				// Close and null queryObject BEFORE any async operation so that
+				// concurrent stop()/interrupt() callers see null and skip their
+				// own close() call. queryPromise is nulled LAST — callers awaiting
+				// it exit the race only after this synchronous block has run,
+				// guaranteeing they observe queryObject=null and skip the redundant
+				// close().
 				if (this.ctx.queryObject) {
 					try {
 						this.ctx.queryObject.close();
 					} catch {
 						// Ignore close errors — subprocess may already be terminated
 					}
+					this.ctx.queryObject = null;
 				}
-				this.ctx.queryObject = null;
 
 				// Restore original env vars
 				const originalEnvVars = this.ctx.originalEnvVars;
@@ -412,6 +413,9 @@ export class QueryRunner {
 				if (!this.ctx.isCleaningUp()) {
 					await stateManager.setIdle();
 				}
+
+				// Null queryPromise last so callers awaiting it see queryObject=null.
+				this.ctx.queryPromise = null;
 			}
 			// Stale query: skip all cleanup — new query owns shared state
 		}

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -384,6 +384,18 @@ export class QueryRunner {
 
 				messageQueue.stop();
 				this.ctx.queryPromise = null;
+
+				// Close query to terminate subprocess and MCP transports before
+				// clearing the reference. This prevents "Already connected to a
+				// transport" errors when a new query starts before the old
+				// subprocess exits (natural completion path).
+				if (this.ctx.queryObject) {
+					try {
+						this.ctx.queryObject.close();
+					} catch {
+						// Ignore close errors — subprocess may already be terminated
+					}
+				}
 				this.ctx.queryObject = null;
 
 				// Restore original env vars

--- a/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
@@ -311,7 +311,6 @@ describe('InterruptHandler', () => {
 			expect(promiseIdx).not.toBe(-1);
 			expect(closeIdx).not.toBe(-1);
 			expect(interruptIdx).toBeLessThan(promiseIdx);
-			expect(interruptIdx).toBeLessThan(closeIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
 		});
 

--- a/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
@@ -310,6 +310,7 @@ describe('InterruptHandler', () => {
 			expect(interruptIdx).not.toBe(-1);
 			expect(promiseIdx).not.toBe(-1);
 			expect(closeIdx).not.toBe(-1);
+			expect(interruptIdx).toBeLessThan(promiseIdx);
 			expect(interruptIdx).toBeLessThan(closeIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
 		});

--- a/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
@@ -294,16 +294,21 @@ describe('InterruptHandler', () => {
 			sdkCloseSpy.mockImplementation(() => {
 				callOrder.push('close');
 			});
-			const queryPromise = Promise.resolve().then(() => {
-				callOrder.push('promise');
+			const queryPromise = new Promise<void>((resolve) => {
+				setTimeout(() => {
+					callOrder.push('promise');
+					resolve();
+				}, 10);
 			});
 			handler = createHandler({ queryPromise });
 
 			await handler.handleInterrupt();
 
 			const interruptIdx = callOrder.indexOf('interrupt');
+			const promiseIdx = callOrder.indexOf('promise');
 			const closeIdx = callOrder.indexOf('close');
 			expect(interruptIdx).toBeLessThan(closeIdx);
+			expect(promiseIdx).toBeLessThan(closeIdx);
 		});
 
 		it('should handle SDK close() failure gracefully', async () => {

--- a/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
@@ -307,6 +307,9 @@ describe('InterruptHandler', () => {
 			const interruptIdx = callOrder.indexOf('interrupt');
 			const promiseIdx = callOrder.indexOf('promise');
 			const closeIdx = callOrder.indexOf('close');
+			expect(interruptIdx).not.toBe(-1);
+			expect(promiseIdx).not.toBe(-1);
+			expect(closeIdx).not.toBe(-1);
 			expect(interruptIdx).toBeLessThan(closeIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
 		});

--- a/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/interrupt-handler.test.ts
@@ -34,6 +34,7 @@ describe('InterruptHandler', () => {
 	let queueClearSpy: ReturnType<typeof mock>;
 	let queueStopSpy: ReturnType<typeof mock>;
 	let sdkInterruptSpy: ReturnType<typeof mock>;
+	let sdkCloseSpy: ReturnType<typeof mock>;
 
 	beforeEach(() => {
 		mockSession = {
@@ -82,8 +83,10 @@ describe('InterruptHandler', () => {
 		} as unknown as Logger;
 
 		sdkInterruptSpy = mock(async () => {});
+		sdkCloseSpy = mock(() => {});
 		mockQueryObject = {
 			interrupt: sdkInterruptSpy,
+			close: sdkCloseSpy,
 		} as unknown as Query;
 
 		mockAbortController = new AbortController();
@@ -273,6 +276,58 @@ describe('InterruptHandler', () => {
 
 			// Should not throw
 			expect(handler).toBeDefined();
+		});
+
+		it('should call SDK close() to terminate subprocess and MCP transports', async () => {
+			handler = createHandler();
+
+			await handler.handleInterrupt();
+
+			expect(sdkCloseSpy).toHaveBeenCalled();
+		});
+
+		it('should call close() after interrupt() and waiting for query promise', async () => {
+			const callOrder: string[] = [];
+			sdkInterruptSpy.mockImplementation(async () => {
+				callOrder.push('interrupt');
+			});
+			sdkCloseSpy.mockImplementation(() => {
+				callOrder.push('close');
+			});
+			const queryPromise = Promise.resolve().then(() => {
+				callOrder.push('promise');
+			});
+			handler = createHandler({ queryPromise });
+
+			await handler.handleInterrupt();
+
+			const interruptIdx = callOrder.indexOf('interrupt');
+			const closeIdx = callOrder.indexOf('close');
+			expect(interruptIdx).toBeLessThan(closeIdx);
+		});
+
+		it('should handle SDK close() failure gracefully', async () => {
+			sdkCloseSpy.mockImplementation(() => {
+				throw new Error('Close failed');
+			});
+			handler = createHandler();
+
+			// Should not throw
+			await handler.handleInterrupt();
+
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('SDK close() failed'),
+				'Close failed'
+			);
+		});
+
+		it('should skip close() when queryObject is null', async () => {
+			handler = createHandler({ queryObject: null });
+
+			// Should not throw
+			await handler.handleInterrupt();
+
+			expect(sdkCloseSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -293,6 +293,37 @@ describe('QueryLifecycleManager', () => {
 			expect(mockContext.queryObject).toBeNull();
 			expect(mockContext.queryPromise).toBeNull();
 		});
+
+		test('calls close() after query promise resolves', async () => {
+			const callOrder: string[] = [];
+			mockContext.queryObject = {
+				interrupt: mock(async () => {
+					callOrder.push('interrupt');
+				}),
+				close: mock(() => {
+					callOrder.push('close');
+				}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			mockContext.queryPromise = new Promise<void>((resolve) => {
+				setTimeout(() => {
+					callOrder.push('promise');
+					resolve();
+				}, 10);
+			});
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			const interruptIdx = callOrder.indexOf('interrupt');
+			const promiseIdx = callOrder.indexOf('promise');
+			const closeIdx = callOrder.indexOf('close');
+			expect(interruptIdx).not.toBe(-1);
+			expect(promiseIdx).not.toBe(-1);
+			expect(closeIdx).not.toBe(-1);
+			expect(promiseIdx).toBeLessThan(closeIdx);
+			expect(interruptIdx).toBeLessThan(closeIdx);
+		});
 	});
 
 	describe('restart', () => {

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -233,6 +233,66 @@ describe('QueryLifecycleManager', () => {
 			// Should not throw
 			await manager.stop();
 		});
+
+		test('calls close() on query object to terminate subprocess', async () => {
+			let closeCalled = false;
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {
+					closeCalled = true;
+				}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.queryPromise = Promise.resolve();
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			expect(closeCalled).toBe(true);
+		});
+
+		test('calls close() even when transport is not ready (firstMessageReceived=false)', async () => {
+			let closeCalled = false;
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {
+					closeCalled = true;
+				}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = false;
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			expect(closeCalled).toBe(true);
+		});
+
+		test('handles close() errors gracefully', async () => {
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {
+					throw new Error('Close failed');
+				}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			manager = new QueryLifecycleManager(mockContext);
+
+			// Should not throw
+			await manager.stop();
+		});
+
+		test('clears query references after close()', async () => {
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.queryPromise = Promise.resolve();
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			expect(mockContext.queryObject).toBeNull();
+			expect(mockContext.queryPromise).toBeNull();
+		});
 	});
 
 	describe('restart', () => {

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -321,6 +321,7 @@ describe('QueryLifecycleManager', () => {
 			expect(interruptIdx).not.toBe(-1);
 			expect(promiseIdx).not.toBe(-1);
 			expect(closeIdx).not.toBe(-1);
+			expect(interruptIdx).toBeLessThan(promiseIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
 			expect(interruptIdx).toBeLessThan(closeIdx);
 		});

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -323,7 +323,6 @@ describe('QueryLifecycleManager', () => {
 			expect(closeIdx).not.toBe(-1);
 			expect(interruptIdx).toBeLessThan(promiseIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
-			expect(interruptIdx).toBeLessThan(closeIdx);
 		});
 	});
 

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -1149,4 +1149,59 @@ describe('QueryRunner cleaning up state', () => {
 
 		expect(setIdleCalled).toBe(true);
 	});
+
+	it('should call close() on queryObject before clearing it in finally block', () => {
+		// Verify the pattern: close() is called before null assignment
+		// This prevents "Already connected to a transport" errors in the natural exit path
+		let closeCalled = false;
+		let nulledAfterClose = false;
+
+		const mockQueryObject = {
+			close: () => {
+				closeCalled = true;
+			},
+		};
+
+		// Simulate the finally block's non-stale cleanup
+		let ctxQueryObject: typeof mockQueryObject | null = mockQueryObject;
+		if (ctxQueryObject) {
+			try {
+				ctxQueryObject.close();
+			} catch {
+				// Ignore
+			}
+		}
+		if (closeCalled) {
+			ctxQueryObject = null;
+			nulledAfterClose = true;
+		}
+
+		expect(closeCalled).toBe(true);
+		expect(nulledAfterClose).toBe(true);
+		expect(ctxQueryObject).toBeNull();
+	});
+
+	it('should handle close() errors gracefully in finally block', () => {
+		let errorHandled = false;
+
+		const mockQueryObject = {
+			close: () => {
+				throw new Error('Close error');
+			},
+		};
+
+		let ctxQueryObject: typeof mockQueryObject | null = mockQueryObject;
+		try {
+			if (ctxQueryObject) {
+				ctxQueryObject.close();
+			}
+		} catch {
+			errorHandled = true;
+		}
+		ctxQueryObject = null;
+
+		// Error was caught, reference was still cleared
+		expect(errorHandled).toBe(true);
+		expect(ctxQueryObject).toBeNull();
+	});
 });

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -642,6 +642,78 @@ describe('QueryRunner', () => {
 			}).toThrow('Some SDK error');
 		});
 	});
+
+	describe('runQuery() finally block close() behaviour', () => {
+		// Integration tests: exercise the actual QueryRunner.start() → runQuery() finally block.
+		// In unit tests, no credentials are configured (setup.ts clears all API keys), so
+		// runQuery() fails at the auth check before creating a new queryObject. This means
+		// ctx.queryObject stays as whatever was pre-set, and the finally block (non-stale path)
+		// calls close() on it and nulls it — exactly the natural-completion cleanup path.
+
+		it('should call close() on pre-existing queryObject in finally block', async () => {
+			const closeSpy = mock(() => {});
+			const ctx = createContext({
+				queryObject: {
+					interrupt: mock(async () => {}),
+					close: closeSpy,
+				} as unknown as Query,
+			});
+			runner = new QueryRunner(ctx);
+
+			// start() launches runQuery() asynchronously; wait for it to settle.
+			// runQuery() fails at the auth check (no credentials in unit tests),
+			// but the finally block still runs and should close + null ctx.queryObject.
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(closeSpy).toHaveBeenCalled();
+			expect(ctx.queryObject).toBeNull();
+		});
+
+		it('should handle close() errors gracefully in finally block', async () => {
+			const ctx = createContext({
+				queryObject: {
+					interrupt: mock(async () => {}),
+					close: mock(() => {
+						throw new Error('Close failed');
+					}),
+				} as unknown as Query,
+			});
+			runner = new QueryRunner(ctx);
+
+			// start() launches runQuery() asynchronously; wait for it to settle.
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			// queryObject is still nulled after error is caught
+			expect(ctx.queryObject).toBeNull();
+		});
+
+		it('should not call close() or null queryObject for stale queries in finally block', async () => {
+			const closeSpy = mock(() => {});
+			let gen = 0;
+			const originalQueryObject = {
+				interrupt: mock(async () => {}),
+				close: closeSpy,
+			} as unknown as Query;
+			const ctx = createContext({
+				queryObject: originalQueryObject,
+				// incrementQueryGeneration returns gen 1, but getQueryGeneration returns 2
+				// → isStaleQuery = true → finally block skips all cleanup
+				incrementQueryGeneration: () => ++gen, // returns 1
+				getQueryGeneration: () => 2, // current gen is 2, query ran as gen 1
+			});
+			runner = new QueryRunner(ctx);
+
+			// start() launches runQuery() asynchronously; wait for it to settle.
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(closeSpy).not.toHaveBeenCalled();
+			// ctx.queryObject is not nulled — it belongs to the current (gen 2) query
+			expect(ctx.queryObject).toBe(originalQueryObject);
+		});
+	});
 });
 
 describe('QueryRunner error categorization', () => {
@@ -1148,60 +1220,5 @@ describe('QueryRunner cleaning up state', () => {
 		}
 
 		expect(setIdleCalled).toBe(true);
-	});
-
-	it('should call close() on queryObject before clearing it in finally block', () => {
-		// Verify the pattern: close() is called before null assignment
-		// This prevents "Already connected to a transport" errors in the natural exit path
-		let closeCalled = false;
-		let nulledAfterClose = false;
-
-		const mockQueryObject = {
-			close: () => {
-				closeCalled = true;
-			},
-		};
-
-		// Simulate the finally block's non-stale cleanup
-		let ctxQueryObject: typeof mockQueryObject | null = mockQueryObject;
-		if (ctxQueryObject) {
-			try {
-				ctxQueryObject.close();
-			} catch {
-				// Ignore
-			}
-		}
-		if (closeCalled) {
-			ctxQueryObject = null;
-			nulledAfterClose = true;
-		}
-
-		expect(closeCalled).toBe(true);
-		expect(nulledAfterClose).toBe(true);
-		expect(ctxQueryObject).toBeNull();
-	});
-
-	it('should handle close() errors gracefully in finally block', () => {
-		let errorHandled = false;
-
-		const mockQueryObject = {
-			close: () => {
-				throw new Error('Close error');
-			},
-		};
-
-		let ctxQueryObject: typeof mockQueryObject | null = mockQueryObject;
-		try {
-			if (ctxQueryObject) {
-				ctxQueryObject.close();
-			}
-		} catch {
-			errorHandled = true;
-		}
-		ctxQueryObject = null;
-
-		// Error was caught, reference was still cleared
-		expect(errorHandled).toBe(true);
-		expect(ctxQueryObject).toBeNull();
 	});
 });


### PR DESCRIPTION
Fixes server crash "Already connected to a transport. Call close() before
connecting to a new transport, or use a separate Protocol instance per
connection."

The SDK's Protocol class requires explicit close() before a new transport
can connect. Previously, QueryLifecycleManager.stop() and
InterruptHandler.handleInterrupt() only nulled the queryObject reference
without calling close(), leaving the subprocess and MCP transports alive.
A subsequent query() call would then collide on the same transport.

Fix: call queryObject.close() after waiting for the query promise to
resolve (and after interrupt()) in both stop paths, before clearing
references. close() is caught-and-ignored if the subprocess already exited.
