### PR TITLE
docs: add provider setup documentation for anthropic-copilot and anthropic-codex

### DIFF
--- a/docs/providers/anthropic-codex-setup.md
+++ b/docs/providers/anthropic-codex-setup.md
@@ -106,14 +106,14 @@ Choose one of the authentication methods above:
 #### Option A: Using OPENAI_API_KEY
 
 ```bash
-# Add to ~/.env or export in shell
+# Add to .env or export in shell
 OPENAI_API_KEY=sk-your-openai-key
 ```
 
 #### Option B: Using CODEX_API_KEY
 
 ```bash
-# Add to ~/.env or export in shell
+# Add to .env or export in shell
 CODEX_API_KEY=your-codex-key
 ```
 

--- a/docs/providers/anthropic-codex-setup.md
+++ b/docs/providers/anthropic-codex-setup.md
@@ -184,7 +184,6 @@ If installed but not found, add the Codex installation directory to your PATH.
 2. Ensure there are no extra spaces or quotes in your environment variable
 3. Check that you're using a valid API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 4. For Codex-specific keys, use `CODEX_API_KEY` instead
-5. Alternatively, try running `kai openai login` to authenticate via CLI
 
 ---
 

--- a/docs/providers/anthropic-codex-setup.md
+++ b/docs/providers/anthropic-codex-setup.md
@@ -159,7 +159,6 @@ If installed but not found, add the Codex installation directory to your PATH.
 **Solution:**
 1. Re-authenticate through NeoKai's authentication flow
 2. For ChatGPT Plus/Pro: Log out and log back in through Settings → Authentication
-3. Alternatively, use `kai openai login` CLI command if available
 
 ### Workspace Isolation
 

--- a/docs/providers/anthropic-codex-setup.md
+++ b/docs/providers/anthropic-codex-setup.md
@@ -4,7 +4,7 @@ This document covers how to configure the `anthropic-codex` provider in NeoKai, 
 
 ## Overview
 
-The `anthropic-codex` provider exposes OpenAI Codex as an Anthropic-compatible API endpoint. This allows NeoKai to use Codex models (like `claude-3-5-sonnet-20241022`, etc.) through the standard Anthropic API interface.
+The `anthropic-codex` provider exposes OpenAI Codex as an Anthropic-compatible API endpoint. This allows NeoKai to use Codex models (like `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.1-codex-mini`) through the standard Anthropic API interface.
 
 ### What It Does
 
@@ -32,7 +32,7 @@ The Codex provider requires the `codex` CLI to be installed and available on you
 
 **Installation:**
 
-1. Download Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+1. Download and install the Codex CLI from the official source (typically via npm or the OpenAI developer portal)
 2. Follow the installation instructions for your platform
 3. Verify installation:
 
@@ -46,12 +46,12 @@ If `codex` is not found on PATH, NeoKai will display an error: "codex binary not
 
 ## Authentication Methods
 
-The provider discovers Codex/OpenAI credentials in the following order:
+The provider discovers Codex/OpenAI credentials in the following priority order:
 
-1. **`OPENAI_API_KEY`** — Environment variable
-2. **`CODEX_API_KEY`** — Environment variable (Codex-specific)
-3. **NeoKai OAuth** — Login via Claude Code (ChatGPT Plus/Pro)
-4. **Legacy migration** — Tokens from `~/.codex/auth.json` (users who previously ran `codex login`)
+1. **`OPENAI_API_KEY`** — Environment variable (checked first)
+2. **`CODEX_API_KEY`** — Environment variable (checked second)
+3. **`~/.neokai/auth.json`** — Stored credentials from a previously completed NeoKai OAuth flow
+4. **Legacy migration** — One-time import from `~/.codex/auth.json` (users who previously ran `codex login`)
 
 ### Option 1: OPENAI_API_KEY
 
@@ -74,8 +74,12 @@ export CODEX_API_KEY=codex-your-key-here
 ### Option 3: NeoKai OAuth (ChatGPT Plus/Pro)
 
 If you have a ChatGPT Plus or Pro subscription:
