### PR TITLE
docs: update multi-agent space task docs with simplified workflow selection design

### DIFF
--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
@@ -189,7 +189,6 @@ Create a single DB migration that creates ALL Space-related tables. Since these 
      name TEXT NOT NULL,
      description TEXT NOT NULL DEFAULT '',
      rules TEXT NOT NULL DEFAULT '[]',
-     is_default INTEGER NOT NULL DEFAULT 0,
      tags TEXT NOT NULL DEFAULT '[]',
      config TEXT,
      created_at INTEGER NOT NULL,
@@ -299,6 +298,7 @@ Create a single DB migration that creates ALL Space-related tables. Since these 
 - CASCADE deletes work correctly for the full entity hierarchy
 - All workflow/agent columns are built into tables from the start (no ALTER TABLE)
 - No `space_goals` table — goals are not part of the Space system
+- No `is_default` column in `space_workflows` — there is no default workflow concept; selection is explicit workflowId or AI auto-select
 - Migration test passes
 - No modifications to any existing tables
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -172,8 +172,7 @@ Build the data access and business logic layers for workflows within Spaces. The
      - At least one step required
      - Step order contiguous (0, 1, 2, ...)
      - Gate command validation: `quality_check` → allowlist only; `custom` → relative path, no `..`; `timeoutMs` within range 0–300000
-   - Business logic:
-     - Workflow selection is either explicit workflowId (caller-provided) or AI auto-select via `list_workflows` + `start_workflow_run`. No default workflow concept.
+   - Business logic: workflow selection is either explicit workflowId (caller-provided) or AI auto-select via `list_workflows` + `start_workflow_run`. No default workflow concept, no `isDefault` flag.
 
 3. Export from `packages/daemon/src/lib/space/index.ts`
 
@@ -190,7 +189,7 @@ Build the data access and business logic layers for workflows within Spaces. The
 - Repository handles CRUD with proper step management using `space_workflows`/`space_workflow_steps` tables
 - Manager validates workflow integrity including gate security
 - Agent reference validation queries `SpaceAgentManager` (NOT a nonexistent `CustomAgentManager`)
-- Default workflow switching works correctly
+- No `isDefault` flag on `SpaceWorkflow` — workflow selection is explicit workflowId or AI auto-select only
 - All files in Space namespace — nothing in `packages/daemon/src/lib/room/`
 - Unit tests cover all paths
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
@@ -223,7 +222,7 @@ Add RPC handlers for workflow CRUD using the `spaceWorkflow.*` namespace. Regist
    - `spaceWorkflow.get { id }` → `{ workflow }`
    - `spaceWorkflow.update { id, ... }` → `{ workflow }`
    - `spaceWorkflow.delete { id }` → `{ success }`
-   - `spaceWorkflow.setDefault { spaceId, workflowId }` → `{ success }`
+   - **No `spaceWorkflow.setDefault`** — there is no default workflow concept
 
 3. Wire handlers in `packages/daemon/src/lib/rpc-handlers/index.ts` (via `setupRPCHandlers()` — add new registration only, do not modify existing handler setup)
 
@@ -248,7 +247,7 @@ Add RPC handlers for workflow CRUD using the `spaceWorkflow.*` namespace. Regist
 
 **Description:**
 
-Create built-in workflow templates that serve as defaults and examples. Also create the seeding utility. All files in Space namespace.
+Create built-in workflow templates that serve as examples. All files in Space namespace.
 
 **Subtasks:**
 
@@ -259,22 +258,16 @@ Create built-in workflow templates that serve as defaults and examples. Also cre
 
 2. Each template includes appropriate gates with only allowlisted commands
 
-3. `getBuiltInWorkflows(): SpaceWorkflow[]` — returns templates without space-specific IDs
+3. `getBuiltInWorkflows(): SpaceWorkflow[]` — returns templates without space-specific IDs (no `isDefault` flag, no seeding logic)
 
