### PR TITLE
feat: add Migration 29 — create all Space system tables

### DIFF
--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1479,7 +1479,8 @@ function runMigration29(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_workspace_path ON spaces(workspace_path)`);
+	// Note: workspace_path has a UNIQUE constraint which SQLite implements as an implicit
+	// unique index — no explicit CREATE INDEX needed.
 
 	// -------------------------------------------------------------------------
 	// space_agents
@@ -1611,7 +1612,8 @@ function runMigration29(db: BunDatabase): void {
 			completed_at INTEGER,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+			FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
 		)
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
@@ -1621,6 +1623,9 @@ function runMigration29(db: BunDatabase): void {
 	);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
 	);
 
 	// -------------------------------------------------------------------------
@@ -1653,7 +1658,8 @@ function runMigration29(db: BunDatabase): void {
 				CHECK(role IN ('worker', 'leader')),
 			order_index INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
-			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE
+			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,
+			UNIQUE(group_id, session_id)
 		)
 	`);
 	db.exec(

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -109,6 +109,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 28: Add mission metadata columns to goals table, create mission_metric_history
 	// and mission_executions tables for Goal V2 / Mission System
 	runMigration28(db);
+
+	// Migration 29: Create all Space system tables (spaces, space_agents, space_workflows,
+	// space_workflow_steps, space_workflow_runs, space_tasks, space_session_groups,
+	// space_session_group_members) in FK-safe order
+	runMigration29(db);
 }
 
 /**
@@ -1432,5 +1437,229 @@ function runMigration28(db: BunDatabase): void {
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running` +
 			` ON mission_executions(goal_id) WHERE status = 'running'`
+	);
+}
+
+/**
+ * Migration 29: Create all Space system tables
+ *
+ * Creates the following tables in FK-safe order:
+ * - spaces: workspace-first multi-agent container
+ * - space_agents: custom agents per space
+ * - space_workflows: workflow definitions per space
+ * - space_workflow_steps: ordered steps within a workflow
+ * - space_workflow_runs: active/historical workflow executions (before space_tasks — FK dep)
+ * - space_tasks: tasks with built-in custom_agent_id, workflow_run_id, workflow_step_id
+ * - space_session_groups: named groups of related sessions
+ * - space_session_group_members: membership records for session groups
+ *
+ * All tables are created with IF NOT EXISTS so the migration is idempotent.
+ * CASCADE deletes propagate from spaces → all child tables.
+ */
+function runMigration29(db: BunDatabase): void {
+	// -------------------------------------------------------------------------
+	// spaces
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS spaces (
+			id TEXT PRIMARY KEY,
+			workspace_path TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			background_context TEXT NOT NULL DEFAULT '',
+			instructions TEXT NOT NULL DEFAULT '',
+			default_model TEXT,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			session_ids TEXT NOT NULL DEFAULT '[]',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'archived')),
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_workspace_path ON spaces(workspace_path)`);
+
+	// -------------------------------------------------------------------------
+	// space_agents
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_agents (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			model TEXT,
+			tools TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '',
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_agents_space_id ON space_agents(space_id)`);
+
+	// -------------------------------------------------------------------------
+	// space_workflows
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`);
+
+	// -------------------------------------------------------------------------
+	// space_workflow_steps
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflow_steps (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			agent_id TEXT,
+			order_index INTEGER NOT NULL,
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_steps_workflow_id ON space_workflow_steps(workflow_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_steps_order ON space_workflow_steps(workflow_id, order_index)`
+	);
+
+	// -------------------------------------------------------------------------
+	// space_workflow_runs  (must be before space_tasks — FK dependency)
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			workflow_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			current_step_index INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
+	);
+
+	// -------------------------------------------------------------------------
+	// space_tasks
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			task_type TEXT
+				CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+			assigned_agent TEXT
+				CHECK(assigned_agent IN ('coder', 'general')),
+			custom_agent_id TEXT,
+			workflow_run_id TEXT,
+			workflow_step_id TEXT,
+			created_by_task_id TEXT,
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			input_draft TEXT,
+			active_session TEXT
+				CHECK(active_session IN ('worker', 'leader')),
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			archived_at INTEGER,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+	);
+
+	// -------------------------------------------------------------------------
+	// space_session_groups
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_session_groups (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
+	);
+
+	// -------------------------------------------------------------------------
+	// space_session_group_members
+	// -------------------------------------------------------------------------
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_session_group_members (
+			id TEXT PRIMARY KEY,
+			group_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			role TEXT NOT NULL
+				CHECK(role IN ('worker', 'leader')),
+			order_index INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_group_id ON space_session_group_members(group_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_session_id ON space_session_group_members(session_id)`
 	);
 }

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -181,7 +181,8 @@ describe('Migration 29: Space system tables', () => {
 
 		const expectedIndexes = [
 			'idx_spaces_status',
-			'idx_spaces_workspace_path',
+			// Note: idx_spaces_workspace_path is NOT created — workspace_path UNIQUE constraint
+			// already creates an implicit index, so an explicit one would be redundant.
 			'idx_space_agents_space_id',
 			'idx_space_workflows_space_id',
 			'idx_space_workflow_steps_workflow_id',
@@ -192,6 +193,7 @@ describe('Migration 29: Space system tables', () => {
 			'idx_space_tasks_space_id',
 			'idx_space_tasks_status',
 			'idx_space_tasks_workflow_run_id',
+			'idx_space_tasks_workflow_step_id',
 			'idx_space_tasks_custom_agent_id',
 			'idx_space_session_groups_space_id',
 			'idx_space_session_group_members_group_id',
@@ -438,6 +440,76 @@ describe('Migration 29: Space system tables', () => {
 			db.exec(
 				`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
 				 VALUES ('sp-u2', '/workspace/unique', 'Space U2', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// SET NULL on space_workflow_steps delete
+	// -------------------------------------------------------------------------
+
+	test('deleting a workflow step sets space_tasks.workflow_step_id to NULL', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-step', '/workspace/stepnull', 'StepNull Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES ('wf-step', 'sp-step', 'Workflow Step', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at)
+			 VALUES ('step-s1', 'wf-step', 'Step 1', 0, ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_tasks (id, space_id, title, workflow_step_id, created_at, updated_at)
+			 VALUES ('task-step', 'sp-step', 'Task Step', 'step-s1', ${now}, ${now})`
+		);
+
+		// Delete the workflow step
+		db.exec(`DELETE FROM space_workflow_steps WHERE id = 'step-s1'`);
+
+		// Task should still exist, but workflow_step_id should be NULL
+		const task = db.prepare(`SELECT * FROM space_tasks WHERE id = 'task-step'`).get() as Record<
+			string,
+			unknown
+		>;
+		expect(task).toBeTruthy();
+		expect(task['workflow_step_id']).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// space_session_group_members uniqueness
+	// -------------------------------------------------------------------------
+
+	test('space_session_group_members prevents duplicate (group_id, session_id)', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-uniq', '/workspace/memberuniq', 'MemberUniq Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_session_groups (id, space_id, name, created_at, updated_at)
+			 VALUES ('sg-uniq', 'sp-uniq', 'Group Uniq', ${now}, ${now})`
+		);
+
+		// First insert — should succeed
+		db.exec(
+			`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+			 VALUES ('sgm-dup-1', 'sg-uniq', 'sess-dup', 'worker', 0, ${now})`
+		);
+
+		// Second insert with same (group_id, session_id) — should fail
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+				 VALUES ('sgm-dup-2', 'sg-uniq', 'sess-dup', 'leader', 1, ${now})`
 			);
 		}).toThrow();
 	});

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -1,0 +1,461 @@
+/**
+ * Migration 29 Tests
+ *
+ * Tests for Migration 29: Space system tables.
+ *
+ * Covers:
+ * - All Space tables created correctly on a fresh DB
+ * - Migration is idempotent (runs twice without error)
+ * - No existing tables are affected
+ * - space_tasks has custom_agent_id, workflow_run_id, workflow_step_id columns from the start
+ * - space_workflow_runs tracks workflow execution state
+ * - FK CASCADE deletes work: delete space → all child rows deleted
+ * - space_tasks.workflow_run_id SET NULL on workflow run delete
+ * - CHECK constraints are enforced (status, priority, role, etc.)
+ * - Indexes are created
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tableExists(db: BunDatabase, name: string): boolean {
+	return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(name);
+}
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const info = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return info.some((c) => c.name === column);
+}
+
+function indexExists(db: BunDatabase, name: string): boolean {
+	return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`).get(name);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 29: Space system tables', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-29', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Table creation
+	// -------------------------------------------------------------------------
+
+	test('all Space tables are created after migration', () => {
+		runMigrations(db, () => {});
+
+		const expectedTables = [
+			'spaces',
+			'space_agents',
+			'space_workflows',
+			'space_workflow_steps',
+			'space_workflow_runs',
+			'space_tasks',
+			'space_session_groups',
+			'space_session_group_members',
+		];
+
+		for (const table of expectedTables) {
+			expect(tableExists(db, table)).toBe(true);
+		}
+	});
+
+	test('migration is idempotent — running twice does not throw', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// space_tasks columns
+	// -------------------------------------------------------------------------
+
+	test('space_tasks has custom_agent_id column from the start', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_tasks', 'custom_agent_id')).toBe(true);
+	});
+
+	test('space_tasks has workflow_run_id column from the start', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_tasks', 'workflow_run_id')).toBe(true);
+	});
+
+	test('space_tasks has workflow_step_id column from the start', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_tasks', 'workflow_step_id')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// space_workflow_runs state tracking
+	// -------------------------------------------------------------------------
+
+	test('space_workflow_runs has all required workflow tracking columns', () => {
+		runMigrations(db, () => {});
+
+		const requiredCols = [
+			'id',
+			'space_id',
+			'workflow_id',
+			'title',
+			'description',
+			'current_step_index',
+			'status',
+			'config',
+			'created_at',
+			'updated_at',
+			'completed_at',
+		];
+
+		for (const col of requiredCols) {
+			expect(columnExists(db, 'space_workflow_runs', col)).toBe(true);
+		}
+	});
+
+	test('space_workflow_runs status CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Insert a space first
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('s-1', '/workspace/a', 'Space A', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES ('wf-1', 's-1', 'Workflow 1', ${now}, ${now})`
+		);
+
+		// Valid status
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+				 VALUES ('wr-ok', 's-1', 'wf-1', 'Run 1', 'in_progress', ${now}, ${now})`
+			);
+		}).not.toThrow();
+
+		// Invalid status
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+				 VALUES ('wr-bad', 's-1', 'wf-1', 'Run 2', 'invalid_status', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// Indexes
+	// -------------------------------------------------------------------------
+
+	test('expected indexes are created', () => {
+		runMigrations(db, () => {});
+
+		const expectedIndexes = [
+			'idx_spaces_status',
+			'idx_spaces_workspace_path',
+			'idx_space_agents_space_id',
+			'idx_space_workflows_space_id',
+			'idx_space_workflow_steps_workflow_id',
+			'idx_space_workflow_steps_order',
+			'idx_space_workflow_runs_space_id',
+			'idx_space_workflow_runs_workflow_id',
+			'idx_space_workflow_runs_status',
+			'idx_space_tasks_space_id',
+			'idx_space_tasks_status',
+			'idx_space_tasks_workflow_run_id',
+			'idx_space_tasks_custom_agent_id',
+			'idx_space_session_groups_space_id',
+			'idx_space_session_group_members_group_id',
+			'idx_space_session_group_members_session_id',
+		];
+
+		for (const idx of expectedIndexes) {
+			expect(indexExists(db, idx)).toBe(true);
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// CASCADE deletes: delete space → all child rows deleted
+	// -------------------------------------------------------------------------
+
+	test('deleting a space cascades to all child tables', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+
+		// Insert a space
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-1', '/workspace/cascade', 'Cascade Space', ${now}, ${now})`
+		);
+
+		// Insert a space agent
+		db.exec(
+			`INSERT INTO space_agents (id, space_id, name, created_at, updated_at)
+			 VALUES ('agent-1', 'sp-1', 'Agent 1', ${now}, ${now})`
+		);
+
+		// Insert a workflow
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES ('wf-1', 'sp-1', 'Workflow 1', ${now}, ${now})`
+		);
+
+		// Insert a workflow step
+		db.exec(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at)
+			 VALUES ('step-1', 'wf-1', 'Step 1', 0, ${now}, ${now})`
+		);
+
+		// Insert a workflow run
+		db.exec(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, created_at, updated_at)
+			 VALUES ('wr-1', 'sp-1', 'wf-1', 'Run 1', ${now}, ${now})`
+		);
+
+		// Insert a task
+		db.exec(
+			`INSERT INTO space_tasks (id, space_id, title, created_at, updated_at)
+			 VALUES ('task-1', 'sp-1', 'Task 1', ${now}, ${now})`
+		);
+
+		// Insert a session group
+		db.exec(
+			`INSERT INTO space_session_groups (id, space_id, name, created_at, updated_at)
+			 VALUES ('sg-1', 'sp-1', 'Group 1', ${now}, ${now})`
+		);
+
+		// Insert a session group member
+		db.exec(
+			`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+			 VALUES ('sgm-1', 'sg-1', 'sess-1', 'worker', 0, ${now})`
+		);
+
+		// Delete the space
+		db.exec(`DELETE FROM spaces WHERE id = 'sp-1'`);
+
+		// All child rows should be gone
+		expect(db.prepare(`SELECT * FROM space_agents WHERE space_id = 'sp-1'`).all()).toHaveLength(0);
+		expect(db.prepare(`SELECT * FROM space_workflows WHERE space_id = 'sp-1'`).all()).toHaveLength(
+			0
+		);
+		expect(
+			db.prepare(`SELECT * FROM space_workflow_steps WHERE workflow_id = 'wf-1'`).all()
+		).toHaveLength(0);
+		expect(
+			db.prepare(`SELECT * FROM space_workflow_runs WHERE space_id = 'sp-1'`).all()
+		).toHaveLength(0);
+		expect(db.prepare(`SELECT * FROM space_tasks WHERE space_id = 'sp-1'`).all()).toHaveLength(0);
+		expect(
+			db.prepare(`SELECT * FROM space_session_groups WHERE space_id = 'sp-1'`).all()
+		).toHaveLength(0);
+		expect(
+			db.prepare(`SELECT * FROM space_session_group_members WHERE group_id = 'sg-1'`).all()
+		).toHaveLength(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// SET NULL on space_workflow_runs delete
+	// -------------------------------------------------------------------------
+
+	test('deleting a workflow run sets space_tasks.workflow_run_id to NULL', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-2', '/workspace/setnull', 'SetNull Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES ('wf-2', 'sp-2', 'Workflow 2', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, created_at, updated_at)
+			 VALUES ('wr-2', 'sp-2', 'wf-2', 'Run 2', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_tasks (id, space_id, title, workflow_run_id, created_at, updated_at)
+			 VALUES ('task-2', 'sp-2', 'Task 2', 'wr-2', ${now}, ${now})`
+		);
+
+		// Delete the workflow run
+		db.exec(`DELETE FROM space_workflow_runs WHERE id = 'wr-2'`);
+
+		// Task should still exist, but workflow_run_id should be NULL
+		const task = db.prepare(`SELECT * FROM space_tasks WHERE id = 'task-2'`).get() as Record<
+			string,
+			unknown
+		>;
+		expect(task).toBeTruthy();
+		expect(task['workflow_run_id']).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// CHECK constraints on space_tasks
+	// -------------------------------------------------------------------------
+
+	test('space_tasks status CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-3', '/workspace/checks', 'Check Space', ${now}, ${now})`
+		);
+
+		// Valid status values
+		for (const status of [
+			'draft',
+			'pending',
+			'in_progress',
+			'review',
+			'completed',
+			'needs_attention',
+			'cancelled',
+		]) {
+			expect(() => {
+				db.exec(
+					`INSERT INTO space_tasks (id, space_id, title, status, created_at, updated_at)
+					 VALUES ('t-${status}', 'sp-3', 'Task', '${status}', ${now}, ${now})`
+				);
+			}).not.toThrow();
+		}
+
+		// Invalid status
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_tasks (id, space_id, title, status, created_at, updated_at)
+				 VALUES ('t-bad', 'sp-3', 'Task', 'invalid', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	test('space_tasks priority CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-4', '/workspace/priority', 'Priority Space', ${now}, ${now})`
+		);
+
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_tasks (id, space_id, title, priority, created_at, updated_at)
+				 VALUES ('t-urgent', 'sp-4', 'Task', 'urgent', ${now}, ${now})`
+			);
+		}).not.toThrow();
+
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_tasks (id, space_id, title, priority, created_at, updated_at)
+				 VALUES ('t-bad-pri', 'sp-4', 'Task', 'extreme', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// space_session_group_members role CHECK
+	// -------------------------------------------------------------------------
+
+	test('space_session_group_members role CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-5', '/workspace/roles', 'Role Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_session_groups (id, space_id, name, created_at, updated_at)
+			 VALUES ('sg-5', 'sp-5', 'Group 5', ${now}, ${now})`
+		);
+
+		// Valid roles
+		for (const role of ['worker', 'leader']) {
+			expect(() => {
+				db.exec(
+					`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+					 VALUES ('sgm-${role}', 'sg-5', 'sess-${role}', '${role}', 0, ${now})`
+				);
+			}).not.toThrow();
+		}
+
+		// Invalid role
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+				 VALUES ('sgm-bad', 'sg-5', 'sess-bad', 'observer', 0, ${now})`
+			);
+		}).toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// spaces workspace_path uniqueness
+	// -------------------------------------------------------------------------
+
+	test('spaces.workspace_path is unique', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-u1', '/workspace/unique', 'Space U1', ${now}, ${now})`
+		);
+
+		expect(() => {
+			db.exec(
+				`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+				 VALUES ('sp-u2', '/workspace/unique', 'Space U2', ${now}, ${now})`
+			);
+		}).toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// No existing tables affected
+	// -------------------------------------------------------------------------
+
+	test('no existing core tables are dropped or modified by migration 29', () => {
+		runMigrations(db, () => {});
+
+		// These tables are created by runMigrations / createTables and must still exist
+		// after migration 29 runs. We just verify the migration itself doesn't drop them.
+		// mission_metric_history and mission_executions were created in migration 28.
+		const tablesFromEarlierMigrations = ['mission_metric_history', 'mission_executions'];
+
+		for (const table of tablesFromEarlierMigrations) {
+			expect(tableExists(db, table)).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
Creates all 8 Space-related tables in a single migration (29) in
FK-safe order: spaces → space_agents, space_workflows →
space_workflow_steps, space_workflow_runs → space_tasks →
space_session_groups → space_session_group_members.

- space_tasks includes custom_agent_id, workflow_run_id, and
  workflow_step_id columns from the start (no ALTER TABLE needed later)
- space_workflow_runs tracks execution state with status CHECK constraint
- All FK cascades: delete space → all child rows deleted
- space_tasks.workflow_run_id SET NULL on workflow run delete
- Indexes created for all FK columns and status columns
- Migration is idempotent (CREATE TABLE/INDEX IF NOT EXISTS throughout)
- 15 unit tests covering all tables, cascades, constraints, and indexes