-1. Log in through NeoKai's authentication flow
-2. Your ChatGPT subscription credentials are used automatically
+
+1. Open NeoKai in your browser
+2. Navigate to Settings → Authentication
+3. Log in with your ChatGPT account (Plus or Pro required)
+
+The OAuth flow uses a PKCE + redirect flow with a callback server on port 1455. Ensure this port is available before initiating the flow.
 
 ### Option 4: Legacy codex login Migration
 
@@ -89,9 +93,8 @@ Users who previously ran `codex login` have their credentials stored in `~/.code
 
 ### Step 1: Install Codex CLI
 
-Download and install the Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+Download and install the Codex CLI from the official source, then verify:
 
-Verify installation:
 ```bash
 codex --version
 ```
@@ -137,7 +140,7 @@ Start NeoKai and check the provider status in the UI. You should see Codex model
 **Cause:** The `codex` CLI is not installed or not available on your system PATH.
 
 **Solution:**
-1. Download Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+1. Download and install the Codex CLI from the official source
 2. Follow the installation instructions for your platform
 3. Ensure the `codex` command is available in your terminal:
 
@@ -156,6 +159,7 @@ If installed but not found, add the Codex installation directory to your PATH.
 **Solution:**
 1. Re-authenticate through NeoKai's authentication flow
 2. For ChatGPT Plus/Pro: Log out and log back in through Settings → Authentication
+3. Alternatively, use `kai openai login` CLI command if available
 
 ### Workspace Isolation
 
@@ -180,6 +184,7 @@ If installed but not found, add the Codex installation directory to your PATH.
 2. Ensure there are no extra spaces or quotes in your environment variable
 3. Check that you're using a valid API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 4. For Codex-specific keys, use `CODEX_API_KEY` instead
+5. Alternatively, try running `kai openai login` to authenticate via CLI
 
 ---
 
@@ -201,12 +206,8 @@ Token usage (`input_tokens`, `output_tokens`) is estimated based on character co
 
 The Codex bridge flattens the full block-structured Anthropic conversation to plain text rather than preserving the structured message format. This means:
 - Multi-message conversations are converted to a single text prompt
-- Role information is preserved through prefixes (e.g., "Human:", "Assistant:")
+- Role information is preserved through prefixes (e.g., "User:", "Assistant:")
 - Some semantic nuances of structured messages may be lost
-
-### Single-Tool-Result Limitation
-
-When providing multiple tool results in a single continuation request, the Codex bridge currently uses only the first tool result (`toolResults[0]`). Additional tool results in the same response are not processed.
 
 ### tool_choice Not Supported
 
@@ -220,6 +221,6 @@ The following Anthropic API parameters are not forwarded to Codex:
 - `metadata`
 - Advanced sampling controls
 
-### Non-Streaming Not Supported
+### Streaming-Only Response
 
-The bridge requires `stream=true`. Requests with `stream=false` will receive a 400 error, though the response will still be delivered as SSE.
+The Codex bridge always responds with SSE (Server-Sent Events), regardless of the `stream` parameter. While it accepts `stream=false` for API compatibility, the response will still be delivered as SSE.

--- a/docs/providers/anthropic-codex-setup.md
+++ b/docs/providers/anthropic-codex-setup.md
@@ -1,0 +1,225 @@
+# Anthropic-Codex Provider Setup
+
+This document covers how to configure the `anthropic-codex` provider in NeoKai, which bridges to OpenAI Codex as an Anthropic-compatible API.
+
+## Overview
+
+The `anthropic-codex` provider exposes OpenAI Codex as an Anthropic-compatible API endpoint. This allows NeoKai to use Codex models (like `claude-3-5-sonnet-20241022`, etc.) through the standard Anthropic API interface.
+
+### What It Does
+
+- Exposes Codex models via an Anthropic-shaped `/v1/messages` endpoint
+- Bridges tool-use/tool-result calls to Codex's native tool system
+- Supports streaming responses via Server-Sent Events (SSE)
+- Uses the Codex CLI (`codex`) as the underlying runtime
+
+### Provider Capability Flags
+
+| Capability | `anthropic` | `anthropic-codex` |
+|------------|-------------|-------------------|
+| Streaming | ✅ | ✅ |
+| Function Calling | ✅ | ✅ |
+| Vision | ✅ | ❌ |
+| Extended Thinking | ✅ | ❌ |
+
+---
+
+## Prerequisites
+
+### Codex CLI Must Be on PATH
+
+The Codex provider requires the `codex` CLI to be installed and available on your system PATH.
+
+**Installation:**
+
+1. Download Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+2. Follow the installation instructions for your platform
+3. Verify installation:
+
+```bash
+codex --version
+```
+
+If `codex` is not found on PATH, NeoKai will display an error: "codex binary not found on PATH. Install Codex CLI to use this provider."
+
+---
+
+## Authentication Methods
+
+The provider discovers Codex/OpenAI credentials in the following order:
+
+1. **`OPENAI_API_KEY`** — Environment variable
+2. **`CODEX_API_KEY`** — Environment variable (Codex-specific)
+3. **NeoKai OAuth** — Login via Claude Code (ChatGPT Plus/Pro)
+4. **Legacy migration** — Tokens from `~/.codex/auth.json` (users who previously ran `codex login`)
+
+### Option 1: OPENAI_API_KEY
+
+Set your OpenAI API key directly:
+
+```bash
+# In your shell or .env file
+export OPENAI_API_KEY=sk-your-key-here
+```
+
+### Option 2: CODEX_API_KEY
+
+Use the Codex-specific API key:
+
+```bash
+# In your shell or .env file
+export CODEX_API_KEY=codex-your-key-here
+```
+
+### Option 3: NeoKai OAuth (ChatGPT Plus/Pro)
+
+If you have a ChatGPT Plus or Pro subscription:
+1. Log in through NeoKai's authentication flow
+2. Your ChatGPT subscription credentials are used automatically
+
+### Option 4: Legacy codex login Migration
+
+Users who previously ran `codex login` have their credentials stored in `~/.codex/auth.json`. NeoKai automatically imports these credentials once into `~/.neokai/auth.json` for first-time use.
+
+> **Note:** For new users, we recommend using `OPENAI_API_KEY` or `CODEX_API_KEY` directly rather than the legacy migration path.
+
+---
+
+## Step-by-Step Setup
+
+### Step 1: Install Codex CLI
+
+Download and install the Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+
+Verify installation:
+```bash
+codex --version
+```
+
+### Step 2: Configure Authentication
+
+Choose one of the authentication methods above:
+
+#### Option A: Using OPENAI_API_KEY
+
+```bash
+# Add to ~/.env or export in shell
+OPENAI_API_KEY=sk-your-openai-key
+```
+
+#### Option B: Using CODEX_API_KEY
+
+```bash
+# Add to ~/.env or export in shell
+CODEX_API_KEY=your-codex-key
+```
+
+#### Option C: Using NeoKai OAuth
+
+1. Open NeoKai in your browser
+2. Navigate to Settings → Authentication
+3. Log in with your ChatGPT account (Plus or Pro required)
+
+### Step 3: Verify Configuration
+
+Start NeoKai and check the provider status in the UI. You should see Codex models available when:
+- The provider indicator shows green (authenticated)
+- Codex models appear in the model picker
+
+---
+
+## Troubleshooting
+
+### Codex Binary Not Found
+
+**Symptom:** Error message: "codex binary not found on PATH. Install Codex CLI to use this provider."
+
+**Cause:** The `codex` CLI is not installed or not available on your system PATH.
+
+**Solution:**
+1. Download Codex CLI from [https://openai.com/codex](https://openai.com/codex)
+2. Follow the installation instructions for your platform
+3. Ensure the `codex` command is available in your terminal:
+
+```bash
+codex --version
+```
+
+If installed but not found, add the Codex installation directory to your PATH.
+
+### OAuth Token Refresh
+
+**Symptom:** Authentication was working but now fails with "Invalid credentials" or "Token expired"
+
+**Cause:** OAuth tokens (from NeoKai OAuth or ChatGPT login) may expire over time.
+
+**Solution:**
+1. Re-authenticate through NeoKai's authentication flow
+2. For ChatGPT Plus/Pro: Log out and log back in through Settings → Authentication
+
+### Workspace Isolation
+
+**Symptom:** Codex fails with permission errors or cannot access files
+
+**Cause:** Codex requires access to the workspace directory for file operations.
+
+**Solution:**
+1. Ensure you're running NeoKai from a directory where Codex has read/write permissions
+2. Check that the workspace path doesn't contain special characters or symlinks that may confuse Codex
+3. For enterprise deployments, ensure Codex is configured with appropriate workspace access
+
+### API Key Not Recognized
+
+**Symptom:** "Invalid API key" error despite setting OPENAI_API_KEY
+
+**Solution:**
+1. Verify the key is set correctly:
+   ```bash
+   echo $OPENAI_API_KEY
+   ```
+2. Ensure there are no extra spaces or quotes in your environment variable
+3. Check that you're using a valid API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+4. For Codex-specific keys, use `CODEX_API_KEY` instead
+
+---
+
+## Known Limitations
+
+### No Vision Support
+
+The Codex bridge does **not** support image input or multimodal content. Attempting to send images will result in an error.
+
+### No Extended Thinking
+
+Extended thinking (thinking blocks in API responses) is not supported by Codex and therefore not available through this bridge.
+
+### Heuristic Token Counting
+
+Token usage (`input_tokens`, `output_tokens`) is estimated based on character count (1 token ≈ 4 characters) by default, unless actual usage data is wired through from the Codex CLI's `thread/tokenUsage/updated` notifications.
+
+### Text-Flattened Conversation Semantics
+
+The Codex bridge flattens the full block-structured Anthropic conversation to plain text rather than preserving the structured message format. This means:
+- Multi-message conversations are converted to a single text prompt
+- Role information is preserved through prefixes (e.g., "Human:", "Assistant:")
+- Some semantic nuances of structured messages may be lost
+
+### Single-Tool-Result Limitation
+
+When providing multiple tool results in a single continuation request, the Codex bridge currently uses only the first tool result (`toolResults[0]`). Additional tool results in the same response are not processed.
+
+### tool_choice Not Supported
+
+The `tool_choice` parameter is accepted for API compatibility but is **not honored** by the Codex bridge. The model will decide which tool to use regardless of the parameter value.
+
+### Request Parameter Restrictions
+
+The following Anthropic API parameters are not forwarded to Codex:
+- `temperature`, `top_p`, `top_k`
+- `stop_sequences`
+- `metadata`
+- Advanced sampling controls
+
+### Non-Streaming Not Supported
+
+The bridge requires `stream=true`. Requests with `stream=false` will receive a 400 error, though the response will still be delivered as SSE.

--- a/docs/providers/anthropic-copilot-setup.md
+++ b/docs/providers/anthropic-copilot-setup.md
@@ -179,6 +179,13 @@ Extended thinking (thinking blocks in API responses) is not supported by Copilot
 
 Token usage (`input_tokens`, `output_tokens`) is estimated based on character count (1 token ≈ 4 characters) rather than actual counts from Copilot. This is due to SDK limitations.
 
+### Text-Flattened Conversation Semantics
+
+The Copilot bridge flattens the full block-structured Anthropic conversation to plain text rather than preserving the structured message format. This means:
+- Multi-message conversations are converted to a single text prompt
+- Role information is preserved through bracketed prefixes (e.g., `[User]:`, `[Assistant]:`)
+- Some semantic nuances of structured messages may be lost
+
 ### tool_choice Limitations
 
 The `tool_choice` parameter is accepted for API compatibility but is **not honored** by the Copilot bridge. The model will decide which tool to use regardless of the parameter value.

--- a/docs/providers/anthropic-copilot-setup.md
+++ b/docs/providers/anthropic-copilot-setup.md
@@ -43,7 +43,10 @@ NeoKai includes a built-in GitHub OAuth device flow specifically for Copilot aut
 1. Open NeoKai in your browser
 2. Navigate to Settings → Authentication (or provider settings)
 3. Look for "Connect GitHub" or similar option to initiate the OAuth flow
-4. Complete the GitHub authorization in your browser
+4. You'll receive a **device code** (e.g., `ABCD-1234`) displayed in NeoKai
+5. Visit the verification URL (typically `github.com/login/device`) and enter the device code
+6. Complete the GitHub authorization in your browser
+7. Return to NeoKai — the connection should complete automatically
 
 The OAuth token is stored in `~/.neokai/auth.json` and automatically used on subsequent sessions.
 

--- a/docs/providers/anthropic-copilot-setup.md
+++ b/docs/providers/anthropic-copilot-setup.md
@@ -1,0 +1,188 @@
+# Anthropic-Copilot Provider Setup
+
+This document covers how to configure the `anthropic-copilot` provider in NeoKai, which bridges to GitHub Copilot as an Anthropic-compatible API.
+
+## Overview
+
+The `anthropic-copilot` provider exposes GitHub Copilot as an Anthropic-compatible API endpoint. This allows NeoKai to use Copilot models (like `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, etc.) through the standard Anthropic API interface.
+
+### What It Does
+
+- Exposes Copilot models via an Anthropic-shaped `/v1/messages` endpoint
+- Bridges tool-use/tool-result calls to Copilot's native tool system
+- Supports streaming responses via Server-Sent Events (SSE)
+
+### Provider Capability Flags
+
+| Capability | `anthropic` | `anthropic-copilot` |
+|------------|-------------|---------------------|
+| Streaming | ✅ | ✅ |
+| Function Calling | ✅ | ✅ |
+| Vision | ✅ | ❌ |
+| Extended Thinking | ✅ | ❌ |
+
+---
+
+## Authentication Methods
+
+The provider discovers GitHub credentials in the following order:
+
+1. **NeoKai OAuth** — If you've logged in via Claude Code OAuth (handled automatically)
+2. **`COPILOT_GITHUB_TOKEN`** — Environment variable with a PAT (Personal Access Token)
+3. **`GH_TOKEN`** — Environment variable (fallback)
+4. **`gh auth token`** — CLI command output
+5. **`~/.config/gh/hosts.yml`** — OAuth token from GitHub CLI configuration
+
+> **Important:** The `GITHUB_TOKEN` environment variable (used by GitHub Actions) is **NOT** used — it lacks the required `copilot_requests` scope.
+
+### Option 1: NeoKai OAuth (Recommended for Claude Code Users)
+
+If you're already logged into Claude Code, NeoKai automatically uses your Claude Code OAuth token for Copilot. No additional configuration needed.
+
+### Option 2: COPILOT_GITHUB_TOKEN Environment Variable
+
+Set a Personal Access Token (PAT) with the `copilot_requests` scope:
+
+```bash
+# In your shell or .env file
+export COPILOT_GITHUB_TOKEN=ghp_your_token_here
+```
+
+To create a PAT:
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+2. Generate new token with:
+   - Repository access: All repositories
+   - Permissions: Copilot (Access: read/write)
+
+### Option 3: GH_TOKEN Environment Variable
+
+If you have a GitHub token already set in your environment:
+
+```bash
+export GH_TOKEN=ghp_your_token_here
+```
+
+### Option 4: gh auth login
+
+If you have the GitHub CLI installed and authenticated:
+
+```bash
+gh auth login
+```
+
+The provider will use `gh auth token` to retrieve your authentication token.
+
+### Option 5: ~/.config/gh/hosts.yml
+
+If you've authenticated via GitHub CLI, your OAuth token is stored in `~/.config/gh/hosts.yml`. The provider automatically reads the `oauth_token` from this file.
+
+---
+
+## Step-by-Step Setup
+
+### Step 1: Choose Your Authentication Method
+
+For most users, **Option 1 (NeoKai OAuth)** works automatically if you're logged into Claude Code.
+
+If you need to configure manually:
+
+### Option A: Using a PAT
+
+1. Create a Personal Access Token with `copilot_requests` scope (see Option 2 above)
+2. Add to your environment:
+
+```bash
+# Add to ~/.env or export in shell
+COPILOT_GITHUB_TOKEN=ghp_your_token_here
+```
+
+### Option B: Using GitHub CLI
+
+1. Install GitHub CLI if not installed: `brew install gh`
+2. Authenticate: `gh auth login`
+3. Ensure Copilot is enabled in your GitHub account settings
+
+### Step 2: Verify Configuration
+
+Start NeoKai and check the provider status in the UI. You should see Copilot models available when:
+- The provider indicator shows green (authenticated)
+- Copilot models appear in the model picker
+
+---
+
+## Troubleshooting
+
+### Classic PAT Rejection
+
+**Symptom:** Authentication fails with error: "Invalid authentication credentials"
+
+**Cause:** Your PAT may lack the required `copilot_requests` scope, or the token has expired.
+
+**Solution:**
+1. Go to GitHub Settings → Developer settings → Personal access tokens
+2. Ensure your token has the `copilot_requests` scope enabled
+3. Regenerate the token if expired
+4. Update `COPILOT_GITHUB_TOKEN` with the new token
+
+### Token Validation Failures
+
+**Symptom:** "Token validation failed" or similar authentication error
+
+**Cause:** Tokens obtained via `gh auth token` or `~/.config/gh/hosts.yml` are OAuth tokens that must be exchanged for a Copilot session token.
+
+**Solution:**
+- The provider automatically performs this exchange for tokens from sources 4 and 5
+- If you're using a PAT directly (source 2), ensure it has the correct scope
+- For enterprise GitHub accounts, ensure Copilot is enabled in your organization
+
+### Enterprise GitHub
+
+**Symptom:** Authentication works but returns no models or "Copilot not enabled"
+
+**Cause:** Your GitHub Enterprise organization may have Copilot disabled or require additional permissions.
+
+**Solution:**
+1. Contact your organization admin to enable Copilot
+2. Ensure you have Copilot access granted in your organization settings
+3. For enterprise-managed users, you may need to use a PAT with organization-specific scopes
+
+### Linux Specific: Node.js Version
+
+**Symptom:** Provider fails to start on Linux with "node:sqlite" module error
+
+**Cause:** The Copilot CLI subprocess requires Node.js >= 22.5.0 with `node:sqlite` support.
+
+**Solution:**
+- On Linux, ensure Node.js 22 LTS or Node.js 24 is installed and available on PATH
+- On macOS, this is handled automatically by Bun
+
+---
+
+## Known Limitations
+
+### No Vision Support
+
+The Copilot bridge does **not** support image input or multimodal content. Attempting to send images will result in an error.
+
+### No Extended Thinking
+
+Extended thinking (thinking blocks in API responses) is not supported by Copilot and therefore not available through this bridge.
+
+### Heuristic Token Counting
+
+Token usage (`input_tokens`, `output_tokens`) is estimated based on character count (1 token ≈ 4 characters) rather than actual counts from Copilot. This is due to SDK limitations.
+
+### tool_choice Limitations
+
+The `tool_choice` parameter is accepted for API compatibility but is **not honored** by the Copilot bridge. The model will decide which tool to use regardless of the parameter value.
+
+### Request Parameter Restrictions
+
+The following Anthropic API parameters are not forwarded to Copilot:
+- `temperature`, `top_p`, `top_k`
+- `stop_sequences`
+- Advanced sampling controls
+
+### Non-Streaming Not Supported
+
+The bridge requires `stream=true`. Requests with `stream=false` will receive a 400 error.

