### PR TITLE
feat: simplify multi-agent space — explicit workflowId or AI auto-select only

### DIFF
--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
@@ -94,7 +94,7 @@ Spaces require a **workspace path** at creation time — the directory where age
 4. **Workflow Runtime Engine** — `WorkflowExecutor` in `packages/daemon/src/lib/space/runtime/`, `SpaceRuntime` orchestration engine, `SpaceRuntimeService`, `spaceWorkflowRun.*` RPC handlers, gate evaluation, step advancement, rule injection. Operates on workflow runs and tasks (no goals).
 5. **Space Frontend Foundation** — Navigation entry point, URL routing, `SpaceStore`, Space creation UX with workspace path picker, minimalist 3-column layout shell (right pane shows placeholder states until M4 provides a running runtime).
 6. **Frontend: Agent & Workflow UI** — Agent creation/editing, visual workflow builder, rules editor — all under `packages/web/src/components/space/`.
-7. **Workflow Selection & Agent Tools** — Workflow selection logic, Space agent tools in `packages/daemon/src/lib/space/tools/`, prompt enhancement with workflow awareness.
+7. **Workflow Selection & Agent Tools** — Two-mode workflow selection (explicit workflowId OR AI auto-select via LLM reasoning), Space agent tools in `packages/daemon/src/lib/space/tools/`, prompt enhancement so the agent can intelligently choose workflows.
 8. **Export/Import & Sharing Foundation** — Export format types in `space.ts`, `spaceExport.*`/`spaceImport.*` RPC handlers in `space-export-import-handlers.ts`, frontend UI under `packages/web/src/components/space/`.
 
 ## Cross-Milestone Dependencies and Sequencing

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -123,6 +123,8 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description?: string;
      steps: Omit<WorkflowStep, 'id'>[];
      rules?: Omit<WorkflowRule, 'id'>[];
+     /** Organizational tags (not used for automatic selection). */
+     tags?: string[];
      config?: Record<string, unknown>;
    }
 
@@ -131,6 +133,8 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description?: string;
      steps?: Omit<WorkflowStep, 'id'>[];
      rules?: Omit<WorkflowRule, 'id'>[];
+     /** Replaces the tag list. Pass `[]` or `null` to clear. Organizational only. */
+     tags?: string[] | null;
      config?: Record<string, unknown>;
    }
    ```

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -106,6 +106,12 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description: string;
      steps: WorkflowStep[];
      rules: WorkflowRule[];
+     /**
+      * @deprecated Not used for workflow selection. Workflow selection uses only
+      * explicit workflowId or AI auto-select. Retained for backward compatibility.
+      */
+     isDefault: boolean;
+     /** Organizational tags. Not used for automatic workflow selection. */
      tags: string[];
      config?: Record<string, unknown>;
      createdAt: number;
@@ -117,7 +123,6 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description?: string;
      steps: Omit<WorkflowStep, 'id'>[];
      rules?: Omit<WorkflowRule, 'id'>[];
-     tags?: string[];
      config?: Record<string, unknown>;
    }
 
@@ -126,7 +131,6 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      description?: string;
      steps?: Omit<WorkflowStep, 'id'>[];
      rules?: Omit<WorkflowRule, 'id'>[];
-     tags?: string[];
      config?: Record<string, unknown>;
    }
    ```
@@ -162,8 +166,9 @@ Build the data access and business logic layers for workflows within Spaces. The
    - `deleteWorkflow(id: string): boolean`
    - `getWorkflowsReferencingAgent(agentId: string): SpaceWorkflow[]` — finds workflows referencing a custom agent (used for deletion protection in `SpaceAgentManager`)
    - Handle step CRUD within workflow transactions (replace all steps on update)
-   - JSON serialization for `rules`, `tags`, `entry_gate`, `exit_gate`
+   - JSON serialization for `rules`, `entry_gate`, `exit_gate`
    - `rowToWorkflow()` and `rowToStep()` mapping functions
+   - **No `getDefaultWorkflow`/`setDefaultWorkflow`** — workflow selection uses only explicit workflowId or AI auto-select.
 
 2. Create `packages/daemon/src/lib/space/managers/space-workflow-manager.ts`:
    - Validation:
