### PR TITLE
feat: add OpenAI token refresh/login in settings for Codex

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -646,41 +646,8 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		const credentials = await this.loadCredentials();
 		if (!credentials?.refresh) return false;
 
-		try {
-			const response = await fetch(OAUTH_CONFIG.tokenUrl, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					grant_type: 'refresh_token',
-					refresh_token: credentials.refresh,
-					client_id: OAUTH_CONFIG.clientId,
-				}),
-			});
-
-			if (!response.ok) {
-				logger.error('Token refresh failed:', response.statusText);
-				return false;
-			}
-
-			const tokens = (await response.json()) as OpenAIOAuthToken;
-			const newCreds: StoredCredentials = {
-				type: 'oauth',
-				access: tokens.access_token,
-				refresh: tokens.refresh_token || credentials.refresh,
-				expires: Date.now() + tokens.expires_in * 1000,
-				accountId: credentials.accountId ?? this.extractAccountId(tokens.access_token),
-				planType: credentials.planType ?? this.extractPlanType(tokens.access_token),
-			};
-
-			await this.saveCredentials(newCreds);
-			this.cachedCredentials = newCreds;
-			this.cachedBridgeAuth = this.toBridgeAuth(newCreds) ?? null;
-			this.cachedApiKey = newCreds.access; // sync so buildSdkConfig() picks up the new token
-			return true;
-		} catch (error) {
-			logger.error('Token refresh failed:', error);
-			return false;
-		}
+		const result = await this.refreshStoredOauthCredentials();
+		return result !== undefined;
 	}
 
 	async logout(): Promise<void> {

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -13,6 +13,8 @@ import type {
 	ProviderAuthResponse,
 	ProviderAuthRequest,
 	ProviderLogoutRequest,
+	ProviderRefreshRequest,
+	ProviderRefreshResponse,
 	ListProviderAuthStatusResponse,
 } from '@neokai/shared/provider';
 import type { AuthManager } from '../auth-manager';
@@ -156,6 +158,47 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 				return {
 					success: false,
 					error: error instanceof Error ? error.message : 'Logout failed',
+				};
+			}
+		}
+	);
+
+	// Refresh token for a provider
+	messageHub.onRequest(
+		'auth.refresh',
+		async (req: ProviderRefreshRequest): Promise<ProviderRefreshResponse> => {
+			const { providerId } = req;
+			const registry = getProviderRegistry();
+
+			const provider = registry.get(providerId);
+			if (!provider) {
+				return {
+					success: false,
+					error: `Provider not found: ${providerId}`,
+				};
+			}
+
+			if (!provider.refreshToken) {
+				return {
+					success: false,
+					error: `Provider ${providerId} does not support token refresh`,
+				};
+			}
+
+			try {
+				const refreshed = await provider.refreshToken();
+				if (!refreshed) {
+					return {
+						success: false,
+						error: 'Token refresh failed. Please try logging out and logging in again.',
+					};
+				}
+				return { success: true };
+			} catch (error) {
+				log.error(`Token refresh failed for ${providerId}:`, error);
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Token refresh failed',
 				};
 			}
 		}

--- a/packages/daemon/tests/unit/rpc-handlers/auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/auth-handlers.test.ts
@@ -328,4 +328,92 @@ describe('Auth RPC Handlers', () => {
 			expect(result.error).toBe('Logout failed');
 		});
 	});
+
+	describe('auth.refresh', () => {
+		it('returns error when provider not found', async () => {
+			const handler = messageHubData.handlers.get('auth.refresh');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ providerId: 'non-existent' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Provider not found');
+		});
+
+		it('returns error when provider does not support token refresh', async () => {
+			const mockProvider = createMockProvider({
+				refreshToken: undefined,
+			});
+			registry.register(mockProvider);
+
+			const handler = messageHubData.handlers.get('auth.refresh');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ providerId: 'test-provider' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('does not support token refresh');
+		});
+
+		it('returns success when token refresh succeeds', async () => {
+			const mockProvider = createMockProvider({
+				refreshToken: mock(async () => true),
+			});
+			registry.register(mockProvider);
+
+			const handler = messageHubData.handlers.get('auth.refresh');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ providerId: 'test-provider' }, {})) as {
+				success: boolean;
+			};
+
+			expect(result.success).toBe(true);
+			expect(mockProvider.refreshToken).toHaveBeenCalled();
+		});
+
+		it('returns error when token refresh fails', async () => {
+			const mockProvider = createMockProvider({
+				refreshToken: mock(async () => false),
+			});
+			registry.register(mockProvider);
+
+			const handler = messageHubData.handlers.get('auth.refresh');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ providerId: 'test-provider' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Please try logging out');
+		});
+
+		it('handles refresh token errors', async () => {
+			const mockProvider = createMockProvider({
+				refreshToken: mock(async () => {
+					throw new Error('Token refresh failed');
+				}),
+			});
+			registry.register(mockProvider);
+
+			const handler = messageHubData.handlers.get('auth.refresh');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ providerId: 'test-provider' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('Token refresh failed');
+		});
+	});
 });

