### PR TITLE
feat: eager leader initialization and fix observer race in TaskGroupManager

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -158,7 +158,7 @@ export class RoomRuntimeService {
 		const worktreeManager = new WorktreeManager();
 
 		return {
-			createAndStartSession: async (init, _role) => {
+			createAndStartSession: async (init, role) => {
 				const session = AgentSession.fromInit(
 					init,
 					ctx.db,
@@ -168,7 +168,12 @@ export class RoomRuntimeService {
 					ctx.defaultModel
 				);
 				agentSessions.set(init.sessionId, session);
-				await session.startStreamingQuery();
+				// Leader sessions are started lazily: injectMessage() calls ensureQueryStarted()
+				// before enqueuing the first message. Starting eagerly here would trigger the
+				// 15s SDK startup timeout because the leader has no queued message yet.
+				if (role !== 'leader') {
+					await session.startStreamingQuery();
+				}
 			},
 			injectMessage: async (sessionId, message, opts) => {
 				const session = agentSessions.get(sessionId);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -768,6 +768,16 @@ export class RoomRuntime {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return;
 
+		// Guard: leader hasn't received any work yet. This can happen if a spurious idle event
+		// fires before the first worker→leader routing (e.g. a race during startup). Ignore it.
+		if (group.feedbackIteration === 0 && !group.submittedForReview) {
+			log.debug(
+				`[onLeaderTerminalState] Group ${groupId}: ignoring terminal event ` +
+					`(feedbackIteration=0, submittedForReview=false) — leader hasn't received work yet`
+			);
+			return;
+		}
+
 		// Clear active session indicator — leader is no longer generating output
 		const leaderTask = await this.taskManager.getTask(group.taskId);
 		if (leaderTask?.activeSession === 'leader') {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2157,6 +2157,21 @@ export class RoomRuntime {
 			const workerState = this.sessionFactory.getProcessingState(group.workerSessionId);
 			if (workerState !== 'idle' && workerState !== 'interrupted') continue;
 
+			// Skip if the worker has no new messages since the last forwarding.
+			// This prevents spurious re-routing when feedbackIteration was reset by
+			// resumeLeaderFromHuman (or resumeWorkerFromHuman) but the worker has not
+			// produced any new output yet — re-routing would inject a sentinel string
+			// into the leader while it is already processing the human's message.
+			// When getWorkerMessages is absent (some test contexts), fall through to
+			// preserve the original safety-net behavior.
+			if (this.getWorkerMessages) {
+				const newMessages = this.getWorkerMessages(
+					group.workerSessionId,
+					group.lastForwardedMessageId
+				);
+				if (newMessages.length === 0) continue;
+			}
+
 			// Guard against duplicate in-flight recovery: if a previous tick already
 			// triggered routing for this group and it hasn't completed yet, skip it.
 			// feedbackIteration is incremented only after routeWorkerToLeader succeeds,

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2753,7 +2753,10 @@ export class RoomRuntime {
 				'plan_review'
 			);
 		} catch (err) {
-			// spawn() already called failTask() before throwing — log and continue
+			// spawn() calls failTask() only for worktree-creation failures (line ~241).
+			// If session init throws after startTask(), the task stays in_progress.
+			// The zombie/stuck-worker recovery will detect and re-trigger routing on the
+			// next tick once the process stabilises.
 			log.error(`Failed to spawn planning group for goal ${goal.id}: ${err}`);
 			await this.emitTaskUpdateById(planningTask.id);
 			return;
@@ -2885,7 +2888,10 @@ export class RoomRuntime {
 				'code_review'
 			);
 		} catch (err) {
-			// spawn() already called failTask() before throwing — log and continue to next task
+			// spawn() calls failTask() only for worktree-creation failures (line ~241).
+			// If session init throws after startTask(), the task stays in_progress.
+			// The zombie/stuck-worker recovery will detect and re-trigger routing on the
+			// next tick once the process stabilises.
 			log.error(`Failed to spawn group for task ${task.id}: ${err}`);
 			await this.emitTaskUpdateById(task.id);
 			return;

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1960,12 +1960,11 @@ export class RoomRuntime {
 	 * checkpoints when there are no zombies (common case).
 	 *
 	 * Leader zombie detection rules:
-	 * - A leader is "expected" if feedbackIteration > 0 (at least one review round completed)
-	 *   OR if deferredLeader is null (no deferred bootstrap config means the leader was already
-	 *   live at some point and may have gone missing after a process restart).
-	 * - When deferredLeader is set (non-null), the leader is lazily created by routeWorkerToLeader;
-	 *   before that happens feedbackIteration == 0 and the leader session does not yet exist —
-	 *   this is normal and must NOT be treated as a zombie.
+	 * - A leader is "expected" if feedbackIteration > 0 (at least one review round completed),
+	 *   OR deferredLeader is null (leader was previously live and may be missing after restart),
+	 *   OR deferredLeader.eagerlyCreated is true (leader was created eagerly in spawn()).
+	 * - Old lazy-init groups (eagerlyCreated unset, feedbackIteration == 0) have NOT created
+	 *   the leader yet — missing leader is expected and must NOT be flagged as zombie.
 	 */
 	private findZombieGroups(): SessionGroup[] {
 		const allActiveGroups = this.groupRepo.getActiveGroups(this.roomId);
@@ -1973,13 +1972,16 @@ export class RoomRuntime {
 
 		for (const group of allActiveGroups) {
 			const workerMissing = !this.sessionFactory.hasSession(group.workerSessionId);
-			// Leader is expected to exist when:
-			//   1. feedbackIteration > 0: leader was created in a prior review round, or
-			//   2. deferredLeader == null: no pending lazy-creation config means the leader
-			//      was previously live and may be missing after a restart.
-			// Groups where deferredLeader is set and feedbackIteration == 0 have NOT created
-			// the leader yet — missing leader is expected there and must NOT be flagged.
-			const leaderExpected = group.feedbackIteration > 0 || group.deferredLeader === null;
+			// Leader is expected when:
+			//   1. feedbackIteration > 0: at least one review round completed (leader was live)
+			//   2. deferredLeader === null: no pending config means leader was previously live
+			//   3. deferredLeader.eagerlyCreated === true: leader was created eagerly in spawn()
+			// Old lazy-init groups (eagerlyCreated unset, feedbackIteration == 0) are NOT flagged:
+			// the missing leader is expected there and routeWorkerToLeader will create it.
+			const leaderExpected =
+				group.feedbackIteration > 0 ||
+				group.deferredLeader === null ||
+				group.deferredLeader?.eagerlyCreated === true;
 			const leaderMissing =
 				leaderExpected && !this.sessionFactory.hasSession(group.leaderSessionId);
 
@@ -2044,9 +2046,13 @@ export class RoomRuntime {
 					});
 					leaderRestored = true;
 				} else {
-					// Leader restoration failure is not fatal - leader may be lazily created
+					// Leader restoration failure: group may have been created with old lazy-init
+					// code (leader never persisted to DB), or the DB record was lost.
+					// For new eager-init groups the leader was persisted at spawn() time, so this
+					// indicates data loss; recovery falls back to recreating the leader from
+					// deferredLeader config in routeWorkerToLeader() when the worker finishes.
 					log.warn(
-						`Could not restore leader ${group.leaderSessionId} for group ${group.id} - may be lazily created later.`
+						`Could not restore leader ${group.leaderSessionId} for group ${group.id} - will be recreated when worker routes output.`
 					);
 				}
 			}
@@ -2066,10 +2072,22 @@ export class RoomRuntime {
 					);
 				}
 				if (leaderRestored) {
-					await this.sessionFactory.injectMessage(
-						group.leaderSessionId,
-						'The system was restarted. Continue reviewing from where you left off.'
-					);
+					// Only inject "continue reviewing" if the leader has already received work
+					// (feedbackIteration > 0 means at least one worker→leader routing happened).
+					// When feedbackIteration == 0 the leader was eagerly created in spawn() but
+					// has not been given any worker output yet — it will receive work when the
+					// worker finishes and routeWorkerToLeader() fires.
+					if (group.feedbackIteration > 0) {
+						await this.sessionFactory.injectMessage(
+							group.leaderSessionId,
+							'The system was restarted. Continue reviewing from where you left off.'
+						);
+					} else {
+						log.debug(
+							`[recoverZombieGroups] Group ${group.id}: leader restored but feedbackIteration=0 ` +
+								`— skipping "continue reviewing" inject; worker will route output on completion.`
+						);
+					}
 				}
 			} catch (error) {
 				log.error(`Failed to inject continuation message for group ${group.id}:`, error);
@@ -2089,7 +2107,8 @@ export class RoomRuntime {
 	 * - feedbackIteration == 0: no review rounds have completed (worker → leader routing never happened)
 	 * - Worker session IS in the session factory (not a zombie)
 	 * - Worker session processing state is terminal (idle or interrupted)
-	 * - Leader session is NOT in the session factory (not yet created)
+	 * - Leader session may or may not exist (with eager init, it always exists; with old lazy
+	 *   init, it may not exist yet — both cases are handled by routeWorkerToLeader)
 	 * - Group is NOT awaiting human review
 	 * - Group is NOT rate-limited
 	 * - Group is NOT paused waiting for a question answer (waiting_for_input is intentional pause)
@@ -2113,9 +2132,6 @@ export class RoomRuntime {
 			// Worker must be in the session factory (not a zombie)
 			if (!this.sessionFactory.hasSession(group.workerSessionId)) continue;
 
-			// Leader must NOT exist yet (routing hasn't happened)
-			if (this.sessionFactory.hasSession(group.leaderSessionId)) continue;
-
 			// Worker must be in a terminal state (idle or interrupted)
 			// Note: waiting_for_input is excluded — it is handled separately as an intentional pause
 			const workerState = this.sessionFactory.getProcessingState(group.workerSessionId);
@@ -2131,11 +2147,11 @@ export class RoomRuntime {
 			}
 
 			log.warn(
-				`[StuckWorker] Group ${group.id}: worker is '${workerState}' but leader never created ` +
-					`(feedbackIteration=0, waitingForQuestion=false). Re-triggering worker→leader routing.`
+				`[StuckWorker] Group ${group.id}: worker is '${workerState}' but routing to leader not yet ` +
+					`completed (feedbackIteration=0, waitingForQuestion=false). Re-triggering worker→leader routing.`
 			);
 			this.appendGroupEvent(group.id, 'status', {
-				text: `Worker found in ${workerState} state without a leader — re-triggering routing to Leader.`,
+				text: `Worker found in ${workerState} state with routing not yet complete — re-triggering routing to Leader.`,
 			});
 
 			// Mark as in-flight before firing, clear when done (success or error)

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -770,10 +770,12 @@ export class RoomRuntime {
 
 		// Guard: leader hasn't received any work yet. This can happen if a spurious idle event
 		// fires before the first worker→leader routing (e.g. a race during startup). Ignore it.
-		if (group.feedbackIteration === 0 && !group.submittedForReview) {
+		// leaderHasWork is set to true by routeWorkerToLeader and resumeLeaderFromHuman before
+		// calling injectMessage, so it is never reset and survives feedbackIteration resets.
+		if (!group.leaderHasWork) {
 			log.debug(
 				`[onLeaderTerminalState] Group ${groupId}: ignoring terminal event ` +
-					`(feedbackIteration=0, submittedForReview=false) — leader hasn't received work yet`
+					`(leaderHasWork=false) — leader hasn't received work yet`
 			);
 			return;
 		}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1422,6 +1422,8 @@ export class RoomRuntime {
 		let injected = false;
 		if (leaderAvailable) {
 			try {
+				// Set leaderHasWork before injecting so the terminal event is not dropped.
+				this.groupRepo.setLeaderHasWork(group.id);
 				await this.sessionFactory.injectMessage(group.leaderSessionId, message);
 				injected = true;
 			} catch (error) {
@@ -1679,6 +1681,8 @@ export class RoomRuntime {
 		}
 
 		try {
+			// Set leaderHasWork before injecting so the terminal event is not dropped.
+			this.groupRepo.setLeaderHasWork(group.id);
 			await this.sessionFactory.injectMessage(group.leaderSessionId, message);
 		} catch (error) {
 			log.error(`Failed to inject message into leader session ${group.leaderSessionId}:`, error);
@@ -2090,6 +2094,10 @@ export class RoomRuntime {
 					// has not been given any worker output yet — it will receive work when the
 					// worker finishes and routeWorkerToLeader() fires.
 					if (group.feedbackIteration > 0) {
+						// Set leaderHasWork before injecting so the terminal event is not
+						// dropped by onLeaderTerminalState. Defensive: if leaderHasWork was
+						// already true (normal case for feedbackIteration>0), this is a no-op.
+						this.groupRepo.setLeaderHasWork(group.id);
 						await this.sessionFactory.injectMessage(
 							group.leaderSessionId,
 							'The system was restarted. Continue reviewing from where you left off.'

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -2,8 +2,8 @@
  * TaskGroupManager - Creates and manages (Worker, Leader) session groups
  *
  * Orchestrates the lifecycle of session groups:
- * 1. Spawns worker session immediately, defers leader creation until needed
- * 2. Routes worker terminal output to Leader for review (lazy-starts leader)
+ * 1. Spawns worker and leader sessions together (eager initialization)
+ * 2. Routes worker terminal output to Leader for review
  * 3. Routes Leader feedback back to worker
  * 4. Handles group completion and failure
  *
@@ -201,12 +201,18 @@ export class TaskGroupManager {
 	 *
 	 * Flow:
 	 * 1. Create worktree for task isolation (ALL roles get an isolated worktree)
-	 * 2. Create worker session via workerConfig and start it immediately
-	 * 3. Build leader init but DEFER creation until first review round
-	 * 4. Create session_groups DB record (active group with submittedForReview=false)
-	 * 5. Set task status to in_progress
-	 * 6. Observe worker session for terminal state
-	 * 7. Kick off worker (inject initial message)
+	 * 2. Create session_groups DB record (active group with submittedForReview=false)
+	 * 3. Persist leader bootstrap config in DB metadata (for restart recovery + leaderTaskContext)
+	 * 4. Set task status to in_progress
+	 * 5. Create and start worker session immediately
+	 * 6. Create and start leader session immediately (eager initialization)
+	 * 7. Observe worker session for terminal state BEFORE injecting message (prevents race condition)
+	 * 8. Observe leader session for terminal state
+	 * 9. Kick off worker (inject initial message)
+	 *
+	 * Both sessions are created eagerly so the leader is ready when the worker completes.
+	 * The worker observer is set up before injection to prevent a race where the worker
+	 * completes before the observer fires.
 	 */
 	async spawn(
 		room: Room,
@@ -214,7 +220,7 @@ export class TaskGroupManager {
 		goal: RoomGoal | null,
 		onWorkerTerminal: (groupId: string, state: TerminalState) => void,
 		onLeaderTerminal: (groupId: string, state: TerminalState) => void,
-		_leaderCallbacksFactory: LeaderCallbacksFactory,
+		leaderCallbacksFactory: LeaderCallbacksFactory,
 		workerConfig: WorkerConfig,
 		reviewContext?: ReviewContext
 	): Promise<SessionGroup> {
@@ -251,35 +257,66 @@ export class TaskGroupManager {
 			groupWorkspacePath
 		);
 
-		// Persist deferred Leader bootstrap config in DB metadata.
-		// This survives daemon restart, unlike in-memory maps.
+		// Persist leader bootstrap config in DB metadata.
+		// Survives daemon restart (used by recoverZombieGroups to recreate leader if lost)
+		// and stores leaderTaskContext for the routing message injected when worker completes.
+		// eagerlyCreated=true signals that the leader session was created here in spawn(),
+		// not deferred — this lets recoverZombieGroups skip injecting "continue reviewing"
+		// when feedbackIteration==0 (the leader has no work to review yet on first restore).
 		const deferredLeader: DeferredLeaderConfig = {
 			roomId: room.id,
 			goalId: goal?.id ?? null,
 			reviewContext,
 			leaderTaskContext: workerConfig.leaderTaskContext,
+			eagerlyCreated: true,
 		};
 		this.groupRepo.setDeferredLeader(group.id, deferredLeader);
 
 		// Set task status to in_progress
 		await this.taskManager.startTask(task.id);
 
-		// Create and start ONLY the worker session
+		// Create and start worker session
 		await this.sessionFactory.createAndStartSession(workerInit, workerConfig.role);
 
-		// Kick off worker so the SDK streaming loop starts processing immediately.
-		await this.sessionFactory.injectMessage(workerSessionId, workerConfig.taskMessage);
+		// Create and start leader session eagerly alongside the worker.
+		// This ensures the leader is ready when the worker completes and routing is triggered.
+		// Previously the leader was lazily created in routeWorkerToLeader(), but this caused
+		// routing to be skipped when the observer event fired before lazy init ran.
+		const leaderCallbacks = leaderCallbacksFactory(group.id);
+		const leaderConfig: LeaderAgentConfig = {
+			task,
+			goal,
+			room,
+			sessionId: leaderSessionId,
+			workspacePath: groupWorkspacePath,
+			groupId: group.id,
+			model: this._model,
+			reviewContext,
+			goalManager: this.goalManager,
+			taskManager: this.taskManager,
+			groupRepo: this.groupRepo,
+		};
+		const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
+		await this.sessionFactory.createAndStartSession(leaderInit, 'leader');
+		log.info(
+			`[spawn] Group ${group.id}: leader session ${leaderSessionId} created eagerly alongside worker`
+		);
 
-		// Observe worker session for terminal state
+		// Observe worker session for terminal state BEFORE injecting the initial message.
+		// This prevents a race where the worker processes and completes synchronously before
+		// the observer is registered, causing the terminal event to be missed entirely.
 		this.observer.observe(workerSessionId, (state) => {
 			onWorkerTerminal(group.id, state);
 		});
 
-		// Observe leader session proactively (even before it's created).
-		// SessionObserver filters by sessionId and callback will fire once leader starts.
+		// Observe leader session for terminal state
 		this.observer.observe(leaderSessionId, (state) => {
 			onLeaderTerminal(group.id, state);
 		});
+
+		// Kick off worker so the SDK streaming loop starts processing immediately.
+		// Observer is already registered above — no race window.
+		await this.sessionFactory.injectMessage(workerSessionId, workerConfig.taskMessage);
 
 		return group;
 	}
@@ -287,12 +324,16 @@ export class TaskGroupManager {
 	/**
 	 * Route worker terminal output to Leader for review.
 	 *
-	 * Lazy-starts the leader session on first call (deferred from spawn).
+	 * The leader session is created eagerly in spawn(), so this method normally just
+	 * injects the worker output into the already-running leader session.
+	 * If the leader is missing (e.g., after a daemon restart where restore failed),
+	 * falls back to recreating it using the deferredLeader bootstrap config.
+	 *
 	 * Increments feedbackIteration to track review rounds (1-based).
 	 *
 	 * Called when worker reaches a terminal state (idle, waiting_for_input, interrupted).
 	 *
-	 * @param leaderCallbacksFactory - Factory to create leader tool callbacks
+	 * @param leaderCallbacksFactory - Factory to create leader tool callbacks (used only for restart recovery)
 	 */
 	async routeWorkerToLeader(
 		groupId: string,

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -346,8 +346,10 @@ export class TaskGroupManager {
 			return null;
 		}
 
-		// Lazy-start leader session if this is the first review round.
-		// Deferred bootstrap data is persisted in DB metadata so restart is safe.
+		// Restart-recovery fallback: re-create the leader session from persisted bootstrap config.
+		// In the normal code path the leader is created eagerly in spawn(), so leaderAlreadyExists
+		// will be true and this block is skipped. This only runs after a daemon restart where the
+		// in-memory session cache was cleared.
 		const deferredLeader = group.deferredLeader;
 		let shouldClearDeferredLeader = false;
 

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -18,7 +18,7 @@ import { Logger } from '../../logger';
 import type {
 	SessionGroupRepository,
 	SessionGroup,
-	DeferredLeaderConfig,
+	LeaderBootstrapConfig,
 } from '../state/session-group-repository';
 import type { SessionObserver, TerminalState } from '../state/session-observer';
 import type { TaskManager } from '../managers/task-manager';
@@ -263,7 +263,7 @@ export class TaskGroupManager {
 		// eagerlyCreated=true signals that the leader session was created here in spawn(),
 		// not deferred — this lets recoverZombieGroups skip injecting "continue reviewing"
 		// when feedbackIteration==0 (the leader has no work to review yet on first restore).
-		const deferredLeader: DeferredLeaderConfig = {
+		const deferredLeader: LeaderBootstrapConfig = {
 			roomId: room.id,
 			goalId: goal?.id ?? null,
 			reviewContext,
@@ -440,6 +440,9 @@ export class TaskGroupManager {
 		log.debug(
 			`[routeWorkerToLeader] Group ${groupId}: injecting worker output into leader session`
 		);
+		// Mark leader as having work before injecting so onLeaderTerminalState won't drop
+		// the resulting idle event even if the leader completes synchronously.
+		this.groupRepo.setLeaderHasWork(groupId);
 		await this.sessionFactory.injectMessage(group.leaderSessionId, leaderMessage);
 		log.info(
 			`[routeWorkerToLeader] Group ${groupId}: worker output injected into leader session successfully`
@@ -616,6 +619,8 @@ export class TaskGroupManager {
 
 		// Inject into leader first. If this fails, caller can safely rollback
 		// task status/approval without restoring group metadata.
+		// Mark before inject so the resulting terminal event is not dropped.
+		this.groupRepo.setLeaderHasWork(groupId);
 		await this.sessionFactory.injectMessage(group.leaderSessionId, message);
 
 		// Reset group metadata for the new cycle (same as resumeWorkerFromHuman).

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -30,7 +30,14 @@ export interface RateLimitBackoff {
 	sessionRole: 'worker' | 'leader';
 }
 
-/** Persisted bootstrap context for lazily creating Leader sessions */
+/**
+ * Persisted bootstrap context for the Leader session.
+ * Survives daemon restart and is used by recoverZombieGroups() to recreate a
+ * missing leader from scratch, and by routeWorkerToLeader() as the restart-recovery
+ * fallback when the leader is absent from the in-memory session cache.
+ * Also carries leaderTaskContext — the message prefix prepended on the first
+ * worker→leader routing call.
+ */
 export interface DeferredLeaderConfig {
 	roomId: string;
 	goalId: string | null;

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -36,6 +36,12 @@ export interface DeferredLeaderConfig {
 	goalId: string | null;
 	reviewContext?: 'plan_review' | 'code_review';
 	leaderTaskContext?: string;
+	/**
+	 * When true, the leader session was already created eagerly in spawn()
+	 * alongside the worker. Used by findZombieGroups() to know the leader is
+	 * expected in cache even on the first review round (feedbackIteration == 0).
+	 */
+	eagerlyCreated?: boolean;
 }
 
 /** Type-specific metadata for task groups */

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -38,7 +38,7 @@ export interface RateLimitBackoff {
  * Also carries leaderTaskContext — the message prefix prepended on the first
  * worker→leader routing call.
  */
-export interface DeferredLeaderConfig {
+export interface LeaderBootstrapConfig {
 	roomId: string;
 	goalId: string | null;
 	reviewContext?: 'plan_review' | 'code_review';
@@ -74,7 +74,7 @@ interface TaskGroupMetadata {
 	/** Rate limit backoff state - when set, nagging is paused until resetsAt */
 	rateLimit?: RateLimitBackoff | null;
 	/** Persisted bootstrap config for deferred Leader creation */
-	deferredLeader?: DeferredLeaderConfig | null;
+	deferredLeader?: LeaderBootstrapConfig | null;
 	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
 	humanInterrupted?: boolean;
 	/** Gate failure history for dead loop detection */
@@ -100,6 +100,12 @@ interface TaskGroupMetadata {
 	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
 	 */
 	executionId?: string;
+	/**
+	 * True once the leader has had at least one message injected (via routeWorkerToLeader
+	 * or resumeLeaderFromHuman). Never reset, so onLeaderTerminalState can reliably
+	 * distinguish spurious pre-work idle events from real terminal events.
+	 */
+	leaderHasWork?: boolean;
 }
 
 function defaultMetadata(): TaskGroupMetadata {
@@ -149,7 +155,7 @@ export interface SessionGroup {
 	/** Rate limit backoff state - when set, nagging is paused until resetsAt */
 	rateLimit: RateLimitBackoff | null;
 	/** Persisted bootstrap config for deferred Leader creation */
-	deferredLeader: DeferredLeaderConfig | null;
+	deferredLeader: LeaderBootstrapConfig | null;
 	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
 	humanInterrupted: boolean;
 	/** Whether the group is paused waiting for a question to be answered */
@@ -170,6 +176,11 @@ export interface SessionGroup {
 	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
 	 */
 	executionId?: string;
+	/**
+	 * True once the leader has had at least one message injected. Never reset.
+	 * Used by onLeaderTerminalState to drop spurious pre-work idle events.
+	 */
+	leaderHasWork: boolean;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -601,10 +612,30 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Mark the leader as having received at least one message.
+	 * Set once by routeWorkerToLeader and resumeLeaderFromHuman; never reset.
+	 * Used by onLeaderTerminalState to drop spurious pre-work idle events.
+	 */
+	setLeaderHasWork(groupId: string): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		if (currentMeta.leaderHasWork) return; // already set, skip the write
+		const merged = { ...currentMeta, leaderHasWork: true };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
 	 * Persist deferred Leader bootstrap configuration.
 	 * Stored in metadata so runtime restart can still lazy-create the leader session.
 	 */
-	setDeferredLeader(groupId: string, deferredLeader: DeferredLeaderConfig | null): void {
+	setDeferredLeader(groupId: string, deferredLeader: LeaderBootstrapConfig | null): void {
 		const raw = (
 			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
 				string,
@@ -823,6 +854,7 @@ export class SessionGroupRepository {
 			workerBypassed: meta.workerBypassed === true,
 			approvalSource: meta.approvalSource ?? null,
 			executionId: meta.executionId,
+			leaderHasWork: meta.leaderHasWork === true,
 			createdAt: row.created_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
 		};

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -73,7 +73,7 @@ interface TaskGroupMetadata {
 	approved?: boolean;
 	/** Rate limit backoff state - when set, nagging is paused until resetsAt */
 	rateLimit?: RateLimitBackoff | null;
-	/** Persisted bootstrap config for deferred Leader creation */
+	/** Persisted bootstrap config for the leader session (restart-recovery and first-routing context) */
 	deferredLeader?: LeaderBootstrapConfig | null;
 	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
 	humanInterrupted?: boolean;
@@ -154,7 +154,7 @@ export interface SessionGroup {
 	approved: boolean;
 	/** Rate limit backoff state - when set, nagging is paused until resetsAt */
 	rateLimit: RateLimitBackoff | null;
-	/** Persisted bootstrap config for deferred Leader creation */
+	/** Persisted bootstrap config for the leader session (restart-recovery and first-routing context) */
 	deferredLeader: LeaderBootstrapConfig | null;
 	/** Whether the user interrupted the session mid-generation (prevents auto-routing to leader) */
 	humanInterrupted: boolean;

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -43,12 +43,14 @@ describe('RoomRuntime flow', () => {
 			ctx.runtime.start();
 			await ctx.runtime.tick();
 
+			// Both worker (planner) and leader are created eagerly in spawn()
 			const createCalls = ctx.sessionFactory.calls.filter(
 				(c) => c.method === 'createAndStartSession'
 			);
-			expect(createCalls).toHaveLength(1);
-			expect(createCalls[0].args[1]).toBe('planner');
-			expect((createCalls[0].args[0] as { model?: string }).model).toBe('planner-model');
+			expect(createCalls).toHaveLength(2);
+			const plannerCall = createCalls.find((c) => c.args[1] === 'planner');
+			expect(plannerCall).toBeDefined();
+			expect((plannerCall!.args[0] as { model?: string }).model).toBe('planner-model');
 
 			const group = ctx.groupRepo.getActiveGroups('room-1')[0];
 			expect(group.workerRole).toBe('planner');
@@ -397,12 +399,13 @@ describe('RoomRuntime flow', () => {
 			const clearedGroup = ctx.groupRepo.getGroup(group!.id);
 			expect(clearedGroup!.humanInterrupted).toBe(false);
 
-			// No leader session should have been created (routing was blocked)
+			// Both worker and leader are created eagerly in spawn (not routing-related).
+			// No additional sessions should be created when routing is blocked.
 			const createCalls = ctx.sessionFactory.calls.filter(
 				(c) => c.method === 'createAndStartSession'
 			);
-			// Only 1 create call (the initial worker), leader was not created
-			expect(createCalls).toHaveLength(1);
+			// 2 create calls: worker + leader (eager spawn). No extra creation from routing.
+			expect(createCalls).toHaveLength(2);
 
 			// No new inject messages (routing to leader sends an envelope)
 			const injectCalls = ctx.sessionFactory.calls.filter((c) => c.method === 'injectMessage');

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -1000,6 +1000,36 @@ describe('RoomRuntime flow', () => {
 			);
 			expect(injectToLeader).toHaveLength(0);
 		});
+
+		it('should process terminal event when feedbackIteration == 0 but submittedForReview == true (bypass workflow)', async () => {
+			// Spawn only — feedbackIteration stays at 0
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+			expect(group!.feedbackIteration).toBe(0);
+
+			// Bypass workflow: submittedForReview is set before routing (e.g. bypass marker)
+			ctx.groupRepo.setSubmittedForReview(group!.id, true);
+			const groupAfter = ctx.groupRepo.getGroup(group!.id)!;
+			expect(groupAfter.submittedForReview).toBe(true);
+
+			// Terminal event must NOT be dropped — the guard passes when submittedForReview==true
+			// The event flows through normal handling (leader hasn't called a tool → no-op aside
+			// from clearing activeSession, which is already null here).
+			await ctx.runtime.onLeaderTerminalState(group!.id, {
+				sessionId: group!.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// Group is still active (no tool was called, so no completion)
+			const updated = ctx.groupRepo.getGroup(group!.id)!;
+			expect(updated.completedAt).toBeNull();
+			// submittedForReview flag is preserved (leader didn't call a completion tool)
+			expect(updated.submittedForReview).toBe(true);
+		});
 	});
 
 	describe('lifecycle hooks', () => {

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -973,16 +973,15 @@ describe('RoomRuntime flow', () => {
 			expect(afterResume.waitingSession).toBeNull();
 		});
 
-		it('should ignore terminal event when feedbackIteration == 0 and leader has not received work', async () => {
-			// Spawn only — do NOT route worker to leader, so feedbackIteration stays at 0
+		it('should ignore terminal event when leaderHasWork == false (leader not yet given any work)', async () => {
+			// Spawn only — do NOT route worker to leader; leaderHasWork stays false
 			const { task } = await createGoalAndTask(ctx);
 			ctx.runtime.start();
 			await ctx.runtime.tick();
 
 			const group = ctx.groupRepo.getGroupByTaskId(task.id);
 			expect(group).toBeDefined();
-			expect(group!.feedbackIteration).toBe(0);
-			expect(group!.submittedForReview).toBe(false);
+			expect(group!.leaderHasWork).toBe(false);
 
 			// Fire a spurious idle event on the leader (e.g. from a race or startup artifact)
 			await ctx.runtime.onLeaderTerminalState(group!.id, {
@@ -993,7 +992,7 @@ describe('RoomRuntime flow', () => {
 			// Group must remain unchanged — no completion, no error, no inject
 			const updated = ctx.groupRepo.getGroup(group!.id)!;
 			expect(updated.completedAt).toBeNull();
-			expect(updated.feedbackIteration).toBe(0);
+			expect(updated.leaderHasWork).toBe(false);
 
 			const injectToLeader = ctx.sessionFactory.calls.filter(
 				(c) => c.method === 'injectMessage' && c.args[0] === group!.leaderSessionId
@@ -1001,34 +1000,37 @@ describe('RoomRuntime flow', () => {
 			expect(injectToLeader).toHaveLength(0);
 		});
 
-		it('should process terminal event when feedbackIteration == 0 but submittedForReview == true (bypass workflow)', async () => {
-			// Spawn only — feedbackIteration stays at 0
+		it('should process terminal event when leaderHasWork == true, regardless of feedbackIteration or submittedForReview', async () => {
+			// Spawn only — feedbackIteration stays 0, submittedForReview stays false
 			const { task } = await createGoalAndTask(ctx);
 			ctx.runtime.start();
 			await ctx.runtime.tick();
 
 			const group = ctx.groupRepo.getGroupByTaskId(task.id);
 			expect(group).toBeDefined();
-			expect(group!.feedbackIteration).toBe(0);
+			expect(group!.leaderHasWork).toBe(false);
 
-			// Bypass workflow: submittedForReview is set before routing (e.g. bypass marker)
-			ctx.groupRepo.setSubmittedForReview(group!.id, true);
-			const groupAfter = ctx.groupRepo.getGroup(group!.id)!;
-			expect(groupAfter.submittedForReview).toBe(true);
+			// Directly mark the leader as having received work (simulates routeWorkerToLeader
+			// or resumeLeaderFromHuman having run). feedbackIteration and submittedForReview
+			// deliberately left at their reset values (0 / false) to prove the guard uses
+			// leaderHasWork, not those fields.
+			ctx.groupRepo.setLeaderHasWork(group!.id);
+			expect(ctx.groupRepo.getGroup(group!.id)!.leaderHasWork).toBe(true);
 
-			// Terminal event must NOT be dropped — the guard passes when submittedForReview==true
-			// The event flows through normal handling (leader hasn't called a tool → no-op aside
-			// from clearing activeSession, which is already null here).
+			// Fire a waiting_for_input terminal event — this has an observable side-effect:
+			// onLeaderTerminalState sets waitingForQuestion=true. If the guard erroneously
+			// dropped the event, waitingForQuestion would remain false.
 			await ctx.runtime.onLeaderTerminalState(group!.id, {
 				sessionId: group!.leaderSessionId,
-				kind: 'idle',
+				kind: 'waiting_for_input',
 			});
 
-			// Group is still active (no tool was called, so no completion)
+			// Handler ran: waitingForQuestion flag was set (concrete proof the guard passed)
 			const updated = ctx.groupRepo.getGroup(group!.id)!;
+			expect(updated.waitingForQuestion).toBe(true);
+			expect(updated.waitingSession).toBe('leader');
+			// Group is still active (not completed)
 			expect(updated.completedAt).toBeNull();
-			// submittedForReview flag is preserved (leader didn't call a completion tool)
-			expect(updated.submittedForReview).toBe(true);
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -972,6 +972,34 @@ describe('RoomRuntime flow', () => {
 			expect(afterResume.waitingForQuestion).toBe(false);
 			expect(afterResume.waitingSession).toBeNull();
 		});
+
+		it('should ignore terminal event when feedbackIteration == 0 and leader has not received work', async () => {
+			// Spawn only — do NOT route worker to leader, so feedbackIteration stays at 0
+			const { task } = await createGoalAndTask(ctx);
+			ctx.runtime.start();
+			await ctx.runtime.tick();
+
+			const group = ctx.groupRepo.getGroupByTaskId(task.id);
+			expect(group).toBeDefined();
+			expect(group!.feedbackIteration).toBe(0);
+			expect(group!.submittedForReview).toBe(false);
+
+			// Fire a spurious idle event on the leader (e.g. from a race or startup artifact)
+			await ctx.runtime.onLeaderTerminalState(group!.id, {
+				sessionId: group!.leaderSessionId,
+				kind: 'idle',
+			});
+
+			// Group must remain unchanged — no completion, no error, no inject
+			const updated = ctx.groupRepo.getGroup(group!.id)!;
+			expect(updated.completedAt).toBeNull();
+			expect(updated.feedbackIteration).toBe(0);
+
+			const injectToLeader = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage' && c.args[0] === group!.leaderSessionId
+			);
+			expect(injectToLeader).toHaveLength(0);
+		});
 	});
 
 	describe('lifecycle hooks', () => {

--- a/packages/daemon/tests/unit/room/room-runtime-measurable.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-measurable.test.ts
@@ -70,12 +70,13 @@ describe('RoomRuntime — measurable missions', () => {
 		ctx.runtime.start();
 		await ctx.runtime.tick();
 
-		// A planner session should be spawned for the metric-based replan
+		// A planner session should be spawned for the metric-based replan (+ leader eagerly)
 		const createCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession'
 		);
-		expect(createCalls).toHaveLength(1);
-		expect(createCalls[0].args[1]).toBe('planner');
+		expect(createCalls).toHaveLength(2);
+		const plannerCall = createCalls.find((c) => c.args[1] === 'planner');
+		expect(plannerCall).toBeDefined();
 
 		// Goal should still be active (not completed)
 		const updated = await ctx.goalManager.getGoal(goal.id);
@@ -141,8 +142,8 @@ describe('RoomRuntime — measurable missions', () => {
 		const createCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession'
 		);
-		// A worker gets spawned for the task, not a planner
-		expect(createCalls).toHaveLength(1);
+		// A worker + leader are spawned eagerly for the task (not a planner)
+		expect(createCalls).toHaveLength(2);
 		expect(createCalls[0].args[1]).not.toBe('planner');
 
 		// Goal remains active

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -458,7 +458,7 @@ describe('Stuck worker detection and recovery', () => {
 		});
 	}
 
-	it('should detect a stuck worker (idle, no leader) during tick and re-trigger routing', async () => {
+	it('should detect a stuck worker (idle, leader in restart recovery) during tick and re-trigger routing', async () => {
 		const group = await spawnGroup();
 
 		// Simulate: worker is idle but leader hasn't been created yet
@@ -477,14 +477,14 @@ describe('Stuck worker detection and recovery', () => {
 		// Wait for the fire-and-forget routing to complete
 		await leaderCreated;
 
-		// Leader session should now be created
+		// Leader session should now be created (1 from eager spawn + 1 from routing recovery)
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(1);
+		expect(leaderCalls).toHaveLength(2);
 	});
 
-	it('should detect a stuck worker in interrupted state and re-trigger routing', async () => {
+	it('should detect a stuck worker in interrupted state (leader in restart recovery) and re-trigger routing', async () => {
 		const group = await spawnGroup();
 
 		ctx.sessionFactory.processingStates.set(group.workerSessionId, 'interrupted');
@@ -498,10 +498,11 @@ describe('Stuck worker detection and recovery', () => {
 		await ctx.runtime.tick();
 		await leaderCreated;
 
+		// Leader session should now be created (1 from eager spawn + 1 from routing recovery)
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(1);
+		expect(leaderCalls).toHaveLength(2);
 	});
 
 	it('should not re-trigger routing if worker is still processing (not stuck)', async () => {
@@ -521,7 +522,7 @@ describe('Stuck worker detection and recovery', () => {
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 	});
 
 	it('should not re-trigger routing when processing state is undefined (unknown)', async () => {
@@ -540,7 +541,7 @@ describe('Stuck worker detection and recovery', () => {
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 	});
 
 	it('should skip stuck-worker recovery for groups with feedbackIteration > 0', async () => {
@@ -564,7 +565,7 @@ describe('Stuck worker detection and recovery', () => {
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 	});
 
 	it('should skip stuck-worker recovery for groups awaiting human review', async () => {
@@ -586,24 +587,28 @@ describe('Stuck worker detection and recovery', () => {
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 	});
 
-	it('should skip stuck-worker recovery when leader already exists in session factory', async () => {
+	it('should route worker to existing leader when leader already exists in session factory', async () => {
+		// With eager init, the leader is always created in spawn(). When worker is idle and
+		// feedbackIteration == 0, recoverStuckWorkers fires routing regardless of leader existence.
+		// routeWorkerToLeader() detects leaderAlreadyExists=true and just injects the message.
 		const group = await spawnGroup();
 
 		ctx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
 		// Leader EXISTS in session factory (default mock returns true for all)
-		// → recoverStuckWorkers should skip this group
+		// recoverStuckWorkers now triggers routing (we removed the leaderExists skip guard)
+		// but routeWorkerToLeader skips creation since leader already exists — only injects
 
 		await ctx.runtime.tick();
 		await new Promise((r) => setTimeout(r, 5));
 
-		// No extra leader creation (first tick already created one worker session)
+		// Only 1 leader creation total (from eager spawn — no second creation in routing)
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 	});
 
 	it('should NOT re-trigger routing when worker is in waiting_for_input (intentional pause)', async () => {
@@ -628,7 +633,7 @@ describe('Stuck worker detection and recovery', () => {
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
-		expect(leaderCalls).toHaveLength(0);
+		expect(leaderCalls).toHaveLength(1);
 
 		// The group should still be active (not failed, not routed)
 		const updated = ctx.groupRepo.getGroup(group.id);

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -295,6 +295,47 @@ describe('Zombie detection in tick', () => {
 
 		expect(ctx.observer.isObserving(leaderSessionId)).toBe(true);
 	});
+
+	it('should set leaderHasWork before injecting "continue reviewing" when restoring zombie leader with feedbackIteration > 0', async () => {
+		// Simulate a group that has already had at least one worker→leader routing round
+		// (feedbackIteration > 0) and then the daemon restarted — the leader is a zombie.
+		const { groupId, leaderSessionId } = await createTaskWithGroup(ctx);
+		const group = ctx.groupRepo.getGroup(groupId)!;
+
+		// Manually advance feedbackIteration to simulate post-routing state.
+		// Also set eagerlyCreated so findZombieGroups treats the leader as expected.
+		ctx.groupRepo.incrementFeedbackIteration(groupId, group.version);
+		ctx.groupRepo.setDeferredLeader(groupId, {
+			roomId: 'room-1',
+			goalId: null,
+			eagerlyCreated: true,
+		});
+
+		// Leader is missing from cache (zombie) but restorable
+		const restoredSessions = new Set<string>();
+		ctx.sessionFactory.hasSession = (sessionId: string) => {
+			if (sessionId === leaderSessionId && !restoredSessions.has(sessionId)) return false;
+			return true;
+		};
+		ctx.sessionFactory.restoreSession = async (sessionId: string) => {
+			restoredSessions.add(sessionId);
+			return true;
+		};
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// recoverZombieGroups should have injected "continue reviewing"
+		const injectCalls = ctx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === leaderSessionId
+		);
+		expect(injectCalls).toHaveLength(1);
+		expect(injectCalls[0].args[1]).toContain('Continue reviewing');
+
+		// leaderHasWork must be true so onLeaderTerminalState won't drop the terminal event
+		const updated = ctx.groupRepo.getGroup(groupId)!;
+		expect(updated.leaderHasWork).toBe(true);
+	});
 });
 
 describe('resumeWorkerFromHuman rollback', () => {

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -688,6 +688,49 @@ describe('Stuck worker detection and recovery', () => {
 		expect(updated!.waitingForQuestion).toBe(true);
 	});
 
+	it('should NOT re-trigger routing after resumeLeaderFromHuman resets feedbackIteration to 0', async () => {
+		// Scenario: worker routed to leader (feedbackIteration=1), leader submitted for review,
+		// human resumed via resumeLeaderFromHuman which reset feedbackIteration=0.
+		// The worker is idle but has no NEW messages — re-routing would corrupt the leader's context.
+		//
+		// Use a separate context with getWorkerMessages so the new guard can operate.
+		const localCtx = createRuntimeTestContext({
+			getWorkerMessages: (_sessionId: string, _afterId: string | null) => [],
+			// Return empty: worker has no new output since last forwarding
+		});
+
+		const group = await (async () => {
+			await createGoalAndTask(localCtx);
+			localCtx.runtime.start();
+			await localCtx.runtime.tick();
+			const groups = localCtx.groupRepo.getActiveGroups('room-1');
+			return groups[0];
+		})();
+
+		// Manually advance to a post-routing state (simulates feedbackIteration reset by human resume)
+		localCtx.groupRepo.incrementFeedbackIteration(group.id, group.version);
+		const afterIncrement = localCtx.groupRepo.getGroup(group.id)!;
+		localCtx.groupRepo.resetFeedbackIteration(group.id, afterIncrement.version);
+		// Mark leaderHasWork=true (routing already happened before the reset)
+		localCtx.groupRepo.setLeaderHasWork(group.id);
+
+		// Worker is idle — but has no new messages (getWorkerMessages returns [])
+		localCtx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
+
+		const callsBefore = localCtx.sessionFactory.calls.length;
+
+		await localCtx.runtime.tick();
+		await new Promise((r) => setTimeout(r, 10));
+
+		// No new injectMessage calls should have been made (routing was suppressed)
+		const newCalls = localCtx.sessionFactory.calls.slice(callsBefore);
+		const injectCalls = newCalls.filter((c) => c.method === 'injectMessage');
+		expect(injectCalls).toHaveLength(0);
+
+		localCtx.runtime.stop();
+		localCtx.db.close();
+	});
+
 	it('should not fire duplicate routing on successive ticks while recovery is in-flight', async () => {
 		const group = await spawnGroup();
 

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -442,8 +442,14 @@ describe('Stuck worker detection and recovery', () => {
 	}
 
 	/**
-	 * Helper: await the next leader session creation by spying on createAndStartSession.
+	 * Helper: await the NEXT leader session creation by spying on createAndStartSession.
 	 * Returns a Promise that resolves when 'createAndStartSession' is called with role 'leader'.
+	 *
+	 * Note: with eager init, spawn() already calls createAndStartSession('leader') once.
+	 * These tests simulate restart-recovery scenarios where the leader is missing from
+	 * the session cache (hasSession returns false for the leader). The spy therefore
+	 * intercepts the *second* leader creation call — the one triggered by recoverStuckWorkers
+	 * → routeWorkerToLeader's restart-recovery fallback path.
 	 */
 	function waitForLeaderCreation(): Promise<void> {
 		return new Promise((resolve) => {

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -63,11 +63,12 @@ describe('RoomRuntime - terminal error detection', () => {
 			const updatedGroup = ctx.groupRepo.getGroup(group.id);
 			expect(updatedGroup!.completedAt).not.toBeNull();
 
-			// No leader session should have been created
-			const leaderCalls = ctx.sessionFactory.calls.filter(
-				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			// Leader was created eagerly in spawn, but routing (inject) must NOT have happened
+			// because the task was failed before the worker output reached the leader
+			const leaderInjectCalls = ctx.sessionFactory.calls.filter(
+				(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
 			);
-			expect(leaderCalls).toHaveLength(0);
+			expect(leaderInjectCalls).toHaveLength(0);
 		});
 
 		it('fails task immediately on HTTP 401 error in worker output', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime.test.ts
@@ -58,7 +58,7 @@ describe('RoomRuntime', () => {
 			ctx.runtime.start();
 			await ctx.runtime.tick();
 
-			// Worker starts immediately, leader is deferred until routeWorkerToLeader
+			// Both worker and leader are created eagerly in spawn()
 			const workerCalls = ctx.sessionFactory.calls.filter(
 				(c) => c.method === 'createAndStartSession' && c.args[1] !== 'leader'
 			);
@@ -66,7 +66,7 @@ describe('RoomRuntime', () => {
 				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 			);
 			expect(workerCalls).toHaveLength(1);
-			expect(leaderCalls).toHaveLength(0);
+			expect(leaderCalls).toHaveLength(1);
 
 			// Task should be in_progress
 			const updated = await ctx.taskManager.getTask(task.id);

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -299,7 +299,7 @@ describe('TaskGroupManager', () => {
 			expect(group.feedbackIteration).toBe(0);
 		});
 
-		it('should create Worker session immediately and defer Leader', async () => {
+		it('should create both Worker and Leader sessions eagerly', async () => {
 			const task = await createTask();
 			const goal = makeGoal(db);
 			const callbacks = createMockLeaderCallbacks();
@@ -320,9 +320,9 @@ describe('TaskGroupManager', () => {
 			const leaderCalls = sessionFactory.calls.filter(
 				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 			);
-			// Worker starts immediately, Leader is deferred until routeWorkerToLeader
+			// Both worker and leader start immediately — eager initialization
 			expect(workerCalls).toHaveLength(1);
-			expect(leaderCalls).toHaveLength(0);
+			expect(leaderCalls).toHaveLength(1);
 		});
 
 		it('should set task to in_progress', async () => {
@@ -360,7 +360,7 @@ describe('TaskGroupManager', () => {
 			);
 
 			expect(observer.isObserving(group.workerSessionId)).toBe(true);
-			// Leader is observed proactively so terminal events are not missed after lazy creation.
+			// Leader session is created eagerly alongside the worker, so it is observed immediately.
 			expect(observer.isObserving(group.leaderSessionId)).toBe(true);
 		});
 
@@ -389,6 +389,7 @@ describe('TaskGroupManager', () => {
 				goalId: goal.id,
 				reviewContext: 'code_review',
 				leaderTaskContext: 'Goal context for leader',
+				eagerlyCreated: true,
 			});
 		});
 
@@ -408,6 +409,87 @@ describe('TaskGroupManager', () => {
 
 			const persisted = groupRepo.getGroup(group.id)!;
 			expect(persisted.deferredLeader?.goalId).toBeNull();
+		});
+
+		it('should register worker observer before injecting the initial message', async () => {
+			// Regression test: verifies the race-condition fix where the worker could
+			// complete before the observer was registered, causing the terminal event to
+			// be missed entirely. The observer must be set up BEFORE injectMessage() fires.
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			// Track call order
+			const callOrder: string[] = [];
+			const trackingFactory = {
+				...sessionFactory,
+				async createAndStartSession(init: unknown, role: string) {
+					callOrder.push(`createAndStartSession:${role}`);
+					await sessionFactory.createAndStartSession(init, role);
+				},
+				async injectMessage(
+					sessionId: string,
+					message: string,
+					opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+				) {
+					callOrder.push(`injectMessage:${sessionId.split(':')[0]}`);
+					await sessionFactory.injectMessage(sessionId, message, opts);
+				},
+			};
+
+			const trackingManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: trackingFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			let observerRegisteredBeforeInject = false;
+			const onWorkerTerminal = () => {};
+			const onLeaderTerminal = () => {};
+
+			// Monkey-patch observer.observe to record when worker is registered
+			const origObserve = observer.observe.bind(observer);
+			let workerObserverRegistered = false;
+			observer.observe = (sessionId: string, cb: unknown) => {
+				if (sessionId.startsWith('coder:')) {
+					workerObserverRegistered = true;
+				}
+				return origObserve(sessionId, cb as Parameters<typeof origObserve>[1]);
+			};
+
+			// Monkey-patch injectMessage to check if worker observer was registered before inject
+			const origInject = trackingFactory.injectMessage.bind(trackingFactory);
+			trackingFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+			) => {
+				if (sessionId.startsWith('coder:')) {
+					observerRegisteredBeforeInject = workerObserverRegistered;
+				}
+				return origInject(sessionId, message, opts);
+			};
+
+			await trackingManager.spawn(
+				room,
+				task,
+				goal,
+				onWorkerTerminal,
+				onLeaderTerminal,
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			// Restore observer
+			observer.observe = origObserve;
+
+			expect(observerRegisteredBeforeInject).toBe(true);
 		});
 	});
 
@@ -566,11 +648,17 @@ describe('TaskGroupManager', () => {
 				makeDefaultWorkerConfig()
 			);
 
-			// Deferred leader config should store null goalId
+			// Leader config should store null goalId
 			const persisted = groupRepo.getGroup(group.id)!;
 			expect(persisted.deferredLeader?.goalId).toBeNull();
 
-			// Routing worker to leader should succeed — leader session is created
+			// Leader session is created eagerly in spawn()
+			const leaderCallsAfterSpawn = sessionFactory.calls.filter(
+				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+			);
+			expect(leaderCallsAfterSpawn).toHaveLength(1);
+
+			// Routing worker to leader should succeed — leader session already exists
 			const result = await manager.routeWorkerToLeader(
 				group.id,
 				'Worker output for goal-free task',
@@ -579,10 +667,11 @@ describe('TaskGroupManager', () => {
 
 			expect(result).not.toBeNull();
 
-			const leaderCalls = sessionFactory.calls.filter(
+			// No additional leader creation — leader was already created in spawn()
+			const leaderCallsAfterRoute = sessionFactory.calls.filter(
 				(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 			);
-			expect(leaderCalls).toHaveLength(1);
+			expect(leaderCallsAfterRoute).toHaveLength(1);
 
 			// Task should not be failed (leader creation succeeded without a goal)
 			const updatedTask = await taskManager.getTask(task.id);


### PR DESCRIPTION
- Create leader session eagerly in spawn() alongside worker instead of
  lazily in routeWorkerToLeader(), ensuring the leader is ready when
  worker output arrives
- Register worker observer BEFORE injectMessage() to eliminate race
  condition where a fast-completing worker could emit 'idle' before
  the observer was set up
- Add eagerlyCreated flag to DeferredLeaderConfig for precise zombie
  detection on restart
- Update recoverStuckWorkers() to remove leaderExists check (no longer
  needed with eager init)
- Update findZombieGroups() to use eagerlyCreated for correct recovery
- Update recoverZombieGroups() to skip "continue reviewing" inject
  when feedbackIteration==0 (leader hasn't received work yet)
- Update all unit tests to reflect eager (worker+leader) session counts
