### PR TITLE
fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -133,15 +133,20 @@ function streamSession(
 	const unsubscribe = session.on((event: SessionEvent) => {
 		switch (event.type) {
 			case 'assistant.message_delta':
-				if (event.data.deltaContent) pendingDeltas.push(event.data.deltaContent as string);
+				if (typeof event.data.deltaContent === 'string' && event.data.deltaContent)
+					pendingDeltas.push(event.data.deltaContent);
 				break;
 
 			case 'assistant.message':
 				// Fallback: if the SDK delivered the full response without any
 				// preceding assistant.message_delta events (valid Copilot SDK
 				// behaviour), capture it now so outputCharCount is non-zero.
-				if (pendingDeltas.length === 0 && event.data.content) {
-					pendingDeltas.push(event.data.content as string);
+				if (
+					pendingDeltas.length === 0 &&
+					typeof event.data.content === 'string' &&
+					event.data.content
+				) {
+					pendingDeltas.push(event.data.content);
 				}
 				flushDeltas();
 				break;

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -434,7 +434,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	 * Lazily starts a per-workspace bridge server and returns env vars that
 	 * route the Anthropic SDK to that bridge's local HTTP endpoint.
 	 */
-	buildSdkConfig(_modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
+	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
 		const workspace = sessionConfig?.workspacePath ?? process.cwd();
 		let bridgeServer = this.bridgeServers.get(workspace);
 
@@ -458,14 +458,38 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 			);
 		}
 
+		// Resolve alias (e.g. 'codex' → 'gpt-5.3-codex') so ANTHROPIC_DEFAULT_*_MODEL
+		// receives real Codex model IDs that the bridge can forward to the app-server.
+		const entry = ANTHROPIC_CODEX_MODELS.find((m) => m.alias === modelId || m.id === modelId);
+		const resolvedId = entry?.id ?? 'gpt-5.3-codex';
+
 		return {
 			envVars: {
 				ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridgeServer.port}`,
 				ANTHROPIC_API_KEY: 'codex-bridge-placeholder',
+				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+				// Map SDK model tiers to Codex model IDs so the Claude Agent SDK
+				// subprocess never falls back to Anthropic model names (e.g.
+				// 'claude-haiku-4-5-20251001') which the Codex bridge does not recognise.
+				ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.4',
+				ANTHROPIC_DEFAULT_SONNET_MODEL: resolvedId,
+				ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5.1-codex-mini',
 			},
 			isAnthropicCompatible: true,
 			apiVersion: 'v1',
 		};
+	}
+
+	/**
+	 * Translate the Codex model ID to the SDK-compatible 'default' tier name.
+	 *
+	 * Codex model IDs (e.g. 'gpt-5.3-codex') are not known to the Claude Agent
+	 * SDK.  By returning 'default' here the SDK will use ANTHROPIC_DEFAULT_SONNET_MODEL
+	 * (set by buildSdkConfig) to pick the actual model, avoiding any fallback to
+	 * Anthropic model names.
+	 */
+	translateModelIdForSdk(_modelId: string): string {
+		return 'default';
 	}
 
 	/** Stop all bridge servers. Called at provider shutdown (e.g. tests). */

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -415,8 +415,12 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	}
 
 	getModelForTier(tier: ModelTier): string | undefined {
+		// Routing policy:
+		//   opus    → gpt-5.4          (latest frontier, matches ANTHROPIC_DEFAULT_OPUS_MODEL)
+		//   sonnet  → gpt-5.3-codex    (primary Codex model, matches ANTHROPIC_DEFAULT_SONNET_MODEL)
+		//   haiku   → gpt-5.1-codex-mini (fast/cheap, matches ANTHROPIC_DEFAULT_HAIKU_MODEL)
 		const map: Record<ModelTier, string> = {
-			opus: 'gpt-5.3-codex',
+			opus: 'gpt-5.4',
 			sonnet: 'gpt-5.3-codex',
 			haiku: 'gpt-5.1-codex-mini',
 			default: 'gpt-5.3-codex',
@@ -471,6 +475,10 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 				// Map SDK model tiers to Codex model IDs so the Claude Agent SDK
 				// subprocess never falls back to Anthropic model names (e.g.
 				// 'claude-haiku-4-5-20251001') which the Codex bridge does not recognise.
+				// Routing policy (mirrors getModelForTier):
+				//   Opus   → gpt-5.4           (latest frontier)
+				//   Sonnet → resolvedId         (user-selected model)
+				//   Haiku  → gpt-5.1-codex-mini (fast/cheap fallback)
 				ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.4',
 				ANTHROPIC_DEFAULT_SONNET_MODEL: resolvedId,
 				ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5.1-codex-mini',

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -488,18 +488,6 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		};
 	}
 
-	/**
-	 * Translate the Codex model ID to the SDK-compatible 'default' tier name.
-	 *
-	 * Codex model IDs (e.g. 'gpt-5.3-codex') are not known to the Claude Agent
-	 * SDK.  By returning 'default' here the SDK will use ANTHROPIC_DEFAULT_SONNET_MODEL
-	 * (set by buildSdkConfig) to pick the actual model, avoiding any fallback to
-	 * Anthropic model names.
-	 */
-	translateModelIdForSdk(_modelId: string): string {
-		return 'default';
-	}
-
 	/** Stop all bridge servers. Called at provider shutdown (e.g. tests). */
 	stopAllBridgeServers(): void {
 		for (const server of this.bridgeServers.values()) {

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -416,9 +416,10 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 
 	getModelForTier(tier: ModelTier): string | undefined {
 		// Routing policy:
-		//   opus    → gpt-5.4          (latest frontier, matches ANTHROPIC_DEFAULT_OPUS_MODEL)
-		//   sonnet  → gpt-5.3-codex    (primary Codex model, matches ANTHROPIC_DEFAULT_SONNET_MODEL)
+		//   opus    → gpt-5.4           (latest frontier, matches ANTHROPIC_DEFAULT_OPUS_MODEL)
+		//   sonnet  → gpt-5.3-codex     (primary Codex model, matches ANTHROPIC_DEFAULT_SONNET_MODEL)
 		//   haiku   → gpt-5.1-codex-mini (fast/cheap, matches ANTHROPIC_DEFAULT_HAIKU_MODEL)
+		//   default → gpt-5.3-codex     (same as sonnet; no separate env var needed)
 		const map: Record<ModelTier, string> = {
 			opus: 'gpt-5.4',
 			sonnet: 'gpt-5.3-codex',

--- a/packages/daemon/tests/helpers/daemon-actions.ts
+++ b/packages/daemon/tests/helpers/daemon-actions.ts
@@ -111,10 +111,16 @@ async function waitForProcessingState(
 			);
 		}, timeout);
 
-		// Subscribe to events FIRST to ensure no events are missed once room is joined
+		// Subscribe to events FIRST to ensure no events are missed once room is joined.
+		// Filter by sessionId: the client may have joined channels from prior test sessions,
+		// so events from those channels must not trigger resolution for the wrong session.
 		unsubscribe = daemon.messageHub.onEvent('state.session', (data: unknown) => {
 			if (resolved) return;
-			const state = data as { agentState?: { status: string } };
+			const state = data as {
+				sessionInfo?: { id?: string };
+				agentState?: { status: string };
+			};
+			if (state.sessionInfo?.id !== sessionId) return;
 			const currentStatus = state.agentState?.status;
 
 			if (currentStatus === targetStatus) {

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -559,7 +559,7 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 	// -------------------------------------------------------------------------
 
 	test(
-		'token usage: SSE stream contains non-zero input_tokens and output_tokens',
+		'token usage: session metadata contains non-zero input_tokens and output_tokens',
 		async () => {
 			// Route through the daemon session lifecycle (uses the existing Copilot
 			// provider that was already warmed up in beforeAll).  Creating a fresh
@@ -579,10 +579,15 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 			await sendMessage(daemon, sessionId, 'Say hello in one sentence.');
 			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
+			// Wait for SDK messages to be persisted — consistent with other tests that
+			// also use waitForSdkMessages before querying session state.
+			await waitForSdkMessages(daemon, sessionId, { minCount: 1, timeout: 5000 });
+
 			// Token counts are accumulated in session metadata by the SDK message handler.
 			// The Copilot bridge emits heuristic input/output counts via SSE (input from
 			// prompt length, output from response character count), which the Claude Agent
-			// SDK processes and stores in the assistant message's usage field.
+			// SDK processes and stores in the assistant message's usage field, then
+			// persists to session.metadata.inputTokens/outputTokens.
 			const { session } = (await daemon.messageHub.request('session.get', {
 				sessionId,
 			})) as { session: { metadata?: { inputTokens?: number; outputTokens?: number } } };

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -555,31 +555,40 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 	);
 
 	// -------------------------------------------------------------------------
-	// 7. Token usage — SSE stream has non-zero input_tokens and output_tokens
+	// 7. Token usage — session metadata has non-zero input_tokens and output_tokens
 	// -------------------------------------------------------------------------
 
 	test(
 		'token usage: SSE stream contains non-zero input_tokens and output_tokens',
 		async () => {
-			const directProvider = new AnthropicToCopilotBridgeProvider();
-			const bridgeUrl = await directProvider.ensureServerStarted();
+			// Route through the daemon session lifecycle (uses the existing Copilot
+			// provider that was already warmed up in beforeAll).  Creating a fresh
+			// AnthropicToCopilotBridgeProvider here would spin up a new CopilotClient
+			// subprocess whose first createSession call lists models, which can return
+			// 429 after the preceding tests have exhausted the rate limit window.
+			const workspacePath = join(TMP_DIR, `copilot-token-usage-${Date.now()}`);
+			mkdirSync(workspacePath, { recursive: true });
 
-			try {
-				const events = await callCopilotBridge(
-					bridgeUrl,
-					[{ role: 'user', content: 'Say hello.' }],
-					testModelId,
-					'You are a helpful assistant. Always respond with plain text.'
-				);
+			const { sessionId } = (await daemon.messageHub.request('session.create', {
+				workspacePath,
+				title: 'Copilot Token Usage Test',
+				config: { model: testModelId, permissionMode: 'acceptEdits' },
+			})) as { sessionId: string };
+			daemon.trackSession(sessionId);
 
-				const inputTokens = getInputTokens(events);
-				const outputTokens = getOutputTokens(events);
+			await sendMessage(daemon, sessionId, 'Say hello in one sentence.');
+			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-				expect(inputTokens).toBeGreaterThan(0);
-				expect(outputTokens).toBeGreaterThan(0);
-			} finally {
-				await directProvider.shutdown();
-			}
+			// Token counts are accumulated in session metadata by the SDK message handler.
+			// The Copilot bridge emits heuristic input/output counts via SSE (input from
+			// prompt length, output from response character count), which the Claude Agent
+			// SDK processes and stores in the assistant message's usage field.
+			const { session } = (await daemon.messageHub.request('session.get', {
+				sessionId,
+			})) as { session: { metadata?: { inputTokens?: number; outputTokens?: number } } };
+
+			expect(session.metadata?.inputTokens ?? 0).toBeGreaterThan(0);
+			expect(session.metadata?.outputTokens ?? 0).toBeGreaterThan(0);
 		},
 		TEST_TIMEOUT
 	);

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -299,13 +299,13 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			expect(cfg.envVars['ANTHROPIC_API_KEY']).toBe('');
 		});
 
-		it('ANTHROPIC_DEFAULT_HAIKU_MODEL is not a claude-* model name', () => {
+		it('ANTHROPIC_DEFAULT_HAIKU_MODEL is gpt-5-mini (not a claude-* fallback)', () => {
 			// Regression guard: the haiku tier for Copilot must map to gpt-5-mini (a model
-			// served by the Copilot bridge), not to a claude-* name. Without this env var
-			// the Claude Agent SDK subprocess defaults to claude-haiku-4-5-20251001 for
-			// background calls (summarisation, compaction), which may not be routed correctly.
+			// served by the Copilot bridge). Without this env var the Claude Agent SDK
+			// subprocess defaults to claude-haiku-4-5-20251001 for background calls
+			// (summarisation, compaction), which the bridge may not serve correctly.
+			// The .toBe assertion is stricter than .not.toMatch(/^claude-/) and subsumes it.
 			const cfg = provider.buildSdkConfig('copilot-anthropic-sonnet');
-			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
 			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5-mini');
 		});
 	});

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -298,6 +298,16 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			const cfg = provider.buildSdkConfig('copilot-anthropic-sonnet');
 			expect(cfg.envVars['ANTHROPIC_API_KEY']).toBe('');
 		});
+
+		it('ANTHROPIC_DEFAULT_HAIKU_MODEL is not a claude-* model name', () => {
+			// Regression guard: the haiku tier for Copilot must map to gpt-5-mini (a model
+			// served by the Copilot bridge), not to a claude-* name. Without this env var
+			// the Claude Agent SDK subprocess defaults to claude-haiku-4-5-20251001 for
+			// background calls (summarisation, compaction), which may not be routed correctly.
+			const cfg = provider.buildSdkConfig('copilot-anthropic-sonnet');
+			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
+			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5-mini');
+		});
 	});
 
 	describe('getModels() pre-warms embedded server', () => {

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -260,6 +260,55 @@ describe('AnthropicToCodexBridgeProvider', () => {
 				await fs.rm(tmpDir, { recursive: true, force: true });
 			}
 		});
+
+		it('sets ANTHROPIC_DEFAULT_*_MODEL env vars to prevent SDK fallback to Anthropic models', () => {
+			// Regression test: without these env vars the Claude Agent SDK subprocess
+			// defaults to Anthropic model names (e.g. 'claude-haiku-4-5-20251001') which
+			// the Codex bridge does not recognise, producing "model does not exist" errors.
+			const cfg = provider.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-model' });
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.1-codex-mini');
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.4');
+		});
+
+		it('resolves model alias to canonical ID in ANTHROPIC_DEFAULT_SONNET_MODEL', () => {
+			const cfg = provider.buildSdkConfig('codex', { workspacePath: '/tmp/ws-alias' });
+			// 'codex' is an alias for 'gpt-5.3-codex'
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
+		});
+
+		it('resolves codex-mini alias correctly', () => {
+			const cfg = provider.buildSdkConfig('codex-mini', { workspacePath: '/tmp/ws-mini' });
+			// 'codex-mini' is an alias for 'gpt-5.1-codex-mini'
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.1-codex-mini');
+		});
+
+		it('falls back to gpt-5.3-codex for unknown model IDs', () => {
+			const cfg = provider.buildSdkConfig('unknown-model', { workspacePath: '/tmp/ws-unk' });
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// translateModelIdForSdk()
+	// -------------------------------------------------------------------------
+
+	describe('translateModelIdForSdk()', () => {
+		beforeEach(() => {
+			provider = makeProvider({});
+		});
+
+		it('always returns "default" so the SDK uses ANTHROPIC_DEFAULT_*_MODEL env vars', () => {
+			// Returning 'default' forces the Claude Agent SDK to look up the model
+			// from ANTHROPIC_DEFAULT_SONNET_MODEL (set in buildSdkConfig), which holds
+			// the real Codex model ID.  Without this, the SDK would pass the raw Codex
+			// model ID ('gpt-5.3-codex') to the API and may fall back to Anthropic defaults.
+			expect(provider.translateModelIdForSdk('gpt-5.3-codex')).toBe('default');
+			expect(provider.translateModelIdForSdk('gpt-5.1-codex-mini')).toBe('default');
+			expect(provider.translateModelIdForSdk('gpt-5.4')).toBe('default');
+			expect(provider.translateModelIdForSdk('codex')).toBe('default');
+			expect(provider.translateModelIdForSdk('unknown')).toBe('default');
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -283,6 +283,12 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.1-codex-mini');
 		});
 
+		it('resolves codex-latest alias correctly', () => {
+			const cfg = provider.buildSdkConfig('codex-latest', { workspacePath: '/tmp/ws-latest' });
+			// 'codex-latest' is an alias for 'gpt-5.4'
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
+		});
+
 		it('falls back to gpt-5.3-codex for unknown model IDs', () => {
 			const cfg = provider.buildSdkConfig('unknown-model', { workspacePath: '/tmp/ws-unk' });
 			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -293,6 +293,20 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			const cfg = provider.buildSdkConfig('unknown-model', { workspacePath: '/tmp/ws-unk' });
 			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
 		});
+
+		it('no claude-* model name leaks through ANTHROPIC_DEFAULT_*_MODEL env vars', () => {
+			// Regression guard for the original bug: without these env vars being set to
+			// Codex model IDs, the Claude Agent SDK subprocess falls back to its built-in
+			// defaults (e.g. claude-haiku-4-5-20251001) for background calls such as
+			// summarisation and compaction. The Codex bridge rejects those names with
+			// "model does not exist". All three tier slots must be non-Anthropic model IDs.
+			const cfg = provider.buildSdkConfig('gpt-5.3-codex', {
+				workspacePath: '/tmp/ws-no-leak',
+			});
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).not.toMatch(/^claude-/);
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).not.toMatch(/^claude-/);
+			expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).not.toMatch(/^claude-/);
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -296,28 +296,6 @@ describe('AnthropicToCodexBridgeProvider', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// translateModelIdForSdk()
-	// -------------------------------------------------------------------------
-
-	describe('translateModelIdForSdk()', () => {
-		beforeEach(() => {
-			provider = makeProvider({});
-		});
-
-		it('always returns "default" so the SDK uses ANTHROPIC_DEFAULT_*_MODEL env vars', () => {
-			// Returning 'default' forces the Claude Agent SDK to look up the model
-			// from ANTHROPIC_DEFAULT_SONNET_MODEL (set in buildSdkConfig), which holds
-			// the real Codex model ID.  Without this, the SDK would pass the raw Codex
-			// model ID ('gpt-5.3-codex') to the API and may fall back to Anthropic defaults.
-			expect(provider.translateModelIdForSdk('gpt-5.3-codex')).toBe('default');
-			expect(provider.translateModelIdForSdk('gpt-5.1-codex-mini')).toBe('default');
-			expect(provider.translateModelIdForSdk('gpt-5.4')).toBe('default');
-			expect(provider.translateModelIdForSdk('codex')).toBe('default');
-			expect(provider.translateModelIdForSdk('unknown')).toBe('default');
-		});
-	});
-
-	// -------------------------------------------------------------------------
 	// ownsModel()
 	// -------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -11,6 +11,8 @@ import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
 import { ProviderContextManager } from '../../../src/lib/providers/context-manager';
 import { ProviderRegistry, resetProviderRegistry } from '../../../src/lib/providers/registry';
 import { resetProviderFactory } from '../../../src/lib/providers/factory';
+import { AnthropicToCodexBridgeProvider } from '../../../src/lib/providers/anthropic-to-codex-bridge-provider';
+import { AnthropicToCopilotBridgeProvider } from '../../../src/lib/providers/anthropic-copilot/index';
 
 // Mock provider for testing
 class MockProvider implements Provider {
@@ -1043,5 +1045,48 @@ describe('ProviderContextManager', () => {
 			expect(providers.length).toBe(1);
 			expect(providers[0].id).toBe('anthropic');
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// No-Anthropic-model-leak invariant — real provider buildSdkConfig()
+//
+// These tests use the actual provider classes (not mocks) to assert that
+// ANTHROPIC_DEFAULT_HAIKU_MODEL never contains a claude-* model name.
+//
+// Root cause of the original bug: without ANTHROPIC_DEFAULT_*_MODEL being set
+// to bridge-compatible model IDs, the Claude Agent SDK subprocess falls back to
+// its built-in defaults (e.g. claude-haiku-4-5-20251001) for background calls
+// such as summarisation and compaction. Both the Codex and Copilot bridges reject
+// those names with "model does not exist" errors.
+// ---------------------------------------------------------------------------
+
+describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()', () => {
+	it('Codex provider: ANTHROPIC_DEFAULT_HAIKU_MODEL does not start with claude-', () => {
+		const p = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
+		const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-codex-leak' });
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
+		p.stopAllBridgeServers();
+	});
+
+	it('Codex provider: all three DEFAULT_*_MODEL slots are non-Anthropic model names', () => {
+		const p = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
+		const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-codex-all' });
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']).not.toMatch(/^claude-/);
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).not.toMatch(/^claude-/);
+		p.stopAllBridgeServers();
+	});
+
+	it('Copilot provider: ANTHROPIC_DEFAULT_HAIKU_MODEL does not start with claude-', () => {
+		const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'tok' });
+		// Inject a fake server URL — buildSdkConfig() requires the embedded server to be
+		// started, but for this assertion we only care about the env var values it returns.
+		(p as unknown as Record<string, unknown>)['serverCache'] = {
+			url: 'http://127.0.0.1:54321',
+			stop: async () => {},
+		};
+		const cfg = p.buildSdkConfig('copilot-anthropic-sonnet');
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
 	});
 });

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -1057,25 +1057,42 @@ describe('ProviderContextManager', () => {
 // Root cause of the original bug: without ANTHROPIC_DEFAULT_*_MODEL being set
 // to bridge-compatible model IDs, the Claude Agent SDK subprocess falls back to
 // its built-in defaults (e.g. claude-haiku-4-5-20251001) for background calls
-// such as summarisation and compaction. Both the Codex and Copilot bridges reject
-// those names with "model does not exist" errors.
+// such as summarisation and compaction.
+//
+// The invariant differs per provider:
+//   Codex bridge:   all three tier slots must be gpt-* model IDs — the bridge
+//                   rejects any claude-* name with "model does not exist".
+//   Copilot bridge: only the haiku slot is at risk. Copilot intentionally routes
+//                   claude-sonnet-4.6 / claude-opus-4.6 for those tiers, but
+//                   gpt-5-mini is required for haiku — a claude-haiku fallback
+//                   would not be served correctly by the Copilot bridge.
 // ---------------------------------------------------------------------------
 
 describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()', () => {
+	// Use a shared let so afterEach can clean up even when assertions throw.
+	let codexProvider: AnthropicToCodexBridgeProvider | undefined;
+
+	afterEach(() => {
+		codexProvider?.stopAllBridgeServers();
+		codexProvider = undefined;
+	});
+
 	it('Codex provider: ANTHROPIC_DEFAULT_HAIKU_MODEL does not start with claude-', () => {
-		const p = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
-		const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-codex-leak' });
+		codexProvider = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
+		const cfg = codexProvider.buildSdkConfig('gpt-5.3-codex', {
+			workspacePath: '/tmp/ws-codex-leak',
+		});
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
-		p.stopAllBridgeServers();
 	});
 
 	it('Codex provider: all three DEFAULT_*_MODEL slots are non-Anthropic model names', () => {
-		const p = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
-		const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-codex-all' });
+		codexProvider = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
+		const cfg = codexProvider.buildSdkConfig('gpt-5.3-codex', {
+			workspacePath: '/tmp/ws-codex-all',
+		});
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']).not.toMatch(/^claude-/);
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).not.toMatch(/^claude-/);
-		p.stopAllBridgeServers();
 	});
 
 	it('Copilot provider: ANTHROPIC_DEFAULT_HAIKU_MODEL does not start with claude-', () => {
@@ -1087,6 +1104,10 @@ describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()',
 			stop: async () => {},
 		};
 		const cfg = p.buildSdkConfig('copilot-anthropic-sonnet');
+		// Only the haiku slot must be non-claude-*. Sonnet/opus intentionally use
+		// claude-sonnet-4.6 / claude-opus-4.6 (the Copilot bridge serves those).
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
+		// p.shutdown() intentionally omitted: serverCache.stop is a no-op and no
+		// real embedded server was started, so there is nothing to clean up.
 	});
 });


### PR DESCRIPTION
## Root Cause

Without `ANTHROPIC_DEFAULT_HAIKU/SONNET/OPUS_MODEL` env vars in `buildSdkConfig()`,
the Claude Agent SDK subprocess falls back to Anthropic model names (e.g.
`claude-haiku-4-5-20251001`) when making API calls. The Codex bridge server
doesn't recognise these names, producing "model does not exist" errors.

## Fix

Adds `ANTHROPIC_DEFAULT_*_MODEL` env vars to `AnthropicToCodexBridgeProvider.buildSdkConfig()`:

- `ANTHROPIC_DEFAULT_SONNET_MODEL` → user-selected Codex model (alias-resolved)
- `ANTHROPIC_DEFAULT_HAIKU_MODEL` → `gpt-5.1-codex-mini` (fast/cheap fallback)
- `ANTHROPIC_DEFAULT_OPUS_MODEL` → `gpt-5.4` (frontier model)

**Note:** `translateModelIdForSdk()` was intentionally NOT added to the Codex provider.
Unlike GLM/MiniMax (which have their own model routing in their bridge), the Codex bridge
server forwards `body.model` directly to Codex's `thread/start` API
(`server.ts:334: const model = body.model`). Returning `'default'` from
`translateModelIdForSdk()` would send `model: 'default'` to the Codex API,
which does not recognise that name. The `ANTHROPIC_DEFAULT_*_MODEL` env vars
alone are sufficient to prevent SDK fallback to Anthropic model names.

## Also Fixes

- Copilot SSE token accounting: `assistant.message.content` is now captured as a
  fallback when the Copilot SDK delivers a complete response without streaming
  `assistant.message_delta` events (valid SDK behaviour observed in CI).