--- a/packages/e2e/tests/settings/providers-settings.e2e.ts
+++ b/packages/e2e/tests/settings/providers-settings.e2e.ts
@@ -36,44 +36,43 @@ test.describe('Settings Modal - Providers Section', () => {
 		// Navigate to the Providers section
 		await page.locator('button:has-text("Providers")').click();
 
-		// Wait for providers to load
-		await page.waitForTimeout(1000);
-
-		// Verify the Providers section heading is visible
+		// Wait for providers section heading to be visible (proves section loaded)
 		await expect(page.locator('h3:has-text("Providers")')).toBeVisible();
 
 		// Verify the description text is visible
 		await expect(page.locator('text=Configure authentication for AI providers')).toBeVisible();
 
 		// Either shows a provider list or "No providers available"
-		const hasProviders = await page.locator('.space-y-3').count();
-		if (hasProviders > 0) {
-			// If providers exist, verify at least one provider card is rendered
-			const providerCards = page.locator('.space-y-3 > div');
-			const cardCount = await providerCards.count();
-			expect(cardCount).toBeGreaterThanOrEqual(0);
-		} else {
-			// Should show "No providers available" message
-			await expect(page.locator('text=No providers available')).toBeVisible();
-		}
+		// Check for provider cards - they should have a button inside
+		const providerCards = page.locator('.space-y-3 > div');
+		const hasProviderCards = (await providerCards.count()) > 0;
+		const hasNoProvidersMessage = (await page.locator('text=No providers available').count()) > 0;
+
+		// At least one of these states should be true
+		expect(hasProviderCards || hasNoProvidersMessage).toBe(true);
 	});
 
-	test('should show Login button for unauthenticated providers', async ({ page }) => {
+	test('should show action buttons for providers', async ({ page }) => {
 		await openSettingsModal(page);
 
 		// Navigate to the Providers section
 		await page.locator('button:has-text("Providers")').click();
 
-		// Wait for providers to load
-		await page.waitForTimeout(1000);
+		// Wait for providers section to load
+		await expect(page.locator('h3:has-text("Providers")')).toBeVisible();
 
-		// Check if there are any Login buttons (for unauthenticated providers)
-		// or Logout/Refresh Login buttons (for authenticated providers)
-		const hasLoginButton = await page.locator('button:has-text("Login")').count();
-		const hasLogoutButton = await page.locator('button:has-text("Logout")').count();
-		const hasRefreshButton = await page.locator('button:has-text("Refresh Login")').count();
+		// Count action buttons in the providers section
+		const loginButtons = await page.locator('button:has-text("Login")').count();
+		const logoutButtons = await page.locator('button:has-text("Logout")').count();
+		const refreshButtons = await page.locator('button:has-text("Refresh Login")').count();
+		const totalButtons = loginButtons + logoutButtons + refreshButtons;
 
-		// At least one type of button should be present if providers exist
-		expect(hasLoginButton + hasLogoutButton + hasRefreshButton).toBeGreaterThanOrEqual(0);
+		// Get the count of provider cards to verify alignment
+		const providerCards = await page.locator('.space-y-3 > div').count();
+
+		// If there are provider cards, there should be action buttons for them
+		if (providerCards > 0) {
+			expect(totalButtons).toBeGreaterThan(0);
+		}
 	});
 });

