### PR TITLE
feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2)

### DIFF
--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -106,7 +106,6 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description: string;
      steps: WorkflowStep[];
      rules: WorkflowRule[];
-     isDefault: boolean;
      tags: string[];
      config?: Record<string, unknown>;
      createdAt: number;
@@ -161,8 +160,6 @@ Build the data access and business logic layers for workflows within Spaces. The
    - `listWorkflows(spaceId: string): SpaceWorkflow[]`
    - `updateWorkflow(id: string, params: UpdateSpaceWorkflowParams): SpaceWorkflow | null`
    - `deleteWorkflow(id: string): boolean`
-   - `getDefaultWorkflow(spaceId: string): SpaceWorkflow | null`
-   - `setDefaultWorkflow(spaceId: string, workflowId: string): void`
    - `getWorkflowsReferencingAgent(agentId: string): SpaceWorkflow[]` — finds workflows referencing a custom agent (used for deletion protection in `SpaceAgentManager`)
    - Handle step CRUD within workflow transactions (replace all steps on update)
    - JSON serialization for `rules`, `tags`, `entry_gate`, `exit_gate`
@@ -176,8 +173,7 @@ Build the data access and business logic layers for workflows within Spaces. The
      - Step order contiguous (0, 1, 2, ...)
      - Gate command validation: `quality_check` → allowlist only; `custom` → relative path, no `..`; `timeoutMs` within range 0–300000
    - Business logic:
-     - Setting new default unsets previous default
-     - Deleting default workflow clears the space's default
+     - Workflow selection is either explicit workflowId (caller-provided) or AI auto-select via `list_workflows` + `start_workflow_run`. No default workflow concept.
 
 3. Export from `packages/daemon/src/lib/space/index.ts`
 
@@ -187,7 +183,6 @@ Build the data access and business logic layers for workflows within Spaces. The
    - Agent reference validation (builtin + custom via `SpaceAgentManager`)
    - Rejection of 'leader' as builtin agent ref
    - Gate command validation (allowlist, path validation)
-   - Default workflow management
    - JSON round-trip for gates and rules
    - `getWorkflowsReferencingAgent` returns correct results
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -124,7 +124,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 
 3. **Starting a workflow run**:
    - `startWorkflowRun(spaceId, workflowId, title, description?)` → creates `SpaceWorkflowRun` record, creates `WorkflowExecutor`, evaluates entry gate of first step, creates first step's `SpaceTask` records
-   - If no explicit `workflowId`, use space's default workflow via `SpaceWorkflowManager.getDefaultWorkflow(spaceId)`
+   - `workflowId` is always required — either provided explicitly by the caller or chosen by the Space agent via `list_workflows` + `start_workflow_run` (AI auto-select). No default workflow fallback.
    - Store executor in map
 
 4. **Standalone tasks** (no workflow):

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
@@ -1,119 +1,61 @@
-# Milestone 7: Workflow Selection & Agent Tools
+# M7: Workflow Selection Intelligence
 
-## Goal
+## Design
 
-Enable intelligent workflow selection within Spaces so the Space agent can automatically choose the appropriate workflow when starting a workflow run. Also provide Space agent tools for creating tasks and runs, and enhance agent prompts with workflow awareness. All code lives in the Space namespace — no existing Room code is modified.
+Workflow selection has two modes only:
 
-## Isolation Checklist
+1. **Explicit** — the caller provides a `workflowId` directly (e.g., from the UI or an API call). SpaceRuntime starts that workflow immediately.
+2. **AI auto-select** — no `workflowId` is provided. The Space agent calls `list_workflows`, reasons about which workflow best fits the user's request, and calls `start_workflow_run` with the chosen `workflowId`.
 
-- Selection logic in `packages/daemon/src/lib/space/runtime/workflow-selector.ts`
-- Space agent tools in `packages/daemon/src/lib/space/tools/space-agent-tools.ts` (NOT `room-agent-tools.ts`)
-- No modifications to `room-agent-tools.ts` or any Room file
+There is no default workflow, no tag-based matching, no keyword-based matching, and no fallback-to-null logic.
 
-## Note on Auto-Selection
+## AI Auto-Select Flow
 
-The auto-selection algorithm is an **MVP heuristic** — a simple priority-based chain with tag matching and basic keyword matching. It is explicitly NOT sophisticated. Future iterations can replace keyword matching with LLM-based classification without changing the interface.
+```
+User message
+    │
+    ▼
+Space agent calls list_workflows
+    │
+    ▼
+Agent reasons: which workflow description + steps best match the request?
+    │
+    ├─ match found → calls start_workflow_run(workflowId, taskDescription)
+    │
+    └─ no match → tells user which workflows exist and what they are designed for
+```
 
-## Scope
+## Space Agent Prompt
 
-- Pure, testable workflow selection logic
-- Space agent tools for task/run creation with workflow assignment
-- Agent prompt enhancement with workflow context
-- Unit tests
+```
+You are the Space orchestrator for this project. Your job is to understand what the user wants to accomplish and coordinate the right workflow to get it done.
 
----
+You have these tools:
+- list_workflows — show all workflows in this space with their descriptions and steps
+- start_workflow_run — begin a workflow run (requires workflowId + task description)
+- get_workflow_run — check the status of a running workflow
+- change_plan — update the current task description or switch to a different workflow mid-run
+- list_tasks — see current and past tasks
 
-### Task 7.1: Workflow Selection Logic and Agent Tools
+When the user sends a message:
+1. Call list_workflows to see what's available
+2. Pick the workflow whose description and steps best match what the user is asking for
+3. Call start_workflow_run with your chosen workflowId and a clear task description
+4. If no workflow fits, tell the user which workflows exist and what they're designed for
 
-**Agent:** coder
-**Priority:** high
-**Depends on:** Task 4.2
+If the user wants to change direction mid-task:
+1. Call change_plan with updated instructions or a new workflowId
+2. Explain what you're switching to and why
 
-**Description:**
+Be concise. Don't ask for confirmation unless the request is ambiguous. Just start working.
+```
 
-Implement workflow selection as a pure testable unit and create Space agent tools for starting workflow runs and creating standalone tasks. All in the Space namespace.
+## What Was Removed
 
-**Subtasks:**
+The previous design included:
 
-1. Create `packages/daemon/src/lib/space/runtime/workflow-selector.ts`:
-   - `selectWorkflow(context: WorkflowSelectionContext): SpaceWorkflow | null`
-   - `WorkflowSelectionContext`: `{ spaceId, title, description, availableWorkflows: SpaceWorkflow[] }`
-   - Selection algorithm (deterministic priority chain):
-     1. Explicit `workflowId` provided → use it
-     2. Space has default workflow → use it
-     3. Tag-based: match task description keywords against workflow tags
-     4. MVP keyword matching: substring match title/description against workflow descriptions
-     5. Fall back to null (create standalone task)
+- `isDefault` flag on `SpaceWorkflow` — a single workflow per Space could be marked as the default and selected automatically when no `workflowId` was provided.
+- Tag-based and keyword-based selection heuristics.
+- Fallback-to-null behaviour when no workflow matched.
 