@@ -190,7 +195,7 @@ Build the data access and business logic layers for workflows within Spaces. The
 - Repository handles CRUD with proper step management using `space_workflows`/`space_workflow_steps` tables
 - Manager validates workflow integrity including gate security
 - Agent reference validation queries `SpaceAgentManager` (NOT a nonexistent `CustomAgentManager`)
-- Default workflow switching works correctly
+- **No default-workflow selection logic** — `isDefault` field is deprecated and has no runtime effect
 - All files in Space namespace — nothing in `packages/daemon/src/lib/room/`
 - Unit tests cover all paths
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
@@ -218,12 +223,12 @@ Add RPC handlers for workflow CRUD using the `spaceWorkflow.*` namespace. Regist
    Import `SpaceWorkflow` from `@neokai/shared`.
 
 2. Create `packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts`:
-   - `spaceWorkflow.create { spaceId, name, description, steps, rules, tags }` → `{ workflow }`
+   - `spaceWorkflow.create { spaceId, name, description, steps, rules }` → `{ workflow }`
    - `spaceWorkflow.list { spaceId }` → `{ workflows }`
    - `spaceWorkflow.get { id }` → `{ workflow }`
    - `spaceWorkflow.update { id, ... }` → `{ workflow }`
    - `spaceWorkflow.delete { id }` → `{ success }`
-   - `spaceWorkflow.setDefault { spaceId, workflowId }` → `{ success }`
+   - **No `spaceWorkflow.setDefault`** — default selection is removed from the design
 
 3. Wire handlers in `packages/daemon/src/lib/rpc-handlers/index.ts` (via `setupRPCHandlers()` — add new registration only, do not modify existing handler setup)
 
@@ -261,20 +266,20 @@ Create built-in workflow templates that serve as defaults and examples. Also cre
 
 3. `getBuiltInWorkflows(): SpaceWorkflow[]` — returns templates without space-specific IDs
 
-4. `seedDefaultWorkflow(spaceId: string, workflowManager: SpaceWorkflowManager): Promise<void>`:
-   - Idempotent: checks if space already has a default workflow
-   - Seeds `CODING_WORKFLOW` as default
+4. `seedBuiltInWorkflows(spaceId: string, workflowManager: SpaceWorkflowManager): Promise<void>`:
+   - Idempotent: checks if space already has any workflows before seeding
+   - Seeds all three built-in workflow templates when creating a new space (so the AI agent has workflows to choose from)
    - **Call site wired in Task 4.2** (in the `space.create` RPC handler, after `SpaceManager.createSpace()` returns), not here
 
 5. Write unit tests:
    - Template structure validation
    - All agent refs are valid builtins (no 'leader')
