### PR TITLE
test: add E2E tests for provider model switching UI

### DIFF
--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -16,13 +16,131 @@
  *   does NOT silently skip (hard-fail rule from CLAUDE.md).
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import {
 	setupMessageHubTesting,
-	createSessionViaUI,
 	cleanupTestSession,
 	waitForAssistantResponse,
+	waitForSessionCreated,
+	getWorkspaceRoot,
+	waitForWebSocketConnected,
 } from '../helpers/wait-helpers';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new session by clicking the "New Session" button in the Lobby UI,
+ * filling in the workspace path, and submitting the form.
+ *
+ * NOTE: `getWorkspaceRoot` uses an RPC call for infrastructure purposes only
+ * (fetching the test workspace path).  The session itself is created through
+ * the UI form — no `session.create` RPC is called directly.
+ */
+async function createSessionViaNewSessionButton(page: Page): Promise<string> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+
+	// Close any stale modal left open from a previous test.  When the SPA does not
+	// fully reset component state across tests, the backdrop blocks the "New Session"
+	// button.  The SPA may keep hidden dialog elements in the DOM — use :visible to
+	// only match dialogs that are actually shown.
+	const anyDialog = page.locator('[role="dialog"]:visible');
+	if (await anyDialog.isVisible({ timeout: 500 }).catch(() => false)) {
+		await page.keyboard.press('Escape');
+		await expect(anyDialog).toBeHidden({ timeout: 3000 });
+	}
+
+	// Click the desktop "New Session" button.  There are two buttons with accessible
+	// name "New Session" (desktop text button + mobile icon-only button), so use
+	// :has-text to match only the one with visible text content.
+	await page.locator('button:has-text("New Session")').first().click();
+
+	// Wait for the modal dialog to appear and scope all subsequent lookups to the
+	// VISIBLE dialog.  Using :visible avoids strict-mode violations when the SPA
+	// keeps hidden dialog elements in the DOM from previous renders.
+	const dialog = page.locator('[role="dialog"]:visible');
+	await expect(dialog).toBeVisible({ timeout: 5000 });
+
+	// Fill in the workspace path — scoped to the visible dialog.
+	const pathInput = dialog.getByTestId('new-session-workspace-input');
+	await expect(pathInput).toBeVisible({ timeout: 5000 });
+
+	// Wait for the modal's async model fetch to settle before filling the path.
+	// NewSessionModal calls fetchAvailableModels() on open; when the cache is warm
+	// (tests 2+) the promise resolves instantly and triggers a Preact re-render that
+	// resets selectedPath to '' — overwriting a fill that happened too early.
+	// Waiting for the "Model (optional)" label confirms the async render completed.
+	await dialog
+		.getByText('Model (optional)')
+		.isVisible({ timeout: 1500 })
+		.catch(() => {});
+
+	await pathInput.fill(workspaceRoot);
+
+	// Submit the form — scoped to the visible dialog to avoid ambiguity.
+	await dialog.getByRole('button', { name: 'Create Session' }).click();
+
+	// waitForSessionCreated handles the rest: it waits for navigation away from the
+	// lobby and confirms the chat view is ready.
+	return waitForSessionCreated(page);
+}
+
+/**
+ * Open the model dropdown and return the provider group labels visible in it.
+ * Relies on `data-testid="provider-group-header"` spans in the dropdown.
+ */
+async function openDropdownAndGetProviderGroups(page: Page): Promise<string[]> {
+	const modelBtn = page.locator('button[title^="Switch Model"]');
+	await expect(modelBtn).toBeVisible({ timeout: 10000 });
+	await modelBtn.click();
+	await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
+
+	const dropdown = page.getByTestId('model-dropdown');
+	const headers = dropdown.getByTestId('provider-group-header');
+	const count = await headers.count();
+	const labels: string[] = [];
+	for (let i = 0; i < count; i++) {
+		const text = (await headers.nth(i).textContent()) ?? '';
+		if (text.trim()) labels.push(text.trim());
+	}
+	return labels;
+}
+
+/**
+ * Hard-fail guard: asserts at least 2 provider groups are available.
+ * Called at the start of every cross-provider test to avoid silent skipping
+ * (CLAUDE.md hard-fail rule).
+ */
+function assertMultiProviderRequired(providerGroups: string[]): void {
+	expect(
+		providerGroups.length,
+		'Cross-provider switch test requires at least 2 configured providers. ' +
+			`Found providers: [${providerGroups.join(', ')}]. ` +
+			'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
+	).toBeGreaterThan(1);
+}
+
+/**
+ * Click the first model listed under a given provider group in the open dropdown
+ * and wait for the dropdown to close.
+ */
+async function switchToProviderModel(page: Page, providerLabel: string): Promise<void> {
+	const dropdown = page.getByTestId('model-dropdown');
+
+	// Find the provider section that contains the matching header
+	const targetSection = dropdown.locator('[data-testid="provider-section"]').filter({
+		has: page.getByTestId('provider-group-header').filter({ hasText: providerLabel }),
+	});
+
+	// Click the first model button in that section
+	await targetSection.getByRole('button').first().click();
+
+	// Wait for dropdown to close
+	await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 10000 });
+}
 
 // ---------------------------------------------------------------------------
 // Suite A: Model picker UI rendering
