### PR TITLE
feat: Space RPC handlers and DaemonEventMap registration (Task 1.4)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -216,6 +216,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		daemonHub: eventBus,
 		db,
 		gitHubService: gitHubService ?? undefined,
+		spaceManager,
 	});
 
 	// Create WebSocket handlers

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -17,6 +17,7 @@ import { createReactiveDatabase } from './storage/reactive-database';
 import { LiveQueryEngine } from './storage/live-query';
 import { SpaceAgentRepository } from './storage/repositories/space-agent-repository';
 import { SpaceAgentManager } from './lib/space/managers/space-agent-manager';
+import { SpaceManager } from './lib/space/managers/space-manager';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -54,6 +55,8 @@ export interface DaemonAppContext {
 	liveQueries: LiveQueryEngine;
 	/** Space agent manager for Space multi-agent system */
 	spaceAgentManager: SpaceAgentManager;
+	/** Space manager for Space CRUD and workspace path validation */
+	spaceManager: SpaceManager;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -93,6 +96,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
+
+	// Initialize Space manager
+	const spaceManager = new SpaceManager(db.getDatabase());
 
 	// Initialize authentication manager
 	const authManager = new AuthManager(db, config);
@@ -426,6 +432,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		reactiveDb,
 		liveQueries,
 		spaceAgentManager,
+		spaceManager,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -402,6 +402,43 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		templateId: string;
 	};
 
+	// Space events (global events - use 'global' as sessionId)
+	'space.created': { sessionId: string; spaceId: string; space: import('@neokai/shared').Space };
+	'space.updated': {
+		sessionId: string;
+		spaceId: string;
+		space?: Partial<import('@neokai/shared').Space>;
+	};
+	'space.deleted': { sessionId: string; spaceId: string };
+
+	// Space task events (global events - use 'global' as sessionId)
+	'space.task.created': {
+		sessionId: string;
+		spaceId: string;
+		taskId: string;
+		task: import('@neokai/shared').SpaceTask;
+	};
+	'space.task.updated': {
+		sessionId: string;
+		spaceId: string;
+		taskId: string;
+		task?: Partial<import('@neokai/shared').SpaceTask>;
+	};
+
+	// Space workflow run events (global events - use 'global' as sessionId)
+	'space.workflowRun.created': {
+		sessionId: string;
+		spaceId: string;
+		runId: string;
+		run: import('@neokai/shared').SpaceWorkflowRun;
+	};
+	'space.workflowRun.updated': {
+		sessionId: string;
+		spaceId: string;
+		runId: string;
+		run?: Partial<import('@neokai/shared').SpaceWorkflowRun>;
+	};
+
 	// Feature Flag events (PHASE 3: Gradual rollout infrastructure)
 	'featureFlag.updated': {
 		sessionId: string;

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -409,6 +409,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		spaceId: string;
 		space?: Partial<import('@neokai/shared').Space>;
 	};
+	'space.archived': { sessionId: string; spaceId: string; space: import('@neokai/shared').Space };
 	'space.deleted': { sessionId: string; spaceId: string };
 
 	// Space task events (global events - use 'global' as sessionId)

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -423,7 +423,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		sessionId: string;
 		spaceId: string;
 		taskId: string;
-		task?: Partial<import('@neokai/shared').SpaceTask>;
+		task: import('@neokai/shared').SpaceTask;
 	};
 
 	// Space workflow run events (global events - use 'global' as sessionId)

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -42,6 +42,13 @@ import { Logger } from '../logger';
 import { GoalManager } from '../room/managers/goal-manager';
 import { TaskManager } from '../room/managers/task-manager';
 import { setupDialogHandlers } from './dialog-handlers';