-   - Idempotent seeding
+   - Idempotent seeding (doesn't re-seed if workflows already exist)
 
 **Acceptance criteria:**
 - Three built-in workflow templates defined
 - Templates mirror existing behavior (Leader is implicit, not a step)
-- `seedDefaultWorkflow` implemented and tested but NOT wired (that's M4)
+- `seedBuiltInWorkflows` implemented and tested but NOT wired (that's M4)
 - All files in `packages/daemon/src/lib/space/workflows/` (NOT `room/workflows/`)
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -124,7 +124,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 
 3. **Starting a workflow run**:
    - `startWorkflowRun(spaceId, workflowId, title, description?)` → creates `SpaceWorkflowRun` record, creates `WorkflowExecutor`, evaluates entry gate of first step, creates first step's `SpaceTask` records
-   - `workflowId` is always required — either provided explicitly by the caller or chosen by the Space agent via `list_workflows` + `start_workflow_run` (AI auto-select). No default workflow fallback.
+   - `workflowId` is always required — the AI agent calls `list_workflows` and decides before calling this method. No default-workflow fallback.
    - Store executor in map
 
 4. **Standalone tasks** (no workflow):
@@ -156,9 +156,10 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
    - Remove from map when: run completes, fails, is cancelled
    - Hook into `SpaceWorkflowRun` status change handlers
 
-9. **Wire `seedDefaultWorkflow`** from Task 3.4:
+9. **Wire `seedBuiltInWorkflows`** from Task 3.4:
    - Call in the `space.create` RPC handler (in `space-handlers.ts`), **after** `SpaceManager.createSpace()` returns — the handler has access to both `SpaceManager` and `SpaceWorkflowManager`, whereas `SpaceManager` itself is constructed without workflow manager dependency
-   - Idempotent: safe if space already has a workflow
+   - Seeds all three built-in workflow templates so the AI agent has workflows to choose from
+   - Idempotent: safe if space already has workflows
    - **This is in the Space RPC handler** — NOT in `room-manager.ts`
 
 10. Write integration tests:
@@ -182,7 +183,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 - Standalone tasks work without a workflow
 - Executors rehydrated on startup, cleaned up on completion
 - `advance()` creates `SpaceTask` DB records only; tick loop handles group spawning
-- `seedDefaultWorkflow` wired into `space.create` RPC handler (NOT `room-manager.ts`)
+- `seedBuiltInWorkflows` wired into `space.create` RPC handler (NOT `room-manager.ts`)
 - Integration tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 
@@ -220,9 +221,9 @@ Build `SpaceRuntimeService` for managing `SpaceRuntime` lifecycle, and configure
    - Any step failure (gate fails after retries) → run → `needs_attention`
 
 5. Create RPC handler for starting workflow runs in `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts`:
-   - `spaceWorkflowRun.start { spaceId, workflowId?, title, description? }` → `{ run: SpaceWorkflowRun }`:
-     - If `workflowId` provided, validate it exists in the space
-     - If `workflowId` omitted, use space's default workflow (error if none)
+   - `spaceWorkflowRun.start { spaceId, workflowId, title, description? }` → `{ run: SpaceWorkflowRun }`:
+     - `workflowId` is **required** — the AI agent always provides one (via `list_workflows` + its own reasoning). No default-workflow fallback.
+     - Validate `workflowId` exists in the space (error if not found)
      - Creates `SpaceWorkflowRun` record via `SpaceWorkflowRunRepository`
      - Calls `SpaceRuntimeService.createOrGetRuntime(spaceId)` then `runtime.startWorkflowRun()` to create the executor and first step's tasks
      - Emits `space.workflowRun.created` event

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/05-space-frontend-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/05-space-frontend-foundation.md
@@ -2,12 +2,13 @@
 
 ## Goal
 
-Build the frontend foundation for Spaces: navigation entry point, URL routing, state management, Space creation UX with workspace path picker, and the minimalist 3-column layout. This creates the shell that all Space UI features plug into.
+Build the frontend foundation for Spaces: navigation entry point, URL routing, state management, Space creation UX with workspace path picker, and a minimalist chat-centered layout. This creates the shell that all Space UI features plug into.
 
 ## Design Principles
 
-- **Minimalist**: Clean, uncluttered, purposeful. Every element earns its place.
-- **3-column layout**: Follows the existing room pattern (nav | work area | detail) but with fresh, focused design.
+- **Chat-first**: The primary interaction model is chat — users describe what they want in natural language and the Space agent figures out the workflow. Configuration is secondary.
+- **Minimal toggles**: The interface exposes almost no configuration controls on the main screen. Workflow/agent setup lives in dedicated settings views, not inline toggles.
+- **3-column layout**: Follows the existing room pattern (nav | chat area | detail) but with fresh, focused design.
 - **Creative**: Not a copy of the Room UI. Fresh visual language, focused interaction model.
 - **Workspace-first**: Space creation prominently features workspace path selection as a required field.
 
@@ -17,8 +18,7 @@ Build the frontend foundation for Spaces: navigation entry point, URL routing, s
 - URL routing: `/space/:spaceId`, `/space/:spaceId/session/:sessionId`, `/space/:spaceId/task/:taskId`
 - `SpaceStore` for reactive state management
 - Space creation dialog with workspace path picker
-- 3-column layout shell
-- Space dashboard/overview
+- 3-column layout shell with chat as the center-pane default
 - Unit tests
 
 ---
@@ -54,7 +54,7 @@ Add the navigation entry point for Spaces, URL routing, and core signals. All ne
      - `packages/web/src/lib/nav-config.tsx`: Add a `'spaces'` entry to `MAIN_NAV_ITEMS` array
      - `packages/web/src/islands/ContextPanel.tsx`: Add a case for `'spaces'` section that renders the new `SpaceContextPanel` component (the panel itself is a new component under `components/space/`)
    - These are the **only** existing file modifications in the entire plan. They are small, additive changes (extending a union, adding an array entry, adding a switch case).
-   - Create new `packages/web/src/components/space/SpaceContextPanel.tsx` — list of spaces with active/archived filter, "Create Space" button
+   - Create new `packages/web/src/components/space/SpaceContextPanel.tsx` — list of spaces with active/archived filter, "Create Space" button.
 
 4. Update `packages/web/src/islands/MainContent.tsx` routing logic:
    - Add condition: if `currentSpaceIdSignal` → render `SpaceIsland` component
@@ -101,7 +101,6 @@ Create `SpaceStore` for managing all Space-related reactive state. Follows the e
    - Computed signals:
      - `activeTasks` — tasks filtered by active status
      - `activeRuns` — workflow runs filtered by in-progress status
-     - `defaultWorkflow` — the space's default workflow
      - `tasksByRun` — tasks grouped by workflow run ID
 
    - Methods:
@@ -109,7 +108,7 @@ Create `SpaceStore` for managing all Space-related reactive state. Follows the e
      - `clearSpace()` — unsubscribe, reset signals
      - CRUD wrappers: `createTask()`, `startWorkflowRun()`, `archiveSpace()`, etc.
 
-2. Promise-chain lock for atomic space switching (prevent race conditions when rapidly switching spaces — same pattern as `RoomStore`)
+2. Promise-chain lock for atomic space switching (prevent race conditions when rapidly switching spaces — same pattern as `RoomStore`).
 
 3. Event subscriptions:
    - Subscribe to `space.task.created`, `space.task.updated`, `space.workflowRun.created`, `space.workflowRun.updated`, `spaceAgent.created/updated/deleted`, `spaceWorkflow.created/updated/deleted`
@@ -131,7 +130,7 @@ Create `SpaceStore` for managing all Space-related reactive state. Follows the e
 
 ---
 
-### Task 5.3: Space Creation UX and 3-Column Layout
+### Task 5.3: Space Creation UX and Chat-Centered Layout
 
 **Agent:** coder
 **Priority:** high
@@ -139,12 +138,18 @@ Create `SpaceStore` for managing all Space-related reactive state. Follows the e
 
 **Description:**
 
-Build the Space creation dialog (with required workspace path) and the main 3-column layout shell. The design should feel fresh, minimalist, and focused.
+Build the Space creation dialog (with required workspace path) and the main 3-column layout shell. The center pane is a chat interface where users describe their intent to the Space agent. Configuration (agents, workflows) lives in dedicated views, not inline on the main screen.
+
+**Design Philosophy:**
+- The main screen is a chat — no toggles, no dropdowns, no config panels on the primary view.
+- Users type what they want: "Fix the authentication bug", "Add a new feature for X". The AI agent handles workflow selection.
+- Status/progress is shown inline in the chat thread (workflow run progress, step indicators).
+- Advanced configuration (agents, workflows) is accessible from the left nav, not from the chat area.
 
 **Subtasks:**
 
 1. Create `packages/web/src/components/space/SpaceCreateDialog.tsx`:
-   - **Workspace path is the hero field** — prominently featured, required
+   - **Workspace path is the hero field** — prominently featured, required.
    - Fields:
      - **Workspace Path**: directory picker or text input with validation (path must exist). Consider a "Browse" button that opens a native file dialog or a path autocomplete.
      - **Name**: text input (auto-suggest from directory name)
@@ -156,16 +161,17 @@ Build the Space creation dialog (with required workspace path) and the main 3-co
 2. Create `packages/web/src/islands/Space.tsx` — the main Space component:
    - **3-column layout**:
      - **Left column (narrow)**: Space navigation panel — workflow runs list, standalone tasks, quick-access sections (Agents, Workflows, Settings), space status indicator
-     - **Middle column (wide)**: Primary work area — workflow run detail, task list, dashboard, or editor views depending on what's selected
-     - **Right column (wide)**: Detail pane — active task conversation, session view, or contextual information
-   - The right column shows task conversations (using the `TaskConversationRenderer` pattern but styled fresh) when a task is selected
-   - Responsive: on narrow screens, columns collapse (right → overlay, left → toggleable)
+     - **Middle column (wide)**: **Primary chat interface** — this is the main interaction area. Users send messages, the Space agent responds, workflow progress appears inline.
+     - **Right column (contextual)**: Detail pane — shows task conversation detail, session view, or workflow run progress when selected from the left nav. Hidden by default until an item is selected.
+   - No configuration toggles in the middle column — it is purely a chat area.
+   - Responsive: on narrow screens, right column collapses (overlay), left column toggleable.
 
-3. Create `packages/web/src/components/space/SpaceDashboard.tsx`:
-   - Default middle-column view when no specific item is selected
-   - Shows: space name, workspace path, workflow run progress, recent activity
-   - Quick actions: "Start Workflow Run", "Create Task", "Configure Agents", "Edit Workflows"
-   - Minimalist design: cards with clear hierarchy, subtle color accents
+3. Create `packages/web/src/components/space/SpaceChatPane.tsx` — the chat interface in the middle column:
+   - Chat message thread showing Space agent conversation
+   - Input area: text input + send button (no extra controls inline)
+   - Workflow run progress appears as status cards within the chat thread (e.g., "Started workflow: Coding — Step 1/3: Planning")
+   - Task completion notifications appear inline
+   - Minimalist: the chat is the full experience
 
 4. Create `packages/web/src/components/space/SpaceNavPanel.tsx`:
    - Left column navigation:
@@ -176,18 +182,19 @@ Build the Space creation dialog (with required workspace path) and the main 3-co
      - "Settings" link → opens space settings
    - Active item highlighted
    - Compact, scannable design
+   - No toggles or controls here — navigation only
 
 5. Create `packages/web/src/components/space/SpaceTaskPane.tsx`:
-   - Right column task detail view
+   - Right column task detail view (shown when task selected from nav)
    - Shows task header (title, status, workflow step indicator like "Step 2/3: Review")
    - Task conversation (Worker + Leader messages)
-   - Human input area for sending messages
+   - Human input area for sending messages to the task
    - Minimalist: focus on the conversation, metadata tucked away
 
 6. Write unit tests:
    - SpaceCreateDialog validates workspace path
    - 3-column layout renders correctly
-   - SpaceDashboard shows correct data
+   - SpaceChatPane renders messages correctly
    - Navigation panel highlights active item
    - Task pane shows workflow step indicator
 
@@ -195,14 +202,15 @@ Build the Space creation dialog (with required workspace path) and the main 3-co
    - Create a new Space via the dialog
    - Verify workspace path is required
    - Navigate to Space and verify 3-column layout renders
-   - Navigate between workflow runs and verify task pane updates
+   - Send a message in the chat pane and verify it appears
+   - Select a workflow run from nav and verify task pane appears
 
 **Acceptance criteria:**
 - Space creation requires workspace path and validates it
-- 3-column layout renders correctly with left nav, middle work area, right detail
-- Dashboard provides clear overview of space status (workflow runs, tasks)
+- 3-column layout renders: left nav, middle chat area (no toggles), right detail pane
+- Chat pane is the primary interaction — no inline config toggles
 - Navigation panel shows workflow runs and standalone tasks
 - Task pane shows workflow step progression
-- Design is minimalist and feels fresh (not a copy of Room UI)
+- Design is minimalist and chat-centered (not a copy of Room UI)
 - E2E tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
@@ -79,10 +79,11 @@ Build the visual workflow editor for composing agent steps with gates.
 **Subtasks:**
 
 1. Create `packages/web/src/components/space/WorkflowList.tsx`:
-   - Workflow cards: name, description, step count, default badge, tag chips
-   - "Create Workflow" button, "Set as Default" action per card
+   - Workflow cards: name, description, step count
+   - "Create Workflow" button
    - Real-time updates via SpaceStore
    - Mini step visualization (horizontal dots/icons showing the step sequence)
+   - **No "Set as Default" button** — the AI agent selects the appropriate workflow based on user intent
 
 2. Create `packages/web/src/components/space/WorkflowEditor.tsx`:
    - Workflow name and description fields at top
@@ -150,30 +151,25 @@ Add the rules editor to the workflow builder, tags editor, and integrate all age
      - Remove button
    - Rules saved as part of the workflow
 
-2. Tags editor:
-   - Tag input (comma-separated or chip input)
-   - Suggestions: "coding", "review", "research", "design", "deployment"
-
-3. Integration into Space layout:
+2. Integration into Space layout:
    - Agent management: accessible via SpaceNavPanel "Agents" link → renders `SpaceAgentList`/`SpaceAgentEditor` in middle column
    - Workflow management: via "Workflows" link → renders `WorkflowList`/`WorkflowEditor`
    - Back navigation between list and editor views
 
-4. Export all new components from `packages/web/src/components/space/index.ts`
+3. Export all new components from `packages/web/src/components/space/index.ts`
 
-5. Write e2e tests:
+4. Write e2e tests:
    - Create a workflow with 3 steps from template
    - Add a custom rule targeting specific steps
    - Save and verify persistence
-   - Set as default workflow
    - Edit existing workflow
    - Delete workflow
    - Create a custom agent, use it in a workflow step
 
 **Acceptance criteria:**
 - Rules can be created and associated with specific steps
-- Tags help categorize workflows
 - Agent and workflow management integrated into Space layout
 - Full CRUD flows work end-to-end
+- No "Set as Default" toggle — workflow selection is handled by the AI agent
 - E2E tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -558,7 +558,7 @@ export interface SpaceWorkflow {
 	 * Workflow selection uses only two modes: explicit workflowId or AI auto-select.
 	 * This field is retained for backward compatibility but has no runtime effect.
 	 */
-	isDefault: boolean;
+	isDefault?: boolean;
 	/** Tags for organizational categorization. Not used for automatic workflow selection. */
 	tags: string[];
 	/** Additional runtime configuration (opaque bag for future extensibility) */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -553,7 +553,13 @@ export interface SpaceWorkflow {
 	steps: WorkflowStep[];
 	/** Rules that govern agent behavior during this workflow */
 	rules: WorkflowRule[];
-	/** Tags for categorization */
+	/**
+	 * @deprecated isDefault is no longer used for workflow selection.
+	 * Workflow selection uses only two modes: explicit workflowId or AI auto-select.
+	 * This field is retained for backward compatibility but has no runtime effect.
+	 */
+	isDefault: boolean;
+	/** Tags for organizational categorization. Not used for automatic workflow selection. */
 	tags: string[];
 	/** Additional runtime configuration (opaque bag for future extensibility) */
 	config?: Record<string, unknown>;
@@ -579,7 +585,11 @@ export interface CreateSpaceWorkflowParams {
 	 * Rules governing agent behavior. `id` is backend-assigned.
 	 */
 	rules?: WorkflowRuleInput[];
-	/** Tags for categorization (default: []). */
+	/**
+	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
+	 */
+	isDefault?: boolean;
+	/** Tags for organizational categorization (default: []). Not used for automatic workflow selection. */
 	tags?: string[];
 	config?: Record<string, unknown>;
 }
@@ -606,7 +616,12 @@ export interface UpdateSpaceWorkflowParams {
 	 */
 	rules?: WorkflowRule[] | null;
 	/**
+	 * @deprecated isDefault has no runtime effect. Workflow selection uses only explicit workflowId or AI auto-select.
+	 */
+	isDefault?: boolean;
+	/**
 	 * Replaces the tag list. Pass `[]` or `null` to clear all tags.
+	 * Tags are for organizational categorization only — not used for automatic workflow selection.
 	 */
 	tags?: string[] | null;
 	config?: Record<string, unknown> | null;


### PR DESCRIPTION
Remove heuristic workflow selection methods (default, tag-based, keyword-based,
fallback) from the Space system design. Workflow selection now has exactly two
modes:
  1. Explicit workflowId provided by the caller
  2. AI auto-select: the Space chat agent reasons about available workflows via
     list_workflows tool and calls start_workflow_run with its chosen workflowId

UI changes (plan docs):
- Main Space view is now chat-centered — no inline config toggles
- SpaceDashboard replaced by SpaceChatPane as the primary interaction area
- Workflow run progress appears as status cards within the chat thread
- Remove "Set as Default" button from WorkflowList
- Remove tag editor from WorkflowRulesEditor (tags kept as org metadata only)
- SpaceNavPanel is navigation-only, no controls

Plan document changes:
- 07: rewrite Task 7.1 to only implement resolveWorkflow (pure lookup by ID)
  and remove all heuristic selection code
- 05: redesign Task 5.3 layout around chat pane, remove toggle-heavy dashboard
- 06: remove "Set as Default" action and tag editor from workflow UI tasks
- 03: remove getDefaultWorkflow/setDefaultWorkflow from repo, remove
  spaceWorkflow.setDefault RPC handler, rename seedDefaultWorkflow →
  seedBuiltInWorkflows
- 00: update M7 description to reflect two-mode selection

Type changes:
- Mark SpaceWorkflow.isDefault as @deprecated (no runtime effect)
- Update tags documentation: organizational only, not used for selection