@@ -47,7 +165,7 @@ test.describe('Model picker UI rendering', () => {
 	});
 
 	test('model name is visible in the session status bar', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
 		// The model switcher button title is "Switch Model (<name>)" once a model
 		// is loaded.  We accept the plain "Switch Model" title too (e.g. when the
@@ -57,7 +175,7 @@ test.describe('Model picker UI rendering', () => {
 	});
 
 	test('model picker dropdown opens when clicking the model button', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
 		const modelBtn = page.locator('button[title^="Switch Model"]');
 		await expect(modelBtn).toBeVisible({ timeout: 10000 });
@@ -68,7 +186,7 @@ test.describe('Model picker UI rendering', () => {
 	});
 
 	test('models are grouped by provider with provider headers', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
 		const modelBtn = page.locator('button[title^="Switch Model"]');
 		await expect(modelBtn).toBeVisible({ timeout: 10000 });
@@ -77,17 +195,15 @@ test.describe('Model picker UI rendering', () => {
 		// Wait for dropdown
 		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
 
-		// At least one provider group header (uppercase text in dropdown, smaller font)
-		// They are rendered as: <span class="... text-[10px] font-semibold text-gray-400 uppercase ...">
-		const providerHeaders = page.locator(
-			'[class*="text-gray-400"][class*="uppercase"], [class*="font-semibold"][class*="uppercase"]'
-		);
-		const headerCount = await providerHeaders.count();
+		// At least one provider group header via data-testid
+		const headers = page.getByTestId('provider-group-header');
+		await expect(headers.first()).toBeVisible({ timeout: 5000 });
+		const headerCount = await headers.count();
 		expect(headerCount).toBeGreaterThan(0);
 	});
 
 	test('closing the dropdown by clicking the model button again hides it', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
 		const modelBtn = page.locator('button[title^="Switch Model"]');
 		await expect(modelBtn).toBeVisible({ timeout: 10000 });
@@ -104,11 +220,15 @@ test.describe('Model picker UI rendering', () => {
 	});
 
 	test('provider badge is visible next to the model button', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
+
+		// Wait for model info to load (title includes the model name when loaded)
+		const modelBtn = page.locator('button[title^="Switch Model ("]');
+		await expect(modelBtn).toBeVisible({ timeout: 20000 });
 
 		// The ProviderBadge renders a span[data-testid="provider-badge"]
-		const badge = page.locator('[data-testid="provider-badge"]');
-		await expect(badge).toBeVisible({ timeout: 10000 });
+		const badge = page.getByTestId('provider-badge');
+		await expect(badge).toBeVisible({ timeout: 5000 });
 	});
 });
 
@@ -134,70 +254,33 @@ test.describe('Cross-provider model switching', () => {
 		}
 	});
 