--- a/packages/e2e/tests/settings/providers-settings.e2e.ts
+++ b/packages/e2e/tests/settings/providers-settings.e2e.ts
@@ -61,18 +61,23 @@ test.describe('Settings Modal - Providers Section', () => {
 		// Wait for providers section to load
 		await expect(page.locator('h3:has-text("Providers")')).toBeVisible();
 
-		// Count action buttons in the providers section
-		const loginButtons = await page.locator('button:has-text("Login")').count();
-		const logoutButtons = await page.locator('button:has-text("Logout")').count();
-		const refreshButtons = await page.locator('button:has-text("Refresh Login")').count();
-		const totalButtons = loginButtons + logoutButtons + refreshButtons;
+		// Either shows provider cards with action buttons, or "No providers available"
+		const providerCards = page.locator('.space-y-3 > div');
+		const hasProviderCards = (await providerCards.count()) > 0;
+		const hasNoProvidersMessage = (await page.locator('text=No providers available').count()) > 0;
 
-		// Get the count of provider cards to verify alignment
-		const providerCards = await page.locator('.space-y-3 > div').count();
+		if (hasProviderCards) {
+			// Count action buttons in the providers section
+			const loginButtons = await page.locator('button:has-text("Login")').count();
+			const logoutButtons = await page.locator('button:has-text("Logout")').count();
+			const refreshButtons = await page.locator('button:has-text("Refresh Login")').count();
+			const totalButtons = loginButtons + logoutButtons + refreshButtons;
 
-		// If there are provider cards, there should be action buttons for them
-		if (providerCards > 0) {
+			// Provider cards should have action buttons
 			expect(totalButtons).toBeGreaterThan(0);
+		} else {
+			// No providers should show the empty message
+			expect(hasNoProvidersMessage).toBe(true);
 		}
 	});
 });

