### PR TITLE
fix: restore dead worker sessions before routing leader feedback

### DIFF
--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -498,6 +498,17 @@ export class TaskGroupManager {
 			this.groupRepo.setHumanInterrupted(groupId, false);
 		}
 
+		// Ensure worker session is alive before attempting to route feedback.
+		// If the worker session is not in the runtime cache (e.g., after daemon restart
+		// or session eviction), restore it from DB and start the SDK query.
+		// This mirrors the fix in question-handlers for leader→worker routing.
+		if (!this.sessionFactory.hasSession(group.workerSessionId)) {
+			const restored = await this.sessionFactory.restoreSession(group.workerSessionId);
+			if (restored) {
+				await this.sessionFactory.startSession(group.workerSessionId);
+			}
+		}
+
 		// If worker is waiting for input (AskUserQuestion), answer the question.
 		// Otherwise inject feedback as a regular message.
 		const answered = await this.sessionFactory.answerQuestion(group.workerSessionId, message);

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -500,12 +500,21 @@ export class TaskGroupManager {
 
 		// Ensure worker session is alive before attempting to route feedback.
 		// If the worker session is not in the runtime cache (e.g., after daemon restart
-		// or session eviction), restore it from DB and start the SDK query.
-		// This mirrors the fix in question-handlers for leader→worker routing.
+		// or session eviction), restore it from DB.
+		// injectMessage will lazily start the SDK query via ensureQueryStarted().
 		if (!this.sessionFactory.hasSession(group.workerSessionId)) {
 			const restored = await this.sessionFactory.restoreSession(group.workerSessionId);
 			if (restored) {
-				await this.sessionFactory.startSession(group.workerSessionId);
+				log.info(
+					`[routeLeaderToWorker] Group ${groupId}: restored worker session ${group.workerSessionId} from DB`
+				);
+			} else {
+				log.error(
+					`[routeLeaderToWorker] Group ${groupId}: failed to restore worker session ` +
+						`${group.workerSessionId} — session not found in DB`
+				);
+				await this.fail(groupId, 'Worker session lost during restart; task will be re-queued');
+				return null;
 			}
 		}
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -43,7 +43,10 @@ function createMockDaemonHub() {
 }
 
 // Mock SessionFactory
-function createMockSessionFactory(initialLiveSessions: string[] = []) {
+function createMockSessionFactory(
+	initialLiveSessions: string[] = [],
+	options?: { restoreSessionFails?: boolean }
+) {
 	const calls: Array<{ method: string; args: unknown[] }> = [];
 	const liveSessions = new Set<string>(initialLiveSessions);
 	const removedWorktrees: string[] = [];
@@ -83,7 +86,10 @@ function createMockSessionFactory(initialLiveSessions: string[] = []) {
 		},
 		async restoreSession(sessionId: string) {
 			calls.push({ method: 'restoreSession', args: [sessionId] });
-			// Restore adds session to liveSessions (simulating DB restore)
+			// If restore fails (simulating session not in DB), don't add to liveSessions
+			if (options?.restoreSessionFails) {
+				return false;
+			}
 			liveSessions.add(sessionId);
 			return true;
 		},
@@ -827,17 +833,13 @@ describe('TaskGroupManager', () => {
 			// Now route leader feedback back to worker
 			await testManager.routeLeaderToWorker(group.id, 'Fix the tests');
 
-			// Verify session was restored and started before injecting message
+			// Verify session was restored before injecting message
 			const restoreCalls = factory.calls.filter(
 				(c) => c.method === 'restoreSession' && c.args[0] === group.workerSessionId
 			);
 			expect(restoreCalls).toHaveLength(1);
 
-			const startCalls = factory.calls.filter(
-				(c) => c.method === 'startSession' && c.args[0] === group.workerSessionId
-			);
-			expect(startCalls).toHaveLength(1);
-
+			// injectMessage lazily starts the SDK query, no explicit startSession needed
 			const injectCalls = factory.calls.filter(
 				(c) =>
 					c.method === 'injectMessage' &&
@@ -845,6 +847,62 @@ describe('TaskGroupManager', () => {
 					c.args[1] === 'Fix the tests'
 			);
 			expect(injectCalls).toHaveLength(1);
+		});
+
+		it('should fail group when worker session restore fails', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			// Create a factory that fails restoreSession (simulating session not in DB)
+			const failFactory = createMockSessionFactory([], { restoreSessionFails: true });
+			const failManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: failFactory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await failManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			// First route to Leader so group is in awaiting_leader state
+			await failManager.routeWorkerToLeader(group.id, 'Worker output', (_groupId) => callbacks);
+
+			// Simulate worker session dying (not in cache)
+			failFactory.liveSessions.delete(group.workerSessionId);
+
+			// Verify worker session is not in cache
+			expect(failFactory.hasSession(group.workerSessionId)).toBe(false);
+
+			// Now route leader feedback back to worker - should fail gracefully
+			const result = await failManager.routeLeaderToWorker(group.id, 'Fix the tests');
+
+			// Verify restore was attempted
+			const restoreCalls = failFactory.calls.filter(
+				(c) => c.method === 'restoreSession' && c.args[0] === group.workerSessionId
+			);
+			expect(restoreCalls).toHaveLength(1);
+
+			// Verify group was failed instead of throwing
+			expect(result).toBeNull();
+
+			// Verify task is marked as needs_attention (failTask sets this status)
+			const failedTask = await taskManager.getTask(task.id);
+			expect(failedTask!.status).toBe('needs_attention');
+			expect(failedTask!.error).toContain('Worker session lost during restart');
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -81,6 +81,19 @@ function createMockSessionFactory(initialLiveSessions: string[] = []) {
 			removedWorktrees.push(workspacePath);
 			return true;
 		},
+		async restoreSession(sessionId: string) {
+			calls.push({ method: 'restoreSession', args: [sessionId] });
+			// Restore adds session to liveSessions (simulating DB restore)
+			liveSessions.add(sessionId);
+			return true;
+		},
+		async startSession(sessionId: string) {
+			calls.push({ method: 'startSession', args: [sessionId] });
+			return true;
+		},
+		setSessionMcpServers(_sessionId: string, _mcpServers: Record<string, unknown>) {
+			return true;
+		},
 	} satisfies SessionFactory & {
 		calls: Array<{ method: string; args: unknown[] }>;
 		liveSessions: Set<string>;
@@ -769,6 +782,69 @@ describe('TaskGroupManager', () => {
 
 			expect(updated!.submittedForReview).toBe(false);
 			expect(updated!.feedbackIteration).toBe(1);
+		});
+
+		it('should restore dead worker session before routing feedback', async () => {
+			const task = await createTask();
+			const goal = makeGoal(db);
+			const callbacks = createMockLeaderCallbacks();
+
+			// Create a factory with the worker already in live sessions (normal spawn behavior)
+			const factory = createMockSessionFactory([]);
+			// Create a new manager with the factory
+			const testManager = new TaskGroupManager({
+				groupRepo,
+				sessionObserver: observer,
+				taskManager,
+				goalManager,
+				sessionFactory: factory,
+				workspacePath: '/workspace',
+				getRoom: (roomId) => (roomId === 'room-1' ? room : null),
+				getTask: (taskId) => taskManager.getTask(taskId),
+				getGoal: (goalId) => goalManager.getGoal(goalId),
+			});
+
+			const group = await testManager.spawn(
+				room,
+				task,
+				goal,
+				() => {},
+				() => {},
+				(_groupId) => callbacks,
+				makeDefaultWorkerConfig()
+			);
+
+			// First route to Leader so group is in awaiting_leader state
+			await testManager.routeWorkerToLeader(group.id, 'Worker output', (_groupId) => callbacks);
+
+			// Simulate worker session dying (e.g., after daemon restart or eviction)
+			// Remove worker from live sessions to simulate dead session
+			factory.liveSessions.delete(group.workerSessionId);
+
+			// Verify worker session is not in cache
+			expect(factory.hasSession(group.workerSessionId)).toBe(false);
+
+			// Now route leader feedback back to worker
+			await testManager.routeLeaderToWorker(group.id, 'Fix the tests');
+
+			// Verify session was restored and started before injecting message
+			const restoreCalls = factory.calls.filter(
+				(c) => c.method === 'restoreSession' && c.args[0] === group.workerSessionId
+			);
+			expect(restoreCalls).toHaveLength(1);
+
+			const startCalls = factory.calls.filter(
+				(c) => c.method === 'startSession' && c.args[0] === group.workerSessionId
+			);
+			expect(startCalls).toHaveLength(1);
+
+			const injectCalls = factory.calls.filter(
+				(c) =>
+					c.method === 'injectMessage' &&
+					c.args[0] === group.workerSessionId &&
+					c.args[1] === 'Fix the tests'
+			);
+			expect(injectCalls).toHaveLength(1);
 		});
 	});
 


### PR DESCRIPTION
When the leader calls send_to_worker to route feedback back to the worker,
the worker session might be dead (e.g., after daemon restart or session
eviction). The previous code would fail because:

1. answerQuestion returns false if session isn't in cache
2. injectMessage throws "Session not in service cache"

This fix adds session restoration logic to routeLeaderToWorker, mirroring
the fix in question-handlers for leader questions routing. Before attempting
to answer a question or inject a message, we now check if the worker session
exists in the runtime cache. If not, we restore it from DB and start the
SDK query.

Add unit test for the dead session restoration path.