-	/**
-	 * Helper: open the model dropdown and return the provider group labels visible
-	 * in the dropdown.  The caller is responsible for ensuring the dropdown is open
-	 * before calling helpers that read it.
-	 */
-	async function openDropdownAndGetProviderGroups(
-		page: import('@playwright/test').Page
-	): Promise<string[]> {
-		const modelBtn = page.locator('button[title^="Switch Model"]');
-		await expect(modelBtn).toBeVisible({ timeout: 10000 });
-		await modelBtn.click();
-		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
-
-		// Provider labels are <span> with uppercase + small font inside the dropdown.
-		// We locate the dropdown container first so we don't pick up stray labels.
-		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
-		const headers = dropdown.locator(
-			'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
-		);
-		const count = await headers.count();
-		const labels: string[] = [];
-		for (let i = 0; i < count; i++) {
-			const text = (await headers.nth(i).textContent()) ?? '';
-			if (text.trim()) labels.push(text.trim());
-		}
-		return labels;
-	}
-
 	test('requires at least 2 providers — fails clearly when only one is configured', async ({
 		page,
 	}) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
 		const providerGroups = await openDropdownAndGetProviderGroups(page);
 
 		// HARD FAIL — no silent skipping (see CLAUDE.md "Hard Fail Rule")
-		expect(
-			providerGroups.length,
-			'Cross-provider switch test requires at least 2 configured providers. ' +
-				`Found providers: [${providerGroups.join(', ')}]. ` +
-				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
-		).toBeGreaterThan(1);
+		assertMultiProviderRequired(providerGroups);
 	});
 
 	test('provider badge updates after switching to a model from a different provider', async ({
 		page,
 	}) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
 
-		// Read the current provider badge label (aria-label = provider display name)
-		const badge = page.locator('[data-testid="provider-badge"]');
-		await expect(badge).toBeVisible({ timeout: 10000 });
+		// Wait for model info to load before reading the badge
+		await expect(page.locator('button[title^="Switch Model ("]')).toBeVisible({ timeout: 20000 });
+
+		// Read the current provider from the badge
+		const badge = page.getByTestId('provider-badge');
+		await expect(badge).toBeVisible({ timeout: 5000 });
 		const initialProvider = await badge.getAttribute('aria-label');
 
-		// Open the dropdown and collect provider groups
+		// Open the dropdown and verify 2+ providers are available
 		const providerGroups = await openDropdownAndGetProviderGroups(page);
-
-		// Hard fail if only one provider
-		expect(
-			providerGroups.length,
-			'Cross-provider switch test requires at least 2 configured providers. ' +
-				`Found providers: [${providerGroups.join(', ')}]. ` +
-				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
-		).toBeGreaterThan(1);
+		assertMultiProviderRequired(providerGroups);
 
 		// Find a provider group different from the current one
 		const targetProvider = providerGroups.find(
@@ -205,69 +288,36 @@ test.describe('Cross-provider model switching', () => {
 		);
 		expect(targetProvider).toBeTruthy();
 
-		// Click the first model under the target provider group.
-		// Provider group headers are followed immediately by model buttons inside the
-		// same parent <div>.  We select the first button in that section.
-		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
-		const targetHeader = dropdown
-			.locator(
-				'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
-			)
-			.filter({ hasText: targetProvider! });
+		// Switch to the first model under the target provider
+		await switchToProviderModel(page, targetProvider!);
 
-		// The header is inside a wrapper div; sibling model buttons follow.
-		// Navigate: header span → parent div (provider section) → first model button
-		const modelBtn = targetHeader.locator('xpath=ancestor::div[1]/following-sibling::button[1]');
-		await expect(modelBtn).toBeVisible({ timeout: 5000 });
-		await modelBtn.click();
-
-		// Wait for the dropdown to close (model switching in progress / complete)
-		await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 10000 });
-
-		// The provider badge aria-label should now reflect the new provider
-		await expect(badge).toBeVisible({ timeout: 10000 });
-		const newProvider = await badge.getAttribute('aria-label');
-		expect(newProvider).not.toEqual(initialProvider);
+		// Use auto-retrying assertion to avoid race condition — the badge was
+		// already visible before the switch; we wait for its label to change.
+		await expect(badge).not.toHaveAttribute('aria-label', initialProvider!, { timeout: 10000 });
 	});
 
 	test('session continues working after cross-provider model switch', async ({ page }) => {
-		sessionId = await createSessionViaUI(page);
+		sessionId = await createSessionViaNewSessionButton(page);
+
+		// Wait for model info to load before reading the badge
+		await expect(page.locator('button[title^="Switch Model ("]')).toBeVisible({ timeout: 20000 });
 
 		// Check provider groups first
 		const providerGroups = await openDropdownAndGetProviderGroups(page);
+		assertMultiProviderRequired(providerGroups);
 
-		// Hard fail if only one provider
-		expect(
-			providerGroups.length,
-			'Cross-provider switch test requires at least 2 configured providers. ' +
-				`Found providers: [${providerGroups.join(', ')}]. ` +
-				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
-		).toBeGreaterThan(1);
-
-		const badge = page.locator('[data-testid="provider-badge"]');
+		const badge = page.getByTestId('provider-badge');
 		const initialProvider = await badge.getAttribute('aria-label');
 
-		// Pick a different provider's first model
+		// Switch to a model from a different provider
 		const targetProvider = providerGroups.find(
 			(label) => label.toLowerCase() !== (initialProvider ?? '').toLowerCase()
 		);
-		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
-		const targetHeader = dropdown
-			.locator(
-				'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
-			)
-			.filter({ hasText: targetProvider! });
-		const switchBtn = targetHeader.locator('xpath=ancestor::div[1]/following-sibling::button[1]');
-		await expect(switchBtn).toBeVisible({ timeout: 5000 });
-		await switchBtn.click();
+		expect(targetProvider).toBeTruthy();
+		await switchToProviderModel(page, targetProvider!);
 
-		// Wait for switch to complete
-		await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 10000 });
-
-		// Verify badge updated
-		await expect(badge).toBeVisible({ timeout: 10000 });
-		const newProvider = await badge.getAttribute('aria-label');
-		expect(newProvider).not.toEqual(initialProvider);
+		// Verify badge updated (auto-retrying assertion — no race condition)
+		await expect(badge).not.toHaveAttribute('aria-label', initialProvider!, { timeout: 10000 });
 
 		// Send a simple message and verify the session produces a response
 		const textarea = page.locator('textarea[placeholder*="Ask"]').first();