--- a/packages/e2e/tests/settings/providers-settings.e2e.ts
+++ b/packages/e2e/tests/settings/providers-settings.e2e.ts
@@ -1,0 +1,79 @@
+/**
+ * Providers Settings E2E Tests
+ *
+ * Tests for the Providers section in settings:
+ * - Navigate to Providers section
+ * - Verify Providers section loads
+ * - Verify provider list is displayed
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { openSettingsModal } from '../helpers/settings-modal-helpers';
+
+test.describe('Settings Modal - Providers Section', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+	});
+
+	test('should navigate to Providers section from settings', async ({ page }) => {
+		await openSettingsModal(page);
+
+		// Verify we're in the General section by default
+		await expect(page.locator('h3:has-text("General")')).toBeVisible();
+
+		// Navigate to the Providers section
+		await page.locator('button:has-text("Providers")').click();
+
+		// Verify Providers section is shown
+		await expect(page.locator('h3:has-text("Providers")')).toBeVisible();
+	});
+
+	test('should display Providers section with providers list or empty state', async ({ page }) => {
+		await openSettingsModal(page);
+
+		// Navigate to the Providers section
+		await page.locator('button:has-text("Providers")').click();
+
+		// Wait for providers to load
+		await page.waitForTimeout(1000);
+
+		// Verify the Providers section heading is visible
+		await expect(page.locator('h3:has-text("Providers")')).toBeVisible();
+
+		// Verify the description text is visible
+		await expect(page.locator('text=Configure authentication for AI providers')).toBeVisible();
+
+		// Either shows a provider list or "No providers available"
+		const hasProviders = await page.locator('.space-y-3').count();
+		if (hasProviders > 0) {
+			// If providers exist, verify at least one provider card is rendered
+			const providerCards = page.locator('.space-y-3 > div');
+			const cardCount = await providerCards.count();
+			expect(cardCount).toBeGreaterThanOrEqual(0);
+		} else {
+			// Should show "No providers available" message
+			await expect(page.locator('text=No providers available')).toBeVisible();
+		}
+	});
+
+	test('should show Login button for unauthenticated providers', async ({ page }) => {
+		await openSettingsModal(page);
+
+		// Navigate to the Providers section
+		await page.locator('button:has-text("Providers")').click();
+
+		// Wait for providers to load
+		await page.waitForTimeout(1000);
+
+		// Check if there are any Login buttons (for unauthenticated providers)
+		// or Logout/Refresh Login buttons (for authenticated providers)
+		const hasLoginButton = await page.locator('button:has-text("Login")').count();
+		const hasLogoutButton = await page.locator('button:has-text("Logout")').count();
+		const hasRefreshButton = await page.locator('button:has-text("Refresh Login")').count();
+
+		// At least one type of button should be present if providers exist
+		expect(hasLoginButton + hasLogoutButton + hasRefreshButton).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/packages/shared/src/provider/auth-types.ts
+++ b/packages/shared/src/provider/auth-types.ts
@@ -65,6 +65,24 @@ export interface ProviderLogoutRequest {
 }
 
 /**
+ * Request to refresh token for a provider
+ */
+export interface ProviderRefreshRequest {
+	/** Provider identifier */
+	providerId: string;
+}
+
+/**
+ * Response from refreshing provider token
+ */
+export interface ProviderRefreshResponse {
+	/** Whether the refresh was successful */
+	success: boolean;
+	/** Error message if failed */
+	error?: string;
+}
+
+/**
  * Response from listing provider auth statuses
  */
 export interface ListProviderAuthStatusResponse {

--- a/packages/shared/src/provider/index.ts
+++ b/packages/shared/src/provider/index.ts
@@ -20,6 +20,8 @@ export type {
 	ProviderAuthRequest,
 	ProviderAuthResponse,
 	ProviderLogoutRequest,
+	ProviderRefreshRequest,
+	ProviderRefreshResponse,
 	ListProviderAuthStatusResponse,
 	OAuthFlowData,
 } from './auth-types.js';

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -191,6 +191,13 @@ export interface Provider {
 	logout?(): Promise<void>;
 
 	/**
+	 * Optional: Refresh authentication token for this provider.
+	 * Used when token has expired and needs refresh without full logout/login.
+	 * Returns true if refresh succeeded, false otherwise.
+	 */
+	refreshToken?(): Promise<boolean>;
+
+	/**
 	 * Optional: Shut down any resources held by this provider (e.g. an embedded
 	 * HTTP server). Called during daemon shutdown so the event loop can exit.
 	 */

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -24,6 +24,7 @@ export function ProvidersSettings() {
 	const [loading, setLoading] = useState(true);
 	const [oauthFlow, setOauthFlow] = useState<OAuthFlowState | null>(null);
 	const [pendingProvider, setPendingProvider] = useState<string | null>(null);
+	const [refreshFailed, setRefreshFailed] = useState<Set<string>>(new Set());
 
 	// Load provider auth statuses
 	const loadProviders = async () => {
@@ -97,6 +98,7 @@ export function ProvidersSettings() {
 	};
 
 	const handleLogout = async (providerId: string, providerName: string) => {
+		setPendingProvider(providerId);
 		try {
 			await logoutProvider(providerId);
 			toast.success(`Logged out from ${providerName}`);
@@ -104,6 +106,8 @@ export function ProvidersSettings() {
 			await loadProviders();
 		} catch (error) {
 			toast.error(error instanceof Error ? error.message : 'Failed to logout');
+		} finally {
+			setPendingProvider(null);
 		}
 	};
 
@@ -113,12 +117,19 @@ export function ProvidersSettings() {
 			const response = await refreshProvider(providerId);
 			if (response.success) {
 				toast.success(`Token refreshed for ${providerName}`);
+				setRefreshFailed((prev) => {
+					const next = new Set(prev);
+					next.delete(providerId);
+					return next;
+				});
 				await loadProviders();
 			} else {
 				toast.error(response.error || 'Failed to refresh token');
+				setRefreshFailed((prev) => new Set(prev).add(providerId));
 			}
 		} catch (error) {
 			toast.error(error instanceof Error ? error.message : 'Failed to refresh token');
+			setRefreshFailed((prev) => new Set(prev).add(providerId));
 		} finally {
 			setPendingProvider(null);
 		}
@@ -181,8 +192,8 @@ export function ProvidersSettings() {
 											</p>
 										)}
 									</div>
-									<div class="flex-shrink-0 ml-4">
-										{provider.needsRefresh ? (
+									<div class="flex-shrink-0 ml-4 flex items-center gap-2">
+										{provider.needsRefresh && (
 											<Button
 												variant="warning"
 												size="sm"
@@ -192,16 +203,22 @@ export function ProvidersSettings() {
 											>
 												Refresh Login
 											</Button>
-										) : provider.isAuthenticated ? (
+										)}
+										{/* Show Logout for authenticated providers, or after refresh failure */}
+										{(provider.isAuthenticated ||
+											(provider.needsRefresh && refreshFailed.has(provider.id))) && (
 											<Button
 												variant="secondary"
 												size="sm"
 												onClick={() => handleLogout(provider.id, provider.displayName)}
-												disabled={pendingProvider === provider.id}
+												loading={pendingProvider === provider.id}
+												disabled={!!pendingProvider}
 											>
 												Logout
 											</Button>
-										) : (
+										)}
+										{/* Show Login for unauthenticated providers */}
+										{!provider.isAuthenticated && !provider.needsRefresh && (
 											<Button
 												variant="primary"
 												size="sm"

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -102,6 +102,12 @@ export function ProvidersSettings() {
 		try {
 			await logoutProvider(providerId);
 			toast.success(`Logged out from ${providerName}`);
+			// Clear refresh failure state for this provider
+			setRefreshFailed((prev) => {
+				const next = new Set(prev);
+				next.delete(providerId);
+				return next;
+			});
 			// Refresh provider list
 			await loadProviders();
 		} catch (error) {

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'preact/hooks';
 import { toast } from '../../lib/toast.ts';
 import type { ProviderAuthStatus, ProviderAuthResponse } from '@neokai/shared/provider';
-import { listProviderAuthStatus, loginProvider, logoutProvider } from '../../lib/api-helpers.ts';
+import {
+	listProviderAuthStatus,
+	loginProvider,
+	logoutProvider,
+	refreshProvider,
+} from '../../lib/api-helpers.ts';
 import { SettingsSection } from './SettingsSection.tsx';
 import { OAuthModal } from './OAuthModal.tsx';
 import { Button } from '../ui/Button.tsx';
@@ -102,6 +107,23 @@ export function ProvidersSettings() {
 		}
 	};
 
+	const handleRefresh = async (providerId: string, providerName: string) => {
+		setPendingProvider(providerId);
+		try {
+			const response = await refreshProvider(providerId);
+			if (response.success) {
+				toast.success(`Token refreshed for ${providerName}`);
+				await loadProviders();
+			} else {
+				toast.error(response.error || 'Failed to refresh token');
+			}
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : 'Failed to refresh token');
+		} finally {
+			setPendingProvider(null);
+		}
+	};
+
 	const handleOAuthCancel = () => {
 		setOauthFlow(null);
 		// Refresh to get current state
@@ -160,7 +182,17 @@ export function ProvidersSettings() {
 										)}
 									</div>
 									<div class="flex-shrink-0 ml-4">
-										{provider.isAuthenticated ? (
+										{provider.needsRefresh ? (
+											<Button
+												variant="warning"
+												size="sm"
+												onClick={() => handleRefresh(provider.id, provider.displayName)}
+												loading={pendingProvider === provider.id}
+												disabled={!!pendingProvider}
+											>
+												Refresh Login
+											</Button>
+										) : provider.isAuthenticated ? (
 											<Button
 												variant="secondary"
 												size="sm"

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import { ComponentChildren, JSX } from 'preact';
 import { cn } from '../../lib/utils.ts';
 import { borderColors } from '../../lib/design-tokens.ts';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps
@@ -40,6 +40,8 @@ export function Button({
 		secondary: `bg-dark-800 hover:bg-dark-700 text-gray-100 border ${borderColors.ui.secondary} hover:border-dark-500 active:scale-[0.98]`,
 		ghost: 'hover:bg-dark-800 text-gray-300 hover:text-gray-100 active:scale-[0.98]',
 		danger: 'bg-red-600 hover:bg-red-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
+		warning:
+			'bg-yellow-600 hover:bg-yellow-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
 	};
 
 	const sizes = {

--- a/packages/web/src/lib/api-helpers.ts
+++ b/packages/web/src/lib/api-helpers.ts
@@ -30,7 +30,11 @@ import type {
 	ArchiveSessionResponse,
 	GetAuthStatusResponse,
 } from '@neokai/shared';
-import type { ProviderAuthResponse, ListProviderAuthStatusResponse } from '@neokai/shared/provider';
+import type {
+	ProviderAuthResponse,
+	ListProviderAuthStatusResponse,
+	ProviderRefreshResponse,
+} from '@neokai/shared/provider';
 import { connectionManager } from './connection-manager.ts';
 import { ConnectionNotReadyError } from './errors.ts';
 
@@ -136,6 +140,11 @@ export async function logoutProvider(
 ): Promise<{ success: boolean; error?: string }> {
 	const hub = getHubOrThrow();
 	return await hub.request<{ success: boolean; error?: string }>('auth.logout', { providerId });
+}
+
+export async function refreshProvider(providerId: string): Promise<ProviderRefreshResponse> {
+	const hub = getHubOrThrow();
+	return await hub.request<ProviderRefreshResponse>('auth.refresh', { providerId });
 }
 
 // ==================== Settings Operations ====================


### PR DESCRIPTION
Add ability to refresh expired OpenAI (Codex) tokens directly from the
settings UI without needing to log out and log back in.

Changes:
- Add auth.refresh RPC handler in daemon for token refresh
- Add ProviderRefreshRequest/Response types in shared package
- Add refreshToken method to Provider interface
- Add refreshProvider API helper in web package
- Add "Refresh Login" button in ProvidersSettings UI (shown when needsRefresh is true)
- Add "warning" button variant for the refresh button
- Add unit tests for the auth.refresh handler
- Add E2E tests for the Providers settings section

The refresh button appears when a provider's token needs refresh
(needsRefresh=true), providing a direct path to refresh the token
without requiring full logout/login flow.
