### PR TITLE
fix: capture assistant.message.content when Copilot SDK skips streaming deltas

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -121,6 +121,11 @@ function buildPlainSessionConfig(
 		streaming: true,
 		infiniteSessions: { enabled: true },
 		workingDirectory: cwd,
+		// Restrict to no built-in tools — plain sessions have no caller-defined tools,
+		// so Copilot's built-in bash/file tools must also be disabled.  Without this
+		// the model may autonomously invoke built-in tools (hanging or returning only
+		// tool-call content) instead of producing a text response.
+		availableTools: [],
 		...(systemMessage
 			? { systemMessage: { mode: 'replace' as const, content: systemMessage } }
 			: {}),

--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -137,6 +137,12 @@ function streamSession(
 				break;
 
 			case 'assistant.message':
+				// Fallback: if the SDK delivered the full response without any
+				// preceding assistant.message_delta events (valid Copilot SDK
+				// behaviour), capture it now so outputCharCount is non-zero.
+				if (pendingDeltas.length === 0 && event.data.content) {
+					pendingDeltas.push(event.data.content as string);
+				}
 				flushDeltas();
 				break;
 

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -100,17 +100,33 @@ function getOutputTokens(events: SseEvent[]): number {
 async function callCopilotBridge(
 	bridgeUrl: string,
 	messages: Array<{ role: 'user' | 'assistant'; content: string }>,
-	model: string
+	model: string,
+	system?: string
 ): Promise<SseEvent[]> {
 	const response = await fetch(`${bridgeUrl}/v1/messages`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ model, messages, stream: true, max_tokens: 256 }),
+		body: JSON.stringify({
+			model,
+			messages,
+			stream: true,
+			max_tokens: 256,
+			...(system ? { system } : {}),
+		}),
 	});
 	if (!response.ok) {
 		throw new Error(`Bridge HTTP ${response.status}: ${await response.text()}`);
 	}
-	return parseSseEvents(await response.text());
+	const events = parseSseEvents(await response.text());
+	// Detect Anthropic SSE error events and surface them as descriptive test failures.
+	const errorEvent = events.find((e) => e.event === 'error');
+	if (errorEvent) {
+		const err = (errorEvent.data as { error?: { type?: string; message?: string } }).error;
+		throw new Error(
+			`Copilot bridge returned SSE error: ${err?.type ?? 'unknown'} — ${err?.message ?? '(no message)'}`
+		);
+	}
+	return events;
 }
 
 /** Per-turn idle timeout. The Copilot API can take 60-90 s per turn. */
@@ -552,7 +568,8 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 				const events = await callCopilotBridge(
 					bridgeUrl,
 					[{ role: 'user', content: 'Say hello.' }],
-					testModelId
+					testModelId,
+					'You are a helpful assistant. Always respond with plain text.'
 				);
 
 				const inputTokens = getInputTokens(events);

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/server.test.ts
@@ -404,6 +404,29 @@ describe('startEmbeddedServer', () => {
 		}
 	});
 