-4. `seedDefaultWorkflow(spaceId: string, workflowManager: SpaceWorkflowManager): Promise<void>`:
-   - Idempotent: checks if space already has a default workflow
-   - Seeds `CODING_WORKFLOW` as default
-   - **Call site wired in Task 4.2** (in the `space.create` RPC handler, after `SpaceManager.createSpace()` returns), not here
-
-5. Write unit tests:
+4. Write unit tests:
    - Template structure validation
    - All agent refs are valid builtins (no 'leader')
-   - Idempotent seeding
 
 **Acceptance criteria:**
 - Three built-in workflow templates defined
 - Templates mirror existing behavior (Leader is implicit, not a step)
-- `seedDefaultWorkflow` implemented and tested but NOT wired (that's M4)
+- No `seedDefaultWorkflow` — there is no default workflow concept; users pick or the Space agent auto-selects via AI
 - All files in `packages/daemon/src/lib/space/workflows/` (NOT `room/workflows/`)
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -216,7 +216,7 @@ Build `SpaceRuntimeService` for managing `SpaceRuntime` lifecycle, and configure
 
 5. Create RPC handler for starting workflow runs in `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts`:
    - `spaceWorkflowRun.start { spaceId, workflowId, title, description? }` → `{ run: SpaceWorkflowRun }`:
-     - `workflowId` is **required** — callers must provide it (UI workflow picker) or the Space agent selects it via AI auto-select. Return an error if omitted.
+     - `workflowId` is **required** — callers must provide it (UI workflow picker) or the Space agent selects it via AI auto-select (the Space agent calls `list_workflows`, reasons about the best fit, then calls `start_workflow_run` with its chosen `workflowId` — `workflowId` is always present at the RPC boundary). Return an error if omitted.
      - Validate `workflowId` exists in the space
      - Creates `SpaceWorkflowRun` record via `SpaceWorkflowRunRepository`
      - Calls `SpaceRuntimeService.createOrGetRuntime(spaceId)` then `runtime.startWorkflowRun()` to create the executor and first step's tasks

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -124,7 +124,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 
 3. **Starting a workflow run**:
    - `startWorkflowRun(spaceId, workflowId, title, description?)` → creates `SpaceWorkflowRun` record, creates `WorkflowExecutor`, evaluates entry gate of first step, creates first step's `SpaceTask` records
-   - `workflowId` is always required — either provided explicitly by the caller or chosen by the Space agent via `list_workflows` + `start_workflow_run` (AI auto-select). No default workflow fallback.
+   - `workflowId` is **always required** — either the caller provides it explicitly (UI picker, API) or the Space agent selects it via AI auto-select (`list_workflows` → reason → `start_workflow_run`). There is no default workflow fallback.
    - Store executor in map
 
 4. **Standalone tasks** (no workflow):
@@ -156,12 +156,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
    - Remove from map when: run completes, fails, is cancelled
    - Hook into `SpaceWorkflowRun` status change handlers
 
-9. **Wire `seedDefaultWorkflow`** from Task 3.4:
-   - Call in the `space.create` RPC handler (in `space-handlers.ts`), **after** `SpaceManager.createSpace()` returns — the handler has access to both `SpaceManager` and `SpaceWorkflowManager`, whereas `SpaceManager` itself is constructed without workflow manager dependency
-   - Idempotent: safe if space already has a workflow
-   - **This is in the Space RPC handler** — NOT in `room-manager.ts`
-
-10. Write integration tests:
+9. Write integration tests:
     - Start workflow run → executor created → first step tasks created
     - First step `SpaceTask` records created with correct agent and task-type
     - Planning-step tasks use planning group path + draft promotion
@@ -182,7 +177,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 - Standalone tasks work without a workflow
 - Executors rehydrated on startup, cleaned up on completion
 - `advance()` creates `SpaceTask` DB records only; tick loop handles group spawning
-- `seedDefaultWorkflow` wired into `space.create` RPC handler (NOT `room-manager.ts`)
+- No `seedDefaultWorkflow` — workflow selection uses explicit workflowId or AI auto-select only
 - Integration tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 
@@ -220,9 +215,9 @@ Build `SpaceRuntimeService` for managing `SpaceRuntime` lifecycle, and configure
    - Any step failure (gate fails after retries) → run → `needs_attention`
 
 5. Create RPC handler for starting workflow runs in `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts`:
-   - `spaceWorkflowRun.start { spaceId, workflowId?, title, description? }` → `{ run: SpaceWorkflowRun }`:
-     - If `workflowId` provided, validate it exists in the space
-     - If `workflowId` omitted, use space's default workflow (error if none)
+   - `spaceWorkflowRun.start { spaceId, workflowId, title, description? }` → `{ run: SpaceWorkflowRun }`:
+     - `workflowId` is **required** — callers must provide it (UI workflow picker) or the Space agent selects it via AI auto-select. Return an error if omitted.
+     - Validate `workflowId` exists in the space
      - Creates `SpaceWorkflowRun` record via `SpaceWorkflowRunRepository`
      - Calls `SpaceRuntimeService.createOrGetRuntime(spaceId)` then `runtime.startWorkflowRun()` to create the executor and first step's tasks
      - Emits `space.workflowRun.created` event

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/05-space-frontend-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/05-space-frontend-foundation.md
@@ -101,7 +101,6 @@ Create `SpaceStore` for managing all Space-related reactive state. Follows the e
    - Computed signals:
      - `activeTasks` — tasks filtered by active status
      - `activeRuns` — workflow runs filtered by in-progress status
-     - `defaultWorkflow` — the space's default workflow
      - `tasksByRun` — tasks grouped by workflow run ID
 
    - Methods:

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
@@ -79,10 +79,11 @@ Build the visual workflow editor for composing agent steps with gates.
 **Subtasks:**
 
 1. Create `packages/web/src/components/space/WorkflowList.tsx`:
-   - Workflow cards: name, description, step count, default badge, tag chips
-   - "Create Workflow" button, "Set as Default" action per card
+   - Workflow cards: name, description, step count, tag chips
+   - "Create Workflow" button
    - Real-time updates via SpaceStore
    - Mini step visualization (horizontal dots/icons showing the step sequence)
+   - **No "default badge" or "Set as Default" action** — there is no default workflow concept
 
 2. Create `packages/web/src/components/space/WorkflowEditor.tsx`:
    - Workflow name and description fields at top
@@ -165,15 +166,15 @@ Add the rules editor to the workflow builder, tags editor, and integrate all age
    - Create a workflow with 3 steps from template
    - Add a custom rule targeting specific steps
    - Save and verify persistence
-   - Set as default workflow
    - Edit existing workflow
    - Delete workflow
    - Create a custom agent, use it in a workflow step
 
 **Acceptance criteria:**
 - Rules can be created and associated with specific steps
-- Tags help categorize workflows
+- Tags help categorize workflows (for display only — not used for selection heuristics)
 - Agent and workflow management integrated into Space layout
 - Full CRUD flows work end-to-end
+- No "Set as Default" UI anywhere — workflow selection is explicit (UI picker) or AI auto-select
 - E2E tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`


### PR DESCRIPTION
Remove isDefault/setDefault/seedDefaultWorkflow concepts from all milestone docs to
align with the simplified two-mode design from 07-workflow-selection-intelligence.md:
- Explicit workflowId (caller-provided) or AI auto-select via list_workflows + start_workflow_run
- No default workflow flag, no tag/keyword heuristics, no fallback-to-null logic

Changes:
- 03: remove spaceWorkflow.setDefault handler, update acceptance criteria, simplify Task 3.4
- 04: workflowId always required in spaceWorkflowRun.start, remove seedDefaultWorkflow wiring
- 05: remove defaultWorkflow computed signal from SpaceStore
- 06: remove "default badge" and "Set as Default" from WorkflowList, remove e2e test step
