### PR TITLE
feat: add task management tools to leader role

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -28,6 +28,7 @@ import type {
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
+import type { DaemonHub } from '../../daemon-hub';
 import { createLeaderContextMcpServer } from '../tools/room-agent-tools';
 
 const DEFAULT_LEADER_MODEL = 'claude-sonnet-4-5-20250929';
@@ -76,6 +77,8 @@ export interface LeaderAgentConfig {
 	goalManager?: GoalManager;
 	taskManager?: TaskManager;
 	groupRepo?: SessionGroupRepository;
+	/** Used to emit task update events to the UI when leader modifies tasks */
+	daemonHub?: DaemonHub;
 }
 
 /**
@@ -144,6 +147,8 @@ function leaderToolContractSection(): string {
 ## Tool Contract (CRITICAL)
 
 You MUST call tools (no text-only final responses).
+
+### Review Tools (primary actions)
 - \`send_to_worker\` — Forward feedback to worker without changing group ownership
   - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)
   - mode=\`steer\`: inject for current-turn steering
@@ -151,6 +156,14 @@ You MUST call tools (no text-only final responses).
 - \`fail_task\` — Mark the task as not achievable
 - \`replan_goal\` — The current approach isn't working; fail this task and trigger replanning with context about what was tried
 - \`submit_for_review\` — Work is done with a PR ready; submit for peer review and human approval
+
+### Task Management Tools (for managing other tasks in the room)
+- \`update_task\` — Edit title, description, priority, or dependencies of any task
+- \`cancel_task\` — Cancel a task and cascade to any pending dependents
+- \`update_task_status\` — Change a task's status (e.g., retry a failed task: needs_attention → pending)
+
+### Context Tools (read-only)
+- \`list_goals\`, \`list_tasks\`, \`get_task_detail\`, \`get_room_status\` — Inspect room state
 
 Do NOT respond with only text.`;
 }
@@ -1026,9 +1039,8 @@ export function createLeaderAgentInit(
 ): AgentSessionInit {
 	const mcpServer = createLeaderMcpServer(config.groupId, callbacks);
 
-	// Create a read-only context MCP server for the leader (list/get tools only).
-	// Deliberately excludes write tools, human-only tools (approve_task, reject_task),
-	// and write-capable dependencies (daemonHub, runtimeService).
+	// Create a context + task management MCP server for the leader.
+	// Excludes human-only tools (approve_task, reject_task) and session management (stop_session).
 	const roomAgentTools =
 		config.goalManager && config.taskManager && config.groupRepo
 			? (createLeaderContextMcpServer({
@@ -1036,6 +1048,7 @@ export function createLeaderAgentInit(
 					goalManager: config.goalManager,
 					taskManager: config.taskManager,
 					groupRepo: config.groupRepo,
+					daemonHub: config.daemonHub,
 				}) as unknown as McpServerConfig)
 			: undefined;
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -280,6 +280,7 @@ export class RoomRuntime {
 			getRoom: config.getRoom,
 			getTask: config.getTask,
 			getGoal: config.getGoal,
+			daemonHub: config.daemonHub,
 		});
 
 		// Keep test and direct-runtime usage predictable: when no explicit leader model

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -23,6 +23,7 @@ import type {
 import type { SessionObserver, TerminalState } from '../state/session-observer';
 import type { TaskManager } from '../managers/task-manager';
 import type { GoalManager } from '../managers/goal-manager';
+import type { DaemonHub } from '../../daemon-hub';
 import type { LeaderToolCallbacks } from '../agents/leader-agent';
 import { createLeaderAgentInit } from '../agents/leader-agent';
 import type { LeaderAgentConfig, ReviewContext } from '../agents/leader-agent';
@@ -161,6 +162,8 @@ export interface TaskGroupManagerConfig {
 	getTask: (taskId: string) => Promise<NeoTask | null>;
 	/** Fetch goal from DB by ID. Used to get CURRENT goal data at route time. */
 	getGoal: (goalId: string) => Promise<RoomGoal | null>;
+	/** Used to emit task update events when leader modifies tasks */
+	daemonHub?: DaemonHub;
 }
 
 export class TaskGroupManager {
@@ -172,6 +175,7 @@ export class TaskGroupManager {
 	private readonly getRoom: (roomId: string) => Room | null;
 	private readonly getTaskById: (taskId: string) => Promise<NeoTask | null>;
 	private readonly getGoalById: (goalId: string) => Promise<RoomGoal | null>;
+	private readonly daemonHub?: DaemonHub;
 	readonly workspacePath: string;
 	private _model?: string;
 	readonly workerModel?: string;
@@ -188,6 +192,7 @@ export class TaskGroupManager {
 		this.workspacePath = config.workspacePath;
 		this._model = config.model;
 		this.workerModel = config.workerModel;
+		this.daemonHub = config.daemonHub;
 	}
 
 	/** Get the current model for leader sessions */
@@ -307,6 +312,7 @@ export class TaskGroupManager {
 			goalManager: this.goalManager,
 			taskManager: this.taskManager,
 			groupRepo: this.groupRepo,
+			daemonHub: this.daemonHub,
 		};
 		const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
 		await this.sessionFactory.createAndStartSession(leaderInit, 'leader');
@@ -427,6 +433,7 @@ export class TaskGroupManager {
 				goalManager: this.goalManager,
 				taskManager: this.taskManager,
 				groupRepo: this.groupRepo,
+				daemonHub: this.daemonHub,
 			};
 			const leaderInit = createLeaderAgentInit(leaderConfig, leaderCallbacks);
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -13,7 +13,6 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { TaskStatus, TaskType, AgentType } from '@neokai/shared';
-import { VALID_STATUS_TRANSITIONS } from '../managers/task-manager';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
@@ -176,6 +175,10 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
+			// Guard against self-dependency (would permanently block the task)
+			if (args.depends_on?.includes(args.task_id)) {
+				return jsonResult({ success: false, error: 'A task cannot depend on itself.' });
+			}
 			const updates: {
 				title?: string;
 				description?: string;
@@ -214,6 +217,27 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
 
+			// Guard: terminal tasks cannot be cancelled
+			if (task.status === 'completed' || task.status === 'cancelled') {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} is already in terminal state '${task.status}' and cannot be cancelled.`,
+				});
+			}
+
+			// Guard: cancelling a task with an active session group requires runtime service
+			// to stop the running session. Without it, the DB would be updated but the
+			// worker session would continue running against a cancelled task.
+			if (task.status === 'in_progress' && !runtimeService) {
+				const activeGroup = groupRepo.getGroupByTaskId(args.task_id);
+				if (activeGroup && activeGroup.completedAt === null) {
+					return jsonResult({
+						success: false,
+						error: `Cannot cancel in_progress task ${args.task_id} without runtime service — the active worker session would not be stopped.`,
+					});
+				}
+			}
+
 			let cancelledTaskIds: string[] = [];
 			let usedRuntimeCancellation = false;
 			if (runtimeService) {
@@ -249,7 +273,11 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					}
 				}
 			}
-			return jsonResult({ success: true, message: `Task ${args.task_id} cancelled` });
+			return jsonResult({
+				success: true,
+				cancelledTaskIds,
+				message: `Task ${args.task_id} and ${cancelledTaskIds.length - 1} dependent task(s) cancelled`,
+			});
 		},
 
 		async stop_session(args: { task_id: string }): Promise<ToolResult> {
@@ -285,6 +313,8 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			return jsonResult({ success: false, error: 'Runtime service unavailable' });
 		},
 
+		// Note: MCP tool is named `update_task_status` but delegates to this handler (set_task_status).
+		// The internal name matches the existing room-agent pattern; the tool name is what the LLM sees.
 		async set_task_status(args: {
 			task_id: string;
 			status: TaskStatus;
@@ -296,13 +326,23 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
 
-			// Validate status transition
-			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
-			if (!allowedTransitions.includes(args.status)) {
-				return jsonResult({
-					success: false,
-					error: `Invalid status transition from '${task.status}' to '${args.status}'. Allowed: ${allowedTransitions.join(', ') || 'none'}`,
-				});
+			const terminalStatuses: TaskStatus[] = ['completed', 'needs_attention', 'cancelled'];
+
+			// Guard: transitioning a task with an active session group to a terminal state
+			// requires runtime service to cancel the running session first. Without it,
+			// the DB would change but the worker session would continue executing.
+			if (
+				(task.status === 'in_progress' || task.status === 'review') &&
+				terminalStatuses.includes(args.status) &&
+				!runtimeService
+			) {
+				const activeGroup = groupRepo.getGroupByTaskId(args.task_id);
+				if (activeGroup && activeGroup.completedAt === null) {
+					return jsonResult({
+						success: false,
+						error: `Cannot transition active task ${args.task_id} (status '${task.status}') to '${args.status}' without runtime service — the active worker session would not be stopped.`,
+					});
+				}
 			}
 
 			// Check for active group when transitioning from in_progress or review

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -227,8 +227,9 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 			// Guard: cancelling a task with an active session group requires runtime service
 			// to stop the running session. Without it, the DB would be updated but the
-			// worker session would continue running against a cancelled task.
-			if (task.status === 'in_progress' && !runtimeService) {
+			// worker/leader sessions would continue running against a cancelled task.
+			// Covers both in_progress and review — both have active session groups.
+			if ((task.status === 'in_progress' || task.status === 'review') && !runtimeService) {
 				const activeGroup = groupRepo.getGroupByTaskId(args.task_id);
 				if (activeGroup && activeGroup.completedAt === null) {
 					return jsonResult({
@@ -273,10 +274,14 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					}
 				}
 			}
+			const dependentCount = cancelledTaskIds.length - 1;
 			return jsonResult({
 				success: true,
 				cancelledTaskIds,
-				message: `Task ${args.task_id} and ${cancelledTaskIds.length - 1} dependent task(s) cancelled`,
+				message:
+					dependentCount > 0
+						? `Task ${args.task_id} and ${dependentCount} dependent task(s) cancelled`
+						: `Task ${args.task_id} cancelled`,
 			});
 		},
 
@@ -1100,8 +1105,8 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 			'Update task fields (title, description, priority, or dependencies). Works for tasks in any status.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
-				title: z.string().optional().describe('New title for the task'),
-				description: z.string().optional().describe('New description for the task'),
+				title: z.string().trim().min(1).optional().describe('New title for the task'),
+				description: z.string().trim().min(1).optional().describe('New description for the task'),
 				priority: z
 					.enum(['low', 'normal', 'high', 'urgent'])
 					.optional()
@@ -1126,6 +1131,8 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 			'Change a task status with transition validation. Use to retry failed tasks (needs_attention → pending), revive to review, or move between valid states.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
+				// 'draft' is intentionally excluded: tasks reach draft status only via the planning
+				// phase (planner agent creates them). The leader must not put tasks back to draft.
 				status: z
 					.enum(['pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled'])
 					.describe('New status for the task'),

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -991,26 +991,31 @@ export type RoomAgentMcpServer = ReturnType<typeof createRoomAgentMcpServer>;
 
 /**
  * Narrow config type for the leader context MCP server.
- * Excludes daemonHub and runtimeService since read-only tools do not need them.
+ * Includes daemonHub (optional) for emitting task update events to the UI.
  */
 export type LeaderContextMcpConfig = Pick<
 	RoomAgentToolsConfig,
-	'roomId' | 'goalManager' | 'taskManager' | 'groupRepo'
+	'roomId' | 'goalManager' | 'taskManager' | 'groupRepo' | 'daemonHub'
 >;
 
 /**
- * Create a minimal read-only MCP server for the Leader agent.
+ * Create an MCP server for the Leader agent with context and task management tools.
  *
  * Registered as `'leader-context'` (distinct from `'room-agent'` used by the full server).
- * Exposes only 4 read-only tools: list_goals, list_tasks, get_task_detail, get_room_status.
+ * Exposes read-only context tools plus task management tools the leader can use directly.
  *
- * The leader only needs context tools — it should NOT have write or human-only tools.
+ * Included tools:
+ *   - list_goals, list_tasks, get_task_detail, get_room_status: read-only context
+ *   - update_task: edit title, description, priority, or dependencies of any task
+ *   - cancel_task: cancel a task and cascade to pending dependents
+ *   - update_task_status: change task status with transition validation
+ *
  * Excluded tools and reasons:
  *   - approve_task / reject_task: human-only decisions
  *   - create_goal / update_goal: not the leader's role
- *   - create_task / update_task: leader delegates to worker via send_to_worker
- *   - cancel_task / stop_session: not the leader's role
- *   - set_task_status: leader uses complete_task / fail_task from leader-agent-tools instead
+ *   - create_task: leader delegates task creation to worker via send_to_worker
+ *   - stop_session: session management is handled by the runtime
+ *   - complete_task / fail_task: leader uses these from leader-agent-tools for the current task
  *   - send_message_to_task: leader uses send_to_worker from leader-agent-tools instead
  */
 export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
@@ -1049,6 +1054,45 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 			'Get an overview of the room state including goals, tasks, active groups, and tasks needing review',
 			{},
 			() => handlers.get_room_status()
+		),
+		tool(
+			'update_task',
+			'Update task fields (title, description, priority, or dependencies). Works for tasks in any status.',
+			{
+				task_id: z.string().describe('ID of the task to update'),
+				title: z.string().optional().describe('New title for the task'),
+				description: z.string().optional().describe('New description for the task'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.describe('New priority level'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('Full replacement list of dependency task IDs'),
+			},
+			(args) => handlers.update_task(args)
+		),
+		tool(
+			'cancel_task',
+			'Cancel a task. Cascades cancellation to any pending tasks that depend on it.',
+			{
+				task_id: z.string().describe('ID of the task to cancel'),
+			},
+			(args) => handlers.cancel_task(args)
+		),
+		tool(
+			'update_task_status',
+			'Change a task status with transition validation. Use to retry failed tasks (needs_attention → pending), revive to review, or move between valid states.',
+			{
+				task_id: z.string().describe('ID of the task to update'),
+				status: z
+					.enum(['pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled'])
+					.describe('New status for the task'),
+				result: z.string().optional().describe('Result summary (for completed status)'),
+				error: z.string().optional().describe('Error message (for needs_attention status)'),
+			},
+			(args) => handlers.set_task_status(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -234,7 +234,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				if (activeGroup && activeGroup.completedAt === null) {
 					return jsonResult({
 						success: false,
-						error: `Cannot cancel in_progress task ${args.task_id} without runtime service — the active worker session would not be stopped.`,
+						error: `Cannot cancel task ${args.task_id} (status '${task.status}') without runtime service — the active worker session would not be stopped.`,
 					});
 				}
 			}

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -138,6 +138,14 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('replan_goal');
 		});
 
+		it('should include task management tools in tool contract', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('update_task');
+			expect(prompt).toContain('cancel_task');
+			expect(prompt).toContain('update_task_status');
+			expect(prompt).toContain('Task Management Tools');
+		});
+
 		it('should NOT include task-specific context', () => {
 			const prompt = buildLeaderSystemPrompt(makeConfig());
 			// Task/goal details belong in buildLeaderTaskContext, not the system prompt
@@ -403,7 +411,7 @@ describe('Leader Agent', () => {
 			expect(init.mcpServers!['leader-agent-tools']).toBeDefined();
 		});
 
-		it('should include leader-context-tools MCP server for read-only context', () => {
+		it('should include leader-context-tools MCP server with context and task management tools', () => {
 			const callbacks = makeCallbacks();
 			const init = createLeaderAgentInit(makeConfig(), callbacks);
 			expect(init.mcpServers).toBeDefined();
@@ -415,8 +423,17 @@ describe('Leader Agent', () => {
 			// Verify it is the narrow leader-context server, not the full room-agent server
 			expect(ctxServer.name).toBe('leader-context');
 			const toolNames = Object.keys(ctxServer.instance._registeredTools).sort();
+			// Should include both read-only context tools and task management tools
 			expect(toolNames).toEqual(
-				['get_room_status', 'get_task_detail', 'list_goals', 'list_tasks'].sort()
+				[
+					'cancel_task',
+					'get_room_status',
+					'get_task_detail',
+					'list_goals',
+					'list_tasks',
+					'update_task',
+					'update_task_status',
+				].sort()
 			);
 		});
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1570,7 +1570,7 @@ describe('Room Agent Tools', () => {
 			expect(result.task.status).toBe('completed');
 		});
 
-		it('should allow status change without runtime even if group exists', async () => {
+		it('should reject status change to terminal state without runtime when active group exists', async () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
@@ -1580,13 +1580,13 @@ describe('Room Agent Tools', () => {
 			// Create an active group
 			insertGroup(taskId, 'awaiting_human');
 
-			// Handler without runtime service - should still allow transition
-			// (for backwards compatibility or when runtime is not available)
+			// Handler without runtime service - should FAIL since active group exists
+			// (would leave a zombie worker session if allowed)
 			const result = parseResult(
 				await handlers.set_task_status({ task_id: taskId, status: 'completed' })
 			);
-			expect(result.success).toBe(true);
-			expect(result.task.status).toBe('completed');
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('runtime service');
 		});
 	});
 
@@ -1731,24 +1731,6 @@ describe('Room Agent Tools', () => {
 			]);
 		});
 
-		it('should expose update_task for editing task fields', () => {
-			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
-			const names = getRegisteredToolNames(server as never);
-			expect(names).toContain('update_task');
-		});
-
-		it('should expose cancel_task for cancelling tasks', () => {
-			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
-			const names = getRegisteredToolNames(server as never);
-			expect(names).toContain('cancel_task');
-		});
-
-		it('should expose update_task_status for status transitions', () => {
-			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
-			const names = getRegisteredToolNames(server as never);
-			expect(names).toContain('update_task_status');
-		});
-
 		it('should NOT expose approve_task', () => {
 			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(server as never);
@@ -1836,6 +1818,21 @@ describe('Room Agent Tools', () => {
 				expect(updated.dependsOn).toContain(dep.id);
 			});
 
+			it('should reject self-dependency', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.update_task({ task_id: task.id, depends_on: [task.id] })
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('cannot depend on itself');
+			});
+
 			it('should fail gracefully when task not found', async () => {
 				const leaderHandlers = createRoomAgentToolHandlers({
 					roomId,
@@ -1852,7 +1849,7 @@ describe('Room Agent Tools', () => {
 		});
 
 		describe('cancel_task tool', () => {
-			it('should cancel a pending task', async () => {
+			it('should cancel a pending task and return cancelledTaskIds', async () => {
 				const task = await taskManager.createTask({ title: 'T', description: 'D' });
 				const leaderHandlers = createRoomAgentToolHandlers({
 					roomId,
@@ -1862,11 +1859,12 @@ describe('Room Agent Tools', () => {
 				});
 				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
 				expect(result.success).toBe(true);
+				expect(result.cancelledTaskIds).toContain(task.id);
 				const updated = await taskManager.getTask(task.id);
 				expect(updated?.status).toBe('cancelled');
 			});
 
-			it('should cascade cancellation to dependent pending tasks', async () => {
+			it('should cascade cancellation and include all cancelled IDs in response', async () => {
 				const parent = await taskManager.createTask({ title: 'Parent', description: 'D' });
 				const child = await taskManager.createTask({
 					title: 'Child',
@@ -1881,10 +1879,45 @@ describe('Room Agent Tools', () => {
 				});
 				const result = parseResult(await leaderHandlers.cancel_task({ task_id: parent.id }));
 				expect(result.success).toBe(true);
+				const cancelledIds = result.cancelledTaskIds as string[];
+				expect(cancelledIds).toContain(parent.id);
+				expect(cancelledIds).toContain(child.id);
 				const updatedParent = await taskManager.getTask(parent.id);
 				const updatedChild = await taskManager.getTask(child.id);
 				expect(updatedParent?.status).toBe('cancelled');
 				expect(updatedChild?.status).toBe('cancelled');
+			});
+
+			it('should reject cancellation of already-terminal tasks', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				await taskManager.startTask(task.id);
+				await taskManager.completeTask(task.id, 'done');
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('terminal state');
+			});
+
+			it('should reject cancellation of in_progress task with active group without runtimeService', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				await taskManager.startTask(task.id);
+				// Create an active group — triggers the guard
+				insertGroup(task.id, 'awaiting_worker');
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+					// no runtimeService — simulates leader context
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('runtime service');
 			});
 
 			it('should fail gracefully when task not found', async () => {
@@ -1917,6 +1950,25 @@ describe('Room Agent Tools', () => {
 				expect(result.success).toBe(true);
 				const updated = await taskManager.getTask(task.id);
 				expect(updated?.status).toBe('pending');
+			});
+
+			it('should reject transitioning in_progress task with active group to terminal status without runtimeService', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				await taskManager.startTask(task.id);
+				// Create an active group — triggers the guard
+				insertGroup(task.id, 'awaiting_worker');
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+					// no runtimeService — simulates leader context
+				});
+				const result = parseResult(
+					await leaderHandlers.set_task_status({ task_id: task.id, status: 'cancelled' })
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('runtime service');
 			});
 
 			it('should reject invalid status transitions', async () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1717,10 +1717,36 @@ describe('Room Agent Tools', () => {
 			return Object.keys(server.instance._registeredTools).sort();
 		}
 
-		it('should expose exactly the 4 read-only context tools', () => {
+		it('should expose the 7 leader tools (context + task management)', () => {
 			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(server as never);
-			expect(names).toEqual(['get_room_status', 'get_task_detail', 'list_goals', 'list_tasks']);
+			expect(names).toEqual([
+				'cancel_task',
+				'get_room_status',
+				'get_task_detail',
+				'list_goals',
+				'list_tasks',
+				'update_task',
+				'update_task_status',
+			]);
+		});
+
+		it('should expose update_task for editing task fields', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			expect(names).toContain('update_task');
+		});
+
+		it('should expose cancel_task for cancelling tasks', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			expect(names).toContain('cancel_task');
+		});
+
+		it('should expose update_task_status for status transitions', () => {
+			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
+			const names = getRegisteredToolNames(server as never);
+			expect(names).toContain('update_task_status');
 		});
 
 		it('should NOT expose approve_task', () => {
@@ -1735,22 +1761,193 @@ describe('Room Agent Tools', () => {
 			expect(names).not.toContain('reject_task');
 		});
 
-		it('should NOT expose any write tools', () => {
+		it('should NOT expose human-only or session management tools', () => {
 			const server = createLeaderContextMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(server as never);
-			const writeTools = [
+			const excluded = [
 				'create_goal',
 				'update_goal',
 				'create_task',
-				'update_task',
-				'cancel_task',
 				'stop_session',
-				'set_task_status',
 				'send_message_to_task',
+				'approve_task',
+				'reject_task',
 			];
-			for (const w of writeTools) {
+			for (const w of excluded) {
 				expect(names).not.toContain(w);
 			}
+		});
+
+		describe('update_task tool', () => {
+			it('should update task title and description', async () => {
+				const task = await taskManager.createTask({
+					title: 'Original title',
+					description: 'Original description',
+				});
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.update_task({
+						task_id: task.id,
+						title: 'Updated title',
+						description: 'Updated description',
+					})
+				);
+				expect(result.success).toBe(true);
+				const updated = result.task as { title: string; description: string };
+				expect(updated.title).toBe('Updated title');
+				expect(updated.description).toBe('Updated description');
+			});
+
+			it('should update task priority', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.update_task({ task_id: task.id, priority: 'urgent' })
+				);
+				expect(result.success).toBe(true);
+				const updated = result.task as { priority: string };
+				expect(updated.priority).toBe('urgent');
+			});
+
+			it('should update task dependencies', async () => {
+				const dep = await taskManager.createTask({ title: 'Dep', description: 'D' });
+				const task = await taskManager.createTask({ title: 'Task', description: 'D' });
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.update_task({ task_id: task.id, depends_on: [dep.id] })
+				);
+				expect(result.success).toBe(true);
+				const updated = result.task as { dependsOn: string[] };
+				expect(updated.dependsOn).toContain(dep.id);
+			});
+
+			it('should fail gracefully when task not found', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.update_task({ task_id: 'nonexistent', title: 'X' })
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toBeDefined();
+			});
+		});
+
+		describe('cancel_task tool', () => {
+			it('should cancel a pending task', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
+				expect(result.success).toBe(true);
+				const updated = await taskManager.getTask(task.id);
+				expect(updated?.status).toBe('cancelled');
+			});
+
+			it('should cascade cancellation to dependent pending tasks', async () => {
+				const parent = await taskManager.createTask({ title: 'Parent', description: 'D' });
+				const child = await taskManager.createTask({
+					title: 'Child',
+					description: 'D',
+					dependsOn: [parent.id],
+				});
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: parent.id }));
+				expect(result.success).toBe(true);
+				const updatedParent = await taskManager.getTask(parent.id);
+				const updatedChild = await taskManager.getTask(child.id);
+				expect(updatedParent?.status).toBe('cancelled');
+				expect(updatedChild?.status).toBe('cancelled');
+			});
+
+			it('should fail gracefully when task not found', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: 'nonexistent' }));
+				expect(result.success).toBe(false);
+				expect(result.error).toBeDefined();
+			});
+		});
+
+		describe('update_task_status tool (set_task_status handler)', () => {
+			it('should transition task from needs_attention to pending', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				await taskManager.startTask(task.id);
+				await taskManager.failTask(task.id, 'failed');
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.set_task_status({ task_id: task.id, status: 'pending' })
+				);
+				expect(result.success).toBe(true);
+				const updated = await taskManager.getTask(task.id);
+				expect(updated?.status).toBe('pending');
+			});
+
+			it('should reject invalid status transitions', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				// draft → completed is not a valid transition
+				const result = parseResult(
+					await leaderHandlers.set_task_status({ task_id: task.id, status: 'completed' })
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('Invalid status transition');
+			});
+
+			it('should fail gracefully when task not found', async () => {
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+				});
+				const result = parseResult(
+					await leaderHandlers.set_task_status({ task_id: 'nonexistent', status: 'pending' })
+				);
+				expect(result.success).toBe(false);
+				expect(result.error).toBeDefined();
+			});
 		});
 
 		it('should use the distinct MCP server name "leader-context"', () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1849,7 +1849,7 @@ describe('Room Agent Tools', () => {
 		});
 
 		describe('cancel_task tool', () => {
-			it('should cancel a pending task and return cancelledTaskIds', async () => {
+			it('should cancel a pending task and return cancelledTaskIds with clean message', async () => {
 				const task = await taskManager.createTask({ title: 'T', description: 'D' });
 				const leaderHandlers = createRoomAgentToolHandlers({
 					roomId,
@@ -1860,6 +1860,8 @@ describe('Room Agent Tools', () => {
 				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
 				expect(result.success).toBe(true);
 				expect(result.cancelledTaskIds).toContain(task.id);
+				// No "0 dependent" phrasing when there are no cascaded dependents
+				expect(result.message).not.toContain('0 dependent');
 				const updated = await taskManager.getTask(task.id);
 				expect(updated?.status).toBe('cancelled');
 			});
@@ -1908,6 +1910,24 @@ describe('Room Agent Tools', () => {
 				await taskManager.startTask(task.id);
 				// Create an active group — triggers the guard
 				insertGroup(task.id, 'awaiting_worker');
+				const leaderHandlers = createRoomAgentToolHandlers({
+					roomId,
+					goalManager,
+					taskManager,
+					groupRepo,
+					// no runtimeService — simulates leader context
+				});
+				const result = parseResult(await leaderHandlers.cancel_task({ task_id: task.id }));
+				expect(result.success).toBe(false);
+				expect(result.error).toContain('runtime service');
+			});
+
+			it('should reject cancellation of review task with active group without runtimeService', async () => {
+				const task = await taskManager.createTask({ title: 'T', description: 'D' });
+				await taskManager.startTask(task.id);
+				await taskManager.reviewTask(task.id);
+				// Create an active group — triggers the guard
+				insertGroup(task.id, 'awaiting_human');
 				const leaderHandlers = createRoomAgentToolHandlers({
 					roomId,
 					goalManager,


### PR DESCRIPTION
Leaders can now directly modify tasks without going through workers:
- update_task: edit title, description, priority, and dependencies
- cancel_task: cancel a task and cascade to pending dependents
- update_task_status: change task status with transition validation

Also adds daemonHub to TaskGroupManagerConfig/TaskGroupManager and
LeaderAgentConfig so task update events are emitted to the UI when
the leader modifies tasks. Updates leader system prompt to document
the new tools.
