### PR TITLE
docs: add final provider parity report

### DIFF
--- a/docs/codex-anthropic-api-parity-review.md
+++ b/docs/codex-anthropic-api-parity-review.md
@@ -1,5 +1,7 @@
 # Codex Anthropic Bridge API Parity Review
 
+> **Note:** This report has been superseded by `docs/reports/provider-parity-final-report.md`.
+
 Date: 2026-03-16
 
 ## Verdict

--- a/docs/reports/anthropic-copilot-parity-report.md
+++ b/docs/reports/anthropic-copilot-parity-report.md
@@ -1,5 +1,7 @@
 # Anthropic-Copilot Parity Report
 
+> **Note:** This report has been superseded by `docs/reports/provider-parity-final-report.md`.
+
 **Date:** 2026-03-16  
 **Branch:** `task/investigate-using-github-copilot-cli-as-transparen`  
 **Scope:** `packages/daemon/src/lib/providers/anthropic-copilot/*`

--- a/docs/reports/codex-anthropic-parity-report.md
+++ b/docs/reports/codex-anthropic-parity-report.md
@@ -1,5 +1,7 @@
 # Codex Anthropic Parity Report
 
+> **Note:** This report has been superseded by `docs/reports/provider-parity-final-report.md`.
+
 **Date:** 2026-03-16  
 **Repo:** `/Users/lsm/focus/dev-neokai`  
 **Scope:** `packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts` + `packages/daemon/src/lib/providers/codex-anthropic-bridge/*`

--- a/docs/reports/provider-parity-final-report.md
+++ b/docs/reports/provider-parity-final-report.md
@@ -114,16 +114,16 @@ This report documents the completion of the provider parity initiative for NeoKa
 
 ### Type System Widening
 
-**PR #373** — Provider type widened from 3 to 5 providers:
+**PR #373** — Provider type widened from 3 to 5 providers in `packages/shared/src/types.ts`:
 ```typescript
-// Before
+// Before (packages/shared/src/types.ts)
 type Provider = 'anthropic' | 'glm' | 'minimax';
 
-// After
+// After (packages/shared/src/types.ts)
 type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex';
 ```
 
-> **Note:** Runtime provider validation happens via the `ProviderRegistry` in `packages/daemon/src/lib/providers/registry.ts`, not solely through the string literal union. The `ProviderId` type is `string`, and the registry ensures deterministic resolution via explicit `providerId` lookup.
+> **Note:** The primary provider interface type is `ProviderId = string` (defined in `packages/shared/src/provider/types.ts`). The `Provider` literal union above exists in `packages/shared/src/types.ts` and is used for type-narrowing in specific call sites. Runtime provider validation happens via the `ProviderRegistry` — the registry ensures deterministic resolution via explicit `providerId` lookup, not via the string literal union alone.
 
 **PR #377** — Unsafe casts removed:
 - `model-switch-handler.ts`: 4 unsafe casts replaced with `as Provider`
@@ -134,7 +134,7 @@ type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthrop
 **PR #376** — Deterministic provider resolution:
 - `detectProviderForModel(modelId, providerId)` requires explicit providerId via `registry.get()`
 - `detectProvider` marked `@deprecated`
-- All call sites updated to pass explicit providerId
+- New call sites use `detectProviderForModel` with explicit providerId; legacy call sites in `provider-service.ts`, `context-manager.ts`, and `query-runner.ts` retain the deprecated `detectProvider` for backward compatibility (those methods are themselves marked `@deprecated`)
 
 **PR #388** — Strict model resolution:
 - `getModelInfo`, `resolveModelAlias`, `isValidModel` all require `providerId`
@@ -214,8 +214,8 @@ type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthrop
 
 ### Online Tests
 
-- `providers-anthropic-copilot` — Matrix shard for Copilot bridge
-- `providers-anthropic-to-codex-bridge` — Matrix shard for Codex bridge
+- `packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts` — Full conversation and tool-use flows (`providers-anthropic-copilot` CI shard; requires real `COPILOT_GITHUB_TOKEN`)
+- `packages/daemon/tests/online/providers/anthropic-to-codex-bridge-provider.test.ts` — Full conversation and tool-use flows (`providers-anthropic-to-codex-bridge` CI shard; requires real `OPENAI_API_KEY`)
 
 ### E2E Tests
 

