### PR TITLE
feat: add leader progress summary at end of each turn

### DIFF
--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -55,12 +55,21 @@ export interface LeaderToolCallbacks {
 	sendToWorker(
 		groupId: string,
 		message: string,
-		mode?: 'steer' | 'queue'
+		mode?: 'steer' | 'queue',
+		progressSummary?: string
 	): Promise<LeaderToolResult>;
-	completeTask(groupId: string, summary: string): Promise<LeaderToolResult>;
-	failTask(groupId: string, reason: string): Promise<LeaderToolResult>;
-	replanGoal(groupId: string, reason: string): Promise<LeaderToolResult>;
-	submitForReview(groupId: string, prUrl: string): Promise<LeaderToolResult>;
+	completeTask(
+		groupId: string,
+		summary: string,
+		progressSummary?: string
+	): Promise<LeaderToolResult>;
+	failTask(groupId: string, reason: string, progressSummary?: string): Promise<LeaderToolResult>;
+	replanGoal(groupId: string, reason: string, progressSummary?: string): Promise<LeaderToolResult>;
+	submitForReview(
+		groupId: string,
+		prUrl: string,
+		progressSummary?: string
+	): Promise<LeaderToolResult>;
 }
 
 export interface LeaderAgentConfig {
@@ -119,6 +128,7 @@ export function buildLeaderSystemPrompt(config: LeaderAgentConfig): string {
 	return [
 		leaderRoleIntro(isPlanReview),
 		leaderToolContractSection(),
+		leaderProgressSummarySection(),
 		leaderPostApprovalSection(isPlanReview),
 		leaderPostRejectionSection(),
 		leaderWorkerQuestionsSection(),
@@ -166,6 +176,17 @@ You MUST call tools (no text-only final responses).
 - \`list_goals\`, \`list_tasks\`, \`get_task_detail\`, \`get_room_status\` — Inspect room state
 
 Do NOT respond with only text.`;
+}
+
+function leaderProgressSummarySection(): string {
+	return `\
+## Progress Summary (Required on every tool call)
+
+Every time you call a tool, include a \`progress_summary\` with 2-4 sentences covering:
+1. **What this task is about** — the goal and what needs to be accomplished
+2. **What has been done so far** — work completed across all iterations, key changes made
+
+This summary is shown to users so they can understand context when returning to a long-running task. Update it each turn to reflect cumulative progress.`;
 }
 
 function leaderPostApprovalSection(isPlanReview: boolean): string {
@@ -434,20 +455,33 @@ export function createLeaderToolHandlers(groupId: string, callbacks: LeaderToolC
 		async send_to_worker(args: {
 			message: string;
 			mode?: 'steer' | 'queue';
+			progress_summary?: string;
 		}): Promise<LeaderToolResult> {
-			return callbacks.sendToWorker(groupId, args.message, args.mode);
+			return callbacks.sendToWorker(groupId, args.message, args.mode, args.progress_summary);
 		},
-		async complete_task(args: { summary: string }): Promise<LeaderToolResult> {
-			return callbacks.completeTask(groupId, args.summary);
+		async complete_task(args: {
+			summary: string;
+			progress_summary?: string;
+		}): Promise<LeaderToolResult> {
+			return callbacks.completeTask(groupId, args.summary, args.progress_summary);
 		},
-		async fail_task(args: { reason: string }): Promise<LeaderToolResult> {
-			return callbacks.failTask(groupId, args.reason);
+		async fail_task(args: {
+			reason: string;
+			progress_summary?: string;
+		}): Promise<LeaderToolResult> {
+			return callbacks.failTask(groupId, args.reason, args.progress_summary);
 		},
-		async replan_goal(args: { reason: string }): Promise<LeaderToolResult> {
-			return callbacks.replanGoal(groupId, args.reason);
+		async replan_goal(args: {
+			reason: string;
+			progress_summary?: string;
+		}): Promise<LeaderToolResult> {
+			return callbacks.replanGoal(groupId, args.reason, args.progress_summary);
 		},
-		async submit_for_review(args: { pr_url: string }): Promise<LeaderToolResult> {
-			return callbacks.submitForReview(groupId, args.pr_url);
+		async submit_for_review(args: {
+			pr_url: string;
+			progress_summary?: string;
+		}): Promise<LeaderToolResult> {
+			return callbacks.submitForReview(groupId, args.pr_url, args.progress_summary);
 		},
 	};
 }
@@ -459,6 +493,13 @@ export function createLeaderToolHandlers(groupId: string, callbacks: LeaderToolC
 export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCallbacks) {
 	const handlers = createLeaderToolHandlers(groupId, callbacks);
 
+	const progressSummaryField = z
+		.string()
+		.optional()
+		.describe(
+			'Progress summary: (1) what this task is about, (2) what has been done/changed so far in this task. Keep it concise (2-4 sentences). This is shown to users to provide context when they return to this task.'
+		);
+
 	const tools = [
 		tool(
 			'send_to_worker',
@@ -469,6 +510,7 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 					.enum(['steer', 'queue'])
 					.optional()
 					.describe('Delivery mode: queue (default) or steer (immediate)'),
+				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.send_to_worker(args)
 		),
@@ -479,6 +521,7 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 				summary: z
 					.string()
 					.describe('Summary of what was accomplished and how it meets requirements'),
+				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.complete_task(args)
 		),
@@ -487,6 +530,7 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 			'Mark the task as not achievable',
 			{
 				reason: z.string().describe('Explanation of why the task cannot be completed'),
+				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.fail_task(args)
 		),
@@ -497,6 +541,7 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 				reason: z
 					.string()
 					.describe('What was tried, what went wrong, and why a different approach is needed'),
+				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.replan_goal(args)
 		),
@@ -505,6 +550,7 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 			'Work is done with a PR ready — free the group slot and park the task for human approval',
 			{
 				pr_url: z.string().min(1).describe('The GitHub PR URL for human review'),
+				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.submit_for_review(args)
 		),

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1931,7 +1931,13 @@ export class RoomRuntime {
 			this.messageHub.event(
 				'state.groupMessages.delta',
 				{
-					added: [{ type: 'status', text: payload?.text ?? kind, timestamp: now }],
+					added: [
+						{
+							type: kind === 'leader_summary' ? 'leader_summary' : 'status',
+							text: payload?.text ?? kind,
+							timestamp: now,
+						},
+					],
 					timestamp: now,
 				},
 				{ channel: `group:${groupId}` }

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -903,11 +903,20 @@ export class RoomRuntime {
 			summary?: string;
 			reason?: string;
 			pr_url?: string;
+			progress_summary?: string;
 		}
 	): Promise<LeaderToolResult> {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) {
 			return jsonResult({ success: false, error: `Group not found: ${groupId}` });
+		}
+
+		// Persist and emit progress summary whenever the leader provides one
+		if (params.progress_summary) {
+			this.groupRepo.setLeaderProgressSummary(groupId, params.progress_summary);
+			this.appendGroupEvent(groupId, 'leader_summary', {
+				text: `[Turn Summary] ${params.progress_summary}`,
+			});
 		}
 
 		// No state guard - tools always available
@@ -1246,20 +1255,41 @@ export class RoomRuntime {
 	 */
 	createLeaderCallbacks(groupId: string): LeaderToolCallbacks {
 		return {
-			sendToWorker: async (_groupId: string, message: string, mode?: 'steer' | 'queue') => {
-				return this.handleLeaderTool(groupId, 'send_to_worker', { message, mode });
+			sendToWorker: async (
+				_groupId: string,
+				message: string,
+				mode?: 'steer' | 'queue',
+				progressSummary?: string
+			) => {
+				return this.handleLeaderTool(groupId, 'send_to_worker', {
+					message,
+					mode,
+					progress_summary: progressSummary,
+				});
 			},
-			completeTask: async (_groupId: string, summary: string) => {
-				return this.handleLeaderTool(groupId, 'complete_task', { summary });
+			completeTask: async (_groupId: string, summary: string, progressSummary?: string) => {
+				return this.handleLeaderTool(groupId, 'complete_task', {
+					summary,
+					progress_summary: progressSummary,
+				});
 			},
-			failTask: async (_groupId: string, reason: string) => {
-				return this.handleLeaderTool(groupId, 'fail_task', { reason });
+			failTask: async (_groupId: string, reason: string, progressSummary?: string) => {
+				return this.handleLeaderTool(groupId, 'fail_task', {
+					reason,
+					progress_summary: progressSummary,
+				});
 			},
-			replanGoal: async (_groupId: string, reason: string) => {
-				return this.handleLeaderTool(groupId, 'replan_goal', { reason });
+			replanGoal: async (_groupId: string, reason: string, progressSummary?: string) => {
+				return this.handleLeaderTool(groupId, 'replan_goal', {
+					reason,
+					progress_summary: progressSummary,
+				});
 			},
-			submitForReview: async (_groupId: string, prUrl: string) => {
-				return this.handleLeaderTool(groupId, 'submit_for_review', { pr_url: prUrl });
+			submitForReview: async (_groupId: string, prUrl: string, progressSummary?: string) => {
+				return this.handleLeaderTool(groupId, 'submit_for_review', {
+					pr_url: prUrl,
+					progress_summary: progressSummary,
+				});
 			},
 		};
 	}

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -79,6 +79,11 @@ interface TaskGroupMetadata {
 	humanInterrupted?: boolean;
 	/** Gate failure history for dead loop detection */
 	gateFailures?: GateFailureRecord[];
+	/**
+	 * Latest progress summary provided by the leader at the end of each turn.
+	 * Summarizes (1) what the task is about and (2) what has been done/changed so far.
+	 */
+	leaderProgressSummary?: string;
 	/** Whether the group is paused waiting for a question to be answered */
 	waitingForQuestion?: boolean;
 	/** Which session is waiting for a question answer ('worker' | 'leader' | null) */
@@ -181,6 +186,11 @@ export interface SessionGroup {
 	 * Used by onLeaderTerminalState to drop spurious pre-work idle events.
 	 */
 	leaderHasWork: boolean;
+	/**
+	 * Latest progress summary provided by the leader at the end of each turn.
+	 * Summarizes (1) what the task is about and (2) what has been done/changed so far.
+	 */
+	leaderProgressSummary: string | null;
 	createdAt: number;
 	completedAt: number | null;
 }
@@ -632,6 +642,24 @@ export class SessionGroupRepository {
 	}
 
 	/**
+	 * Update the leader progress summary for a group without version check.
+	 * Called at the end of each leader turn to persist a summary of task progress.
+	 */
+	setLeaderProgressSummary(groupId: string, summary: string): void {
+		const raw = (
+			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<
+				string,
+				unknown
+			>
+		)?.metadata as string;
+		const currentMeta = this.parseMetadata(raw);
+		const merged = { ...currentMeta, leaderProgressSummary: summary };
+		this.db
+			.prepare(`UPDATE session_groups SET metadata = ? WHERE id = ?`)
+			.run(JSON.stringify(merged), groupId);
+	}
+
+	/**
 	 * Persist deferred Leader bootstrap configuration.
 	 * Stored in metadata so runtime restart can still lazy-create the leader session.
 	 */
@@ -855,6 +883,7 @@ export class SessionGroupRepository {
 			approvalSource: meta.approvalSource ?? null,
 			executionId: meta.executionId,
 			leaderHasWork: meta.leaderHasWork === true,
+			leaderProgressSummary: meta.leaderProgressSummary ?? null,
 			createdAt: row.created_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
 		};

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -666,7 +666,7 @@ export function setupTaskHandlers(
 					groupId: event.groupId,
 					sessionId: null,
 					role: 'system',
-					messageType: 'status',
+					messageType: event.kind === 'leader_summary' ? 'leader_summary' : 'status',
 					content: text,
 				};
 			}),

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -104,24 +104,29 @@ function makeCallbacks(): LeaderToolCallbacks & {
 	const calls: Array<{ method: string; args: unknown[] }> = [];
 	return {
 		calls,
-		async sendToWorker(groupId: string, message: string, mode?: 'steer' | 'queue') {
-			calls.push({ method: 'sendToWorker', args: [groupId, message, mode] });
+		async sendToWorker(
+			groupId: string,
+			message: string,
+			mode?: 'steer' | 'queue',
+			progressSummary?: string
+		) {
+			calls.push({ method: 'sendToWorker', args: [groupId, message, mode, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
-		async completeTask(groupId: string, summary: string) {
-			calls.push({ method: 'completeTask', args: [groupId, summary] });
+		async completeTask(groupId: string, summary: string, progressSummary?: string) {
+			calls.push({ method: 'completeTask', args: [groupId, summary, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
-		async failTask(groupId: string, reason: string) {
-			calls.push({ method: 'failTask', args: [groupId, reason] });
+		async failTask(groupId: string, reason: string, progressSummary?: string) {
+			calls.push({ method: 'failTask', args: [groupId, reason, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
-		async replanGoal(groupId: string, reason: string) {
-			calls.push({ method: 'replanGoal', args: [groupId, reason] });
+		async replanGoal(groupId: string, reason: string, progressSummary?: string) {
+			calls.push({ method: 'replanGoal', args: [groupId, reason, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
-		async submitForReview(groupId: string, prUrl: string) {
-			calls.push({ method: 'submitForReview', args: [groupId, prUrl] });
+		async submitForReview(groupId: string, prUrl: string, progressSummary?: string) {
+			calls.push({ method: 'submitForReview', args: [groupId, prUrl, progressSummary] });
 			return { content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }] };
 		},
 	};
@@ -144,6 +149,19 @@ describe('Leader Agent', () => {
 			expect(prompt).toContain('cancel_task');
 			expect(prompt).toContain('update_task_status');
 			expect(prompt).toContain('Task Management Tools');
+		});
+
+		it('should include progress summary section', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig());
+			expect(prompt).toContain('Progress Summary');
+			expect(prompt).toContain('progress_summary');
+			expect(prompt).toContain('What has been done so far');
+		});
+
+		it('should include progress summary section for plan review', () => {
+			const prompt = buildLeaderSystemPrompt(makeConfig({ reviewContext: 'plan_review' }));
+			expect(prompt).toContain('Progress Summary');
+			expect(prompt).toContain('progress_summary');
 		});
 
 		it('should NOT include task-specific context', () => {
@@ -325,7 +343,12 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('sendToWorker');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'Fix the error handling', undefined]);
+			expect(callbacks.calls[0].args).toEqual([
+				'group-1',
+				'Fix the error handling',
+				undefined,
+				undefined,
+			]);
 		});
 
 		it('should route send_to_worker mode to callback', async () => {
@@ -336,7 +359,26 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('sendToWorker');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'Queue this', 'queue']);
+			expect(callbacks.calls[0].args).toEqual(['group-1', 'Queue this', 'queue', undefined]);
+		});
+
+		it('should route send_to_worker with progress_summary to callback', async () => {
+			const callbacks = makeCallbacks();
+			const handlers = createLeaderToolHandlers('group-1', callbacks);
+
+			await handlers.send_to_worker({
+				message: 'Fix the tests',
+				progress_summary: 'Task adds a health endpoint. Worker created the route but tests fail.',
+			});
+
+			expect(callbacks.calls).toHaveLength(1);
+			expect(callbacks.calls[0].method).toBe('sendToWorker');
+			expect(callbacks.calls[0].args).toEqual([
+				'group-1',
+				'Fix the tests',
+				undefined,
+				'Task adds a health endpoint. Worker created the route but tests fail.',
+			]);
 		});
 
 		it('should route complete_task to callback with groupId', async () => {
@@ -347,7 +389,25 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('completeTask');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'All requirements met']);
+			expect(callbacks.calls[0].args).toEqual(['group-1', 'All requirements met', undefined]);
+		});
+
+		it('should route complete_task with progress_summary to callback', async () => {
+			const callbacks = makeCallbacks();
+			const handlers = createLeaderToolHandlers('group-1', callbacks);
+
+			await handlers.complete_task({
+				summary: 'All requirements met',
+				progress_summary: 'Task adds GET /health. Endpoint implemented with tests, PR merged.',
+			});
+
+			expect(callbacks.calls).toHaveLength(1);
+			expect(callbacks.calls[0].method).toBe('completeTask');
+			expect(callbacks.calls[0].args).toEqual([
+				'group-1',
+				'All requirements met',
+				'Task adds GET /health. Endpoint implemented with tests, PR merged.',
+			]);
 		});
 
 		it('should route fail_task to callback with groupId', async () => {
@@ -358,7 +418,7 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('failTask');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'API does not support this']);
+			expect(callbacks.calls[0].args).toEqual(['group-1', 'API does not support this', undefined]);
 		});
 
 		it('should route submit_for_review to callback with groupId and prUrl', async () => {
@@ -369,7 +429,11 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('submitForReview');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'https://github.com/org/repo/pull/42']);
+			expect(callbacks.calls[0].args).toEqual([
+				'group-1',
+				'https://github.com/org/repo/pull/42',
+				undefined,
+			]);
 		});
 
 		it('should route replan_goal to callback with groupId', async () => {
@@ -383,6 +447,7 @@ describe('Leader Agent', () => {
 			expect(callbacks.calls[0].args).toEqual([
 				'group-1',
 				'Wrong approach, need different strategy',
+				undefined,
 			]);
 		});
 	});

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -686,4 +686,81 @@ describe('RoomRuntime leader tools', () => {
 			}
 		});
 	});
+
+	describe('progress_summary handling', () => {
+		it('persists progress_summary to group metadata when provided with send_to_worker', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+			const summary =
+				'Task adds GET /health endpoint. Worker created the route but tests are failing.';
+
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Fix the failing tests',
+				progress_summary: summary,
+			});
+
+			const updated = ctx.groupRepo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBe(summary);
+		});
+
+		it('persists progress_summary to group metadata when provided with fail_task', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+			const summary = 'Task adds GET /health. Worker could not resolve a dependency conflict.';
+
+			await ctx.runtime.handleLeaderTool(group.id, 'fail_task', {
+				reason: 'Dependency conflict unresolvable',
+				progress_summary: summary,
+			});
+
+			const updated = ctx.groupRepo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBe(summary);
+		});
+
+		it('emits a leader_summary group event when progress_summary is provided', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+			const summary = 'Task adds a health endpoint. Worker created route; tests pass.';
+
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Looks good, approve',
+				progress_summary: summary,
+			});
+
+			const { events } = ctx.groupRepo.getEvents(group.id);
+			const summaryEvent = events.find((e) => e.kind === 'leader_summary');
+			expect(summaryEvent).toBeDefined();
+			const payload = JSON.parse(summaryEvent!.payloadJson!);
+			expect(payload.text).toContain(summary);
+		});
+
+		it('does not persist or emit event when progress_summary is absent', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Fix the tests',
+			});
+
+			const updated = ctx.groupRepo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBeNull();
+
+			const { events } = ctx.groupRepo.getEvents(group.id);
+			const summaryEvent = events.find((e) => e.kind === 'leader_summary');
+			expect(summaryEvent).toBeUndefined();
+		});
+
+		it('updates progress_summary on subsequent tool calls', async () => {
+			const { group } = await spawnAndRouteToLeader(ctx);
+
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Fix the tests',
+				progress_summary: 'First iteration: route created, tests failing.',
+			});
+
+			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
+				message: 'Update docs too',
+				progress_summary: 'Second iteration: tests fixed, docs missing.',
+			});
+
+			const updated = ctx.groupRepo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBe('Second iteration: tests fixed, docs missing.');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -654,4 +654,38 @@ describe('SessionGroupRepository', () => {
 			expect(history).toHaveLength(1);
 		});
 	});
+
+	describe('setLeaderProgressSummary', () => {
+		it('should default to null when not set', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			expect(group.leaderProgressSummary).toBeNull();
+		});
+
+		it('should persist a progress summary', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const summary =
+				'Task adds GET /health endpoint. Worker created the route; tests are failing.';
+			repo.setLeaderProgressSummary(group.id, summary);
+			const updated = repo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBe(summary);
+		});
+
+		it('should overwrite an existing progress summary', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.setLeaderProgressSummary(group.id, 'First summary');
+			repo.setLeaderProgressSummary(group.id, 'Updated summary after second iteration');
+			const updated = repo.getGroup(group.id)!;
+			expect(updated.leaderProgressSummary).toBe('Updated summary after second iteration');
+		});
+
+		it('should preserve existing metadata fields when setting summary', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.setApproved(group.id, true);
+			repo.setLeaderProgressSummary(group.id, 'Progress so far');
+			const updated = repo.getGroup(group.id)!;
+			// Both fields should be set
+			expect(updated.approved).toBe(true);
+			expect(updated.leaderProgressSummary).toBe('Progress so far');
+		});
+	});
 });

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -83,6 +83,20 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 			},
 		} as unknown as SDKMessage;
 	}