--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -1,0 +1,284 @@
+/**
+ * Provider / Model Switching E2E Tests
+ *
+ * Two suites that cover provider-related UI behaviour:
+ *
+ * Suite A – "Model picker UI rendering"
+ *   Works with any single provider.  Verifies static rendering: model name visible
+ *   in the session status bar, dropdown opens, models are grouped by provider, and
+ *   provider labels appear as group headers.
+ *
+ * Suite B – "Cross-provider model switching"
+ *   Requires at least two configured providers.  Verifies that switching to a model
+ *   from a different provider updates the provider badge and that the session
+ *   continues to work (sends a message, gets a response).
+ *   If only one provider is available the suite FAILS with a clear message — it
+ *   does NOT silently skip (hard-fail rule from CLAUDE.md).
+ */
+
+import { test, expect } from '../../fixtures';
+import {
+	setupMessageHubTesting,
+	createSessionViaUI,
+	cleanupTestSession,
+	waitForAssistantResponse,
+} from '../helpers/wait-helpers';
+
+// ---------------------------------------------------------------------------
+// Suite A: Model picker UI rendering
+// ---------------------------------------------------------------------------
+test.describe('Model picker UI rendering', () => {
+	let sessionId: string | null = null;
+
+	test.beforeEach(async ({ page }) => {
+		await setupMessageHubTesting(page);
+		sessionId = null;
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (sessionId) {
+			try {
+				await cleanupTestSession(page, sessionId);
+			} catch (error) {
+				console.warn(`Failed to cleanup session ${sessionId}:`, error);
+			}
+			sessionId = null;
+		}
+	});
+
+	test('model name is visible in the session status bar', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		// The model switcher button title is "Switch Model (<name>)" once a model
+		// is loaded.  We accept the plain "Switch Model" title too (e.g. when the
+		// daemon defaults are unknown), but at minimum the button must exist.
+		const modelBtn = page.locator('button[title^="Switch Model"]');
+		await expect(modelBtn).toBeVisible({ timeout: 10000 });
+	});
+
+	test('model picker dropdown opens when clicking the model button', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		const modelBtn = page.locator('button[title^="Switch Model"]');
+		await expect(modelBtn).toBeVisible({ timeout: 10000 });
+		await modelBtn.click();
+
+		// The dropdown header "Select Model" should be visible
+		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('models are grouped by provider with provider headers', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		const modelBtn = page.locator('button[title^="Switch Model"]');
+		await expect(modelBtn).toBeVisible({ timeout: 10000 });
+		await modelBtn.click();
+
+		// Wait for dropdown
+		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
+
+		// At least one provider group header (uppercase text in dropdown, smaller font)
+		// They are rendered as: <span class="... text-[10px] font-semibold text-gray-400 uppercase ...">
+		const providerHeaders = page.locator(
+			'[class*="text-gray-400"][class*="uppercase"], [class*="font-semibold"][class*="uppercase"]'
+		);
+		const headerCount = await providerHeaders.count();
+		expect(headerCount).toBeGreaterThan(0);
+	});
+
+	test('closing the dropdown by clicking the model button again hides it', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		const modelBtn = page.locator('button[title^="Switch Model"]');
+		await expect(modelBtn).toBeVisible({ timeout: 10000 });
+
+		// Open dropdown
+		await modelBtn.click();
+		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
+
+		// Click the same button again to close (toggle)
+		await modelBtn.click();
+
+		// Dropdown should disappear
+		await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 5000 });
+	});
+
+	test('provider badge is visible next to the model button', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		// The ProviderBadge renders a span[data-testid="provider-badge"]
+		const badge = page.locator('[data-testid="provider-badge"]');
+		await expect(badge).toBeVisible({ timeout: 10000 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Suite B: Cross-provider model switching
+// ---------------------------------------------------------------------------
+test.describe('Cross-provider model switching', () => {
+	let sessionId: string | null = null;
+
+	test.beforeEach(async ({ page }) => {
+		await setupMessageHubTesting(page);
+		sessionId = null;
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (sessionId) {
+			try {
+				await cleanupTestSession(page, sessionId);
+			} catch (error) {
+				console.warn(`Failed to cleanup session ${sessionId}:`, error);
+			}
+			sessionId = null;
+		}
+	});
+
+	/**
+	 * Helper: open the model dropdown and return the provider group labels visible
+	 * in the dropdown.  The caller is responsible for ensuring the dropdown is open
+	 * before calling helpers that read it.
+	 */
+	async function openDropdownAndGetProviderGroups(
+		page: import('@playwright/test').Page
+	): Promise<string[]> {
+		const modelBtn = page.locator('button[title^="Switch Model"]');
+		await expect(modelBtn).toBeVisible({ timeout: 10000 });
+		await modelBtn.click();
+		await expect(page.locator('text=Select Model')).toBeVisible({ timeout: 5000 });
+
+		// Provider labels are <span> with uppercase + small font inside the dropdown.
+		// We locate the dropdown container first so we don't pick up stray labels.
+		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
+		const headers = dropdown.locator(
+			'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
+		);
+		const count = await headers.count();
+		const labels: string[] = [];
+		for (let i = 0; i < count; i++) {
+			const text = (await headers.nth(i).textContent()) ?? '';
+			if (text.trim()) labels.push(text.trim());
+		}
+		return labels;
+	}
+
+	test('requires at least 2 providers — fails clearly when only one is configured', async ({
+		page,
+	}) => {
+		sessionId = await createSessionViaUI(page);
+
+		const providerGroups = await openDropdownAndGetProviderGroups(page);
+
+		// HARD FAIL — no silent skipping (see CLAUDE.md "Hard Fail Rule")
+		expect(
+			providerGroups.length,
+			'Cross-provider switch test requires at least 2 configured providers. ' +
+				`Found providers: [${providerGroups.join(', ')}]. ` +
+				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
+		).toBeGreaterThan(1);
+	});
+
+	test('provider badge updates after switching to a model from a different provider', async ({
+		page,
+	}) => {
+		sessionId = await createSessionViaUI(page);
+
+		// Read the current provider badge label (aria-label = provider display name)
+		const badge = page.locator('[data-testid="provider-badge"]');
+		await expect(badge).toBeVisible({ timeout: 10000 });
+		const initialProvider = await badge.getAttribute('aria-label');
+
+		// Open the dropdown and collect provider groups
+		const providerGroups = await openDropdownAndGetProviderGroups(page);
+
+		// Hard fail if only one provider
+		expect(
+			providerGroups.length,
+			'Cross-provider switch test requires at least 2 configured providers. ' +
+				`Found providers: [${providerGroups.join(', ')}]. ` +
+				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
+		).toBeGreaterThan(1);
+
+		// Find a provider group different from the current one
+		const targetProvider = providerGroups.find(
+			(label) => label.toLowerCase() !== (initialProvider ?? '').toLowerCase()
+		);
+		expect(targetProvider).toBeTruthy();
+
+		// Click the first model under the target provider group.
+		// Provider group headers are followed immediately by model buttons inside the
+		// same parent <div>.  We select the first button in that section.
+		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
+		const targetHeader = dropdown
+			.locator(
+				'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
+			)
+			.filter({ hasText: targetProvider! });
+
+		// The header is inside a wrapper div; sibling model buttons follow.
+		// Navigate: header span → parent div (provider section) → first model button
+		const modelBtn = targetHeader.locator('xpath=ancestor::div[1]/following-sibling::button[1]');
+		await expect(modelBtn).toBeVisible({ timeout: 5000 });
+		await modelBtn.click();
+
+		// Wait for the dropdown to close (model switching in progress / complete)
+		await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 10000 });
+
+		// The provider badge aria-label should now reflect the new provider
+		await expect(badge).toBeVisible({ timeout: 10000 });
+		const newProvider = await badge.getAttribute('aria-label');
+		expect(newProvider).not.toEqual(initialProvider);
+	});
+
+	test('session continues working after cross-provider model switch', async ({ page }) => {
+		sessionId = await createSessionViaUI(page);
+
+		// Check provider groups first
+		const providerGroups = await openDropdownAndGetProviderGroups(page);
+
+		// Hard fail if only one provider
+		expect(
+			providerGroups.length,
+			'Cross-provider switch test requires at least 2 configured providers. ' +
+				`Found providers: [${providerGroups.join(', ')}]. ` +
+				'Configure a second provider (e.g. anthropic-copilot or anthropic-codex) to run this suite.'
+		).toBeGreaterThan(1);
+
+		const badge = page.locator('[data-testid="provider-badge"]');
+		const initialProvider = await badge.getAttribute('aria-label');
+
+		// Pick a different provider's first model
+		const targetProvider = providerGroups.find(
+			(label) => label.toLowerCase() !== (initialProvider ?? '').toLowerCase()
+		);
+		const dropdown = page.locator('div:has(> div:has-text("Select Model"))').last();
+		const targetHeader = dropdown
+			.locator(
+				'span[class*="uppercase"][class*="text-gray-400"], span[class*="uppercase"][class*="font-semibold"]'
+			)
+			.filter({ hasText: targetProvider! });
+		const switchBtn = targetHeader.locator('xpath=ancestor::div[1]/following-sibling::button[1]');
+		await expect(switchBtn).toBeVisible({ timeout: 5000 });
+		await switchBtn.click();
+
+		// Wait for switch to complete
+		await expect(page.locator('text=Select Model')).toBeHidden({ timeout: 10000 });
+
+		// Verify badge updated
+		await expect(badge).toBeVisible({ timeout: 10000 });
+		const newProvider = await badge.getAttribute('aria-label');
+		expect(newProvider).not.toEqual(initialProvider);
+
+		// Send a simple message and verify the session produces a response
+		const textarea = page.locator('textarea[placeholder*="Ask"]').first();
+		await expect(textarea).toBeEnabled({ timeout: 10000 });
+		await textarea.fill('Reply with exactly: OK');
+		await page.keyboard.press('Meta+Enter');
+
+		// An assistant message should appear
+		await waitForAssistantResponse(page, { timeout: 90000 });
+
+		// Session input should be re-enabled, meaning the session is still functional
+		await expect(textarea).toBeEnabled({ timeout: 20000 });
+	});
+});

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -441,6 +441,7 @@ export default function SessionStatusBar({
 						{/* Model Dropdown */}
 						{modelDropdown.isOpen && (
 							<div
+								data-testid="model-dropdown"
 								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
 							>
 								<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
@@ -448,13 +449,16 @@ export default function SessionStatusBar({
 									([provider, models], groupIndex) => {
 										const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
 										return (
-											<div key={provider}>
+											<div key={provider} data-testid={`provider-section`}>
 												{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
 												<div class="px-3 py-1 flex items-center gap-1.5">
 													<span
 														class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
 													/>
-													<span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">
+													<span
+														data-testid="provider-group-header"
+														class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide"
+													>
 														{getProviderLabel(provider)}
 													</span>
 												</div>

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -220,6 +220,7 @@ export function NewSessionModal({
 					{/* Path Input */}
 					<input
 						type="text"
+						data-testid="new-session-workspace-input"
 						value={selectedPath}
 						onInput={(e) => setSelectedPath((e.target as HTMLInputElement).value)}
 						placeholder="Enter workspace path..."


### PR DESCRIPTION
## Summary

- Add `packages/e2e/tests/features/provider-model-switching.e2e.ts` with two suites covering provider-related UI behaviour
- **Suite A: "Model picker UI rendering"** — 5 tests that verify the model button is visible, the dropdown opens, models are grouped by provider with headers, the dropdown closes on toggle, and the provider badge is visible; works with any single provider
- **Suite B: "Cross-provider model switching"** — 3 tests that verify provider badge updates after switching, the session stays functional post-switch, and the suite FAILS CLEARLY (not skips) when fewer than 2 providers are configured, following the hard-fail rule in CLAUDE.md

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `make run-e2e TEST=tests/features/provider-model-switching.e2e.ts` — 8/8 passed (38s)
- [x] All test actions go through the UI; no RPC calls in test bodies; no internal state access