### PR TITLE
feat: add Space repositories and managers (Task 1.3)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -24,6 +24,7 @@
 		"scripts/**",
 		"packages/daemon/src/lib/agent/output-limiter-hook.ts",
 		"packages/daemon/src/lib/lobby/index.ts",
+		"packages/daemon/src/lib/space/index.ts",
 		"packages/daemon/src/lib/prompts/index.ts",
 		"packages/shared/src/event-bus.ts",
 		"packages/daemon/src/lib/room/task-message-queue.ts",

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Space module — managers for the Space multi-agent workflow system.
+ */
+
+export { SpaceManager } from './managers/space-manager';
+export {
+	SpaceTaskManager,
+	VALID_SPACE_TASK_TRANSITIONS,
+	isValidSpaceTaskTransition,
+} from './managers/space-task-manager';

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -1,0 +1,176 @@
+/**
+ * SpaceManager - Space management with workspace path validation
+ *
+ * Handles:
+ * - Creating spaces with workspace path validation (symlink resolution, existence check, uniqueness)
+ * - Listing, updating, archiving, and deleting spaces
+ * - Session association
+ */
+
+import { promises as fs } from 'node:fs';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { SpaceRepository } from '../../../storage/repositories/space-repository';
+import type { Space, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
+
+const execAsync = promisify(exec);
+
+export class SpaceManager {
+	private spaceRepo: SpaceRepository;
+
+	constructor(private db: BunDatabase) {
+		this.spaceRepo = new SpaceRepository(db);
+	}
+
+	/**
+	 * Create a new space.
+	 * Validates the workspace path: resolves symlinks, checks existence, ensures uniqueness.
+	 * Warns (but does not fail) if the path is not a git repository.
+	 */
+	async createSpace(params: CreateSpaceParams): Promise<Space> {
+		const resolvedPath = await this.resolveAndValidatePath(params.workspacePath);
+
+		// Check uniqueness across active spaces
+		const existing = this.spaceRepo.getSpaceByPath(resolvedPath);
+		if (existing) {
+			throw new Error(
+				`A space already exists for workspace path: ${resolvedPath} (space id: ${existing.id})`
+			);
+		}
+
+		// Warn if not a git repository (non-fatal)
+		const isGit = await this.isGitRepository(resolvedPath);
+		if (!isGit) {
+			// Warn only — using a logger would require injecting one; warn via stderr for now
+			process.stderr.write(
+				`[SpaceManager] Warning: workspace path is not a git repository: ${resolvedPath}\n`
+			);
+		}
+
+		return this.spaceRepo.createSpace({ ...params, workspacePath: resolvedPath });
+	}
+
+	/**
+	 * Get a space by ID
+	 */
+	async getSpace(id: string): Promise<Space | null> {
+		return this.spaceRepo.getSpace(id);
+	}
+
+	/**
+	 * List spaces
+	 */
+	async listSpaces(includeArchived = false): Promise<Space[]> {
+		return this.spaceRepo.listSpaces(includeArchived);
+	}
+
+	/**
+	 * Update a space
+	 */
+	async updateSpace(id: string, params: UpdateSpaceParams): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+
+		const updated = this.spaceRepo.updateSpace(id, params);
+		if (!updated) {
+			throw new Error(`Failed to update space: ${id}`);
+		}
+
+		return updated;
+	}
+
+	/**
+	 * Archive a space
+	 */
+	async archiveSpace(id: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+
+		const archived = this.spaceRepo.archiveSpace(id);
+		if (!archived) {
+			throw new Error(`Failed to archive space: ${id}`);
+		}
+
+		return archived;
+	}
+
+	/**
+	 * Delete a space by ID
+	 */
+	async deleteSpace(id: string): Promise<boolean> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			return false;
+		}
+
+		return this.spaceRepo.deleteSpace(id);
+	}
+
+	/**
+	 * Add a session to a space
+	 */
+	async addSession(spaceId: string, sessionId: string): Promise<Space> {
+		const updated = this.spaceRepo.addSessionToSpace(spaceId, sessionId);
+		if (!updated) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+		return updated;
+	}
+
+	/**
+	 * Remove a session from a space
+	 */
+	async removeSession(spaceId: string, sessionId: string): Promise<Space> {
+		const updated = this.spaceRepo.removeSessionFromSpace(spaceId, sessionId);
+		if (!updated) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+		return updated;
+	}
+
+	/**
+	 * Resolve symlinks and validate the workspace path exists and is a directory.
+	 * Returns the real (resolved) absolute path.
+	 */
+	private async resolveAndValidatePath(workspacePath: string): Promise<string> {
+		// Resolve symlinks to get the canonical real path
+		let realPath: string;
+		try {
+			realPath = await fs.realpath(workspacePath);
+		} catch {
+			throw new Error(`Workspace path does not exist: ${workspacePath}`);
+		}
+
+		// Verify it is accessible and is a directory
+		try {
+			const stat = await fs.stat(realPath);
+			if (!stat.isDirectory()) {
+				throw new Error(`Workspace path is not a directory: ${realPath}`);
+			}
+		} catch (err) {
+			if (err instanceof Error && err.message.includes('not a directory')) {
+				throw err;
+			}
+			throw new Error(`Cannot access workspace path: ${realPath}`);
+		}
+
+		return realPath;
+	}
+
+	/**
+	 * Check if the given path is inside a git repository (non-fatal check)
+	 */
+	private async isGitRepository(dirPath: string): Promise<boolean> {
+		try {
+			await execAsync('git rev-parse --git-dir', { cwd: dirPath });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -12,9 +12,11 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRepository } from '../../../storage/repositories/space-repository';
+import { Logger } from '../../logger';
 import type { Space, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
 
 const execAsync = promisify(exec);
+const log = new Logger('SpaceManager');
 
 export class SpaceManager {
 	private spaceRepo: SpaceRepository;
@@ -42,10 +44,7 @@ export class SpaceManager {
 		// Warn if not a git repository (non-fatal)
 		const isGit = await this.isGitRepository(resolvedPath);
 		if (!isGit) {
-			// Warn only — using a logger would require injecting one; warn via stderr for now
-			process.stderr.write(
-				`[SpaceManager] Warning: workspace path is not a git repository: ${resolvedPath}\n`
-			);
+			log.warn(`workspace path is not a git repository: ${resolvedPath}`);
 		}
 
 		return this.spaceRepo.createSpace({ ...params, workspacePath: resolvedPath });

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -115,10 +115,13 @@ export class SpaceTaskManager {
 			updates.error = options.error;
 		}
 
-		// Clear error/result when restarting
+		// Clear error/result/progress when restarting from a failed/cancelled state.
+		// For needs_attention: allowed targets are pending, in_progress, review.
+		// For cancelled: allowed targets are pending, in_progress (review is not valid from cancelled).
 		if (
-			(task.status === 'needs_attention' || task.status === 'cancelled') &&
-			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')
+			(task.status === 'needs_attention' &&
+				(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')) ||
+			(task.status === 'cancelled' && (newStatus === 'pending' || newStatus === 'in_progress'))
 		) {
 			updates.error = null;
 			updates.result = null;
@@ -209,35 +212,27 @@ export class SpaceTaskManager {
 	}
 
 	/**
-	 * Move task to review
+	 * Move task to review (work done, awaiting human approval).
+	 * Validates the transition via setTaskStatus, then applies PR metadata.
 	 */
 	async reviewTask(taskId: string, prUrl?: string): Promise<SpaceTask> {
-		const task = await this.getTask(taskId);
-		if (!task) {
-			throw new Error(`Task not found: ${taskId}`);
-		}
+		// setTaskStatus handles existence check, transition validation, and field clearing
+		await this.setTaskStatus(taskId, 'review');
 
-		if (!isValidSpaceTaskTransition(task.status, 'review')) {
-			throw new Error(
-				`Invalid status transition from '${task.status}' to 'review'. ` +
-					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
-			);
-		}
-
-		const updates: Parameters<SpaceTaskRepository['updateTask']>[1] = {
-			status: 'review',
+		// Apply PR metadata on top of the transition
+		const prUpdates: Parameters<SpaceTaskRepository['updateTask']>[1] = {
 			currentStep: prUrl ?? 'Awaiting review',
 			progress: 80,
 		};
 
 		if (prUrl !== undefined) {
-			updates.prUrl = prUrl;
+			prUpdates.prUrl = prUrl;
 			const match = prUrl.match(/\/pull\/(\d+)/);
-			updates.prNumber = match ? parseInt(match[1], 10) : null;
-			updates.prCreatedAt = Date.now();
+			prUpdates.prNumber = match ? parseInt(match[1], 10) : null;
+			prUpdates.prCreatedAt = Date.now();
 		}
 
-		const updated = this.taskRepo.updateTask(taskId, updates);
+		const updated = this.taskRepo.updateTask(taskId, prUpdates);
 		if (!updated) {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -1,0 +1,301 @@
+/**
+ * SpaceTaskManager - Space task management with status transitions
+ *
+ * Handles:
+ * - Creating space tasks with dependency validation
+ * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review)
+ * - Task assignment and progress tracking
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceTask, SpaceTaskStatus, CreateSpaceTaskParams } from '@neokai/shared';
+
+/**
+ * Valid task status transitions for space tasks
+ * Maps current status -> allowed next statuses
+ */
+export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
+	draft: ['pending'],
+	pending: ['in_progress', 'cancelled'],
+	in_progress: ['review', 'completed', 'needs_attention', 'cancelled'],
+	review: ['completed', 'needs_attention', 'in_progress'],
+	completed: [],
+	needs_attention: ['pending', 'in_progress', 'review'],
+	cancelled: ['pending', 'in_progress'],
+};
+
+/**
+ * Check if a space task status transition is valid
+ */
+export function isValidSpaceTaskTransition(from: SpaceTaskStatus, to: SpaceTaskStatus): boolean {
+	return VALID_SPACE_TASK_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export class SpaceTaskManager {
+	private taskRepo: SpaceTaskRepository;
+
+	constructor(
+		private db: BunDatabase,
+		private spaceId: string
+	) {
+		this.taskRepo = new SpaceTaskRepository(db);
+	}
+
+	/**
+	 * Create a task in this space
+	 */
+	async createTask(params: Omit<CreateSpaceTaskParams, 'spaceId'>): Promise<SpaceTask> {
+		// Validate dependency task IDs exist in this space
+		if (params.dependsOn && params.dependsOn.length > 0) {
+			for (const depId of params.dependsOn) {
+				const dep = await this.getTask(depId);
+				if (!dep) {
+					throw new Error(`Dependency task not found in space: ${depId}`);
+				}
+			}
+		}
+
+		return this.taskRepo.createTask({ ...params, spaceId: this.spaceId });
+	}
+
+	/**
+	 * Get a task by ID (validates it belongs to this space)
+	 */
+	async getTask(taskId: string): Promise<SpaceTask | null> {
+		const task = this.taskRepo.getTask(taskId);
+		if (task && task.spaceId === this.spaceId) {
+			return task;
+		}
+		return null;
+	}
+
+	/**
+	 * List tasks in this space
+	 */
+	async listTasks(includeArchived = false): Promise<SpaceTask[]> {
+		return this.taskRepo.listBySpace(this.spaceId, includeArchived);
+	}
+
+	/**
+	 * List tasks by status
+	 */
+	async listTasksByStatus(status: SpaceTaskStatus): Promise<SpaceTask[]> {
+		return this.taskRepo.listByStatus(this.spaceId, status);
+	}
+
+	/**
+	 * Update task status with validation
+	 */
+	async setTaskStatus(
+		taskId: string,
+		newStatus: SpaceTaskStatus,
+		options?: { result?: string; error?: string }
+	): Promise<SpaceTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		if (!isValidSpaceTaskTransition(task.status, newStatus)) {
+			throw new Error(
+				`Invalid status transition from '${task.status}' to '${newStatus}'. ` +
+					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
+		}
+
+		const updates: Parameters<SpaceTaskRepository['updateTask']>[1] = { status: newStatus };
+
+		if (newStatus === 'completed') {
+			updates.progress = 100;
+			if (options?.result) updates.result = options.result;
+		}
+
+		if (newStatus === 'needs_attention' && options?.error) {
+			updates.error = options.error;
+		}
+
+		// Clear error/result when restarting
+		if (
+			(task.status === 'needs_attention' || task.status === 'cancelled') &&
+			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')
+		) {
+			updates.error = null;
+			updates.result = null;
+			updates.progress = null;
+		}
+
+		const updated = this.taskRepo.updateTask(taskId, updates);
+		if (!updated) {
+			throw new Error(`Failed to update task: ${taskId}`);
+		}
+
+		return updated;
+	}
+
+	/**
+	 * Update task progress
+	 */
+	async updateTaskProgress(
+		taskId: string,
+		progress: number,
+		currentStep?: string
+	): Promise<SpaceTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		const updated = this.taskRepo.updateTask(taskId, {
+			progress: Math.min(100, Math.max(0, progress)),
+			currentStep,
+		});
+
+		if (!updated) {
+			throw new Error(`Failed to update task progress: ${taskId}`);
+		}
+
+		return updated;
+	}
+
+	/**
+	 * Start a task (mark as in_progress)
+	 */
+	async startTask(taskId: string): Promise<SpaceTask> {
+		return this.setTaskStatus(taskId, 'in_progress');
+	}
+
+	/**
+	 * Complete a task
+	 */
+	async completeTask(taskId: string, result: string): Promise<SpaceTask> {
+		return this.setTaskStatus(taskId, 'completed', { result });
+	}
+
+	/**
+	 * Fail a task (mark as needs_attention)
+	 */
+	async failTask(taskId: string, error: string): Promise<SpaceTask> {
+		return this.setTaskStatus(taskId, 'needs_attention', { error });
+	}
+
+	/**
+	 * Cancel a task and cascade to pending dependents
+	 */
+	async cancelTask(taskId: string): Promise<SpaceTask> {
+		const all = await this.cancelTaskCascade(taskId);
+		return all[0];
+	}
+
+	/**
+	 * Cancel task and cascade to pending dependents recursively
+	 */
+	async cancelTaskCascade(taskId: string): Promise<SpaceTask[]> {
+		return this.doCancelCascade(taskId, []);
+	}
+
+	private async doCancelCascade(taskId: string, acc: SpaceTask[]): Promise<SpaceTask[]> {
+		const result = await this.setTaskStatus(taskId, 'cancelled');
+		acc.push(result);
+
+		const pendingTasks = await this.listTasksByStatus('pending');
+		for (const t of pendingTasks) {
+			if (t.dependsOn?.includes(taskId)) {
+				await this.doCancelCascade(t.id, acc);
+			}
+		}
+
+		return acc;
+	}
+
+	/**
+	 * Move task to review
+	 */
+	async reviewTask(taskId: string, prUrl?: string): Promise<SpaceTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		if (!isValidSpaceTaskTransition(task.status, 'review')) {
+			throw new Error(
+				`Invalid status transition from '${task.status}' to 'review'. ` +
+					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
+		}
+
+		const updates: Parameters<SpaceTaskRepository['updateTask']>[1] = {
+			status: 'review',
+			currentStep: prUrl ?? 'Awaiting review',
+			progress: 80,
+		};
+
+		if (prUrl !== undefined) {
+			updates.prUrl = prUrl;
+			const match = prUrl.match(/\/pull\/(\d+)/);
+			updates.prNumber = match ? parseInt(match[1], 10) : null;
+			updates.prCreatedAt = Date.now();
+		}
+
+		const updated = this.taskRepo.updateTask(taskId, updates);
+		if (!updated) {
+			throw new Error(`Failed to update task: ${taskId}`);
+		}
+
+		return updated;
+	}
+
+	/**
+	 * Promote draft tasks created by a planning task to pending
+	 */
+	async promoteDraftTasks(creatorTaskId: string): Promise<number> {
+		return this.taskRepo.promoteDraftTasksByCreator(creatorTaskId);
+	}
+
+	/**
+	 * Archive a task
+	 */
+	async archiveTask(taskId: string): Promise<SpaceTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		const updated = this.taskRepo.archiveTask(taskId);
+		if (!updated) {
+			throw new Error(`Failed to archive task: ${taskId}`);
+		}
+
+		return updated;
+	}
+
+	/**
+	 * Delete a task
+	 */
+	async deleteTask(taskId: string): Promise<boolean> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			return false;
+		}
+
+		return this.taskRepo.deleteTask(taskId);
+	}
+
+	/**
+	 * Check if all dependencies for a task are met (completed)
+	 */
+	async areDependenciesMet(task: SpaceTask): Promise<boolean> {
+		if (!task.dependsOn || task.dependsOn.length === 0) {
+			return true;
+		}
+
+		for (const depId of task.dependsOn) {
+			const dep = await this.getTask(depId);
+			if (!dep || dep.status !== 'completed') {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -55,7 +55,12 @@ export class SpaceRepository {
 	}
 
 	/**
-	 * Get a space by workspace path
+	 * Get a space by workspace path (any status, including archived).
+	 *
+	 * NOTE: This intentionally returns archived spaces. The `workspace_path` column
+	 * has a UNIQUE constraint in the schema, so archived spaces permanently claim their
+	 * path — no new space can be created for the same path after archiving. This is
+	 * the chosen design: workspace paths are a permanent identifier, not a reusable slot.
 	 */
 	getSpaceByPath(workspacePath: string): Space | null {
 		const stmt = this.db.prepare(`SELECT * FROM spaces WHERE workspace_path = ?`);

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -1,0 +1,220 @@
+/**
+ * Space Repository
+ *
+ * Repository for Space CRUD operations.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type { Space, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
+import type { SQLiteValue } from '../types';
+
+export class SpaceRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new space
+	 */
+	createSpace(params: CreateSpaceParams): Space {
+		const id = generateUUID();
+		const now = Date.now();
+
+		const stmt = this.db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		);
+
+		stmt.run(
+			id,
+			params.workspacePath,
+			params.name,
+			params.description ?? '',
+			params.backgroundContext ?? '',
+			params.instructions ?? '',
+			params.defaultModel ?? null,
+			JSON.stringify(params.allowedModels ?? []),
+			'[]',
+			'active',
+			params.config ? JSON.stringify(params.config) : null,
+			now,
+			now
+		);
+
+		return this.getSpace(id)!;
+	}
+
+	/**
+	 * Get a space by ID
+	 */
+	getSpace(id: string): Space | null {
+		const stmt = this.db.prepare(`SELECT * FROM spaces WHERE id = ?`);
+		const row = stmt.get(id) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+		return this.rowToSpace(row);
+	}
+
+	/**
+	 * Get a space by workspace path
+	 */
+	getSpaceByPath(workspacePath: string): Space | null {
+		const stmt = this.db.prepare(`SELECT * FROM spaces WHERE workspace_path = ?`);
+		const row = stmt.get(workspacePath) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+		return this.rowToSpace(row);
+	}
+
+	/**
+	 * List all spaces, optionally including archived ones
+	 */
+	listSpaces(includeArchived = false): Space[] {
+		let query = `SELECT * FROM spaces`;
+		if (!includeArchived) {
+			query += ` WHERE status = 'active'`;
+		}
+		query += ` ORDER BY updated_at DESC`;
+
+		const stmt = this.db.prepare(query);
+		const rows = stmt.all() as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpace(r));
+	}
+
+	/**
+	 * Update a space with partial updates
+	 */
+	updateSpace(id: string, params: UpdateSpaceParams): Space | null {
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (params.name !== undefined) {
+			fields.push('name = ?');
+			values.push(params.name);
+		}
+		if (params.description !== undefined) {
+			fields.push('description = ?');
+			values.push(params.description);
+		}
+		if (params.backgroundContext !== undefined) {
+			fields.push('background_context = ?');
+			values.push(params.backgroundContext);
+		}
+		if (params.instructions !== undefined) {
+			fields.push('instructions = ?');
+			values.push(params.instructions);
+		}
+		if (params.defaultModel !== undefined) {
+			fields.push('default_model = ?');
+			values.push(params.defaultModel ?? null);
+		}
+		if (params.allowedModels !== undefined) {
+			fields.push('allowed_models = ?');
+			values.push(JSON.stringify(params.allowedModels));
+		}
+		if (params.config !== undefined) {
+			fields.push('config = ?');
+			values.push(JSON.stringify(params.config));
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
+			values.push(id);
+			const stmt = this.db.prepare(`UPDATE spaces SET ${fields.join(', ')} WHERE id = ?`);
+			stmt.run(...values);
+		}
+
+		return this.getSpace(id);
+	}
+
+	/**
+	 * Archive a space
+	 */
+	archiveSpace(id: string): Space | null {
+		const stmt = this.db.prepare(
+			`UPDATE spaces SET status = 'archived', updated_at = ? WHERE id = ?`
+		);
+		stmt.run(Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
+	 * Add a session to a space
+	 */
+	addSessionToSpace(spaceId: string, sessionId: string): Space | null {
+		const tx = this.db.transaction(() => {
+			const space = this.getSpace(spaceId);
+			if (!space) return null;
+
+			if (space.sessionIds.includes(sessionId)) {
+				return space;
+			}
+
+			const sessionIds = [...space.sessionIds, sessionId];
+			const stmt = this.db.prepare(
+				`UPDATE spaces SET session_ids = ?, updated_at = ? WHERE id = ?`
+			);
+			stmt.run(JSON.stringify(sessionIds), Date.now(), spaceId);
+			return this.getSpace(spaceId);
+		});
+
+		return tx() as Space | null;
+	}
+
+	/**
+	 * Remove a session from a space
+	 */
+	removeSessionFromSpace(spaceId: string, sessionId: string): Space | null {
+		const tx = this.db.transaction(() => {
+			const space = this.getSpace(spaceId);
+			if (!space) return null;
+
+			if (!space.sessionIds.includes(sessionId)) {
+				return space;
+			}
+
+			const sessionIds = space.sessionIds.filter((id) => id !== sessionId);
+			const stmt = this.db.prepare(
+				`UPDATE spaces SET session_ids = ?, updated_at = ? WHERE id = ?`
+			);
+			stmt.run(JSON.stringify(sessionIds), Date.now(), spaceId);
+			return this.getSpace(spaceId);
+		});
+
+		return tx() as Space | null;
+	}
+
+	/**
+	 * Delete a space by ID
+	 */
+	deleteSpace(id: string): boolean {
+		const stmt = this.db.prepare(`DELETE FROM spaces WHERE id = ?`);
+		const result = stmt.run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Convert a database row to a Space object
+	 */
+	private rowToSpace(row: Record<string, unknown>): Space {
+		const rawModels = JSON.parse((row.allowed_models as string) ?? '[]') as string[];
+		const rawConfig = row.config as string | null;
+		const config = rawConfig ? (JSON.parse(rawConfig) as Record<string, unknown>) : undefined;
+
+		return {
+			id: row.id as string,
+			workspacePath: row.workspace_path as string,
+			name: row.name as string,
+			description: (row.description as string) ?? '',
+			backgroundContext: (row.background_context as string) ?? '',
+			instructions: (row.instructions as string) ?? '',
+			defaultModel: (row.default_model as string | null) ?? undefined,
+			allowedModels: rawModels.length > 0 ? rawModels : undefined,
+			sessionIds: JSON.parse(row.session_ids as string) as string[],
+			status: row.status as 'active' | 'archived',
+			config,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -1,0 +1,239 @@
+/**
+ * Space Session Group Repository
+ *
+ * Repository for SpaceSessionGroup and SpaceSessionGroupMember CRUD operations.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type { SpaceSessionGroup, SpaceSessionGroupMember } from '@neokai/shared';
+
+export interface CreateSessionGroupParams {
+	spaceId: string;
+	name: string;
+	description?: string;
+}
+
+export interface UpdateSessionGroupParams {
+	name?: string;
+	description?: string;
+}
+
+export class SpaceSessionGroupRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new session group
+	 */
+	createGroup(params: CreateSessionGroupParams): SpaceSessionGroup {
+		const id = generateUUID();
+		const now = Date.now();
+
+		const stmt = this.db.prepare(
+			`INSERT INTO space_session_groups (id, space_id, name, description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+		);
+
+		stmt.run(id, params.spaceId, params.name, params.description ?? null, now, now);
+
+		return this.getGroup(id)!;
+	}
+
+	/**
+	 * Get a session group by ID, including its members
+	 */
+	getGroup(id: string): SpaceSessionGroup | null {
+		const stmt = this.db.prepare(`SELECT * FROM space_session_groups WHERE id = ?`);
+		const row = stmt.get(id) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+
+		const members = this.getGroupMembers(id);
+		return this.rowToGroup(row, members);
+	}
+
+	/**
+	 * List all session groups for a space, including their members
+	 */
+	getGroupsBySpace(spaceId: string): SpaceSessionGroup[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_session_groups WHERE space_id = ? ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+
+		return rows.map((row) => {
+			const members = this.getGroupMembers(row.id as string);
+			return this.rowToGroup(row, members);
+		});
+	}
+
+	/**
+	 * Get all session groups that contain a specific task's associated sessions.
+	 * Returns groups matching by spaceId and name pattern (groups for a given task).
+	 */
+	getGroupsByTask(spaceId: string, taskId: string): SpaceSessionGroup[] {
+		// Groups are associated to tasks by their name convention (e.g. "task:{taskId}")
+		// or by querying members. We query groups that are named for a task.
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_session_groups WHERE space_id = ? AND name = ? ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(spaceId, `task:${taskId}`) as Record<string, unknown>[];
+
+		return rows.map((row) => {
+			const members = this.getGroupMembers(row.id as string);
+			return this.rowToGroup(row, members);
+		});
+	}
+
+	/**
+	 * Update a session group
+	 */
+	updateGroup(id: string, params: UpdateSessionGroupParams): SpaceSessionGroup | null {
+		const fields: string[] = [];
+		const values: (string | number | null)[] = [];
+
+		if (params.name !== undefined) {
+			fields.push('name = ?');
+			values.push(params.name);
+		}
+		if (params.description !== undefined) {
+			fields.push('description = ?');
+			values.push(params.description ?? null);
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
+			values.push(id);
+			const stmt = this.db.prepare(
+				`UPDATE space_session_groups SET ${fields.join(', ')} WHERE id = ?`
+			);
+			stmt.run(...values);
+		}
+
+		return this.getGroup(id);
+	}
+
+	/**
+	 * Delete a session group (cascades to members)
+	 */
+	deleteGroup(id: string): boolean {
+		const stmt = this.db.prepare(`DELETE FROM space_session_groups WHERE id = ?`);
+		const result = stmt.run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Add a session member to a group
+	 * Idempotent — updates role/orderIndex if the session is already a member
+	 */
+	addMember(
+		groupId: string,
+		sessionId: string,
+		role: 'worker' | 'leader',
+		orderIndex = 0
+	): SpaceSessionGroupMember {
+		const existing = this.db
+			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+			.get(groupId, sessionId) as Record<string, unknown> | undefined;
+
+		if (existing) {
+			this.db
+				.prepare(
+					`UPDATE space_session_group_members SET role = ?, order_index = ? WHERE group_id = ? AND session_id = ?`
+				)
+				.run(role, orderIndex, groupId, sessionId);
+			return this.getMember(existing.id as string)!;
+		}
+
+		const id = generateUUID();
+		const now = Date.now();
+
+		this.db
+			.prepare(
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run(id, groupId, sessionId, role, orderIndex, now);
+
+		// Touch group updated_at
+		this.db
+			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+			.run(now, groupId);
+
+		return this.getMember(id)!;
+	}
+
+	/**
+	 * Remove a session from a group
+	 */
+	removeMember(groupId: string, sessionId: string): boolean {
+		const result = this.db
+			.prepare(`DELETE FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+			.run(groupId, sessionId);
+
+		if (result.changes > 0) {
+			this.db
+				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+				.run(Date.now(), groupId);
+		}
+
+		return result.changes > 0;
+	}
+
+	/**
+	 * Get a single member record by ID
+	 */
+	getMember(id: string): SpaceSessionGroupMember | null {
+		const row = this.db.prepare(`SELECT * FROM space_session_group_members WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+
+		if (!row) return null;
+		return this.rowToMember(row);
+	}
+
+	/**
+	 * Get all members of a group, ordered by order_index
+	 */
+	private getGroupMembers(groupId: string): SpaceSessionGroupMember[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_session_group_members WHERE group_id = ? ORDER BY order_index ASC, created_at ASC`
+			)
+			.all(groupId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToMember(r));
+	}
+
+	/**
+	 * Convert a database row to a SpaceSessionGroup object
+	 */
+	private rowToGroup(
+		row: Record<string, unknown>,
+		members: SpaceSessionGroupMember[]
+	): SpaceSessionGroup {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			name: row.name as string,
+			description: (row.description as string | null) ?? undefined,
+			members,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+		};
+	}
+
+	/**
+	 * Convert a database row to a SpaceSessionGroupMember object
+	 */
+	private rowToMember(row: Record<string, unknown>): SpaceSessionGroupMember {
+		return {
+			id: row.id as string,
+			groupId: row.group_id as string,
+			sessionId: row.session_id as string,
+			role: row.role as 'worker' | 'leader',
+			orderIndex: row.order_index as number,
+			createdAt: row.created_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -118,6 +118,9 @@ export class SpaceTaskRepository {
 			values.push(params.status);
 
 			if (params.status === 'in_progress') {
+				// Always stamp started_at on entry to in_progress, including re-entries from
+				// needs_attention or cancelled. This records when the most recent work began,
+				// not when the task was originally created. Mirrors TaskRepository behavior.
 				fields.push('started_at = ?');
 				values.push(Date.now());
 			} else if (

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -1,0 +1,304 @@
+/**
+ * Space Task Repository
+ *
+ * Repository for SpaceTask CRUD operations.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	SpaceTask,
+	SpaceTaskStatus,
+	CreateSpaceTaskParams,
+	UpdateSpaceTaskParams,
+} from '@neokai/shared';
+import type { SQLiteValue } from '../types';
+
+export class SpaceTaskRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new space task
+	 */
+	createTask(params: CreateSpaceTaskParams): SpaceTask {
+		const id = generateUUID();
+		const now = Date.now();
+
+		const stmt = this.db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, depends_on, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		);
+
+		stmt.run(
+			id,
+			params.spaceId,
+			params.title,
+			params.description,
+			params.status ?? 'pending',
+			params.priority ?? 'normal',
+			params.taskType ?? null,
+			params.assignedAgent ?? 'coder',
+			params.customAgentId ?? null,
+			params.workflowRunId ?? null,
+			params.workflowStepId ?? null,
+			params.createdByTaskId ?? null,
+			JSON.stringify(params.dependsOn ?? []),
+			now,
+			now
+		);
+
+		return this.getTask(id)!;
+	}
+
+	/**
+	 * Get a task by ID
+	 */
+	getTask(id: string): SpaceTask | null {
+		const stmt = this.db.prepare(`SELECT * FROM space_tasks WHERE id = ?`);
+		const row = stmt.get(id) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+		return this.rowToSpaceTask(row);
+	}
+
+	/**
+	 * List tasks for a space, with optional status filter
+	 */
+	listBySpace(spaceId: string, includeArchived = false): SpaceTask[] {
+		let query = `SELECT * FROM space_tasks WHERE space_id = ?`;
+		if (!includeArchived) {
+			query += ` AND archived_at IS NULL`;
+		}
+		query += ` ORDER BY updated_at DESC`;
+
+		const stmt = this.db.prepare(query);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * List tasks for a workflow run
+	 */
+	listByWorkflowRun(workflowRunId: string): SpaceTask[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_tasks WHERE workflow_run_id = ? AND archived_at IS NULL ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(workflowRunId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * List tasks by status within a space
+	 */
+	listByStatus(spaceId: string, status: SpaceTaskStatus): SpaceTask[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? AND archived_at IS NULL ORDER BY updated_at DESC`
+		);
+		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * Update a task with partial updates
+	 */
+	updateTask(id: string, params: UpdateSpaceTaskParams): SpaceTask | null {
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (params.title !== undefined) {
+			fields.push('title = ?');
+			values.push(params.title);
+		}
+		if (params.description !== undefined) {
+			fields.push('description = ?');
+			values.push(params.description);
+		}
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+
+			if (params.status === 'in_progress') {
+				fields.push('started_at = ?');
+				values.push(Date.now());
+			} else if (
+				params.status === 'completed' ||
+				params.status === 'needs_attention' ||
+				params.status === 'cancelled'
+			) {
+				fields.push('completed_at = ?');
+				values.push(Date.now());
+			}
+		}
+		if (params.priority !== undefined) {
+			fields.push('priority = ?');
+			values.push(params.priority);
+		}
+		if (params.taskType !== undefined) {
+			fields.push('task_type = ?');
+			values.push(params.taskType ?? null);
+		}
+		if (params.assignedAgent !== undefined) {
+			fields.push('assigned_agent = ?');
+			values.push(params.assignedAgent ?? null);
+		}
+		if (params.customAgentId !== undefined) {
+			fields.push('custom_agent_id = ?');
+			values.push(params.customAgentId ?? null);
+		}
+		if (params.workflowRunId !== undefined) {
+			fields.push('workflow_run_id = ?');
+			values.push(params.workflowRunId ?? null);
+		}
+		if (params.workflowStepId !== undefined) {
+			fields.push('workflow_step_id = ?');
+			values.push(params.workflowStepId ?? null);
+		}
+		if (params.progress !== undefined) {
+			fields.push('progress = ?');
+			values.push(params.progress ?? null);
+		}
+		if (params.currentStep !== undefined) {
+			fields.push('current_step = ?');
+			values.push(params.currentStep ?? null);
+		}
+		if (params.result !== undefined) {
+			fields.push('result = ?');
+			values.push(params.result ?? null);
+		}
+		if (params.error !== undefined) {
+			fields.push('error = ?');
+			values.push(params.error ?? null);
+		}
+		if (params.dependsOn !== undefined) {
+			fields.push('depends_on = ?');
+			values.push(JSON.stringify(params.dependsOn));
+		}
+		if (params.activeSession !== undefined) {
+			fields.push('active_session = ?');
+			values.push(params.activeSession ?? null);
+		}
+		// Auto-clear active_session when task reaches a terminal status
+		if (
+			params.activeSession === undefined &&
+			(params.status === 'completed' ||
+				params.status === 'needs_attention' ||
+				params.status === 'cancelled')
+		) {
+			fields.push('active_session = ?');
+			values.push(null);
+		}
+		if (params.prUrl !== undefined) {
+			fields.push('pr_url = ?');
+			values.push(params.prUrl ?? null);
+		}
+		if (params.prNumber !== undefined) {
+			fields.push('pr_number = ?');
+			values.push(params.prNumber ?? null);
+		}
+		if (params.prCreatedAt !== undefined) {
+			fields.push('pr_created_at = ?');
+			values.push(params.prCreatedAt ?? null);
+		}
+		if (params.inputDraft !== undefined) {
+			fields.push('input_draft = ?');
+			values.push(params.inputDraft ?? null);
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
+			values.push(id);
+			const stmt = this.db.prepare(`UPDATE space_tasks SET ${fields.join(', ')} WHERE id = ?`);
+			stmt.run(...values);
+		}
+
+		return this.getTask(id);
+	}
+
+	/**
+	 * Archive a task by setting archived_at timestamp
+	 */
+	archiveTask(id: string): SpaceTask | null {
+		const now = Date.now();
+		const stmt = this.db.prepare(
+			`UPDATE space_tasks SET archived_at = ?, updated_at = ? WHERE id = ?`
+		);
+		stmt.run(now, now, id);
+		return this.getTask(id);
+	}
+
+	/**
+	 * Delete a task by ID
+	 */
+	deleteTask(id: string): boolean {
+		const stmt = this.db.prepare(`DELETE FROM space_tasks WHERE id = ?`);
+		const result = stmt.run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Delete all tasks for a space
+	 */
+	deleteTasksForSpace(spaceId: string): void {
+		this.db.prepare(`DELETE FROM space_tasks WHERE space_id = ?`).run(spaceId);
+	}
+
+	/**
+	 * Promote draft tasks created by a planning task to pending
+	 */
+	promoteDraftTasksByCreator(createdByTaskId: string): number {
+		const result = this.db
+			.prepare(
+				`UPDATE space_tasks SET status = 'pending', updated_at = ? WHERE created_by_task_id = ? AND status = 'draft'`
+			)
+			.run(Date.now(), createdByTaskId);
+		return result.changes;
+	}
+
+	/**
+	 * Get draft tasks created by a specific planning task
+	 */
+	getDraftTasksByCreator(createdByTaskId: string): SpaceTask[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_tasks WHERE created_by_task_id = ? AND status = 'draft' ORDER BY created_at ASC`
+			)
+			.all(createdByTaskId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * Convert a database row to a SpaceTask object
+	 */
+	private rowToSpaceTask(row: Record<string, unknown>): SpaceTask {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			title: row.title as string,
+			description: (row.description as string) ?? '',
+			status: row.status as SpaceTask['status'],
+			priority: row.priority as SpaceTask['priority'],
+			taskType: (row.task_type as SpaceTask['taskType'] | null) ?? undefined,
+			assignedAgent: (row.assigned_agent as SpaceTask['assignedAgent'] | null) ?? undefined,
+			customAgentId: (row.custom_agent_id as string | null) ?? undefined,
+			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
+			workflowStepId: (row.workflow_step_id as string | null) ?? undefined,
+			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
+			progress: (row.progress as number | null) ?? undefined,
+			currentStep: (row.current_step as string | null) ?? undefined,
+			result: (row.result as string | null) ?? undefined,
+			error: (row.error as string | null) ?? undefined,
+			dependsOn: JSON.parse(row.depends_on as string) as string[],
+			inputDraft: (row.input_draft as string | null) ?? undefined,
+			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,
+			prUrl: (row.pr_url as string | null) ?? undefined,
+			prNumber: (row.pr_number as number | null) ?? undefined,
+			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,
+			archivedAt: (row.archived_at as number | null) ?? undefined,
+			createdAt: row.created_at as number,
+			startedAt: (row.started_at as number | null) ?? undefined,
+			completedAt: (row.completed_at as number | null) ?? undefined,
+			updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -1,0 +1,174 @@
+/**
+ * Space Workflow Run Repository
+ *
+ * Repository for SpaceWorkflowRun CRUD operations.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type { SpaceWorkflowRun, WorkflowRunStatus, CreateWorkflowRunParams } from '@neokai/shared';
+import type { SQLiteValue } from '../types';
+
+export interface UpdateWorkflowRunParams {
+	title?: string;
+	description?: string;
+	status?: WorkflowRunStatus;
+	currentStepIndex?: number;
+	config?: Record<string, unknown>;
+}
+
+export class SpaceWorkflowRunRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new workflow run
+	 */
+	createRun(params: CreateWorkflowRunParams): SpaceWorkflowRun {
+		const id = generateUUID();
+		const now = Date.now();
+
+		const stmt = this.db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, status, config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		);
+
+		stmt.run(
+			id,
+			params.spaceId,
+			params.workflowId,
+			params.title,
+			params.description ?? '',
+			0,
+			'pending',
+			null,
+			now,
+			now
+		);
+
+		return this.getRun(id)!;
+	}
+
+	/**
+	 * Get a workflow run by ID
+	 */
+	getRun(id: string): SpaceWorkflowRun | null {
+		const stmt = this.db.prepare(`SELECT * FROM space_workflow_runs WHERE id = ?`);
+		const row = stmt.get(id) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+		return this.rowToRun(row);
+	}
+
+	/**
+	 * List workflow runs for a space
+	 */
+	listBySpace(spaceId: string): SpaceWorkflowRun[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_workflow_runs WHERE space_id = ? ORDER BY created_at DESC`
+		);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRun(r));
+	}
+
+	/**
+	 * List active (non-terminal) workflow runs for a space
+	 */
+	getActiveRuns(spaceId: string): SpaceWorkflowRun[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status IN ('pending', 'in_progress') ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRun(r));
+	}
+
+	/**
+	 * Update a workflow run with partial updates
+	 */
+	updateRun(id: string, params: UpdateWorkflowRunParams): SpaceWorkflowRun | null {
+		const fields: string[] = [];
+		const values: SQLiteValue[] = [];
+
+		if (params.title !== undefined) {
+			fields.push('title = ?');
+			values.push(params.title);
+		}
+		if (params.description !== undefined) {
+			fields.push('description = ?');
+			values.push(params.description);
+		}
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+
+			if (params.status === 'completed' || params.status === 'cancelled') {
+				fields.push('completed_at = ?');
+				values.push(Date.now());
+			}
+		}
+		if (params.currentStepIndex !== undefined) {
+			fields.push('current_step_index = ?');
+			values.push(params.currentStepIndex);
+		}
+		if (params.config !== undefined) {
+			fields.push('config = ?');
+			values.push(JSON.stringify(params.config));
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(Date.now());
+			values.push(id);
+			const stmt = this.db.prepare(
+				`UPDATE space_workflow_runs SET ${fields.join(', ')} WHERE id = ?`
+			);
+			stmt.run(...values);
+		}
+
+		return this.getRun(id);
+	}
+
+	/**
+	 * Advance the current step index for a run
+	 */
+	updateStepIndex(id: string, stepIndex: number): SpaceWorkflowRun | null {
+		return this.updateRun(id, { currentStepIndex: stepIndex });
+	}
+
+	/**
+	 * Update only the status of a run
+	 */
+	updateStatus(id: string, status: WorkflowRunStatus): SpaceWorkflowRun | null {
+		return this.updateRun(id, { status });
+	}
+
+	/**
+	 * Delete a workflow run by ID
+	 */
+	deleteRun(id: string): boolean {
+		const stmt = this.db.prepare(`DELETE FROM space_workflow_runs WHERE id = ?`);
+		const result = stmt.run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Convert a database row to a SpaceWorkflowRun object
+	 */
+	private rowToRun(row: Record<string, unknown>): SpaceWorkflowRun {
+		const rawConfig = row.config as string | null;
+		const config = rawConfig ? (JSON.parse(rawConfig) as Record<string, unknown>) : undefined;
+
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			workflowId: row.workflow_id as string,
+			title: row.title as string,
+			description: (row.description as string | null) ?? undefined,
+			currentStepIndex: row.current_step_index as number,
+			status: row.status as WorkflowRunStatus,
+			config,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+			completedAt: (row.completed_at as number | null) ?? undefined,
+		};
+	}
+}

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -1,0 +1,144 @@
+/**
+ * Space test database helper
+ *
+ * Creates the minimal set of tables needed for Space system tests
+ * without requiring a full migration run.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+export function createSpaceTables(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = ON');
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS spaces (
+			id TEXT PRIMARY KEY,
+			workspace_path TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			background_context TEXT NOT NULL DEFAULT '',
+			instructions TEXT NOT NULL DEFAULT '',
+			default_model TEXT,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			session_ids TEXT NOT NULL DEFAULT '[]',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'archived')),
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflow_steps (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			agent_id TEXT,
+			order_index INTEGER NOT NULL,
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			workflow_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			current_step_index INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			task_type TEXT
+				CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+			assigned_agent TEXT
+				CHECK(assigned_agent IN ('coder', 'general')),
+			custom_agent_id TEXT,
+			workflow_run_id TEXT,
+			workflow_step_id TEXT,
+			created_by_task_id TEXT,
+			progress INTEGER,
+			current_step TEXT,
+			result TEXT,
+			error TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			input_draft TEXT,
+			active_session TEXT
+				CHECK(active_session IN ('worker', 'leader')),
+			pr_url TEXT,
+			pr_number INTEGER,
+			pr_created_at INTEGER,
+			archived_at INTEGER,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+			FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_session_groups (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_session_group_members (
+			id TEXT PRIMARY KEY,
+			group_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			role TEXT NOT NULL
+				CHECK(role IN ('worker', 'leader')),
+			order_index INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,
+			UNIQUE(group_id, session_id)
+		)
+	`);
+}

--- a/packages/daemon/tests/unit/lib/space-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-manager.test.ts
@@ -88,6 +88,17 @@ describe('SpaceManager', () => {
 				'already exists'
 			);
 		});
+
+		it('throws if workspace path is used by an archived space (paths are permanent identifiers)', async () => {
+			// Design decision: workspace_path has a UNIQUE DB constraint with no status filter,
+			// so archived spaces permanently claim their path. This test documents that behavior.
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'First' });
+			await manager.archiveSpace(space.id);
+
+			await expect(manager.createSpace({ workspacePath: tmpDir, name: 'Second' })).rejects.toThrow(
+				'already exists'
+			);
+		});
 	});
 
 	describe('getSpace', () => {

--- a/packages/daemon/tests/unit/lib/space-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-manager.test.ts
@@ -1,0 +1,176 @@
+/**
+ * SpaceManager Tests
+ *
+ * Tests workspace path validation, space lifecycle, and session management.
+ * Uses real temporary directories to exercise path resolution.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceManager', () => {
+	let db: Database;
+	let manager: SpaceManager;
+	let tmpDir: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		manager = new SpaceManager(db as any);
+
+		// Create a real temporary directory for workspace path tests
+		tmpDir = mkdtempSync(join(tmpdir(), 'space-manager-test-'));
+	});
+
+	afterEach(() => {
+		db.close();
+		try {
+			rmSync(tmpDir, { recursive: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	describe('createSpace', () => {
+		it('creates a space for a valid directory', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'My Project',
+			});
+
+			expect(space.id).toBeDefined();
+			expect(space.name).toBe('My Project');
+			// Real path should be stored (symlinks resolved)
+			expect(space.workspacePath).toBeTruthy();
+			expect(space.status).toBe('active');
+		});
+
+		it('resolves symlinks and stores the real path', async () => {
+			const realDir = mkdtempSync(join(tmpdir(), 'real-dir-'));
+			const linkPath = join(tmpDir, 'link');
+			symlinkSync(realDir, linkPath);
+
+			try {
+				const space = await manager.createSpace({ workspacePath: linkPath, name: 'Linked' });
+				// The stored path should be the real path (with all symlinks resolved)
+				// Use realpathSync to get the canonical path for comparison (handles macOS /var -> /private/var)
+				const expectedRealPath = realpathSync(realDir);
+				expect(space.workspacePath).toBe(expectedRealPath);
+			} finally {
+				rmSync(realDir, { recursive: true });
+			}
+		});
+
+		it('throws for a non-existent path', async () => {
+			await expect(
+				manager.createSpace({ workspacePath: '/nonexistent/path/xyz', name: 'X' })
+			).rejects.toThrow('does not exist');
+		});
+
+		it('throws if path is not a directory (is a file)', async () => {
+			const filePath = join(tmpDir, 'somefile.txt');
+			await Bun.write(filePath, 'hello');
+
+			await expect(manager.createSpace({ workspacePath: filePath, name: 'X' })).rejects.toThrow(
+				'not a directory'
+			);
+		});
+
+		it('throws if workspace path is already used by an active space', async () => {
+			await manager.createSpace({ workspacePath: tmpDir, name: 'First' });
+
+			await expect(manager.createSpace({ workspacePath: tmpDir, name: 'Second' })).rejects.toThrow(
+				'already exists'
+			);
+		});
+	});
+
+	describe('getSpace', () => {
+		it('returns space by ID', async () => {
+			const created = await manager.createSpace({ workspacePath: tmpDir, name: 'P' });
+			const found = await manager.getSpace(created.id);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+		});
+
+		it('returns null for unknown ID', async () => {
+			expect(await manager.getSpace('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('listSpaces', () => {
+		it('lists active spaces', async () => {
+			const dir2 = mkdtempSync(join(tmpdir(), 'space-list-test-'));
+			try {
+				await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+				const b = await manager.createSpace({ workspacePath: dir2, name: 'B' });
+				await manager.archiveSpace(b.id);
+
+				const spaces = await manager.listSpaces();
+				expect(spaces).toHaveLength(1);
+				expect(spaces[0].name).toBe('A');
+			} finally {
+				rmSync(dir2, { recursive: true });
+			}
+		});
+	});
+
+	describe('updateSpace', () => {
+		it('updates space fields', async () => {
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'Old' });
+			const updated = await manager.updateSpace(space.id, { name: 'New', description: 'Desc' });
+			expect(updated.name).toBe('New');
+			expect(updated.description).toBe('Desc');
+		});
+
+		it('throws for unknown space', async () => {
+			await expect(manager.updateSpace('nonexistent', { name: 'X' })).rejects.toThrow('not found');
+		});
+	});
+
+	describe('archiveSpace', () => {
+		it('archives a space', async () => {
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+			const archived = await manager.archiveSpace(space.id);
+			expect(archived.status).toBe('archived');
+		});
+
+		it('throws for unknown space', async () => {
+			await expect(manager.archiveSpace('nonexistent')).rejects.toThrow('not found');
+		});
+	});
+
+	describe('deleteSpace', () => {
+		it('deletes a space', async () => {
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+			expect(await manager.deleteSpace(space.id)).toBe(true);
+			expect(await manager.getSpace(space.id)).toBeNull();
+		});
+
+		it('returns false for unknown space', async () => {
+			expect(await manager.deleteSpace('nonexistent')).toBe(false);
+		});
+	});
+
+	describe('addSession / removeSession', () => {
+		it('adds and removes sessions', async () => {
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+
+			const withSession = await manager.addSession(space.id, 'sess-1');
+			expect(withSession.sessionIds).toContain('sess-1');
+
+			const without = await manager.removeSession(space.id, 'sess-1');
+			expect(without.sessionIds).not.toContain('sess-1');
+		});
+
+		it('throws for unknown space', async () => {
+			await expect(manager.addSession('nonexistent', 's1')).rejects.toThrow('not found');
+			await expect(manager.removeSession('nonexistent', 's1')).rejects.toThrow('not found');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -127,6 +127,30 @@ describe('SpaceTaskManager', () => {
 			expect(restarted.progress).toBeUndefined();
 		});
 
+		it('clears error and result when restarting from cancelled -> pending', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'needs_attention', { error: 'Failed' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.cancelTask(task.id);
+
+			const restarted = await manager.setTaskStatus(task.id, 'pending');
+			expect(restarted.status).toBe('pending');
+			expect(restarted.error).toBeUndefined();
+			expect(restarted.progress).toBeUndefined();
+		});
+
+		it('clears fields when restarting from cancelled -> in_progress', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.cancelTask(task.id);
+
+			const restarted = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(restarted.status).toBe('in_progress');
+			expect(restarted.error).toBeUndefined();
+			expect(restarted.progress).toBeUndefined();
+		});
+
 		it('throws for unknown task', async () => {
 			await expect(manager.setTaskStatus('nonexistent', 'in_progress')).rejects.toThrow(
 				'not found'

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -1,0 +1,261 @@
+/**
+ * SpaceTaskManager Tests
+ *
+ * Tests task lifecycle, status transitions, and dependency validation.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import {
+	SpaceTaskManager,
+	VALID_SPACE_TASK_TRANSITIONS,
+	isValidSpaceTaskTransition,
+} from '../../../src/lib/space/managers/space-task-manager';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceTaskManager', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let manager: SpaceTaskManager;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+
+		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		spaceId = space.id;
+		manager = new SpaceTaskManager(db as any, spaceId);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('isValidSpaceTaskTransition', () => {
+		it('allows valid transitions', () => {
+			expect(isValidSpaceTaskTransition('pending', 'in_progress')).toBe(true);
+			expect(isValidSpaceTaskTransition('in_progress', 'completed')).toBe(true);
+			expect(isValidSpaceTaskTransition('in_progress', 'review')).toBe(true);
+			expect(isValidSpaceTaskTransition('review', 'completed')).toBe(true);
+		});
+
+		it('rejects invalid transitions', () => {
+			expect(isValidSpaceTaskTransition('completed', 'pending')).toBe(false);
+			expect(isValidSpaceTaskTransition('pending', 'completed')).toBe(false);
+		});
+	});
+
+	describe('createTask', () => {
+		it('creates a task with minimal params', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			expect(task.spaceId).toBe(spaceId);
+			expect(task.title).toBe('T');
+			expect(task.status).toBe('pending');
+		});
+
+		it('creates a task with dependencies', async () => {
+			const dep = await manager.createTask({ title: 'Dep', description: '' });
+			const task = await manager.createTask({
+				title: 'Child',
+				description: '',
+				dependsOn: [dep.id],
+			});
+			expect(task.dependsOn).toContain(dep.id);
+		});
+
+		it('throws when a dependency does not exist', async () => {
+			await expect(
+				manager.createTask({ title: 'T', description: '', dependsOn: ['nonexistent'] })
+			).rejects.toThrow('Dependency task not found');
+		});
+	});
+
+	describe('getTask', () => {
+		it('returns task belonging to this space', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			expect(await manager.getTask(task.id)).not.toBeNull();
+		});
+
+		it('returns null for task in another space', async () => {
+			// Create another space and its manager
+			const otherSpace = spaceRepo.createSpace({
+				workspacePath: '/workspace/other',
+				name: 'Other',
+			});
+			const otherManager = new SpaceTaskManager(db as any, otherSpace.id);
+			const otherTask = await otherManager.createTask({ title: 'T', description: '' });
+
+			// Task from other space is not visible
+			expect(await manager.getTask(otherTask.id)).toBeNull();
+		});
+	});
+
+	describe('setTaskStatus', () => {
+		it('transitions pending -> in_progress', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const updated = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(updated.status).toBe('in_progress');
+		});
+
+		it('transitions in_progress -> completed with result', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			const done = await manager.setTaskStatus(task.id, 'completed', { result: 'Done!' });
+			expect(done.status).toBe('completed');
+			expect(done.progress).toBe(100);
+			expect(done.result).toBe('Done!');
+		});
+
+		it('throws for invalid transition', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await expect(manager.setTaskStatus(task.id, 'completed')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+
+		it('clears error and result when restarting from needs_attention', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'needs_attention', { error: 'Oops' });
+
+			const restarted = await manager.setTaskStatus(task.id, 'pending');
+			expect(restarted.error).toBeUndefined();
+			expect(restarted.result).toBeUndefined();
+			expect(restarted.progress).toBeUndefined();
+		});
+
+		it('throws for unknown task', async () => {
+			await expect(manager.setTaskStatus('nonexistent', 'in_progress')).rejects.toThrow(
+				'not found'
+			);
+		});
+	});
+
+	describe('startTask / completeTask / failTask', () => {
+		it('starts a task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const started = await manager.startTask(task.id);
+			expect(started.status).toBe('in_progress');
+		});
+
+		it('completes a task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const done = await manager.completeTask(task.id, 'All done');
+			expect(done.status).toBe('completed');
+		});
+
+		it('fails a task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const failed = await manager.failTask(task.id, 'Something went wrong');
+			expect(failed.status).toBe('needs_attention');
+			expect(failed.error).toBe('Something went wrong');
+		});
+	});
+
+	describe('cancelTask', () => {
+		it('cancels a task and cascades to pending dependents', async () => {
+			const t1 = await manager.createTask({ title: 'T1', description: '' });
+			const t2 = await manager.createTask({
+				title: 'T2',
+				description: '',
+				dependsOn: [t1.id],
+			});
+
+			await manager.cancelTask(t1.id);
+
+			expect((await manager.getTask(t1.id))!.status).toBe('cancelled');
+			expect((await manager.getTask(t2.id))!.status).toBe('cancelled');
+		});
+	});
+
+	describe('reviewTask', () => {
+		it('moves task to review with PR info', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			const reviewed = await manager.reviewTask(task.id, 'https://github.com/org/repo/pull/42');
+			expect(reviewed.status).toBe('review');
+			expect(reviewed.prUrl).toBe('https://github.com/org/repo/pull/42');
+			expect(reviewed.prNumber).toBe(42);
+		});
+	});
+
+	describe('updateTaskProgress', () => {
+		it('updates progress and current step', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const updated = await manager.updateTaskProgress(task.id, 50, 'halfway');
+			expect(updated.progress).toBe(50);
+			expect(updated.currentStep).toBe('halfway');
+		});
+
+		it('clamps progress to 0-100', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			expect((await manager.updateTaskProgress(task.id, 150)).progress).toBe(100);
+			expect((await manager.updateTaskProgress(task.id, -10)).progress).toBe(0);
+		});
+	});
+
+	describe('archiveTask', () => {
+		it('archives a task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			const archived = await manager.archiveTask(task.id);
+			expect(archived.archivedAt).toBeDefined();
+		});
+	});
+
+	describe('deleteTask', () => {
+		it('deletes a task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			expect(await manager.deleteTask(task.id)).toBe(true);
+			expect(await manager.getTask(task.id)).toBeNull();
+		});
+
+		it('returns false for unknown task', async () => {
+			expect(await manager.deleteTask('nonexistent')).toBe(false);
+		});
+	});
+
+	describe('areDependenciesMet', () => {
+		it('returns true when no dependencies', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			expect(await manager.areDependenciesMet(task)).toBe(true);
+		});
+
+		it('returns false when dependency is not completed', async () => {
+			const dep = await manager.createTask({ title: 'Dep', description: '' });
+			const task = await manager.createTask({
+				title: 'Child',
+				description: '',
+				dependsOn: [dep.id],
+			});
+			expect(await manager.areDependenciesMet(task)).toBe(false);
+		});
+
+		it('returns true when all dependencies are completed', async () => {
+			const dep = await manager.createTask({ title: 'Dep', description: '' });
+			await manager.startTask(dep.id);
+			await manager.completeTask(dep.id, 'done');
+
+			const task = await manager.createTask({
+				title: 'Child',
+				description: '',
+				dependsOn: [dep.id],
+			});
+			expect(await manager.areDependenciesMet(task)).toBe(true);
+		});
+	});
+
+	describe('VALID_SPACE_TASK_TRANSITIONS', () => {
+		it('completed is a terminal state with no transitions', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.completed).toEqual([]);
+		});
+
+		it('draft can only go to pending', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.draft).toEqual(['pending']);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -137,6 +137,7 @@ describe('SpaceTaskManager', () => {
 			const restarted = await manager.setTaskStatus(task.id, 'pending');
 			expect(restarted.status).toBe('pending');
 			expect(restarted.error).toBeUndefined();
+			expect(restarted.result).toBeUndefined();
 			expect(restarted.progress).toBeUndefined();
 		});
 

--- a/packages/daemon/tests/unit/storage/space-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-repository.test.ts
@@ -1,0 +1,190 @@
+/**
+ * SpaceRepository Tests
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceRepository', () => {
+	let db: Database;
+	let repo: SpaceRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		repo = new SpaceRepository(db as any);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createSpace', () => {
+		it('creates a space with required fields', () => {
+			const space = repo.createSpace({
+				workspacePath: '/workspace/project',
+				name: 'My Project',
+			});
+
+			expect(space.id).toBeDefined();
+			expect(space.workspacePath).toBe('/workspace/project');
+			expect(space.name).toBe('My Project');
+			expect(space.description).toBe('');
+			expect(space.backgroundContext).toBe('');
+			expect(space.instructions).toBe('');
+			expect(space.status).toBe('active');
+			expect(space.sessionIds).toEqual([]);
+			expect(space.config).toBeUndefined();
+			expect(space.createdAt).toBeGreaterThan(0);
+			expect(space.updatedAt).toBeGreaterThan(0);
+		});
+
+		it('creates a space with all optional fields', () => {
+			const space = repo.createSpace({
+				workspacePath: '/workspace/project',
+				name: 'My Project',
+				description: 'A description',
+				backgroundContext: 'Some context',
+				instructions: 'Do this',
+				defaultModel: 'claude-opus',
+				allowedModels: ['claude-opus', 'claude-sonnet'],
+				config: { maxConcurrentTasks: 3 },
+			});
+
+			expect(space.description).toBe('A description');
+			expect(space.backgroundContext).toBe('Some context');
+			expect(space.instructions).toBe('Do this');
+			expect(space.defaultModel).toBe('claude-opus');
+			expect(space.allowedModels).toEqual(['claude-opus', 'claude-sonnet']);
+			expect(space.config).toEqual({ maxConcurrentTasks: 3 });
+		});
+
+		it('enforces unique workspace_path', () => {
+			repo.createSpace({ workspacePath: '/workspace/project', name: 'A' });
+			expect(() => {
+				repo.createSpace({ workspacePath: '/workspace/project', name: 'B' });
+			}).toThrow();
+		});
+	});
+
+	describe('getSpace', () => {
+		it('returns space by ID', () => {
+			const created = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const found = repo.getSpace(created.id);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.getSpace('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('getSpaceByPath', () => {
+		it('returns space by workspace path', () => {
+			const created = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const found = repo.getSpaceByPath('/workspace/a');
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+		});
+
+		it('returns null for unknown path', () => {
+			expect(repo.getSpaceByPath('/does/not/exist')).toBeNull();
+		});
+	});
+
+	describe('listSpaces', () => {
+		it('lists active spaces by default', () => {
+			repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const b = repo.createSpace({ workspacePath: '/workspace/b', name: 'B' });
+			repo.archiveSpace(b.id);
+
+			const spaces = repo.listSpaces();
+			expect(spaces).toHaveLength(1);
+			expect(spaces[0].name).toBe('A');
+		});
+
+		it('includes archived spaces when requested', () => {
+			repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const b = repo.createSpace({ workspacePath: '/workspace/b', name: 'B' });
+			repo.archiveSpace(b.id);
+
+			const spaces = repo.listSpaces(true);
+			expect(spaces).toHaveLength(2);
+		});
+	});
+
+	describe('updateSpace', () => {
+		it('updates name and description', () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const updated = repo.updateSpace(space.id, { name: 'A Updated', description: 'New desc' });
+
+			expect(updated).not.toBeNull();
+			expect(updated!.name).toBe('A Updated');
+			expect(updated!.description).toBe('New desc');
+		});
+
+		it('clears defaultModel when set to null', () => {
+			const space = repo.createSpace({
+				workspacePath: '/workspace/a',
+				name: 'A',
+				defaultModel: 'claude-opus',
+			});
+			const updated = repo.updateSpace(space.id, { defaultModel: null });
+			expect(updated!.defaultModel).toBeUndefined();
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.updateSpace('nonexistent', { name: 'X' })).toBeNull();
+		});
+	});
+
+	describe('archiveSpace', () => {
+		it('sets status to archived', () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const archived = repo.archiveSpace(space.id);
+			expect(archived!.status).toBe('archived');
+		});
+	});
+
+	describe('addSessionToSpace / removeSessionFromSpace', () => {
+		it('adds and removes sessions idempotently', () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+
+			// Add
+			const withSession = repo.addSessionToSpace(space.id, 'session-1');
+			expect(withSession!.sessionIds).toContain('session-1');
+
+			// Add again (idempotent)
+			const again = repo.addSessionToSpace(space.id, 'session-1');
+			expect(again!.sessionIds).toHaveLength(1);
+
+			// Remove
+			const without = repo.removeSessionFromSpace(space.id, 'session-1');
+			expect(without!.sessionIds).not.toContain('session-1');
+
+			// Remove again (idempotent)
+			const noOp = repo.removeSessionFromSpace(space.id, 'session-1');
+			expect(noOp!.sessionIds).toHaveLength(0);
+		});
+
+		it('returns null for unknown space', () => {
+			expect(repo.addSessionToSpace('nonexistent', 's1')).toBeNull();
+			expect(repo.removeSessionFromSpace('nonexistent', 's1')).toBeNull();
+		});
+	});
+
+	describe('deleteSpace', () => {
+		it('deletes a space', () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			expect(repo.deleteSpace(space.id)).toBe(true);
+			expect(repo.getSpace(space.id)).toBeNull();
+		});
+
+		it('returns false for unknown ID', () => {
+			expect(repo.deleteSpace('nonexistent')).toBe(false);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SpaceSessionGroupRepository Tests
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceSessionGroupRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let repo: SpaceSessionGroupRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+		repo = new SpaceSessionGroupRepository(db as any);
+
+		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createGroup', () => {
+		it('creates a group with required fields', () => {
+			const group = repo.createGroup({ spaceId, name: 'Group A' });
+
+			expect(group.id).toBeDefined();
+			expect(group.spaceId).toBe(spaceId);
+			expect(group.name).toBe('Group A');
+			expect(group.description).toBeUndefined();
+			expect(group.members).toEqual([]);
+			expect(group.createdAt).toBeGreaterThan(0);
+		});
+
+		it('creates a group with description', () => {
+			const group = repo.createGroup({ spaceId, name: 'Group B', description: 'Desc' });
+			expect(group.description).toBe('Desc');
+		});
+	});
+
+	describe('getGroup', () => {
+		it('returns group with members', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', 'worker');
+
+			const found = repo.getGroup(group.id);
+			expect(found).not.toBeNull();
+			expect(found!.members).toHaveLength(1);
+			expect(found!.members[0].sessionId).toBe('session-1');
+			expect(found!.members[0].role).toBe('worker');
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.getGroup('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('getGroupsBySpace', () => {
+		it('returns all groups for a space', () => {
+			repo.createGroup({ spaceId, name: 'G1' });
+			repo.createGroup({ spaceId, name: 'G2' });
+
+			const groups = repo.getGroupsBySpace(spaceId);
+			expect(groups).toHaveLength(2);
+		});
+
+		it('returns empty array for unknown space', () => {
+			expect(repo.getGroupsBySpace('unknown')).toHaveLength(0);
+		});
+	});
+
+	describe('getGroupsByTask', () => {
+		it('returns groups named task:{taskId}', () => {
+			repo.createGroup({ spaceId, name: 'task:task-1' });
+			repo.createGroup({ spaceId, name: 'task:task-2' });
+			repo.createGroup({ spaceId, name: 'other-group' });
+
+			const groups = repo.getGroupsByTask(spaceId, 'task-1');
+			expect(groups).toHaveLength(1);
+			expect(groups[0].name).toBe('task:task-1');
+		});
+	});
+
+	describe('updateGroup', () => {
+		it('updates name and description', () => {
+			const group = repo.createGroup({ spaceId, name: 'Old' });
+			const updated = repo.updateGroup(group.id, { name: 'New', description: 'Updated' });
+			expect(updated!.name).toBe('New');
+			expect(updated!.description).toBe('Updated');
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.updateGroup('nonexistent', { name: 'X' })).toBeNull();
+		});
+	});
+
+	describe('deleteGroup', () => {
+		it('deletes a group', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			expect(repo.deleteGroup(group.id)).toBe(true);
+			expect(repo.getGroup(group.id)).toBeNull();
+		});
+
+		it('returns false for unknown ID', () => {
+			expect(repo.deleteGroup('nonexistent')).toBe(false);
+		});
+	});
+
+	describe('addMember', () => {
+		it('adds a member to a group', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', 'leader', 0);
+
+			expect(member.groupId).toBe(group.id);
+			expect(member.sessionId).toBe('session-1');
+			expect(member.role).toBe('leader');
+			expect(member.orderIndex).toBe(0);
+		});
+
+		it('is idempotent — updates existing member', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', 'worker');
+			const updated = repo.addMember(group.id, 'session-1', 'leader', 1);
+
+			expect(updated.role).toBe('leader');
+			expect(updated.orderIndex).toBe(1);
+
+			const found = repo.getGroup(group.id);
+			expect(found!.members).toHaveLength(1);
+		});
+
+		it('multiple members are ordered by order_index', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-2', 'worker', 1);
+			repo.addMember(group.id, 'session-1', 'leader', 0);
+
+			const found = repo.getGroup(group.id);
+			expect(found!.members[0].sessionId).toBe('session-1');
+			expect(found!.members[1].sessionId).toBe('session-2');
+		});
+	});
+
+	describe('removeMember', () => {
+		it('removes a member from a group', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', 'worker');
+
+			const removed = repo.removeMember(group.id, 'session-1');
+			expect(removed).toBe(true);
+			expect(repo.getGroup(group.id)!.members).toHaveLength(0);
+		});
+
+		it('returns false when member does not exist', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			expect(repo.removeMember(group.id, 'nonexistent')).toBe(false);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -1,0 +1,247 @@
+/**
+ * SpaceTaskRepository Tests
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceTaskRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let repo: SpaceTaskRepository;
+	let spaceId: string;
+	let workflowId: string;
+	let workflowRunId: string;
+	let workflowStepId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+		repo = new SpaceTaskRepository(db as any);
+
+		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		spaceId = space.id;
+
+		// Set up workflow records for FK-constrained fields
+		const now = Date.now();
+		workflowId = 'wf-1';
+		workflowRunId = 'run-1';
+		workflowStepId = 'step-1';
+
+		(db as any)
+			.prepare(
+				`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+			)
+			.run(workflowId, spaceId, 'Workflow', now, now);
+
+		(db as any)
+			.prepare(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run(workflowRunId, spaceId, workflowId, 'Run 1', now, now);
+
+		(db as any)
+			.prepare(
+				`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run(workflowStepId, workflowId, 'Step 1', 0, now, now);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createTask', () => {
+		it('creates a task with required fields', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Fix bug',
+				description: 'Fix the login bug',
+			});
+
+			expect(task.id).toBeDefined();
+			expect(task.spaceId).toBe(spaceId);
+			expect(task.title).toBe('Fix bug');
+			expect(task.description).toBe('Fix the login bug');
+			expect(task.status).toBe('pending');
+			expect(task.priority).toBe('normal');
+			expect(task.dependsOn).toEqual([]);
+			expect(task.customAgentId).toBeUndefined();
+			expect(task.workflowRunId).toBeUndefined();
+			expect(task.workflowStepId).toBeUndefined();
+		});
+
+		it('creates a task with workflow routing fields', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Step task',
+				description: '',
+				customAgentId: 'agent-1',
+				workflowRunId,
+				workflowStepId,
+			});
+
+			expect(task.customAgentId).toBe('agent-1');
+			expect(task.workflowRunId).toBe(workflowRunId);
+			expect(task.workflowStepId).toBe(workflowStepId);
+		});
+
+		it('creates a task with draft status', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Draft task',
+				description: '',
+				status: 'draft',
+			});
+			expect(task.status).toBe('draft');
+		});
+	});
+
+	describe('getTask', () => {
+		it('returns task by ID', () => {
+			const created = repo.createTask({ spaceId, title: 'T', description: '' });
+			expect(repo.getTask(created.id)).not.toBeNull();
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.getTask('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('listBySpace', () => {
+		it('lists non-archived tasks for a space', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			const b = repo.createTask({ spaceId, title: 'B', description: '' });
+			repo.archiveTask(b.id);
+
+			const tasks = repo.listBySpace(spaceId);
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe('A');
+		});
+
+		it('includes archived tasks when requested', () => {
+			repo.createTask({ spaceId, title: 'A', description: '' });
+			const b = repo.createTask({ spaceId, title: 'B', description: '' });
+			repo.archiveTask(b.id);
+
+			expect(repo.listBySpace(spaceId, true)).toHaveLength(2);
+		});
+	});
+
+	describe('listByWorkflowRun', () => {
+		it('lists tasks by workflow run ID', () => {
+			repo.createTask({ spaceId, title: 'A', description: '', workflowRunId });
+			repo.createTask({ spaceId, title: 'C', description: '' });
+
+			const tasks = repo.listByWorkflowRun(workflowRunId);
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe('A');
+		});
+	});
+
+	describe('listByStatus', () => {
+		it('lists tasks by status', () => {
+			repo.createTask({ spaceId, title: 'Pending', description: '', status: 'pending' });
+			repo.createTask({ spaceId, title: 'Draft', description: '', status: 'draft' });
+
+			const pending = repo.listByStatus(spaceId, 'pending');
+			expect(pending).toHaveLength(1);
+			expect(pending[0].title).toBe('Pending');
+		});
+	});
+
+	describe('updateTask', () => {
+		it('updates status and sets started_at for in_progress', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, { status: 'in_progress' });
+			expect(updated!.status).toBe('in_progress');
+			expect(updated!.startedAt).toBeDefined();
+		});
+
+		it('sets completed_at for completed status', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			repo.updateTask(task.id, { status: 'in_progress' });
+			const updated = repo.updateTask(task.id, { status: 'completed' });
+			expect(updated!.completedAt).toBeDefined();
+		});
+
+		it('auto-clears active_session on terminal status', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			repo.updateTask(task.id, { status: 'in_progress', activeSession: 'worker' });
+			const updated = repo.updateTask(task.id, { status: 'completed' });
+			expect(updated!.activeSession).toBeNull();
+		});
+
+		it('updates customAgentId, workflowRunId, workflowStepId', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, {
+				customAgentId: 'custom-agent',
+				workflowRunId,
+				workflowStepId,
+			});
+			expect(updated!.customAgentId).toBe('custom-agent');
+			expect(updated!.workflowRunId).toBe(workflowRunId);
+			expect(updated!.workflowStepId).toBe(workflowStepId);
+		});
+
+		it('clears nullable fields', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'T',
+				description: '',
+				customAgentId: 'ca',
+			});
+			const updated = repo.updateTask(task.id, { customAgentId: null });
+			expect(updated!.customAgentId).toBeUndefined();
+		});
+	});
+
+	describe('archiveTask', () => {
+		it('sets archivedAt timestamp', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const archived = repo.archiveTask(task.id);
+			expect(archived!.archivedAt).toBeDefined();
+		});
+	});
+
+	describe('deleteTask', () => {
+		it('deletes a task', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			expect(repo.deleteTask(task.id)).toBe(true);
+			expect(repo.getTask(task.id)).toBeNull();
+		});
+
+		it('returns false for unknown ID', () => {
+			expect(repo.deleteTask('nonexistent')).toBe(false);
+		});
+	});
+
+	describe('promoteDraftTasksByCreator', () => {
+		it('promotes draft tasks to pending', () => {
+			repo.createTask({
+				spaceId,
+				title: 'D',
+				description: '',
+				status: 'draft',
+				createdByTaskId: 'planner-1',
+			});
+			repo.createTask({
+				spaceId,
+				title: 'P',
+				description: '',
+				status: 'pending',
+				createdByTaskId: 'planner-1',
+			});
+
+			const count = repo.promoteDraftTasksByCreator('planner-1');
+			expect(count).toBe(1);
+
+			const tasks = repo.listBySpace(spaceId);
+			expect(tasks.every((t) => t.status !== 'draft')).toBe(true);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SpaceWorkflowRunRepository Tests
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceWorkflowRunRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let repo: SpaceWorkflowRunRepository;
+	let spaceId: string;
+	const WORKFLOW_ID = 'workflow-1';
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+		repo = new SpaceWorkflowRunRepository(db as any);
+
+		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		spaceId = space.id;
+
+		// Insert a dummy workflow row to satisfy the FK
+		const now = Date.now();
+		(db as any)
+			.prepare(
+				`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+			)
+			.run(WORKFLOW_ID, spaceId, 'My Workflow', now, now);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createRun', () => {
+		it('creates a run with required fields', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Run #1' });
+
+			expect(run.id).toBeDefined();
+			expect(run.spaceId).toBe(spaceId);
+			expect(run.workflowId).toBe(WORKFLOW_ID);
+			expect(run.title).toBe('Run #1');
+			expect(run.status).toBe('pending');
+			expect(run.currentStepIndex).toBe(0);
+			expect(run.config).toBeUndefined();
+			expect(run.completedAt).toBeUndefined();
+		});
+
+		it('creates a run with description', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Run #2',
+				description: 'Deploy v2.0',
+			});
+			expect(run.description).toBe('Deploy v2.0');
+		});
+	});
+
+	describe('getRun', () => {
+		it('returns run by ID', () => {
+			const created = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			expect(repo.getRun(created.id)).not.toBeNull();
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.getRun('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('listBySpace', () => {
+		it('returns runs for a space in descending order', () => {
+			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R1' });
+			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R2' });
+
+			const runs = repo.listBySpace(spaceId);
+			expect(runs).toHaveLength(2);
+		});
+
+		it('returns empty for unknown space', () => {
+			expect(repo.listBySpace('unknown')).toHaveLength(0);
+		});
+	});
+
+	describe('getActiveRuns', () => {
+		it('returns only pending/in_progress runs', () => {
+			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Pending' });
+			const r2 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Completed' });
+			repo.updateStatus(r2.id, 'completed');
+
+			const active = repo.getActiveRuns(spaceId);
+			expect(active).toHaveLength(1);
+			expect(active[0].title).toBe('Pending');
+		});
+	});
+
+	describe('updateRun', () => {
+		it('updates title and description', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateRun(run.id, { title: 'Updated', description: 'New desc' });
+			expect(updated!.title).toBe('Updated');
+			expect(updated!.description).toBe('New desc');
+		});
+
+		it('sets completedAt when status is completed', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateRun(run.id, { status: 'completed' });
+			expect(updated!.completedAt).toBeDefined();
+		});
+
+		it('sets completedAt when status is cancelled', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateRun(run.id, { status: 'cancelled' });
+			expect(updated!.completedAt).toBeDefined();
+		});
+	});
+
+	describe('updateStepIndex', () => {
+		it('updates the current step index', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateStepIndex(run.id, 2);
+			expect(updated!.currentStepIndex).toBe(2);
+		});
+	});
+
+	describe('updateStatus', () => {
+		it('updates only the status', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateStatus(run.id, 'in_progress');
+			expect(updated!.status).toBe('in_progress');
+		});
+	});
+
+	describe('deleteRun', () => {
+		it('deletes a run', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			expect(repo.deleteRun(run.id)).toBe(true);
+			expect(repo.getRun(run.id)).toBeNull();
+		});
+
+		it('returns false for unknown ID', () => {
+			expect(repo.deleteRun('nonexistent')).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Introduces the data access and business logic layers for the Space system:

Repositories (packages/daemon/src/storage/repositories/):
- SpaceRepository: full CRUD with JSON serialization for allowedModels,
  sessionIds, config; getSpaceByPath, addSessionToSpace, removeSessionFromSpace
- SpaceTaskRepository: full CRUD with batch ops (listByWorkflowRun,
  listBySpace, listByStatus); handles customAgentId, workflowRunId,
  workflowStepId, promoteDraftTasksByCreator
- SpaceWorkflowRunRepository: CRUD for workflow runs; getActiveRuns,
  updateStepIndex, updateStatus; sets completedAt on terminal status
- SpaceSessionGroupRepository: CRUD for groups and members; getGroupsByTask,
  getGroupsBySpace, addMember (idempotent), removeMember

Managers (packages/daemon/src/lib/space/managers/):
- SpaceManager: workspace path validation — resolves symlinks via fs.realpath,
  validates directory via fs.stat, enforces uniqueness across active spaces,
  warns (non-fatal) when path is not a git repo, stores resolved real path
- SpaceTaskManager: task lifecycle with VALID_SPACE_TASK_TRANSITIONS, status
  transition validation, dependency checks, cascade cancellation, reviewTask

Barrel export at packages/daemon/src/lib/space/index.ts.
knip.json: ignore space/index.ts (no callers yet — wired in later tasks).

Tests: 108 unit tests across 6 test files covering happy paths and error cases.