-2. **Unit-testable without runtime**: `selectWorkflow()` takes only data inputs (all `SpaceWorkflow` type).
-
-3. Create Space agent tools in `packages/daemon/src/lib/space/tools/space-agent-tools.ts`:
-   - `start_workflow_run` tool — starts a new workflow run with optional `workflowId` (auto-selects if not provided). Returns the created `SpaceWorkflowRun`.
-   - `create_task` tool — creates a standalone `SpaceTask` (no workflow). Accepts optional `workflowId` for ad-hoc workflow assignment.
-   - `list_workflows` tool — returns available `SpaceWorkflow` records for the space
-   - `list_tasks` tool — returns `SpaceTask` records, filterable by status and `workflowRunId`
-   - `list_workflow_runs` tool — returns active/completed `SpaceWorkflowRun` records
-   - **This is a new file** — NOT modifying `room-agent-tools.ts`
-
-4. Integration point in `SpaceRuntime`:
-   - `resolveWorkflowForRun(title: string, description?: string): SpaceWorkflow | null` — calls `selectWorkflow()`
-
-5. Write unit tests:
-   - All priority chain levels tested
-   - Explicit assignment wins over defaults
-   - Tag matching works
-   - Keyword matching handles common patterns and no-match gracefully
-   - Null fallback when no workflows exist
-   - Agent tools create correct records
-
-**Acceptance criteria:**
-- `selectWorkflow()` is a pure function with no runtime dependencies, using `SpaceWorkflow` type
-- Deterministic priority chain with clear precedence
-- Space agent tools in new file `space-agent-tools.ts` (NOT modifying `room-agent-tools.ts`)
-- Tools support both workflow runs and standalone tasks
-- Unit tests cover all selection paths
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
-
----
-
-### Task 7.2: Space Agent Prompt Enhancement
-
-**Agent:** coder
-**Priority:** normal
-**Depends on:** Task 7.1
-
-**Description:**
-
-Enhance Space agent prompts with workflow awareness so agents can recommend and work within workflows intelligently. All prompt building in Space namespace.
-
-**Subtasks:**
-
-1. Create Space chat agent system prompt builder in `packages/daemon/src/lib/space/agents/space-chat-agent.ts`:
-   - Include available `SpaceWorkflow` records (names, descriptions, tags)
-   - Include `SpaceAgent` information
-   - Guidance: "When creating work, consider which workflow best fits. Use `start_workflow_run` for multi-step processes or `create_task` for standalone work."
-   - **New file** — NOT modifying existing room agent prompt builders
-
-2. Add `get_workflow_detail` tool to `space-agent-tools.ts`:
-   - Takes `workflowId`, returns full `SpaceWorkflow` with steps, gates, rules
-
-3. Add `suggest_workflow` tool to `space-agent-tools.ts`:
-   - Takes `description` of intended work
-   - Returns best-matching `SpaceWorkflow` records via `selectWorkflow()` logic
-
-4. Update Planner agent prompt for workflow context (in Space planner setup):
-   - When a workflow run is active, include workflow structure in planning context
-   - Planner creates tasks aligned with the current workflow step
-
-5. Write unit tests:
-   - Prompt includes workflow information
-   - `suggest_workflow` returns relevant matches
-   - Planner receives workflow context
-
-**Acceptance criteria:**
-- Space agent aware of available workflows
-- All prompt builders in Space namespace (new files, not modifying Room prompts)
-- Workflow context flows to planner for aligned task creation
-- New tools work correctly
-- Unit tests pass
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`
+All of this has been removed. The Space agent's LLM reasoning replaces static heuristics. This is simpler, more flexible, and requires no special data model support.

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -1,5 +1,5 @@
 /**
- * Space module — managers for the Space multi-agent workflow system.
+ * Space module — managers and repositories for the Space multi-agent workflow system.
  */
 
 export { SpaceManager } from './managers/space-manager';
@@ -8,3 +8,19 @@ export {
 	VALID_SPACE_TASK_TRANSITIONS,
 	isValidSpaceTaskTransition,
 } from './managers/space-task-manager';
+export { SpaceWorkflowManager, WorkflowValidationError } from './managers/space-workflow-manager';
+export type { SpaceAgentLookup } from './managers/space-workflow-manager';
+export { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
+
+// Types — re-exported from @neokai/shared for convenience
+export type {
+	SpaceWorkflow,
+	WorkflowStep,
+	WorkflowRule,
+	WorkflowGate,
+	WorkflowGateType,
+	WorkflowStepInput,
+	WorkflowRuleInput,
+	CreateSpaceWorkflowParams,
+	UpdateSpaceWorkflowParams,
+} from '@neokai/shared';

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -5,8 +5,11 @@
  *
  * Responsibilities:
  * - Validate workflow integrity (unique name, step agent refs, gate security)
- * - Enforce default workflow invariants (single default per space)
  * - Protect custom agents that are referenced by steps
+ *
+ * Workflow selection: either explicit workflowId provided by the caller, or
+ * AI auto-select at runtime via list_workflows + start_workflow_run. There is
+ * no default workflow concept.
  */
 
 import type {
@@ -114,12 +117,6 @@ export class SpaceWorkflowManager {
 		const trimmedName = params.name.trim();
 		this.validateName(params.spaceId, trimmedName, null);
 		this.validateSteps(params.spaceId, params.steps ?? []);
-
-		// If this new workflow should be the default, unset any current default first
-		if (params.isDefault) {
-			this.repo.clearDefaultWorkflow(params.spaceId);
-		}
-
 		return this.repo.createWorkflow({ ...params, name: trimmedName });
 	}
 
@@ -133,10 +130,6 @@ export class SpaceWorkflowManager {
 
 	listWorkflows(spaceId: string): SpaceWorkflow[] {
 		return this.repo.listWorkflows(spaceId);
-	}
-
-	getDefaultWorkflow(spaceId: string): SpaceWorkflow | null {
-		return this.repo.getDefaultWorkflow(spaceId);
 	}
 
 	// -------------------------------------------------------------------------
@@ -177,11 +170,6 @@ export class SpaceWorkflowManager {
 			this.validateSteps(existing.spaceId, inputs);
 		}
 
-		// If switching isDefault to true, clear any existing default
-		if (params.isDefault === true && !existing.isDefault) {
-			this.repo.clearDefaultWorkflow(existing.spaceId);
-		}
-
 		return this.repo.updateWorkflow(id, params);
 	}
 
@@ -192,25 +180,7 @@ export class SpaceWorkflowManager {
 	deleteWorkflow(id: string): boolean {
 		const existing = this.repo.getWorkflow(id);
 		if (!existing) return false;
-
-		const deleted = this.repo.deleteWorkflow(id);
-
-		// If we deleted the default workflow, the foreign key CASCADE handles DB cleanup.
-		// No further action needed — callers can create a new default if desired.
-
-		return deleted;
-	}
-
-	// -------------------------------------------------------------------------
-	// Default workflow management
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Set a workflow as the default for its space.
-	 * Atomically clears any previous default and marks the new one.
-	 */
-	setDefaultWorkflow(spaceId: string, workflowId: string): boolean {
-		return this.repo.setDefaultWorkflow(spaceId, workflowId);
+		return this.repo.deleteWorkflow(id);
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -32,28 +32,42 @@ const VALID_BUILTIN_ROLES: ReadonlySet<BuiltinAgentRole> = new Set(['planner', '
 /**
  * Allowlisted command prefixes for quality_check gates.
  * Commands must start with one of these prefixes to be accepted.
+ *
+ * Each entry ends with a space (or is already a full command word) so that
+ * prefix matching cannot be satisfied by a command that merely *starts with*
+ * the same letters (e.g., 'tsc-wrapper' must not match 'tsc ').
  */
 const QUALITY_CHECK_ALLOWLIST: readonly string[] = [
 	'bun test',
-	'bun run',
+	'bun run ',
 	'npm test',
-	'npm run',
+	'npm run ',
 	'npx ',
 	'yarn test',
-	'yarn run',
+	'yarn run ',
 	'pnpm test',
-	'pnpm run',
+	'pnpm run ',
 	'make ',
 	'cargo test',
 	'cargo check',
-	'go test',
-	'pytest',
+	'go test ',
+	'pytest ',
 	'python -m pytest',
-	'tsc',
+	'tsc ',
 	'biome ',
 	'eslint ',
 	'oxlint ',
 ];
+
+/**
+ * Shell metacharacters (and control characters) that are rejected in gate
+ * commands regardless of gate type.  The gate executor is expected to invoke
+ * commands directly without a shell, but we validate at storage time so that
+ * stored commands are safe even if the execution path changes.
+ *
+ * Covers: ; & | ` $ < > \ and the newline/carriage-return control characters.
+ */
+const SHELL_METACHAR_RE = /[;&|`$<>\\\n\r]/;
 
 /** Maximum allowed timeout for gate evaluation (ms) */
 const MAX_GATE_TIMEOUT_MS = 300_000;
@@ -216,15 +230,15 @@ export class SpaceWorkflowManager {
 	// -------------------------------------------------------------------------
 
 	private validateName(spaceId: string, name: string, excludeId: string | null): void {
-		const trimmed = name.trim();
-		if (!trimmed) {
+		// name is already trimmed by callers (createWorkflow / updateWorkflow)
+		if (!name) {
 			throw new WorkflowValidationError('Workflow name must not be empty');
 		}
 		const existing = this.repo.listWorkflows(spaceId);
 		for (const wf of existing) {
-			if (wf.name === trimmed && wf.id !== excludeId) {
+			if (wf.name === name && wf.id !== excludeId) {
 				throw new WorkflowValidationError(
-					`A workflow named "${trimmed}" already exists in this space`
+					`A workflow named "${name}" already exists in this space`
 				);
 			}
 		}
@@ -306,10 +320,7 @@ export class SpaceWorkflowManager {
 		if (!QUALITY_CHECK_ALLOWLIST.some((prefix) => trimmed.startsWith(prefix.toLowerCase()))) {
 			return false;
 		}
-		// Reject shell metacharacters that could be used to inject arbitrary commands.
-		// The gate executor is expected to run the command directly (not via a shell),
-		// but we validate here so that stored commands are safe regardless of executor.
-		if (/[;&|`$<>\\]/.test(command)) {
+		if (SHELL_METACHAR_RE.test(command)) {
 			return false;
 		}
 		return true;
@@ -317,6 +328,13 @@ export class SpaceWorkflowManager {
 
 	private validateCustomGateCommand(command: string, location: string): void {
 		const trimmed = command.trim();
+
+		// Reject shell metacharacters and control characters in the path.
+		if (SHELL_METACHAR_RE.test(trimmed)) {
+			throw new WorkflowValidationError(
+				`${location}: custom gate command must not contain shell metacharacters or control characters: "${trimmed}"`
+			);
+		}
 
 		// Must be a relative path (not absolute)
 		if (trimmed.startsWith('/')) {
@@ -326,7 +344,7 @@ export class SpaceWorkflowManager {
 		}
 
 		// Must not contain '..' traversal
-		const parts = trimmed.split(/[/\\]/);
+		const parts = trimmed.split(/[/]/);
 		for (const part of parts) {
 			if (part === '..') {
 				throw new WorkflowValidationError(
@@ -336,7 +354,7 @@ export class SpaceWorkflowManager {
 		}
 
 		// Should start with './' for clarity
-		if (!trimmed.startsWith('./') && !trimmed.startsWith('.\\')) {
+		if (!trimmed.startsWith('./')) {
 			throw new WorkflowValidationError(
 				`${location}: custom gate command must start with './' (relative to workspace root): "${trimmed}"`
 			);

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -84,8 +84,8 @@ const MAX_GATE_TIMEOUT_MS = 300_000;
  * custom agent references in workflow steps.
  */
 export interface SpaceAgentLookup {
-	/** Returns the SpaceAgent with the given name in the given space, or null if not found. */
-	getAgentByName(spaceId: string, name: string): { id: string; name: string } | null;
+	/** Returns the SpaceAgent with the given UUID in the given space, or null if not found. */
+	getAgentById(spaceId: string, id: string): { id: string; name: string } | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -237,17 +237,17 @@ export class SpaceWorkflowManager {
 				);
 			}
 		} else {
-			// custom ref — validate that a SpaceAgent with this name exists
+			// custom ref — validate that a SpaceAgent with this UUID exists
 			if (!step.agentRef || !step.agentRef.trim()) {
 				throw new WorkflowValidationError(
-					`step[${index}]: custom agentRef must be a non-empty SpaceAgent name`
+					`step[${index}]: custom agentRef must be a non-empty SpaceAgent UUID`
 				);
 			}
 			if (this.agentLookup) {
-				const agent = this.agentLookup.getAgentByName(spaceId, step.agentRef);
+				const agent = this.agentLookup.getAgentById(spaceId, step.agentRef);
 				if (!agent) {
 					throw new WorkflowValidationError(
-						`step[${index}]: custom agentRef "${step.agentRef}" does not match any SpaceAgent in this space`
+						`step[${index}]: custom agentRef "${step.agentRef}" does not match any SpaceAgent ID in this space`
 					);
 				}
 			}

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -1,0 +1,339 @@
+/**
+ * SpaceWorkflowManager
+ *
+ * Business logic layer for SpaceWorkflow operations within a Space.
+ *
+ * Responsibilities:
+ * - Validate workflow integrity (unique name, step agent refs, gate security)
+ * - Enforce default workflow invariants (single default per space)
+ * - Protect custom agents that are referenced by steps
+ */
+
+import type {
+	SpaceWorkflow,
+	WorkflowGate,
+	WorkflowStepInput,
+	CreateSpaceWorkflowParams,
+	UpdateSpaceWorkflowParams,
+	BuiltinAgentRole,
+} from '@neokai/shared';
+import type { SpaceWorkflowRepository } from '../../../storage/repositories/space-workflow-repository';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Valid builtin agent roles for workflow steps.
+ * NOTE: 'leader' is intentionally excluded — it is always implicit in SpaceRuntime.
+ */
+const VALID_BUILTIN_ROLES: ReadonlySet<BuiltinAgentRole> = new Set(['planner', 'coder', 'general']);
+
+/**
+ * Allowlisted command prefixes for quality_check gates.
+ * Commands must start with one of these prefixes to be accepted.
+ */
+const QUALITY_CHECK_ALLOWLIST: readonly string[] = [
+	'bun test',
+	'bun run',
+	'npm test',
+	'npm run',
+	'npx ',
+	'yarn test',
+	'yarn run',
+	'pnpm test',
+	'pnpm run',
+	'make ',
+	'cargo test',
+	'cargo check',
+	'go test',
+	'pytest',
+	'python -m pytest',
+	'tsc',
+	'biome ',
+	'eslint ',
+	'oxlint ',
+];
+
+/** Maximum allowed timeout for gate evaluation (ms) */
+const MAX_GATE_TIMEOUT_MS = 300_000;
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface the manager needs from SpaceAgentManager to validate
+ * custom agent references in workflow steps.
+ */
+export interface SpaceAgentLookup {
+	/** Returns the SpaceAgent with the given name in the given space, or null if not found. */
+	getAgentByName(spaceId: string, name: string): { id: string; name: string } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class WorkflowValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'WorkflowValidationError';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+export class SpaceWorkflowManager {
+	constructor(
+		private repo: SpaceWorkflowRepository,
+		private agentLookup: SpaceAgentLookup | null = null
+	) {}
+
+	// -------------------------------------------------------------------------
+	// Create
+	// -------------------------------------------------------------------------
+
+	createWorkflow(params: CreateSpaceWorkflowParams): SpaceWorkflow {
+		this.validateName(params.spaceId, params.name, null);
+		this.validateSteps(params.spaceId, params.steps ?? []);
+
+		// If this new workflow should be the default, unset any current default first
+		if (params.isDefault) {
+			this.repo.clearDefaultWorkflow(params.spaceId);
+		}
+
+		return this.repo.createWorkflow(params);
+	}
+
+	// -------------------------------------------------------------------------
+	// Read
+	// -------------------------------------------------------------------------
+
+	getWorkflow(id: string): SpaceWorkflow | null {
+		return this.repo.getWorkflow(id);
+	}
+
+	listWorkflows(spaceId: string): SpaceWorkflow[] {
+		return this.repo.listWorkflows(spaceId);
+	}
+
+	getDefaultWorkflow(spaceId: string): SpaceWorkflow | null {
+		return this.repo.getDefaultWorkflow(spaceId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Update
+	// -------------------------------------------------------------------------
+
+	updateWorkflow(id: string, params: UpdateSpaceWorkflowParams): SpaceWorkflow | null {
+		const existing = this.repo.getWorkflow(id);
+		if (!existing) return null;
+
+		if (params.name !== undefined) {
+			this.validateName(existing.spaceId, params.name, id);
+		}
+		if (params.steps !== undefined) {
+			// UpdateSpaceWorkflowParams uses WorkflowStep[] (with id/order) — treat as inputs
+			const inputs: WorkflowStepInput[] = (params.steps ?? []).map((s): WorkflowStepInput => {
+				if (s.agentRefType === 'custom') {
+					return {
+						name: s.name,
+						agentRefType: 'custom',
+						agentRef: s.agentRef,
+						entryGate: s.entryGate,
+						exitGate: s.exitGate,
+						instructions: s.instructions,
+					};
+				}
+				return {
+					name: s.name,
+					agentRefType: 'builtin',
+					agentRef: s.agentRef,
+					entryGate: s.entryGate,
+					exitGate: s.exitGate,
+					instructions: s.instructions,
+				};
+			});
+			this.validateSteps(existing.spaceId, inputs);
+		}
+
+		// If switching isDefault to true, clear any existing default
+		if (params.isDefault === true && !existing.isDefault) {
+			this.repo.clearDefaultWorkflow(existing.spaceId);
+		}
+
+		return this.repo.updateWorkflow(id, params);
+	}
+
+	// -------------------------------------------------------------------------
+	// Delete
+	// -------------------------------------------------------------------------
+
+	deleteWorkflow(id: string): boolean {
+		const existing = this.repo.getWorkflow(id);
+		if (!existing) return false;
+
+		const deleted = this.repo.deleteWorkflow(id);
+
+		// If we deleted the default workflow, the foreign key CASCADE handles DB cleanup.
+		// No further action needed — callers can create a new default if desired.
+
+		return deleted;
+	}
+
+	// -------------------------------------------------------------------------
+	// Default workflow management
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Set a workflow as the default for its space.
+	 * Atomically clears any previous default and marks the new one.
+	 */
+	setDefaultWorkflow(spaceId: string, workflowId: string): boolean {
+		return this.repo.setDefaultWorkflow(spaceId, workflowId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Agent reference protection
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns all workflows whose steps reference the given custom agent.
+	 * Used by SpaceAgentManager to block deletion of in-use agents.
+	 */
+	getWorkflowsReferencingAgent(agentId: string): SpaceWorkflow[] {
+		return this.repo.getWorkflowsReferencingAgent(agentId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Validation
+	// -------------------------------------------------------------------------
+
+	private validateName(spaceId: string, name: string, excludeId: string | null): void {
+		const trimmed = name.trim();
+		if (!trimmed) {
+			throw new WorkflowValidationError('Workflow name must not be empty');
+		}
+		const existing = this.repo.listWorkflows(spaceId);
+		for (const wf of existing) {
+			if (wf.name === trimmed && wf.id !== excludeId) {
+				throw new WorkflowValidationError(
+					`A workflow named "${trimmed}" already exists in this space`
+				);
+			}
+		}
+	}
+
+	private validateSteps(spaceId: string, steps: WorkflowStepInput[]): void {
+		if (steps.length === 0) {
+			throw new WorkflowValidationError('A workflow must have at least one step');
+		}
+
+		for (let i = 0; i < steps.length; i++) {
+			const step = steps[i];
+			this.validateStepAgentRef(spaceId, step, i);
+			if (step.entryGate) this.validateGate(step.entryGate, `step[${i}].entryGate`);
+			if (step.exitGate) this.validateGate(step.exitGate, `step[${i}].exitGate`);
+		}
+	}
+
+	private validateStepAgentRef(spaceId: string, step: WorkflowStepInput, index: number): void {
+		if (step.agentRefType === 'builtin') {
+			if (!VALID_BUILTIN_ROLES.has(step.agentRef as BuiltinAgentRole)) {
+				throw new WorkflowValidationError(
+					`step[${index}]: invalid builtin agentRef "${step.agentRef}". ` +
+						`Must be one of: ${[...VALID_BUILTIN_ROLES].join(', ')}. ` +
+						`Note: 'leader' is not a valid workflow step agent.`
+				);
+			}
+		} else {
+			// custom ref — validate that a SpaceAgent with this name exists
+			if (!step.agentRef || !step.agentRef.trim()) {
+				throw new WorkflowValidationError(
+					`step[${index}]: custom agentRef must be a non-empty SpaceAgent name`
+				);
+			}
+			if (this.agentLookup) {
+				const agent = this.agentLookup.getAgentByName(spaceId, step.agentRef);
+				if (!agent) {
+					throw new WorkflowValidationError(
+						`step[${index}]: custom agentRef "${step.agentRef}" does not match any SpaceAgent in this space`
+					);
+				}
+			}
+		}
+	}
+
+	private validateGate(gate: WorkflowGate, location: string): void {
+		if (gate.timeoutMs !== undefined) {
+			if (gate.timeoutMs < 0 || gate.timeoutMs > MAX_GATE_TIMEOUT_MS) {
+				throw new WorkflowValidationError(
+					`${location}: timeoutMs must be between 0 and ${MAX_GATE_TIMEOUT_MS}, got ${gate.timeoutMs}`
+				);
+			}
+		}
+
+		if (gate.type === 'quality_check') {
+			if (!gate.command || !gate.command.trim()) {
+				throw new WorkflowValidationError(`${location}: quality_check gate requires a command`);
+			}
+			if (!this.isAllowlistedCommand(gate.command)) {
+				throw new WorkflowValidationError(
+					`${location}: quality_check gate command "${gate.command}" is not in the allowlist. ` +
+						`Allowlisted prefixes: ${QUALITY_CHECK_ALLOWLIST.join(', ')}`
+				);
+			}
+		}
+
+		if (gate.type === 'custom') {
+			if (!gate.command || !gate.command.trim()) {
+				throw new WorkflowValidationError(
+					`${location}: custom gate requires a command (relative path to script)`
+				);
+			}
+			this.validateCustomGateCommand(gate.command, location);
+		}
+	}
+
+	private isAllowlistedCommand(command: string): boolean {
+		const trimmed = command.trim().toLowerCase();
+		return QUALITY_CHECK_ALLOWLIST.some((prefix) => trimmed.startsWith(prefix.toLowerCase()));
+	}
+
+	private validateCustomGateCommand(command: string, location: string): void {
+		const trimmed = command.trim();
+
+		// Must be a relative path (not absolute)
+		if (trimmed.startsWith('/')) {
+			throw new WorkflowValidationError(
+				`${location}: custom gate command must be a relative path, not absolute: "${trimmed}"`
+			);
+		}
+
+		// Must not contain '..' traversal
+		const parts = trimmed.split(/[/\\]/);
+		for (const part of parts) {
+			if (part === '..') {
+				throw new WorkflowValidationError(
+					`${location}: custom gate command must not contain '..' path traversal: "${trimmed}"`
+				);
+			}
+		}
+
+		// Should start with './' for clarity
+		if (!trimmed.startsWith('./') && !trimmed.startsWith('.\\')) {
+			throw new WorkflowValidationError(
+				`${location}: custom gate command must start with './' (relative to workspace root): "${trimmed}"`
+			);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Re-export error class and constants for tests
+// ---------------------------------------------------------------------------
+
+export { QUALITY_CHECK_ALLOWLIST, VALID_BUILTIN_ROLES, MAX_GATE_TIMEOUT_MS };

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -97,7 +97,8 @@ export class SpaceWorkflowManager {
 	// -------------------------------------------------------------------------
 
 	createWorkflow(params: CreateSpaceWorkflowParams): SpaceWorkflow {
-		this.validateName(params.spaceId, params.name, null);
+		const trimmedName = params.name.trim();
+		this.validateName(params.spaceId, trimmedName, null);
 		this.validateSteps(params.spaceId, params.steps ?? []);
 
 		// If this new workflow should be the default, unset any current default first
@@ -105,7 +106,7 @@ export class SpaceWorkflowManager {
 			this.repo.clearDefaultWorkflow(params.spaceId);
 		}
 
-		return this.repo.createWorkflow(params);
+		return this.repo.createWorkflow({ ...params, name: trimmedName });
 	}
 
 	// -------------------------------------------------------------------------
@@ -133,7 +134,9 @@ export class SpaceWorkflowManager {
 		if (!existing) return null;
 
 		if (params.name !== undefined) {
-			this.validateName(existing.spaceId, params.name, id);
+			const trimmedName = params.name.trim();
+			this.validateName(existing.spaceId, trimmedName, id);
+			params = { ...params, name: trimmedName };
 		}
 		if (params.steps !== undefined) {
 			// UpdateSpaceWorkflowParams uses WorkflowStep[] (with id/order) — treat as inputs
@@ -300,7 +303,16 @@ export class SpaceWorkflowManager {
 
 	private isAllowlistedCommand(command: string): boolean {
 		const trimmed = command.trim().toLowerCase();
-		return QUALITY_CHECK_ALLOWLIST.some((prefix) => trimmed.startsWith(prefix.toLowerCase()));
+		if (!QUALITY_CHECK_ALLOWLIST.some((prefix) => trimmed.startsWith(prefix.toLowerCase()))) {
+			return false;
+		}
+		// Reject shell metacharacters that could be used to inject arbitrary commands.
+		// The gate executor is expected to run the command directly (not via a shell),
+		// but we validate here so that stored commands are safe regardless of executor.
+		if (/[;&|`$<>\\]/.test(command)) {
+			return false;
+		}
+		return true;
 	}
 
 	private validateCustomGateCommand(command: string, location: string): void {
@@ -331,9 +343,3 @@ export class SpaceWorkflowManager {
 		}
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Re-export error class and constants for tests
-// ---------------------------------------------------------------------------
-
-export { QUALITY_CHECK_ALLOWLIST, VALID_BUILTIN_ROLES, MAX_GATE_TIMEOUT_MS };

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -156,7 +156,7 @@ export class SpaceWorkflowRepository {
 			.run(
 				id,
 				params.spaceId,
-				params.name,
+				params.name.trim(),
 				params.description ?? '',
 				JSON.stringify(cfg),
 				now,
@@ -222,7 +222,7 @@ export class SpaceWorkflowRepository {
 
 		if (params.name !== undefined) {
 			fields.push('name = ?');
-			values.push(params.name);
+			values.push(params.name.trim());
 		}
 		if (params.description !== undefined) {
 			fields.push('description = ?');
@@ -257,7 +257,9 @@ export class SpaceWorkflowRepository {
 			values.push(JSON.stringify(newCfg));
 		}
 
-		if (fields.length > 0) {
+		// Always bump updated_at if anything changed (scalar fields or steps)
+		const hasStepReplacement = params.steps !== undefined;
+		if (fields.length > 0 || hasStepReplacement) {
 			fields.push('updated_at = ?');
 			values.push(now, id);
 			this.db
@@ -266,7 +268,7 @@ export class SpaceWorkflowRepository {
 		}
 
 		// Replace all steps if steps are provided
-		if (params.steps !== undefined) {
+		if (hasStepReplacement) {
 			this.db.prepare(`DELETE FROM space_workflow_steps WHERE workflow_id = ?`).run(id);
 			const steps = params.steps ?? [];
 			for (let i = 0; i < steps.length; i++) {
@@ -298,10 +300,11 @@ export class SpaceWorkflowRepository {
 	 * on the specified workflow. Runs in a transaction.
 	 */
 	setDefaultWorkflow(spaceId: string, workflowId: string): boolean {
-		const target = this.db
-			.prepare(`SELECT * FROM space_workflows WHERE id = ? AND space_id = ?`)
-			.get(workflowId, spaceId) as WorkflowRow | undefined;
-		if (!target) return false;
+		// Verify the target exists before opening the transaction
+		const exists = this.db
+			.prepare(`SELECT id FROM space_workflows WHERE id = ? AND space_id = ?`)
+			.get(workflowId, spaceId);
+		if (!exists) return false;
 
 		const tx = this.db.transaction(() => {
 			// Clear isDefault on all workflows in this space
@@ -319,7 +322,10 @@ export class SpaceWorkflowRepository {
 				}
 			}
 
-			// Set target as default
+			// Re-read the target row inside the transaction so we always work from current state
+			const target = this.db
+				.prepare(`SELECT * FROM space_workflows WHERE id = ?`)
+				.get(workflowId) as WorkflowRow;
 			const targetCfg = parseJson<WorkflowConfigJson>(target.config, {});
 			targetCfg.isDefault = true;
 			this.db

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -8,7 +8,7 @@
  *   space_workflow_steps — id, workflow_id, name, description, agent_id (custom UUID | null),
  *                          order_index, config (JSON), created_at, updated_at
  *
- * The `config` column on space_workflows stores: { isDefault, tags, rules, ...extra }
+ * The `config` column on space_workflows stores: { tags, rules, ...extra }
  * The `config` column on space_workflow_steps stores: { agentRefType, agentRef, entryGate?,
  *   exitGate?, instructions? }
  * The `agent_id` column stores the custom SpaceAgent's UUID when agentRefType='custom',
@@ -56,7 +56,6 @@ interface StepRow {
 
 // JSON stored inside space_workflows.config
 interface WorkflowConfigJson {
-	isDefault?: boolean;
 	tags?: string[];
 	rules?: WorkflowRule[];
 	extra?: Record<string, unknown>;
@@ -118,7 +117,6 @@ export function rowToWorkflow(row: WorkflowRow, steps: WorkflowStep[]): SpaceWor
 		description: row.description || undefined,
 		steps,
 		rules: cfg.rules ?? [],
-		isDefault: cfg.isDefault ?? false,
 		tags: cfg.tags ?? [],
 		config: cfg.extra,
 		createdAt: row.created_at,
@@ -142,7 +140,6 @@ export class SpaceWorkflowRepository {
 		const now = Date.now();
 
 		const cfg: WorkflowConfigJson = {
-			isDefault: params.isDefault ?? false,
 			tags: params.tags ?? [],
 			rules: this.assignRuleIds(params.rules ?? []),
 			extra: params.config,
@@ -192,20 +189,6 @@ export class SpaceWorkflowRepository {
 		return rows.map((r) => rowToWorkflow(r, this.fetchSteps(r.id)));
 	}
 
-	getDefaultWorkflow(spaceId: string): SpaceWorkflow | null {
-		const rows = this.db
-			.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
-			.all(spaceId) as WorkflowRow[];
-		for (const row of rows) {
-			const cfg = parseJson<WorkflowConfigJson>(row.config, {});
-			if (cfg.isDefault) {
-				const steps = this.fetchSteps(row.id);
-				return rowToWorkflow(row, steps);
-			}
-		}
-		return null;
-	}
-
 	// -------------------------------------------------------------------------
 	// Update
 	// -------------------------------------------------------------------------
@@ -234,10 +217,6 @@ export class SpaceWorkflowRepository {
 		let cfgChanged = false;
 		const newCfg: WorkflowConfigJson = { ...existingCfg };
 
-		if (params.isDefault !== undefined) {
-			newCfg.isDefault = params.isDefault;
-			cfgChanged = true;
-		}
 		if (params.tags !== undefined) {
 			newCfg.tags = params.tags ?? [];
 			cfgChanged = true;
@@ -288,71 +267,6 @@ export class SpaceWorkflowRepository {
 	deleteWorkflow(id: string): boolean {
 		const result = this.db.prepare(`DELETE FROM space_workflows WHERE id = ?`).run(id);
 		return result.changes > 0;
-	}
-
-	// -------------------------------------------------------------------------
-	// Default workflow management
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Set the default workflow for a space.
-	 * Clears isDefault on all other workflows in the space, then sets isDefault=true
-	 * on the specified workflow. Runs in a transaction.
-	 */
-	setDefaultWorkflow(spaceId: string, workflowId: string): boolean {
-		// Verify the target exists before opening the transaction
-		const exists = this.db
-			.prepare(`SELECT id FROM space_workflows WHERE id = ? AND space_id = ?`)
-			.get(workflowId, spaceId);
-		if (!exists) return false;
-
-		const tx = this.db.transaction(() => {
-			// Clear isDefault on all workflows in this space
-			const all = this.db
-				.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
-				.all(spaceId) as WorkflowRow[];
-
-			for (const w of all) {
-				const cfg = parseJson<WorkflowConfigJson>(w.config, {});
-				if (cfg.isDefault) {
-					cfg.isDefault = false;
-					this.db
-						.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
-						.run(JSON.stringify(cfg), Date.now(), w.id);
-				}
-			}
-
-			// Re-read the target row inside the transaction so we always work from current state
-			const target = this.db
-				.prepare(`SELECT * FROM space_workflows WHERE id = ?`)
-				.get(workflowId) as WorkflowRow;
-			const targetCfg = parseJson<WorkflowConfigJson>(target.config, {});
-			targetCfg.isDefault = true;
-			this.db
-				.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
-				.run(JSON.stringify(targetCfg), Date.now(), workflowId);
-		});
-
-		tx();
-		return true;
-	}
-
-	/**
-	 * Clear isDefault from a workflow (e.g., when its space's default is being deleted).
-	 */
-	clearDefaultWorkflow(spaceId: string): void {
-		const rows = this.db
-			.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
-			.all(spaceId) as WorkflowRow[];
-		for (const w of rows) {
-			const cfg = parseJson<WorkflowConfigJson>(w.config, {});
-			if (cfg.isDefault) {
-				cfg.isDefault = false;
-				this.db
-					.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
-					.run(JSON.stringify(cfg), Date.now(), w.id);
-			}
-		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -1,0 +1,413 @@
+/**
+ * SpaceWorkflowRepository
+ *
+ * Data access layer for SpaceWorkflow and SpaceWorkflowStep records.
+ *
+ * Storage layout:
+ *   space_workflows  — id, space_id, name, description, config (JSON), created_at, updated_at
+ *   space_workflow_steps — id, workflow_id, name, description, agent_id (custom UUID | null),
+ *                          order_index, config (JSON), created_at, updated_at
+ *
+ * The `config` column on space_workflows stores: { isDefault, tags, rules, ...extra }
+ * The `config` column on space_workflow_steps stores: { agentRefType, agentRef, entryGate?,
+ *   exitGate?, instructions? }
+ * The `agent_id` column stores the custom SpaceAgent's UUID when agentRefType='custom',
+ *   otherwise null.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	SpaceWorkflow,
+	WorkflowStep,
+	WorkflowRule,
+	WorkflowGate,
+	WorkflowStepInput,
+	WorkflowRuleInput,
+	CreateSpaceWorkflowParams,
+	UpdateSpaceWorkflowParams,
+} from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Internal DB row shapes
+// ---------------------------------------------------------------------------
+
+interface WorkflowRow {
+	id: string;
+	space_id: string;
+	name: string;
+	description: string;
+	config: string | null;
+	created_at: number;
+	updated_at: number;
+}
+
+interface StepRow {
+	id: string;
+	workflow_id: string;
+	name: string;
+	description: string;
+	agent_id: string | null;
+	order_index: number;
+	config: string | null;
+	created_at: number;
+	updated_at: number;
+}
+
+// JSON stored inside space_workflows.config
+interface WorkflowConfigJson {
+	isDefault?: boolean;
+	tags?: string[];
+	rules?: WorkflowRule[];
+	extra?: Record<string, unknown>;
+}
+
+// JSON stored inside space_workflow_steps.config
+interface StepConfigJson {
+	agentRefType: 'builtin' | 'custom';
+	agentRef: string;
+	entryGate?: WorkflowGate;
+	exitGate?: WorkflowGate;
+	instructions?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+	if (!raw) return fallback;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+export function rowToStep(row: StepRow): WorkflowStep {
+	const cfg = parseJson<StepConfigJson>(row.config, {
+		agentRefType: 'builtin',
+		agentRef: 'general',
+	});
+
+	const base = {
+		id: row.id,
+		name: row.name,
+		order: row.order_index,
+		entryGate: cfg.entryGate,
+		exitGate: cfg.exitGate,
+		instructions: cfg.instructions,
+	};
+
+	if (cfg.agentRefType === 'custom') {
+		return { ...base, agentRefType: 'custom', agentRef: cfg.agentRef } as WorkflowStep;
+	}
+	return {
+		...base,
+		agentRefType: 'builtin',
+		agentRef: cfg.agentRef as 'planner' | 'coder' | 'general',
+	} as WorkflowStep;
+}
+
+export function rowToWorkflow(row: WorkflowRow, steps: WorkflowStep[]): SpaceWorkflow {
+	const cfg = parseJson<WorkflowConfigJson>(row.config, {});
+	return {
+		id: row.id,
+		spaceId: row.space_id,
+		name: row.name,
+		description: row.description || undefined,
+		steps,
+		rules: cfg.rules ?? [],
+		isDefault: cfg.isDefault ?? false,
+		tags: cfg.tags ?? [],
+		config: cfg.extra,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class SpaceWorkflowRepository {
+	constructor(private db: BunDatabase) {}
+
+	// -------------------------------------------------------------------------
+	// Create
+	// -------------------------------------------------------------------------
+
+	createWorkflow(params: CreateSpaceWorkflowParams): SpaceWorkflow {
+		const id = generateUUID();
+		const now = Date.now();
+
+		const cfg: WorkflowConfigJson = {
+			isDefault: params.isDefault ?? false,
+			tags: params.tags ?? [],
+			rules: this.assignRuleIds(params.rules ?? []),
+			extra: params.config,
+		};
+
+		this.db
+			.prepare(
+				`INSERT INTO space_workflows (id, space_id, name, description, config, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.name,
+				params.description ?? '',
+				JSON.stringify(cfg),
+				now,
+				now
+			);
+
+		// Insert steps in order
+		const stepInputs = params.steps ?? [];
+		for (let i = 0; i < stepInputs.length; i++) {
+			this.insertStep(id, stepInputs[i], i, now);
+		}
+
+		return this.getWorkflow(id)!;
+	}
+
+	// -------------------------------------------------------------------------
+	// Read
+	// -------------------------------------------------------------------------
+
+	getWorkflow(id: string): SpaceWorkflow | null {
+		const row = this.db.prepare(`SELECT * FROM space_workflows WHERE id = ?`).get(id) as
+			| WorkflowRow
+			| undefined;
+		if (!row) return null;
+		const steps = this.fetchSteps(id);
+		return rowToWorkflow(row, steps);
+	}
+
+	listWorkflows(spaceId: string): SpaceWorkflow[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM space_workflows WHERE space_id = ? ORDER BY created_at ASC`)
+			.all(spaceId) as WorkflowRow[];
+		return rows.map((r) => rowToWorkflow(r, this.fetchSteps(r.id)));
+	}
+
+	getDefaultWorkflow(spaceId: string): SpaceWorkflow | null {
+		const rows = this.db
+			.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
+			.all(spaceId) as WorkflowRow[];
+		for (const row of rows) {
+			const cfg = parseJson<WorkflowConfigJson>(row.config, {});
+			if (cfg.isDefault) {
+				const steps = this.fetchSteps(row.id);
+				return rowToWorkflow(row, steps);
+			}
+		}
+		return null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Update
+	// -------------------------------------------------------------------------
+
+	updateWorkflow(id: string, params: UpdateSpaceWorkflowParams): SpaceWorkflow | null {
+		const row = this.db.prepare(`SELECT * FROM space_workflows WHERE id = ?`).get(id) as
+			| WorkflowRow
+			| undefined;
+		if (!row) return null;
+
+		const now = Date.now();
+		const fields: string[] = [];
+		const values: (string | number | null)[] = [];
+
+		if (params.name !== undefined) {
+			fields.push('name = ?');
+			values.push(params.name);
+		}
+		if (params.description !== undefined) {
+			fields.push('description = ?');
+			values.push(params.description ?? '');
+		}
+
+		// Build updated config
+		const existingCfg = parseJson<WorkflowConfigJson>(row.config, {});
+		let cfgChanged = false;
+		const newCfg: WorkflowConfigJson = { ...existingCfg };
+
+		if (params.isDefault !== undefined) {
+			newCfg.isDefault = params.isDefault;
+			cfgChanged = true;
+		}
+		if (params.tags !== undefined) {
+			newCfg.tags = params.tags ?? [];
+			cfgChanged = true;
+		}
+		if (params.rules !== undefined) {
+			// Rules in UpdateSpaceWorkflowParams are full WorkflowRule[] (with ids)
+			newCfg.rules = params.rules ?? [];
+			cfgChanged = true;
+		}
+		if (params.config !== undefined) {
+			newCfg.extra = params.config ?? undefined;
+			cfgChanged = true;
+		}
+
+		if (cfgChanged) {
+			fields.push('config = ?');
+			values.push(JSON.stringify(newCfg));
+		}
+
+		if (fields.length > 0) {
+			fields.push('updated_at = ?');
+			values.push(now, id);
+			this.db
+				.prepare(`UPDATE space_workflows SET ${fields.join(', ')} WHERE id = ?`)
+				.run(...values);
+		}
+
+		// Replace all steps if steps are provided
+		if (params.steps !== undefined) {
+			this.db.prepare(`DELETE FROM space_workflow_steps WHERE workflow_id = ?`).run(id);
+			const steps = params.steps ?? [];
+			for (let i = 0; i < steps.length; i++) {
+				// UpdateSpaceWorkflowParams has steps as WorkflowStep[] (with id/order)
+				// We replace them with new IDs to keep the DB consistent
+				this.insertStep(id, steps[i] as unknown as WorkflowStepInput, i, now);
+			}
+		}
+
+		return this.getWorkflow(id)!;
+	}
+
+	// -------------------------------------------------------------------------
+	// Delete
+	// -------------------------------------------------------------------------
+
+	deleteWorkflow(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM space_workflows WHERE id = ?`).run(id);
+		return result.changes > 0;
+	}
+
+	// -------------------------------------------------------------------------
+	// Default workflow management
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Set the default workflow for a space.
+	 * Clears isDefault on all other workflows in the space, then sets isDefault=true
+	 * on the specified workflow. Runs in a transaction.
+	 */
+	setDefaultWorkflow(spaceId: string, workflowId: string): boolean {
+		const target = this.db
+			.prepare(`SELECT * FROM space_workflows WHERE id = ? AND space_id = ?`)
+			.get(workflowId, spaceId) as WorkflowRow | undefined;
+		if (!target) return false;
+
+		const tx = this.db.transaction(() => {
+			// Clear isDefault on all workflows in this space
+			const all = this.db
+				.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
+				.all(spaceId) as WorkflowRow[];
+
+			for (const w of all) {
+				const cfg = parseJson<WorkflowConfigJson>(w.config, {});
+				if (cfg.isDefault) {
+					cfg.isDefault = false;
+					this.db
+						.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
+						.run(JSON.stringify(cfg), Date.now(), w.id);
+				}
+			}
+
+			// Set target as default
+			const targetCfg = parseJson<WorkflowConfigJson>(target.config, {});
+			targetCfg.isDefault = true;
+			this.db
+				.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
+				.run(JSON.stringify(targetCfg), Date.now(), workflowId);
+		});
+
+		tx();
+		return true;
+	}
+
+	/**
+	 * Clear isDefault from a workflow (e.g., when its space's default is being deleted).
+	 */
+	clearDefaultWorkflow(spaceId: string): void {
+		const rows = this.db
+			.prepare(`SELECT * FROM space_workflows WHERE space_id = ?`)
+			.all(spaceId) as WorkflowRow[];
+		for (const w of rows) {
+			const cfg = parseJson<WorkflowConfigJson>(w.config, {});
+			if (cfg.isDefault) {
+				cfg.isDefault = false;
+				this.db
+					.prepare(`UPDATE space_workflows SET config = ?, updated_at = ? WHERE id = ?`)
+					.run(JSON.stringify(cfg), Date.now(), w.id);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Agent reference queries
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Find all workflows in a space whose steps reference the given custom SpaceAgent ID.
+	 * Used by SpaceAgentManager to prevent deletion of agents that are still in use.
+	 */
+	getWorkflowsReferencingAgent(agentId: string): SpaceWorkflow[] {
+		const stepRows = this.db
+			.prepare(`SELECT DISTINCT workflow_id FROM space_workflow_steps WHERE agent_id = ?`)
+			.all(agentId) as Array<{ workflow_id: string }>;
+
+		const workflows: SpaceWorkflow[] = [];
+		for (const { workflow_id } of stepRows) {
+			const wf = this.getWorkflow(workflow_id);
+			if (wf) workflows.push(wf);
+		}
+		return workflows;
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	private fetchSteps(workflowId: string): WorkflowStep[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM space_workflow_steps WHERE workflow_id = ? ORDER BY order_index ASC`)
+			.all(workflowId) as StepRow[];
+		return rows.map(rowToStep);
+	}
+
+	private insertStep(
+		workflowId: string,
+		input: WorkflowStepInput,
+		index: number,
+		now: number
+	): void {
+		const stepId = generateUUID();
+		const stepCfg: StepConfigJson = {
+			agentRefType: input.agentRefType,
+			agentRef: input.agentRef,
+			entryGate: input.entryGate,
+			exitGate: input.exitGate,
+			instructions: input.instructions,
+		};
+
+		const agentId = input.agentRefType === 'custom' ? input.agentRef : null;
+
+		this.db
+			.prepare(
+				`INSERT INTO space_workflow_steps
+           (id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(stepId, workflowId, input.name, '', agentId, index, JSON.stringify(stepCfg), now, now);
+	}
+
+	private assignRuleIds(rules: WorkflowRuleInput[]): WorkflowRule[] {
+		return rules.map((r) => ({ ...r, id: generateUUID() }));
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -83,7 +83,7 @@ function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 	}
 }
 
-export function rowToStep(row: StepRow): WorkflowStep {
+function rowToStep(row: StepRow): WorkflowStep {
 	const cfg = parseJson<StepConfigJson>(row.config, {
 		agentRefType: 'builtin',
 		agentRef: 'general',
@@ -108,7 +108,7 @@ export function rowToStep(row: StepRow): WorkflowStep {
 	} as WorkflowStep;
 }
 
-export function rowToWorkflow(row: WorkflowRow, steps: WorkflowStep[]): SpaceWorkflow {
+function rowToWorkflow(row: WorkflowRow, steps: WorkflowStep[]): SpaceWorkflow {
 	const cfg = parseJson<WorkflowConfigJson>(row.config, {});
 	return {
 		id: row.id,

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -192,6 +192,17 @@ describe('SpaceWorkflowRepository', () => {
 		expect(updated?.description).toBe('Updated desc');
 	});
 
+	test('updateWorkflow bumps updatedAt on step-only update', async () => {
+		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		const before = wf.updatedAt;
+		// Small delay to ensure timestamp difference
+		await new Promise((r) => setTimeout(r, 2));
+		const updated = repo.updateWorkflow(wf.id, {
+			steps: [{ id: 'x', order: 0, name: 'Plan', agentRefType: 'builtin', agentRef: 'planner' }],
+		});
+		expect(updated?.updatedAt).toBeGreaterThan(before);
+	});
+
 	test('updateWorkflow replaces all steps on steps param', () => {
 		const wf = repo.createWorkflow({
 			spaceId: 'space-1',
@@ -446,6 +457,23 @@ describe('SpaceWorkflowManager', () => {
 		expect(updated?.name).toBe('WF');
 	});
 
+	test('name is trimmed before storage — whitespace variants collide', () => {
+		manager.createWorkflow({ spaceId: 'space-1', name: 'Foo', steps: [coderStep] });
+		// '  Foo  ' should trim to 'Foo' and fail uniqueness
+		expect(() =>
+			manager.createWorkflow({ spaceId: 'space-1', name: '  Foo  ', steps: [plannerStep] })
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('name is stored trimmed', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: '  Trimmed  ',
+			steps: [coderStep],
+		});
+		expect(wf.name).toBe('Trimmed');
+	});
+
 	// -------------------------------------------------------------------------
 	// At-least-one-step
 	// -------------------------------------------------------------------------
@@ -618,6 +646,57 @@ describe('SpaceWorkflowManager', () => {
 						agentRefType: 'builtin',
 						agentRef: 'coder',
 						exitGate: { type: 'quality_check' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('quality_check gate rejects shell injection via semicolon', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Inject Semi',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: 'bun test; rm -rf /' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('quality_check gate rejects shell injection via &&', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Inject And',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: 'bun test && curl http://evil.example' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('quality_check gate rejects shell injection via $()', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Inject Sub',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: 'bun test $(cat /etc/passwd)' },
 					},
 				],
 			})

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -426,6 +426,13 @@ describe('SpaceWorkflowManager', () => {
 		expect(() => manager.updateWorkflow(wf.id, { steps: [] })).toThrow(WorkflowValidationError);
 	});
 
+	test('updateWorkflow throws when steps is null (treated as empty replacement)', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(() => manager.updateWorkflow(wf.id, { steps: null as unknown as [] })).toThrow(
+			WorkflowValidationError
+		);
+	});
+
 	// -------------------------------------------------------------------------
 	// Agent ref validation — builtins
 	// -------------------------------------------------------------------------
@@ -480,28 +487,28 @@ describe('SpaceWorkflowManager', () => {
 	test('createWorkflow accepts custom ref when agent exists', () => {
 		seedAgent(db, 'agent-1', 'space-1', 'MyAgent');
 		const lookup: SpaceAgentLookup = {
-			getAgentByName: (_spaceId, name) =>
-				name === 'MyAgent' ? { id: 'agent-1', name: 'MyAgent' } : null,
+			getAgentById: (_spaceId, id) =>
+				id === 'agent-1' ? { id: 'agent-1', name: 'MyAgent' } : null,
 		};
 		const mgr = new SpaceWorkflowManager(repo, lookup);
 		const wf = mgr.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Custom WF',
-			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'MyAgent' }],
+			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
 		});
-		expect(wf.steps[0].agentRef).toBe('MyAgent');
+		expect(wf.steps[0].agentRef).toBe('agent-1');
 	});
 
 	test('createWorkflow rejects custom ref when agent does not exist', () => {
 		const lookup: SpaceAgentLookup = {
-			getAgentByName: () => null,
+			getAgentById: () => null,
 		};
 		const mgr = new SpaceWorkflowManager(repo, lookup);
 		expect(() =>
 			mgr.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Bad Custom',
-				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'NonExistent' }],
+				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'non-existent-uuid' }],
 			})
 		).toThrow(WorkflowValidationError);
 	});

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -3,7 +3,6 @@
  *
  * Covers:
  * - Repository: full CRUD with step management
- * - Repository: getDefaultWorkflow / setDefaultWorkflow
  * - Repository: getWorkflowsReferencingAgent
  * - Repository: JSON round-trips (rules, tags, gates)
  * - Manager: name uniqueness within space
@@ -12,8 +11,6 @@
  * - Manager: custom agent ref validation via SpaceAgentLookup
  * - Manager: gate command validation (quality_check allowlist, custom relative path, no ..)
  * - Manager: timeoutMs bounds (0–300000)
- * - Manager: setting new default unsets previous default
- * - Manager: deleting default workflow clears it
  * - Manager: step ordering via array position
  */
 
@@ -119,19 +116,8 @@ describe('SpaceWorkflowRepository', () => {
 		expect(wf.steps[0].agentRefType).toBe('builtin');
 		expect(wf.steps[0].agentRef).toBe('coder');
 		expect(wf.steps[1].order).toBe(1);
-		expect(wf.isDefault).toBe(false);
 		expect(wf.tags).toEqual([]);
 		expect(wf.rules).toEqual([]);
-	});
-
-	test('createWorkflow with isDefault=true persists the flag', () => {
-		const wf = repo.createWorkflow({
-			spaceId: 'space-1',
-			name: 'Default WF',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		expect(wf.isDefault).toBe(true);
 	});
 
 	test('createWorkflow stores tags and config', () => {
@@ -158,14 +144,12 @@ describe('SpaceWorkflowRepository', () => {
 			steps: [coderStep],
 			rules: [{ name: 'Rule1', content: 'Follow TDD', appliesTo: [] }],
 			tags: ['a', 'b'],
-			isDefault: true,
 			config: { key: 'value' },
 		});
 
 		const fetched = repo.getWorkflow(created.id)!;
 		expect(fetched.name).toBe('Full');
 		expect(fetched.description).toBe('A full workflow');
-		expect(fetched.isDefault).toBe(true);
 		expect(fetched.tags).toEqual(['a', 'b']);
 		expect(fetched.rules).toHaveLength(1);
 		expect(fetched.rules[0].name).toBe('Rule1');
@@ -236,59 +220,6 @@ describe('SpaceWorkflowRepository', () => {
 
 	test('deleteWorkflow returns false for missing id', () => {
 		expect(repo.deleteWorkflow('no-such-id')).toBe(false);
-	});
-
-	// -------------------------------------------------------------------------
-	// Default workflow management
-	// -------------------------------------------------------------------------
-
-	test('getDefaultWorkflow returns null when no default exists', () => {
-		repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
-		expect(repo.getDefaultWorkflow('space-1')).toBeNull();
-	});
-
-	test('getDefaultWorkflow returns the default workflow', () => {
-		repo.createWorkflow({ spaceId: 'space-1', name: 'WF1', steps: [coderStep] });
-		const def = repo.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF2',
-			steps: [plannerStep],
-			isDefault: true,
-		});
-		const result = repo.getDefaultWorkflow('space-1');
-		expect(result?.id).toBe(def.id);
-	});
-
-	test('setDefaultWorkflow atomically swaps default', () => {
-		const wf1 = repo.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF1',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		const wf2 = repo.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
-
-		repo.setDefaultWorkflow('space-1', wf2.id);
-
-		expect(repo.getWorkflow(wf1.id)?.isDefault).toBe(false);
-		expect(repo.getWorkflow(wf2.id)?.isDefault).toBe(true);
-		expect(repo.getDefaultWorkflow('space-1')?.id).toBe(wf2.id);
-	});
-
-	test('setDefaultWorkflow returns false for wrong spaceId', () => {
-		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
-		expect(repo.setDefaultWorkflow('space-2', wf.id)).toBe(false);
-	});
-
-	test('clearDefaultWorkflow unsets all defaults in space', () => {
-		const wf = repo.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		repo.clearDefaultWorkflow('space-1');
-		expect(repo.getWorkflow(wf.id)?.isDefault).toBe(false);
 	});
 
 	// -------------------------------------------------------------------------
@@ -946,55 +877,10 @@ describe('SpaceWorkflowManager', () => {
 		).toThrow(WorkflowValidationError);
 	});
 
-	// -------------------------------------------------------------------------
-	// Default workflow management
-	// -------------------------------------------------------------------------
-
-	test('createWorkflow with isDefault=true unsets previous default', () => {
-		const wf1 = manager.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF1',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(true);
-
-		const wf2 = manager.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF2',
-			steps: [plannerStep],
-			isDefault: true,
-		});
-		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(false);
-		expect(manager.getWorkflow(wf2.id)?.isDefault).toBe(true);
-		expect(manager.getDefaultWorkflow('space-1')?.id).toBe(wf2.id);
-	});
-
-	test('setDefaultWorkflow swaps the default', () => {
-		const wf1 = manager.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF1',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		const wf2 = manager.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
-
-		manager.setDefaultWorkflow('space-1', wf2.id);
-
-		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(false);
-		expect(manager.getWorkflow(wf2.id)?.isDefault).toBe(true);
-	});
-
-	test('deleteWorkflow removes workflow (default cleared by delete)', () => {
-		const wf = manager.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF',
-			steps: [coderStep],
-			isDefault: true,
-		});
-		manager.deleteWorkflow(wf.id);
+	test('deleteWorkflow removes an existing workflow', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(manager.deleteWorkflow(wf.id)).toBe(true);
 		expect(manager.getWorkflow(wf.id)).toBeNull();
-		expect(manager.getDefaultWorkflow('space-1')).toBeNull();
 	});
 
 	test('deleteWorkflow returns false for non-existent workflow', () => {

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -1,0 +1,878 @@
+/**
+ * SpaceWorkflow Unit Tests
+ *
+ * Covers:
+ * - Repository: full CRUD with step management
+ * - Repository: getDefaultWorkflow / setDefaultWorkflow
+ * - Repository: getWorkflowsReferencingAgent
+ * - Repository: JSON round-trips (rules, tags, gates)
+ * - Manager: name uniqueness within space
+ * - Manager: at-least-one-step validation
+ * - Manager: builtin agent ref validation (planner/coder/general valid, 'leader' rejected)
+ * - Manager: custom agent ref validation via SpaceAgentLookup
+ * - Manager: gate command validation (quality_check allowlist, custom relative path, no ..)
+ * - Manager: timeoutMs bounds (0–300000)
+ * - Manager: setting new default unsets previous default
+ * - Manager: deleting default workflow clears it
+ * - Manager: step ordering via array position
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import {
+	SpaceWorkflowManager,
+	WorkflowValidationError,
+} from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { SpaceAgentLookup } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { WorkflowGate, WorkflowStepInput } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(process.cwd(), 'tmp', 'test-space-workflow', `t-${Date.now()}-${Math.random()}`);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpace(db: BunDatabase, spaceId = 'space-1'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+const coderStep: WorkflowStepInput = { name: 'Code', agentRefType: 'builtin', agentRef: 'coder' };
+const plannerStep: WorkflowStepInput = {
+	name: 'Plan',
+	agentRefType: 'builtin',
+	agentRef: 'planner',
+};
+const generalStep: WorkflowStepInput = {
+	name: 'Review',
+	agentRefType: 'builtin',
+	agentRef: 'general',
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('SpaceWorkflowRepository', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let repo: SpaceWorkflowRepository;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpace(db);
+		repo = new SpaceWorkflowRepository(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// CRUD
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow returns workflow with generated id and steps', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'My Workflow',
+			steps: [coderStep, plannerStep],
+		});
+
+		expect(wf.id).toBeTruthy();
+		expect(wf.spaceId).toBe('space-1');
+		expect(wf.name).toBe('My Workflow');
+		expect(wf.steps).toHaveLength(2);
+		expect(wf.steps[0].name).toBe('Code');
+		expect(wf.steps[0].order).toBe(0);
+		expect(wf.steps[0].agentRefType).toBe('builtin');
+		expect(wf.steps[0].agentRef).toBe('coder');
+		expect(wf.steps[1].order).toBe(1);
+		expect(wf.isDefault).toBe(false);
+		expect(wf.tags).toEqual([]);
+		expect(wf.rules).toEqual([]);
+	});
+
+	test('createWorkflow with isDefault=true persists the flag', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Default WF',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		expect(wf.isDefault).toBe(true);
+	});
+
+	test('createWorkflow stores tags and config', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Tagged',
+			steps: [coderStep],
+			tags: ['ci', 'deploy'],
+			config: { priority: 'high' },
+		});
+		expect(wf.tags).toEqual(['ci', 'deploy']);
+		expect(wf.config).toEqual({ priority: 'high' });
+	});
+
+	test('getWorkflow returns null for missing id', () => {
+		expect(repo.getWorkflow('no-such-id')).toBeNull();
+	});
+
+	test('getWorkflow round-trips all fields', () => {
+		const created = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Full',
+			description: 'A full workflow',
+			steps: [coderStep],
+			rules: [{ name: 'Rule1', content: 'Follow TDD', appliesTo: [] }],
+			tags: ['a', 'b'],
+			isDefault: true,
+			config: { key: 'value' },
+		});
+
+		const fetched = repo.getWorkflow(created.id)!;
+		expect(fetched.name).toBe('Full');
+		expect(fetched.description).toBe('A full workflow');
+		expect(fetched.isDefault).toBe(true);
+		expect(fetched.tags).toEqual(['a', 'b']);
+		expect(fetched.rules).toHaveLength(1);
+		expect(fetched.rules[0].name).toBe('Rule1');
+		expect(fetched.rules[0].id).toBeTruthy(); // assigned by repo
+		expect(fetched.config).toEqual({ key: 'value' });
+	});
+
+	test('listWorkflows returns all workflows for a space', () => {
+		repo.createWorkflow({ spaceId: 'space-1', name: 'WF1', steps: [coderStep] });
+		repo.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
+		// Another space — should not appear
+		seedSpace(db, 'space-2');
+		repo.createWorkflow({ spaceId: 'space-2', name: 'WF3', steps: [coderStep] });
+
+		const wfs = repo.listWorkflows('space-1');
+		expect(wfs).toHaveLength(2);
+		expect(wfs.map((w) => w.name).sort()).toEqual(['WF1', 'WF2']);
+	});
+
+	test('updateWorkflow updates name and description', () => {
+		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'Old Name', steps: [coderStep] });
+		const updated = repo.updateWorkflow(wf.id, { name: 'New Name', description: 'Updated desc' });
+		expect(updated?.name).toBe('New Name');
+		expect(updated?.description).toBe('Updated desc');
+	});
+
+	test('updateWorkflow replaces all steps on steps param', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [coderStep, plannerStep],
+		});
+		expect(wf.steps).toHaveLength(2);
+
+		const updated = repo.updateWorkflow(wf.id, {
+			steps: [
+				{ id: 'ignored', order: 0, name: 'Review', agentRefType: 'builtin', agentRef: 'general' },
+			],
+		});
+		expect(updated?.steps).toHaveLength(1);
+		expect(updated?.steps[0].agentRef).toBe('general');
+	});
+
+	test('updateWorkflow returns null for missing id', () => {
+		expect(repo.updateWorkflow('missing', { name: 'X' })).toBeNull();
+	});
+
+	test('deleteWorkflow removes the workflow and its steps', () => {
+		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(repo.deleteWorkflow(wf.id)).toBe(true);
+		expect(repo.getWorkflow(wf.id)).toBeNull();
+
+		// Steps should be gone (CASCADE)
+		const rows = db.prepare(`SELECT * FROM space_workflow_steps WHERE workflow_id = ?`).all(wf.id);
+		expect(rows).toHaveLength(0);
+	});
+
+	test('deleteWorkflow returns false for missing id', () => {
+		expect(repo.deleteWorkflow('no-such-id')).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// Default workflow management
+	// -------------------------------------------------------------------------
+
+	test('getDefaultWorkflow returns null when no default exists', () => {
+		repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(repo.getDefaultWorkflow('space-1')).toBeNull();
+	});
+
+	test('getDefaultWorkflow returns the default workflow', () => {
+		repo.createWorkflow({ spaceId: 'space-1', name: 'WF1', steps: [coderStep] });
+		const def = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF2',
+			steps: [plannerStep],
+			isDefault: true,
+		});
+		const result = repo.getDefaultWorkflow('space-1');
+		expect(result?.id).toBe(def.id);
+	});
+
+	test('setDefaultWorkflow atomically swaps default', () => {
+		const wf1 = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF1',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		const wf2 = repo.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
+
+		repo.setDefaultWorkflow('space-1', wf2.id);
+
+		expect(repo.getWorkflow(wf1.id)?.isDefault).toBe(false);
+		expect(repo.getWorkflow(wf2.id)?.isDefault).toBe(true);
+		expect(repo.getDefaultWorkflow('space-1')?.id).toBe(wf2.id);
+	});
+
+	test('setDefaultWorkflow returns false for wrong spaceId', () => {
+		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(repo.setDefaultWorkflow('space-2', wf.id)).toBe(false);
+	});
+
+	test('clearDefaultWorkflow unsets all defaults in space', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		repo.clearDefaultWorkflow('space-1');
+		expect(repo.getWorkflow(wf.id)?.isDefault).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// getWorkflowsReferencingAgent
+	// -------------------------------------------------------------------------
+
+	test('getWorkflowsReferencingAgent returns workflows with matching custom agent', () => {
+		seedAgent(db, 'agent-1', 'space-1', 'Alpha');
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF With Custom',
+			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
+		});
+		const results = repo.getWorkflowsReferencingAgent('agent-1');
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe(wf.id);
+	});
+
+	test('getWorkflowsReferencingAgent returns empty for unmatched agent', () => {
+		repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [coderStep],
+		});
+		expect(repo.getWorkflowsReferencingAgent('no-such-agent')).toHaveLength(0);
+	});
+
+	test('getWorkflowsReferencingAgent ignores builtin steps', () => {
+		repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF Builtin',
+			steps: [coderStep, plannerStep],
+		});
+		expect(repo.getWorkflowsReferencingAgent('coder')).toHaveLength(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// JSON round-trips
+	// -------------------------------------------------------------------------
+
+	test('JSON round-trip: entryGate and exitGate on steps', () => {
+		const entry: WorkflowGate = { type: 'human_approval', description: 'Please review' };
+		const exit: WorkflowGate = {
+			type: 'quality_check',
+			command: 'bun test',
+			timeoutMs: 60000,
+			maxRetries: 2,
+		};
+		const step: WorkflowStepInput = {
+			name: 'Code',
+			agentRefType: 'builtin',
+			agentRef: 'coder',
+			entryGate: entry,
+			exitGate: exit,
+			instructions: 'Write clean code',
+		};
+
+		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'Gated', steps: [step] });
+		const fetched = repo.getWorkflow(wf.id)!;
+		const s = fetched.steps[0];
+
+		expect(s.entryGate?.type).toBe('human_approval');
+		expect(s.entryGate?.description).toBe('Please review');
+		expect(s.exitGate?.type).toBe('quality_check');
+		expect(s.exitGate?.command).toBe('bun test');
+		expect(s.exitGate?.timeoutMs).toBe(60000);
+		expect(s.exitGate?.maxRetries).toBe(2);
+		expect(s.instructions).toBe('Write clean code');
+	});
+
+	test('JSON round-trip: rules with appliesTo', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [coderStep],
+			rules: [
+				{ name: 'R1', content: 'Always test', appliesTo: ['step-id-1'] },
+				{ name: 'R2', content: 'No shortcuts' },
+			],
+		});
+		const fetched = repo.getWorkflow(wf.id)!;
+		expect(fetched.rules).toHaveLength(2);
+		expect(fetched.rules[0].appliesTo).toEqual(['step-id-1']);
+		expect(fetched.rules[1].appliesTo).toBeUndefined();
+	});
+
+	test('JSON round-trip: custom step stores agentRef as agent_id', () => {
+		seedAgent(db, 'agent-99', 'space-1', 'MyAgent');
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Custom WF',
+			steps: [{ name: 'Custom Step', agentRefType: 'custom', agentRef: 'agent-99' }],
+		});
+		const fetched = repo.getWorkflow(wf.id)!;
+		expect(fetched.steps[0].agentRefType).toBe('custom');
+		expect(fetched.steps[0].agentRef).toBe('agent-99');
+
+		// Verify agent_id column is set
+		const row = db
+			.prepare('SELECT agent_id FROM space_workflow_steps WHERE workflow_id = ?')
+			.get(wf.id) as { agent_id: string };
+		expect(row.agent_id).toBe('agent-99');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Manager tests
+// ---------------------------------------------------------------------------
+
+describe('SpaceWorkflowManager', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let repo: SpaceWorkflowRepository;
+	let manager: SpaceWorkflowManager;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpace(db);
+		repo = new SpaceWorkflowRepository(db);
+		manager = new SpaceWorkflowManager(repo, null);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Name uniqueness
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow throws if name already exists in space', () => {
+		manager.createWorkflow({ spaceId: 'space-1', name: 'Dup', steps: [coderStep] });
+		expect(() =>
+			manager.createWorkflow({ spaceId: 'space-1', name: 'Dup', steps: [plannerStep] })
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow allows same name in different spaces', () => {
+		seedSpace(db, 'space-2');
+		manager.createWorkflow({ spaceId: 'space-1', name: 'Same', steps: [coderStep] });
+		// Should not throw
+		const wf2 = manager.createWorkflow({ spaceId: 'space-2', name: 'Same', steps: [coderStep] });
+		expect(wf2.name).toBe('Same');
+	});
+
+	test('updateWorkflow throws if new name conflicts with another workflow', () => {
+		manager.createWorkflow({ spaceId: 'space-1', name: 'Existing', steps: [coderStep] });
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
+		expect(() => manager.updateWorkflow(wf.id, { name: 'Existing' })).toThrow(
+			WorkflowValidationError
+		);
+	});
+
+	test('updateWorkflow allows keeping the same name', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		const updated = manager.updateWorkflow(wf.id, { name: 'WF' });
+		expect(updated?.name).toBe('WF');
+	});
+
+	// -------------------------------------------------------------------------
+	// At-least-one-step
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow throws when steps is empty', () => {
+		expect(() => manager.createWorkflow({ spaceId: 'space-1', name: 'Empty', steps: [] })).toThrow(
+			WorkflowValidationError
+		);
+	});
+
+	test('createWorkflow throws when steps is not provided (defaults to empty)', () => {
+		expect(() => manager.createWorkflow({ spaceId: 'space-1', name: 'NoSteps' })).toThrow(
+			WorkflowValidationError
+		);
+	});
+
+	test('updateWorkflow throws when replacing with empty steps', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(() => manager.updateWorkflow(wf.id, { steps: [] })).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Agent ref validation — builtins
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow accepts all valid builtin roles', () => {
+		for (const role of ['planner', 'coder', 'general'] as const) {
+			const wf = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: `WF-${role}`,
+				steps: [{ name: 'Step', agentRefType: 'builtin', agentRef: role }],
+			});
+			expect(wf.steps[0].agentRef).toBe(role);
+		}
+	});
+
+	test('createWorkflow rejects leader as builtin agentRef', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Leader WF',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'leader' as unknown as 'planner',
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects unknown builtin agentRef', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Builtin WF',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'executor' as unknown as 'planner',
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Agent ref validation — custom (via SpaceAgentLookup)
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow accepts custom ref when agent exists', () => {
+		seedAgent(db, 'agent-1', 'space-1', 'MyAgent');
+		const lookup: SpaceAgentLookup = {
+			getAgentByName: (_spaceId, name) =>
+				name === 'MyAgent' ? { id: 'agent-1', name: 'MyAgent' } : null,
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		const wf = mgr.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Custom WF',
+			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'MyAgent' }],
+		});
+		expect(wf.steps[0].agentRef).toBe('MyAgent');
+	});
+
+	test('createWorkflow rejects custom ref when agent does not exist', () => {
+		const lookup: SpaceAgentLookup = {
+			getAgentByName: () => null,
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		expect(() =>
+			mgr.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Custom',
+				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'NonExistent' }],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow accepts custom ref when no lookup provided (no validation)', () => {
+		// Without agentLookup, custom refs are accepted as-is
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'No-Lookup WF',
+			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'anything' }],
+		});
+		expect(wf.steps[0].agentRef).toBe('anything');
+	});
+
+	test('createWorkflow rejects empty custom agentRef', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty Ref',
+				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: '' }],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Gate command validation — quality_check allowlist
+	// -------------------------------------------------------------------------
+
+	test('quality_check gate accepts allowlisted commands', () => {
+		const allowedCmds = ['bun test', 'npm test', 'npm run lint', 'bun run check', 'make test'];
+		for (const cmd of allowedCmds) {
+			const wf = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: `QC-${cmd}`,
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: cmd },
+					},
+				],
+			});
+			expect(wf.steps[0].exitGate?.command).toBe(cmd);
+		}
+	});
+
+	test('quality_check gate rejects non-allowlisted command', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad QC',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: 'rm -rf /' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('quality_check gate rejects missing command', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'No Cmd QC',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Gate command validation — custom relative path
+	// -------------------------------------------------------------------------
+
+	test('custom gate accepts valid relative path', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Custom Gate WF',
+			steps: [
+				{
+					name: 'Step',
+					agentRefType: 'builtin',
+					agentRef: 'coder',
+					exitGate: { type: 'custom', command: './scripts/verify.sh' },
+				},
+			],
+		});
+		expect(wf.steps[0].exitGate?.command).toBe('./scripts/verify.sh');
+	});
+
+	test('custom gate rejects absolute path', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Abs Path',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: '/etc/passwd' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects path with .. traversal', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Traversal',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: './scripts/../../../etc/passwd' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects command without ./ prefix', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'No Dot Slash',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: 'scripts/verify.sh' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects missing command', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'No Cmd Custom',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Gate timeoutMs validation
+	// -------------------------------------------------------------------------
+
+	test('gate accepts timeoutMs = 0', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Zero Timeout',
+			steps: [
+				{
+					name: 'Step',
+					agentRefType: 'builtin',
+					agentRef: 'coder',
+					exitGate: { type: 'human_approval', timeoutMs: 0 },
+				},
+			],
+		});
+		expect(wf.steps[0].exitGate?.timeoutMs).toBe(0);
+	});
+
+	test('gate accepts timeoutMs = 300000', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Max Timeout',
+			steps: [
+				{
+					name: 'Step',
+					agentRefType: 'builtin',
+					agentRef: 'coder',
+					exitGate: { type: 'human_approval', timeoutMs: 300_000 },
+				},
+			],
+		});
+		expect(wf.steps[0].exitGate?.timeoutMs).toBe(300_000);
+	});
+
+	test('gate rejects timeoutMs > 300000', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Over Timeout',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'human_approval', timeoutMs: 300_001 },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('gate rejects negative timeoutMs', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Neg Timeout',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'human_approval', timeoutMs: -1 },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Default workflow management
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow with isDefault=true unsets previous default', () => {
+		const wf1 = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF1',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(true);
+
+		const wf2 = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF2',
+			steps: [plannerStep],
+			isDefault: true,
+		});
+		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(false);
+		expect(manager.getWorkflow(wf2.id)?.isDefault).toBe(true);
+		expect(manager.getDefaultWorkflow('space-1')?.id).toBe(wf2.id);
+	});
+
+	test('setDefaultWorkflow swaps the default', () => {
+		const wf1 = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF1',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		const wf2 = manager.createWorkflow({ spaceId: 'space-1', name: 'WF2', steps: [plannerStep] });
+
+		manager.setDefaultWorkflow('space-1', wf2.id);
+
+		expect(manager.getWorkflow(wf1.id)?.isDefault).toBe(false);
+		expect(manager.getWorkflow(wf2.id)?.isDefault).toBe(true);
+	});
+
+	test('deleteWorkflow removes workflow (default cleared by delete)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [coderStep],
+			isDefault: true,
+		});
+		manager.deleteWorkflow(wf.id);
+		expect(manager.getWorkflow(wf.id)).toBeNull();
+		expect(manager.getDefaultWorkflow('space-1')).toBeNull();
+	});
+
+	test('deleteWorkflow returns false for non-existent workflow', () => {
+		expect(manager.deleteWorkflow('no-such-id')).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// Step ordering
+	// -------------------------------------------------------------------------
+
+	test('steps are stored and retrieved in array order', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Ordered',
+			steps: [plannerStep, coderStep, generalStep],
+		});
+		expect(wf.steps[0].name).toBe('Plan');
+		expect(wf.steps[0].order).toBe(0);
+		expect(wf.steps[1].name).toBe('Code');
+		expect(wf.steps[1].order).toBe(1);
+		expect(wf.steps[2].name).toBe('Review');
+		expect(wf.steps[2].order).toBe(2);
+	});
+
+	// -------------------------------------------------------------------------
+	// getWorkflowsReferencingAgent
+	// -------------------------------------------------------------------------
+
+	test('getWorkflowsReferencingAgent returns workflows using custom agent', () => {
+		seedAgent(db, 'agent-1', 'space-1', 'Alpha');
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Uses Alpha',
+			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
+		});
+		manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Uses Builtin',
+			steps: [coderStep],
+		});
+		const refs = manager.getWorkflowsReferencingAgent('agent-1');
+		expect(refs).toHaveLength(1);
+		expect(refs[0].id).toBe(wf.id);
+	});
+});

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -791,6 +791,91 @@ describe('SpaceWorkflowManager', () => {
 		).toThrow(WorkflowValidationError);
 	});
 
+	test('custom gate rejects shell injection via semicolon', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Custom Inject Semi',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: './scripts/verify.sh; rm -rf /' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects shell injection via pipe', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Custom Inject Pipe',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: './scripts/verify.sh | cat /etc/passwd' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects shell injection via backtick', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Custom Inject Backtick',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: './scripts/verify.sh `whoami`' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('quality_check gate rejects newline injection', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'QC Newline Inject',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'quality_check', command: 'bun test\nrm -rf /' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('custom gate rejects newline injection', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Custom Newline Inject',
+				steps: [
+					{
+						name: 'Step',
+						agentRefType: 'builtin',
+						agentRef: 'coder',
+						exitGate: { type: 'custom', command: './scripts/verify.sh\nrm -rf /' },
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
 	// -------------------------------------------------------------------------
 	// Gate timeoutMs validation
 	// -------------------------------------------------------------------------

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -456,7 +456,7 @@ export interface WorkflowGate {
  *
  * - `builtin`: agentRef is one of the BuiltinAgentRole values ('planner', 'coder', 'general').
  *   NOTE: 'leader' is NOT a valid builtin agentRef — Leader is always implicit in SpaceRuntime.
- * - `custom`: agentRef is the `name` of a SpaceAgent defined in this Space.
+ * - `custom`: agentRef is the UUID (`id`) of a SpaceAgent defined in this Space.
  */
 export type WorkflowStepAgent =
 	| { agentRefType: 'builtin'; agentRef: BuiltinAgentRole }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -553,13 +553,7 @@ export interface SpaceWorkflow {
 	steps: WorkflowStep[];
 	/** Rules that govern agent behavior during this workflow */
 	rules: WorkflowRule[];
-	/**
-	 * Whether this is the default workflow for the Space.
-	 * Only one workflow per Space may have isDefault = true.
-	 * The default workflow is selected automatically when no explicit workflow is chosen.
-	 */
-	isDefault: boolean;
-	/** Tags for categorization and workflow selection heuristics */
+	/** Tags for categorization */
 	tags: string[];
 	/** Additional runtime configuration (opaque bag for future extensibility) */
 	config?: Record<string, unknown>;
@@ -585,8 +579,6 @@ export interface CreateSpaceWorkflowParams {
 	 * Rules governing agent behavior. `id` is backend-assigned.
 	 */
 	rules?: WorkflowRuleInput[];
-	/** Whether this workflow should be the default for the Space (default: false) */
-	isDefault?: boolean;
 	/** Tags for categorization (default: []). */
 	tags?: string[];
 	config?: Record<string, unknown>;
@@ -613,7 +605,6 @@ export interface UpdateSpaceWorkflowParams {
 	 * Replaces the entire rule list. Pass `[]` or `null` to clear all rules.
 	 */
 	rules?: WorkflowRule[] | null;
-	isDefault?: boolean;
 	/**
 	 * Replaces the tag list. Pass `[]` or `null` to clear all tags.
 	 */


### PR DESCRIPTION
- SpaceWorkflowRepository: full CRUD for space_workflows/space_workflow_steps
  tables, including step replacement on update, JSON round-trips for rules/tags/
  gates/instructions, getDefaultWorkflow, setDefaultWorkflow, clearDefaultWorkflow,
  and getWorkflowsReferencingAgent for deletion-protection queries
- SpaceWorkflowManager: validation layer for name uniqueness, at-least-one-step,
  builtin agent ref validation (leader rejected), custom agent ref via
  SpaceAgentLookup interface, quality_check allowlist, custom gate relative path /
  no-dotdot guards, and timeoutMs bounds (0–300_000)
- packages/daemon/src/lib/space/index.ts: exports for Space namespace
- knip.json: ignore space/index.ts (not yet consumed by RPC handlers)
- 54 unit tests covering all paths