+// Space handlers
+import { setupSpaceHandlers } from './space-handlers';
+import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
+import { SpaceManager } from '../space/managers/space-manager';
+import { SpaceTaskManager } from '../space/managers/space-task-manager';
+import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -157,6 +164,25 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
+
+	// Space handlers
+	const spaceManager = new SpaceManager(deps.db.getDatabase());
+	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
+	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
+
+	setupSpaceHandlers(
+		deps.messageHub,
+		spaceManager,
+		spaceTaskRepo,
+		spaceWorkflowRunRepo,
+		deps.daemonHub
+	);
+
+	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
+		return new SpaceTaskManager(deps.db.getDatabase(), spaceId);
+	};
+
+	setupSpaceTaskHandlers(deps.messageHub, spaceManager, spaceTaskManagerFactory, deps.daemonHub);
 
 	// Return cleanup function to stop background services
 	return () => {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -45,7 +45,7 @@ import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
 import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
-import { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
@@ -59,6 +59,8 @@ export interface RPCHandlerDependencies {
 	daemonHub: DaemonHub;
 	db: Database;
 	gitHubService?: GitHubService;
+	/** Space manager instance — shared with DaemonAppContext (single source of truth) */
+	spaceManager: SpaceManager;
 }
 
 const log = new Logger('rpc-handlers');
@@ -165,14 +167,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
 
-	// Space handlers
-	const spaceManager = new SpaceManager(deps.db.getDatabase());
+	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
 	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 
 	setupSpaceHandlers(
 		deps.messageHub,
-		spaceManager,
+		deps.spaceManager,
 		spaceTaskRepo,
 		spaceWorkflowRunRepo,
 		deps.daemonHub
@@ -182,7 +183,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId);
 	};
 
-	setupSpaceTaskHandlers(deps.messageHub, spaceManager, spaceTaskManagerFactory, deps.daemonHub);
+	setupSpaceTaskHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceTaskManagerFactory,
+		deps.daemonHub
+	);
 
 	// Return cleanup function to stop background services
 	return () => {

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -6,7 +6,7 @@
  * - space.list    - List all Spaces (optionally including archived)
  * - space.get     - Get a Space by ID
  * - space.update  - Update Space metadata
- * - space.archive - Archive a Space
+ * - space.archive - Archive a Space (emits dedicated space.archived event)
  * - space.delete  - Delete a Space
  * - space.overview - Get a Space with tasks, workflowRuns, and sessions
  */
@@ -113,14 +113,12 @@ export function setupSpaceHandlers(
 
 		const space = await spaceManager.archiveSpace(params.id);
 
+		// Emit a dedicated space.archived event (consistent with room.archived pattern),
+		// carrying the full archived space object so subscribers have complete state.
 		daemonHub
-			.emit('space.updated', {
-				sessionId: 'global',
-				spaceId: params.id,
-				space: { status: 'archived' },
-			})
+			.emit('space.archived', { sessionId: 'global', spaceId: params.id, space })
 			.catch((err) => {
-				log.warn('Failed to emit space.updated (archive):', err);
+				log.warn('Failed to emit space.archived:', err);
 			});
 
 		return space;

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -1,0 +1,174 @@
+/**
+ * Space RPC Handlers
+ *
+ * RPC handlers for Space CRUD operations:
+ * - space.create  - Create a Space (validates workspace path exists, rejects invalid paths)
+ * - space.list    - List all Spaces (optionally including archived)
+ * - space.get     - Get a Space by ID
+ * - space.update  - Update Space metadata
+ * - space.archive - Archive a Space
+ * - space.delete  - Delete a Space
+ * - space.overview - Get a Space with tasks, workflowRuns, and sessions
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type {
+	Space,
+	CreateSpaceParams,
+	UpdateSpaceParams,
+	SpaceTask,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import { Logger } from '../logger';
+
+const log = new Logger('space-handlers');
+
+export interface SpaceOverviewResult {
+	space: Space;
+	tasks: SpaceTask[];
+	workflowRuns: SpaceWorkflowRun[];
+	sessions: string[];
+}
+
+export function setupSpaceHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager,
+	taskRepo: SpaceTaskRepository,
+	workflowRunRepo: SpaceWorkflowRunRepository,
+	daemonHub: DaemonHub
+): void {
+	// ─── space.create ───────────────────────────────────────────────────────────
+	messageHub.onRequest('space.create', async (data) => {
+		const params = data as CreateSpaceParams;
+
+		if (!params.workspacePath) {
+			throw new Error('workspacePath is required');
+		}
+		if (!params.name || params.name.trim() === '') {
+			throw new Error('name is required');
+		}
+
+		const space = await spaceManager.createSpace(params);
+
+		daemonHub
+			.emit('space.created', { sessionId: 'global', spaceId: space.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.created:', err);
+			});
+
+		return space;
+	});
+
+	// ─── space.list ─────────────────────────────────────────────────────────────
+	messageHub.onRequest('space.list', async (data) => {
+		const params = (data ?? {}) as { includeArchived?: boolean };
+		return spaceManager.listSpaces(params.includeArchived ?? false);
+	});
+
+	// ─── space.get ──────────────────────────────────────────────────────────────
+	messageHub.onRequest('space.get', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.getSpace(params.id);
+		if (!space) {
+			throw new Error(`Space not found: ${params.id}`);
+		}
+
+		return space;
+	});
+
+	// ─── space.update ───────────────────────────────────────────────────────────
+	messageHub.onRequest('space.update', async (data) => {
+		const params = data as { id: string } & UpdateSpaceParams;
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const { id, ...updateParams } = params;
+		const space = await spaceManager.updateSpace(id, updateParams);
+
+		daemonHub.emit('space.updated', { sessionId: 'global', spaceId: id, space }).catch((err) => {
+			log.warn('Failed to emit space.updated:', err);
+		});
+
+		return space;
+	});
+
+	// ─── space.archive ──────────────────────────────────────────────────────────
+	messageHub.onRequest('space.archive', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.archiveSpace(params.id);
+
+		daemonHub
+			.emit('space.updated', {
+				sessionId: 'global',
+				spaceId: params.id,
+				space: { status: 'archived' },
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.updated (archive):', err);
+			});
+
+		return space;
+	});
+
+	// ─── space.delete ───────────────────────────────────────────────────────────
+	messageHub.onRequest('space.delete', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const deleted = await spaceManager.deleteSpace(params.id);
+		if (!deleted) {
+			throw new Error(`Space not found: ${params.id}`);
+		}
+
+		daemonHub.emit('space.deleted', { sessionId: 'global', spaceId: params.id }).catch((err) => {
+			log.warn('Failed to emit space.deleted:', err);
+		});
+
+		return { success: true };
+	});
+
+	// ─── space.overview ─────────────────────────────────────────────────────────
+	messageHub.onRequest('space.overview', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.getSpace(params.id);
+		if (!space) {
+			throw new Error(`Space not found: ${params.id}`);
+		}
+
+		const tasks = taskRepo.listBySpace(params.id);
+		const workflowRuns = workflowRunRepo.listBySpace(params.id);
+
+		const result: SpaceOverviewResult = {
+			space,
+			tasks,
+			workflowRuns,
+			sessions: space.sessionIds,
+		};
+
+		return result;
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -1,0 +1,148 @@
+/**
+ * Space Task RPC Handlers
+ *
+ * RPC handlers for SpaceTask CRUD operations:
+ * - spaceTask.create - Create a task in a Space
+ * - spaceTask.list   - List tasks in a Space
+ * - spaceTask.get    - Get a task by ID
+ * - spaceTask.update - Update task fields (metadata and status with transition validation)
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { CreateSpaceTaskParams, UpdateSpaceTaskParams, SpaceTaskStatus } from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceTaskManager } from '../space/managers/space-task-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('space-task-handlers');
+
+/**
+ * Factory that creates a SpaceTaskManager bound to a specific spaceId.
+ * Injected so tests can substitute a mock manager.
+ */
+export type SpaceTaskManagerFactory = (spaceId: string) => SpaceTaskManager;
+
+export function setupSpaceTaskHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager,
+	taskManagerFactory: SpaceTaskManagerFactory,
+	daemonHub: DaemonHub
+): void {
+	// ─── spaceTask.create ───────────────────────────────────────────────────────
+	messageHub.onRequest('spaceTask.create', async (data) => {
+		const params = data as CreateSpaceTaskParams;
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.title || params.title.trim() === '') {
+			throw new Error('title is required');
+		}
+		if (params.description === undefined || params.description === null) {
+			throw new Error('description is required');
+		}
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const taskManager = taskManagerFactory(params.spaceId);
+		const { spaceId, ...rest } = params;
+		const task = await taskManager.createTask(rest);
+
+		daemonHub
+			.emit('space.task.created', {
+				sessionId: 'global',
+				spaceId,
+				taskId: task.id,
+				task,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.task.created:', err);
+			});
+
+		return task;
+	});
+
+	// ─── spaceTask.list ─────────────────────────────────────────────────────────
+	messageHub.onRequest('spaceTask.list', async (data) => {
+		const params = data as { spaceId: string; includeArchived?: boolean };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const taskManager = taskManagerFactory(params.spaceId);
+		return taskManager.listTasks(params.includeArchived ?? false);
+	});
+
+	// ─── spaceTask.get ──────────────────────────────────────────────────────────
+	messageHub.onRequest('spaceTask.get', async (data) => {
+		const params = data as { spaceId: string; taskId: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.taskId) {
+			throw new Error('taskId is required');
+		}
+
+		const taskManager = taskManagerFactory(params.spaceId);
+		const task = await taskManager.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		return task;
+	});
+
+	// ─── spaceTask.update ───────────────────────────────────────────────────────
+	messageHub.onRequest('spaceTask.update', async (data) => {
+		const params = data as { spaceId: string; taskId: string } & UpdateSpaceTaskParams;
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.taskId) {
+			throw new Error('taskId is required');
+		}
+
+		const { spaceId, taskId, ...updateParams } = params;
+		const taskManager = taskManagerFactory(spaceId);
+
+		let task;
+
+		// If status is being changed, use the validated transition method
+		if (updateParams.status !== undefined) {
+			task = await taskManager.setTaskStatus(taskId, updateParams.status as SpaceTaskStatus, {
+				result: updateParams.result ?? undefined,
+				error: updateParams.error ?? undefined,
+			});
+		} else {
+			// General field update via manager's updateTask
+			task = await taskManager.updateTask(taskId, updateParams);
+		}
+
+		daemonHub
+			.emit('space.task.updated', {
+				sessionId: 'global',
+				spaceId,
+				taskId,
+				task,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.task.updated:', err);
+			});
+
+		return task;
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { MessageHub } from '@neokai/shared';
-import type { CreateSpaceTaskParams, UpdateSpaceTaskParams, SpaceTaskStatus } from '@neokai/shared';
+import type { CreateSpaceTaskParams, UpdateSpaceTaskParams } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
@@ -39,8 +39,9 @@ export function setupSpaceTaskHandlers(
 		if (!params.title || params.title.trim() === '') {
 			throw new Error('title is required');
 		}
+		// description is required but may be an empty string — reject only null/undefined
 		if (params.description === undefined || params.description === null) {
-			throw new Error('description is required');
+			throw new Error('description must not be null');
 		}
 
 		// Verify space exists
@@ -96,6 +97,12 @@ export function setupSpaceTaskHandlers(
 			throw new Error('taskId is required');
 		}
 
+		// Verify space exists (consistent with create/list validation pattern)
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
 		const taskManager = taskManagerFactory(params.spaceId);
 		const task = await taskManager.getTask(params.taskId);
 		if (!task) {
@@ -121,14 +128,29 @@ export function setupSpaceTaskHandlers(
 
 		let task;
 
-		// If status is being changed, use the validated transition method
+		// Route to setTaskStatus only when the status is actually changing.
+		// Sending the current status as part of a broader metadata update must not
+		// trigger a transition check (same→same is not in the transition table and
+		// would throw a misleading "Invalid status transition" error).
 		if (updateParams.status !== undefined) {
-			task = await taskManager.setTaskStatus(taskId, updateParams.status as SpaceTaskStatus, {
-				result: updateParams.result ?? undefined,
-				error: updateParams.error ?? undefined,
-			});
+			// Fetch the current task to compare status before routing
+			const currentTask = await taskManager.getTask(taskId);
+			if (!currentTask) {
+				throw new Error(`Task not found: ${taskId}`);
+			}
+
+			if (updateParams.status !== currentTask.status) {
+				// Status is changing — validate via setTaskStatus (enforces transitions)
+				task = await taskManager.setTaskStatus(taskId, updateParams.status, {
+					result: updateParams.result ?? undefined,
+					error: updateParams.error ?? undefined,
+				});
+			} else {
+				// Status is the same — treat as a regular field update
+				task = await taskManager.updateTask(taskId, updateParams);
+			}
 		} else {
-			// General field update via manager's updateTask
+			// No status field — general field update
 			task = await taskManager.updateTask(taskId, updateParams);
 		}
 

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -124,6 +124,15 @@ export function setupSpaceTaskHandlers(
 		}
 
 		const { spaceId, taskId, ...updateParams } = params;
+
+		// Verify space exists — consistent with create/list/get validation.
+		// Without this check, a bad spaceId would surface as "Task not found" rather
+		// than "Space not found", which is misleading.
+		const space = await spaceManager.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+
 		const taskManager = taskManagerFactory(spaceId);
 
 		let task;
@@ -146,7 +155,10 @@ export function setupSpaceTaskHandlers(
 					error: updateParams.error ?? undefined,
 				});
 			} else {
-				// Status is the same — treat as a regular field update
+				// Status is the same — treat as a regular field update.
+				// updateParams still contains the unchanged status field; SpaceTaskManager.updateTask
+				// strips it internally (guard: params.status !== task.status is false) so no
+				// transition check fires and the status column is left untouched in the DB.
 				task = await taskManager.updateTask(taskId, updateParams);
 			}
 		} else {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -9,7 +9,12 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
-import type { SpaceTask, SpaceTaskStatus, CreateSpaceTaskParams } from '@neokai/shared';
+import type {
+	SpaceTask,
+	SpaceTaskStatus,
+	CreateSpaceTaskParams,
+	UpdateSpaceTaskParams,
+} from '@neokai/shared';
 
 /**
  * Valid task status transitions for space tasks
@@ -274,6 +279,31 @@ export class SpaceTaskManager {
 		}
 
 		return this.taskRepo.deleteTask(taskId);
+	}
+
+	/**
+	 * Update task fields directly (non-status fields).
+	 * For status transitions use setTaskStatus instead.
+	 */
+	async updateTask(taskId: string, params: UpdateSpaceTaskParams): Promise<SpaceTask> {
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		// Status changes must go through setTaskStatus for transition validation
+		if (params.status !== undefined && params.status !== task.status) {
+			throw new Error('Use setTaskStatus to change task status — it enforces valid transitions');
+		}
+
+		// Strip status from the update params so the repo call is clean
+		const { status: _status, ...repoParams } = params;
+		const updated = this.taskRepo.updateTask(taskId, repoParams);
+		if (!updated) {
+			throw new Error(`Failed to update task: ${taskId}`);
+		}
+
+		return updated;
 	}
 
 	/**

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for Space RPC Handlers
+ *
+ * Covers:
+ * - space.create: happy path, missing workspacePath, missing name, invalid path, duplicate path
+ * - space.list: happy path, includeArchived flag
+ * - space.get: happy path, missing id, not found
+ * - space.update: happy path, missing id, not found
+ * - space.archive: happy path, missing id, not found
+ * - space.delete: happy path, missing id, not found
+ * - space.overview: happy path, missing id, not found
+ * - DaemonHub events emitted on mutations
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceTask, SpaceWorkflowRun } from '@neokai/shared';
+import { setupSpaceHandlers } from '../../../src/lib/rpc-handlers/space-handlers';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: 'A test space',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockTask: SpaceTask = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	title: 'Test Task',
+	description: 'desc',
+	status: 'pending',
+	priority: 'normal',
+	dependsOn: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockRun: SpaceWorkflowRun = {
+	id: 'run-1',
+	spaceId: 'space-1',
+	workflowId: 'wf-1',
+	title: 'Run 1',
+	currentStepIndex: 0,
+	status: 'pending',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		createSpace: mock(async () => space!),
+		getSpace: mock(async () => space),
+		listSpaces: mock(async () => (space ? [space] : [])),
+		updateSpace: mock(async () => space!),
+		archiveSpace: mock(async () => ({ ...space!, status: 'archived' as const })),
+		deleteSpace: mock(async () => true),
+		addSession: mock(async () => space!),
+		removeSession: mock(async () => space!),
+	} as unknown as SpaceManager;
+}
+
+function createMockTaskRepo(tasks: SpaceTask[] = [mockTask]): SpaceTaskRepository {
+	return {
+		listBySpace: mock(() => tasks),
+	} as unknown as SpaceTaskRepository;
+}
+
+function createMockRunRepo(runs: SpaceWorkflowRun[] = [mockRun]): SpaceWorkflowRunRepository {
+	return {
+		listBySpace: mock(() => runs),
+	} as unknown as SpaceWorkflowRunRepository;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('space-handlers', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let taskRepo: SpaceTaskRepository;
+	let runRepo: SpaceWorkflowRunRepository;
+
+	function setup(space: Space | null = mockSpace) {
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager(space);
+		taskRepo = createMockTaskRepo();
+		runRepo = createMockRunRepo();
+		setupSpaceHandlers(hub, spaceManager, taskRepo, runRepo, daemonHub);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	// ─── space.create ──────────────────────────────────────────────────────────
+
+	describe('space.create', () => {
+		beforeEach(() => setup());
+
+		it('creates a space and emits space.created', async () => {
+			const result = await call('space.create', {
+				workspacePath: '/tmp/test',
+				name: 'My Space',
+			});
+
+			expect(result).toEqual(mockSpace);
+			expect(spaceManager.createSpace).toHaveBeenCalledTimes(1);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.created', {
+				sessionId: 'global',
+				spaceId: mockSpace.id,
+				space: mockSpace,
+			});
+		});
+
+		it('throws when workspacePath is missing', async () => {
+			await expect(call('space.create', { name: 'X' })).rejects.toThrow(
+				'workspacePath is required'
+			);
+		});
+
+		it('throws when name is missing', async () => {
+			await expect(call('space.create', { workspacePath: '/tmp/x' })).rejects.toThrow(
+				'name is required'
+			);
+		});
+
+		it('throws when name is empty string', async () => {
+			await expect(call('space.create', { workspacePath: '/tmp/x', name: '  ' })).rejects.toThrow(
+				'name is required'
+			);
+		});
+
+		it('propagates SpaceManager errors (e.g. invalid path)', async () => {
+			(spaceManager.createSpace as ReturnType<typeof mock>).mockImplementation(async () => {
+				throw new Error('Workspace path does not exist: /nonexistent');
+			});
+
+			await expect(
+				call('space.create', { workspacePath: '/nonexistent', name: 'Bad' })
+			).rejects.toThrow('Workspace path does not exist');
+		});
+
+		it('propagates duplicate path error from SpaceManager', async () => {
+			(spaceManager.createSpace as ReturnType<typeof mock>).mockImplementation(async () => {
+				throw new Error('A space already exists for workspace path: /tmp/test');
+			});
+
+			await expect(
+				call('space.create', { workspacePath: '/tmp/test', name: 'Dup' })
+			).rejects.toThrow('A space already exists');
+		});
+	});
+
+	// ─── space.list ────────────────────────────────────────────────────────────
+
+	describe('space.list', () => {
+		beforeEach(() => setup());
+
+		it('lists active spaces by default', async () => {
+			const result = await call('space.list', {});
+			expect(result).toEqual([mockSpace]);
+			expect(spaceManager.listSpaces).toHaveBeenCalledWith(false);
+		});
+
+		it('lists including archived when requested', async () => {
+			await call('space.list', { includeArchived: true });
+			expect(spaceManager.listSpaces).toHaveBeenCalledWith(true);
+		});
+
+		it('accepts null/undefined data', async () => {
+			await call('space.list', null);
+			expect(spaceManager.listSpaces).toHaveBeenCalledWith(false);
+		});
+	});
+
+	// ─── space.get ─────────────────────────────────────────────────────────────
+
+	describe('space.get', () => {
+		beforeEach(() => setup());
+
+		it('returns the space when found', async () => {
+			const result = await call('space.get', { id: 'space-1' });
+			expect(result).toEqual(mockSpace);
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.get', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when space is not found', async () => {
+			setup(null);
+			await expect(call('space.get', { id: 'nope' })).rejects.toThrow('Space not found: nope');
+		});
+	});
+
+	// ─── space.update ──────────────────────────────────────────────────────────
+
+	describe('space.update', () => {
+		beforeEach(() => setup());
+
+		it('updates the space and emits space.updated', async () => {
+			const updated = { ...mockSpace, name: 'Renamed' };
+			(spaceManager.updateSpace as ReturnType<typeof mock>).mockResolvedValue(updated);
+
+			const result = await call('space.update', { id: 'space-1', name: 'Renamed' });
+
+			expect(result).toEqual(updated);
+			expect(spaceManager.updateSpace).toHaveBeenCalledWith('space-1', { name: 'Renamed' });
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: updated,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.update', { name: 'X' })).rejects.toThrow('id is required');
+		});
+
+		it('propagates errors from SpaceManager', async () => {
+			(spaceManager.updateSpace as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('Space not found: bad-id')
+			);
+
+			await expect(call('space.update', { id: 'bad-id', name: 'X' })).rejects.toThrow(
+				'Space not found'
+			);
+		});
+	});
+
+	// ─── space.archive ─────────────────────────────────────────────────────────
+
+	describe('space.archive', () => {
+		beforeEach(() => setup());
+
+		it('archives the space and emits space.updated with archived status', async () => {
+			const result = await call('space.archive', { id: 'space-1' });
+
+			expect((result as Space).status).toBe('archived');
+			expect(spaceManager.archiveSpace).toHaveBeenCalledWith('space-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: { status: 'archived' },
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.archive', {})).rejects.toThrow('id is required');
+		});
+
+		it('propagates errors from SpaceManager', async () => {
+			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('Space not found: nope')
+			);
+
+			await expect(call('space.archive', { id: 'nope' })).rejects.toThrow('Space not found');
+		});
+	});
+
+	// ─── space.delete ──────────────────────────────────────────────────────────
+
+	describe('space.delete', () => {
+		beforeEach(() => setup());
+
+		it('deletes the space and emits space.deleted', async () => {
+			const result = await call('space.delete', { id: 'space-1' });
+
+			expect(result).toEqual({ success: true });
+			expect(spaceManager.deleteSpace).toHaveBeenCalledWith('space-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.deleted', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.delete', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when space is not found (deleteSpace returns false)', async () => {
+			(spaceManager.deleteSpace as ReturnType<typeof mock>).mockResolvedValue(false);
+
+			await expect(call('space.delete', { id: 'ghost' })).rejects.toThrow('Space not found: ghost');
+		});
+	});
+
+	// ─── space.overview ────────────────────────────────────────────────────────
+
+	describe('space.overview', () => {
+		beforeEach(() => setup());
+
+		it('returns space, tasks, workflowRuns, and sessions', async () => {
+			const result = (await call('space.overview', { id: 'space-1' })) as {
+				space: Space;
+				tasks: SpaceTask[];
+				workflowRuns: SpaceWorkflowRun[];
+				sessions: string[];
+			};
+
+			expect(result.space).toEqual(mockSpace);
+			expect(result.tasks).toEqual([mockTask]);
+			expect(result.workflowRuns).toEqual([mockRun]);
+			expect(result.sessions).toEqual(mockSpace.sessionIds);
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.overview', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when space is not found', async () => {
+			setup(null);
+			await expect(call('space.overview', { id: 'ghost' })).rejects.toThrow(
+				'Space not found: ghost'
+			);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -6,7 +6,7 @@
  * - space.list: happy path, includeArchived flag
  * - space.get: happy path, missing id, not found
  * - space.update: happy path, missing id, not found
- * - space.archive: happy path, missing id, not found
+ * - space.archive: happy path (emits space.archived with full space), missing id
  * - space.delete: happy path, missing id, not found
  * - space.overview: happy path, missing id, not found
  * - DaemonHub events emitted on mutations
@@ -295,16 +295,28 @@ describe('space-handlers', () => {
 	describe('space.archive', () => {
 		beforeEach(() => setup());
 
-		it('archives the space and emits space.updated with archived status', async () => {
+		it('archives the space and emits dedicated space.archived event with full space', async () => {
+			const archivedSpace = { ...mockSpace, status: 'archived' as const };
+			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockResolvedValue(archivedSpace);
+
 			const result = await call('space.archive', { id: 'space-1' });
 
 			expect((result as Space).status).toBe('archived');
 			expect(spaceManager.archiveSpace).toHaveBeenCalledWith('space-1');
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+			// Must emit space.archived (not space.updated) with the full space object
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.archived', {
 				sessionId: 'global',
 				spaceId: 'space-1',
-				space: { status: 'archived' },
+				space: archivedSpace,
 			});
+		});
+
+		it('does NOT emit space.updated on archive', async () => {
+			await call('space.archive', { id: 'space-1' });
+
+			const calls = (daemonHub.emit as ReturnType<typeof mock>).mock.calls;
+			const updatedCall = calls.find((c: unknown[]) => c[0] === 'space.updated');
+			expect(updatedCall).toBeUndefined();
 		});
 
 		it('throws when id is missing', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -373,6 +373,15 @@ describe('space-task-handlers', () => {
 			);
 		});
 
+		it('throws Space not found when space does not exist', async () => {
+			setup(null); // spaceManager.getSpace returns null
+			await expect(
+				call('spaceTask.update', { spaceId: 'ghost', taskId: 'task-1', title: 'X' })
+			).rejects.toThrow('Space not found: ghost');
+			expect(taskManager.updateTask).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+		});
+
 		it('propagates errors from setTaskStatus (invalid transitions)', async () => {
 			// For this test, use a task that is already 'completed' to trigger an invalid transition
 			const completedTask = { ...mockTask, status: 'completed' as const };

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -2,12 +2,12 @@
  * Tests for Space Task RPC Handlers
  *
  * Covers:
- * - spaceTask.create: happy path, missing spaceId, missing title, missing description,
- *   space not found, dependency not found error propagation
+ * - spaceTask.create: happy path, missing spaceId, missing title, null description,
+ *   empty description (allowed), space not found, dependency not found error propagation
  * - spaceTask.list: happy path, missing spaceId, space not found
- * - spaceTask.get: happy path, missing params, task not found
- * - spaceTask.update: status transition (delegates to setTaskStatus), non-status update
- *   (delegates to updateTask), missing params, task not found propagation
+ * - spaceTask.get: happy path, space existence check, missing params, task not found
+ * - spaceTask.update: status transition (delegates to setTaskStatus), same-status update
+ *   (routes to updateTask — not spurious transition error), non-status update, missing params
  * - DaemonHub events emitted on mutations
  */
 
@@ -156,6 +156,12 @@ describe('space-task-handlers', () => {
 			});
 		});
 
+		it('allows empty string description', async () => {
+			await expect(
+				call('spaceTask.create', { spaceId: 'space-1', title: 'T', description: '' })
+			).resolves.toBeDefined();
+		});
+
 		it('throws when spaceId is missing', async () => {
 			await expect(call('spaceTask.create', { title: 'T', description: 'D' })).rejects.toThrow(
 				'spaceId is required'
@@ -174,9 +180,15 @@ describe('space-task-handlers', () => {
 			).rejects.toThrow('title is required');
 		});
 
-		it('throws when description is missing', async () => {
+		it('throws when description is null', async () => {
+			await expect(
+				call('spaceTask.create', { spaceId: 'space-1', title: 'T', description: null })
+			).rejects.toThrow('description must not be null');
+		});
+
+		it('throws when description is undefined', async () => {
 			await expect(call('spaceTask.create', { spaceId: 'space-1', title: 'T' })).rejects.toThrow(
-				'description is required'
+				'description must not be null'
 			);
 		});
 
@@ -248,6 +260,14 @@ describe('space-task-handlers', () => {
 			expect(result).toEqual(mockTask);
 		});
 
+		it('verifies space existence before fetching task', async () => {
+			setup(null);
+			await expect(call('spaceTask.get', { spaceId: 'ghost', taskId: 'task-1' })).rejects.toThrow(
+				'Space not found: ghost'
+			);
+			expect(taskManager.getTask).not.toHaveBeenCalled();
+		});
+
 		it('throws when spaceId is missing', async () => {
 			await expect(call('spaceTask.get', { taskId: 'task-1' })).rejects.toThrow(
 				'spaceId is required'
@@ -291,6 +311,23 @@ describe('space-task-handlers', () => {
 				taskId: 'task-1',
 				task: expect.objectContaining({ status: 'in_progress' }),
 			});
+		});
+
+		it('does NOT call setTaskStatus when status is unchanged (avoids spurious transition error)', async () => {
+			// mockTask has status: 'pending'; sending status: 'pending' should not call setTaskStatus
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'pending', // same as current
+				title: 'New title',
+			});
+
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
+				status: 'pending',
+				title: 'New title',
+			});
+			expect(result).toBeDefined();
 		});
 
 		it('delegates non-status update to updateTask', async () => {
@@ -337,17 +374,21 @@ describe('space-task-handlers', () => {
 		});
 
 		it('propagates errors from setTaskStatus (invalid transitions)', async () => {
+			// For this test, use a task that is already 'completed' to trigger an invalid transition
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			setup(mockSpace, completedTask);
+
 			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockRejectedValue(
-				new Error("Invalid status transition from 'pending' to 'completed'")
+				new Error("Invalid status transition from 'completed' to 'pending'. Allowed: none")
 			);
 
 			await expect(
 				call('spaceTask.update', {
 					spaceId: 'space-1',
 					taskId: 'task-1',
-					status: 'completed',
+					status: 'pending',
 				})
-			).rejects.toThrow("Invalid status transition from 'pending' to 'completed'");
+			).rejects.toThrow('Invalid status transition');
 		});
 
 		it('propagates errors from updateTask', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for Space Task RPC Handlers
+ *
+ * Covers:
+ * - spaceTask.create: happy path, missing spaceId, missing title, missing description,
+ *   space not found, dependency not found error propagation
+ * - spaceTask.list: happy path, missing spaceId, space not found
+ * - spaceTask.get: happy path, missing params, task not found
+ * - spaceTask.update: status transition (delegates to setTaskStatus), non-status update
+ *   (delegates to updateTask), missing params, task not found propagation
+ * - DaemonHub events emitted on mutations
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceTask } from '@neokai/shared';
+import { setupSpaceTaskHandlers } from '../../../src/lib/rpc-handlers/space-task-handlers';
+import type { SpaceTaskManagerFactory } from '../../../src/lib/rpc-handlers/space-task-handlers';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockTask: SpaceTask = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	title: 'Test Task',
+	description: 'A task description',
+	status: 'pending',
+	priority: 'normal',
+	dependsOn: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function createMockTaskManager(task: SpaceTask | null = mockTask): SpaceTaskManager {
+	return {
+		createTask: mock(async () => task!),
+		getTask: mock(async () => task),
+		listTasks: mock(async () => (task ? [task] : [])),
+		setTaskStatus: mock(async () => ({ ...task!, status: 'in_progress' as const })),
+		updateTask: mock(async () => ({ ...task!, title: 'Updated' })),
+		updateTaskProgress: mock(async () => ({ ...task!, progress: 50 })),
+	} as unknown as SpaceTaskManager;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('space-task-handlers', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let taskManager: SpaceTaskManager;
+	let taskManagerFactory: SpaceTaskManagerFactory;
+
+	function setup(space: Space | null = mockSpace, task: SpaceTask | null = mockTask) {
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager(space);
+		taskManager = createMockTaskManager(task);
+		taskManagerFactory = mock((_spaceId: string) => taskManager);
+		setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, daemonHub);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	// ─── spaceTask.create ──────────────────────────────────────────────────────
+
+	describe('spaceTask.create', () => {
+		beforeEach(() => setup());
+
+		it('creates a task and emits space.task.created', async () => {
+			const result = await call('spaceTask.create', {
+				spaceId: 'space-1',
+				title: 'Do work',
+				description: 'description',
+			});
+
+			expect(result).toEqual(mockTask);
+			expect(taskManager.createTask).toHaveBeenCalledTimes(1);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.task.created', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				taskId: mockTask.id,
+				task: mockTask,
+			});
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceTask.create', { title: 'T', description: 'D' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when title is missing', async () => {
+			await expect(
+				call('spaceTask.create', { spaceId: 'space-1', description: 'D' })
+			).rejects.toThrow('title is required');
+		});
+
+		it('throws when title is empty string', async () => {
+			await expect(
+				call('spaceTask.create', { spaceId: 'space-1', title: '', description: 'D' })
+			).rejects.toThrow('title is required');
+		});
+
+		it('throws when description is missing', async () => {
+			await expect(call('spaceTask.create', { spaceId: 'space-1', title: 'T' })).rejects.toThrow(
+				'description is required'
+			);
+		});
+
+		it('throws when space is not found', async () => {
+			setup(null);
+			await expect(
+				call('spaceTask.create', {
+					spaceId: 'ghost',
+					title: 'T',
+					description: 'D',
+				})
+			).rejects.toThrow('Space not found: ghost');
+		});
+
+		it('propagates task manager errors (e.g. invalid dependency)', async () => {
+			(taskManager.createTask as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('Dependency task not found in space: bad-dep')
+			);
+
+			await expect(
+				call('spaceTask.create', {
+					spaceId: 'space-1',
+					title: 'T',
+					description: 'D',
+					dependsOn: ['bad-dep'],
+				})
+			).rejects.toThrow('Dependency task not found');
+		});
+	});
+
+	// ─── spaceTask.list ────────────────────────────────────────────────────────
+
+	describe('spaceTask.list', () => {
+		beforeEach(() => setup());
+
+		it('lists tasks for a space', async () => {
+			const result = await call('spaceTask.list', { spaceId: 'space-1' });
+			expect(result).toEqual([mockTask]);
+			expect(taskManager.listTasks).toHaveBeenCalledWith(false);
+		});
+
+		it('passes includeArchived flag', async () => {
+			await call('spaceTask.list', { spaceId: 'space-1', includeArchived: true });
+			expect(taskManager.listTasks).toHaveBeenCalledWith(true);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceTask.list', {})).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when space is not found', async () => {
+			setup(null);
+			await expect(call('spaceTask.list', { spaceId: 'ghost' })).rejects.toThrow(
+				'Space not found: ghost'
+			);
+		});
+	});
+
+	// ─── spaceTask.get ─────────────────────────────────────────────────────────
+
+	describe('spaceTask.get', () => {
+		beforeEach(() => setup());
+
+		it('returns the task when found', async () => {
+			const result = await call('spaceTask.get', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+			});
+			expect(result).toEqual(mockTask);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceTask.get', { taskId: 'task-1' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(call('spaceTask.get', { spaceId: 'space-1' })).rejects.toThrow(
+				'taskId is required'
+			);
+		});
+
+		it('throws when task is not found', async () => {
+			setup(mockSpace, null);
+			await expect(call('spaceTask.get', { spaceId: 'space-1', taskId: 'ghost' })).rejects.toThrow(
+				'Task not found: ghost'
+			);
+		});
+	});
+
+	// ─── spaceTask.update ──────────────────────────────────────────────────────
+
+	describe('spaceTask.update', () => {
+		beforeEach(() => setup());
+
+		it('delegates status change to setTaskStatus and emits space.task.updated', async () => {
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'in_progress',
+			});
+
+			expect((result as SpaceTask).status).toBe('in_progress');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
+				result: undefined,
+				error: undefined,
+			});
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.task.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				task: expect.objectContaining({ status: 'in_progress' }),
+			});
+		});
+
+		it('delegates non-status update to updateTask', async () => {
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				title: 'Updated',
+			});
+
+			expect((result as SpaceTask).title).toBe('Updated');
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', { title: 'Updated' });
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.task.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				task: expect.objectContaining({ title: 'Updated' }),
+			});
+		});
+
+		it('passes result and error to setTaskStatus when provided with status', async () => {
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'needs_attention',
+				error: 'Build failed',
+			});
+
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'needs_attention', {
+				result: undefined,
+				error: 'Build failed',
+			});
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceTask.update', { taskId: 'task-1', title: 'X' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(call('spaceTask.update', { spaceId: 'space-1', title: 'X' })).rejects.toThrow(
+				'taskId is required'
+			);
+		});
+
+		it('propagates errors from setTaskStatus (invalid transitions)', async () => {
+			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockRejectedValue(
+				new Error("Invalid status transition from 'pending' to 'completed'")
+			);
+
+			await expect(
+				call('spaceTask.update', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					status: 'completed',
+				})
+			).rejects.toThrow("Invalid status transition from 'pending' to 'completed'");
+		});
+
+		it('propagates errors from updateTask', async () => {
+			(taskManager.updateTask as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('Task not found: task-1')
+			);
+
+			await expect(
+				call('spaceTask.update', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					title: 'X',
+				})
+			).rejects.toThrow('Task not found');
+		});
+	});
+});


### PR DESCRIPTION
- Register space.created, space.updated, space.deleted,
  space.task.created, space.task.updated, space.workflowRun.created,
  space.workflowRun.updated in DaemonEventMap
- Add space-handlers.ts: space.create (with path validation), space.list,
  space.get, space.update, space.archive, space.delete, space.overview
- Add space-task-handlers.ts: spaceTask.create, spaceTask.list,
  spaceTask.get, spaceTask.update (status → setTaskStatus, else updateTask)
- Wire both handler sets in rpc-handlers/index.ts via setupRPCHandlers()
- Add SpaceTaskManager.updateTask() for direct non-status field updates
- Expose SpaceManager in DaemonAppContext (app.ts)
- 46 unit tests — all passing; lint and typecheck clean