+	it('sets availableTools:[] on plain sessions to prevent built-in tool use', async () => {
+		let captured: unknown;
+		const cap = makeMockClient(() => session);
+		spyOn(cap, 'createSession').mockImplementation(async (cfg: unknown) => {
+			captured = cfg;
+			return session as unknown as CopilotSession;
+		});
+		const s2 = await startEmbeddedServer(cap, '/tmp');
+		try {
+			await postMessages(s2.url, {
+				model: 'x',
+				max_tokens: 100,
+				messages: [{ role: 'user', content: 'hi' }],
+			});
+			// Plain sessions (no tools in request) must set availableTools: [] to
+			// prevent the Copilot model from autonomously using built-in bash/file
+			// tools, which can cause hangs or empty text output.
+			expect((captured as Record<string, unknown>)['availableTools']).toEqual([]);
+		} finally {
+			await s2.stop();
+		}
+	});
+
 	// -------------------------------------------------------------------------
 	// Error paths
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/streaming.test.ts
@@ -251,6 +251,81 @@ function parseEvents(written: string[]): Array<{ type: string; data: unknown }> 
 // Token accounting via inputText parameter
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// output_tokens — assistant.message fallback
+// ---------------------------------------------------------------------------
+
+describe('runSessionStreaming — output_tokens via assistant.message fallback', () => {
+	it('counts output chars from assistant.message.content when no message_delta events arrived', async () => {
+		// Simulate the Copilot SDK sending assistant.message (complete response)
+		// WITHOUT any preceding assistant.message_delta events.  This is valid
+		// Copilot SDK behaviour observed in CI: the SDK delivers the full text
+		// in a single assistant.message event instead of streaming deltas.
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+
+		const responseText = 'Hello! How can I help you today?'; // 32 chars → ceil(32/4) = 8
+
+		const p = runSessionStreaming(
+			session as unknown as CopilotSession,
+			'prompt',
+			'model',
+			req,
+			res
+		);
+		await Promise.resolve();
+		// Emit assistant.message with full content (NO assistant.message_delta)
+		session.emit('assistant.message', { content: responseText });
+		session.emit('session.idle');
+		await p;
+
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const outputTokens = (
+			(delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>
+		)['output_tokens'];
+		expect(outputTokens).toBe(estimateTokens(responseText.length)); // = 8
+		expect(outputTokens).toBeGreaterThan(0);
+	});
+
+	it('does not double-count when both assistant.message_delta and assistant.message arrive', async () => {
+		// Normal streaming path: deltas arrive first, then assistant.message fires.
+		// The fallback must NOT add assistant.message.content on top of the deltas.
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+
+		const delta1 = 'Hello ';
+		const delta2 = 'world!';
+		// assistant.message.content is the combined text — should NOT be counted again.
+		const fullContent = delta1 + delta2;
+
+		const p = runSessionStreaming(
+			session as unknown as CopilotSession,
+			'prompt',
+			'model',
+			req,
+			res
+		);
+		await Promise.resolve();
+		session.emit('assistant.message_delta', { deltaContent: delta1 });
+		session.emit('assistant.message_delta', { deltaContent: delta2 });
+		// Now assistant.message fires — pendingDeltas is non-empty, so fallback skips.
+		session.emit('assistant.message', { content: fullContent });
+		session.emit('session.idle');
+		await p;
+
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const outputTokens = (
+			(delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>
+		)['output_tokens'];
+		// Should count delta1+delta2 only (12 chars → 3), NOT fullContent twice (24 chars → 6).
+		expect(outputTokens).toBe(estimateTokens(fullContent.length)); // = ceil(12/4) = 3
+	});
+});
+
 describe('runSessionStreaming — inputText / input_tokens', () => {
 	it('message_start carries non-zero input_tokens when inputText is provided', async () => {
 		const session = new MockSession();


### PR DESCRIPTION
## Summary

- Fixes the Copilot bridge token usage test that was failing in PR #417's CI run
- When the GitHub Copilot SDK delivers a complete response via a single `assistant.message` event (without preceding `assistant.message_delta` events), `outputCharCount` stayed at 0, causing `estimateTokens(0) = 0` in the SSE `message_delta` epilogue
- Adds a fallback in the `assistant.message` handler to capture the full content string when no deltas were accumulated

## Context

This fix was discovered while investigating PR #417 ("Fix SQLITE_BUSY retries and closed SSE controller handling"). That PR's CI was failing with `expect(outputTokens).toBeGreaterThan(0)` returning 0. The root cause was the Copilot SDK non-incremental response delivery path. PR #417 was closed as a duplicate of #415 (already merged).

## Test plan

- [ ] Unit test added: `runSessionStreaming — output_tokens via assistant.message fallback`
- [ ] Verifies `output_tokens > 0` when SDK delivers via `assistant.message` without deltas
- [ ] Online test `token usage: SSE stream contains non-zero input_tokens and output_tokens` should now pass