--- a/docs/reports/provider-parity-final-report.md
+++ b/docs/reports/provider-parity-final-report.md
@@ -3,6 +3,11 @@
 **Date:** 2026-03-18
 **Scope:** Full anthropic-copilot and anthropic-to-codex-bridge provider support implementation
 
+> **Supersedes:** This report supersedes the following original parity reports:
+> - `docs/reports/anthropic-copilot-parity-report.md`
+> - `docs/codex-anthropic-api-parity-review.md`
+> - `docs/reports/codex-anthropic-parity-report.md`
+
 ## Executive Summary
 
 This report documents the completion of the provider parity initiative for NeoKai, implementing first-class support for two new providers: `anthropic-copilot` (GitHub Copilot) and `anthropic-codex` (Anthropic Codex).
@@ -23,10 +28,11 @@ This report documents the completion of the provider parity initiative for NeoKa
 
 - Vision input (multimodal)
 - Extended thinking
-- `stream: false` response mode (Codex bridge)
+- `stream: false` response mode (both bridges, explicitly rejected with 400 for Copilot)
 - `tool_choice` enforcement (both bridges)
-- Full structured conversation semantics (Codex bridge)
-- `stop_sequences` support
+- Full structured conversation semantics (both bridges - messages flattened to text)
+- `stop_sequences` support (both bridges)
+- Sampling controls: `temperature`, `top_p`, `top_k` (both bridges)
 
 ---
 
@@ -42,17 +48,22 @@ This report documents the completion of the provider parity initiative for NeoKa
 | UI integration | ✅ Closed | PR #391: Brand-accurate colored provider indicator in status bar; PR #398: Provider-grouped model picker; PR #401: Provider-aware session creation |
 | Routing | ✅ Closed | PR #376: `detectProviderForModel(modelId, providerId)` requires explicit providerId; PR #388: Strict provider-aware model resolution |
 | `tool_choice` | ⚠️ Partial | PR #386: Logs warning when provided but not honored; SDK limitation prevents full support |
+| `stream: false` | ❌ Open | Server explicitly rejects with 400: "Only streaming responses are supported" |
 | Vision | ❌ Open | SDK does not support vision input |
 | Extended thinking | ❌ Open | SDK does not support extended thinking |
+| Sampling controls | ❌ Open | `temperature`, `top_p`, `top_k` not forwarded to SDK |
+| `stop_sequences` | ❌ Open | Not supported |
+| Full conversation semantics | ⚠️ Partial | Messages flattened to prompt text; structured blocks not preserved |
 
 ### Test Evidence
 
 **Unit Tests:**
-- `packages/daemon/tests/unit/providers/anthropic-copilot/` — 185+ tests covering SSE flow, tool_use/tool_result round-trip, parallel tool calls, continuation routing, error handling, auth/env wiring
+- `packages/daemon/tests/unit/providers/anthropic-copilot/` — 215 tests covering SSE flow, tool_use/tool_result round-trip, parallel tool calls, continuation routing, error handling, auth/env wiring
 - `packages/daemon/tests/unit/providers/provider-registry.test.ts` — Tests all 5 providers registered by `initializeProviders`
 - `packages/daemon/tests/unit/model-service-provider-routing.test.ts` — Tests `getModelInfo`, `resolveModelAlias`, `isValidModel` with explicit providerId
 
 **Online Tests:**
+- `packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts` — Full conversation and tool-use flows
 - `providers-anthropic-copilot` shard in CI matrix
 
 **E2E Tests:**
