### PR TITLE
feat: define Space system shared types (Task 3.1)

### DIFF
--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -320,3 +320,303 @@ export interface SpaceSessionGroup {
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
 }
+
+// ============================================================================
+// SpaceAgent Types (M2)
+// ============================================================================
+
+/**
+ * Builtin agent roles available in the Space system.
+ *
+ * NOTE: 'leader' is intentionally NOT a valid agent role — the Leader agent is
+ * always implicit and managed by SpaceRuntime. User-configurable agents are
+ * limited to worker roles: 'planner', 'coder', 'general'.
+ */
+export type BuiltinAgentRole = 'planner' | 'coder' | 'general';
+
+/**
+ * A named agent configuration within a Space.
+ * SpaceAgents can be referenced by name in SpaceWorkflow steps.
+ */
+export interface SpaceAgent {
+	/** Unique identifier */
+	id: string;
+	/** Space this agent belongs to */
+	spaceId: string;
+	/** Human-readable name (unique within a space) */
+	name: string;
+	/** Optional description of this agent's specialization */
+	description?: string;
+	/**
+	 * Builtin role preset — determines default tools and behavior.
+	 * One of: 'planner', 'coder', 'general'.
+	 * NOTE: 'leader' is NOT a valid role here — Leader is implicit in SpaceRuntime.
+	 */
+	role: BuiltinAgentRole;
+	/** Model ID override (e.g., 'claude-haiku-4-5') — uses space default if unset */
+	model?: string;
+	/** Provider name override (e.g., 'anthropic', 'openai') */
+	provider?: string;
+	/** Custom system prompt appended to the role preset */
+	systemPrompt?: string;
+	/** Tool configuration overrides */
+	toolConfig?: Record<string, unknown>;
+	/** Creation timestamp (milliseconds since epoch) */
+	createdAt: number;
+	/** Last update timestamp (milliseconds since epoch) */
+	updatedAt: number;
+}
+
+/**
+ * Parameters for creating a new SpaceAgent
+ */
+export interface CreateSpaceAgentParams {
+	spaceId: string;
+	name: string;
+	role: BuiltinAgentRole;
+	description?: string;
+	model?: string;
+	provider?: string;
+	systemPrompt?: string;
+	toolConfig?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for updating a SpaceAgent
+ */
+export interface UpdateSpaceAgentParams {
+	name?: string;
+	description?: string | null;
+	role?: BuiltinAgentRole;
+	model?: string | null;
+	provider?: string | null;
+	systemPrompt?: string | null;
+	toolConfig?: Record<string, unknown> | null;
+}
+
+// ============================================================================
+// Workflow Types (M3)
+// ============================================================================
+
+/**
+ * The type of gate used at workflow step boundaries.
+ *
+ * - `auto`: Gate passes automatically when the agent step finishes
+ * - `human_approval`: Requires a human to explicitly approve before proceeding
+ * - `quality_check`: Runs an allowlisted command and passes only on exit code 0
+ * - `pr_review`: Waits for a GitHub PR review to approve before proceeding
+ * - `custom`: Runs a custom script at a relative workspace path (must be allowlisted)
+ */
+export type WorkflowGateType = 'auto' | 'human_approval' | 'quality_check' | 'pr_review' | 'custom';
+
+/**
+ * A gate that controls whether a workflow step may start (entry gate) or
+ * whether the workflow may advance to the next step (exit gate).
+ */
+export interface WorkflowGate {
+	/**
+	 * Type of gate.
+	 * - 'auto': passes immediately
+	 * - 'human_approval': blocks until a human approves
+	 * - 'quality_check': runs an allowlisted shell command
+	 * - 'pr_review': waits for GitHub PR approval
+	 * - 'custom': runs a script at a relative workspace path
+	 */
+	type: WorkflowGateType;
+	/**
+	 * Command or script to execute for 'quality_check' and 'custom' gate types.
+	 *
+	 * - For `quality_check`: must be an allowlisted command (e.g., 'bun test', 'npm run lint').
+	 *   Gate passes on exit code 0, fails on any non-zero exit.
+	 * - For `custom`: must be a path relative to the workspace root (e.g., './scripts/verify.sh').
+	 *   The script is resolved relative to the Space's workspacePath.
+	 */
+	command?: string;
+	/** Human-readable description of what this gate checks */
+	description?: string;
+	/**
+	 * Maximum number of times the gate evaluation is retried on failure.
+	 *
+	 * IMPORTANT: retries re-evaluate the gate only — they do NOT re-run the
+	 * agent step that preceded the gate. To re-run the step itself, the entire
+	 * workflow step must be retried at a higher level.
+	 *
+	 * Defaults to 0 (no retries — fail immediately on first failure).
+	 */
+	maxRetries?: number;
+	/** Timeout for gate evaluation in milliseconds (0 = no timeout) */
+	timeoutMs?: number;
+}
+
+/**
+ * Discriminated union encoding the agent reference within a workflow step.
+ *
+ * Using a union (rather than two separate fields) lets TypeScript enforce that
+ * 'leader' is rejected at compile time when agentRefType is 'builtin'.
+ *
+ * - `builtin`: agentRef is one of the BuiltinAgentRole values ('planner', 'coder', 'general').
+ *   NOTE: 'leader' is NOT a valid builtin agentRef — Leader is always implicit in SpaceRuntime.
+ * - `custom`: agentRef is the `name` of a SpaceAgent defined in this Space.
+ */
+export type WorkflowStepAgent =
+	| { agentRefType: 'builtin'; agentRef: BuiltinAgentRole }
+	| { agentRefType: 'custom'; agentRef: string };
+
+/**
+ * A single step within a SpaceWorkflow.
+ * Each step runs one agent and optionally has entry/exit gates.
+ */
+export type WorkflowStep = WorkflowStepAgent & {
+	/** Unique identifier for this step (stable across renames) */
+	id: string;
+	/** Human-readable name for display */
+	name: string;
+	/**
+	 * Gate checked before this step begins execution.
+	 * If absent, the step starts automatically when the previous step's exit gate passes.
+	 */
+	entryGate?: WorkflowGate;
+	/**
+	 * Gate checked after this step's agent finishes.
+	 * If absent, the workflow advances to the next step automatically.
+	 */
+	exitGate?: WorkflowGate;
+	/** Step-specific instructions appended to the agent's system prompt */
+	instructions?: string;
+	/** Zero-based execution order within the workflow */
+	order: number;
+};
+
+/**
+ * A rule that applies to workflow execution, similar to room-level rules.
+ * Rules express constraints, standards, or guidelines the agent must follow.
+ */
+export interface WorkflowRule {
+	/** Unique identifier (stable across renames) */
+	id: string;
+	/** Human-readable name for display */
+	name: string;
+	/** Rule content — markdown prose describing the constraint or guideline */
+	content: string;
+	/**
+	 * List of step IDs this rule applies to.
+	 *
+	 * Uses step **IDs** (not names) so that rules survive step renames.
+	 * Empty array or omitted means the rule applies to ALL steps in the workflow.
+	 */
+	appliesTo?: string[];
+}
+
+/**
+ * Distributive Omit that preserves discriminated union structure.
+ *
+ * TypeScript's built-in `Omit<T, K>` does not distribute over union members —
+ * when applied to an intersection type that wraps a union (like `WorkflowStep`),
+ * it collapses the discriminant and silently drops union enforcement.
+ * `DistributiveOmit` maps over each union branch individually so that
+ * discriminated-union invariants are preserved in the result.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/**
+ * Input shape for a workflow step at creation time.
+ * `id` and `order` are backend-assigned and must not be provided by callers.
+ * The backend assigns `id` (UUID) and derives `order` from the array position.
+ *
+ * Uses `DistributiveOmit` (not `Omit`) so that the `WorkflowStepAgent`
+ * discriminated union is preserved: TypeScript will still reject
+ * `agentRef: 'leader'` when `agentRefType: 'builtin'` at compile time.
+ */
+export type WorkflowStepInput = DistributiveOmit<WorkflowStep, 'id' | 'order'>;
+
+/**
+ * Input shape for a workflow rule at creation time.
+ * `id` is backend-assigned and must not be provided by callers.
+ */
+export type WorkflowRuleInput = Omit<WorkflowRule, 'id'>;
+
+/**
+ * A named, reusable workflow definition within a Space.
+ * Workflows define an ordered sequence of agent steps with gates and rules.
+ * The SpaceRuntime executes workflows by creating SpaceWorkflowRun instances.
+ */
+export interface SpaceWorkflow {
+	/** Unique identifier */
+	id: string;
+	/** Space this workflow belongs to */
+	spaceId: string;
+	/** Human-readable name */
+	name: string;
+	/** Optional description of what this workflow accomplishes */
+	description?: string;
+	/** Ordered list of steps — executed in ascending `order` */
+	steps: WorkflowStep[];
+	/** Rules that govern agent behavior during this workflow */
+	rules: WorkflowRule[];
+	/**
+	 * Whether this is the default workflow for the Space.
+	 * Only one workflow per Space may have isDefault = true.
+	 * The default workflow is selected automatically when no explicit workflow is chosen.
+	 */
+	isDefault: boolean;
+	/** Tags for categorization and workflow selection heuristics */
+	tags: string[];
+	/** Additional runtime configuration (opaque bag for future extensibility) */
+	config?: Record<string, unknown>;
+	/** Creation timestamp (milliseconds since epoch) */
+	createdAt: number;
+	/** Last update timestamp (milliseconds since epoch) */
+	updatedAt: number;
+}
+
+/**
+ * Parameters for creating a new SpaceWorkflow
+ */
+export interface CreateSpaceWorkflowParams {
+	spaceId: string;
+	name: string;
+	description?: string;
+	/**
+	 * Steps in execution order. `id` and `order` are backend-assigned;
+	 * the array position determines execution order.
+	 */
+	steps?: WorkflowStepInput[];
+	/**
+	 * Rules governing agent behavior. `id` is backend-assigned.
+	 */
+	rules?: WorkflowRuleInput[];
+	/** Whether this workflow should be the default for the Space (default: false) */
+	isDefault?: boolean;
+	/** Tags for categorization (default: []). */
+	tags?: string[];
+	config?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for updating an existing SpaceWorkflow.
+ * All fields are optional — only provided fields are updated.
+ *
+ * For array fields (`steps`, `rules`, `tags`):
+ * - Pass a new array to replace the entire collection.
+ * - Pass `null` to explicitly clear the field to an empty collection.
+ * - Pass `[]` to clear all entries (equivalent to null for arrays).
+ */
+export interface UpdateSpaceWorkflowParams {
+	name?: string;
+	description?: string | null;
+	/**
+	 * Replaces the entire step list. Pass `[]` or `null` to clear all steps.
+	 * The backend re-assigns `order` from the array position.
+	 */
+	steps?: WorkflowStep[] | null;
+	/**
+	 * Replaces the entire rule list. Pass `[]` or `null` to clear all rules.
+	 */
+	rules?: WorkflowRule[] | null;
+	isDefault?: boolean;
+	/**
+	 * Replaces the tag list. Pass `[]` or `null` to clear all tags.
+	 */
+	tags?: string[] | null;
+	config?: Record<string, unknown> | null;
+}


### PR DESCRIPTION
Add packages/shared/src/types/space.ts with all Space, SpaceAgent, and
SpaceWorkflow types. Export from shared barrel (mod.ts).

Types added:
- Space, SpaceStatus, CreateSpaceParams, UpdateSpaceParams (M1)
- SpaceTask, SpaceTaskStatus (M1)
- SpaceWorkflowRun, SpaceWorkflowRunStatus (M1)
- SpaceAgent, BuiltinAgentRole, CreateSpaceAgentParams, UpdateSpaceAgentParams (M2)
- WorkflowGateType, WorkflowGate, WorkflowStep, WorkflowRule (M3)
- SpaceWorkflow, CreateSpaceWorkflowParams, UpdateSpaceWorkflowParams (M3)

JSDoc clarifies: 'leader' is NOT a valid agentRef/BuiltinAgentRole;
maxRetries re-evaluates gate only (does not re-run agent step);
appliesTo uses step IDs (not names) for rename stability.
