### PR TITLE
fix: resolve leader questions routing to dead session instances

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -93,6 +93,17 @@ export class RoomRuntimeService {
 		return agentModels?.worker ?? room.defaultModel ?? this.ctx.defaultModel;
 	}
 
+	/**
+	 * Get an active AgentSession by ID from the runtime session pool.
+	 *
+	 * Room worker/leader sessions are stored here (not in SessionManager's cache),
+	 * so this must be used when routing question responses to the correct instance.
+	 * Returns undefined if the session is not currently active in this service.
+	 */
+	getAgentSession(sessionId: string): AgentSession | undefined {
+		return this.agentSessions.get(sessionId);
+	}
+
 	pauseRuntime(roomId: string): boolean {
 		const runtime = this.runtimes.get(roomId);
 		if (!runtime) return false;
@@ -252,6 +263,15 @@ export class RoomRuntimeService {
 				// started lazily when injectMessage() is called. Eagerly starting
 				// without a queued message causes a 15s startup timeout because the
 				// SDK waits for user input that never arrives.
+				return true;
+			},
+			startSession: async (sessionId) => {
+				const session = agentSessions.get(sessionId);
+				if (!session) return false;
+				// Eagerly start the SDK query for waiting_for_input sessions so the
+				// SDK re-encounters the pending AskUserQuestion in its session file
+				// and re-calls canUseTool, re-establishing the pendingResolver.
+				await session.ensureQueryStarted();
 				return true;
 			},
 			setSessionMcpServers: (sessionId, mcpServers) => {

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -598,13 +598,22 @@ export class RoomRuntimeService {
 						// Restore MCP servers (planner-tools, leader-agent-tools)
 						await runtime.restoreMcpServersForGroup(group);
 
-						// Inject continuation message to resume work
-						// Groups awaiting human review don't need a message — human will provide one
-						if (!group.submittedForReview) {
+						// Resume work after restart.
+						// - Groups awaiting human review: no message needed, human will provide one.
+						// - Groups waiting for a question answer: start the SDK query so it
+						//   re-encounters the pending AskUserQuestion tool call and re-establishes
+						//   pendingResolver. Injecting a user message would corrupt the conversation
+						//   by adding an orphaned turn after the unanswered tool use.
+						// - All other groups: inject a continuation message to resume work.
+						if (!group.submittedForReview && !group.waitingForQuestion) {
 							await sessionFactory.injectMessage(
 								group.workerSessionId,
 								'The system was restarted. Continue working on the task.'
 							);
+						} else if (group.waitingForQuestion) {
+							const sessionId =
+								group.waitingSession === 'leader' ? group.leaderSessionId : group.workerSessionId;
+							await sessionFactory.startSession(sessionId);
 						}
 					} catch (error) {
 						log.error(`Failed to restore/inject continuation for group ${group.id}:`, error);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2080,6 +2080,34 @@ export class RoomRuntime {
 				continue; // Awaiting human - no continuation message needed
 			}
 
+			// Groups waiting for a question answer need special handling.
+			// Injecting a regular continuation message would leave an orphaned user
+			// message after the pending AskUserQuestion tool use (invalid conversation
+			// state) and confuse the agent once it resumes.
+			// Instead, just start the SDK query so the SDK re-encounters the pending
+			// AskUserQuestion in its session file and re-calls canUseTool, which
+			// re-establishes the pendingResolver so the user can submit their answer.
+			if (group.waitingForQuestion) {
+				try {
+					const sessionId =
+						group.waitingSession === 'leader' ? group.leaderSessionId : group.workerSessionId;
+					const restored = group.waitingSession === 'leader' ? leaderRestored : workerRestored;
+					if (restored && this.sessionFactory.startSession) {
+						await this.sessionFactory.startSession(sessionId);
+						log.info(
+							`[ZombieRecovery] Group ${group.id}: started SDK query for ` +
+								`${group.waitingSession} session waiting for question answer`
+						);
+					}
+				} catch (error) {
+					log.error(
+						`[ZombieRecovery] Group ${group.id}: failed to start session for waitingForQuestion:`,
+						error
+					);
+				}
+				continue; // Skip regular continuation message injection
+			}
+
 			try {
 				if (workerRestored) {
 					await this.sessionFactory.injectMessage(

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2092,7 +2092,7 @@ export class RoomRuntime {
 					const sessionId =
 						group.waitingSession === 'leader' ? group.leaderSessionId : group.workerSessionId;
 					const restored = group.waitingSession === 'leader' ? leaderRestored : workerRestored;
-					if (restored && this.sessionFactory.startSession) {
+					if (restored) {
 						await this.sessionFactory.startSession(sessionId);
 						log.info(
 							`[ZombieRecovery] Group ${group.id}: started SDK query for ` +

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -91,7 +91,7 @@ export interface SessionFactory {
 	 *
 	 * Returns true if successful, false if the session is not in the cache.
 	 */
-	startSession?(sessionId: string): Promise<boolean>;
+	startSession(sessionId: string): Promise<boolean>;
 	/**
 	 * Set runtime MCP servers on a restored session.
 	 * MCP servers are non-serializable and lost on restart — must be re-created.

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -76,10 +76,22 @@ export interface SessionFactory {
 	createWorktree(basePath: string, sessionId: string, branchName?: string): Promise<string | null>;
 	/**
 	 * Restore a session from DB after daemon restart.
-	 * Adds it to the in-memory cache and starts the streaming query.
+	 * Adds it to the in-memory cache but does NOT start the streaming query
+	 * (lazy start via injectMessage or startSession).
 	 * Returns true if successful, false if session not found in DB.
 	 */
 	restoreSession(sessionId: string): Promise<boolean>;
+	/**
+	 * Start the SDK streaming query for a restored session without injecting a message.
+	 *
+	 * Used for sessions in waiting_for_input state after daemon restart: the SDK
+	 * will re-encounter the pending AskUserQuestion tool call in its session file
+	 * and re-call canUseTool, re-establishing the pendingResolver so the user can
+	 * answer the question via question.respond RPC.
+	 *
+	 * Returns true if successful, false if the session is not in the cache.
+	 */
+	startSession?(sessionId: string): Promise<boolean>;
 	/**
 	 * Set runtime MCP servers on a restored session.
 	 * MCP servers are non-serializable and lost on restart — must be re-created.

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -85,7 +85,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 	setupFileHandlers(deps.messageHub, deps.sessionManager);
 	setupSystemHandlers(deps.messageHub, deps.sessionManager, deps.authManager, deps.config);
 	setupAuthHandlers(deps.messageHub, deps.authManager);
-	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
+	// Note: setupQuestionHandlers is called after roomRuntimeService is created below
+	// so that it can receive a runtime session lookup function. Room worker/leader
+	// sessions live in RoomRuntimeService.agentSessions (separate from SessionManager),
+	// so the handler needs to check the runtime pool first.
 	registerMcpHandlers(deps.messageHub, deps.sessionManager);
 	registerSettingsHandlers(deps.messageHub, deps.settingsManager, deps.daemonHub, deps.db);
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
@@ -115,6 +118,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 	roomRuntimeService.start().catch((error) => {
 		log.error('Failed to start RoomRuntimeService:', error);
 	});
+
+	// Wire question handlers now that roomRuntimeService is available.
+	// Pass its session lookup so question.respond reaches the correct live AgentSession
+	// (room worker/leader sessions are stored in RoomRuntimeService.agentSessions,
+	// not in SessionManager's cache).
+	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub, (sessionId) =>
+		roomRuntimeService.getAgentSession(sessionId)
+	);
+
 	setupRoomRuntimeHandlers(deps.messageHub, deps.daemonHub, roomRuntimeService);
 	setupTaskHandlers(
 		deps.messageHub,

--- a/packages/daemon/src/lib/rpc-handlers/question-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/question-handlers.ts
@@ -7,6 +7,7 @@
 import type { MessageHub, QuestionDraftResponse } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SessionManager } from '../session-manager';
+import type { AgentSession } from '../agent/agent-session';
 
 /**
  * Payload for question.respond RPC call
@@ -36,8 +37,37 @@ interface QuestionCancelPayload {
 export function setupQuestionHandlers(
 	messageHub: MessageHub,
 	sessionManager: SessionManager,
-	_daemonHub: DaemonHub
+	_daemonHub: DaemonHub,
+	/**
+	 * Optional lookup for room worker/leader sessions.
+	 *
+	 * Room worker and leader sessions live in RoomRuntimeService.agentSessions,
+	 * a separate in-memory map from SessionManager's cache. If SessionManager is
+	 * used alone it creates a fresh AgentSession from the DB (no live SDK query,
+	 * pendingResolver = null) and handleQuestionResponse always throws.
+	 *
+	 * Pass RoomRuntimeService.getAgentSession.bind(runtimeService) here so the
+	 * handler resolves the correct live instance first.
+	 */
+	getRuntimeSession?: (sessionId: string) => AgentSession | undefined
 ): void {
+	/**
+	 * Resolve the AgentSession that owns the live SDK query for a given session ID.
+	 *
+	 * Prefers the runtime pool (worker/leader sessions) over SessionManager's cache
+	 * because SessionManager.getSessionAsync() loads a fresh instance from the DB
+	 * when the session is not in its own cache — that instance has no pendingResolver
+	 * and handleQuestionResponse would always throw "No pending question to respond to".
+	 */
+	async function resolveSession(sessionId: string): Promise<AgentSession | null> {
+		// Room worker/leader sessions: check runtime pool first
+		const runtimeSession = getRuntimeSession?.(sessionId);
+		if (runtimeSession) return runtimeSession;
+
+		// Lobby/room-chat sessions: fall back to SessionManager
+		return sessionManager.getSessionAsync(sessionId);
+	}
+
 	/**
 	 * question.respond - Send user's response to pending question
 	 *
@@ -47,7 +77,7 @@ export function setupQuestionHandlers(
 	messageHub.onRequest('question.respond', async (data) => {
 		const { sessionId, toolUseId, responses } = data as QuestionRespondPayload;
 
-		const agentSession = await sessionManager.getSessionAsync(sessionId);
+		const agentSession = await resolveSession(sessionId);
 		if (!agentSession) {
 			throw new Error(`Session not found: ${sessionId}`);
 		}
@@ -65,7 +95,7 @@ export function setupQuestionHandlers(
 	messageHub.onRequest('question.saveDraft', async (data) => {
 		const { sessionId, draftResponses } = data as QuestionSaveDraftPayload;
 
-		const agentSession = await sessionManager.getSessionAsync(sessionId);
+		const agentSession = await resolveSession(sessionId);
 		if (!agentSession) {
 			throw new Error(`Session not found: ${sessionId}`);
 		}
@@ -83,7 +113,7 @@ export function setupQuestionHandlers(
 	messageHub.onRequest('question.cancel', async (data) => {
 		const { sessionId, toolUseId } = data as QuestionCancelPayload;
 
-		const agentSession = await sessionManager.getSessionAsync(sessionId);
+		const agentSession = await resolveSession(sessionId);
 		if (!agentSession) {
 			throw new Error(`Session not found: ${sessionId}`);
 		}

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -540,7 +540,13 @@ export class StateManager {
 
 		// Get all session state in one place
 		const sessionData = agentSession.getSessionData();
-		const agentState = agentSession.getProcessingState();
+		// Prefer event-sourced processingStateCache over the session's in-memory state.
+		// Room leader/worker sessions are live in RoomRuntimeService.agentSessions but are
+		// loaded separately into SessionCache (as "ghosts") when state.session is fetched.
+		// The ghost's in-memory processingState becomes stale once the live session changes
+		// state. processingStateCache is always up-to-date via session.updated DaemonHub events.
+		const agentState =
+			this.processingStateCache.get(sessionId) ?? agentSession.getProcessingState();
 		const commands = await agentSession.getSlashCommands();
 
 		// Get error from cache (null if no error or error has been cleared)

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -767,3 +767,116 @@ describe('Stuck worker detection and recovery', () => {
 		expect(leaderCreateCount).toBe(1);
 	});
 });
+
+describe('Zombie recovery — waitingForQuestion groups', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		ctx = createRuntimeTestContext();
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('should call startSession (not injectMessage) for a zombie worker waiting for question answer', async () => {
+		const { groupId, workerSessionId } = await createTaskWithGroup(ctx);
+
+		// Mark the group as waiting for a question from the worker
+		ctx.groupRepo.setWaitingForQuestion(groupId, true, 'worker');
+
+		// Worker session is missing from cache (zombie)
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === workerSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			ctx.sessionFactory.calls.push({ method: 'restoreSession', args: [sessionId] });
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// startSession should have been called for the worker
+		const startCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'startSession' && c.args[0] === workerSessionId
+		);
+		expect(startCalls).toHaveLength(1);
+
+		// injectMessage should NOT have been called (would corrupt conversation state)
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === workerSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+
+		// Group should still be active
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.completedAt).toBeNull();
+	});
+
+	it('should call startSession for a zombie leader waiting for question answer', async () => {
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+
+		// Mark the group as waiting for a question from the leader
+		ctx.groupRepo.setWaitingForQuestion(groupId, true, 'leader');
+
+		// Leader session is missing from cache (zombie)
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			ctx.sessionFactory.calls.push({ method: 'restoreSession', args: [sessionId] });
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// startSession should have been called for the leader session
+		const startCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'startSession' && c.args[0] === leaderSessionId
+		);
+		expect(startCalls).toHaveLength(1);
+
+		// injectMessage should NOT have been called for the leader
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(0);
+
+		// Group should still be active
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.completedAt).toBeNull();
+	});
+
+	it('should NOT call startSession when session was already live (not a zombie)', async () => {
+		const { groupId, workerSessionId } = await createTaskWithGroup(ctx);
+
+		// Mark as waiting for a question
+		ctx.groupRepo.setWaitingForQuestion(groupId, true, 'worker');
+
+		// Session IS in cache — hasSession returns true, no restore needed
+		ctx.sessionFactory.hasSession = () => true;
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// No restore and no startSession needed — session was already live
+		const startCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'startSession' && c.args[0] === workerSessionId
+		);
+		expect(startCalls).toHaveLength(0);
+
+		// Group should remain active
+		const updated = ctx.groupRepo.getGroup(groupId);
+		expect(updated!.completedAt).toBeNull();
+		expect(updated!.waitingForQuestion).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -90,6 +90,10 @@ export function createMockSessionFactory() {
 		async stopSession(sessionId: string) {
 			calls.push({ method: 'stopSession', args: [sessionId] });
 		},
+		async startSession(sessionId: string) {
+			calls.push({ method: 'startSession', args: [sessionId] });
+			return true;
+		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
 		processingStates: Map<

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -52,6 +52,10 @@ function createMockSessionFactory() {
 			calls.push({ method: 'restoreSession', args: [sessionId] });
 			return true;
 		},
+		async startSession(sessionId: string) {
+			calls.push({ method: 'startSession', args: [sessionId] });
+			return true;
+		},
 	} satisfies SessionFactory & { calls: Array<{ method: string; args: unknown[] }> };
 }
 

--- a/packages/daemon/tests/unit/rpc-handlers/question-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/question-handlers.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for question RPC handlers (question.respond, question.saveDraft, question.cancel)
+ *
+ * Covers:
+ * - question.respond: routes to runtime session first, falls back to SessionManager
+ * - question.respond: throws when session not found in either pool
+ * - question.saveDraft: routes to runtime session first, falls back to SessionManager
+ * - question.cancel: routes to runtime session first, falls back to SessionManager
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { setupQuestionHandlers } from '../../../src/lib/rpc-handlers/question-handlers';
+import type { AgentSession } from '../../../src/lib/agent/agent-session';
+import type { SessionManager } from '../../../src/lib/session-manager';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+
+type RequestHandler = (data: unknown, context?: unknown) => Promise<unknown>;
+
+// ─── Mock helpers ───
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockAgentSession(overrides?: Partial<AgentSession>): AgentSession {
+	return {
+		handleQuestionResponse: mock(async () => {}),
+		updateQuestionDraft: mock(async () => {}),
+		handleQuestionCancel: mock(async () => {}),
+		...overrides,
+	} as unknown as AgentSession;
+}
+
+function createMockSessionManager(session: AgentSession | null = null): SessionManager {
+	return {
+		getSessionAsync: mock(async () => session),
+	} as unknown as SessionManager;
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {} as unknown as DaemonHub;
+}
+
+describe('question handlers — session routing', () => {
+	let mockHub: ReturnType<typeof createMockMessageHub>;
+	let daemonHub: DaemonHub;
+
+	beforeEach(() => {
+		mockHub = createMockMessageHub();
+		daemonHub = createMockDaemonHub();
+	});
+
+	// ─── question.respond ───
+
+	describe('question.respond', () => {
+		it('routes to runtime session when found in runtime pool', async () => {
+			const runtimeSession = createMockAgentSession();
+			const sessionManagerSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(sessionManagerSession);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (id) =>
+				id === 'runtime-session-1' ? runtimeSession : undefined
+			);
+
+			const handler = mockHub.handlers.get('question.respond')!;
+			await handler({ sessionId: 'runtime-session-1', toolUseId: 'tool-1', responses: [] });
+
+			expect(runtimeSession.handleQuestionResponse).toHaveBeenCalledWith('tool-1', []);
+			expect(sessionManagerSession.handleQuestionResponse).not.toHaveBeenCalled();
+			expect(sessionManager.getSessionAsync).not.toHaveBeenCalled();
+		});
+
+		it('falls back to SessionManager when session not in runtime pool', async () => {
+			const sessionManagerSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(sessionManagerSession);
+
+			setupQuestionHandlers(
+				mockHub.hub,
+				sessionManager,
+				daemonHub,
+				(_id) => undefined // runtime pool has nothing
+			);
+
+			const handler = mockHub.handlers.get('question.respond')!;
+			await handler({ sessionId: 'lobby-session-1', toolUseId: 'tool-2', responses: [] });
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('lobby-session-1');
+			expect(sessionManagerSession.handleQuestionResponse).toHaveBeenCalledWith('tool-2', []);
+		});
+
+		it('works without getRuntimeSession callback (no runtime pool)', async () => {
+			const sessionManagerSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(sessionManagerSession);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub);
+
+			const handler = mockHub.handlers.get('question.respond')!;
+			await handler({ sessionId: 'lobby-session-1', toolUseId: 'tool-3', responses: [] });
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('lobby-session-1');
+			expect(sessionManagerSession.handleQuestionResponse).toHaveBeenCalledWith('tool-3', []);
+		});
+
+		it('throws when session not found in either pool', async () => {
+			const sessionManager = createMockSessionManager(null);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (_id) => undefined);
+
+			const handler = mockHub.handlers.get('question.respond')!;
+			await expect(
+				handler({ sessionId: 'missing-session', toolUseId: 'tool-4', responses: [] })
+			).rejects.toThrow('Session not found: missing-session');
+		});
+	});
+
+	// ─── question.saveDraft ───
+
+	describe('question.saveDraft', () => {
+		it('routes to runtime session when found in runtime pool', async () => {
+			const runtimeSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(null);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (id) =>
+				id === 'runtime-session-2' ? runtimeSession : undefined
+			);
+
+			const handler = mockHub.handlers.get('question.saveDraft')!;
+			const draftResponses = [{ questionId: 'q1', value: 'draft' }];
+			await handler({ sessionId: 'runtime-session-2', draftResponses });
+
+			expect(runtimeSession.updateQuestionDraft).toHaveBeenCalledWith(draftResponses);
+			expect(sessionManager.getSessionAsync).not.toHaveBeenCalled();
+		});
+
+		it('falls back to SessionManager when session not in runtime pool', async () => {
+			const sessionManagerSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(sessionManagerSession);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (_id) => undefined);
+
+			const handler = mockHub.handlers.get('question.saveDraft')!;
+			const draftResponses = [{ questionId: 'q2', value: 'draft-value' }];
+			await handler({ sessionId: 'lobby-session-2', draftResponses });
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('lobby-session-2');
+			expect(sessionManagerSession.updateQuestionDraft).toHaveBeenCalledWith(draftResponses);
+		});
+	});
+
+	// ─── question.cancel ───
+
+	describe('question.cancel', () => {
+		it('routes to runtime session when found in runtime pool', async () => {
+			const runtimeSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(null);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (id) =>
+				id === 'runtime-session-3' ? runtimeSession : undefined
+			);
+
+			const handler = mockHub.handlers.get('question.cancel')!;
+			await handler({ sessionId: 'runtime-session-3', toolUseId: 'tool-cancel-1' });
+
+			expect(runtimeSession.handleQuestionCancel).toHaveBeenCalledWith('tool-cancel-1');
+			expect(sessionManager.getSessionAsync).not.toHaveBeenCalled();
+		});
+
+		it('falls back to SessionManager when session not in runtime pool', async () => {
+			const sessionManagerSession = createMockAgentSession();
+			const sessionManager = createMockSessionManager(sessionManagerSession);
+
+			setupQuestionHandlers(mockHub.hub, sessionManager, daemonHub, (_id) => undefined);
+
+			const handler = mockHub.handlers.get('question.cancel')!;
+			await handler({ sessionId: 'lobby-session-3', toolUseId: 'tool-cancel-2' });
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('lobby-session-3');
+			expect(sessionManagerSession.handleQuestionCancel).toHaveBeenCalledWith('tool-cancel-2');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -266,6 +266,52 @@ describe('StateManager', () => {
 			expect(result).toHaveProperty('error');
 			expect(result).toHaveProperty('timestamp');
 		});
+
+		it('should prefer processingStateCache over ghost session in-memory state', async () => {
+			// Simulate a room leader/worker session where the SessionCache has a "ghost"
+			// (an AgentSession loaded from DB) with stale idle state. The live session
+			// in RoomRuntimeService has transitioned to waiting_for_input, which was
+			// propagated to processingStateCache via session.updated event.
+			const pendingQuestion = {
+				toolUseId: 'tool-use-123',
+				questions: [
+					{
+						question: 'Which approach?',
+						header: 'Architecture',
+						options: [{ label: 'Option A', description: 'First option' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+
+			// Ghost session loaded from DB has stale idle state
+			const ghostAgentSession = {
+				getSessionData: mock(() => ({ id: 'leader-session-id', title: 'Leader' })),
+				getProcessingState: mock(() => ({ status: 'idle' as const })),
+				getSlashCommands: mock(async () => []),
+				getContextInfo: mock(() => null),
+			};
+			(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
+				ghostAgentSession
+			);
+
+			// Simulate session.updated event from ProcessingStateManager populating the cache
+			const updateHandler = eventHandlers.get('session.updated');
+			await updateHandler!({
+				sessionId: 'leader-session-id',
+				processingState: { status: 'waiting_for_input', pendingQuestion },
+			});
+
+			// The state.session RPC should return cached waiting_for_input, not ghost's idle
+			const handler = requestHandlers.get(STATE_CHANNELS.SESSION);
+			const result = await handler!({ sessionId: 'leader-session-id' });
+
+			expect(result.agentState.status).toBe('waiting_for_input');
+			expect(result.agentState.pendingQuestion).toEqual(pendingQuestion);
+			// Confirm the ghost's getProcessingState was NOT used as the final value
+			expect(ghostAgentSession.getProcessingState).toHaveBeenCalledTimes(0);
+		});
 	});
 
 	describe('getSessionSnapshot', () => {


### PR DESCRIPTION
- question.respond/saveDraft/cancel now check RoomRuntimeService.agentSessions
  first before falling back to SessionManager; room worker/leader sessions were
  never in SessionManager's cache so the old code always created a fresh DB
  instance with pendingResolver=null, causing handleQuestionResponse to throw
  "No pending question to respond to"

- Zombie recovery skips injectMessage for groups with waitingForQuestion=true;
  injecting a continuation message after an unanswered AskUserQuestion tool use
  creates invalid conversation state — instead, startSession() is called so the
  SDK re-encounters the pending tool call and re-establishes the resolver

- Add startSession() to SessionFactory interface and RoomRuntimeService
  implementation so the SDK query can be restarted without injecting a message

- Add tests for question handler session routing (runtime pool vs SessionManager
  fallback) and for waitingForQuestion zombie recovery behavior
