### PR TITLE
feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -16,7 +16,7 @@ export {
 	RESEARCH_WORKFLOW,
 	REVIEW_ONLY_WORKFLOW,
 	getBuiltInWorkflows,
-	seedDefaultWorkflow,
+	seedBuiltInWorkflows,
 } from './workflows/built-in-workflows';
 
 // Types — re-exported from @neokai/shared for convenience

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -11,6 +11,13 @@ export {
 export { SpaceWorkflowManager, WorkflowValidationError } from './managers/space-workflow-manager';
 export type { SpaceAgentLookup } from './managers/space-workflow-manager';
 export { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
+export {
+	CODING_WORKFLOW,
+	RESEARCH_WORKFLOW,
+	REVIEW_ONLY_WORKFLOW,
+	getBuiltInWorkflows,
+	seedDefaultWorkflow,
+} from './workflows/built-in-workflows';
 
 // Types — re-exported from @neokai/shared for convenience
 export type {

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -6,45 +6,16 @@
  *
  * Design notes:
  * - Leader is always implicit in SpaceRuntime — never a workflow step.
- * - Templates use placeholder `id` / `spaceId` (empty strings); the seeding
- *   utility stamps in the real spaceId at creation time.
- * - Steps carry stable template-scoped IDs so that the in-memory template
- *   objects satisfy the `SpaceWorkflow` shape.
+ * - Templates use placeholder `id` / `spaceId` (empty strings) and role names
+ *   as `agentId` placeholders ('planner', 'coder', 'general'). These are
+ *   replaced with real SpaceAgent UUIDs by `seedBuiltInWorkflows`.
+ * - At Space creation time, preset SpaceAgent records are seeded for each
+ *   BuiltinAgentRole. `seedBuiltInWorkflows` must be called after those agents
+ *   exist so that the `agentId` values resolve correctly.
  */
 
-import type { SpaceWorkflow, WorkflowStepInput } from '@neokai/shared';
+import type { BuiltinAgentRole, SpaceWorkflow, WorkflowStepInput } from '@neokai/shared';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
-
-// ---------------------------------------------------------------------------
-// Template helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Converts SpaceWorkflow steps to WorkflowStepInput[] (drops id/order)
- * so they can be passed to SpaceWorkflowManager.createWorkflow().
- */
-function stepsToInputs(steps: SpaceWorkflow['steps']): WorkflowStepInput[] {
-	return steps.map((s): WorkflowStepInput => {
-		if (s.agentRefType === 'custom') {
-			return {
-				name: s.name,
-				agentRefType: 'custom',
-				agentRef: s.agentRef,
-				entryGate: s.entryGate,
-				exitGate: s.exitGate,
-				instructions: s.instructions,
-			};
-		}
-		return {
-			name: s.name,
-			agentRefType: 'builtin',
-			agentRef: s.agentRef,
-			entryGate: s.entryGate,
-			exitGate: s.exitGate,
-			instructions: s.instructions,
-		};
-	});
-}
 
 // ---------------------------------------------------------------------------
 // Built-in templates
@@ -57,7 +28,8 @@ function stepsToInputs(steps: SpaceWorkflow['steps']): WorkflowStepInput[] {
  * - Planner produces a plan; human must approve before coding begins.
  * - Coder implements the plan; a PR review is required before the run completes.
  *
- * Leader is implicit per group — not modelled as a step.
+ * Steps use role names as `agentId` placeholders. Call `seedBuiltInWorkflows`
+ * to persist the workflow with real SpaceAgent IDs.
  */
 export const CODING_WORKFLOW: SpaceWorkflow = {
 	id: '',
@@ -69,8 +41,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 		{
 			id: 'tpl-coding-planner',
 			name: 'Plan',
-			agentRefType: 'builtin',
-			agentRef: 'planner',
+			agentId: 'planner',
 			exitGate: {
 				type: 'human_approval',
 				description: 'Review and approve the plan before coding begins',
@@ -80,8 +51,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 		{
 			id: 'tpl-coding-coder',
 			name: 'Code',
-			agentRefType: 'builtin',
-			agentRef: 'coder',
+			agentId: 'coder',
 			exitGate: {
 				type: 'pr_review',
 				description: 'Wait for PR review and approval before completing',
@@ -112,8 +82,7 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 		{
 			id: 'tpl-research-planner',
 			name: 'Plan Research',
-			agentRefType: 'builtin',
-			agentRef: 'planner',
+			agentId: 'planner',
 			exitGate: {
 				type: 'auto',
 				description: 'Automatically advance after planning is complete',
@@ -123,8 +92,7 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 		{
 			id: 'tpl-research-general',
 			name: 'Research',
-			agentRefType: 'builtin',
-			agentRef: 'general',
+			agentId: 'general',
 			exitGate: {
 				type: 'auto',
 				description: 'Automatically complete after research is done',
@@ -155,8 +123,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 		{
 			id: 'tpl-review-coder',
 			name: 'Code',
-			agentRefType: 'builtin',
-			agentRef: 'coder',
+			agentId: 'coder',
 			exitGate: {
 				type: 'pr_review',
 				description: 'Wait for PR review and approval before completing',
@@ -177,27 +144,41 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 /**
  * Returns all built-in workflow templates.
  *
- * The returned objects have empty `id` and `spaceId` fields — they are
- * templates, not persisted entities. Callers that need real workflows must
- * seed them into a Space via `seedDefaultWorkflow` or `createWorkflow`.
+ * The returned objects have empty `id` and `spaceId` fields and use role names
+ * (e.g., `'planner'`, `'coder'`, `'general'`) as `agentId` placeholders.
+ * They are templates, not persisted entities. Call `seedBuiltInWorkflows`
+ * to persist them with real SpaceAgent IDs for a given space.
  */
 export function getBuiltInWorkflows(): SpaceWorkflow[] {
 	return [CODING_WORKFLOW, RESEARCH_WORKFLOW, REVIEW_ONLY_WORKFLOW];
 }
 
 /**
- * Seeds `CODING_WORKFLOW` as the default workflow for the given space.
+ * Seeds all three built-in workflow templates into the given space.
+ *
+ * Each template step's `agentId` placeholder (e.g., `'planner'`, `'coder'`,
+ * `'general'`) is resolved to a real SpaceAgent UUID via `resolveAgentId`.
+ * If a role cannot be resolved, that step is skipped and the workflow is
+ * still created — the unresolved step will use the placeholder string.
  *
  * Idempotent: if the space already has at least one workflow, this is a no-op.
- * (The assumption is that any existing workflow was intentionally created,
- * either by a prior seed or by the user.)
  *
  * NOTE: This function is NOT wired to a call site yet — that happens in
- * Task 4.2 (inside the `space.create` RPC handler).
+ * Task 4.2 (inside the `space.create` RPC handler, after preset agents are
+ * seeded). The resolver should map BuiltinAgentRole → real SpaceAgent ID.
+ *
+ * Example call site:
+ * ```ts
+ * const agents = spaceAgentManager.listBySpaceId(spaceId);
+ * await seedBuiltInWorkflows(spaceId, workflowManager, (role) =>
+ *   agents.find(a => a.role === role)?.id
+ * );
+ * ```
  */
-export async function seedDefaultWorkflow(
+export async function seedBuiltInWorkflows(
 	spaceId: string,
-	workflowManager: SpaceWorkflowManager
+	workflowManager: SpaceWorkflowManager,
+	resolveAgentId: (role: BuiltinAgentRole) => string | undefined
 ): Promise<void> {
 	const existing = workflowManager.listWorkflows(spaceId);
 	if (existing.length > 0) {
@@ -205,12 +186,23 @@ export async function seedDefaultWorkflow(
 		return;
 	}
 
-	workflowManager.createWorkflow({
-		spaceId,
-		name: CODING_WORKFLOW.name,
-		description: CODING_WORKFLOW.description,
-		steps: stepsToInputs(CODING_WORKFLOW.steps),
-		rules: [],
-		tags: [...CODING_WORKFLOW.tags],
-	});
+	for (const template of getBuiltInWorkflows()) {
+		const steps: WorkflowStepInput[] = template.steps.map((s) => ({
+			name: s.name,
+			// Resolve role placeholder to real agent ID; fall back to placeholder if unresolvable.
+			agentId: resolveAgentId(s.agentId as BuiltinAgentRole) ?? s.agentId,
+			entryGate: s.entryGate,
+			exitGate: s.exitGate,
+			instructions: s.instructions,
+		}));
+
+		workflowManager.createWorkflow({
+			spaceId,
+			name: template.name,
+			description: template.description,
+			steps,
+			rules: [],
+			tags: [...template.tags],
+		});
+	}
 }

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1,0 +1,216 @@
+/**
+ * Built-in Workflow Templates
+ *
+ * Defines the canonical workflow templates bundled with NeoKai.
+ * These serve as defaults and examples for Space users.
+ *
+ * Design notes:
+ * - Leader is always implicit in SpaceRuntime — never a workflow step.
+ * - Templates use placeholder `id` / `spaceId` (empty strings); the seeding
+ *   utility stamps in the real spaceId at creation time.
+ * - Steps carry stable template-scoped IDs so that the in-memory template
+ *   objects satisfy the `SpaceWorkflow` shape.
+ */
+
+import type { SpaceWorkflow, WorkflowStepInput } from '@neokai/shared';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+
+// ---------------------------------------------------------------------------
+// Template helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts SpaceWorkflow steps to WorkflowStepInput[] (drops id/order)
+ * so they can be passed to SpaceWorkflowManager.createWorkflow().
+ */
+function stepsToInputs(steps: SpaceWorkflow['steps']): WorkflowStepInput[] {
+	return steps.map((s): WorkflowStepInput => {
+		if (s.agentRefType === 'custom') {
+			return {
+				name: s.name,
+				agentRefType: 'custom',
+				agentRef: s.agentRef,
+				entryGate: s.entryGate,
+				exitGate: s.exitGate,
+				instructions: s.instructions,
+			};
+		}
+		return {
+			name: s.name,
+			agentRefType: 'builtin',
+			agentRef: s.agentRef,
+			entryGate: s.entryGate,
+			exitGate: s.exitGate,
+			instructions: s.instructions,
+		};
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Built-in templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Coding Workflow
+ *
+ * Two-step workflow: Planner → Coder.
+ * - Planner produces a plan; human must approve before coding begins.
+ * - Coder implements the plan; a PR review is required before the run completes.
+ *
+ * Leader is implicit per group — not modelled as a step.
+ */
+export const CODING_WORKFLOW: SpaceWorkflow = {
+	id: '',
+	spaceId: '',
+	name: 'Coding Workflow',
+	description:
+		'Plan-first coding workflow. A human reviews the plan before implementation starts, and a PR review gates completion.',
+	steps: [
+		{
+			id: 'tpl-coding-planner',
+			name: 'Plan',
+			agentRefType: 'builtin',
+			agentRef: 'planner',
+			exitGate: {
+				type: 'human_approval',
+				description: 'Review and approve the plan before coding begins',
+			},
+			order: 0,
+		},
+		{
+			id: 'tpl-coding-coder',
+			name: 'Code',
+			agentRefType: 'builtin',
+			agentRef: 'coder',
+			exitGate: {
+				type: 'pr_review',
+				description: 'Wait for PR review and approval before completing',
+			},
+			order: 1,
+		},
+	],
+	rules: [],
+	tags: ['coding', 'default'],
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+/**
+ * Research Workflow
+ *
+ * Two-step workflow: Planner → General.
+ * Both steps use automatic gates — the workflow advances without human intervention,
+ * suited for fully autonomous research and summarisation tasks.
+ */
+export const RESEARCH_WORKFLOW: SpaceWorkflow = {
+	id: '',
+	spaceId: '',
+	name: 'Research Workflow',
+	description:
+		'Fully automated research workflow. Planner scopes the research; General agent executes and summarises findings.',
+	steps: [
+		{
+			id: 'tpl-research-planner',
+			name: 'Plan Research',
+			agentRefType: 'builtin',
+			agentRef: 'planner',
+			exitGate: {
+				type: 'auto',
+				description: 'Automatically advance after planning is complete',
+			},
+			order: 0,
+		},
+		{
+			id: 'tpl-research-general',
+			name: 'Research',
+			agentRefType: 'builtin',
+			agentRef: 'general',
+			exitGate: {
+				type: 'auto',
+				description: 'Automatically complete after research is done',
+			},
+			order: 1,
+		},
+	],
+	rules: [],
+	tags: ['research'],
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+/**
+ * Review-Only Workflow
+ *
+ * Single-step workflow: Coder only.
+ * No planning phase — used when the task is well-defined and only
+ * implementation + PR review are needed.
+ */
+export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
+	id: '',
+	spaceId: '',
+	name: 'Review-Only Workflow',
+	description:
+		'Single-step coding workflow with no planning phase. Coder implements directly; a PR review gates completion.',
+	steps: [
+		{
+			id: 'tpl-review-coder',
+			name: 'Code',
+			agentRefType: 'builtin',
+			agentRef: 'coder',
+			exitGate: {
+				type: 'pr_review',
+				description: 'Wait for PR review and approval before completing',
+			},
+			order: 0,
+		},
+	],
+	rules: [],
+	tags: ['coding', 'review'],
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all built-in workflow templates.
+ *
+ * The returned objects have empty `id` and `spaceId` fields — they are
+ * templates, not persisted entities. Callers that need real workflows must
+ * seed them into a Space via `seedDefaultWorkflow` or `createWorkflow`.
+ */
+export function getBuiltInWorkflows(): SpaceWorkflow[] {
+	return [CODING_WORKFLOW, RESEARCH_WORKFLOW, REVIEW_ONLY_WORKFLOW];
+}
+
+/**
+ * Seeds `CODING_WORKFLOW` as the default workflow for the given space.
+ *
+ * Idempotent: if the space already has at least one workflow, this is a no-op.
+ * (The assumption is that any existing workflow was intentionally created,
+ * either by a prior seed or by the user.)
+ *
+ * NOTE: This function is NOT wired to a call site yet — that happens in
+ * Task 4.2 (inside the `space.create` RPC handler).
+ */
+export async function seedDefaultWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager
+): Promise<void> {
+	const existing = workflowManager.listWorkflows(spaceId);
+	if (existing.length > 0) {
+		// Already seeded — nothing to do.
+		return;
+	}
+
+	workflowManager.createWorkflow({
+		spaceId,
+		name: CODING_WORKFLOW.name,
+		description: CODING_WORKFLOW.description,
+		steps: stepsToInputs(CODING_WORKFLOW.steps),
+		rules: [],
+		tags: [...CODING_WORKFLOW.tags],
+	});
+}

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -158,8 +158,8 @@ export function getBuiltInWorkflows(): SpaceWorkflow[] {
  *
  * Each template step's `agentId` placeholder (e.g., `'planner'`, `'coder'`,
  * `'general'`) is resolved to a real SpaceAgent UUID via `resolveAgentId`.
- * If a role cannot be resolved, that step is skipped and the workflow is
- * still created — the unresolved step will use the placeholder string.
+ * If any role cannot be resolved, this function throws — persisting a
+ * placeholder string as an `agentId` would create broken workflow data.
  *
  * Idempotent: if the space already has at least one workflow, this is a no-op.
  *
@@ -187,14 +187,23 @@ export async function seedBuiltInWorkflows(
 	}
 
 	for (const template of getBuiltInWorkflows()) {
-		const steps: WorkflowStepInput[] = template.steps.map((s) => ({
-			name: s.name,
-			// Resolve role placeholder to real agent ID; fall back to placeholder if unresolvable.
-			agentId: resolveAgentId(s.agentId as BuiltinAgentRole) ?? s.agentId,
-			entryGate: s.entryGate,
-			exitGate: s.exitGate,
-			instructions: s.instructions,
-		}));
+		const steps: WorkflowStepInput[] = template.steps.map((s) => {
+			const role = s.agentId as BuiltinAgentRole;
+			const agentId = resolveAgentId(role);
+			if (!agentId) {
+				throw new Error(
+					`seedBuiltInWorkflows: no SpaceAgent found for role '${role}' in space '${spaceId}'. ` +
+						`Preset agents must be seeded before calling seedBuiltInWorkflows.`
+				);
+			}
+			return {
+				name: s.name,
+				agentId,
+				entryGate: s.entryGate,
+				exitGate: s.exitGate,
+				instructions: s.instructions,
+			};
+		});
 
 		workflowManager.createWorkflow({
 			spaceId,

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -186,24 +186,34 @@ export async function seedBuiltInWorkflows(
 		return;
 	}
 
-	for (const template of getBuiltInWorkflows()) {
-		const steps: WorkflowStepInput[] = template.steps.map((s) => {
-			const role = s.agentId as BuiltinAgentRole;
-			const agentId = resolveAgentId(role);
-			if (!agentId) {
-				throw new Error(
-					`seedBuiltInWorkflows: no SpaceAgent found for role '${role}' in space '${spaceId}'. ` +
-						`Preset agents must be seeded before calling seedBuiltInWorkflows.`
-				);
-			}
-			return {
-				name: s.name,
-				agentId,
-				entryGate: s.entryGate,
-				exitGate: s.exitGate,
-				instructions: s.instructions,
-			};
-		});
+	// Pre-validate: resolve every role needed across ALL templates before
+	// persisting anything. This guarantees all-or-nothing behaviour — a failure
+	// on any role will throw before a single workflow is created.
+	const templates = getBuiltInWorkflows();
+	const neededRoles = new Set<BuiltinAgentRole>(
+		templates.flatMap((t) => t.steps.map((s) => s.agentId as BuiltinAgentRole))
+	);
+	const resolvedIds = new Map<BuiltinAgentRole, string>();
+	for (const role of neededRoles) {
+		const agentId = resolveAgentId(role);
+		if (!agentId) {
+			throw new Error(
+				`seedBuiltInWorkflows: no SpaceAgent found for role '${role}' in space '${spaceId}'. ` +
+					`Preset agents must be seeded before calling seedBuiltInWorkflows.`
+			);
+		}
+		resolvedIds.set(role, agentId);
+	}
+
+	// All roles resolved — safe to persist.
+	for (const template of templates) {
+		const steps: WorkflowStepInput[] = template.steps.map((s) => ({
+			name: s.name,
+			agentId: resolvedIds.get(s.agentId as BuiltinAgentRole)!,
+			entryGate: s.entryGate,
+			exitGate: s.exitGate,
+			instructions: s.instructions,
+		}));
 
 		workflowManager.createWorkflow({
 			spaceId,

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -2,11 +2,11 @@
  * Built-in Workflow Templates Unit Tests
  *
  * Covers:
- * - Template structure: correct agent refs, gate types, step count
- * - No 'leader' agent refs in any template
+ * - Template structure: correct agentId placeholders, gate types, step count
+ * - agentId placeholders are valid builtin role names (no 'leader')
  * - getBuiltInWorkflows() returns all three templates
- * - seedDefaultWorkflow(): creates CODING_WORKFLOW when space is empty
- * - seedDefaultWorkflow(): idempotent — no second workflow when one exists
+ * - seedBuiltInWorkflows(): seeds all three templates with real agent IDs
+ * - seedBuiltInWorkflows(): idempotent — no re-seed if workflows already exist
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -21,9 +21,9 @@ import {
 	RESEARCH_WORKFLOW,
 	REVIEW_ONLY_WORKFLOW,
 	getBuiltInWorkflows,
-	seedDefaultWorkflow,
+	seedBuiltInWorkflows,
 } from '../../../src/lib/space/workflows/built-in-workflows.ts';
-import type { SpaceWorkflow } from '@neokai/shared';
+import type { BuiltinAgentRole, SpaceWorkflow } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,11 +51,28 @@ function seedSpace(db: BunDatabase, spaceId: string): void {
 	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
 }
 
+function seedAgent(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	name: string,
+	role: string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt,
+     role, config, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, null, ?, ?)`
+	).run(agentId, spaceId, name, role, Date.now(), Date.now());
+}
+
+/** Valid builtin roles — 'leader' must NOT appear in any template step. */
+const VALID_BUILTIN_ROLES = new Set<string>(['planner', 'coder', 'general', 'reviewer']);
+
 /**
- * Returns true if any step in the workflow references 'leader'.
+ * Returns true if any step in the workflow has 'leader' as its agentId placeholder.
  */
-function hasLeaderRef(wf: SpaceWorkflow): boolean {
-	return wf.steps.some((s) => s.agentRef === 'leader');
+function hasLeaderAgentId(wf: SpaceWorkflow): boolean {
+	return wf.steps.some((s) => s.agentId === 'leader');
 }
 
 // ---------------------------------------------------------------------------
@@ -67,16 +84,12 @@ describe('CODING_WORKFLOW template', () => {
 		expect(CODING_WORKFLOW.steps).toHaveLength(2);
 	});
 
-	test('first step uses planner builtin', () => {
-		const step = CODING_WORKFLOW.steps[0];
-		expect(step.agentRefType).toBe('builtin');
-		expect(step.agentRef).toBe('planner');
+	test('first step agentId placeholder is planner', () => {
+		expect(CODING_WORKFLOW.steps[0].agentId).toBe('planner');
 	});
 
-	test('second step uses coder builtin', () => {
-		const step = CODING_WORKFLOW.steps[1];
-		expect(step.agentRefType).toBe('builtin');
-		expect(step.agentRef).toBe('coder');
+	test('second step agentId placeholder is coder', () => {
+		expect(CODING_WORKFLOW.steps[1].agentId).toBe('coder');
 	});
 
 	test('planner step exit gate is human_approval', () => {
@@ -88,7 +101,7 @@ describe('CODING_WORKFLOW template', () => {
 	});
 
 	test('does not reference leader', () => {
-		expect(hasLeaderRef(CODING_WORKFLOW)).toBe(false);
+		expect(hasLeaderAgentId(CODING_WORKFLOW)).toBe(false);
 	});
 
 	test('steps have ascending order values', () => {
@@ -107,16 +120,12 @@ describe('RESEARCH_WORKFLOW template', () => {
 		expect(RESEARCH_WORKFLOW.steps).toHaveLength(2);
 	});
 
-	test('first step uses planner builtin', () => {
-		const step = RESEARCH_WORKFLOW.steps[0];
-		expect(step.agentRefType).toBe('builtin');
-		expect(step.agentRef).toBe('planner');
+	test('first step agentId placeholder is planner', () => {
+		expect(RESEARCH_WORKFLOW.steps[0].agentId).toBe('planner');
 	});
 
-	test('second step uses general builtin', () => {
-		const step = RESEARCH_WORKFLOW.steps[1];
-		expect(step.agentRefType).toBe('builtin');
-		expect(step.agentRef).toBe('general');
+	test('second step agentId placeholder is general', () => {
+		expect(RESEARCH_WORKFLOW.steps[1].agentId).toBe('general');
 	});
 
 	test('planner step exit gate is auto', () => {
@@ -128,7 +137,7 @@ describe('RESEARCH_WORKFLOW template', () => {
 	});
 
 	test('does not reference leader', () => {
-		expect(hasLeaderRef(RESEARCH_WORKFLOW)).toBe(false);
+		expect(hasLeaderAgentId(RESEARCH_WORKFLOW)).toBe(false);
 	});
 
 	test('steps have ascending order values', () => {
@@ -147,10 +156,8 @@ describe('REVIEW_ONLY_WORKFLOW template', () => {
 		expect(REVIEW_ONLY_WORKFLOW.steps).toHaveLength(1);
 	});
 
-	test('step uses coder builtin', () => {
-		const step = REVIEW_ONLY_WORKFLOW.steps[0];
-		expect(step.agentRefType).toBe('builtin');
-		expect(step.agentRef).toBe('coder');
+	test('step agentId placeholder is coder', () => {
+		expect(REVIEW_ONLY_WORKFLOW.steps[0].agentId).toBe('coder');
 	});
 
 	test('coder step exit gate is pr_review', () => {
@@ -158,7 +165,7 @@ describe('REVIEW_ONLY_WORKFLOW template', () => {
 	});
 
 	test('does not reference leader', () => {
-		expect(hasLeaderRef(REVIEW_ONLY_WORKFLOW)).toBe(false);
+		expect(hasLeaderAgentId(REVIEW_ONLY_WORKFLOW)).toBe(false);
 	});
 
 	test('step order is 0', () => {
@@ -195,38 +202,55 @@ describe('getBuiltInWorkflows()', () => {
 		expect(names).toContain(REVIEW_ONLY_WORKFLOW.name);
 	});
 
-	test('no template references leader as builtin agent', () => {
+	test('no template references leader as agent', () => {
 		for (const wf of getBuiltInWorkflows()) {
-			expect(hasLeaderRef(wf)).toBe(false);
+			expect(hasLeaderAgentId(wf)).toBe(false);
 		}
 	});
 
-	test('all builtin agent refs are valid (planner/coder/general)', () => {
-		const validRoles = new Set(['planner', 'coder', 'general']);
+	test('all agentId placeholders are valid builtin role names', () => {
 		for (const wf of getBuiltInWorkflows()) {
 			for (const step of wf.steps) {
-				if (step.agentRefType === 'builtin') {
-					expect(validRoles.has(step.agentRef)).toBe(true);
-				}
+				expect(VALID_BUILTIN_ROLES.has(step.agentId)).toBe(true);
 			}
 		}
 	});
 });
 
 // ---------------------------------------------------------------------------
-// seedDefaultWorkflow()
+// seedBuiltInWorkflows()
 // ---------------------------------------------------------------------------
 
-describe('seedDefaultWorkflow()', () => {
+describe('seedBuiltInWorkflows()', () => {
 	let db: BunDatabase;
 	let dir: string;
 	let manager: SpaceWorkflowManager;
 	const SPACE_ID = 'seed-test-space';
 
+	// Preset agent IDs seeded in the space
+	const PLANNER_ID = 'agent-planner-uuid';
+	const CODER_ID = 'agent-coder-uuid';
+	const GENERAL_ID = 'agent-general-uuid';
+
+	// Role resolver — mirrors what the real call site does
+	const roleMap: Record<BuiltinAgentRole, string> = {
+		planner: PLANNER_ID,
+		coder: CODER_ID,
+		general: GENERAL_ID,
+		reviewer: 'agent-reviewer-uuid',
+	};
+	const resolveAgentId = (role: BuiltinAgentRole): string | undefined => roleMap[role];
+
 	beforeEach(() => {
 		({ db, dir } = makeDb());
 		seedSpace(db, SPACE_ID);
+		// Seed preset agents so the manager's agentLookup (when wired) would find them
+		seedAgent(db, PLANNER_ID, SPACE_ID, 'Planner', 'planner');
+		seedAgent(db, CODER_ID, SPACE_ID, 'Coder', 'coder');
+		seedAgent(db, GENERAL_ID, SPACE_ID, 'General', 'general');
+
 		const repo = new SpaceWorkflowRepository(db);
+		// No agentLookup — seeder bypasses lookup by passing real IDs directly
 		manager = new SpaceWorkflowManager(repo);
 	});
 
@@ -243,50 +267,75 @@ describe('seedDefaultWorkflow()', () => {
 		}
 	});
 
-	test('creates CODING_WORKFLOW for an empty space', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
+	test('seeds all three built-in templates for an empty space', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const workflows = manager.listWorkflows(SPACE_ID);
-		expect(workflows).toHaveLength(1);
-		expect(workflows[0].name).toBe(CODING_WORKFLOW.name);
+		expect(workflows).toHaveLength(3);
 	});
 
-	test('seeded workflow has the planner and coder steps', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		const [wf] = manager.listWorkflows(SPACE_ID);
-		expect(wf.steps).toHaveLength(2);
-		expect(wf.steps[0].agentRef).toBe('planner');
-		expect(wf.steps[1].agentRef).toBe('coder');
+	test('seeded workflow names match all three templates', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const names = manager.listWorkflows(SPACE_ID).map((w) => w.name);
+		expect(names).toContain(CODING_WORKFLOW.name);
+		expect(names).toContain(RESEARCH_WORKFLOW.name);
+		expect(names).toContain(REVIEW_ONLY_WORKFLOW.name);
 	});
 
-	test('seeded workflow has human_approval exit gate on planner step', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		const [wf] = manager.listWorkflows(SPACE_ID);
-		expect(wf.steps[0].exitGate?.type).toBe('human_approval');
+	test('CODING_WORKFLOW seeded correctly — planner + coder steps with real agent IDs', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		expect(wf!.steps).toHaveLength(2);
+		expect(wf!.steps[0].agentId).toBe(PLANNER_ID);
+		expect(wf!.steps[1].agentId).toBe(CODER_ID);
 	});
 
-	test('seeded workflow has pr_review exit gate on coder step', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		const [wf] = manager.listWorkflows(SPACE_ID);
-		expect(wf.steps[1].exitGate?.type).toBe('pr_review');
+	test('CODING_WORKFLOW seeded with human_approval + pr_review gates', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
+		expect(wf!.steps[0].exitGate?.type).toBe('human_approval');
+		expect(wf!.steps[1].exitGate?.type).toBe('pr_review');
 	});
 
-	test('seeded workflow gets a real spaceId assigned', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		const [wf] = manager.listWorkflows(SPACE_ID);
-		expect(wf.spaceId).toBe(SPACE_ID);
+	test('RESEARCH_WORKFLOW seeded correctly — planner + general with auto gates', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === RESEARCH_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		expect(wf!.steps).toHaveLength(2);
+		expect(wf!.steps[0].agentId).toBe(PLANNER_ID);
+		expect(wf!.steps[1].agentId).toBe(GENERAL_ID);
+		expect(wf!.steps[0].exitGate?.type).toBe('auto');
+		expect(wf!.steps[1].exitGate?.type).toBe('auto');
 	});
 
-	test('seeded workflow gets a real id assigned (non-empty)', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		const [wf] = manager.listWorkflows(SPACE_ID);
-		expect(wf.id).toBeTruthy();
+	test('REVIEW_ONLY_WORKFLOW seeded correctly — single coder step with pr_review gate', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === REVIEW_ONLY_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		expect(wf!.steps).toHaveLength(1);
+		expect(wf!.steps[0].agentId).toBe(CODER_ID);
+		expect(wf!.steps[0].exitGate?.type).toBe('pr_review');
 	});
 
-	test('is idempotent — second call does not create another workflow', async () => {
-		await seedDefaultWorkflow(SPACE_ID, manager);
-		await seedDefaultWorkflow(SPACE_ID, manager);
+	test('all seeded workflows have the real spaceId assigned', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		for (const wf of manager.listWorkflows(SPACE_ID)) {
+			expect(wf.spaceId).toBe(SPACE_ID);
+		}
+	});
+
+	test('all seeded workflows have non-empty ids assigned', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		for (const wf of manager.listWorkflows(SPACE_ID)) {
+			expect(wf.id).toBeTruthy();
+		}
+	});
+
+	test('is idempotent — second call does not create additional workflows', async () => {
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const workflows = manager.listWorkflows(SPACE_ID);
-		expect(workflows).toHaveLength(1);
+		expect(workflows).toHaveLength(3);
 	});
 
 	test('is idempotent — leaves user-created workflows untouched', async () => {
@@ -294,10 +343,10 @@ describe('seedDefaultWorkflow()', () => {
 		manager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'My Custom Workflow',
-			steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+			steps: [{ name: 'Code', agentId: CODER_ID }],
 		});
 
-		await seedDefaultWorkflow(SPACE_ID, manager);
+		await seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 
 		const workflows = manager.listWorkflows(SPACE_ID);
 		expect(workflows).toHaveLength(1);

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -352,4 +352,29 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(workflows).toHaveLength(1);
 		expect(workflows[0].name).toBe('My Custom Workflow');
 	});
+
+	test('throws if resolveAgentId returns undefined for a required role', async () => {
+		// Resolver that cannot resolve 'planner'
+		const brokenResolver = (role: BuiltinAgentRole): string | undefined =>
+			role === 'planner' ? undefined : roleMap[role];
+
+		await expect(seedBuiltInWorkflows(SPACE_ID, manager, brokenResolver)).rejects.toThrow(
+			"no SpaceAgent found for role 'planner'"
+		);
+	});
+
+	test('does not persist any workflow when resolveAgentId fails mid-seed', async () => {
+		// Resolver fails on 'planner' — first template's first step
+		const brokenResolver = (role: BuiltinAgentRole): string | undefined =>
+			role === 'planner' ? undefined : roleMap[role];
+
+		try {
+			await seedBuiltInWorkflows(SPACE_ID, manager, brokenResolver);
+		} catch {
+			// expected
+		}
+		// CODING_WORKFLOW creation throws before any workflow is committed,
+		// so the space should still have zero workflows
+		expect(manager.listWorkflows(SPACE_ID)).toHaveLength(0);
+	});
 });

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Built-in Workflow Templates Unit Tests
+ *
+ * Covers:
+ * - Template structure: correct agent refs, gate types, step count
+ * - No 'leader' agent refs in any template
+ * - getBuiltInWorkflows() returns all three templates
+ * - seedDefaultWorkflow(): creates CODING_WORKFLOW when space is empty
+ * - seedDefaultWorkflow(): idempotent — no second workflow when one exists
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import {
+	CODING_WORKFLOW,
+	RESEARCH_WORKFLOW,
+	REVIEW_ONLY_WORKFLOW,
+	getBuiltInWorkflows,
+	seedDefaultWorkflow,
+} from '../../../src/lib/space/workflows/built-in-workflows.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-built-in-workflows',
+		`t-${Date.now()}-${Math.random()}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpace(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+/**
+ * Returns true if any step in the workflow references 'leader'.
+ */
+function hasLeaderRef(wf: SpaceWorkflow): boolean {
+	return wf.steps.some((s) => s.agentRef === 'leader');
+}
+
+// ---------------------------------------------------------------------------
+// Template structure tests
+// ---------------------------------------------------------------------------
+
+describe('CODING_WORKFLOW template', () => {
+	test('has two steps', () => {
+		expect(CODING_WORKFLOW.steps).toHaveLength(2);
+	});
+
+	test('first step uses planner builtin', () => {
+		const step = CODING_WORKFLOW.steps[0];
+		expect(step.agentRefType).toBe('builtin');
+		expect(step.agentRef).toBe('planner');
+	});
+
+	test('second step uses coder builtin', () => {
+		const step = CODING_WORKFLOW.steps[1];
+		expect(step.agentRefType).toBe('builtin');
+		expect(step.agentRef).toBe('coder');
+	});
+
+	test('planner step exit gate is human_approval', () => {
+		expect(CODING_WORKFLOW.steps[0].exitGate?.type).toBe('human_approval');
+	});
+
+	test('coder step exit gate is pr_review', () => {
+		expect(CODING_WORKFLOW.steps[1].exitGate?.type).toBe('pr_review');
+	});
+
+	test('does not reference leader', () => {
+		expect(hasLeaderRef(CODING_WORKFLOW)).toBe(false);
+	});
+
+	test('steps have ascending order values', () => {
+		const orders = CODING_WORKFLOW.steps.map((s) => s.order);
+		expect(orders).toEqual([0, 1]);
+	});
+
+	test('template id and spaceId are empty (not space-specific)', () => {
+		expect(CODING_WORKFLOW.id).toBe('');
+		expect(CODING_WORKFLOW.spaceId).toBe('');
+	});
+});
+
+describe('RESEARCH_WORKFLOW template', () => {
+	test('has two steps', () => {
+		expect(RESEARCH_WORKFLOW.steps).toHaveLength(2);
+	});
+
+	test('first step uses planner builtin', () => {
+		const step = RESEARCH_WORKFLOW.steps[0];
+		expect(step.agentRefType).toBe('builtin');
+		expect(step.agentRef).toBe('planner');
+	});
+
+	test('second step uses general builtin', () => {
+		const step = RESEARCH_WORKFLOW.steps[1];
+		expect(step.agentRefType).toBe('builtin');
+		expect(step.agentRef).toBe('general');
+	});
+
+	test('planner step exit gate is auto', () => {
+		expect(RESEARCH_WORKFLOW.steps[0].exitGate?.type).toBe('auto');
+	});
+
+	test('general step exit gate is auto', () => {
+		expect(RESEARCH_WORKFLOW.steps[1].exitGate?.type).toBe('auto');
+	});
+
+	test('does not reference leader', () => {
+		expect(hasLeaderRef(RESEARCH_WORKFLOW)).toBe(false);
+	});
+
+	test('steps have ascending order values', () => {
+		const orders = RESEARCH_WORKFLOW.steps.map((s) => s.order);
+		expect(orders).toEqual([0, 1]);
+	});
+
+	test('template id and spaceId are empty (not space-specific)', () => {
+		expect(RESEARCH_WORKFLOW.id).toBe('');
+		expect(RESEARCH_WORKFLOW.spaceId).toBe('');
+	});
+});
+
+describe('REVIEW_ONLY_WORKFLOW template', () => {
+	test('has one step', () => {
+		expect(REVIEW_ONLY_WORKFLOW.steps).toHaveLength(1);
+	});
+
+	test('step uses coder builtin', () => {
+		const step = REVIEW_ONLY_WORKFLOW.steps[0];
+		expect(step.agentRefType).toBe('builtin');
+		expect(step.agentRef).toBe('coder');
+	});
+
+	test('coder step exit gate is pr_review', () => {
+		expect(REVIEW_ONLY_WORKFLOW.steps[0].exitGate?.type).toBe('pr_review');
+	});
+
+	test('does not reference leader', () => {
+		expect(hasLeaderRef(REVIEW_ONLY_WORKFLOW)).toBe(false);
+	});
+
+	test('step order is 0', () => {
+		expect(REVIEW_ONLY_WORKFLOW.steps[0].order).toBe(0);
+	});
+
+	test('template id and spaceId are empty (not space-specific)', () => {
+		expect(REVIEW_ONLY_WORKFLOW.id).toBe('');
+		expect(REVIEW_ONLY_WORKFLOW.spaceId).toBe('');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getBuiltInWorkflows()
+// ---------------------------------------------------------------------------
+
+describe('getBuiltInWorkflows()', () => {
+	test('returns exactly three templates', () => {
+		expect(getBuiltInWorkflows()).toHaveLength(3);
+	});
+
+	test('includes CODING_WORKFLOW', () => {
+		const names = getBuiltInWorkflows().map((w) => w.name);
+		expect(names).toContain(CODING_WORKFLOW.name);
+	});
+
+	test('includes RESEARCH_WORKFLOW', () => {
+		const names = getBuiltInWorkflows().map((w) => w.name);
+		expect(names).toContain(RESEARCH_WORKFLOW.name);
+	});
+
+	test('includes REVIEW_ONLY_WORKFLOW', () => {
+		const names = getBuiltInWorkflows().map((w) => w.name);
+		expect(names).toContain(REVIEW_ONLY_WORKFLOW.name);
+	});
+
+	test('no template references leader as builtin agent', () => {
+		for (const wf of getBuiltInWorkflows()) {
+			expect(hasLeaderRef(wf)).toBe(false);
+		}
+	});
+
+	test('all builtin agent refs are valid (planner/coder/general)', () => {
+		const validRoles = new Set(['planner', 'coder', 'general']);
+		for (const wf of getBuiltInWorkflows()) {
+			for (const step of wf.steps) {
+				if (step.agentRefType === 'builtin') {
+					expect(validRoles.has(step.agentRef)).toBe(true);
+				}
+			}
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// seedDefaultWorkflow()
+// ---------------------------------------------------------------------------
+
+describe('seedDefaultWorkflow()', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let manager: SpaceWorkflowManager;
+	const SPACE_ID = 'seed-test-space';
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpace(db, SPACE_ID);
+		const repo = new SpaceWorkflowRepository(db);
+		manager = new SpaceWorkflowManager(repo);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('creates CODING_WORKFLOW for an empty space', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const workflows = manager.listWorkflows(SPACE_ID);
+		expect(workflows).toHaveLength(1);
+		expect(workflows[0].name).toBe(CODING_WORKFLOW.name);
+	});
+
+	test('seeded workflow has the planner and coder steps', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const [wf] = manager.listWorkflows(SPACE_ID);
+		expect(wf.steps).toHaveLength(2);
+		expect(wf.steps[0].agentRef).toBe('planner');
+		expect(wf.steps[1].agentRef).toBe('coder');
+	});
+
+	test('seeded workflow has human_approval exit gate on planner step', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const [wf] = manager.listWorkflows(SPACE_ID);
+		expect(wf.steps[0].exitGate?.type).toBe('human_approval');
+	});
+
+	test('seeded workflow has pr_review exit gate on coder step', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const [wf] = manager.listWorkflows(SPACE_ID);
+		expect(wf.steps[1].exitGate?.type).toBe('pr_review');
+	});
+
+	test('seeded workflow gets a real spaceId assigned', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const [wf] = manager.listWorkflows(SPACE_ID);
+		expect(wf.spaceId).toBe(SPACE_ID);
+	});
+
+	test('seeded workflow gets a real id assigned (non-empty)', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const [wf] = manager.listWorkflows(SPACE_ID);
+		expect(wf.id).toBeTruthy();
+	});
+
+	test('is idempotent — second call does not create another workflow', async () => {
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		await seedDefaultWorkflow(SPACE_ID, manager);
+		const workflows = manager.listWorkflows(SPACE_ID);
+		expect(workflows).toHaveLength(1);
+	});
+
+	test('is idempotent — leaves user-created workflows untouched', async () => {
+		// User already created a custom workflow before seeding
+		manager.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'My Custom Workflow',
+			steps: [{ name: 'Code', agentRefType: 'builtin', agentRef: 'coder' }],
+		});
+
+		await seedDefaultWorkflow(SPACE_ID, manager);
+
+		const workflows = manager.listWorkflows(SPACE_ID);
+		expect(workflows).toHaveLength(1);
+		expect(workflows[0].name).toBe('My Custom Workflow');
+	});
+});

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -363,7 +363,7 @@ describe('seedBuiltInWorkflows()', () => {
 		);
 	});
 
-	test('does not persist any workflow when resolveAgentId fails mid-seed', async () => {
+	test('does not persist any workflow when resolveAgentId fails on first-template role', async () => {
 		// Resolver fails on 'planner' — first template's first step
 		const brokenResolver = (role: BuiltinAgentRole): string | undefined =>
 			role === 'planner' ? undefined : roleMap[role];
@@ -373,8 +373,22 @@ describe('seedBuiltInWorkflows()', () => {
 		} catch {
 			// expected
 		}
-		// CODING_WORKFLOW creation throws before any workflow is committed,
-		// so the space should still have zero workflows
+		// Pre-validation throws before any workflow is committed
+		expect(manager.listWorkflows(SPACE_ID)).toHaveLength(0);
+	});
+
+	test('does not persist any workflow when resolveAgentId fails on a later-template role', async () => {
+		// 'general' is only needed by RESEARCH_WORKFLOW (2nd template).
+		// Without pre-validation, CODING_WORKFLOW would already be committed when this throws.
+		const brokenResolver = (role: BuiltinAgentRole): string | undefined =>
+			role === 'general' ? undefined : roleMap[role];
+
+		try {
+			await seedBuiltInWorkflows(SPACE_ID, manager, brokenResolver);
+		} catch {
+			// expected
+		}
+		// Pre-validation catches the missing role before any workflow is persisted
 		expect(manager.listWorkflows(SPACE_ID)).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Summary

- Three built-in workflow templates: `CODING_WORKFLOW` (Planner→Coder, human_approval + pr_review gates), `RESEARCH_WORKFLOW` (Planner→General, auto gates), `REVIEW_ONLY_WORKFLOW` (Coder only, pr_review gate)
- `getBuiltInWorkflows()` returns all three templates with role-name `agentId` placeholders
- `seedBuiltInWorkflows(spaceId, workflowManager, resolveAgentId)` idempotently seeds all three — throws if a role cannot be resolved to a real SpaceAgent UUID
- Exported from `packages/daemon/src/lib/space/index.ts`
- NOT wired to a call site (that's Task 4.2)

## Test plan

- [ ] 40 unit tests pass: template structure, valid agentId placeholders, no 'leader' refs, all three templates seeded, gate types correct, real agent IDs substituted, idempotency, error on unresolved role