+
+	// Leader summary messages are plain text with distinct rendering
+	if (msg.messageType === 'leader_summary') {
+		return {
+			type: 'leader_summary',
+			text: msg.content,
+			_taskMeta: {
+				authorRole: 'system',
+				authorSessionId: '',
+				turnId: `leader-summary-${msg.id}`,
+				iteration: 0,
+			},
+		} as unknown as SDKMessage;
+	}
 	try {
 		return JSON.parse(msg.content) as SDKMessage;
 	} catch {
@@ -382,6 +396,38 @@ export function TaskConversationRenderer({
 							<div class="flex-1 h-px bg-dark-700" />
 							<span class="text-xs text-gray-500 whitespace-nowrap">{statusText}</span>
 							<div class="flex-1 h-px bg-dark-700" />
+						</div>
+					);
+				}
+
+				// Leader summary messages: render as a context card
+				if (raw.type === 'leader_summary') {
+					const rawText = typeof raw.text === 'string' ? raw.text : '';
+					const summaryText = rawText.startsWith('[Turn Summary] ')
+						? rawText.slice('[Turn Summary] '.length)
+						: rawText;
+					return (
+						<div
+							key={key}
+							class="my-1.5 rounded border border-purple-800/40 bg-purple-950/20 px-3 py-2"
+						>
+							<div class="flex items-center gap-1.5 mb-1">
+								<svg
+									class="w-3 h-3 text-purple-400 flex-shrink-0"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+									/>
+								</svg>
+								<span class="text-xs font-medium text-purple-400">Turn Summary</span>
+							</div>
+							<p class="text-xs text-gray-300 leading-relaxed">{summaryText}</p>
 						</div>
 					);
 				}


### PR DESCRIPTION
Leader agents now include a progress_summary parameter when calling
any tool (send_to_worker, complete_task, fail_task, replan_goal,
submit_for_review). The summary covers:
1. What the task is about (goal and requirements)
2. What has been done/changed so far across all iterations

The summary is persisted in session group metadata
(leaderProgressSummary field) and emitted as a 'leader_summary'
group event so it appears in the task conversation timeline.
This helps users understand context when returning to a long-running
task after multiple iterations.