@@ -78,6 +89,9 @@ This report documents the completion of the provider parity initiative for NeoKa
 | `tool_choice` | ❌ Open | Not implemented; logs warning (PR #386) |
 | Full conversation semantics | ❌ Open | Messages flattened to text, not structured blocks |
 | `stop_sequences` | ❌ Open | Not supported |
+| Sampling controls | ❌ Open | `temperature`, `top_p`, `top_k` not supported |
+| Parallel tool output | ❌ Open | Codex does not emit multiple tool_use blocks in one response |
+| `metadata` fields | ❌ Open | Not supported |
 
 ### Test Evidence
 
@@ -88,6 +102,7 @@ This report documents the completion of the provider parity initiative for NeoKa
 - `packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts` — Request translation, multiple tool results handling
 
 **Online Tests:**
+- `packages/daemon/tests/online/providers/anthropic-to-codex-bridge-provider.test.ts` — Full conversation and tool-use flows
 - `providers-anthropic-to-codex-bridge` shard in CI matrix
 
 **E2E Tests:**
@@ -107,6 +122,8 @@ type Provider = 'anthropic' | 'glm' | 'minimax';
 // After
 type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex';
 ```
+
+> **Note:** Runtime provider validation happens via the `ProviderRegistry` in `packages/daemon/src/lib/providers/registry.ts`, not solely through the string literal union. The `ProviderId` type is `string`, and the registry ensures deterministic resolution via explicit `providerId` lookup.
 
 **PR #377** — Unsafe casts removed:
 - `model-switch-handler.ts`: 4 unsafe casts replaced with `as Provider`
@@ -140,14 +157,15 @@ type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthrop
 
 ### Auth UX
 
-**Task 6.1** — Auth status indicator in chat UI:
+**PR #410** — Filter unauthenticated providers from model picker:
+- Unauthenticated providers hidden from model picker dropdown
 - Authentication state visible in UI
 - Unauthenticated state handling
 - Actionable error messages
 
 ### Graceful Degradation
 
-**Task 6.2** — Provider unavailability handling:
+**PR #408** — Provider unavailability handling:
 - Provider availability checked on mount
 - Graceful fallback when provider unavailable
 - User-friendly error messaging
@@ -160,15 +178,17 @@ type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthrop
 
 | Gap | Provider | Reason | Notes |
 |-----|----------|--------|-------|
-| `stream: false` | Codex | Blocking | Current implementation always returns SSE; needs non-stream response path |
+| `stream: false` | Both | Blocking | Copilot explicitly rejects (400); Codex always returns SSE |
 | `tool_choice` enforcement | Both | Feature gap | SDK/backend limitations; warning logging in place (PR #386) |
 
 ### Medium Priority
 
 | Gap | Provider | Reason | Notes |
 |-----|----------|--------|-------|
-| Full conversation semantics | Codex | Accuracy | Text flattening loses structure; complex to implement |
-| `stop_sequences` | Codex | Feature gap | Not supported by Codex backend |
+| Full conversation semantics | Both | Accuracy | Text flattening loses structure; complex to implement |
+| `stop_sequences` | Both | Feature gap | Not supported by backends |
+| Sampling controls | Both | Feature gap | `temperature`, `top_p`, `top_k` not forwarded |
+| Parallel tool output | Codex | Backend limitation | Codex does not emit multiple tool_use blocks in one response |
 
 ### Low Priority (SDK/Backend Limitations)
 
@@ -176,6 +196,7 @@ type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthrop
 |-----|----------|-------|
 | Vision input | Both | SDK/backend does not support multimodal |
 | Extended thinking | Both | SDK/backend does not support extended thinking |
+| `metadata` fields | Codex | Not supported |
 
 ---
 

--- a/docs/reports/provider-parity-final-report.md
+++ b/docs/reports/provider-parity-final-report.md
@@ -1,0 +1,219 @@
+# Provider Parity Final Report
+
+**Date:** 2026-03-18
+**Scope:** Full anthropic-copilot and anthropic-to-codex-bridge provider support implementation
+
+## Executive Summary
+
+This report documents the completion of the provider parity initiative for NeoKai, implementing first-class support for two new providers: `anthropic-copilot` (GitHub Copilot) and `anthropic-codex` (Anthropic Codex).
+
+**Overall Status: Parity gaps significantly reduced; both providers now support core NeoKai workflows.**
+
+### Key Achievements
+
+- **Type system widened** to include all five providers (`anthropic`, `glm`, `minimax`, `anthropic-copilot`, `anthropic-codex`)
+- **Collision-safe routing** implemented with explicit `providerId` required throughout the stack
+- **UI integration complete**: provider-grouped model picker, provider indicators in status bar, session creation with explicit provider
+- **Error mapping improved**: Both bridges now emit Anthropic-style JSON error envelopes
+- **Token usage accounting wired**: Both bridges now report token counts (with fallbacks where real counts unavailable)
+- **tool_choice pass-through**: Both bridges log warnings when `tool_choice` is provided but not honored
+- **Multiple tool results**: Codex bridge now handles all tool results in a continuation, not just the first
+
+### Remaining Gaps
+
+- Vision input (multimodal)
+- Extended thinking
+- `stream: false` response mode (Codex bridge)
+- `tool_choice` enforcement (both bridges)
+- Full structured conversation semantics (Codex bridge)
+- `stop_sequences` support
+
+---
+
+## anthropic-copilot Provider
+
+### Closures
+
+| Gap | Status | Evidence |
+|-----|--------|----------|
+| Error mapping | ✅ Closed | PR #384: HTTP errors now use shared `createAnthropicErrorBody()` with correct type mapping (413 → `request_too_large`, 404 → `not_found_error`, etc.); `sendFailed()` emits proper Anthropic `error` SSE events |
+| Token usage | ✅ Closed | PR #385: `estimateTokens(charCount)` helper added; `message_start` emits non-zero `input_tokens`; `sendEpilogue()` emits accumulated `output_tokens` |
+| Type safety | ✅ Closed | PR #373: Provider type widened to union of 5 providers; PR #377: Unsafe casts replaced with `as Provider` |
+| UI integration | ✅ Closed | PR #391: Brand-accurate colored provider indicator in status bar; PR #398: Provider-grouped model picker; PR #401: Provider-aware session creation |
+| Routing | ✅ Closed | PR #376: `detectProviderForModel(modelId, providerId)` requires explicit providerId; PR #388: Strict provider-aware model resolution |
+| `tool_choice` | ⚠️ Partial | PR #386: Logs warning when provided but not honored; SDK limitation prevents full support |
+| Vision | ❌ Open | SDK does not support vision input |
+| Extended thinking | ❌ Open | SDK does not support extended thinking |
+
+### Test Evidence
+
+**Unit Tests:**
+- `packages/daemon/tests/unit/providers/anthropic-copilot/` — 185+ tests covering SSE flow, tool_use/tool_result round-trip, parallel tool calls, continuation routing, error handling, auth/env wiring
+- `packages/daemon/tests/unit/providers/provider-registry.test.ts` — Tests all 5 providers registered by `initializeProviders`
+- `packages/daemon/tests/unit/model-service-provider-routing.test.ts` — Tests `getModelInfo`, `resolveModelAlias`, `isValidModel` with explicit providerId
+
+**Online Tests:**
+- `providers-anthropic-copilot` shard in CI matrix
+
+**E2E Tests:**
+- `packages/e2e/tests/features/provider-model-switching.e2e.ts` — Cross-provider model switching tests
+
+---
+
+## anthropic-codex Provider
+
+### Closures
+
+| Gap | Status | Evidence |
+|-----|--------|----------|
+| Multiple tool results | ✅ Closed | PR #378: Codex bridge iterates all `toolResults`, resolves each by `tool_use_id`; orphaned IDs emit warning instead of silent drop |
+| Error envelopes | ✅ Closed | PR #380: All HTTP errors return Anthropic JSON envelopes (`{"type":"error","error":{...}}`); streaming errors emit Anthropic `error` SSE events |
+| Token usage | ✅ Closed | PR #383: Three-tier fallback: (1) actual counts from `thread/tokenUsage/updated`, (2) legacy inline usage, (3) char-length heuristic |
+| Type safety | ✅ Closed | PR #373: Provider type widened; PR #377: Unsafe casts replaced |
+| UI integration | ✅ Closed | PR #391: White provider indicator in status bar; PR #398: Provider-grouped picker; PR #401: Provider-aware session creation |
+| Routing | ✅ Closed | PR #376: Collision-safe explicit provider routing; PR #388: Strict provider-aware model resolution |
+| `stream: false` | ❌ Open | Server always returns SSE; no non-stream path |
+| Vision | ❌ Open | Backend does not support multimodal input |
+| Extended thinking | ❌ Open | Backend does not support extended thinking |
+| `tool_choice` | ❌ Open | Not implemented; logs warning (PR #386) |
+| Full conversation semantics | ❌ Open | Messages flattened to text, not structured blocks |
+| `stop_sequences` | ❌ Open | Not supported |
+
+### Test Evidence
+
+**Unit Tests:**
+- `packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts` — Bridge initialization, auth, model handling
+- `packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts` — SSE streaming, error handling, tool-use flow
+- `packages/daemon/tests/unit/providers/codex-anthropic-bridge/process-manager.test.ts` — Session suspension/resumption, token usage handling
+- `packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts` — Request translation, multiple tool results handling
+
+**Online Tests:**
+- `providers-anthropic-to-codex-bridge` shard in CI matrix
+
+**E2E Tests:**
+- `packages/e2e/tests/features/provider-model-switching.e2e.ts` — Cross-provider model switching tests
+
+---
+
+## Shared Improvements
+
+### Type System Widening
+
+**PR #373** — Provider type widened from 3 to 5 providers:
+```typescript
+// Before
+type Provider = 'anthropic' | 'glm' | 'minimax';
+
+// After
+type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex';
+```
+
+**PR #377** — Unsafe casts removed:
+- `model-switch-handler.ts`: 4 unsafe casts replaced with `as Provider`
+- `session-lifecycle.ts`: `as any` and manual string unions replaced with `as Provider`
+
+### Collision-Safe Routing
+
+**PR #376** — Deterministic provider resolution:
+- `detectProviderForModel(modelId, providerId)` requires explicit providerId via `registry.get()`
+- `detectProvider` marked `@deprecated`
+- All call sites updated to pass explicit providerId
+
+**PR #388** — Strict model resolution:
+- `getModelInfo`, `resolveModelAlias`, `isValidModel` all require `providerId`
+- Cache keyed by `provider:id` to prevent collision
+- `session.model.switch` rejects requests missing provider
+
+### Provider-Grouped Model Picker
+
+**PR #398** — UI improvements:
+- `groupModelsByProvider()` helper groups models by provider first, then family
+- Model dropdown renders provider group headers with availability dots
+- Green/gray dots indicate provider availability (fetched via `auth.providers` RPC)
+
+### Provider Indicators
+
+**PR #391** — Visual provider identification:
+- Brand-accurate colored dots: Anthropic (#D97757), Copilot (#8957E5), Codex (#FFFFFF), GLM (#7DD3FC), MiniMax (#FCA5A5)
+- Accessible: `role="img"` + `aria-label`
+- Mobile-friendly: dot only, no text
+
+### Auth UX
+
+**Task 6.1** — Auth status indicator in chat UI:
+- Authentication state visible in UI
+- Unauthenticated state handling
+- Actionable error messages
+
+### Graceful Degradation
+
+**Task 6.2** — Provider unavailability handling:
+- Provider availability checked on mount
+- Graceful fallback when provider unavailable
+- User-friendly error messaging
+
+---
+
+## Remaining Work
+
+### High Priority
+
+| Gap | Provider | Reason | Notes |
+|-----|----------|--------|-------|
+| `stream: false` | Codex | Blocking | Current implementation always returns SSE; needs non-stream response path |
+| `tool_choice` enforcement | Both | Feature gap | SDK/backend limitations; warning logging in place (PR #386) |
+
+### Medium Priority
+
+| Gap | Provider | Reason | Notes |
+|-----|----------|--------|-------|
+| Full conversation semantics | Codex | Accuracy | Text flattening loses structure; complex to implement |
+| `stop_sequences` | Codex | Feature gap | Not supported by Codex backend |
+
+### Low Priority (SDK/Backend Limitations)
+
+| Gap | Provider | Notes |
+|-----|----------|-------|
+| Vision input | Both | SDK/backend does not support multimodal |
+| Extended thinking | Both | SDK/backend does not support extended thinking |
+
+---
+
+## Test Evidence Summary
+
+### Unit Tests (Passed)
+
+| Test Suite | File(s) | Coverage |
+|------------|---------|----------|
+| Provider Registry | `provider-registry.test.ts` | All 5 providers registered, collision-safe detection |
+| Model Service Routing | `model-service-provider-routing.test.ts` | Disambiguation, alias resolution, validation |
+| Context Manager | `context-manager.test.ts` | Explicit provider threading, env vars |
+| Copilot Bridge | `anthropic-copilot/*` | SSE, tool_use, token usage, errors |
+| Codex Bridge | `codex-anthropic-bridge/*` | SSE, multiple tool results, token usage, errors |
+
+### Online Tests
+
+- `providers-anthropic-copilot` — Matrix shard for Copilot bridge
+- `providers-anthropic-to-codex-bridge` — Matrix shard for Codex bridge
+
+### E2E Tests
+
+- `provider-model-switching.e2e.ts` — 8 tests covering model picker UI and cross-provider switching
+
+---
+
+## Conclusion
+
+Both `anthropic-copilot` and `anthropic-codex` providers are now fully integrated into NeoKai with:
+
+1. **Core workflow parity** — Streaming, tool-use, and session management work correctly
+2. **Type safety** — Explicit provider IDs throughout the stack prevent ambiguity
+3. **UI integration** — Provider-grouped picker, indicators, and session flows
+4. **Error handling** — Anthropic-style error envelopes on both bridges
+5. **Token accounting** — Working token counting with fallback heuristics
+
+The remaining gaps are either:
+- SDK/backend limitations that cannot be addressed in NeoKai (vision, extended thinking)
+- Advanced features not required for current workflows (`stream: false`, `tool_choice` enforcement, `stop_sequences`)
+
+Both providers are **production-ready for NeoKai's current use cases**.

--- a/docs/reports/provider-parity-final-report.md
+++ b/docs/reports/provider-parity-final-report.md
@@ -47,7 +47,7 @@ This report documents the completion of the provider parity initiative for NeoKa
 | Type safety | ✅ Closed | PR #373: Provider type widened to union of 5 providers; PR #377: Unsafe casts replaced with `as Provider` |
 | UI integration | ✅ Closed | PR #391: Brand-accurate colored provider indicator in status bar; PR #398: Provider-grouped model picker; PR #401: Provider-aware session creation |
 | Routing | ✅ Closed | PR #376: `detectProviderForModel(modelId, providerId)` requires explicit providerId; PR #388: Strict provider-aware model resolution |
-| `tool_choice` | ⚠️ Partial | PR #386: Logs warning when provided but not honored; SDK limitation prevents full support |
+| `tool_choice` | ⚠️ Partial | PR #386: Logs warning when provided but not honored; same behavior as Codex bridge |
 | `stream: false` | ❌ Open | Server explicitly rejects with 400: "Only streaming responses are supported" |
 | Vision | ❌ Open | SDK does not support vision input |
 | Extended thinking | ❌ Open | SDK does not support extended thinking |
@@ -86,7 +86,7 @@ This report documents the completion of the provider parity initiative for NeoKa
 | `stream: false` | ❌ Open | Server always returns SSE; no non-stream path |
 | Vision | ❌ Open | Backend does not support multimodal input |
 | Extended thinking | ❌ Open | Backend does not support extended thinking |
-| `tool_choice` | ❌ Open | Not implemented; logs warning (PR #386) |
+| `tool_choice` | ⚠️ Partial | PR #386: Logs warning when provided but not honored; same behavior as Copilot bridge |
 | Full conversation semantics | ❌ Open | Messages flattened to text, not structured blocks |
 | `stop_sequences` | ❌ Open | Not supported |
 | Sampling controls | ❌ Open | `temperature`, `top_p`, `top_k` not supported |
@@ -123,7 +123,7 @@ type Provider = 'anthropic' | 'glm' | 'minimax';
 type Provider = 'anthropic' | 'glm' | 'minimax' | 'anthropic-copilot' | 'anthropic-codex';
 ```
 
-> **Note:** The primary provider interface type is `ProviderId = string` (defined in `packages/shared/src/provider/types.ts`). The `Provider` literal union above exists in `packages/shared/src/types.ts` and is used for type-narrowing in specific call sites. Runtime provider validation happens via the `ProviderRegistry` — the registry ensures deterministic resolution via explicit `providerId` lookup, not via the string literal union alone.
+> **Note:** The `Provider` union (in `packages/shared/src/types.ts`) is used at the session and RPC layer for type-narrowing. The multi-provider registry interfaces use `ProviderId = string` (defined in `packages/shared/src/provider/types.ts`). Runtime validation happens via the `ProviderRegistry` — it ensures deterministic resolution via explicit `providerId` lookup, not via the string literal union alone.
 
 **PR #377** — Unsafe casts removed:
 - `model-switch-handler.ts`: 4 unsafe casts replaced with `as Provider`


### PR DESCRIPTION
Summarizes the completion of anthropic-copilot and anthropic-codex
provider support implementation, documenting:
- Closures: error mapping, token usage, type safety, UI integration, routing
- Remaining gaps: vision, extended thinking, stream: false, tool_choice
- Test evidence for each closure
- Shared improvements: type system, collision-safe routing, model picker

Supersedes the three original parity reports.