--- a/docs/providers/anthropic-copilot-setup.md
+++ b/docs/providers/anthropic-copilot-setup.md
@@ -4,7 +4,7 @@ This document covers how to configure the `anthropic-copilot` provider in NeoKai
 
 ## Overview
 
-The `anthropic-copilot` provider exposes GitHub Copilot as an Anthropic-compatible API endpoint. This allows NeoKai to use Copilot models (like `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, etc.) through the standard Anthropic API interface.
+The `anthropic-copilot` provider exposes GitHub Copilot as an Anthropic-compatible API endpoint. This allows NeoKai to use Copilot models (like `claude-opus-4.6`, `claude-sonnet-4.6`, `gpt-5.3-codex`, `gemini-3-pro-preview`, `gpt-5-mini`) through the standard Anthropic API interface.
 
 ### What It Does
 
@@ -27,39 +27,52 @@ The `anthropic-copilot` provider exposes GitHub Copilot as an Anthropic-compatib
 
 The provider discovers GitHub credentials in the following order:
 
-1. **NeoKai OAuth** — If you've logged in via Claude Code OAuth (handled automatically)
-2. **`COPILOT_GITHUB_TOKEN`** — Environment variable with a PAT (Personal Access Token)
+1. **`~/.neokai/auth.json`** — Stored credentials from a previously completed NeoKai GitHub OAuth device flow
+2. **`COPILOT_GITHUB_TOKEN`** — Environment variable with a fine-grained PAT
 3. **`GH_TOKEN`** — Environment variable (fallback)
 4. **`gh auth token`** — CLI command output
 5. **`~/.config/gh/hosts.yml`** — OAuth token from GitHub CLI configuration
 
-> **Important:** The `GITHUB_TOKEN` environment variable (used by GitHub Actions) is **NOT** used — it lacks the required `copilot_requests` scope.
+> **Important:** The `GITHUB_TOKEN` environment variable (used by GitHub Actions) is **NOT** used — it lacks the required `copilot_requests` scope. Classic PATs (tokens starting with `ghp_`) are **hard rejected** by the Copilot CLI.
 
-### Option 1: NeoKai OAuth (Recommended for Claude Code Users)
+### Option 1: NeoKai GitHub OAuth (Recommended)
 
-If you're already logged into Claude Code, NeoKai automatically uses your Claude Code OAuth token for Copilot. No additional configuration needed.
+NeoKai includes a built-in GitHub OAuth device flow specifically for Copilot authentication.
+
+**To trigger the OAuth flow:**
+1. Open NeoKai in your browser
+2. Navigate to Settings → Authentication (or provider settings)
+3. Look for "Connect GitHub" or similar option to initiate the OAuth flow
+4. Complete the GitHub authorization in your browser
+
+The OAuth token is stored in `~/.neokai/auth.json` and automatically used on subsequent sessions.
 
 ### Option 2: COPILOT_GITHUB_TOKEN Environment Variable
 
-Set a Personal Access Token (PAT) with the `copilot_requests` scope:
+> **Important:** You MUST use a **fine-grained PAT**, not a classic PAT. Classic PATs (starting with `ghp_`) are hard rejected by the GitHub Copilot CLI.
+
+Set a fine-grained Personal Access Token:
 
 ```bash
 # In your shell or .env file
-export COPILOT_GITHUB_TOKEN=ghp_your_token_here
+export COPILOT_GITHUB_TOKEN=github_pat_your_token_here
 ```
 
-To create a PAT:
+To create a fine-grained PAT:
 1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
 2. Generate new token with:
+   - Token name: NeoKai Copilot
    - Repository access: All repositories
    - Permissions: Copilot (Access: read/write)
 
+> **Note:** Classic PATs (starting with `ghp_`) are NOT supported and will be rejected with the error: "Classic PATs (ghp_...) are not supported by the GitHub Copilot CLI."
+
 ### Option 3: GH_TOKEN Environment Variable
 
-If you have a GitHub token already set in your environment:
+If you have a fine-grained GitHub token already set in your environment:
 
 ```bash
-export GH_TOKEN=ghp_your_token_here
+export GH_TOKEN=github_pat_your_token_here
 ```
 
 ### Option 4: gh auth login
@@ -70,7 +83,7 @@ If you have the GitHub CLI installed and authenticated:
 gh auth login
 ```
 
-The provider will use `gh auth token` to retrieve your authentication token.
+The provider will use `gh auth token` to retrieve your authentication token. This returns an OAuth token (not a classic PAT), which is supported.
 
 ### Option 5: ~/.config/gh/hosts.yml
 
@@ -82,25 +95,17 @@ If you've authenticated via GitHub CLI, your OAuth token is stored in `~/.config
 
 ### Step 1: Choose Your Authentication Method
 
-For most users, **Option 1 (NeoKai OAuth)** works automatically if you're logged into Claude Code.
+For most users, **Option 1 (NeoKai GitHub OAuth)** is recommended:
+1. Open NeoKai settings and initiate the GitHub OAuth flow
+2. Authorize NeoKai to access your GitHub account for Copilot
+3. Credentials are stored automatically
 
-If you need to configure manually:
-
-### Option A: Using a PAT
-
-1. Create a Personal Access Token with `copilot_requests` scope (see Option 2 above)
-2. Add to your environment:
-
-```bash
-# Add to ~/.env or export in shell
-COPILOT_GITHUB_TOKEN=ghp_your_token_here
-```
-
-### Option B: Using GitHub CLI
+### Alternative: Using GitHub CLI
 
 1. Install GitHub CLI if not installed: `brew install gh`
 2. Authenticate: `gh auth login`
 3. Ensure Copilot is enabled in your GitHub account settings
+4. The provider will automatically discover your token
 
 ### Step 2: Verify Configuration
 
@@ -114,15 +119,18 @@ Start NeoKai and check the provider status in the UI. You should see Copilot mod
 
 ### Classic PAT Rejection
 
-**Symptom:** Authentication fails with error: "Invalid authentication credentials"
+**Symptom:** Authentication fails with error: "Classic PATs (ghp_...) are not supported by the GitHub Copilot CLI."
 
-**Cause:** Your PAT may lack the required `copilot_requests` scope, or the token has expired.
+**Cause:** You're using a classic PAT (token starting with `ghp_`). Classic PATs are hard rejected by Copilot.
 
 **Solution:**
 1. Go to GitHub Settings → Developer settings → Personal access tokens
-2. Ensure your token has the `copilot_requests` scope enabled
-3. Regenerate the token if expired
-4. Update `COPILOT_GITHUB_TOKEN` with the new token
+2. Delete any classic PATs you may have created
+3. Create a **fine-grained token** instead:
+   - Token name: NeoKai Copilot
+   - Repository access: All repositories
+   - Permissions: Copilot (Access: read/write)
+4. Use the new fine-grained token (starts with `github_pat_`, not `ghp_`)
 
 ### Token Validation Failures
 
@@ -132,7 +140,6 @@ Start NeoKai and check the provider status in the UI. You should see Copilot mod
 
 **Solution:**
 - The provider automatically performs this exchange for tokens from sources 4 and 5
-- If you're using a PAT directly (source 2), ensure it has the correct scope
 - For enterprise GitHub accounts, ensure Copilot is enabled in your organization
 
 ### Enterprise GitHub
@@ -144,7 +151,7 @@ Start NeoKai and check the provider status in the UI. You should see Copilot mod
 **Solution:**
 1. Contact your organization admin to enable Copilot
 2. Ensure you have Copilot access granted in your organization settings
-3. For enterprise-managed users, you may need to use a PAT with organization-specific scopes
+3. For enterprise-managed users, you may need to use a fine-grained PAT with organization-specific scopes
 
 ### Linux Specific: Node.js Version
 


### PR DESCRIPTION
Add setup documentation for both providers covering:
- Overview of each provider and its capabilities
- Authentication methods (OAuth, API keys, CLI-based auth)
- Step-by-step setup instructions
- Troubleshooting for common issues
- Known limitations (vision, extended thinking, token counting, etc.)
