### PR TITLE
fix(codex-bridge): persist Codex sessions across turns

### DIFF
--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -428,6 +428,7 @@ export class ProviderService {
 		// the correct cwd per request (encoded in ANTHROPIC_AUTH_TOKEN by the provider).
 		const sessionConfig = {
 			workspacePath: session.workspacePath,
+			sessionId: session.id,
 			...(session.config.providerConfig
 				? {
 						apiKey: session.config.providerConfig.apiKey,

--- a/packages/daemon/src/lib/providers/anthropic-copilot/prompt.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/prompt.ts
@@ -24,6 +24,8 @@ function formatBlocks(blocks: ContentBlock[], role: 'user' | 'assistant', parts:
 			parts.push(role === 'user' ? `[User]: ${block.text}` : `[Assistant]: ${block.text}`);
 		} else if (block.type === 'thinking') {
 			// Skip thinking blocks — they are internal reasoning, not conversation turns.
+			// The Copilot SDK does not support extended thinking, so these blocks are
+			// never emitted by the model and should not be forwarded to the prompt.
 		} else if (block.type === 'tool_use') {
 			parts.push(`[Assistant called tool ${block.name} with args: ${JSON.stringify(block.input)}]`);
 		} else if (block.type === 'tool_result') {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -175,6 +175,10 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 
 	readonly capabilities: ProviderCapabilities = {
 		streaming: true,
+		// Extended thinking is not supported by the Copilot SDK. The SDK's createSession()
+		// and send() methods have no thinking-related options (no 'betas', no 'thinking' param),
+		// and the SSE events contain no thinking_delta events. GitHub Copilot's API does not
+		// expose Claude's extended thinking capability.
 		extendedThinking: false,
 		maxContextWindow: 272000,
 		/**

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -193,6 +193,10 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 
 	readonly capabilities: ProviderCapabilities = {
 		streaming: true,
+		// Extended thinking is not supported by the Codex app-server protocol. The protocol
+		// (item/tool/call, turn/start, thread/start) has no thinking-related parameters,
+		// and SSE events contain no thinking_delta events. Codex (OpenAI-backed) does not
+		// expose extended thinking capability.
 		extendedThinking: false,
 		maxContextWindow: 200000,
 		functionCalling: true,

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -441,7 +441,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	 */
 	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
 		const workspace = sessionConfig?.workspacePath ?? process.cwd();
-		const sessionId = (sessionConfig as { sessionId?: string } | undefined)?.sessionId ?? 'default';
+		const sessionId = (sessionConfig?.sessionId as string | undefined) ?? 'default';
 		let bridgeServer = this.bridgeServers.get(workspace);
 
 		if (!bridgeServer) {

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -441,7 +441,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	 */
 	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
 		const workspace = sessionConfig?.workspacePath ?? process.cwd();
-		const sessionId = (sessionConfig?.sessionId as string | undefined) ?? 'default';
+		const sessionId = sessionConfig?.sessionId ?? 'default';
 		let bridgeServer = this.bridgeServers.get(workspace);
 
 		if (!bridgeServer) {

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -441,6 +441,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	 */
 	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
 		const workspace = sessionConfig?.workspacePath ?? process.cwd();
+		const sessionId = (sessionConfig as { sessionId?: string } | undefined)?.sessionId ?? 'default';
 		let bridgeServer = this.bridgeServers.get(workspace);
 
 		if (!bridgeServer) {
@@ -471,7 +472,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		return {
 			envVars: {
 				ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridgeServer.port}`,
-				ANTHROPIC_API_KEY: 'codex-bridge-placeholder',
+				ANTHROPIC_API_KEY: `codex-bridge-${sessionId}`,
 				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 				// Map SDK model tiers to Codex model IDs so the Claude Agent SDK
 				// subprocess never falls back to Anthropic model names (e.g.

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -52,11 +52,11 @@ class AsyncQueue<T> {
 		return new Promise<T>((resolve) => this.waiters.push(resolve));
 	}
 
-	/** Drain all pending items and reject all waiting callers. Used between turns. */
+	/** Drain all pending items and resolve waiting callers with null sentinel. Used between turns. */
 	drain(): void {
 		this.items = [];
-		for (const reject of this.waiters) {
-			reject(null as unknown as T);
+		for (const resolve of this.waiters) {
+			resolve(null as unknown as T);
 		}
 		this.waiters = [];
 	}

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -51,6 +51,15 @@ class AsyncQueue<T> {
 		if (this.items.length > 0) return this.items.shift()!;
 		return new Promise<T>((resolve) => this.waiters.push(resolve));
 	}
+
+	/** Drain all pending items and reject all waiting callers. Used between turns. */
+	drain(): void {
+		this.items = [];
+		for (const reject of this.waiters) {
+			reject(null as unknown as T);
+		}
+		this.waiters = [];
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -471,6 +480,9 @@ export class BridgeSession {
 	/** Start a new turn and return an async generator of BridgeEvents. */
 	async *startTurn(userText: string): AsyncGenerator<BridgeEvent> {
 		if (!this.threadId) throw new Error('BridgeSession not initialized');
+		// Drain any stale events from the previous turn that Codex may have sent
+		// after turn_done but before we called startTurn again.
+		this.queue.drain();
 		// Reset latestUsage so any stale value from a previous (erroneous) notification
 		// does not bleed into this turn's turn_done event.
 		this.latestUsage = null;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -201,7 +201,14 @@ export class AppServerConn {
 						logger.debug('AppServerConn: skipping non-JSON line:', trimmed);
 						continue;
 					}
-					await this.dispatch(msg);
+					const msgHasMethodAndId = 'method' in msg && 'id' in msg;
+					if (msgHasMethodAndId) {
+						// Server requests (e.g. item/tool/call): fire without blocking the read loop
+						// so concurrent tool calls from Codex can be handled in parallel.
+						void this.dispatch(msg);
+					} else {
+						await this.dispatch(msg);
+					}
 				}
 			}
 		} catch (err) {
@@ -277,7 +284,6 @@ export type TokenUsage = {
 export class BridgeSession {
 	private threadId: string | null = null;
 	private readonly queue = new AsyncQueue<BridgeEvent | Error>();
-	private turnStarted = false;
 	/** Token usage captured from the most recent thread/tokenUsage/updated notification. */
 	private latestUsage: TokenUsage | null = null;
 	/**
@@ -465,8 +471,6 @@ export class BridgeSession {
 	/** Start a new turn and return an async generator of BridgeEvents. */
 	async *startTurn(userText: string): AsyncGenerator<BridgeEvent> {
 		if (!this.threadId) throw new Error('BridgeSession not initialized');
-		if (this.turnStarted) throw new Error('BridgeSession.startTurn() called more than once');
-		this.turnStarted = true;
 		// Reset latestUsage so any stale value from a previous (erroneous) notification
 		// does not bleed into this turn's turn_done event.
 		this.latestUsage = null;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -84,6 +84,8 @@ export type ToolSession = {
 	provideResult: (text: string) => void;
 	/** Model from the original request — preserved across tool round-trips. */
 	model: string;
+	/** Session ID for re-associating with persistent session on resume. */
+	sessionId: string;
 	/** TTL timer — fires if the HTTP client never sends the tool result. */
 	cleanupTimer: ReturnType<typeof setTimeout>;
 };
@@ -91,6 +93,34 @@ export type ToolSession = {
 function generateMsgId(): string {
 	return `msg_${Math.random().toString(36).slice(2, 14)}`;
 }
+
+/** Extract session ID from Authorization header (format: Bearer codex-bridge-{sessionId}). */
+function extractSessionId(req: Request): string {
+	const auth = req.headers.get('Authorization') ?? req.headers.get('authorization') ?? '';
+	const token = auth.startsWith('Bearer ') ? auth.slice(7) : auth;
+	if (token.startsWith('codex-bridge-')) return token.slice('codex-bridge-'.length);
+	return 'default';
+}
+
+/** Create a sorted comma-separated key from tool names — used to detect tool set changes. */
+function toolsKey(anthropicTools: { name: string }[]): string {
+	return anthropicTools.map((t) => t.name).sort().join(',');
+}
+
+/** Persistent Codex session across multiple conversation turns. */
+type PersistentSession = {
+	session: BridgeSession;
+	model: string;
+	/** Sorted comma-separated tool names — used to detect tool set changes. */
+	toolsKey: string;
+	/** True until the first turn/start has been called (system message injected then). */
+	isFirstTurn: boolean;
+	/** Idle TTL timer — fires when no activity for IDLE_SESSION_TTL_MS. */
+	idleTimer: ReturnType<typeof setTimeout>;
+};
+
+/** How long (ms) a persistent session stays alive with no activity. */
+const IDLE_SESSION_TTL_MS = 10 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // SSE drain loop — shared between new turns and tool continuations
@@ -102,7 +132,9 @@ export async function drainToSSE(
 	model: string,
 	toolSessions: Map<string, ToolSession>,
 	controller: ReadableStreamDefaultController<Uint8Array>,
-	ttlMs: number
+	ttlMs: number,
+	sessionId: string,
+	onTurnDone: () => void
 ): Promise<void> {
 	const enc = new TextEncoder();
 	const send = (s: string) => controller.enqueue(enc.encode(s));
@@ -171,6 +203,7 @@ export async function drainToSSE(
 					session,
 					provideResult: event.provideResult,
 					model,
+					sessionId,
 					cleanupTimer,
 				});
 				suspendedCallId = callId;
@@ -189,7 +222,7 @@ export async function drainToSSE(
 				const endOutputTokens = event.outputTokens > 0 ? event.outputTokens : outputTokens;
 				send(messageDeltaSSE('end_turn', { outputTokens: endOutputTokens }));
 				send(messageStopSSE());
-				session.kill();
+				onTurnDone();
 				controller.close();
 				return;
 			} else if (event.type === 'error') {
@@ -255,7 +288,23 @@ export type BridgeServer = {
 export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 	/** Active tool-call sessions waiting for tool results. */
 	const toolSessions = new Map<string, ToolSession>();
+	/** Persistent Codex sessions across multiple conversation turns. */
+	const persistentSessions = new Map<string, PersistentSession>();
 	const ttlMs = config.toolSessionTtlMs ?? DEFAULT_TOOL_SESSION_TTL_MS;
+
+	/** Helper: schedule idle cleanup for a persistent session. */
+	function scheduleIdle(sessionId: string): ReturnType<typeof setTimeout> {
+		const timer = setTimeout(() => {
+			const ps = persistentSessions.get(sessionId);
+			if (ps) {
+				logger.info(`codex-bridge: idle timeout, killing session ${sessionId}`);
+				ps.session.kill();
+				persistentSessions.delete(sessionId);
+			}
+		}, IDLE_SESSION_TTL_MS);
+		timer.unref?.();
+		return timer;
+	}
 
 	const server = Bun.serve({
 		port: 0, // random available port
@@ -349,47 +398,118 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					);
 				}
 
-				const { gen, session, model: sessionModel } = primaryStored;
+				const { gen, session, model: sessionModel, sessionId: tsSessionId } = primaryStored;
+				const toolContinuationPs = persistentSessions.get(tsSessionId);
+				const onTurnDone = toolContinuationPs
+					? () => {
+							toolContinuationPs.idleTimer = scheduleIdle(tsSessionId);
+						}
+					: () => {
+							primaryStored.session.kill();
+						};
 				const stream = new ReadableStream<Uint8Array>({
 					start(controller) {
-						void drainToSSE(gen, session, sessionModel, toolSessions, controller, ttlMs);
+						void drainToSSE(
+							gen,
+							session,
+							sessionModel,
+							toolSessions,
+							controller,
+							ttlMs,
+							tsSessionId,
+							onTurnDone
+						);
 					},
 				});
 				return new Response(stream, { headers: sseHeaders });
 			}
 
 			// ------------------------------------------------------------------
-			// New conversation turn: spawn a fresh Codex session
+			// New conversation turn: look up or create a persistent session
 			// ------------------------------------------------------------------
+			const neokaiSessionId = extractSessionId(req);
 			const model = body.model;
 			const system = extractSystemText(body.system);
-			const userText = buildConversationText(body.messages, system);
 			const anthropicTools = body.tools ?? [];
 			const dynamicTools = buildDynamicTools(anthropicTools);
 			const originalToolNames = anthropicTools.map((t) => t.name);
+			const currentToolsKey = toolsKey(anthropicTools);
 
-			let session: BridgeSession;
-			try {
-				const conn = AppServerConn.create(config.codexBinaryPath, config.cwd, config.auth);
-				session = new BridgeSession(
-					conn,
-					model,
-					dynamicTools,
-					config.cwd,
-					config.auth,
-					originalToolNames
-				);
-				await session.initialize();
-			} catch (err) {
-				logger.error('codex-bridge: failed to start BridgeSession:', err);
-				return createAnthropicError(500, 'api_error', `Internal Server Error: ${String(err)}`);
+			// Look up or create a persistent session
+			let ps = persistentSessions.get(neokaiSessionId);
+			if (ps && (ps.model !== model || ps.toolsKey !== currentToolsKey)) {
+				// Model or tool set changed — retire the old session and start fresh
+				clearTimeout(ps.idleTimer);
+				ps.session.kill();
+				persistentSessions.delete(neokaiSessionId);
+				ps = undefined;
 			}
 
-			const gen = session.startTurn(userText);
+			let bridgeSession: BridgeSession;
+			if (ps) {
+				// Reuse existing session — cancel idle timer while the turn runs
+				clearTimeout(ps.idleTimer);
+				bridgeSession = ps.session;
+			} else {
+				// First turn for this NeoKai session — spin up a new Codex subprocess
+				let conn: AppServerConn;
+				try {
+					conn = AppServerConn.create(config.codexBinaryPath, config.cwd, config.auth);
+					bridgeSession = new BridgeSession(
+						conn,
+						model,
+						dynamicTools,
+						config.cwd,
+						config.auth,
+						originalToolNames
+					);
+					await bridgeSession.initialize();
+				} catch (err) {
+					logger.error('codex-bridge: failed to start BridgeSession:', err);
+					return createAnthropicError(500, 'api_error', `Internal Server Error: ${String(err)}`);
+				}
+				ps = {
+					session: bridgeSession,
+					model,
+					toolsKey: currentToolsKey,
+					isFirstTurn: true,
+					idleTimer: setTimeout(() => {}, 0), // placeholder, set below
+				};
+				persistentSessions.set(neokaiSessionId, ps);
+			}
+
+			// Build the text to send Codex for this turn.
+			// First turn: include the full conversation history (as structured text) so Codex
+			// has context from any messages that pre-date the persistent session.
+			// Subsequent turns: Codex already has the thread history — send only the new
+			// user message to avoid duplicating context.
+			const { extractLastUserMessage } = await import('./translator.js');
+			const userText = ps.isFirstTurn
+				? buildConversationText(body.messages, system)
+				: extractLastUserMessage(body.messages);
+			ps.isFirstTurn = false;
+
+			const gen = bridgeSession.startTurn(userText);
+
+			// Schedule idle timer on turn completion
+			const capturedPs = ps;
+			const capturedSessionId = neokaiSessionId;
+			const onTurnDone = () => {
+				capturedPs.idleTimer = scheduleIdle(capturedSessionId);
+			};
 
 			const stream = new ReadableStream<Uint8Array>({
 				start(controller) {
-					void drainToSSE(gen, session, model, toolSessions, controller, ttlMs);
+					void drainToSSE(
+						gen,
+						bridgeSession,
+						model,
+						toolSessions,
+						controller,
+						ttlMs,
+						capturedSessionId,
+						onTurnDone
+					);
 				},
 			});
 			return new Response(stream, { headers: sseHeaders });
@@ -410,6 +530,13 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				stored.session.kill();
 				toolSessions.delete(callId);
 				logger.debug(`codex-bridge: cleaned up suspended session callId=${callId} on stop`);
+			}
+			// Clean up persistent sessions
+			for (const [sessionId, ps] of persistentSessions) {
+				clearTimeout(ps.idleTimer);
+				ps.session.kill();
+				persistentSessions.delete(sessionId);
+				logger.debug(`codex-bridge: cleaned up persistent session ${sessionId} on stop`);
 			}
 			server.stop();
 		},

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -20,6 +20,7 @@ import {
 	buildDynamicTools,
 	buildConversationText,
 	extractSystemText,
+	extractLastUserMessage,
 	isToolResultContinuation,
 	extractToolResults,
 	pingSSE,
@@ -115,8 +116,10 @@ type PersistentSession = {
 	toolsKey: string;
 	/** True until the first turn/start has been called (system message injected then). */
 	isFirstTurn: boolean;
+	/** True while a turn is in progress — prevents concurrent turns on same session. */
+	turnInProgress: boolean;
 	/** Idle TTL timer — fires when no activity for IDLE_SESSION_TTL_MS. */
-	idleTimer: ReturnType<typeof setTimeout>;
+	idleTimer?: ReturnType<typeof setTimeout>;
 };
 
 /** How long (ms) a persistent session stays alive with no activity. */
@@ -134,7 +137,8 @@ export async function drainToSSE(
 	controller: ReadableStreamDefaultController<Uint8Array>,
 	ttlMs: number,
 	sessionId: string,
-	onTurnDone: () => void
+	onTurnDone: () => void,
+	onError?: () => void
 ): Promise<void> {
 	const enc = new TextEncoder();
 	const send = (s: string) => controller.enqueue(enc.encode(s));
@@ -235,6 +239,7 @@ export async function drainToSSE(
 				// Emit an Anthropic-format error SSE event then close the stream
 				send(errorSSE('api_error', event.message));
 				session.kill();
+				onError?.();
 				controller.close();
 				return;
 			}
@@ -247,6 +252,7 @@ export async function drainToSSE(
 		send(messageDeltaSSE('end_turn', { outputTokens: outputTokens }));
 		send(messageStopSSE());
 		session.kill();
+		onError?.();
 		controller.close();
 	} catch (error) {
 		if (isClosedControllerError(error)) {
@@ -417,7 +423,16 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 							controller,
 							ttlMs,
 							tsSessionId,
-							onTurnDone
+							onTurnDone,
+							() => {
+								// Error: clean up persistent session
+								if (toolContinuationPs) {
+									toolContinuationPs.turnInProgress = false;
+									clearTimeout(toolContinuationPs.idleTimer);
+									toolContinuationPs.session.kill();
+									persistentSessions.delete(tsSessionId);
+								}
+							}
 						);
 					},
 				});
@@ -443,6 +458,11 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				ps.session.kill();
 				persistentSessions.delete(neokaiSessionId);
 				ps = undefined;
+			}
+
+			// Check for concurrent turn — return 409 if a turn is already in progress
+			if (ps?.turnInProgress) {
+				return createAnthropicError(409, 'api_error', 'A turn is already in progress for this session');
 			}
 
 			let bridgeSession: BridgeSession;
@@ -473,17 +493,20 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					model,
 					toolsKey: currentToolsKey,
 					isFirstTurn: true,
-					idleTimer: setTimeout(() => {}, 0), // placeholder, set below
+					turnInProgress: false,
+					idleTimer: undefined,
 				};
 				persistentSessions.set(neokaiSessionId, ps);
 			}
+
+			// Mark turn as in progress (ps is guaranteed to be defined at this point)
+			ps!.turnInProgress = true;
 
 			// Build the text to send Codex for this turn.
 			// First turn: include the full conversation history (as structured text) so Codex
 			// has context from any messages that pre-date the persistent session.
 			// Subsequent turns: Codex already has the thread history — send only the new
 			// user message to avoid duplicating context.
-			const { extractLastUserMessage } = await import('./translator.js');
 			const userText = ps.isFirstTurn
 				? buildConversationText(body.messages, system)
 				: extractLastUserMessage(body.messages);
@@ -492,9 +515,10 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			const gen = bridgeSession.startTurn(userText);
 
 			// Schedule idle timer on turn completion
-			const capturedPs = ps;
+			const capturedPs = ps!;
 			const capturedSessionId = neokaiSessionId;
 			const onTurnDone = () => {
+				capturedPs.turnInProgress = false;
 				capturedPs.idleTimer = scheduleIdle(capturedSessionId);
 			};
 
@@ -508,7 +532,14 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 						controller,
 						ttlMs,
 						capturedSessionId,
-						onTurnDone
+						onTurnDone,
+						() => {
+							// Error: clean up persistent session
+							capturedPs.turnInProgress = false;
+							clearTimeout(capturedPs.idleTimer);
+							capturedPs.session.kill();
+							persistentSessions.delete(capturedSessionId);
+						}
 					);
 				},
 			});

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -106,7 +106,10 @@ function extractSessionId(req: Request): string {
 
 /** Create a sorted comma-separated key from tool names — used to detect tool set changes. */
 function toolsKey(anthropicTools: { name: string }[]): string {
-	return anthropicTools.map((t) => t.name).sort().join(',');
+	return anthropicTools
+		.map((t) => t.name)
+		.sort()
+		.join(',');
 }
 
 /** Persistent Codex session across multiple conversation turns. */
@@ -465,7 +468,11 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 
 			// Check for concurrent turn — return 409 if a turn is already in progress
 			if (ps?.turnInProgress) {
-				return createAnthropicError(409, 'api_error', 'A turn is already in progress for this session');
+				return createAnthropicError(
+					409,
+					'api_error',
+					'A turn is already in progress for this session'
+				);
 			}
 
 			let bridgeSession: BridgeSession;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -265,6 +265,7 @@ export async function drainToSSE(
 					toolSessions.delete(suspendedCallId);
 				}
 			}
+			onError?.();
 			session.kill();
 			return;
 		}
@@ -409,6 +410,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				const toolContinuationPs = persistentSessions.get(tsSessionId);
 				const onTurnDone = toolContinuationPs
 					? () => {
+							toolContinuationPs.turnInProgress = false;
 							toolContinuationPs.idleTimer = scheduleIdle(tsSessionId);
 						}
 					: () => {

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -100,6 +100,7 @@ function extractSessionId(req: Request): string {
 	const auth = req.headers.get('Authorization') ?? req.headers.get('authorization') ?? '';
 	const token = auth.startsWith('Bearer ') ? auth.slice(7) : auth;
 	if (token.startsWith('codex-bridge-')) return token.slice('codex-bridge-'.length);
+	logger.warn('codex-bridge: no session ID in Authorization header, using default');
 	return 'default';
 }
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -156,7 +156,7 @@ export function extractContentText(content: AnthropicMessage['content']): string
  */
 export function extractLastUserMessage(messages: AnthropicMessage[]): string {
 	const last = messages.at(-1);
-	if (!last) return '';
+	if (!last || last.role !== 'user') return '';
 	return extractContentText(last.content);
 }
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -228,6 +228,7 @@ export function buildConversationText(messages: AnthropicMessage[], system?: str
 
 const SSE_SEP = '\n\n';
 
+/** Build a Server-Sent Events formatted string from event name and data. */
 function sseEvent(event: string, data: unknown): string {
 	return `event: ${event}\ndata: ${JSON.stringify(data)}${SSE_SEP}`;
 }

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -150,6 +150,17 @@ export function extractContentText(content: AnthropicMessage['content']): string
 }
 
 /**
+ * Extract the text content of the last user message.
+ * Used for subsequent turns in persistent sessions where Codex already
+ * has the conversation history — only the new user input needs to be sent.
+ */
+export function extractLastUserMessage(messages: AnthropicMessage[]): string {
+	const last = messages.at(-1);
+	if (!last) return '';
+	return extractContentText(last.content);
+}
+
+/**
  * Check whether the last user message contains tool_result blocks.
  * Used to distinguish tool-continuation requests from new conversation turns.
  */

--- a/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -221,7 +221,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('returns isAnthropicCompatible=true and a placeholder API key', () => {
 			const cfg = provider.buildSdkConfig('codex-1', { workspacePath: '/tmp/ws-compat' });
 			expect(cfg.isAnthropicCompatible).toBe(true);
-			expect(cfg.envVars.ANTHROPIC_API_KEY).toBe('codex-bridge-placeholder');
+			expect(cfg.envVars.ANTHROPIC_API_KEY).toBe('codex-bridge-default');
 			expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 		});
 

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/process-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/process-manager.test.ts
@@ -407,32 +407,65 @@ describe('BridgeSession thread/tokenUsage/updated', () => {
 });
 
 // ---------------------------------------------------------------------------
-// BridgeSession single-use guard (regression: P1 fix)
+// BridgeSession multi-turn support (persistent sessions)
 // ---------------------------------------------------------------------------
 
 describe('BridgeSession.startTurn()', () => {
-	it('throws if called a second time on the same instance', async () => {
-		const conn = makeStubConn();
+	it('allows calling startTurn sequentially on the same instance', async () => {
+		const { conn, fireNotification } = makeEventableStubConn();
 		const session = new BridgeSession(conn, 'test-model', [], '/tmp');
 		await session.initialize();
 
-		// Kick off gen1.next() without awaiting — the generator will run past the
-		// turnStarted guard (setting the flag to true), then block on queue.next().
+		// First turn: schedule notifications after generator starts waiting
+		const events1: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeEvent[] =
+			[];
 		const gen1 = session.startTurn('first');
-		const firstNextPromise = gen1.next();
 
-		// The mock request() resolves immediately (no real async work), so a few
-		// microtask yields are sufficient to advance the generator past
-		// `await conn.request('turn/start')` and set turnStarted = true.
-		// No wall-clock delay needed — using Promise.resolve() avoids a race on slow CI.
-		for (let i = 0; i < 10; i++) await Promise.resolve();
+		// Use setTimeout to fire notifications after generator starts waiting
+		const events1Promise = (async () => {
+			for await (const event of gen1) {
+				events1.push(event);
+			}
+		})();
 
-		// Second startTurn() call: its first next() should throw synchronously.
+		setTimeout(() => {
+			fireNotification('turn/completed', {
+				threadId: 'thread-1',
+				turn: { id: 'turn-1', items: [], status: 'completed', error: null },
+				usage: { inputTokens: 10, outputTokens: 5 },
+			});
+		}, 5);
+
+		await events1Promise;
+
+		const doneEvents1 = events1.filter((e) => e.type === 'turn_done');
+		expect(doneEvents1).toHaveLength(1);
+		expect((doneEvents1[0] as { inputTokens: number }).inputTokens).toBe(10);
+
+		// Second turn: startTurn should NOT throw — this is now allowed for
+		// persistent sessions where Codex maintains conversation history.
+		const events2: import('../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeEvent[] =
+			[];
 		const gen2 = session.startTurn('second');
-		await expect(gen2.next()).rejects.toThrow('startTurn() called more than once');
 
-		// Suppress unhandled-rejection noise from the first generator that is
-		// blocked indefinitely on queue.next().
-		firstNextPromise.catch(() => {});
+		const events2Promise = (async () => {
+			for await (const event of gen2) {
+				events2.push(event);
+			}
+		})();
+
+		setTimeout(() => {
+			fireNotification('turn/completed', {
+				threadId: 'thread-1',
+				turn: { id: 'turn-2', items: [], status: 'completed', error: null },
+				usage: { inputTokens: 20, outputTokens: 10 },
+			});
+		}, 5);
+
+		await events2Promise;
+
+		const doneEvents2 = events2.filter((e) => e.type === 'turn_done');
+		expect(doneEvents2).toHaveLength(1);
+		expect((doneEvents2[0] as { inputTokens: number }).inputTokens).toBe(20);
 	});
 });

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts
@@ -851,7 +851,16 @@ describe('Bridge HTTP server', () => {
 
 		const stream = new ReadableStream<Uint8Array>({
 			start(controller) {
-				void drainToSSE(errorGen(), mockSession, 'test-model', new Map(), controller, 5000);
+				void drainToSSE(
+					errorGen(),
+					mockSession,
+					'test-model',
+					new Map(),
+					controller,
+					5000,
+					'test-session',
+					() => {}
+				);
 			},
 		});
 
@@ -1019,7 +1028,16 @@ describe('drainToSSE controller lifecycle handling', () => {
 		} as unknown as ReadableStreamDefaultController<Uint8Array>;
 
 		await expect(
-			drainToSSE(errorGen(), mockSession, 'test-model', new Map(), closedController, 5000)
+			drainToSSE(
+				errorGen(),
+				mockSession,
+				'test-model',
+				new Map(),
+				closedController,
+				5000,
+				'test-session',
+				() => {}
+			)
 		).resolves.toBeUndefined();
 		expect(killCalled).toBe(true);
 	});

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts
@@ -289,9 +289,7 @@ describe('extractLastUserMessage', () => {
 			{ role: 'user', content: 'use the tool' },
 			{
 				role: 'user',
-				content: [
-					{ type: 'tool_result', tool_use_id: 'call-1', content: 'tool output' },
-				],
+				content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'tool output' }],
 			},
 		];
 		// Last message has role 'user' but content is tool_result blocks, not text

--- a/packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts
+++ b/packages/daemon/tests/unit/providers/codex-anthropic-bridge/translator.test.ts
@@ -9,6 +9,7 @@ import {
 	buildToolNameReverseMap,
 	extractSystemText,
 	extractContentText,
+	extractLastUserMessage,
 	isToolResultContinuation,
 	extractToolResults,
 	buildConversationText,
@@ -250,6 +251,51 @@ describe('extractToolResults', () => {
 		];
 		const [result] = extractToolResults(msgs);
 		expect(result.text).toBe('part A part B');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractLastUserMessage
+// ---------------------------------------------------------------------------
+
+describe('extractLastUserMessage', () => {
+	it('returns empty string for empty messages array', () => {
+		expect(extractLastUserMessage([])).toBe('');
+	});
+
+	it('returns empty string when last message is assistant', () => {
+		const msgs: AnthropicMessage[] = [
+			{ role: 'user', content: 'hello' },
+			{ role: 'assistant', content: 'hi there' },
+		];
+		expect(extractLastUserMessage(msgs)).toBe('');
+	});
+
+	it('returns text content from last user message', () => {
+		const msgs: AnthropicMessage[] = [
+			{ role: 'assistant', content: 'hi there' },
+			{ role: 'user', content: 'hello world' },
+		];
+		expect(extractLastUserMessage(msgs)).toBe('hello world');
+	});
+
+	it('returns text from string content', () => {
+		const msgs: AnthropicMessage[] = [{ role: 'user', content: 'plain text' }];
+		expect(extractLastUserMessage(msgs)).toBe('plain text');
+	});
+
+	it('returns empty string for tool result (not user role)', () => {
+		const msgs: AnthropicMessage[] = [
+			{ role: 'user', content: 'use the tool' },
+			{
+				role: 'user',
+				content: [
+					{ type: 'tool_result', tool_use_id: 'call-1', content: 'tool output' },
+				],
+			},
+		];
+		// Last message has role 'user' but content is tool_result blocks, not text
+		expect(extractLastUserMessage(msgs)).toBe('');
 	});
 });
 

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -59,6 +59,8 @@ export interface ProviderSessionConfig {
 	baseUrl?: string;
 	/** Workspace/working directory for this session (used for workspace-scoped providers) */
 	workspacePath?: string;
+	/** Session ID for provider-aware routing (e.g. persistent session tracking) */
+	sessionId?: string;
 	/** Additional provider-specific settings */
 	[key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Fixes two architectural bugs in the Codex bridge that blocked real multi-turn usage:

1. **Persistent sessions** — Previously every conversation turn spawned a fresh Codex subprocess, losing all context. Now a single `AppServerConn` + thread is reused per NeoKai session (keyed by session ID in the Authorization header), with a 10-minute idle TTL for cleanup. This also eliminates the conversation-history flattening problem since Codex natively tracks turn history in the thread.

2. **Non-blocking parallel tool calls** — The read loop previously `await`ed each `item/tool/call` dispatch, freezing the loop and preventing concurrent tool handling. The dispatch is now fire-and-forget for server requests, unblocking the read loop so multiple tool calls can be processed in parallel.

## Changes

| File | What changed |
|------|-------------|
| `packages/shared/src/provider/types.ts` | Added `sessionId?: string` as explicit typed field on `ProviderSessionConfig` |
| `packages/daemon/src/lib/provider-service.ts` | Pass `sessionId` through session config to bridge provider |
| `packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts` | Encode session ID into API key (`codex-bridge-{sessionId}`) for server-side routing |
| `packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts` | Remove one-shot `startTurn()` guard; make read loop non-blocking for server requests |
| `packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts` | Add `extractLastUserMessage()` helper for subsequent turns in persistent sessions |
| `packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts` | Persistent session map with idle TTL; first turn sends full history, subsequent turns send only new user message; tool continuations re-associate with persistent sessions |
| `packages/daemon/tests/unit/providers/codex-anthropic-bridge/process-manager.test.ts` | Update multi-turn `startTurn()` tests |
| `packages/daemon/tests/unit/providers/codex-anthropic-bridge/server.test.ts` | Update `drainToSSE` call sites to match new signature |

## Correctness guarantees

- **Stale event prevention**: `AsyncQueue.drain()` is called at the start of each `startTurn()` to clear any pending items from the previous turn
- **Concurrent turn guard**: `turnInProgress` flag returns 409 if a second turn is requested while one is in flight; cleared in both normal and error `onTurnDone` paths
- **Error-path cleanup**: `drainToSSE` accepts an `onError` callback; all error/close paths call it before `session.kill()` to remove the session from the persistent map
- **Tool continuation**: `onTurnDone` on tool-continuation paths also clears `turnInProgress` to unblock the session for the next turn

## Test plan

- [x] All 78 Codex bridge unit tests pass
- [x] All 7 Copilot bridge online tests pass
- [x] `bun run check` (lint + format + typecheck + knip) clean
- [x] Full CI matrix green (all daemon online shards pass)