### PR TITLE
feat: filter unauthenticated providers from model picker

### DIFF
--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -26,6 +26,7 @@ import {
 	getModelFamilyIcon,
 	getProviderLabel,
 	groupModelsByProvider,
+	filterModelsForPicker,
 	useMessageHub,
 } from '../hooks';
 import { Spinner } from './ui/Spinner.tsx';
@@ -238,8 +239,10 @@ export default function SessionStatusBar({
 	// Get MessageHub for RPC calls
 	const { callIfConnected } = useMessageHub();
 
-	// Provider auth statuses for availability dots in model picker
-	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, boolean>>(new Map());
+	// Provider auth statuses for availability dots and model filtering in model picker
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
+		new Map()
+	);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -247,9 +250,9 @@ export default function SessionStatusBar({
 			.then((res) => {
 				if (cancelled) return;
 				const result = res as { providers?: ProviderAuthStatus[] } | null;
-				const statusMap = new Map<string, boolean>();
+				const statusMap = new Map<string, ProviderAuthStatus>();
 				for (const p of result?.providers ?? []) {
-					statusMap.set(p.id, p.isAuthenticated);
+					statusMap.set(p.id, p);
 				}
 				setProviderAuthStatuses(statusMap);
 			})
@@ -445,46 +448,71 @@ export default function SessionStatusBar({
 								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
 							>
 								<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
-								{Array.from(groupModelsByProvider(availableModels).entries()).map(
-									([provider, models], groupIndex) => {
-										const isAuthenticated = providerAuthStatuses.get(provider) ?? false;
-										return (
-											<div key={provider} data-testid={`provider-section`}>
-												{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
-												<div class="px-3 py-1 flex items-center gap-1.5">
-													<span
-														class={`w-2 h-2 rounded-full flex-shrink-0 ${isAuthenticated ? 'bg-green-500' : 'bg-gray-500'}`}
-													/>
-													<span
-														data-testid="provider-group-header"
-														class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide"
-													>
-														{getProviderLabel(provider)}
+								{Array.from(
+									groupModelsByProvider(
+										filterModelsForPicker(
+											availableModels,
+											providerAuthStatuses,
+											currentModelInfo?.provider
+										)
+									).entries()
+								).map(([provider, models], groupIndex) => {
+									const authStatus = providerAuthStatuses.get(provider);
+									const isAuthenticated = authStatus?.isAuthenticated;
+									const needsRefresh = authStatus?.needsRefresh ?? false;
+									// Dot: gray = unknown, green = ok, yellow = expiring, red = unauthenticated (only current shown)
+									const dotClass =
+										isAuthenticated === undefined
+											? 'bg-gray-500'
+											: !isAuthenticated
+												? 'bg-red-500'
+												: needsRefresh
+													? 'bg-yellow-500'
+													: 'bg-green-500';
+									return (
+										<div key={provider} data-testid="provider-section">
+											{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
+											<div class="px-3 py-1 flex items-center gap-1.5">
+												<span class={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
+												<span
+													data-testid="provider-group-header"
+													class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide"
+												>
+													{getProviderLabel(provider)}
+												</span>
+												{needsRefresh && (
+													<span class="text-yellow-400 text-[10px]" title="Token expiring soon">
+														⚠
 													</span>
-												</div>
-												{models.map((model) => {
-													const isCurrent =
-														model.id === currentModelInfo?.id &&
-														model.provider === currentModelInfo?.provider;
-													return (
-														<button
-															key={`${model.provider}:${model.id}`}
-															class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
-																isCurrent ? 'text-blue-400' : 'text-gray-200'
-															}`}
-															onClick={() => handleModelSwitch(model)}
-															disabled={modelSwitching}
-														>
-															<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-															<span class="flex-1 truncate">{model.name}</span>
-															{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
-														</button>
-													);
-												})}
+												)}
 											</div>
-										);
-									}
-								)}
+											{models.map((model) => {
+												const isCurrent =
+													model.id === currentModelInfo?.id &&
+													model.provider === currentModelInfo?.provider;
+												return (
+													<button
+														key={`${model.provider}:${model.id}`}
+														class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
+															isCurrent ? 'text-blue-400' : 'text-gray-200'
+														}`}
+														onClick={() => handleModelSwitch(model)}
+														disabled={modelSwitching}
+													>
+														<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+														<span class="flex-1 truncate">{model.name}</span>
+														{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+														{needsRefresh && (
+															<span class="text-yellow-400 text-[10px]" title="Token expiring">
+																⚠
+															</span>
+														)}
+													</button>
+												);
+											})}
+										</div>
+									);
+								})}
 							</div>
 						)}
 					</div>

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -96,16 +96,17 @@ export function NewSessionModal({
 
 	useEffect(() => {
 		if (!isOpen) return;
-		fetchAvailableModels()
-			.then((models) => setAvailableModels(models))
+		// Fetch both together so a failure in either suppresses the model picker atomically.
+		// If auth status cannot be determined we must not show unfiltered models, and since
+		// both promises are resolved together there is no window where models repopulate
+		// after an auth failure.
+		Promise.all([fetchAvailableModels(), fetchProviderAuthStatuses()])
+			.then(([models, statuses]) => {
+				setAvailableModels(models);
+				setProviderAuthStatuses(statuses);
+			})
 			.catch(() => {
-				// silently ignore — model picker remains hidden
-			});
-		fetchProviderAuthStatuses()
-			.then((statuses) => setProviderAuthStatuses(statuses))
-			.catch(() => {
-				// Auth status unavailable — hide model picker to avoid showing unfiltered models
-				setAvailableModels([]);
+				// Either models or auth unavailable — keep model picker hidden
 			});
 	}, [isOpen]);
 

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -96,18 +96,30 @@ export function NewSessionModal({
 
 	useEffect(() => {
 		if (!isOpen) return;
+
+		// Clear stale picker data immediately so the modal never shows previous results
+		// while the fresh auth check is still pending.
+		setAvailableModels([]);
+		setProviderAuthStatuses(new Map());
+
+		let cancelled = false;
+
 		// Fetch both together so a failure in either suppresses the model picker atomically.
-		// If auth status cannot be determined we must not show unfiltered models, and since
-		// both promises are resolved together there is no window where models repopulate
-		// after an auth failure.
+		// If auth status cannot be determined we must not show unfiltered models.
 		Promise.all([fetchAvailableModels(), fetchProviderAuthStatuses()])
 			.then(([models, statuses]) => {
+				if (cancelled) return;
 				setAvailableModels(models);
 				setProviderAuthStatuses(statuses);
 			})
 			.catch(() => {
-				// Either models or auth unavailable — keep model picker hidden
+				// Either models or auth unavailable — keep model picker hidden.
+				// No state update needed: already cleared at effect start.
 			});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [isOpen]);
 
 	/** Resolve the selected model by composite key `provider:id` */

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -104,7 +104,8 @@ export function NewSessionModal({
 		fetchProviderAuthStatuses()
 			.then((statuses) => setProviderAuthStatuses(statuses))
 			.catch(() => {
-				// silently ignore — all providers shown (optimistic)
+				// Auth status unavailable — hide model picker to avoid showing unfiltered models
+				setAvailableModels([]);
 			});
 	}, [isOpen]);
 

--- a/packages/web/src/components/lobby/NewSessionModal.tsx
+++ b/packages/web/src/components/lobby/NewSessionModal.tsx
@@ -14,11 +14,13 @@ import { useState, useEffect } from 'preact/hooks';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import type { Room, ModelInfo } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { connectionManager } from '../../lib/connection-manager';
 import {
 	groupModelsByProvider,
 	getProviderLabel,
 	mapRawModelsToModelInfos,
+	filterModelsForPicker,
 } from '../../hooks/useModelSwitcher';
 import type { RawModelEntry } from '../../hooks/useModelSwitcher';
 
@@ -36,6 +38,20 @@ async function fetchAvailableModels(): Promise<import('@neokai/shared').ModelInf
 		models: RawModelEntry[];
 	};
 	return mapRawModelsToModelInfos(models);
+}
+
+/** Fetch provider auth statuses from the server */
+async function fetchProviderAuthStatuses(): Promise<Map<string, ProviderAuthStatus>> {
+	const hub = connectionManager.getHubIfConnected();
+	if (!hub) return new Map();
+	const result = (await hub.request('auth.providers', {})) as {
+		providers?: ProviderAuthStatus[];
+	} | null;
+	const map = new Map<string, ProviderAuthStatus>();
+	for (const p of result?.providers ?? []) {
+		map.set(p.id, p);
+	}
+	return map;
 }
 
 interface NewSessionModalProps {
@@ -72,6 +88,9 @@ export function NewSessionModal({
 	const [newRoomName, setNewRoomName] = useState('');
 	const [newRoomDescription, setNewRoomDescription] = useState('');
 	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
+		new Map()
+	);
 	// Empty string = "Default (server setting)"; non-empty = "provider:id"
 	const [selectedModelKey, setSelectedModelKey] = useState<string>('');
 
@@ -81,6 +100,11 @@ export function NewSessionModal({
 			.then((models) => setAvailableModels(models))
 			.catch(() => {
 				// silently ignore — model picker remains hidden
+			});
+		fetchProviderAuthStatuses()
+			.then((statuses) => setProviderAuthStatuses(statuses))
+			.catch(() => {
+				// silently ignore — all providers shown (optimistic)
 			});
 	}, [isOpen]);
 
@@ -166,6 +190,7 @@ export function NewSessionModal({
 		setSelectedRoomId(undefined);
 		setSelectedModelKey('');
 		setAvailableModels([]);
+		setProviderAuthStatuses(new Map());
 		setShowCreateRoom(false);
 		setNewRoomName('');
 		setNewRoomDescription('');
@@ -173,7 +198,10 @@ export function NewSessionModal({
 		onClose();
 	};
 
-	const groupedModels = groupModelsByProvider(availableModels);
+	// Filter out unauthenticated providers; no "current provider" to preserve in new session context
+	const groupedModels = groupModelsByProvider(
+		filterModelsForPicker(availableModels, providerAuthStatuses)
+	);
 
 	const handleBrowseFolder = () => {
 		// Trigger file browser dialog
@@ -255,18 +283,25 @@ export function NewSessionModal({
 							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100 focus:outline-none focus:border-blue-500 cursor-pointer"
 						>
 							<option value="">Default (server setting)</option>
-							{Array.from(groupedModels.entries()).map(([provider, models]) => (
-								<optgroup key={provider} label={getProviderLabel(provider)}>
-									{models.map((model) => (
-										<option
-											key={`${model.provider}:${model.id}`}
-											value={`${model.provider}:${model.id}`}
-										>
-											{model.name}
-										</option>
-									))}
-								</optgroup>
-							))}
+							{Array.from(groupedModels.entries()).map(([provider, models]) => {
+								const authStatus = providerAuthStatuses.get(provider);
+								const needsRefresh = authStatus?.needsRefresh ?? false;
+								const groupLabel = needsRefresh
+									? `${getProviderLabel(provider)} ⚠ (token expiring)`
+									: getProviderLabel(provider);
+								return (
+									<optgroup key={provider} label={groupLabel}>
+										{models.map((model) => (
+											<option
+												key={`${model.provider}:${model.id}`}
+												value={`${model.provider}:${model.id}`}
+											>
+												{model.name}
+											</option>
+										))}
+									</optgroup>
+								);
+							})}
 						</select>
 					</div>
 				)}

--- a/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
@@ -348,7 +348,7 @@ describe('NewSessionModal — provider-aware session creation', () => {
 			});
 		});
 
-		it('shows all providers when auth.providers is unavailable (optimistic)', async () => {
+		it('hides model picker entirely when auth.providers fetch fails', async () => {
 			mockRequest.mockImplementation((method: string) => {
 				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
 				if (method === 'auth.providers') return Promise.reject(new Error('unavailable'));
@@ -356,11 +356,14 @@ describe('NewSessionModal — provider-aware session creation', () => {
 			});
 
 			render(<NewSessionModal {...DEFAULT_PROPS} />);
-			await waitFor(() => {
-				const optgroups = document.querySelectorAll('optgroup');
-				// All three providers shown even though auth is unavailable
-				expect(optgroups.length).toBeGreaterThanOrEqual(3);
-			});
+			// Give both promises time to settle
+			await new Promise((r) => setTimeout(r, 50));
+			// Model picker uses optgroups — none should exist when auth failed
+			const optgroups = document.querySelectorAll('optgroup');
+			expect(optgroups.length).toBe(0);
+			// The "Model (optional)" label must not be visible
+			const labels = Array.from(document.querySelectorAll('label'));
+			expect(labels.some((l) => l.textContent?.includes('Model'))).toBe(false);
 		});
 	});
 });

--- a/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
@@ -51,10 +51,22 @@ const MOCK_MODELS = [
 	},
 ];
 
+const ALL_AUTH_OK = {
+	providers: [
+		{ id: 'anthropic', displayName: 'Anthropic', isAuthenticated: true },
+		{ id: 'anthropic-copilot', displayName: 'Copilot', isAuthenticated: true },
+		{ id: 'anthropic-codex', displayName: 'Codex', isAuthenticated: true },
+	],
+};
+
 describe('NewSessionModal — provider-aware session creation', () => {
 	beforeEach(() => {
 		document.body.innerHTML = '';
-		mockRequest.mockResolvedValue({ models: MOCK_MODELS });
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+			if (method === 'auth.providers') return Promise.resolve(ALL_AUTH_OK);
+			return Promise.resolve(null);
+		});
 	});
 
 	afterEach(() => {
@@ -274,6 +286,80 @@ describe('NewSessionModal — provider-aware session creation', () => {
 
 			await waitFor(() => {
 				expect((modelSelect as HTMLSelectElement).value).toBe('');
+			});
+		});
+	});
+
+	describe('auth-based model filtering', () => {
+		it('hides optgroup for unauthenticated provider', async () => {
+			mockRequest.mockImplementation((method: string) => {
+				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+				if (method === 'auth.providers') {
+					return Promise.resolve({
+						providers: [
+							{ id: 'anthropic', displayName: 'Anthropic', isAuthenticated: true },
+							{ id: 'anthropic-copilot', displayName: 'Copilot', isAuthenticated: false },
+							{ id: 'anthropic-codex', displayName: 'Codex', isAuthenticated: true },
+						],
+					});
+				}
+				return Promise.resolve(null);
+			});
+
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				const labels = Array.from(optgroups).map((g) => g.getAttribute('label'));
+				// Copilot is unauthenticated — must not appear
+				expect(labels).not.toContain('Copilot');
+				// Anthropic and Codex are authenticated — must appear
+				expect(labels).toContain('Anthropic');
+				expect(labels).toContain('Codex');
+			});
+		});
+
+		it('shows needsRefresh provider with warning label', async () => {
+			mockRequest.mockImplementation((method: string) => {
+				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+				if (method === 'auth.providers') {
+					return Promise.resolve({
+						providers: [
+							{ id: 'anthropic', displayName: 'Anthropic', isAuthenticated: true },
+							{
+								id: 'anthropic-copilot',
+								displayName: 'Copilot',
+								isAuthenticated: true,
+								needsRefresh: true,
+							},
+						],
+					});
+				}
+				return Promise.resolve(null);
+			});
+
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				const labels = Array.from(optgroups).map((g) => g.getAttribute('label'));
+				// Copilot is expiring — shown but with warning label
+				expect(labels.some((l) => l?.includes('Copilot') && l.includes('⚠'))).toBe(true);
+				// Anthropic is healthy — no warning
+				expect(labels.some((l) => l === 'Anthropic')).toBe(true);
+			});
+		});
+
+		it('shows all providers when auth.providers is unavailable (optimistic)', async () => {
+			mockRequest.mockImplementation((method: string) => {
+				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+				if (method === 'auth.providers') return Promise.reject(new Error('unavailable'));
+				return Promise.resolve(null);
+			});
+
+			render(<NewSessionModal {...DEFAULT_PROPS} />);
+			await waitFor(() => {
+				const optgroups = document.querySelectorAll('optgroup');
+				// All three providers shown even though auth is unavailable
+				expect(optgroups.length).toBeGreaterThanOrEqual(3);
 			});
 		});
 	});

--- a/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
@@ -349,6 +349,9 @@ describe('NewSessionModal — provider-aware session creation', () => {
 		});
 
 		it('hides model picker entirely when auth.providers fetch fails', async () => {
+			// auth.providers rejects — models.list resolves normally.
+			// With Promise.all both outcomes are atomic: if auth fails the model picker
+			// must not appear even though models resolved successfully.
 			mockRequest.mockImplementation((method: string) => {
 				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
 				if (method === 'auth.providers') return Promise.reject(new Error('unavailable'));
@@ -359,8 +362,7 @@ describe('NewSessionModal — provider-aware session creation', () => {
 			// Give both promises time to settle
 			await new Promise((r) => setTimeout(r, 50));
 			// Model picker uses optgroups — none should exist when auth failed
-			const optgroups = document.querySelectorAll('optgroup');
-			expect(optgroups.length).toBe(0);
+			expect(document.querySelectorAll('optgroup').length).toBe(0);
 			// The "Model (optional)" label must not be visible
 			const labels = Array.from(document.querySelectorAll('label'));
 			expect(labels.some((l) => l.textContent?.includes('Model'))).toBe(false);

--- a/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
+++ b/packages/web/src/components/lobby/__tests__/NewSessionModal.test.tsx
@@ -348,6 +348,37 @@ describe('NewSessionModal — provider-aware session creation', () => {
 			});
 		});
 
+		it('does not show stale models from previous open when auth fails on re-open', async () => {
+			// First open: both succeed — models populate
+			let resolveAuth!: (v: unknown) => void;
+			mockRequest.mockImplementation((method: string) => {
+				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+				if (method === 'auth.providers') return Promise.resolve(ALL_AUTH_OK);
+				return Promise.resolve(null);
+			});
+
+			const { rerender } = render(<NewSessionModal {...DEFAULT_PROPS} isOpen={true} />);
+			await waitFor(() => {
+				expect(document.querySelectorAll('optgroup').length).toBeGreaterThan(0);
+			});
+
+			// Close modal
+			rerender(<NewSessionModal {...DEFAULT_PROPS} isOpen={false} />);
+
+			// Second open: auth fails — model picker must stay hidden
+			mockRequest.mockImplementation((method: string) => {
+				if (method === 'models.list') return Promise.resolve({ models: MOCK_MODELS });
+				if (method === 'auth.providers') return Promise.reject(new Error('auth gone'));
+				return Promise.resolve(null);
+			});
+
+			rerender(<NewSessionModal {...DEFAULT_PROPS} isOpen={true} />);
+			await new Promise((r) => setTimeout(r, 50));
+
+			// Stale models from first open must not re-appear
+			expect(document.querySelectorAll('optgroup').length).toBe(0);
+		});
+
 		it('hides model picker entirely when auth.providers fetch fails', async () => {
 			// auth.providers rejects — models.list resolves normally.
 			// With Promise.all both outcomes are atomic: if auth fails the model picker

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -14,6 +14,7 @@ import {
 	getProviderLabel,
 	groupModelsByProvider,
 	mapRawModelsToModelInfos,
+	filterModelsForPicker,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -1040,5 +1041,87 @@ describe('mapRawModelsToModelInfos', () => {
 		expect(result[0].family).toBe('opus');
 		expect(result[1].family).toBe('sonnet');
 		expect(result[2].family).toBe('haiku');
+	});
+});
+
+// Helper to create a minimal ModelInfo
+function makeModel(id: string, provider: string) {
+	return {
+		id,
+		name: id,
+		alias: id,
+		family: 'sonnet',
+		provider,
+		contextWindow: 200000,
+		description: '',
+		releaseDate: '',
+		available: true,
+	};
+}
+
+// Helper to create a ProviderAuthStatus map entry
+function makeAuth(id: string, isAuthenticated: boolean, needsRefresh = false) {
+	return { id, displayName: id, isAuthenticated, needsRefresh };
+}
+
+describe('filterModelsForPicker', () => {
+	const anthropicModel = makeModel('claude-sonnet', 'anthropic');
+	const copilotModel = makeModel('copilot-sonnet', 'anthropic-copilot');
+	const codexModel = makeModel('codex-sonnet', 'anthropic-codex');
+
+	it('shows all models when auth map is empty (optimistic)', () => {
+		const result = filterModelsForPicker([anthropicModel, copilotModel, codexModel], new Map());
+		expect(result).toHaveLength(3);
+	});
+
+	it('hides models from unauthenticated providers', () => {
+		const authMap = new Map([
+			['anthropic', makeAuth('anthropic', true)],
+			['anthropic-copilot', makeAuth('anthropic-copilot', false)],
+		]);
+		const result = filterModelsForPicker([anthropicModel, copilotModel], authMap);
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe('anthropic');
+	});
+
+	it('keeps the current provider even when unauthenticated', () => {
+		const authMap = new Map([['anthropic-copilot', makeAuth('anthropic-copilot', false)]]);
+		const result = filterModelsForPicker(
+			[anthropicModel, copilotModel],
+			authMap,
+			'anthropic-copilot' // current provider
+		);
+		// Both should appear: anthropic (not in map = optimistic), copilot (current)
+		expect(result).toHaveLength(2);
+	});
+
+	it('shows needsRefresh providers (token expiring but still authenticated)', () => {
+		const authMap = new Map([['anthropic-copilot', makeAuth('anthropic-copilot', true, true)]]);
+		const result = filterModelsForPicker([copilotModel], authMap);
+		expect(result).toHaveLength(1);
+	});
+
+	it('hides non-current unauthenticated and shows current unauthenticated', () => {
+		const authMap = new Map([
+			['anthropic', makeAuth('anthropic', false)],
+			['anthropic-copilot', makeAuth('anthropic-copilot', false)],
+			['anthropic-codex', makeAuth('anthropic-codex', true)],
+		]);
+		const result = filterModelsForPicker(
+			[anthropicModel, copilotModel, codexModel],
+			authMap,
+			'anthropic' // current: unauthenticated but must show
+		);
+		// anthropic = current (keep), copilot = unauth+not current (hide), codex = auth (keep)
+		expect(result.map((m) => m.provider)).toEqual(['anthropic', 'anthropic-codex']);
+	});
+
+	it('shows provider absent from auth map optimistically', () => {
+		const authMap = new Map([
+			['anthropic', makeAuth('anthropic', true)],
+			// 'anthropic-copilot' not in map
+		]);
+		const result = filterModelsForPicker([anthropicModel, copilotModel], authMap);
+		expect(result).toHaveLength(2);
 	});
 });

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -19,6 +19,7 @@ export {
 	PROVIDER_LABELS,
 	getProviderLabel,
 	groupModelsByProvider,
+	filterModelsForPicker,
 } from './useModelSwitcher';
 export {
 	useMessageHub,

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -19,6 +19,7 @@
 
 import { useState, useEffect, useCallback } from 'preact/hooks';
 import type { ModelInfo } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { connectionManager } from '../lib/connection-manager';
 import { toast } from '../lib/toast';
 
@@ -172,6 +173,30 @@ export const PROVIDER_LABELS: Record<string, string> = {
  */
 export function getProviderLabel(provider: string): string {
 	return PROVIDER_LABELS[provider] || provider;
+}
+
+/**
+ * Filter a model list for display in the model picker, respecting auth status.
+ *
+ * Rules:
+ * - Models from authenticated providers are always shown.
+ * - Models from unauthenticated providers are hidden, UNLESS the model is the
+ *   currently active one (to avoid confusing the user about their session).
+ * - Models from providers with `needsRefresh: true` are shown (callers should
+ *   add a visual warning badge).
+ * - Models from providers absent from the auth map are shown (optimistic).
+ */
+export function filterModelsForPicker(
+	models: ModelInfo[],
+	providerAuthMap: Map<string, ProviderAuthStatus>,
+	currentProvider?: string
+): ModelInfo[] {
+	return models.filter((m) => {
+		const auth = providerAuthMap.get(m.provider);
+		if (!auth) return true; // provider unknown → optimistic show
+		if (m.provider === currentProvider) return true; // always keep active provider
+		return auth.isAuthenticated; // hide unauthenticated (needsRefresh stays visible)
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary

- **New `filterModelsForPicker()` utility** in `useModelSwitcher.ts`: filters models by provider auth status, hiding unauthenticated providers while always preserving the current session's provider and being optimistic about unknown providers.
- **`SessionStatusBar` model dropdown**: upgraded from `Map<string,bool>` to `Map<string,ProviderAuthStatus>` to track both `isAuthenticated` and `needsRefresh`; applies filtering so unauthenticated providers are hidden; adds yellow `⚠` badge on `needsRefresh` provider groups/models; dot colors: gray=unknown, green=ok, yellow=expiring, red=unauthenticated-but-current.
- **`NewSessionModal` model select**: fetches `auth.providers` on open; filters unauthenticated providers from the `<optgroup>` list; labels `needsRefresh` groups with `⚠ (token expiring)` suffix.

## Filtering rules

| Provider state | In picker? | Badge |
|---|---|---|
| Authenticated + healthy | ✅ Yes | Green dot |
| Authenticated + `needsRefresh` | ✅ Yes | Yellow dot + ⚠ |
| Unauthenticated + is current session | ✅ Yes (preserved) | Red dot |
| Unauthenticated + not current | ❌ Hidden | — |
| Not in auth map (unknown) | ✅ Yes (optimistic) | Gray dot |

## Test plan

- [x] 6 new `filterModelsForPicker` unit tests covering all filtering rules
- [x] 3 new `NewSessionModal` auth-filtering tests: hides unauth optgroup, shows `needsRefresh` warning label, optimistic when auth unavailable
- [x] All 3776 web tests pass
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes