### PR TITLE
feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3)

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -458,19 +458,18 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	};
 
 	// Space workflow definition events (global events - use 'global' as sessionId)
-	'space.workflow.created': {
+	// NOTE: namespace is 'spaceWorkflow.*' (not 'space.workflow.*') — matches SpaceStore subscriptions in M5
+	'spaceWorkflow.created': {
 		sessionId: string;
 		spaceId: string;
-		workflowId: string;
 		workflow: import('@neokai/shared').SpaceWorkflow;
 	};
-	'space.workflow.updated': {
+	'spaceWorkflow.updated': {
 		sessionId: string;
 		spaceId: string;
-		workflowId: string;
 		workflow: import('@neokai/shared').SpaceWorkflow;
 	};
-	'space.workflow.deleted': {
+	'spaceWorkflow.deleted': {
 		sessionId: string;
 		spaceId: string;
 		workflowId: string;

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -458,19 +458,19 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	};
 
 	// Space workflow definition events (global events - use 'global' as sessionId)
-	'spaceWorkflow.created': {
+	'space.workflow.created': {
 		sessionId: string;
 		spaceId: string;
 		workflowId: string;
 		workflow: import('@neokai/shared').SpaceWorkflow;
 	};
-	'spaceWorkflow.updated': {
+	'space.workflow.updated': {
 		sessionId: string;
 		spaceId: string;
 		workflowId: string;
 		workflow: import('@neokai/shared').SpaceWorkflow;
 	};
-	'spaceWorkflow.deleted': {
+	'space.workflow.deleted': {
 		sessionId: string;
 		spaceId: string;
 		workflowId: string;

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -457,6 +457,25 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		agentId: string;
 	};
 
+	// Space workflow definition events (global events - use 'global' as sessionId)
+	'spaceWorkflow.created': {
+		sessionId: string;
+		spaceId: string;
+		workflowId: string;
+		workflow: import('@neokai/shared').SpaceWorkflow;
+	};
+	'spaceWorkflow.updated': {
+		sessionId: string;
+		spaceId: string;
+		workflowId: string;
+		workflow: import('@neokai/shared').SpaceWorkflow;
+	};
+	'spaceWorkflow.deleted': {
+		sessionId: string;
+		spaceId: string;
+		workflowId: string;
+	};
+
 	// Feature Flag events (PHASE 3: Gradual rollout infrastructure)
 	'featureFlag.updated': {
 		sessionId: string;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -49,11 +49,13 @@ import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
 import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
+import type { SpaceAgentLookup } from '../space/managers/space-workflow-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
+import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -199,9 +201,18 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 	// Space agent handlers
 	setupSpaceAgentHandlers(deps.messageHub, deps.daemonHub, deps.spaceAgentManager);
 
-	// Space workflow handlers
+	// Space workflow handlers — wire SpaceAgentRepository as agentLookup so custom
+	// agent refs in workflow steps are validated against actual SpaceAgent records.
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
-	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo);
+	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
+	const agentLookup: SpaceAgentLookup = {
+		getAgentById(spaceId: string, id: string) {
+			const agent = spaceAgentRepo.getById(id);
+			if (!agent || agent.spaceId !== spaceId) return null;
+			return { id: agent.id, name: agent.name };
+		},
+	};
+	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
 
 	setupSpaceWorkflowHandlers(
 		deps.messageHub,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -45,12 +45,15 @@ import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
 import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
+import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
+import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
+import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -195,6 +198,17 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 
 	// Space agent handlers
 	setupSpaceAgentHandlers(deps.messageHub, deps.daemonHub, deps.spaceAgentManager);
+
+	// Space workflow handlers
+	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
+	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo);
+
+	setupSpaceWorkflowHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceWorkflowManager,
+		deps.daemonHub
+	);
 
 	// Return cleanup function to stop background services
 	return () => {

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -4,9 +4,9 @@
  * RPC handlers for SpaceWorkflow CRUD operations:
  * - spaceWorkflow.create    - Create a workflow in a Space
  * - spaceWorkflow.list      - List workflows in a Space
- * - spaceWorkflow.get       - Get a workflow by ID (optional spaceId ownership check)
- * - spaceWorkflow.update    - Update workflow fields (optional spaceId ownership check)
- * - spaceWorkflow.delete    - Delete a workflow (optional spaceId ownership check)
+ * - spaceWorkflow.get       - Get a workflow by ID (optional spaceId: existence + ownership check)
+ * - spaceWorkflow.update    - Update workflow fields (optional spaceId: existence + ownership check)
+ * - spaceWorkflow.delete    - Delete a workflow (optional spaceId: existence + ownership check)
  * - spaceWorkflow.setDefault - Unsupported (concept removed; use explicit workflowId or AI auto-select)
  *
  * Events emitted (space.* hierarchy):
@@ -89,12 +89,22 @@ export function setupSpaceWorkflowHandlers(
 			throw new Error('id is required');
 		}
 
+		// When spaceId is provided: verify the space exists before fetching the workflow.
+		// This matches the space-task-handlers.ts pattern and surfaces "Space not found"
+		// correctly instead of silently returning an orphaned workflow.
+		if (params.spaceId) {
+			const space = await spaceManager.getSpace(params.spaceId);
+			if (!space) {
+				throw new Error(`Space not found: ${params.spaceId}`);
+			}
+		}
+
 		const workflow = workflowManager.getWorkflow(params.id);
 		if (!workflow) {
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
 
-		// Optional spaceId ownership check — reject if caller provides a spaceId that doesn't match
+		// Ownership check — reject if caller's spaceId doesn't match the workflow's owner
 		if (params.spaceId && workflow.spaceId !== params.spaceId) {
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
@@ -110,8 +120,14 @@ export function setupSpaceWorkflowHandlers(
 			throw new Error('id is required');
 		}
 
-		// Ownership check before mutating: if spaceId is provided, verify ownership
+		// When spaceId is provided: verify space exists and ownership before mutating.
+		// The ownership check requires fetching the workflow here; updateWorkflow will
+		// re-fetch internally (synchronous SQLite — acceptable for this pattern).
 		if (params.spaceId) {
+			const space = await spaceManager.getSpace(params.spaceId);
+			if (!space) {
+				throw new Error(`Space not found: ${params.spaceId}`);
+			}
 			const existing = workflowManager.getWorkflow(params.id);
 			if (!existing) {
 				throw new Error(`Workflow not found: ${params.id}`);
@@ -150,13 +166,21 @@ export function setupSpaceWorkflowHandlers(
 			throw new Error('id is required');
 		}
 
+		// When spaceId is provided: verify space exists before fetching the workflow.
+		if (params.spaceId) {
+			const space = await spaceManager.getSpace(params.spaceId);
+			if (!space) {
+				throw new Error(`Space not found: ${params.spaceId}`);
+			}
+		}
+
 		// Fetch before deleting — needed for the event payload and optional ownership check
 		const workflow = workflowManager.getWorkflow(params.id);
 		if (!workflow) {
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
 
-		// Optional spaceId ownership check
+		// Ownership check
 		if (params.spaceId && workflow.spaceId !== params.spaceId) {
 			throw new Error(`Workflow not found: ${params.id}`);
 		}

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -7,12 +7,14 @@
  * - spaceWorkflow.get       - Get a workflow by ID (optional spaceId: existence + ownership check)
  * - spaceWorkflow.update    - Update workflow fields (optional spaceId: existence + ownership check)
  * - spaceWorkflow.delete    - Delete a workflow (optional spaceId: existence + ownership check)
- * - spaceWorkflow.setDefault - Unsupported (concept removed; use explicit workflowId or AI auto-select)
  *
- * Events emitted (space.* hierarchy):
- * - space.workflow.created
- * - space.workflow.updated
- * - space.workflow.deleted
+ * No spaceWorkflow.setDefault — default selection is removed from the design.
+ * Workflow selection uses only explicit workflowId or AI auto-select.
+ *
+ * Events emitted (spaceWorkflow.* namespace — matches SpaceStore subscriptions in M5):
+ * - spaceWorkflow.created
+ * - spaceWorkflow.updated
+ * - spaceWorkflow.deleted
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -50,14 +52,13 @@ export function setupSpaceWorkflowHandlers(
 		const workflow = workflowManager.createWorkflow(params);
 
 		daemonHub
-			.emit('space.workflow.created', {
+			.emit('spaceWorkflow.created', {
 				sessionId: 'global',
 				spaceId: params.spaceId,
-				workflowId: workflow.id,
 				workflow,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit space.workflow.created:', err);
+				log.warn('Failed to emit spaceWorkflow.created:', err);
 			});
 
 		return { workflow };
@@ -145,14 +146,13 @@ export function setupSpaceWorkflowHandlers(
 		}
 
 		daemonHub
-			.emit('space.workflow.updated', {
+			.emit('spaceWorkflow.updated', {
 				sessionId: 'global',
 				spaceId: workflow.spaceId,
-				workflowId: id,
 				workflow,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit space.workflow.updated:', err);
+				log.warn('Failed to emit spaceWorkflow.updated:', err);
 			});
 
 		return { workflow };
@@ -191,25 +191,15 @@ export function setupSpaceWorkflowHandlers(
 		}
 
 		daemonHub
-			.emit('space.workflow.deleted', {
+			.emit('spaceWorkflow.deleted', {
 				sessionId: 'global',
 				spaceId: workflow.spaceId,
 				workflowId: params.id,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit space.workflow.deleted:', err);
+				log.warn('Failed to emit spaceWorkflow.deleted:', err);
 			});
 
 		return { success: true };
-	});
-
-	// ─── spaceWorkflow.setDefault ────────────────────────────────────────────
-	// The default workflow concept was removed in the design (Task 3.2).
-	// Workflow selection uses either an explicit workflowId or AI auto-select at runtime.
-	// Callers that attempt to set a default will receive a clear error rather than silent failure.
-	messageHub.onRequest('spaceWorkflow.setDefault', async (_data) => {
-		throw new Error(
-			'spaceWorkflow.setDefault is not supported. Use explicit workflowId or AI auto-select.'
-		);
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -51,6 +51,8 @@ export function setupSpaceWorkflowHandlers(
 
 		const workflow = workflowManager.createWorkflow(params);
 
+		// sessionId: 'global' — spaceWorkflow.* events are global broadcast events,
+		// not channel-scoped. The SpaceStore (M5) will subscribe globally and filter by spaceId.
 		daemonHub
 			.emit('spaceWorkflow.created', {
 				sessionId: 'global',
@@ -190,7 +192,9 @@ export function setupSpaceWorkflowHandlers(
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
 
-		daemonHub
+		// Await so subscribers (e.g. SpaceStore in M5) see the deletion before the handler returns,
+		// consistent with how spaceAgent.delete emits spaceAgent.deleted.
+		await daemonHub
 			.emit('spaceWorkflow.deleted', {
 				sessionId: 'global',
 				spaceId: workflow.spaceId,

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -4,10 +4,15 @@
  * RPC handlers for SpaceWorkflow CRUD operations:
  * - spaceWorkflow.create    - Create a workflow in a Space
  * - spaceWorkflow.list      - List workflows in a Space
- * - spaceWorkflow.get       - Get a workflow by ID
- * - spaceWorkflow.update    - Update workflow fields
- * - spaceWorkflow.delete    - Delete a workflow
- * - spaceWorkflow.setDefault - No-op stub (default concept removed in design; use explicit workflowId or AI auto-select)
+ * - spaceWorkflow.get       - Get a workflow by ID (optional spaceId ownership check)
+ * - spaceWorkflow.update    - Update workflow fields (optional spaceId ownership check)
+ * - spaceWorkflow.delete    - Delete a workflow (optional spaceId ownership check)
+ * - spaceWorkflow.setDefault - Unsupported (concept removed; use explicit workflowId or AI auto-select)
+ *
+ * Events emitted (space.* hierarchy):
+ * - space.workflow.created
+ * - space.workflow.updated
+ * - space.workflow.deleted
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -45,14 +50,14 @@ export function setupSpaceWorkflowHandlers(
 		const workflow = workflowManager.createWorkflow(params);
 
 		daemonHub
-			.emit('spaceWorkflow.created', {
+			.emit('space.workflow.created', {
 				sessionId: 'global',
 				spaceId: params.spaceId,
 				workflowId: workflow.id,
 				workflow,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit spaceWorkflow.created:', err);
+				log.warn('Failed to emit space.workflow.created:', err);
 			});
 
 		return { workflow };
@@ -78,7 +83,7 @@ export function setupSpaceWorkflowHandlers(
 
 	// ─── spaceWorkflow.get ───────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflow.get', async (data) => {
-		const params = data as { id: string };
+		const params = data as { id: string; spaceId?: string };
 
 		if (!params.id) {
 			throw new Error('id is required');
@@ -89,18 +94,34 @@ export function setupSpaceWorkflowHandlers(
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
 
+		// Optional spaceId ownership check — reject if caller provides a spaceId that doesn't match
+		if (params.spaceId && workflow.spaceId !== params.spaceId) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
 		return { workflow };
 	});
 
 	// ─── spaceWorkflow.update ────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflow.update', async (data) => {
-		const params = data as { id: string } & UpdateSpaceWorkflowParams;
+		const params = data as { id: string; spaceId?: string } & UpdateSpaceWorkflowParams;
 
 		if (!params.id) {
 			throw new Error('id is required');
 		}
 
-		const { id, ...updateParams } = params;
+		// Ownership check before mutating: if spaceId is provided, verify ownership
+		if (params.spaceId) {
+			const existing = workflowManager.getWorkflow(params.id);
+			if (!existing) {
+				throw new Error(`Workflow not found: ${params.id}`);
+			}
+			if (existing.spaceId !== params.spaceId) {
+				throw new Error(`Workflow not found: ${params.id}`);
+			}
+		}
+
+		const { id, spaceId: _spaceId, ...updateParams } = params;
 
 		const workflow = workflowManager.updateWorkflow(id, updateParams);
 		if (!workflow) {
@@ -108,14 +129,14 @@ export function setupSpaceWorkflowHandlers(
 		}
 
 		daemonHub
-			.emit('spaceWorkflow.updated', {
+			.emit('space.workflow.updated', {
 				sessionId: 'global',
 				spaceId: workflow.spaceId,
 				workflowId: id,
 				workflow,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit spaceWorkflow.updated:', err);
+				log.warn('Failed to emit space.workflow.updated:', err);
 			});
 
 		return { workflow };
@@ -123,15 +144,20 @@ export function setupSpaceWorkflowHandlers(
 
 	// ─── spaceWorkflow.delete ────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflow.delete', async (data) => {
-		const params = data as { id: string };
+		const params = data as { id: string; spaceId?: string };
 
 		if (!params.id) {
 			throw new Error('id is required');
 		}
 
-		// Fetch before deleting so we have spaceId for the event
+		// Fetch before deleting — needed for the event payload and optional ownership check
 		const workflow = workflowManager.getWorkflow(params.id);
 		if (!workflow) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		// Optional spaceId ownership check
+		if (params.spaceId && workflow.spaceId !== params.spaceId) {
 			throw new Error(`Workflow not found: ${params.id}`);
 		}
 
@@ -141,13 +167,13 @@ export function setupSpaceWorkflowHandlers(
 		}
 
 		daemonHub
-			.emit('spaceWorkflow.deleted', {
+			.emit('space.workflow.deleted', {
 				sessionId: 'global',
 				spaceId: workflow.spaceId,
 				workflowId: params.id,
 			})
 			.catch((err) => {
-				log.warn('Failed to emit spaceWorkflow.deleted:', err);
+				log.warn('Failed to emit space.workflow.deleted:', err);
 			});
 
 		return { success: true };
@@ -155,13 +181,11 @@ export function setupSpaceWorkflowHandlers(
 
 	// ─── spaceWorkflow.setDefault ────────────────────────────────────────────
 	// The default workflow concept was removed in the design (Task 3.2).
-	// Workflow selection uses either an explicit workflowId or AI auto-select.
-	// This handler is a documented no-op stub for API compatibility.
+	// Workflow selection uses either an explicit workflowId or AI auto-select at runtime.
+	// Callers that attempt to set a default will receive a clear error rather than silent failure.
 	messageHub.onRequest('spaceWorkflow.setDefault', async (_data) => {
-		return {
-			success: false,
-			reason:
-				'Default workflow selection is not supported. Use explicit workflowId or AI auto-select.',
-		};
+		throw new Error(
+			'spaceWorkflow.setDefault is not supported. Use explicit workflowId or AI auto-select.'
+		);
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -1,0 +1,167 @@
+/**
+ * Space Workflow RPC Handlers
+ *
+ * RPC handlers for SpaceWorkflow CRUD operations:
+ * - spaceWorkflow.create    - Create a workflow in a Space
+ * - spaceWorkflow.list      - List workflows in a Space
+ * - spaceWorkflow.get       - Get a workflow by ID
+ * - spaceWorkflow.update    - Update workflow fields
+ * - spaceWorkflow.delete    - Delete a workflow
+ * - spaceWorkflow.setDefault - No-op stub (default concept removed in design; use explicit workflowId or AI auto-select)
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { CreateSpaceWorkflowParams, UpdateSpaceWorkflowParams } from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('space-workflow-handlers');
+
+export function setupSpaceWorkflowHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager,
+	workflowManager: SpaceWorkflowManager,
+	daemonHub: DaemonHub
+): void {
+	// ─── spaceWorkflow.create ────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.create', async (data) => {
+		const params = data as CreateSpaceWorkflowParams;
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.name || params.name.trim() === '') {
+			throw new Error('name is required');
+		}
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const workflow = workflowManager.createWorkflow(params);
+
+		daemonHub
+			.emit('spaceWorkflow.created', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				workflowId: workflow.id,
+				workflow,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceWorkflow.created:', err);
+			});
+
+		return { workflow };
+	});
+
+	// ─── spaceWorkflow.list ──────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.list', async (data) => {
+		const params = data as { spaceId: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const workflows = workflowManager.listWorkflows(params.spaceId);
+		return { workflows };
+	});
+
+	// ─── spaceWorkflow.get ───────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.get', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const workflow = workflowManager.getWorkflow(params.id);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		return { workflow };
+	});
+
+	// ─── spaceWorkflow.update ────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.update', async (data) => {
+		const params = data as { id: string } & UpdateSpaceWorkflowParams;
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const { id, ...updateParams } = params;
+
+		const workflow = workflowManager.updateWorkflow(id, updateParams);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${id}`);
+		}
+
+		daemonHub
+			.emit('spaceWorkflow.updated', {
+				sessionId: 'global',
+				spaceId: workflow.spaceId,
+				workflowId: id,
+				workflow,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceWorkflow.updated:', err);
+			});
+
+		return { workflow };
+	});
+
+	// ─── spaceWorkflow.delete ────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.delete', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		// Fetch before deleting so we have spaceId for the event
+		const workflow = workflowManager.getWorkflow(params.id);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		const deleted = workflowManager.deleteWorkflow(params.id);
+		if (!deleted) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		daemonHub
+			.emit('spaceWorkflow.deleted', {
+				sessionId: 'global',
+				spaceId: workflow.spaceId,
+				workflowId: params.id,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceWorkflow.deleted:', err);
+			});
+
+		return { success: true };
+	});
+
+	// ─── spaceWorkflow.setDefault ────────────────────────────────────────────
+	// The default workflow concept was removed in the design (Task 3.2).
+	// Workflow selection uses either an explicit workflowId or AI auto-select.
+	// This handler is a documented no-op stub for API compatibility.
+	messageHub.onRequest('spaceWorkflow.setDefault', async (_data) => {
+		return {
+			success: false,
+			reason:
+				'Default workflow selection is not supported. Use explicit workflowId or AI auto-select.',
+		};
+	});
+}

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -3,15 +3,15 @@
  *
  * Covers:
  * - spaceWorkflow.create: happy path, missing spaceId, missing/empty name, space not found,
- *   validation error propagation, event emission (space.workflow.created)
+ *   validation error propagation, event emission (spaceWorkflow.created)
  * - spaceWorkflow.list: happy path, missing spaceId, space not found
  * - spaceWorkflow.get: happy path, missing id, workflow not found, optional spaceId space-existence
  *   check, optional spaceId ownership check
  * - spaceWorkflow.update: happy path, missing id, workflow not found, optional spaceId
- *   space-existence check, ownership check, validation error, event emission (space.workflow.updated)
+ *   space-existence check, ownership check, validation error, event emission (spaceWorkflow.updated)
  * - spaceWorkflow.delete: happy path, missing id, workflow not found, optional spaceId
- *   space-existence check, ownership check, event emission (space.workflow.deleted)
- * - spaceWorkflow.setDefault: throws (unsupported — concept removed)
+ *   space-existence check, ownership check, event emission (spaceWorkflow.deleted)
+ * - spaceWorkflow.setDefault: NOT registered (concept removed from design)
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
@@ -149,7 +149,7 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.create', () => {
 		beforeEach(() => setup());
 
-		it('creates a workflow and emits space.workflow.created', async () => {
+		it('creates a workflow and emits spaceWorkflow.created', async () => {
 			const result = (await call('spaceWorkflow.create', {
 				spaceId: 'space-1',
 				name: 'Test Workflow',
@@ -158,10 +158,9 @@ describe('space-workflow-handlers', () => {
 
 			expect(result.workflow).toEqual(mockWorkflow);
 			expect(workflowManager.createWorkflow).toHaveBeenCalledTimes(1);
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.created', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.created', {
 				sessionId: 'global',
 				spaceId: 'space-1',
-				workflowId: mockWorkflow.id,
 				workflow: mockWorkflow,
 			});
 		});
@@ -309,7 +308,7 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.update', () => {
 		beforeEach(() => setup());
 
-		it('updates a workflow and emits space.workflow.updated', async () => {
+		it('updates a workflow and emits spaceWorkflow.updated', async () => {
 			const updated = { ...mockWorkflow, name: 'Updated' };
 			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(updated);
 
@@ -320,10 +319,9 @@ describe('space-workflow-handlers', () => {
 
 			expect(result.workflow.name).toBe('Updated');
 			expect(workflowManager.updateWorkflow).toHaveBeenCalledWith('wf-1', { name: 'Updated' });
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.updated', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.updated', {
 				sessionId: 'global',
 				spaceId: updated.spaceId,
-				workflowId: 'wf-1',
 				workflow: updated,
 			});
 		});
@@ -387,12 +385,12 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.delete', () => {
 		beforeEach(() => setup());
 
-		it('deletes a workflow and emits space.workflow.deleted', async () => {
+		it('deletes a workflow and emits spaceWorkflow.deleted', async () => {
 			const result = (await call('spaceWorkflow.delete', { id: 'wf-1' })) as { success: boolean };
 
 			expect(result.success).toBe(true);
 			expect(workflowManager.deleteWorkflow).toHaveBeenCalledWith('wf-1');
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.deleted', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.deleted', {
 				sessionId: 'global',
 				spaceId: mockWorkflow.spaceId,
 				workflowId: 'wf-1',
@@ -439,22 +437,13 @@ describe('space-workflow-handlers', () => {
 		});
 	});
 
-	// ─── spaceWorkflow.setDefault ──────────────────────────────────────────────
+	// ─── spaceWorkflow.setDefault (removed from design) ───────────────────────
 
 	describe('spaceWorkflow.setDefault', () => {
 		beforeEach(() => setup());
 
-		it('throws — default workflow concept is not supported', async () => {
-			await expect(
-				call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' })
-			).rejects.toThrow('spaceWorkflow.setDefault is not supported');
-		});
-
-		it('does not emit any event', async () => {
-			await expect(
-				call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' })
-			).rejects.toThrow();
-			expect(daemonHub.emit).not.toHaveBeenCalled();
+		it('does not register spaceWorkflow.setDefault (removed from design)', () => {
+			expect(handlers.has('spaceWorkflow.setDefault')).toBe(false);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -5,11 +5,12 @@
  * - spaceWorkflow.create: happy path, missing spaceId, missing/empty name, space not found,
  *   validation error propagation, event emission (space.workflow.created)
  * - spaceWorkflow.list: happy path, missing spaceId, space not found
- * - spaceWorkflow.get: happy path, missing id, workflow not found, optional spaceId ownership
- * - spaceWorkflow.update: happy path, missing id, workflow not found, validation error,
- *   event emission (space.workflow.updated), optional spaceId ownership
- * - spaceWorkflow.delete: happy path, missing id, workflow not found, event emission
- *   (space.workflow.deleted), optional spaceId ownership
+ * - spaceWorkflow.get: happy path, missing id, workflow not found, optional spaceId space-existence
+ *   check, optional spaceId ownership check
+ * - spaceWorkflow.update: happy path, missing id, workflow not found, optional spaceId
+ *   space-existence check, ownership check, validation error, event emission (space.workflow.updated)
+ * - spaceWorkflow.delete: happy path, missing id, workflow not found, optional spaceId
+ *   space-existence check, ownership check, event emission (space.workflow.deleted)
  * - spaceWorkflow.setDefault: throws (unsupported — concept removed)
  */
 
@@ -261,7 +262,7 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.get', () => {
 		beforeEach(() => setup());
 
-		it('returns the workflow when found', async () => {
+		it('returns the workflow when found (no spaceId)', async () => {
 			const result = (await call('spaceWorkflow.get', { id: 'wf-1' })) as {
 				workflow: SpaceWorkflow;
 			};
@@ -275,6 +276,14 @@ describe('space-workflow-handlers', () => {
 				spaceId: 'space-1',
 			})) as { workflow: SpaceWorkflow };
 			expect(result.workflow).toEqual(mockWorkflow);
+		});
+
+		it('throws Space not found when spaceId is provided but space does not exist', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.get', { id: 'wf-1', spaceId: 'deleted-space' })
+			).rejects.toThrow('Space not found: deleted-space');
+			expect(workflowManager.getWorkflow).not.toHaveBeenCalled();
 		});
 
 		it('throws when spaceId does not match workflow owner', async () => {
@@ -317,6 +326,15 @@ describe('space-workflow-handlers', () => {
 				workflowId: 'wf-1',
 				workflow: updated,
 			});
+		});
+
+		it('throws Space not found when spaceId is provided but space does not exist', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.update', { id: 'wf-1', spaceId: 'deleted-space', name: 'X' })
+			).rejects.toThrow('Space not found: deleted-space');
+			expect(workflowManager.getWorkflow).not.toHaveBeenCalled();
+			expect(workflowManager.updateWorkflow).not.toHaveBeenCalled();
 		});
 
 		it('rejects when optional spaceId does not match workflow owner', async () => {
@@ -381,6 +399,16 @@ describe('space-workflow-handlers', () => {
 			});
 		});
 
+		it('throws Space not found when spaceId is provided but space does not exist', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.delete', { id: 'wf-1', spaceId: 'deleted-space' })
+			).rejects.toThrow('Space not found: deleted-space');
+			expect(workflowManager.getWorkflow).not.toHaveBeenCalled();
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalled();
+			expect(daemonHub.emit).not.toHaveBeenCalled();
+		});
+
 		it('rejects when optional spaceId does not match workflow owner', async () => {
 			await expect(
 				call('spaceWorkflow.delete', { id: 'wf-1', spaceId: 'space-other' })
@@ -423,9 +451,9 @@ describe('space-workflow-handlers', () => {
 		});
 
 		it('does not emit any event', async () => {
-			await call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' }).catch(
-				() => {}
-			);
+			await expect(
+				call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' })
+			).rejects.toThrow();
 			expect(daemonHub.emit).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -51,8 +51,7 @@ const mockWorkflow: SpaceWorkflow = {
 		{
 			id: 'step-1',
 			name: 'Code',
-			agentRefType: 'builtin',
-			agentRef: 'coder',
+			agentId: 'agent-uuid-1',
 			order: 0,
 		},
 	],
@@ -153,7 +152,7 @@ describe('space-workflow-handlers', () => {
 			const result = (await call('spaceWorkflow.create', {
 				spaceId: 'space-1',
 				name: 'Test Workflow',
-				steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+				steps: [{ name: 'Code', agentId: 'agent-uuid-1' }],
 			})) as { workflow: SpaceWorkflow };
 
 			expect(result.workflow).toEqual(mockWorkflow);
@@ -202,7 +201,7 @@ describe('space-workflow-handlers', () => {
 				call('spaceWorkflow.create', {
 					spaceId: 'space-1',
 					name: 'Test Workflow',
-					steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+					steps: [{ name: 'Code', agentId: 'agent-uuid-1' }],
 				})
 			).rejects.toThrow('already exists in this space');
 		});
@@ -364,19 +363,19 @@ describe('space-workflow-handlers', () => {
 			);
 		});
 
-		it('propagates step validation error (invalid builtin agentRef)', async () => {
+		it('propagates step validation error (unknown agentId)', async () => {
 			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockImplementation(() => {
-				throw new WorkflowValidationError('step[0]: invalid builtin agentRef "leader"');
+				throw new WorkflowValidationError(
+					'step[0]: agentId "unknown-uuid" does not match any SpaceAgent in this space'
+				);
 			});
 
 			await expect(
 				call('spaceWorkflow.update', {
 					id: 'wf-1',
-					steps: [
-						{ id: 's1', name: 'Lead', agentRefType: 'builtin', agentRef: 'leader', order: 0 },
-					],
+					steps: [{ id: 's1', name: 'Lead', agentId: 'unknown-uuid', order: 0 }],
 				})
-			).rejects.toThrow('invalid builtin agentRef');
+			).rejects.toThrow('does not match any SpaceAgent in this space');
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Tests for Space Workflow RPC Handlers
+ *
+ * Covers:
+ * - spaceWorkflow.create: happy path, missing spaceId, missing/empty name, space not found,
+ *   validation error propagation, event emission
+ * - spaceWorkflow.list: happy path, missing spaceId, space not found
+ * - spaceWorkflow.get: happy path, missing id, workflow not found
+ * - spaceWorkflow.update: happy path, missing id, workflow not found, validation error,
+ *   event emission
+ * - spaceWorkflow.delete: happy path, missing id, workflow not found, event emission
+ * - spaceWorkflow.setDefault: always returns success:false (stub)
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceWorkflow } from '@neokai/shared';
+import { setupSpaceWorkflowHandlers } from '../../../src/lib/rpc-handlers/space-workflow-handlers';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
+import { WorkflowValidationError } from '../../../src/lib/space/managers/space-workflow-manager';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockWorkflow: SpaceWorkflow = {
+	id: 'wf-1',
+	spaceId: 'space-1',
+	name: 'Test Workflow',
+	description: 'A test workflow',
+	steps: [
+		{
+			id: 'step-1',
+			name: 'Code',
+			agentRefType: 'builtin',
+			agentRef: 'coder',
+			order: 0,
+		},
+	],
+	rules: [],
+	tags: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function createMockWorkflowManager(
+	workflow: SpaceWorkflow | null = mockWorkflow
+): SpaceWorkflowManager {
+	return {
+		createWorkflow: mock(() => workflow!),
+		getWorkflow: mock(() => workflow),
+		listWorkflows: mock(() => (workflow ? [workflow] : [])),
+		updateWorkflow: mock(() => ({ ...workflow!, name: 'Updated' })),
+		deleteWorkflow: mock(() => true),
+	} as unknown as SpaceWorkflowManager;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('space-workflow-handlers', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let workflowManager: SpaceWorkflowManager;
+
+	function setup(space: Space | null = mockSpace, workflow: SpaceWorkflow | null = mockWorkflow) {
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager(space);
+		workflowManager = createMockWorkflowManager(workflow);
+		setupSpaceWorkflowHandlers(hub, spaceManager, workflowManager, daemonHub);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	// ─── spaceWorkflow.create ──────────────────────────────────────────────────
+
+	describe('spaceWorkflow.create', () => {
+		beforeEach(() => setup());
+
+		it('creates a workflow and emits spaceWorkflow.created', async () => {
+			const result = (await call('spaceWorkflow.create', {
+				spaceId: 'space-1',
+				name: 'Test Workflow',
+				steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+			})) as { workflow: SpaceWorkflow };
+
+			expect(result.workflow).toEqual(mockWorkflow);
+			expect(workflowManager.createWorkflow).toHaveBeenCalledTimes(1);
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.created', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				workflowId: mockWorkflow.id,
+				workflow: mockWorkflow,
+			});
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceWorkflow.create', { name: 'Wf' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when name is missing', async () => {
+			await expect(call('spaceWorkflow.create', { spaceId: 'space-1' })).rejects.toThrow(
+				'name is required'
+			);
+		});
+
+		it('throws when name is empty string', async () => {
+			await expect(
+				call('spaceWorkflow.create', { spaceId: 'space-1', name: '   ' })
+			).rejects.toThrow('name is required');
+		});
+
+		it('throws when space not found', async () => {
+			setup(null);
+			await expect(call('spaceWorkflow.create', { spaceId: 'ghost', name: 'Wf' })).rejects.toThrow(
+				'Space not found: ghost'
+			);
+			expect(workflowManager.createWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('propagates WorkflowValidationError from manager', async () => {
+			(workflowManager.createWorkflow as ReturnType<typeof mock>).mockImplementation(() => {
+				throw new WorkflowValidationError(
+					'A workflow named "Test Workflow" already exists in this space'
+				);
+			});
+
+			await expect(
+				call('spaceWorkflow.create', {
+					spaceId: 'space-1',
+					name: 'Test Workflow',
+					steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+				})
+			).rejects.toThrow('already exists in this space');
+		});
+
+		it('propagates step validation error from manager', async () => {
+			(workflowManager.createWorkflow as ReturnType<typeof mock>).mockImplementation(() => {
+				throw new WorkflowValidationError('A workflow must have at least one step');
+			});
+
+			await expect(
+				call('spaceWorkflow.create', {
+					spaceId: 'space-1',
+					name: 'Empty',
+					steps: [],
+				})
+			).rejects.toThrow('at least one step');
+		});
+	});
+
+	// ─── spaceWorkflow.list ────────────────────────────────────────────────────
+
+	describe('spaceWorkflow.list', () => {
+		beforeEach(() => setup());
+
+		it('lists workflows for a space', async () => {
+			const result = (await call('spaceWorkflow.list', { spaceId: 'space-1' })) as {
+				workflows: SpaceWorkflow[];
+			};
+			expect(result.workflows).toEqual([mockWorkflow]);
+			expect(workflowManager.listWorkflows).toHaveBeenCalledWith('space-1');
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceWorkflow.list', {})).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when space not found', async () => {
+			setup(null);
+			await expect(call('spaceWorkflow.list', { spaceId: 'ghost' })).rejects.toThrow(
+				'Space not found: ghost'
+			);
+			expect(workflowManager.listWorkflows).not.toHaveBeenCalled();
+		});
+
+		it('returns empty list when space has no workflows', async () => {
+			setup(mockSpace, null);
+			const result = (await call('spaceWorkflow.list', { spaceId: 'space-1' })) as {
+				workflows: SpaceWorkflow[];
+			};
+			expect(result.workflows).toEqual([]);
+		});
+	});
+
+	// ─── spaceWorkflow.get ─────────────────────────────────────────────────────
+
+	describe('spaceWorkflow.get', () => {
+		beforeEach(() => setup());
+
+		it('returns the workflow when found', async () => {
+			const result = (await call('spaceWorkflow.get', { id: 'wf-1' })) as {
+				workflow: SpaceWorkflow;
+			};
+			expect(result.workflow).toEqual(mockWorkflow);
+			expect(workflowManager.getWorkflow).toHaveBeenCalledWith('wf-1');
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('spaceWorkflow.get', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when workflow not found', async () => {
+			setup(mockSpace, null);
+			await expect(call('spaceWorkflow.get', { id: 'ghost' })).rejects.toThrow(
+				'Workflow not found: ghost'
+			);
+		});
+	});
+
+	// ─── spaceWorkflow.update ──────────────────────────────────────────────────
+
+	describe('spaceWorkflow.update', () => {
+		beforeEach(() => setup());
+
+		it('updates a workflow and emits spaceWorkflow.updated', async () => {
+			const updated = { ...mockWorkflow, name: 'Updated' };
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(updated);
+
+			const result = (await call('spaceWorkflow.update', {
+				id: 'wf-1',
+				name: 'Updated',
+			})) as { workflow: SpaceWorkflow };
+
+			expect(result.workflow.name).toBe('Updated');
+			expect(workflowManager.updateWorkflow).toHaveBeenCalledWith('wf-1', { name: 'Updated' });
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.updated', {
+				sessionId: 'global',
+				spaceId: updated.spaceId,
+				workflowId: 'wf-1',
+				workflow: updated,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('spaceWorkflow.update', { name: 'X' })).rejects.toThrow('id is required');
+		});
+
+		it('throws when workflow not found', async () => {
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(null);
+			await expect(call('spaceWorkflow.update', { id: 'ghost', name: 'X' })).rejects.toThrow(
+				'Workflow not found: ghost'
+			);
+			expect(daemonHub.emit).not.toHaveBeenCalled();
+		});
+
+		it('propagates WorkflowValidationError from manager (e.g. duplicate name)', async () => {
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockImplementation(() => {
+				throw new WorkflowValidationError('A workflow named "Dupe" already exists in this space');
+			});
+
+			await expect(call('spaceWorkflow.update', { id: 'wf-1', name: 'Dupe' })).rejects.toThrow(
+				'already exists in this space'
+			);
+		});
+
+		it('propagates step validation error (invalid builtin agentRef)', async () => {
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockImplementation(() => {
+				throw new WorkflowValidationError('step[0]: invalid builtin agentRef "leader"');
+			});
+
+			await expect(
+				call('spaceWorkflow.update', {
+					id: 'wf-1',
+					steps: [
+						{ id: 's1', name: 'Lead', agentRefType: 'builtin', agentRef: 'leader', order: 0 },
+					],
+				})
+			).rejects.toThrow('invalid builtin agentRef');
+		});
+	});
+
+	// ─── spaceWorkflow.delete ──────────────────────────────────────────────────
+
+	describe('spaceWorkflow.delete', () => {
+		beforeEach(() => setup());
+
+		it('deletes a workflow and emits spaceWorkflow.deleted', async () => {
+			const result = (await call('spaceWorkflow.delete', { id: 'wf-1' })) as { success: boolean };
+
+			expect(result.success).toBe(true);
+			expect(workflowManager.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.deleted', {
+				sessionId: 'global',
+				spaceId: mockWorkflow.spaceId,
+				workflowId: 'wf-1',
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('spaceWorkflow.delete', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when workflow not found (getWorkflow returns null)', async () => {
+			setup(mockSpace, null);
+			await expect(call('spaceWorkflow.delete', { id: 'ghost' })).rejects.toThrow(
+				'Workflow not found: ghost'
+			);
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalled();
+			expect(daemonHub.emit).not.toHaveBeenCalled();
+		});
+
+		it('throws when deleteWorkflow returns false', async () => {
+			(workflowManager.deleteWorkflow as ReturnType<typeof mock>).mockReturnValue(false);
+
+			await expect(call('spaceWorkflow.delete', { id: 'wf-1' })).rejects.toThrow(
+				'Workflow not found: wf-1'
+			);
+		});
+	});
+
+	// ─── spaceWorkflow.setDefault ──────────────────────────────────────────────
+
+	describe('spaceWorkflow.setDefault', () => {
+		beforeEach(() => setup());
+
+		it('returns success:false (stub — default concept removed)', async () => {
+			const result = (await call('spaceWorkflow.setDefault', {
+				spaceId: 'space-1',
+				workflowId: 'wf-1',
+			})) as { success: boolean; reason: string };
+
+			expect(result.success).toBe(false);
+			expect(result.reason).toContain('not supported');
+		});
+
+		it('does not emit any event', async () => {
+			await call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' });
+			expect(daemonHub.emit).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-handlers.test.ts
@@ -3,13 +3,14 @@
  *
  * Covers:
  * - spaceWorkflow.create: happy path, missing spaceId, missing/empty name, space not found,
- *   validation error propagation, event emission
+ *   validation error propagation, event emission (space.workflow.created)
  * - spaceWorkflow.list: happy path, missing spaceId, space not found
- * - spaceWorkflow.get: happy path, missing id, workflow not found
+ * - spaceWorkflow.get: happy path, missing id, workflow not found, optional spaceId ownership
  * - spaceWorkflow.update: happy path, missing id, workflow not found, validation error,
- *   event emission
+ *   event emission (space.workflow.updated), optional spaceId ownership
  * - spaceWorkflow.delete: happy path, missing id, workflow not found, event emission
- * - spaceWorkflow.setDefault: always returns success:false (stub)
+ *   (space.workflow.deleted), optional spaceId ownership
+ * - spaceWorkflow.setDefault: throws (unsupported — concept removed)
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
@@ -147,7 +148,7 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.create', () => {
 		beforeEach(() => setup());
 
-		it('creates a workflow and emits spaceWorkflow.created', async () => {
+		it('creates a workflow and emits space.workflow.created', async () => {
 			const result = (await call('spaceWorkflow.create', {
 				spaceId: 'space-1',
 				name: 'Test Workflow',
@@ -156,7 +157,7 @@ describe('space-workflow-handlers', () => {
 
 			expect(result.workflow).toEqual(mockWorkflow);
 			expect(workflowManager.createWorkflow).toHaveBeenCalledTimes(1);
-			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.created', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.created', {
 				sessionId: 'global',
 				spaceId: 'space-1',
 				workflowId: mockWorkflow.id,
@@ -268,6 +269,20 @@ describe('space-workflow-handlers', () => {
 			expect(workflowManager.getWorkflow).toHaveBeenCalledWith('wf-1');
 		});
 
+		it('accepts matching optional spaceId', async () => {
+			const result = (await call('spaceWorkflow.get', {
+				id: 'wf-1',
+				spaceId: 'space-1',
+			})) as { workflow: SpaceWorkflow };
+			expect(result.workflow).toEqual(mockWorkflow);
+		});
+
+		it('throws when spaceId does not match workflow owner', async () => {
+			await expect(
+				call('spaceWorkflow.get', { id: 'wf-1', spaceId: 'space-other' })
+			).rejects.toThrow('Workflow not found: wf-1');
+		});
+
 		it('throws when id is missing', async () => {
 			await expect(call('spaceWorkflow.get', {})).rejects.toThrow('id is required');
 		});
@@ -285,7 +300,7 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.update', () => {
 		beforeEach(() => setup());
 
-		it('updates a workflow and emits spaceWorkflow.updated', async () => {
+		it('updates a workflow and emits space.workflow.updated', async () => {
 			const updated = { ...mockWorkflow, name: 'Updated' };
 			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(updated);
 
@@ -296,12 +311,19 @@ describe('space-workflow-handlers', () => {
 
 			expect(result.workflow.name).toBe('Updated');
 			expect(workflowManager.updateWorkflow).toHaveBeenCalledWith('wf-1', { name: 'Updated' });
-			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.updated', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.updated', {
 				sessionId: 'global',
 				spaceId: updated.spaceId,
 				workflowId: 'wf-1',
 				workflow: updated,
 			});
+		});
+
+		it('rejects when optional spaceId does not match workflow owner', async () => {
+			await expect(
+				call('spaceWorkflow.update', { id: 'wf-1', spaceId: 'space-other', name: 'X' })
+			).rejects.toThrow('Workflow not found: wf-1');
+			expect(workflowManager.updateWorkflow).not.toHaveBeenCalled();
 		});
 
 		it('throws when id is missing', async () => {
@@ -347,16 +369,24 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.delete', () => {
 		beforeEach(() => setup());
 
-		it('deletes a workflow and emits spaceWorkflow.deleted', async () => {
+		it('deletes a workflow and emits space.workflow.deleted', async () => {
 			const result = (await call('spaceWorkflow.delete', { id: 'wf-1' })) as { success: boolean };
 
 			expect(result.success).toBe(true);
 			expect(workflowManager.deleteWorkflow).toHaveBeenCalledWith('wf-1');
-			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.deleted', {
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflow.deleted', {
 				sessionId: 'global',
 				spaceId: mockWorkflow.spaceId,
 				workflowId: 'wf-1',
 			});
+		});
+
+		it('rejects when optional spaceId does not match workflow owner', async () => {
+			await expect(
+				call('spaceWorkflow.delete', { id: 'wf-1', spaceId: 'space-other' })
+			).rejects.toThrow('Workflow not found: wf-1');
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalled();
+			expect(daemonHub.emit).not.toHaveBeenCalled();
 		});
 
 		it('throws when id is missing', async () => {
@@ -386,18 +416,16 @@ describe('space-workflow-handlers', () => {
 	describe('spaceWorkflow.setDefault', () => {
 		beforeEach(() => setup());
 
-		it('returns success:false (stub — default concept removed)', async () => {
-			const result = (await call('spaceWorkflow.setDefault', {
-				spaceId: 'space-1',
-				workflowId: 'wf-1',
-			})) as { success: boolean; reason: string };
-
-			expect(result.success).toBe(false);
-			expect(result.reason).toContain('not supported');
+		it('throws — default workflow concept is not supported', async () => {
+			await expect(
+				call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' })
+			).rejects.toThrow('spaceWorkflow.setDefault is not supported');
 		});
 
 		it('does not emit any event', async () => {
-			await call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' });
+			await call('spaceWorkflow.setDefault', { spaceId: 'space-1', workflowId: 'wf-1' }).catch(
+				() => {}
+			);
 			expect(daemonHub.emit).not.toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
- Register spaceWorkflow.created/updated/deleted in DaemonEventMap
- Add space-workflow-handlers.ts: create, list, get, update, delete, setDefault (stub)
- Wire SpaceWorkflowManager singleton via SpaceWorkflowRepository in setupRPCHandlers()
- Emit DaemonHub events on mutations (created/updated/deleted)
- 25 unit tests covering all handlers, error paths, and event emission
