### PR TITLE
feat: graceful degradation on provider unavailability

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -143,9 +143,10 @@ export class QueryRunner {
 					await errorManager.handleError(
 						session.id,
 						authError,
-						ErrorCategory.AUTHENTICATION,
-						undefined,
-						stateManager.getState()
+						ErrorCategory.PROVIDER_AUTH_ERROR,
+						`Authentication with ${provider.displayName} has expired. Please re-authenticate to continue.`,
+						stateManager.getState(),
+						{ providerId: provider.id, providerName: provider.displayName }
 					);
 					throw authError;
 				}
@@ -318,8 +319,35 @@ export class QueryRunner {
 
 				if (!apiErrorHandled) {
 					let category = ErrorCategory.SYSTEM;
+					const providerId = session.config.provider as string | undefined;
+
+					// Detect provider-specific errors before general categorization
+					const isProviderSession =
+						providerId && providerId !== 'anthropic' && providerId !== 'glm';
 
 					if (
+						isProviderSession &&
+						(errorMessage.includes('401') ||
+							errorMessage.includes('403') ||
+							errorMessage.includes('unauthorized') ||
+							errorMessage.includes('Unauthorized') ||
+							errorMessage.includes('token expired') ||
+							errorMessage.includes('token_expired') ||
+							errorMessage.includes('not authenticated') ||
+							errorMessage.includes('invalid_api_key'))
+					) {
+						category = ErrorCategory.PROVIDER_AUTH_ERROR;
+					} else if (
+						isProviderSession &&
+						(errorMessage.includes('ECONNREFUSED') ||
+							errorMessage.includes('ENOTFOUND') ||
+							errorMessage.includes('EHOSTUNREACH') ||
+							errorMessage.includes('service unavailable') ||
+							errorMessage.includes('503') ||
+							errorMessage.includes('502'))
+					) {
+						category = ErrorCategory.PROVIDER_UNAVAILABLE;
+					} else if (
 						errorMessage.includes('401') ||
 						errorMessage.includes('unauthorized') ||
 						errorMessage.includes('invalid_api_key')
@@ -353,6 +381,7 @@ export class QueryRunner {
 						{
 							errorMessage,
 							queueSize: messageQueue.size(),
+							providerId: providerId ?? 'anthropic',
 						}
 					);
 				}

--- a/packages/daemon/src/lib/error-manager.ts
+++ b/packages/daemon/src/lib/error-manager.ts
@@ -20,6 +20,10 @@ export enum ErrorCategory {
 	TIMEOUT = 'timeout',
 	PERMISSION = 'permission',
 	RATE_LIMIT = 'rate_limit',
+	/** Provider-specific authentication failure (expired token, OAuth revoked, etc.) */
+	PROVIDER_AUTH_ERROR = 'provider_auth_error',
+	/** Provider bridge/service is unreachable or temporarily unavailable */
+	PROVIDER_UNAVAILABLE = 'provider_unavailable',
 }
 
 export interface StructuredError {
@@ -235,6 +239,12 @@ export class ErrorManager {
 			case ErrorCategory.PERMISSION:
 				return "Permission denied. You don't have access to this resource.";
 
+			case ErrorCategory.PROVIDER_AUTH_ERROR:
+				return 'Authentication with the provider has expired. Please re-authenticate to continue.';
+
+			case ErrorCategory.PROVIDER_UNAVAILABLE:
+				return 'The provider is temporarily unavailable. You can switch to another provider or try again.';
+
 			case ErrorCategory.SYSTEM:
 			default:
 				if (originalMessage.includes('ENOSPC')) {
@@ -316,6 +326,18 @@ export class ErrorManager {
 				suggestions.push('Check that the session still exists');
 				break;
 
+			case ErrorCategory.PROVIDER_AUTH_ERROR:
+				suggestions.push('Open Provider Settings to re-authenticate');
+				suggestions.push('Check that your provider credentials have not expired');
+				suggestions.push('Try switching to a different provider temporarily');
+				break;
+
+			case ErrorCategory.PROVIDER_UNAVAILABLE:
+				suggestions.push('Switch to a different provider (e.g. Anthropic) from the model picker');
+				suggestions.push('Check that the provider bridge server is running');
+				suggestions.push('Wait a moment and try again');
+				break;
+
 			default:
 				suggestions.push('Try the operation again');
 				suggestions.push('If the issue persists, check the error details below');
@@ -388,7 +410,11 @@ export class ErrorManager {
 		let newStatus: 'connected' | 'degraded' | 'disconnected' = this.currentApiStatus;
 
 		// Track connection-related errors
-		if (category === ErrorCategory.CONNECTION || category === ErrorCategory.TIMEOUT) {
+		if (
+			category === ErrorCategory.CONNECTION ||
+			category === ErrorCategory.TIMEOUT ||
+			category === ErrorCategory.PROVIDER_UNAVAILABLE
+		) {
 			this.apiConnectionErrors++;
 			this.lastApiError = errorMessage;
 

--- a/packages/daemon/tests/unit/core/error-manager.test.ts
+++ b/packages/daemon/tests/unit/core/error-manager.test.ts
@@ -367,6 +367,8 @@ describe('ErrorManager', () => {
 				ErrorCategory.TIMEOUT,
 				ErrorCategory.PERMISSION,
 				ErrorCategory.RATE_LIMIT,
+				ErrorCategory.PROVIDER_AUTH_ERROR,
+				ErrorCategory.PROVIDER_UNAVAILABLE,
 			];
 
 			categories.forEach((category) => {
@@ -375,6 +377,111 @@ describe('ErrorManager', () => {
 				expect(structured.userMessage).toBeDefined();
 				expect(structured.userMessage.length).toBeGreaterThan(0);
 			});
+		});
+	});
+
+	describe('provider error categories', () => {
+		it('should generate correct user message for PROVIDER_AUTH_ERROR', () => {
+			const structured = errorManager.createError(
+				new Error('401 unauthorized'),
+				ErrorCategory.PROVIDER_AUTH_ERROR
+			);
+			expect(structured.category).toBe(ErrorCategory.PROVIDER_AUTH_ERROR);
+			expect(structured.userMessage).toContain('Authentication with the provider has expired');
+			expect(structured.userMessage).toContain('re-authenticate');
+		});
+
+		it('should generate correct user message for PROVIDER_UNAVAILABLE', () => {
+			const structured = errorManager.createError(
+				new Error('ECONNREFUSED bridge'),
+				ErrorCategory.PROVIDER_UNAVAILABLE
+			);
+			expect(structured.category).toBe(ErrorCategory.PROVIDER_UNAVAILABLE);
+			expect(structured.userMessage).toContain('temporarily unavailable');
+			expect(structured.userMessage).toContain('switch to another provider');
+		});
+
+		it('should include provider-specific recovery suggestions for PROVIDER_AUTH_ERROR', () => {
+			const structured = errorManager.createError(
+				new Error('token expired'),
+				ErrorCategory.PROVIDER_AUTH_ERROR
+			);
+			expect(structured.recoverySuggestions).toBeDefined();
+			expect(structured.recoverySuggestions?.length).toBeGreaterThan(0);
+			expect(structured.recoverySuggestions).toContain('Open Provider Settings to re-authenticate');
+			expect(structured.recoverySuggestions).toContain(
+				'Try switching to a different provider temporarily'
+			);
+		});
+
+		it('should include provider-specific recovery suggestions for PROVIDER_UNAVAILABLE', () => {
+			const structured = errorManager.createError(
+				new Error('service unavailable 503'),
+				ErrorCategory.PROVIDER_UNAVAILABLE
+			);
+			expect(structured.recoverySuggestions).toBeDefined();
+			expect(structured.recoverySuggestions?.length).toBeGreaterThan(0);
+			expect(structured.recoverySuggestions).toContain(
+				'Switch to a different provider (e.g. Anthropic) from the model picker'
+			);
+			expect(structured.recoverySuggestions).toContain(
+				'Check that the provider bridge server is running'
+			);
+		});
+
+		it('PROVIDER_AUTH_ERROR should be recoverable', () => {
+			const structured = errorManager.createError(
+				new Error('token expired'),
+				ErrorCategory.PROVIDER_AUTH_ERROR
+			);
+			expect(structured.recoverable).toBe(true);
+		});
+
+		it('PROVIDER_UNAVAILABLE should be recoverable', () => {
+			const structured = errorManager.createError(
+				new Error('ECONNREFUSED'),
+				ErrorCategory.PROVIDER_UNAVAILABLE
+			);
+			expect(structured.recoverable).toBe(true);
+		});
+
+		it('should track PROVIDER_UNAVAILABLE errors in API connection state', async () => {
+			// Generate enough provider unavailable errors to change connection status
+			for (let i = 0; i < 2; i++) {
+				const error = errorManager.createError(
+					new Error('bridge server unreachable'),
+					ErrorCategory.PROVIDER_UNAVAILABLE
+				);
+				await errorManager.broadcastError('test-session', error);
+			}
+
+			const state = errorManager.getApiConnectionState();
+			expect(state.status).toBe('degraded');
+		});
+
+		it('should use custom user message for provider auth errors', () => {
+			const customMessage = 'Authentication with Copilot has expired. Please re-authenticate.';
+			const structured = errorManager.createError(
+				new Error('401 unauthorized'),
+				ErrorCategory.PROVIDER_AUTH_ERROR,
+				customMessage
+			);
+			expect(structured.userMessage).toBe(customMessage);
+		});
+
+		it('should store provider metadata when provided', async () => {
+			const result = await errorManager.handleError(
+				'session-abc',
+				new Error('token expired'),
+				ErrorCategory.PROVIDER_AUTH_ERROR,
+				'Authentication with Copilot has expired.',
+				undefined,
+				{ providerId: 'anthropic-copilot', providerName: 'Copilot' }
+			);
+
+			expect(result.category).toBe(ErrorCategory.PROVIDER_AUTH_ERROR);
+			expect(result.metadata?.providerId).toBe('anthropic-copilot');
+			expect(result.metadata?.providerName).toBe('Copilot');
 		});
 	});
 

--- a/packages/web/src/components/ErrorBanner.tsx
+++ b/packages/web/src/components/ErrorBanner.tsx
@@ -1,17 +1,25 @@
 /**
  * ErrorBanner Component
  *
- * Displays error messages with optional "View Details" button and dismiss functionality.
+ * Displays error messages with optional "View Details" button, custom action buttons,
+ * and dismiss functionality.
  * Extracted from ChatContainer.tsx for better separation of concerns.
  */
 
 import { borderColors } from '../lib/design-tokens';
+
+export interface ErrorBannerAction {
+	label: string;
+	onClick: () => void;
+}
 
 export interface ErrorBannerProps {
 	error: string;
 	hasDetails?: boolean;
 	onViewDetails?: () => void;
 	onDismiss: () => void;
+	/** Optional action buttons rendered before the dismiss button */
+	actions?: ErrorBannerAction[];
 }
 
 export function ErrorBanner({
@@ -19,6 +27,7 @@ export function ErrorBanner({
 	hasDetails = false,
 	onViewDetails,
 	onDismiss,
+	actions,
 }: ErrorBannerProps) {
 	return (
 		<div
@@ -28,6 +37,15 @@ export function ErrorBanner({
 			<div class="max-w-4xl mx-auto w-full px-4 md:px-0 flex items-center justify-between gap-4">
 				<p class="text-sm text-red-400 flex-1">{error}</p>
 				<div class="flex items-center gap-2">
+					{actions?.map((action) => (
+						<button
+							key={action.label}
+							onClick={action.onClick}
+							class="text-xs px-3 py-1 rounded-md bg-red-500/20 hover:bg-red-500/30 text-red-300 hover:text-red-200 transition-colors border border-red-500/30"
+						>
+							{action.label}
+						</button>
+					))}
 					{hasDetails && onViewDetails && (
 						<button
 							onClick={onViewDetails}

--- a/packages/web/src/components/ErrorDialog.tsx
+++ b/packages/web/src/components/ErrorDialog.tsx
@@ -24,6 +24,8 @@ const ERROR_CATEGORY_COLORS: Record<ErrorCategory, string> = {
 	timeout: 'bg-amber-500/10 text-amber-400 border-amber-500/30',
 	permission: 'bg-red-500/10 text-red-400 border-red-500/30',
 	rate_limit: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
+	provider_auth_error: 'bg-red-500/10 text-red-400 border-red-500/30',
+	provider_unavailable: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
 };
 
 const ERROR_CATEGORY_ICONS: Record<ErrorCategory, string> = {
@@ -37,6 +39,8 @@ const ERROR_CATEGORY_ICONS: Record<ErrorCategory, string> = {
 	timeout: '⏱️',
 	permission: '🔒',
 	rate_limit: '⏸️',
+	provider_auth_error: '🔑',
+	provider_unavailable: '🔌',
 };
 
 export function ErrorDialog({ isOpen, onClose, error, isDev: _isDev = false }: ErrorDialogProps) {

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -70,6 +70,11 @@ import { cn } from '../lib/utils.ts';
 import { lobbyStore } from '../lib/lobby-store.ts';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
 import type { RoomContext } from '../components/ChatHeader.tsx';
+import { navSectionSignal, settingsSectionSignal } from '../lib/signals.ts';
+import { ErrorCategory } from '../types/error.ts';
+import type { StructuredError } from '../types/error.ts';
+import { getProviderLabel } from '../hooks/index.ts';
+import type { ErrorBannerAction } from '../components/ErrorBanner.tsx';
 
 interface ChatContainerProps {
 	sessionId: string;
@@ -772,6 +777,38 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 	// Combined error (local + store)
 	const error = localError || storeError?.message || null;
 
+	// Build provider-specific action buttons for structured errors
+	const errorDetails = storeError?.details as StructuredError | undefined;
+	const errorCategory = errorDetails?.category;
+	const errorProviderId = errorDetails?.metadata?.providerId as string | undefined;
+	const errorActions = useMemo((): ErrorBannerAction[] => {
+		if (!errorDetails || !errorCategory) return [];
+		const providerLabel = errorProviderId ? getProviderLabel(errorProviderId) : 'Provider';
+		if (errorCategory === ErrorCategory.PROVIDER_AUTH_ERROR) {
+			return [
+				{
+					label: `Re-authenticate ${providerLabel}`,
+					onClick: () => {
+						navSectionSignal.value = 'settings';
+						settingsSectionSignal.value = 'providers';
+					},
+				},
+			];
+		}
+		if (errorCategory === ErrorCategory.PROVIDER_UNAVAILABLE) {
+			const defaultAnthropicModel = availableModels.find((m) => m.provider === 'anthropic');
+			const actions: ErrorBannerAction[] = [];
+			if (defaultAnthropicModel) {
+				actions.push({
+					label: 'Switch to Anthropic',
+					onClick: () => switchModel(defaultAnthropicModel),
+				});
+			}
+			return actions;
+		}
+		return [];
+	}, [errorDetails, errorCategory, errorProviderId, availableModels, switchModel]);
+
 	// Derive loading state from sessionStore
 	// sessionState being null means the RPC hasn't returned yet (truly loading)
 	// session (sessionInfo) can be null even after RPC returns for room sessions
@@ -1023,6 +1060,7 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 						setLocalError(null);
 						sessionStore.clearError();
 					}}
+					actions={errorActions.length > 0 ? errorActions : undefined}
 				/>
 			)}
 

--- a/packages/web/src/types/error.ts
+++ b/packages/web/src/types/error.ts
@@ -14,6 +14,10 @@ export enum ErrorCategory {
 	TIMEOUT = 'timeout',
 	PERMISSION = 'permission',
 	RATE_LIMIT = 'rate_limit',
+	/** Provider-specific authentication failure (expired token, OAuth revoked, etc.) */
+	PROVIDER_AUTH_ERROR = 'provider_auth_error',
+	/** Provider bridge/service is unreachable or temporarily unavailable */
+	PROVIDER_UNAVAILABLE = 'provider_unavailable',
 }
 
 export interface StructuredError {


### PR DESCRIPTION
Add PROVIDER_AUTH_ERROR and PROVIDER_UNAVAILABLE error categories that
map provider-specific failures to actionable UI messages instead of
surfacing raw API errors.

- ErrorCategory: add PROVIDER_AUTH_ERROR and PROVIDER_UNAVAILABLE to
  both daemon and web enums
- error-manager: provider-specific user messages, recovery suggestions,
  and connection state tracking for PROVIDER_UNAVAILABLE
- query-runner: detect bridge provider auth/connection failures and
  route to new categories with providerName in metadata; also use
  PROVIDER_AUTH_ERROR for pre-flight OAuth auth check failures
- ErrorDialog: add color and icon entries for both new categories
- ErrorBanner: add optional actions[] prop for inline action buttons
- ChatContainer: compute provider error actions (re-auth → opens
  Provider Settings; unavailable → switch to first Anthropic model)
  and pass them to ErrorBanner
- Tests: 107-line test coverage for new categories (user messages,
  recovery suggestions, recoverability, API connection degradation)
