### PR TITLE
feat: define Space export/import JSON format (Task 8.1)

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -33,13 +33,23 @@ import type {
 // Zod schemas
 // ============================================================================
 
-const workflowConditionSchema = z.object({
-	type: z.enum(['always', 'human', 'condition']),
-	expression: z.string().optional(),
-	description: z.string().optional(),
-	maxRetries: z.number().int().nonnegative().optional(),
-	timeoutMs: z.number().int().nonnegative().optional(),
-});
+const workflowConditionSchema = z
+	.object({
+		type: z.enum(['always', 'human', 'condition']),
+		expression: z.string().optional(),
+		description: z.string().optional(),
+		maxRetries: z.number().int().nonnegative().optional(),
+		timeoutMs: z.number().int().nonnegative().optional(),
+	})
+	.superRefine((val, ctx) => {
+		if (val.type === 'condition' && (!val.expression || !val.expression.trim())) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "'condition' type requires a non-empty expression",
+				path: ['expression'],
+			});
+		}
+	});
 
 const exportedWorkflowStepSchema = z.object({
 	agentRef: z.string().min(1),
@@ -289,6 +299,40 @@ export function validateExportedWorkflow(data: unknown): ValidationResult<Export
 	if (!result.success) {
 		return { ok: false, error: `invalid: ${result.error.issues.map((i) => i.message).join('; ')}` };
 	}
+
+	// Referential integrity checks — enforce the cross-reference invariants that
+	// the rest of the format depends on (step names as stable cross-reference keys).
+	const stepNameSet = new Set<string>();
+	for (const step of result.data.steps) {
+		if (stepNameSet.has(step.name)) {
+			return { ok: false, error: `invalid: duplicate step name: "${step.name}"` };
+		}
+		stepNameSet.add(step.name);
+	}
+	// startStep must reference a known step name (skip check when steps is empty)
+	if (result.data.steps.length > 0 && !stepNameSet.has(result.data.startStep)) {
+		return {
+			ok: false,
+			error: `invalid: startStep "${result.data.startStep}" does not reference a known step name`,
+		};
+	}
+	// Transition endpoints must reference known step names
+	for (let i = 0; i < result.data.transitions.length; i++) {
+		const t = result.data.transitions[i];
+		if (!stepNameSet.has(t.fromStep)) {
+			return {
+				ok: false,
+				error: `invalid: transitions[${i}].fromStep "${t.fromStep}" does not reference a known step name`,
+			};
+		}
+		if (!stepNameSet.has(t.toStep)) {
+			return {
+				ok: false,
+				error: `invalid: transitions[${i}].toStep "${t.toStep}" does not reference a known step name`,
+			};
+		}
+	}
+
 	return { ok: true, value: { version: 1, ...result.data } };
 }
 
@@ -319,14 +363,14 @@ export function validateExportBundle(data: unknown): ValidationResult<SpaceExpor
 	for (let i = 0; i < rawAgents.length; i++) {
 		const agentResult = validateExportedAgent(rawAgents[i]);
 		if (!agentResult.ok) {
-			return { ok: false, error: `invalid: agents[${i}]: ${agentResult.error}` };
+			return { ok: false, error: `agents[${i}]: ${agentResult.error}` };
 		}
 	}
 	const rawWorkflows = Array.isArray(raw.workflows) ? raw.workflows : [];
 	for (let i = 0; i < rawWorkflows.length; i++) {
 		const wfResult = validateExportedWorkflow(rawWorkflows[i]);
 		if (!wfResult.ok) {
-			return { ok: false, error: `invalid: workflows[${i}]: ${wfResult.error}` };
+			return { ok: false, error: `workflows[${i}]: ${wfResult.error}` };
 		}
 	}
 

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -1,0 +1,314 @@
+/**
+ * Space Export/Import Format
+ *
+ * Functions for serializing SpaceAgent and SpaceWorkflow instances to a
+ * portable JSON format and validating imported data with Zod schemas.
+ *
+ * Key remappings performed during export:
+ * - Step `id` fields are stripped (regenerated on import)
+ * - Rule `appliesTo` step UUIDs → step order indices (stable across re-import)
+ * - Custom agent `agentRef` UUIDs → agent names (portable across Space instances)
+ *
+ * Version policy:
+ * - Accept: version === 1
+ * - Reject with "requires newer version": version > 1 (or version >= 2)
+ * - Reject as invalid: version missing, null, < 1, or non-integer
+ */
+
+import { z } from 'zod';
+import type {
+	SpaceAgent,
+	SpaceWorkflow,
+	ExportedSpaceAgent,
+	ExportedSpaceWorkflow,
+	ExportedWorkflowStep,
+	ExportedWorkflowRule,
+	SpaceExportBundle,
+} from '@neokai/shared';
+
+// ============================================================================
+// Zod schemas
+// ============================================================================
+
+const workflowGateSchema = z.object({
+	type: z.enum(['auto', 'human_approval', 'quality_check', 'pr_review', 'custom']),
+	command: z.string().optional(),
+	description: z.string().optional(),
+	maxRetries: z.number().int().nonnegative().optional(),
+	timeoutMs: z.number().int().nonnegative().optional(),
+});
+
+const exportedWorkflowStepSchema = z.discriminatedUnion('agentRefType', [
+	z.object({
+		agentRefType: z.literal('builtin'),
+		agentRef: z.enum(['planner', 'coder', 'general']),
+		name: z.string().min(1),
+		entryGate: workflowGateSchema.optional(),
+		exitGate: workflowGateSchema.optional(),
+		instructions: z.string().optional(),
+		order: z.number().int().nonnegative(),
+	}),
+	z.object({
+		agentRefType: z.literal('custom'),
+		agentRef: z.string().min(1),
+		name: z.string().min(1),
+		entryGate: workflowGateSchema.optional(),
+		exitGate: workflowGateSchema.optional(),
+		instructions: z.string().optional(),
+		order: z.number().int().nonnegative(),
+	}),
+]);
+
+const exportedWorkflowRuleSchema = z.object({
+	name: z.string().min(1),
+	content: z.string().min(1),
+	appliesTo: z.array(z.number().int().nonnegative()).optional(),
+});
+
+/** Validates the version field; returns an error string or null. */
+function checkVersion(version: unknown): string | null {
+	if (version === null || version === undefined) return 'invalid: version is required';
+	if (typeof version !== 'number') return 'invalid: version must be a number';
+	if (!Number.isInteger(version) || version < 1)
+		return 'invalid: version must be a positive integer';
+	if (version > 1)
+		return `requires newer version: this client supports version 1 but received version ${version}`;
+	return null;
+}
+
+const exportedAgentBaseSchema = z.object({
+	type: z.literal('agent'),
+	name: z.string().min(1),
+	description: z.string().optional(),
+	model: z.string().optional(),
+	provider: z.string().optional(),
+	role: z.enum(['planner', 'coder', 'general']),
+	systemPrompt: z.string().optional(),
+	tools: z.record(z.string(), z.unknown()).optional(),
+	config: z.record(z.string(), z.unknown()).optional(),
+});
+
+const exportedWorkflowBaseSchema = z.object({
+	type: z.literal('workflow'),
+	name: z.string().min(1),
+	description: z.string().optional(),
+	steps: z.array(exportedWorkflowStepSchema),
+	rules: z.array(exportedWorkflowRuleSchema),
+	tags: z.array(z.string()),
+	config: z.record(z.string(), z.unknown()).optional(),
+});
+
+const exportBundleBaseSchema = z.object({
+	type: z.literal('bundle'),
+	name: z.string().min(1),
+	description: z.string().optional(),
+	agents: z.array(exportedAgentBaseSchema),
+	workflows: z.array(exportedWorkflowBaseSchema),
+	exportedAt: z.number().int().positive(),
+	exportedFrom: z.string().optional(),
+});
+
+// ============================================================================
+// Validation result type
+// ============================================================================
+
+export type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+// ============================================================================
+// Export functions
+// ============================================================================
+
+/**
+ * Convert a SpaceAgent to the portable export format.
+ * Strips `id`, `spaceId`, `createdAt`, `updatedAt`.
+ */
+export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
+	const exported: ExportedSpaceAgent = {
+		version: 1,
+		type: 'agent',
+		name: agent.name,
+		role: agent.role,
+	};
+	if (agent.description !== undefined) exported.description = agent.description;
+	if (agent.model !== undefined) exported.model = agent.model;
+	if (agent.provider !== undefined) exported.provider = agent.provider;
+	if (agent.systemPrompt !== undefined) exported.systemPrompt = agent.systemPrompt;
+	if (agent.toolConfig !== undefined) exported.tools = agent.toolConfig;
+	return exported;
+}
+
+/**
+ * Convert a SpaceWorkflow to the portable export format.
+ *
+ * Remappings:
+ * 1. Step `id` fields are stripped.
+ * 2. `rules[].appliesTo` is converted from step UUIDs to step order indices.
+ * 3. For steps with `agentRefType: 'custom'`, `agentRef` UUID is replaced with
+ *    the matching agent's name. If no matching agent is found, `agentRef` is
+ *    preserved as-is (graceful degradation).
+ */
+export function exportWorkflow(
+	workflow: SpaceWorkflow,
+	agents: SpaceAgent[]
+): ExportedSpaceWorkflow {
+	// Build a map from step UUID → order index for rule appliesTo remapping
+	const stepIdToOrder = new Map<string, number>();
+	for (const step of workflow.steps) {
+		stepIdToOrder.set(step.id, step.order);
+	}
+
+	// Build a map from agent UUID → agent name for custom agentRef remapping
+	const agentIdToName = new Map<string, string>();
+	for (const agent of agents) {
+		agentIdToName.set(agent.id, agent.name);
+	}
+
+	// Export steps — strip `id`, remap custom agentRef UUID → name
+	const exportedSteps: ExportedWorkflowStep[] = workflow.steps.map((step) => {
+		const base = {
+			name: step.name,
+			order: step.order,
+			...(step.entryGate !== undefined ? { entryGate: step.entryGate } : {}),
+			...(step.exitGate !== undefined ? { exitGate: step.exitGate } : {}),
+			...(step.instructions !== undefined ? { instructions: step.instructions } : {}),
+		};
+
+		if (step.agentRefType === 'builtin') {
+			return { agentRefType: 'builtin', agentRef: step.agentRef, ...base };
+		} else {
+			// custom: remap UUID → name (fallback to UUID if agent not found)
+			const agentName = agentIdToName.get(step.agentRef) ?? step.agentRef;
+			return { agentRefType: 'custom', agentRef: agentName, ...base };
+		}
+	});
+
+	// Export rules — strip `id`, remap appliesTo UUID[] → order index[]
+	const exportedRules: ExportedWorkflowRule[] = workflow.rules.map((rule) => {
+		const exported: ExportedWorkflowRule = {
+			name: rule.name,
+			content: rule.content,
+		};
+		if (rule.appliesTo !== undefined && rule.appliesTo.length > 0) {
+			const orderIndices = rule.appliesTo
+				.map((stepId) => stepIdToOrder.get(stepId))
+				.filter((idx): idx is number => idx !== undefined);
+			if (orderIndices.length > 0) {
+				exported.appliesTo = orderIndices;
+			}
+		}
+		return exported;
+	});
+
+	const result: ExportedSpaceWorkflow = {
+		version: 1,
+		type: 'workflow',
+		name: workflow.name,
+		steps: exportedSteps,
+		rules: exportedRules,
+		tags: workflow.tags,
+	};
+	if (workflow.description !== undefined) result.description = workflow.description;
+	if (workflow.config !== undefined) result.config = workflow.config;
+	return result;
+}
+
+/**
+ * Create a SpaceExportBundle from a set of agents and workflows.
+ */
+export function exportBundle(
+	agents: SpaceAgent[],
+	workflows: SpaceWorkflow[],
+	name: string,
+	options?: { description?: string; exportedFrom?: string }
+): SpaceExportBundle {
+	const exportedAgents = agents.map(exportAgent);
+	const exportedWorkflows = workflows.map((wf) => exportWorkflow(wf, agents));
+	const bundle: SpaceExportBundle = {
+		version: 1,
+		type: 'bundle',
+		name,
+		agents: exportedAgents,
+		workflows: exportedWorkflows,
+		exportedAt: Date.now(),
+	};
+	if (options?.description !== undefined) bundle.description = options.description;
+	if (options?.exportedFrom !== undefined) bundle.exportedFrom = options.exportedFrom;
+	return bundle;
+}
+
+// ============================================================================
+// Validation functions
+// ============================================================================
+
+/**
+ * Validate an unknown value as an ExportedSpaceAgent.
+ *
+ * Version handling:
+ * - version === 1 → accepted
+ * - version > 1 → error: "requires newer version: ..."
+ * - version < 1 or missing/non-integer → error: "invalid: ..."
+ */
+export function validateExportedAgent(data: unknown): ValidationResult<ExportedSpaceAgent> {
+	if (typeof data !== 'object' || data === null) {
+		return { ok: false, error: 'invalid: expected an object' };
+	}
+	const versionError = checkVersion((data as Record<string, unknown>).version);
+	if (versionError) return { ok: false, error: versionError };
+
+	const result = exportedAgentBaseSchema.safeParse(data);
+	if (!result.success) {
+		return { ok: false, error: `invalid: ${result.error.issues.map((i) => i.message).join('; ')}` };
+	}
+	return { ok: true, value: { version: 1, ...result.data } };
+}
+
+/**
+ * Validate an unknown value as an ExportedSpaceWorkflow.
+ *
+ * Version handling: same as validateExportedAgent.
+ */
+export function validateExportedWorkflow(data: unknown): ValidationResult<ExportedSpaceWorkflow> {
+	if (typeof data !== 'object' || data === null) {
+		return { ok: false, error: 'invalid: expected an object' };
+	}
+	const versionError = checkVersion((data as Record<string, unknown>).version);
+	if (versionError) return { ok: false, error: versionError };
+
+	const result = exportedWorkflowBaseSchema.safeParse(data);
+	if (!result.success) {
+		return { ok: false, error: `invalid: ${result.error.issues.map((i) => i.message).join('; ')}` };
+	}
+	return { ok: true, value: { version: 1, ...result.data } };
+}
+
+/**
+ * Validate an unknown value as a SpaceExportBundle.
+ *
+ * Version handling: same as validateExportedAgent.
+ * Also validates each embedded agent and workflow against their respective schemas.
+ */
+export function validateExportBundle(data: unknown): ValidationResult<SpaceExportBundle> {
+	if (typeof data !== 'object' || data === null) {
+		return { ok: false, error: 'invalid: expected an object' };
+	}
+	const versionError = checkVersion((data as Record<string, unknown>).version);
+	if (versionError) return { ok: false, error: versionError };
+
+	const result = exportBundleBaseSchema.safeParse(data);
+	if (!result.success) {
+		return { ok: false, error: `invalid: ${result.error.issues.map((i) => i.message).join('; ')}` };
+	}
+	return {
+		ok: true,
+		value: {
+			version: 1,
+			type: 'bundle',
+			name: result.data.name,
+			...(result.data.description !== undefined ? { description: result.data.description } : {}),
+			agents: result.data.agents.map((a) => ({ version: 1 as const, ...a })),
+			workflows: result.data.workflows.map((w) => ({ version: 1 as const, ...w })),
+			exportedAt: result.data.exportedAt,
+			...(result.data.exportedFrom !== undefined ? { exportedFrom: result.data.exportedFrom } : {}),
+		},
+	};
+}

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -38,26 +38,14 @@ const workflowGateSchema = z.object({
 	timeoutMs: z.number().int().nonnegative().optional(),
 });
 
-const exportedWorkflowStepSchema = z.discriminatedUnion('agentRefType', [
-	z.object({
-		agentRefType: z.literal('builtin'),
-		agentRef: z.enum(['planner', 'coder', 'general']),
-		name: z.string().min(1),
-		entryGate: workflowGateSchema.optional(),
-		exitGate: workflowGateSchema.optional(),
-		instructions: z.string().optional(),
-		order: z.number().int().nonnegative(),
-	}),
-	z.object({
-		agentRefType: z.literal('custom'),
-		agentRef: z.string().min(1),
-		name: z.string().min(1),
-		entryGate: workflowGateSchema.optional(),
-		exitGate: workflowGateSchema.optional(),
-		instructions: z.string().optional(),
-		order: z.number().int().nonnegative(),
-	}),
-]);
+const exportedWorkflowStepSchema = z.object({
+	agentRef: z.string().min(1),
+	name: z.string().min(1),
+	entryGate: workflowGateSchema.optional(),
+	exitGate: workflowGateSchema.optional(),
+	instructions: z.string().optional(),
+	order: z.number().int().nonnegative(),
+});
 
 const exportedWorkflowRuleSchema = z.object({
 	name: z.string().min(1),
@@ -82,9 +70,9 @@ const exportedAgentBaseSchema = z.object({
 	description: z.string().optional(),
 	model: z.string().optional(),
 	provider: z.string().optional(),
-	role: z.enum(['planner', 'coder', 'general']),
+	role: z.enum(['planner', 'coder', 'general', 'reviewer']),
 	systemPrompt: z.string().optional(),
-	tools: z.record(z.string(), z.unknown()).optional(),
+	tools: z.array(z.string()).optional(),
 	config: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -133,7 +121,7 @@ export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
 	if (agent.model !== undefined) exported.model = agent.model;
 	if (agent.provider !== undefined) exported.provider = agent.provider;
 	if (agent.systemPrompt !== undefined) exported.systemPrompt = agent.systemPrompt;
-	if (agent.toolConfig !== undefined) exported.tools = agent.toolConfig;
+	if (agent.tools !== undefined) exported.tools = agent.tools;
 	return exported;
 }
 
@@ -142,10 +130,11 @@ export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
  *
  * Remappings:
  * 1. Step `id` fields are stripped.
- * 2. `rules[].appliesTo` is converted from step UUIDs to step order indices.
- * 3. For steps with `agentRefType: 'custom'`, `agentRef` UUID is replaced with
- *    the matching agent's name. If no matching agent is found, `agentRef` is
- *    preserved as-is (graceful degradation).
+ * 2. Step `agentId` UUID is replaced by the agent's **name** (`agentRef`),
+ *    making the reference portable across Space instances.
+ *    If no matching agent is found in `agents`, the UUID is preserved as-is
+ *    (graceful degradation).
+ * 3. `rules[].appliesTo` is converted from step UUIDs to step order indices.
  */
 export function exportWorkflow(
 	workflow: SpaceWorkflow,
@@ -157,29 +146,21 @@ export function exportWorkflow(
 		stepIdToOrder.set(step.id, step.order);
 	}
 
-	// Build a map from agent UUID → agent name for custom agentRef remapping
+	// Build a map from agent UUID → agent name
 	const agentIdToName = new Map<string, string>();
 	for (const agent of agents) {
 		agentIdToName.set(agent.id, agent.name);
 	}
 
-	// Export steps — strip `id`, remap custom agentRef UUID → name
+	// Export steps — strip `id`, remap agentId UUID → agent name
 	const exportedSteps: ExportedWorkflowStep[] = workflow.steps.map((step) => {
-		const base = {
-			name: step.name,
-			order: step.order,
-			...(step.entryGate !== undefined ? { entryGate: step.entryGate } : {}),
-			...(step.exitGate !== undefined ? { exitGate: step.exitGate } : {}),
-			...(step.instructions !== undefined ? { instructions: step.instructions } : {}),
-		};
-
-		if (step.agentRefType === 'builtin') {
-			return { agentRefType: 'builtin', agentRef: step.agentRef, ...base };
-		} else {
-			// custom: remap UUID → name (fallback to UUID if agent not found)
-			const agentName = agentIdToName.get(step.agentRef) ?? step.agentRef;
-			return { agentRefType: 'custom', agentRef: agentName, ...base };
-		}
+		// Remap agentId UUID → agent name (fallback to UUID when agent not found)
+		const agentRef = agentIdToName.get(step.agentId) ?? step.agentId;
+		const exported: ExportedWorkflowStep = { agentRef, name: step.name, order: step.order };
+		if (step.entryGate !== undefined) exported.entryGate = step.entryGate;
+		if (step.exitGate !== undefined) exported.exitGate = step.exitGate;
+		if (step.instructions !== undefined) exported.instructions = step.instructions;
+		return exported;
 	});
 
 	// Export rules — strip `id`, remap appliesTo UUID[] → order index[]

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -192,6 +192,11 @@ export function exportWorkflow(
 			const orderIndices = rule.appliesTo
 				.map((stepId) => stepIdToOrder.get(stepId))
 				.filter((idx): idx is number => idx !== undefined);
+			// If all referenced step UUIDs are absent from the workflow (e.g., stale data),
+			// orderIndices will be empty and `appliesTo` is omitted. This changes the rule
+			// semantics from "applies to specific steps" to "applies to all steps" — an
+			// intentional graceful degradation: a rule that can't resolve its targets is
+			// treated as a global rule rather than silently dropped.
 			if (orderIndices.length > 0) {
 				exported.appliesTo = orderIndices;
 			}
@@ -285,7 +290,9 @@ export function validateExportedWorkflow(data: unknown): ValidationResult<Export
  * Validate an unknown value as a SpaceExportBundle.
  *
  * Version handling: same as validateExportedAgent.
- * Also validates each embedded agent and workflow against their respective schemas.
+ * Each embedded agent and workflow is validated individually via
+ * `validateExportedAgent` / `validateExportedWorkflow` so that nested version
+ * checks (e.g. a v2 agent inside a v1 bundle) are caught and reported.
  */
 export function validateExportBundle(data: unknown): ValidationResult<SpaceExportBundle> {
 	if (typeof data !== 'object' || data === null) {
@@ -298,6 +305,25 @@ export function validateExportBundle(data: unknown): ValidationResult<SpaceExpor
 	if (!result.success) {
 		return { ok: false, error: `invalid: ${result.error.issues.map((i) => i.message).join('; ')}` };
 	}
+
+	// Validate each nested agent and workflow using the full per-item validators
+	// so that their individual version fields are also checked.
+	const raw = data as Record<string, unknown>;
+	const rawAgents = Array.isArray(raw.agents) ? raw.agents : [];
+	for (let i = 0; i < rawAgents.length; i++) {
+		const agentResult = validateExportedAgent(rawAgents[i]);
+		if (!agentResult.ok) {
+			return { ok: false, error: `invalid: agents[${i}]: ${agentResult.error}` };
+		}
+	}
+	const rawWorkflows = Array.isArray(raw.workflows) ? raw.workflows : [];
+	for (let i = 0; i < rawWorkflows.length; i++) {
+		const wfResult = validateExportedWorkflow(rawWorkflows[i]);
+		if (!wfResult.ok) {
+			return { ok: false, error: `invalid: workflows[${i}]: ${wfResult.error}` };
+		}
+	}
+
 	return {
 		ok: true,
 		value: {

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -109,6 +109,10 @@ export type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: s
 /**
  * Convert a SpaceAgent to the portable export format.
  * Strips `id`, `spaceId`, `createdAt`, `updatedAt`.
+ *
+ * `SpaceAgent.toolConfig` (per-tool configuration map) is intentionally **not**
+ * exported — it is an implementation detail of the runtime and is not part of the
+ * portable format. Only `tools` (the list of tool names) is exported.
  */
 export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
 	const exported: ExportedSpaceAgent = {

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -6,8 +6,10 @@
  *
  * Key remappings performed during export:
  * - Step `id` fields are stripped (regenerated on import)
- * - Rule `appliesTo` step UUIDs → step order indices (stable across re-import)
- * - Custom agent `agentRef` UUIDs → agent names (portable across Space instances)
+ * - Step `agentId` UUID → agent name (`agentRef`) — portable across Spaces
+ * - Transition `id` stripped; `from`/`to` step UUIDs → step names
+ * - `startStepId` UUID → step name (`startStep`)
+ * - Rule `appliesTo` step UUIDs → step names (stable across re-import)
  *
  * Version policy:
  * - Accept: version === 1
@@ -22,6 +24,7 @@ import type {
 	ExportedSpaceAgent,
 	ExportedSpaceWorkflow,
 	ExportedWorkflowStep,
+	ExportedWorkflowTransition,
 	ExportedWorkflowRule,
 	SpaceExportBundle,
 } from '@neokai/shared';
@@ -30,9 +33,9 @@ import type {
 // Zod schemas
 // ============================================================================
 
-const workflowGateSchema = z.object({
-	type: z.enum(['auto', 'human_approval', 'quality_check', 'pr_review', 'custom']),
-	command: z.string().optional(),
+const workflowConditionSchema = z.object({
+	type: z.enum(['always', 'human', 'condition']),
+	expression: z.string().optional(),
 	description: z.string().optional(),
 	maxRetries: z.number().int().nonnegative().optional(),
 	timeoutMs: z.number().int().nonnegative().optional(),
@@ -41,16 +44,20 @@ const workflowGateSchema = z.object({
 const exportedWorkflowStepSchema = z.object({
 	agentRef: z.string().min(1),
 	name: z.string().min(1),
-	entryGate: workflowGateSchema.optional(),
-	exitGate: workflowGateSchema.optional(),
 	instructions: z.string().optional(),
-	order: z.number().int().nonnegative(),
+});
+
+const exportedWorkflowTransitionSchema = z.object({
+	fromStep: z.string().min(1),
+	toStep: z.string().min(1),
+	condition: workflowConditionSchema.optional(),
+	order: z.number().int().optional(),
 });
 
 const exportedWorkflowRuleSchema = z.object({
 	name: z.string().min(1),
 	content: z.string().min(1),
-	appliesTo: z.array(z.number().int().nonnegative()).optional(),
+	appliesTo: z.array(z.string()).optional(),
 });
 
 /** Validates the version field; returns an error string or null. */
@@ -70,7 +77,7 @@ const exportedAgentBaseSchema = z.object({
 	description: z.string().optional(),
 	model: z.string().optional(),
 	provider: z.string().optional(),
-	role: z.enum(['planner', 'coder', 'general', 'reviewer']),
+	role: z.string().min(1),
 	systemPrompt: z.string().optional(),
 	tools: z.array(z.string()).optional(),
 	config: z.record(z.string(), z.unknown()).optional(),
@@ -81,6 +88,8 @@ const exportedWorkflowBaseSchema = z.object({
 	name: z.string().min(1),
 	description: z.string().optional(),
 	steps: z.array(exportedWorkflowStepSchema),
+	transitions: z.array(exportedWorkflowTransitionSchema),
+	startStep: z.string().min(1),
 	rules: z.array(exportedWorkflowRuleSchema),
 	tags: z.array(z.string()),
 	config: z.record(z.string(), z.unknown()).optional(),
@@ -133,21 +142,24 @@ export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
  * Convert a SpaceWorkflow to the portable export format.
  *
  * Remappings:
- * 1. Step `id` fields are stripped.
- * 2. Step `agentId` UUID is replaced by the agent's **name** (`agentRef`),
- *    making the reference portable across Space instances.
- *    If no matching agent is found in `agents`, the UUID is preserved as-is
- *    (graceful degradation).
- * 3. `rules[].appliesTo` is converted from step UUIDs to step order indices.
+ * 1. Step `id` fields are stripped; step `agentId` UUID → agent name (`agentRef`).
+ *    Falls back to the UUID string when no matching agent is found in `agents`.
+ * 2. Transition `id` stripped; `from`/`to` step UUIDs → step names.
+ *    Falls back to the UUID string when no matching step is found.
+ * 3. `startStepId` UUID → step name (`startStep`).
+ * 4. Rule `appliesTo` step UUIDs → step names (stable cross-references on re-import).
+ *    If a UUID has no matching step (stale data), it is silently dropped from
+ *    `appliesTo`. If all UUIDs are stale the field is omitted, treating the rule
+ *    as global (applies to all steps) rather than discarding it entirely.
  */
 export function exportWorkflow(
 	workflow: SpaceWorkflow,
 	agents: SpaceAgent[]
 ): ExportedSpaceWorkflow {
-	// Build a map from step UUID → order index for rule appliesTo remapping
-	const stepIdToOrder = new Map<string, number>();
+	// Build a map from step UUID → step name
+	const stepIdToName = new Map<string, string>();
 	for (const step of workflow.steps) {
-		stepIdToOrder.set(step.id, step.order);
+		stepIdToName.set(step.id, step.name);
 	}
 
 	// Build a map from agent UUID → agent name
@@ -158,32 +170,39 @@ export function exportWorkflow(
 
 	// Export steps — strip `id`, remap agentId UUID → agent name
 	const exportedSteps: ExportedWorkflowStep[] = workflow.steps.map((step) => {
-		// Remap agentId UUID → agent name (fallback to UUID when agent not found)
 		const agentRef = agentIdToName.get(step.agentId) ?? step.agentId;
-		const exported: ExportedWorkflowStep = { agentRef, name: step.name, order: step.order };
-		if (step.entryGate !== undefined) exported.entryGate = step.entryGate;
-		if (step.exitGate !== undefined) exported.exitGate = step.exitGate;
+		const exported: ExportedWorkflowStep = { agentRef, name: step.name };
 		if (step.instructions !== undefined) exported.instructions = step.instructions;
 		return exported;
 	});
 
-	// Export rules — strip `id`, remap appliesTo UUID[] → order index[]
+	// Export transitions — strip `id`, remap from/to step UUIDs → step names
+	const exportedTransitions: ExportedWorkflowTransition[] = workflow.transitions.map((t) => {
+		const fromStep = stepIdToName.get(t.from) ?? t.from;
+		const toStep = stepIdToName.get(t.to) ?? t.to;
+		const exported: ExportedWorkflowTransition = { fromStep, toStep };
+		if (t.condition !== undefined) exported.condition = t.condition;
+		if (t.order !== undefined) exported.order = t.order;
+		return exported;
+	});
+
+	// Export startStepId UUID → step name
+	const startStep = stepIdToName.get(workflow.startStepId) ?? workflow.startStepId;
+
+	// Export rules — strip `id`, remap appliesTo step UUIDs → step names
 	const exportedRules: ExportedWorkflowRule[] = workflow.rules.map((rule) => {
-		const exported: ExportedWorkflowRule = {
-			name: rule.name,
-			content: rule.content,
-		};
+		const exported: ExportedWorkflowRule = { name: rule.name, content: rule.content };
 		if (rule.appliesTo !== undefined && rule.appliesTo.length > 0) {
-			const orderIndices = rule.appliesTo
-				.map((stepId) => stepIdToOrder.get(stepId))
-				.filter((idx): idx is number => idx !== undefined);
+			const stepNames = rule.appliesTo
+				.map((stepId) => stepIdToName.get(stepId))
+				.filter((n): n is string => n !== undefined);
 			// If all referenced step UUIDs are absent from the workflow (e.g., stale data),
-			// orderIndices will be empty and `appliesTo` is omitted. This changes the rule
+			// stepNames will be empty and `appliesTo` is omitted. This changes the rule
 			// semantics from "applies to specific steps" to "applies to all steps" — an
 			// intentional graceful degradation: a rule that can't resolve its targets is
-			// treated as a global rule rather than silently dropped.
-			if (orderIndices.length > 0) {
-				exported.appliesTo = orderIndices;
+			// treated as global rather than silently dropped.
+			if (stepNames.length > 0) {
+				exported.appliesTo = stepNames;
 			}
 		}
 		return exported;
@@ -194,6 +213,8 @@ export function exportWorkflow(
 		type: 'workflow',
 		name: workflow.name,
 		steps: exportedSteps,
+		transitions: exportedTransitions,
+		startStep,
 		rules: exportedRules,
 		tags: workflow.tags,
 	};

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -24,6 +24,16 @@ export {
 } from './runtime/workflow-executor';
 export type { ConditionContext, ConditionResult, CommandRunner } from './runtime/workflow-executor';
 
+export {
+	exportAgent,
+	exportWorkflow,
+	exportBundle,
+	validateExportedAgent,
+	validateExportedWorkflow,
+	validateExportBundle,
+} from './export-format';
+export type { ValidationResult } from './export-format';
+
 // Types — re-exported from @neokai/shared for convenience
 export type {
 	SpaceWorkflow,

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -598,7 +598,10 @@ describe('validateExportedWorkflow', () => {
 			version: 1,
 			type: 'workflow',
 			name: 'W',
-			steps: [],
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
 			transitions: [
 				{ fromStep: 'Step A', toStep: 'Step B', condition: { type: 'human' }, order: 0 },
 			],
@@ -614,12 +617,87 @@ describe('validateExportedWorkflow', () => {
 		}
 	});
 
+	test('accepts condition type with expression', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [
+				{
+					fromStep: 'Step A',
+					toStep: 'Step B',
+					condition: { type: 'condition', expression: 'bun test --exit-zero' },
+				},
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].condition).toEqual({
+				type: 'condition',
+				expression: 'bun test --exit-zero',
+			});
+		}
+	});
+
+	test('rejects condition type without expression', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [{ fromStep: 'Step A', toStep: 'Step B', condition: { type: 'condition' } }],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('expression');
+		}
+	});
+
+	test('rejects condition type with blank expression', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [
+				{
+					fromStep: 'Step A',
+					toStep: 'Step B',
+					condition: { type: 'condition', expression: '   ' },
+				},
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
 	test('rejects transition with empty fromStep', () => {
 		const data = {
 			version: 1,
 			type: 'workflow',
 			name: 'Bad',
-			steps: [],
+			steps: [{ agentRef: 'Agent B', name: 'Step B' }],
 			transitions: [{ fromStep: '', toStep: 'Step B' }],
 			startStep: 'Step B',
 			rules: [],
@@ -627,6 +705,85 @@ describe('validateExportedWorkflow', () => {
 		};
 		const result = validateExportedWorkflow(data);
 		expect(result.ok).toBe(false);
+	});
+
+	test('rejects transition whose fromStep does not match any step name', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRef: 'Agent A', name: 'Step A' }],
+			transitions: [{ fromStep: 'ghost', toStep: 'Step A' }],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('fromStep');
+			expect(result.error).toContain('ghost');
+		}
+	});
+
+	test('rejects transition whose toStep does not match any step name', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRef: 'Agent A', name: 'Step A' }],
+			transitions: [{ fromStep: 'Step A', toStep: 'phantom' }],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('toStep');
+			expect(result.error).toContain('phantom');
+		}
+	});
+
+	test('rejects workflow with duplicate step names', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step A' }, // duplicate
+			],
+			transitions: [],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('duplicate step name');
+			expect(result.error).toContain('Step A');
+		}
+	});
+
+	test('rejects startStep that does not match any step name', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRef: 'Agent A', name: 'Step A' }],
+			transitions: [],
+			startStep: 'nonexistent',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('startStep');
+			expect(result.error).toContain('nonexistent');
+		}
 	});
 
 	test('rejects version > 1 with "requires newer version"', () => {
@@ -809,6 +966,36 @@ describe('round-trip: export → JSON → validate', () => {
 			expect(result.value.transitions[0].toStep).toBe('Review step');
 			// startStep preserved as step name
 			expect(result.value.startStep).toBe('Code step');
+		}
+	});
+
+	test('condition type with expression round-trip', () => {
+		const workflow = makeWorkflow({
+			steps: [
+				{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Build' },
+				{ id: 'step-uuid-2', agentId: 'agent-uuid-2', name: 'Deploy' },
+			],
+			transitions: [
+				{
+					id: 'trans-uuid-1',
+					from: 'step-uuid-1',
+					to: 'step-uuid-2',
+					condition: { type: 'condition', expression: 'bun test --exit-zero' },
+				},
+			],
+			startStepId: 'step-uuid-1',
+			rules: [],
+		});
+		const exported = exportWorkflow(workflow, []);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].condition).toEqual({
+				type: 'condition',
+				expression: 'bun test --exit-zero',
+			});
 		}
 	});
 

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -2,11 +2,11 @@
  * Export Format Unit Tests
  *
  * Covers:
- * - exportAgent: strips space-specific fields, maps toolConfig → tools
- * - exportWorkflow: strips step IDs, remaps custom agentRef UUID → name,
+ * - exportAgent: strips space-specific fields, maps agent.tools (string[]) → exported.tools
+ * - exportWorkflow: strips step IDs, remaps step agentId UUID → agent name (agentRef),
  *   remaps rule appliesTo step UUIDs → order indices
  * - exportBundle: wraps agents + workflows, adds exportedAt
- * - validateExportedAgent: accepts v1, rejects malformed, version checks
+ * - validateExportedAgent: accepts v1, rejects malformed, version checks, reviewer role
  * - validateExportedWorkflow: accepts v1, rejects malformed, version checks
  * - validateExportBundle: accepts v1, nested agent/workflow validation
  * - Round-trip: export → JSON serialize → deserialize → validate
@@ -38,7 +38,7 @@ function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
 		model: 'claude-sonnet-4-6',
 		provider: 'anthropic',
 		systemPrompt: 'You are an expert coder.',
-		toolConfig: { bash: true, read_file: true },
+		tools: ['bash', 'read_file'],
 		createdAt: 1000,
 		updatedAt: 2000,
 		...overrides,
@@ -57,6 +57,18 @@ function makeMinimalAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
 	};
 }
 
+function makeReviewerAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
+	return {
+		id: 'agent-uuid-3',
+		spaceId: 'space-uuid-1',
+		name: 'Reviewer',
+		role: 'reviewer',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
 function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 	return {
 		id: 'workflow-uuid-1',
@@ -66,23 +78,20 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		steps: [
 			{
 				id: 'step-uuid-1',
-				agentRefType: 'builtin',
-				agentRef: 'coder',
+				agentId: 'agent-uuid-1',
 				name: 'Code step',
 				order: 0,
 			},
 			{
 				id: 'step-uuid-2',
-				agentRefType: 'custom',
-				agentRef: 'agent-uuid-1',
+				agentId: 'agent-uuid-3',
 				name: 'Review step',
 				order: 1,
 				instructions: 'Review carefully',
 			},
 			{
 				id: 'step-uuid-3',
-				agentRefType: 'builtin',
-				agentRef: 'planner',
+				agentId: 'agent-uuid-2',
 				name: 'Plan step',
 				order: 2,
 			},
@@ -126,7 +135,7 @@ describe('exportAgent', () => {
 		expect(exported.model).toBe('claude-sonnet-4-6');
 		expect(exported.provider).toBe('anthropic');
 		expect(exported.systemPrompt).toBe('You are an expert coder.');
-		expect(exported.tools).toEqual({ bash: true, read_file: true });
+		expect(exported.tools).toEqual(['bash', 'read_file']);
 	});
 
 	test('strips space-specific fields (id, spaceId, createdAt, updatedAt)', () => {
@@ -150,10 +159,22 @@ describe('exportAgent', () => {
 		expect('tools' in exported).toBe(false);
 	});
 
-	test('maps toolConfig → tools', () => {
-		const agent = makeAgent({ toolConfig: { edit_file: true } });
+	test('exports tools as string array', () => {
+		const agent = makeAgent({ tools: ['edit_file', 'bash'] });
 		const exported = exportAgent(agent);
-		expect(exported.tools).toEqual({ edit_file: true });
+		expect(exported.tools).toEqual(['edit_file', 'bash']);
+	});
+
+	test('exports reviewer role', () => {
+		const agent = makeReviewerAgent();
+		const exported = exportAgent(agent);
+		expect(exported.role).toBe('reviewer');
+	});
+
+	test('does not export toolConfig (legacy field)', () => {
+		const agent = makeAgent({ toolConfig: { foo: true } });
+		const exported = exportAgent(agent) as Record<string, unknown>;
+		expect('toolConfig' in exported).toBe(false);
 	});
 });
 
@@ -164,7 +185,7 @@ describe('exportAgent', () => {
 describe('exportWorkflow', () => {
 	test('strips workflow-level space fields', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents) as Record<string, unknown>;
 
 		expect('id' in exported).toBe(false);
@@ -175,7 +196,7 @@ describe('exportWorkflow', () => {
 
 	test('strips step IDs', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
 		for (const step of exported.steps) {
@@ -183,9 +204,19 @@ describe('exportWorkflow', () => {
 		}
 	});
 
+	test('strips agentId from steps', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		for (const step of exported.steps) {
+			expect('agentId' in step).toBe(false);
+		}
+	});
+
 	test('retains step order, name, and other fields', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
 		expect(exported.steps[0].order).toBe(0);
@@ -196,37 +227,40 @@ describe('exportWorkflow', () => {
 		expect(exported.steps[2].order).toBe(2);
 	});
 
-	test('remaps custom agentRef UUID → agent name', () => {
+	test('remaps agentId UUID → agent name as agentRef', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()]; // id: 'agent-uuid-1', name: 'My Coder'
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
-		const reviewStep = exported.steps[1];
-		expect(reviewStep.agentRefType).toBe('custom');
-		expect(reviewStep.agentRef).toBe('My Coder');
-	});
-
-	test('preserves builtin agentRef as-is', () => {
-		const workflow = makeWorkflow();
-		const exported = exportWorkflow(workflow, []);
-
-		expect(exported.steps[0].agentRefType).toBe('builtin');
-		expect(exported.steps[0].agentRef).toBe('coder');
-		expect(exported.steps[2].agentRefType).toBe('builtin');
-		expect(exported.steps[2].agentRef).toBe('planner');
+		// step 0: agent-uuid-1 → 'My Coder'
+		expect(exported.steps[0].agentRef).toBe('My Coder');
+		// step 1: agent-uuid-3 → 'Reviewer'
+		expect(exported.steps[1].agentRef).toBe('Reviewer');
+		// step 2: agent-uuid-2 → 'Simple Agent'
+		expect(exported.steps[2].agentRef).toBe('Simple Agent');
 	});
 
 	test('falls back to UUID when agent not found', () => {
 		const workflow = makeWorkflow();
-		// Pass no agents — custom ref should fall back to UUID
+		// Pass no agents — all agentId refs should fall back to UUID
 		const exported = exportWorkflow(workflow, []);
-		const reviewStep = exported.steps[1];
-		expect(reviewStep.agentRef).toBe('agent-uuid-1');
+
+		expect(exported.steps[0].agentRef).toBe('agent-uuid-1');
+		expect(exported.steps[1].agentRef).toBe('agent-uuid-3');
+		expect(exported.steps[2].agentRef).toBe('agent-uuid-2');
+	});
+
+	test('no agentRefType field on exported steps', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+		for (const step of exported.steps) {
+			expect('agentRefType' in step).toBe(false);
+		}
 	});
 
 	test('remaps rule appliesTo step UUIDs → order indices', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
 		// rule 0: appliesTo step-uuid-1 (order 0) and step-uuid-2 (order 1)
@@ -325,6 +359,27 @@ describe('validateExportedAgent', () => {
 		expect(result.ok).toBe(true);
 	});
 
+	test('accepts reviewer role', () => {
+		const data = { version: 1, type: 'agent', name: 'R', role: 'reviewer' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('accepts agent with string[] tools', () => {
+		const data = { version: 1, type: 'agent', name: 'Bot', role: 'coder', tools: ['bash'] };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.tools).toEqual(['bash']);
+		}
+	});
+
+	test('rejects agent with object tools (old format)', () => {
+		const data = { version: 1, type: 'agent', name: 'Bot', role: 'coder', tools: { bash: true } };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+	});
+
 	test('rejects version > 1 with "requires newer version" message', () => {
 		const data = { version: 2, type: 'agent', name: 'Bot', role: 'general' };
 		const result = validateExportedAgent(data);
@@ -359,7 +414,7 @@ describe('validateExportedAgent', () => {
 		expect(result.ok).toBe(false);
 	});
 
-	test('rejects invalid role', () => {
+	test('rejects invalid role (leader)', () => {
 		const data = { version: 1, type: 'agent', name: 'Bot', role: 'leader' };
 		const result = validateExportedAgent(data);
 		expect(result.ok).toBe(false);
@@ -388,7 +443,7 @@ describe('validateExportedAgent', () => {
 describe('validateExportedWorkflow', () => {
 	test('accepts a valid v1 workflow', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 		const result = validateExportedWorkflow(exported);
 		expect(result.ok).toBe(true);
@@ -409,6 +464,48 @@ describe('validateExportedWorkflow', () => {
 		};
 		const result = validateExportedWorkflow(data);
 		expect(result.ok).toBe(true);
+	});
+
+	test('accepts workflow step with flat agentRef', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [{ agentRef: 'My Coder', name: 'Step', order: 0 }],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.steps[0].agentRef).toBe('My Coder');
+		}
+	});
+
+	test('rejects step with empty agentRef', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRef: '', name: 'Step', order: 0 }],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects step missing agentRef', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ name: 'Step', order: 0 }],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
 	});
 
 	test('rejects version > 1 with "requires newer version"', () => {
@@ -439,32 +536,6 @@ describe('validateExportedWorkflow', () => {
 		expect(result.ok).toBe(false);
 	});
 
-	test('rejects step with invalid agentRefType', () => {
-		const data = {
-			version: 1,
-			type: 'workflow',
-			name: 'Bad',
-			steps: [{ agentRefType: 'unknown', agentRef: 'foo', name: 'Step', order: 0 }],
-			rules: [],
-			tags: [],
-		};
-		const result = validateExportedWorkflow(data);
-		expect(result.ok).toBe(false);
-	});
-
-	test('rejects builtin step with leader agentRef', () => {
-		const data = {
-			version: 1,
-			type: 'workflow',
-			name: 'Bad',
-			steps: [{ agentRefType: 'builtin', agentRef: 'leader', name: 'Step', order: 0 }],
-			rules: [],
-			tags: [],
-		};
-		const result = validateExportedWorkflow(data);
-		expect(result.ok).toBe(false);
-	});
-
 	test('rejects rule with negative appliesTo index', () => {
 		const data = {
 			version: 1,
@@ -485,7 +556,7 @@ describe('validateExportedWorkflow', () => {
 
 describe('validateExportBundle', () => {
 	test('accepts a valid v1 bundle', () => {
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const workflows = [makeWorkflow()];
 		const bundle = exportBundle(agents, workflows, 'Bundle');
 		const result = validateExportBundle(bundle);
@@ -493,7 +564,7 @@ describe('validateExportBundle', () => {
 		if (result.ok) {
 			expect(result.value.name).toBe('Bundle');
 			expect(result.value.version).toBe(1);
-			expect(result.value.agents).toHaveLength(1);
+			expect(result.value.agents).toHaveLength(3);
 			expect(result.value.workflows).toHaveLength(1);
 		}
 	});
@@ -574,12 +645,25 @@ describe('round-trip: export → JSON → validate', () => {
 			expect(result.value.name).toBe(agent.name);
 			expect(result.value.role).toBe(agent.role);
 			expect(result.value.model).toBe(agent.model);
+			expect(result.value.tools).toEqual(['bash', 'read_file']);
+		}
+	});
+
+	test('reviewer agent round-trip', () => {
+		const agent = makeReviewerAgent();
+		const exported = exportAgent(agent);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedAgent(parsed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.role).toBe('reviewer');
 		}
 	});
 
 	test('workflow round-trip', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 		const json = JSON.stringify(exported);
 		const parsed = JSON.parse(json) as unknown;
@@ -588,11 +672,15 @@ describe('round-trip: export → JSON → validate', () => {
 		if (result.ok) {
 			expect(result.value.name).toBe(workflow.name);
 			expect(result.value.steps).toHaveLength(3);
+			// agentRef is agent name, not UUID
+			expect(result.value.steps[0].agentRef).toBe('My Coder');
+			expect(result.value.steps[1].agentRef).toBe('Reviewer');
+			expect(result.value.steps[2].agentRef).toBe('Simple Agent');
 		}
 	});
 
 	test('bundle round-trip', () => {
-		const agents = [makeAgent(), makeMinimalAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const workflows = [makeWorkflow()];
 		const bundle = exportBundle(agents, workflows, 'My Bundle', {
 			description: 'Test',
@@ -603,7 +691,7 @@ describe('round-trip: export → JSON → validate', () => {
 		const result = validateExportBundle(parsed);
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.value.agents).toHaveLength(2);
+			expect(result.value.agents).toHaveLength(3);
 			expect(result.value.workflows).toHaveLength(1);
 			expect(result.value.exportedFrom).toBe('/workspace');
 		}
@@ -632,7 +720,7 @@ describe('rule appliesTo round-trip', () => {
 
 	test('workflow round-trip preserves rule appliesTo order indices', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()];
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 		const json = JSON.stringify(exported);
 		const parsed = JSON.parse(json) as unknown;
@@ -644,15 +732,19 @@ describe('rule appliesTo round-trip', () => {
 		}
 	});
 
-	test('custom agentRef UUID does not appear in JSON after export', () => {
+	test('agent UUIDs do not appear in JSON after export', () => {
 		const workflow = makeWorkflow();
-		const agents = [makeAgent()]; // agent-uuid-1 → 'My Coder'
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 		const json = JSON.stringify(exported);
 
-		// UUID must not appear in exported JSON
+		// UUIDs must not appear in exported JSON
 		expect(json).not.toContain('agent-uuid-1');
-		// Name must appear instead
+		expect(json).not.toContain('agent-uuid-2');
+		expect(json).not.toContain('agent-uuid-3');
+		// Names must appear instead
 		expect(json).toContain('My Coder');
+		expect(json).toContain('Reviewer');
+		expect(json).toContain('Simple Agent');
 	});
 });

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1,0 +1,620 @@
+/**
+ * Export Format Unit Tests
+ *
+ * Covers:
+ * - exportAgent: strips space-specific fields, maps toolConfig → tools
+ * - exportWorkflow: strips step IDs, remaps custom agentRef UUID → name,
+ *   remaps rule appliesTo step UUIDs → order indices
+ * - exportBundle: wraps agents + workflows, adds exportedAt
+ * - validateExportedAgent: accepts v1, rejects malformed, version checks
+ * - validateExportedWorkflow: accepts v1, rejects malformed, version checks
+ * - validateExportBundle: accepts v1, nested agent/workflow validation
+ * - Round-trip: export → JSON serialize → deserialize → validate
+ * - rule appliesTo round-trip: verify order indices in JSON, verify on re-import
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	exportAgent,
+	exportWorkflow,
+	exportBundle,
+	validateExportedAgent,
+	validateExportedWorkflow,
+	validateExportBundle,
+} from '../../../src/lib/space/export-format.ts';
+import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
+	return {
+		id: 'agent-uuid-1',
+		spaceId: 'space-uuid-1',
+		name: 'My Coder',
+		role: 'coder',
+		description: 'Writes code',
+		model: 'claude-sonnet-4-6',
+		provider: 'anthropic',
+		systemPrompt: 'You are an expert coder.',
+		toolConfig: { bash: true, read_file: true },
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeMinimalAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
+	return {
+		id: 'agent-uuid-2',
+		spaceId: 'space-uuid-1',
+		name: 'Simple Agent',
+		role: 'general',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	return {
+		id: 'workflow-uuid-1',
+		spaceId: 'space-uuid-1',
+		name: 'CI Workflow',
+		description: 'Runs CI pipeline',
+		steps: [
+			{
+				id: 'step-uuid-1',
+				agentRefType: 'builtin',
+				agentRef: 'coder',
+				name: 'Code step',
+				order: 0,
+			},
+			{
+				id: 'step-uuid-2',
+				agentRefType: 'custom',
+				agentRef: 'agent-uuid-1',
+				name: 'Review step',
+				order: 1,
+				instructions: 'Review carefully',
+			},
+			{
+				id: 'step-uuid-3',
+				agentRefType: 'builtin',
+				agentRef: 'planner',
+				name: 'Plan step',
+				order: 2,
+			},
+		],
+		rules: [
+			{
+				id: 'rule-uuid-1',
+				name: 'All tests must pass',
+				content: 'Run `bun test` before completing each step.',
+				appliesTo: ['step-uuid-1', 'step-uuid-2'],
+			},
+			{
+				id: 'rule-uuid-2',
+				name: 'Global rule',
+				content: 'Always follow coding conventions.',
+				appliesTo: [],
+			},
+		],
+		tags: ['ci', 'test'],
+		config: { maxRuntime: 3600 },
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// exportAgent
+// ---------------------------------------------------------------------------
+
+describe('exportAgent', () => {
+	test('exports all fields correctly', () => {
+		const agent = makeAgent();
+		const exported = exportAgent(agent);
+
+		expect(exported.version).toBe(1);
+		expect(exported.type).toBe('agent');
+		expect(exported.name).toBe('My Coder');
+		expect(exported.role).toBe('coder');
+		expect(exported.description).toBe('Writes code');
+		expect(exported.model).toBe('claude-sonnet-4-6');
+		expect(exported.provider).toBe('anthropic');
+		expect(exported.systemPrompt).toBe('You are an expert coder.');
+		expect(exported.tools).toEqual({ bash: true, read_file: true });
+	});
+
+	test('strips space-specific fields (id, spaceId, createdAt, updatedAt)', () => {
+		const agent = makeAgent();
+		const exported = exportAgent(agent) as Record<string, unknown>;
+
+		expect('id' in exported).toBe(false);
+		expect('spaceId' in exported).toBe(false);
+		expect('createdAt' in exported).toBe(false);
+		expect('updatedAt' in exported).toBe(false);
+	});
+
+	test('omits undefined optional fields', () => {
+		const agent = makeMinimalAgent();
+		const exported = exportAgent(agent) as Record<string, unknown>;
+
+		expect('description' in exported).toBe(false);
+		expect('model' in exported).toBe(false);
+		expect('provider' in exported).toBe(false);
+		expect('systemPrompt' in exported).toBe(false);
+		expect('tools' in exported).toBe(false);
+	});
+
+	test('maps toolConfig → tools', () => {
+		const agent = makeAgent({ toolConfig: { edit_file: true } });
+		const exported = exportAgent(agent);
+		expect(exported.tools).toEqual({ edit_file: true });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// exportWorkflow
+// ---------------------------------------------------------------------------
+
+describe('exportWorkflow', () => {
+	test('strips workflow-level space fields', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents) as Record<string, unknown>;
+
+		expect('id' in exported).toBe(false);
+		expect('spaceId' in exported).toBe(false);
+		expect('createdAt' in exported).toBe(false);
+		expect('updatedAt' in exported).toBe(false);
+	});
+
+	test('strips step IDs', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		for (const step of exported.steps) {
+			expect('id' in step).toBe(false);
+		}
+	});
+
+	test('retains step order, name, and other fields', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		expect(exported.steps[0].order).toBe(0);
+		expect(exported.steps[0].name).toBe('Code step');
+		expect(exported.steps[1].order).toBe(1);
+		expect(exported.steps[1].name).toBe('Review step');
+		expect(exported.steps[1].instructions).toBe('Review carefully');
+		expect(exported.steps[2].order).toBe(2);
+	});
+
+	test('remaps custom agentRef UUID → agent name', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()]; // id: 'agent-uuid-1', name: 'My Coder'
+		const exported = exportWorkflow(workflow, agents);
+
+		const reviewStep = exported.steps[1];
+		expect(reviewStep.agentRefType).toBe('custom');
+		expect(reviewStep.agentRef).toBe('My Coder');
+	});
+
+	test('preserves builtin agentRef as-is', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+
+		expect(exported.steps[0].agentRefType).toBe('builtin');
+		expect(exported.steps[0].agentRef).toBe('coder');
+		expect(exported.steps[2].agentRefType).toBe('builtin');
+		expect(exported.steps[2].agentRef).toBe('planner');
+	});
+
+	test('falls back to UUID when agent not found', () => {
+		const workflow = makeWorkflow();
+		// Pass no agents — custom ref should fall back to UUID
+		const exported = exportWorkflow(workflow, []);
+		const reviewStep = exported.steps[1];
+		expect(reviewStep.agentRef).toBe('agent-uuid-1');
+	});
+
+	test('remaps rule appliesTo step UUIDs → order indices', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// rule 0: appliesTo step-uuid-1 (order 0) and step-uuid-2 (order 1)
+		expect(exported.rules[0].appliesTo).toEqual([0, 1]);
+	});
+
+	test('omits appliesTo for rule with empty appliesTo array', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// rule 1: appliesTo is []
+		expect(exported.rules[1].appliesTo).toBeUndefined();
+	});
+
+	test('strips rule IDs', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+
+		for (const rule of exported.rules) {
+			expect('id' in rule).toBe(false);
+		}
+	});
+
+	test('preserves tags and config', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+
+		expect(exported.tags).toEqual(['ci', 'test']);
+		expect(exported.config).toEqual({ maxRuntime: 3600 });
+	});
+
+	test('has version 1 and type workflow', () => {
+		const exported = exportWorkflow(makeWorkflow(), []);
+		expect(exported.version).toBe(1);
+		expect(exported.type).toBe('workflow');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// exportBundle
+// ---------------------------------------------------------------------------
+
+describe('exportBundle', () => {
+	test('creates bundle with correct structure', () => {
+		const agents = [makeAgent()];
+		const workflows = [makeWorkflow()];
+		const bundle = exportBundle(agents, workflows, 'My Bundle', {
+			description: 'A test bundle',
+			exportedFrom: '/workspace/foo',
+		});
+
+		expect(bundle.version).toBe(1);
+		expect(bundle.type).toBe('bundle');
+		expect(bundle.name).toBe('My Bundle');
+		expect(bundle.description).toBe('A test bundle');
+		expect(bundle.exportedFrom).toBe('/workspace/foo');
+		expect(bundle.agents).toHaveLength(1);
+		expect(bundle.workflows).toHaveLength(1);
+		expect(typeof bundle.exportedAt).toBe('number');
+		expect(bundle.exportedAt).toBeGreaterThan(0);
+	});
+
+	test('works with empty agents and workflows', () => {
+		const bundle = exportBundle([], [], 'Empty Bundle');
+		expect(bundle.agents).toHaveLength(0);
+		expect(bundle.workflows).toHaveLength(0);
+	});
+
+	test('omits optional fields when not provided', () => {
+		const bundle = exportBundle([], [], 'Minimal') as Record<string, unknown>;
+		expect('description' in bundle).toBe(false);
+		expect('exportedFrom' in bundle).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateExportedAgent
+// ---------------------------------------------------------------------------
+
+describe('validateExportedAgent', () => {
+	test('accepts a valid v1 agent', () => {
+		const agent = makeAgent();
+		const exported = exportAgent(agent);
+		const result = validateExportedAgent(exported);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe('My Coder');
+			expect(result.value.version).toBe(1);
+		}
+	});
+
+	test('accepts minimal valid agent', () => {
+		const data = { version: 1, type: 'agent', name: 'Bot', role: 'general' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('rejects version > 1 with "requires newer version" message', () => {
+		const data = { version: 2, type: 'agent', name: 'Bot', role: 'general' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('requires newer version');
+			expect(result.error).toContain('version 2');
+		}
+	});
+
+	test('rejects version 0 as invalid', () => {
+		const data = { version: 0, type: 'agent', name: 'Bot', role: 'general' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('invalid');
+		}
+	});
+
+	test('rejects missing version', () => {
+		const data = { type: 'agent', name: 'Bot', role: 'general' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('invalid');
+		}
+	});
+
+	test('rejects non-integer version', () => {
+		const data = { version: 1.5, type: 'agent', name: 'Bot', role: 'general' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects invalid role', () => {
+		const data = { version: 1, type: 'agent', name: 'Bot', role: 'leader' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('invalid');
+		}
+	});
+
+	test('rejects missing name', () => {
+		const data = { version: 1, type: 'agent', role: 'coder' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects non-object input', () => {
+		expect(validateExportedAgent(null).ok).toBe(false);
+		expect(validateExportedAgent('string').ok).toBe(false);
+		expect(validateExportedAgent(42).ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateExportedWorkflow
+// ---------------------------------------------------------------------------
+
+describe('validateExportedWorkflow', () => {
+	test('accepts a valid v1 workflow', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const result = validateExportedWorkflow(exported);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe('CI Workflow');
+			expect(result.value.version).toBe(1);
+		}
+	});
+
+	test('accepts minimal valid workflow', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Simple',
+			steps: [],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+	});
+
+	test('rejects version > 1 with "requires newer version"', () => {
+		const data = {
+			version: 3,
+			type: 'workflow',
+			name: 'Simple',
+			steps: [],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('requires newer version');
+		}
+	});
+
+	test('rejects missing version', () => {
+		const data = { type: 'workflow', name: 'Simple', steps: [], rules: [], tags: [] };
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects negative version', () => {
+		const data = { version: -1, type: 'workflow', name: 'Simple', steps: [], rules: [], tags: [] };
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects step with invalid agentRefType', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRefType: 'unknown', agentRef: 'foo', name: 'Step', order: 0 }],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects builtin step with leader agentRef', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agentRefType: 'builtin', agentRef: 'leader', name: 'Step', order: 0 }],
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects rule with negative appliesTo index', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [],
+			rules: [{ name: 'Rule', content: 'Content', appliesTo: [-1] }],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateExportBundle
+// ---------------------------------------------------------------------------
+
+describe('validateExportBundle', () => {
+	test('accepts a valid v1 bundle', () => {
+		const agents = [makeAgent()];
+		const workflows = [makeWorkflow()];
+		const bundle = exportBundle(agents, workflows, 'Bundle');
+		const result = validateExportBundle(bundle);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe('Bundle');
+			expect(result.value.version).toBe(1);
+			expect(result.value.agents).toHaveLength(1);
+			expect(result.value.workflows).toHaveLength(1);
+		}
+	});
+
+	test('rejects version > 1', () => {
+		const bundle = { ...exportBundle([], [], 'B'), version: 5 };
+		const result = validateExportBundle(bundle);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('requires newer version');
+		}
+	});
+
+	test('rejects missing exportedAt', () => {
+		const b = exportBundle([], [], 'B') as Record<string, unknown>;
+		delete b.exportedAt;
+		const result = validateExportBundle(b);
+		expect(result.ok).toBe(false);
+	});
+
+	test('rejects non-object', () => {
+		expect(validateExportBundle(null).ok).toBe(false);
+		expect(validateExportBundle([]).ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip tests
+// ---------------------------------------------------------------------------
+
+describe('round-trip: export → JSON → validate', () => {
+	test('agent round-trip', () => {
+		const agent = makeAgent();
+		const exported = exportAgent(agent);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedAgent(parsed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe(agent.name);
+			expect(result.value.role).toBe(agent.role);
+			expect(result.value.model).toBe(agent.model);
+		}
+	});
+
+	test('workflow round-trip', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.name).toBe(workflow.name);
+			expect(result.value.steps).toHaveLength(3);
+		}
+	});
+
+	test('bundle round-trip', () => {
+		const agents = [makeAgent(), makeMinimalAgent()];
+		const workflows = [makeWorkflow()];
+		const bundle = exportBundle(agents, workflows, 'My Bundle', {
+			description: 'Test',
+			exportedFrom: '/workspace',
+		});
+		const json = JSON.stringify(bundle);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportBundle(parsed);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.agents).toHaveLength(2);
+			expect(result.value.workflows).toHaveLength(1);
+			expect(result.value.exportedFrom).toBe('/workspace');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// rule appliesTo round-trip (verify order indices in JSON)
+// ---------------------------------------------------------------------------
+
+describe('rule appliesTo round-trip', () => {
+	test('order indices appear in serialized JSON, not UUIDs', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+		const json = JSON.stringify(exported);
+
+		// step UUIDs must NOT appear
+		expect(json).not.toContain('step-uuid-1');
+		expect(json).not.toContain('step-uuid-2');
+		expect(json).not.toContain('step-uuid-3');
+
+		// appliesTo must contain numbers (0 and 1)
+		const parsed = JSON.parse(json) as { rules: Array<{ appliesTo?: number[] }> };
+		expect(parsed.rules[0].appliesTo).toEqual([0, 1]);
+	});
+
+	test('workflow round-trip preserves rule appliesTo order indices', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.rules[0].appliesTo).toEqual([0, 1]);
+		}
+	});
+
+	test('custom agentRef UUID does not appear in JSON after export', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent()]; // agent-uuid-1 → 'My Coder'
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+
+		// UUID must not appear in exported JSON
+		expect(json).not.toContain('agent-uuid-1');
+		// Name must appear instead
+		expect(json).toContain('My Coder');
+	});
+});

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -4,13 +4,14 @@
  * Covers:
  * - exportAgent: strips space-specific fields, maps agent.tools (string[]) → exported.tools
  * - exportWorkflow: strips step IDs, remaps step agentId UUID → agent name (agentRef),
- *   remaps rule appliesTo step UUIDs → order indices
+ *   remaps transition from/to step UUIDs → step names, remaps startStepId UUID → step name,
+ *   remaps rule appliesTo step UUIDs → step names
  * - exportBundle: wraps agents + workflows, adds exportedAt
- * - validateExportedAgent: accepts v1, rejects malformed, version checks, reviewer role
- * - validateExportedWorkflow: accepts v1, rejects malformed, version checks
+ * - validateExportedAgent: accepts v1, rejects malformed, version checks
+ * - validateExportedWorkflow: accepts v1, rejects malformed, version checks, transitions/startStep
  * - validateExportBundle: accepts v1, nested agent/workflow validation
  * - Round-trip: export → JSON serialize → deserialize → validate
- * - rule appliesTo round-trip: verify order indices in JSON, verify on re-import
+ * - rule appliesTo round-trip: verify step names in JSON, verify on re-import
  */
 
 import { describe, test, expect } from 'bun:test';
@@ -76,26 +77,26 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		name: 'CI Workflow',
 		description: 'Runs CI pipeline',
 		steps: [
-			{
-				id: 'step-uuid-1',
-				agentId: 'agent-uuid-1',
-				name: 'Code step',
-				order: 0,
-			},
+			{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Code step' },
 			{
 				id: 'step-uuid-2',
 				agentId: 'agent-uuid-3',
 				name: 'Review step',
-				order: 1,
 				instructions: 'Review carefully',
 			},
+			{ id: 'step-uuid-3', agentId: 'agent-uuid-2', name: 'Plan step' },
+		],
+		transitions: [
+			{ id: 'trans-uuid-1', from: 'step-uuid-1', to: 'step-uuid-2' },
 			{
-				id: 'step-uuid-3',
-				agentId: 'agent-uuid-2',
-				name: 'Plan step',
-				order: 2,
+				id: 'trans-uuid-2',
+				from: 'step-uuid-2',
+				to: 'step-uuid-3',
+				condition: { type: 'human' },
+				order: 0,
 			},
 		],
+		startStepId: 'step-uuid-1',
 		rules: [
 			{
 				id: 'rule-uuid-1',
@@ -171,7 +172,7 @@ describe('exportAgent', () => {
 		expect(exported.role).toBe('reviewer');
 	});
 
-	test('does not export toolConfig (legacy field)', () => {
+	test('does not export toolConfig (runtime-only field)', () => {
 		const agent = makeAgent({ toolConfig: { foo: true } });
 		const exported = exportAgent(agent) as Record<string, unknown>;
 		expect('toolConfig' in exported).toBe(false);
@@ -214,17 +215,15 @@ describe('exportWorkflow', () => {
 		}
 	});
 
-	test('retains step order, name, and other fields', () => {
+	test('retains step name and instructions', () => {
 		const workflow = makeWorkflow();
 		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
-		expect(exported.steps[0].order).toBe(0);
 		expect(exported.steps[0].name).toBe('Code step');
-		expect(exported.steps[1].order).toBe(1);
 		expect(exported.steps[1].name).toBe('Review step');
 		expect(exported.steps[1].instructions).toBe('Review carefully');
-		expect(exported.steps[2].order).toBe(2);
+		expect(exported.steps[2].name).toBe('Plan step');
 	});
 
 	test('remaps agentId UUID → agent name as agentRef', () => {
@@ -250,21 +249,56 @@ describe('exportWorkflow', () => {
 		expect(exported.steps[2].agentRef).toBe('agent-uuid-2');
 	});
 
-	test('no agentRefType field on exported steps', () => {
-		const workflow = makeWorkflow();
-		const exported = exportWorkflow(workflow, []);
-		for (const step of exported.steps) {
-			expect('agentRefType' in step).toBe(false);
-		}
-	});
-
-	test('remaps rule appliesTo step UUIDs → order indices', () => {
+	test('exports transitions with step names replacing UUIDs', () => {
 		const workflow = makeWorkflow();
 		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
 
-		// rule 0: appliesTo step-uuid-1 (order 0) and step-uuid-2 (order 1)
-		expect(exported.rules[0].appliesTo).toEqual([0, 1]);
+		expect(exported.transitions).toHaveLength(2);
+		expect(exported.transitions[0].fromStep).toBe('Code step');
+		expect(exported.transitions[0].toStep).toBe('Review step');
+		expect(exported.transitions[1].fromStep).toBe('Review step');
+		expect(exported.transitions[1].toStep).toBe('Plan step');
+		expect(exported.transitions[1].condition).toEqual({ type: 'human' });
+		expect(exported.transitions[1].order).toBe(0);
+	});
+
+	test('strips transition IDs', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+		for (const t of exported.transitions) {
+			expect('id' in t).toBe(false);
+		}
+	});
+
+	test('falls back to UUID when transition step not found', () => {
+		const workflow = makeWorkflow({
+			transitions: [{ id: 'trans-uuid-1', from: 'step-uuid-UNKNOWN', to: 'step-uuid-1' }],
+		});
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.transitions[0].fromStep).toBe('step-uuid-UNKNOWN');
+		expect(exported.transitions[0].toStep).toBe('Code step');
+	});
+
+	test('exports startStep as step name', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.startStep).toBe('Code step');
+	});
+
+	test('falls back to UUID for startStep when not found', () => {
+		const workflow = makeWorkflow({ startStepId: 'step-uuid-MISSING' });
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.startStep).toBe('step-uuid-MISSING');
+	});
+
+	test('remaps rule appliesTo step UUIDs → step names', () => {
+		const workflow = makeWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// rule 0: appliesTo step-uuid-1 and step-uuid-2 → names
+		expect(exported.rules[0].appliesTo).toEqual(['Code step', 'Review step']);
 	});
 
 	test('omits appliesTo for rule with empty appliesTo array', () => {
@@ -277,13 +311,13 @@ describe('exportWorkflow', () => {
 	});
 
 	test('partial appliesTo resolution — keeps resolved subset, drops stale UUIDs', () => {
-		// Workflow has 2 steps: step-uuid-1 (order 0) and step-uuid-2 (order 1).
-		// Rule references step-uuid-1 (valid) and step-uuid-STALE (not in steps list).
 		const workflow = makeWorkflow({
 			steps: [
-				{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Step A', order: 0 },
-				{ id: 'step-uuid-2', agentId: 'agent-uuid-2', name: 'Step B', order: 1 },
+				{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Step A' },
+				{ id: 'step-uuid-2', agentId: 'agent-uuid-2', name: 'Step B' },
 			],
+			transitions: [],
+			startStepId: 'step-uuid-1',
 			rules: [
 				{
 					id: 'rule-uuid-1',
@@ -295,8 +329,28 @@ describe('exportWorkflow', () => {
 		});
 		const exported = exportWorkflow(workflow, []);
 
-		// Only the resolved index (0) should appear; stale UUID is dropped
-		expect(exported.rules[0].appliesTo).toEqual([0]);
+		// Only the resolved name 'Step A' appears; stale UUID is dropped
+		expect(exported.rules[0].appliesTo).toEqual(['Step A']);
+	});
+
+	test('all-stale appliesTo → appliesTo omitted (rule becomes global)', () => {
+		const workflow = makeWorkflow({
+			steps: [{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Step A' }],
+			transitions: [],
+			startStepId: 'step-uuid-1',
+			rules: [
+				{
+					id: 'rule-uuid-1',
+					name: 'Stale rule',
+					content: 'All refs are stale.',
+					appliesTo: ['step-uuid-STALE-1', 'step-uuid-STALE-2'],
+				},
+			],
+		});
+		const exported = exportWorkflow(workflow, []);
+
+		// All UUIDs unresolvable → omitted (rule applies to all steps)
+		expect(exported.rules[0].appliesTo).toBeUndefined();
 	});
 
 	test('strips rule IDs', () => {
@@ -388,6 +442,13 @@ describe('validateExportedAgent', () => {
 		expect(result.ok).toBe(true);
 	});
 
+	test('accepts any free-form role string', () => {
+		// role is a free-form label — no enum validation
+		const data = { version: 1, type: 'agent', name: 'Bot', role: 'leader' };
+		const result = validateExportedAgent(data);
+		expect(result.ok).toBe(true);
+	});
+
 	test('accepts agent with string[] tools', () => {
 		const data = { version: 1, type: 'agent', name: 'Bot', role: 'coder', tools: ['bash'] };
 		const result = validateExportedAgent(data);
@@ -437,15 +498,6 @@ describe('validateExportedAgent', () => {
 		expect(result.ok).toBe(false);
 	});
 
-	test('rejects invalid role (leader)', () => {
-		const data = { version: 1, type: 'agent', name: 'Bot', role: 'leader' };
-		const result = validateExportedAgent(data);
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error).toContain('invalid');
-		}
-	});
-
 	test('rejects missing name', () => {
 		const data = { version: 1, type: 'agent', role: 'coder' };
 		const result = validateExportedAgent(data);
@@ -473,6 +525,8 @@ describe('validateExportedWorkflow', () => {
 		if (result.ok) {
 			expect(result.value.name).toBe('CI Workflow');
 			expect(result.value.version).toBe(1);
+			expect(result.value.transitions).toHaveLength(2);
+			expect(result.value.startStep).toBe('Code step');
 		}
 	});
 
@@ -482,6 +536,8 @@ describe('validateExportedWorkflow', () => {
 			type: 'workflow',
 			name: 'Simple',
 			steps: [],
+			transitions: [],
+			startStep: 'first',
 			rules: [],
 			tags: [],
 		};
@@ -494,7 +550,9 @@ describe('validateExportedWorkflow', () => {
 			version: 1,
 			type: 'workflow',
 			name: 'W',
-			steps: [{ agentRef: 'My Coder', name: 'Step', order: 0 }],
+			steps: [{ agentRef: 'My Coder', name: 'Step' }],
+			transitions: [],
+			startStep: 'Step',
 			rules: [],
 			tags: [],
 		};
@@ -510,7 +568,9 @@ describe('validateExportedWorkflow', () => {
 			version: 1,
 			type: 'workflow',
 			name: 'Bad',
-			steps: [{ agentRef: '', name: 'Step', order: 0 }],
+			steps: [{ agentRef: '', name: 'Step' }],
+			transitions: [],
+			startStep: 'Step',
 			rules: [],
 			tags: [],
 		};
@@ -523,7 +583,45 @@ describe('validateExportedWorkflow', () => {
 			version: 1,
 			type: 'workflow',
 			name: 'Bad',
-			steps: [{ name: 'Step', order: 0 }],
+			steps: [{ name: 'Step' }],
+			transitions: [],
+			startStep: 'Step',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+
+	test('accepts valid transition', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [],
+			transitions: [
+				{ fromStep: 'Step A', toStep: 'Step B', condition: { type: 'human' }, order: 0 },
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].fromStep).toBe('Step A');
+			expect(result.value.transitions[0].condition).toEqual({ type: 'human' });
+		}
+	});
+
+	test('rejects transition with empty fromStep', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [],
+			transitions: [{ fromStep: '', toStep: 'Step B' }],
+			startStep: 'Step B',
 			rules: [],
 			tags: [],
 		};
@@ -537,6 +635,8 @@ describe('validateExportedWorkflow', () => {
 			type: 'workflow',
 			name: 'Simple',
 			steps: [],
+			transitions: [],
+			startStep: 'x',
 			rules: [],
 			tags: [],
 		};
@@ -548,24 +648,28 @@ describe('validateExportedWorkflow', () => {
 	});
 
 	test('rejects missing version', () => {
-		const data = { type: 'workflow', name: 'Simple', steps: [], rules: [], tags: [] };
+		const data = {
+			type: 'workflow',
+			name: 'Simple',
+			steps: [],
+			transitions: [],
+			startStep: 'x',
+			rules: [],
+			tags: [],
+		};
 		const result = validateExportedWorkflow(data);
 		expect(result.ok).toBe(false);
 	});
 
 	test('rejects negative version', () => {
-		const data = { version: -1, type: 'workflow', name: 'Simple', steps: [], rules: [], tags: [] };
-		const result = validateExportedWorkflow(data);
-		expect(result.ok).toBe(false);
-	});
-
-	test('rejects rule with negative appliesTo index', () => {
 		const data = {
-			version: 1,
+			version: -1,
 			type: 'workflow',
-			name: 'Bad',
+			name: 'Simple',
 			steps: [],
-			rules: [{ name: 'Rule', content: 'Content', appliesTo: [-1] }],
+			transitions: [],
+			startStep: 'x',
+			rules: [],
 			tags: [],
 		};
 		const result = validateExportedWorkflow(data);
@@ -699,6 +803,12 @@ describe('round-trip: export → JSON → validate', () => {
 			expect(result.value.steps[0].agentRef).toBe('My Coder');
 			expect(result.value.steps[1].agentRef).toBe('Reviewer');
 			expect(result.value.steps[2].agentRef).toBe('Simple Agent');
+			// transitions preserved with step names
+			expect(result.value.transitions).toHaveLength(2);
+			expect(result.value.transitions[0].fromStep).toBe('Code step');
+			expect(result.value.transitions[0].toStep).toBe('Review step');
+			// startStep preserved as step name
+			expect(result.value.startStep).toBe('Code step');
 		}
 	});
 
@@ -722,11 +832,11 @@ describe('round-trip: export → JSON → validate', () => {
 });
 
 // ---------------------------------------------------------------------------
-// rule appliesTo round-trip (verify order indices in JSON)
+// rule appliesTo round-trip (verify step names in JSON)
 // ---------------------------------------------------------------------------
 
 describe('rule appliesTo round-trip', () => {
-	test('order indices appear in serialized JSON, not UUIDs', () => {
+	test('step names appear in serialized JSON, not UUIDs', () => {
 		const workflow = makeWorkflow();
 		const exported = exportWorkflow(workflow, []);
 		const json = JSON.stringify(exported);
@@ -736,12 +846,16 @@ describe('rule appliesTo round-trip', () => {
 		expect(json).not.toContain('step-uuid-2');
 		expect(json).not.toContain('step-uuid-3');
 
-		// appliesTo must contain numbers (0 and 1)
-		const parsed = JSON.parse(json) as { rules: Array<{ appliesTo?: number[] }> };
-		expect(parsed.rules[0].appliesTo).toEqual([0, 1]);
+		// transition UUIDs must NOT appear
+		expect(json).not.toContain('trans-uuid-1');
+		expect(json).not.toContain('trans-uuid-2');
+
+		// appliesTo must contain step names (strings)
+		const parsed = JSON.parse(json) as { rules: Array<{ appliesTo?: string[] }> };
+		expect(parsed.rules[0].appliesTo).toEqual(['Code step', 'Review step']);
 	});
 
-	test('workflow round-trip preserves rule appliesTo order indices', () => {
+	test('workflow round-trip preserves rule appliesTo step names', () => {
 		const workflow = makeWorkflow();
 		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
 		const exported = exportWorkflow(workflow, agents);
@@ -751,7 +865,7 @@ describe('rule appliesTo round-trip', () => {
 
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.value.rules[0].appliesTo).toEqual([0, 1]);
+			expect(result.value.rules[0].appliesTo).toEqual(['Code step', 'Review step']);
 		}
 	});
 

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -518,6 +518,44 @@ describe('validateExportBundle', () => {
 		expect(validateExportBundle(null).ok).toBe(false);
 		expect(validateExportBundle([]).ok).toBe(false);
 	});
+
+	test('rejects bundle whose nested agent has version > 1', () => {
+		const bundle = exportBundle([makeAgent()], [], 'B') as Record<string, unknown>;
+		// Override the nested agent's version to simulate a v2 agent embedded in a v1 bundle
+		const agents = bundle.agents as Array<Record<string, unknown>>;
+		agents[0] = { ...agents[0], version: 2 };
+		const result = validateExportBundle(bundle);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('agents[0]');
+			expect(result.error).toContain('requires newer version');
+		}
+	});
+
+	test('rejects bundle whose nested workflow has version > 1', () => {
+		const bundle = exportBundle([], [makeWorkflow()], 'B') as Record<string, unknown>;
+		const workflows = bundle.workflows as Array<Record<string, unknown>>;
+		workflows[0] = { ...workflows[0], version: 3 };
+		const result = validateExportBundle(bundle);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('workflows[0]');
+			expect(result.error).toContain('requires newer version');
+		}
+	});
+
+	test('rejects bundle whose nested agent has invalid (missing) version', () => {
+		const bundle = exportBundle([makeAgent()], [], 'B') as Record<string, unknown>;
+		const agents = bundle.agents as Array<Record<string, unknown>>;
+		const { version: _v, ...agentWithoutVersion } = agents[0];
+		agents[0] = agentWithoutVersion;
+		const result = validateExportBundle(bundle);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('agents[0]');
+			expect(result.error).toContain('invalid');
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -276,6 +276,29 @@ describe('exportWorkflow', () => {
 		expect(exported.rules[1].appliesTo).toBeUndefined();
 	});
 
+	test('partial appliesTo resolution — keeps resolved subset, drops stale UUIDs', () => {
+		// Workflow has 2 steps: step-uuid-1 (order 0) and step-uuid-2 (order 1).
+		// Rule references step-uuid-1 (valid) and step-uuid-STALE (not in steps list).
+		const workflow = makeWorkflow({
+			steps: [
+				{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Step A', order: 0 },
+				{ id: 'step-uuid-2', agentId: 'agent-uuid-2', name: 'Step B', order: 1 },
+			],
+			rules: [
+				{
+					id: 'rule-uuid-1',
+					name: 'Partial rule',
+					content: 'One valid, one stale.',
+					appliesTo: ['step-uuid-1', 'step-uuid-STALE'],
+				},
+			],
+		});
+		const exported = exportWorkflow(workflow, []);
+
+		// Only the resolved index (0) should appear; stale UUID is dropped
+		expect(exported.rules[0].appliesTo).toEqual([0]);
+	});
+
 	test('strips rule IDs', () => {
 		const workflow = makeWorkflow();
 		const exported = exportWorkflow(workflow, []);

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -662,7 +662,19 @@ export interface ExportedWorkflowStep {
 	exitGate?: WorkflowGate;
 	/** Step-specific instructions appended to the agent's system prompt */
 	instructions?: string;
-	/** Zero-based execution order — array position is authoritative on import */
+	/**
+	 * Zero-based execution order for this step.
+	 *
+	 * **On import**: array position is authoritative — the importer assigns new
+	 * order indices from the array index and ignores this field.
+	 *
+	 * **For `appliesTo` in `ExportedWorkflowRule`**: the indices stored in
+	 * `appliesTo` correspond to this field's value (not to the step's position in
+	 * the `steps` array). Because order values are always sequential and 0-based
+	 * after a round-trip through the DB, the two are equivalent in practice —
+	 * but importers should match `appliesTo` values against `order` fields, not
+	 * array indices, for correctness when order values diverge.
+	 */
 	order: number;
 }
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -644,29 +644,27 @@ export interface UpdateSpaceWorkflowParams {
  *
  * Differences from `WorkflowStep`:
  * - `id` is stripped (space-specific, regenerated on import)
- * - For `agentRefType: 'custom'`, `agentRef` holds the agent **name** (not UUID)
- *   so the export is portable across different Space instances.
+ * - `agentId` UUID is replaced by `agentRef` (the agent's **name**), making the
+ *   reference portable across Space instances that may have different UUIDs.
  * - `order` is retained for readability, though array position is authoritative.
+ *
+ * There is no `agentRefType` field — all agents (preset and user-created) are
+ * `SpaceAgent` records referenced uniformly by name in the export format.
  */
-export type ExportedWorkflowStep =
-	| {
-			agentRefType: 'builtin';
-			agentRef: BuiltinAgentRole;
-			name: string;
-			entryGate?: WorkflowGate;
-			exitGate?: WorkflowGate;
-			instructions?: string;
-			order: number;
-	  }
-	| {
-			agentRefType: 'custom';
-			agentRef: string;
-			name: string;
-			entryGate?: WorkflowGate;
-			exitGate?: WorkflowGate;
-			instructions?: string;
-			order: number;
-	  };
+export interface ExportedWorkflowStep {
+	/** Name of the SpaceAgent assigned to this step (portable, not a UUID) */
+	agentRef: string;
+	/** Human-readable step name */
+	name: string;
+	/** Gate checked before this step begins */
+	entryGate?: WorkflowGate;
+	/** Gate checked after this step's agent finishes */
+	exitGate?: WorkflowGate;
+	/** Step-specific instructions appended to the agent's system prompt */
+	instructions?: string;
+	/** Zero-based execution order — array position is authoritative on import */
+	order: number;
+}
 
 /**
  * A workflow rule in the exported format.
@@ -706,14 +704,18 @@ export interface ExportedSpaceAgent {
 	/** Provider name override */
 	provider?: string;
 	/**
-	 * Builtin role preset ('planner' | 'coder' | 'general').
+	 * Builtin role preset ('planner' | 'coder' | 'general' | 'reviewer').
 	 * NOTE: 'leader' is intentionally absent — it is never user-configurable.
 	 */
 	role: BuiltinAgentRole;
 	/** Custom system prompt */
 	systemPrompt?: string;
-	/** Tool configuration */
-	tools?: Record<string, unknown>;
+	/**
+	 * Tool name overrides — list of tool names from KNOWN_TOOLS this agent may use.
+	 * When absent, role-based defaults apply on import.
+	 * Mirrors `SpaceAgent.tools`.
+	 */
+	tools?: string[];
 	/**
 	 * Additional agent configuration.
 	 *

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -640,42 +640,43 @@ export interface UpdateSpaceWorkflowParams {
 // ============================================================================
 
 /**
- * A single workflow step in the exported format.
+ * A single workflow step (graph node) in the exported format.
  *
  * Differences from `WorkflowStep`:
  * - `id` is stripped (space-specific, regenerated on import)
  * - `agentId` UUID is replaced by `agentRef` (the agent's **name**), making the
  *   reference portable across Space instances that may have different UUIDs.
- * - `order` is retained for readability, though array position is authoritative.
  *
- * There is no `agentRefType` field — all agents (preset and user-created) are
- * `SpaceAgent` records referenced uniformly by name in the export format.
+ * Step names are used as cross-references throughout the exported format
+ * (in `ExportedWorkflowTransition.fromStep`/`toStep`,
+ * `ExportedSpaceWorkflow.startStep`, and `ExportedWorkflowRule.appliesTo`).
+ * Step names must therefore be unique within an exported workflow.
  */
 export interface ExportedWorkflowStep {
 	/** Name of the SpaceAgent assigned to this step (portable, not a UUID) */
 	agentRef: string;
-	/** Human-readable step name */
+	/** Human-readable step name — used as the stable cross-reference key in the export */
 	name: string;
-	/** Gate checked before this step begins */
-	entryGate?: WorkflowGate;
-	/** Gate checked after this step's agent finishes */
-	exitGate?: WorkflowGate;
 	/** Step-specific instructions appended to the agent's system prompt */
 	instructions?: string;
-	/**
-	 * Zero-based execution order for this step.
-	 *
-	 * **On import**: array position is authoritative — the importer assigns new
-	 * order indices from the array index and ignores this field.
-	 *
-	 * **For `appliesTo` in `ExportedWorkflowRule`**: the indices stored in
-	 * `appliesTo` correspond to this field's value (not to the step's position in
-	 * the `steps` array). Because order values are always sequential and 0-based
-	 * after a round-trip through the DB, the two are equivalent in practice —
-	 * but importers should match `appliesTo` values against `order` fields, not
-	 * array indices, for correctness when order values diverge.
-	 */
-	order: number;
+}
+
+/**
+ * A directed edge in the exported workflow graph.
+ *
+ * Differences from `WorkflowTransition`:
+ * - `id` is stripped (space-specific, regenerated on import)
+ * - `from`/`to` step UUIDs are replaced by step **names** for portability
+ */
+export interface ExportedWorkflowTransition {
+	/** Name of the source step */
+	fromStep: string;
+	/** Name of the target step */
+	toStep: string;
+	/** Optional condition guarding this transition. Absent = unconditional. */
+	condition?: WorkflowCondition;
+	/** Sort order among transitions with the same source step. Lower = evaluated first. */
+	order?: number;
 }
 
 /**
@@ -683,7 +684,7 @@ export interface ExportedWorkflowStep {
  *
  * Differences from `WorkflowRule`:
  * - `id` is stripped (space-specific, regenerated on import)
- * - `appliesTo` contains step **order indices** (numbers) instead of step UUIDs (strings),
+ * - `appliesTo` contains step **names** instead of step UUIDs (strings),
  *   so the reference survives re-import with freshly generated step IDs.
  */
 export interface ExportedWorkflowRule {
@@ -692,10 +693,10 @@ export interface ExportedWorkflowRule {
 	/** Rule content — markdown prose describing the constraint or guideline */
 	content: string;
 	/**
-	 * Zero-based order indices of the steps this rule applies to.
+	 * Names of the steps this rule applies to.
 	 * Empty array or omitted means the rule applies to ALL steps.
 	 */
-	appliesTo?: number[];
+	appliesTo?: string[];
 }
 
 /**
@@ -716,10 +717,11 @@ export interface ExportedSpaceAgent {
 	/** Provider name override */
 	provider?: string;
 	/**
-	 * Builtin role preset ('planner' | 'coder' | 'general' | 'reviewer').
-	 * NOTE: 'leader' is intentionally absent — it is never user-configurable.
+	 * Role label — free-form string describing the agent's purpose (e.g. 'coder', 'reviewer').
+	 * Used for display and default system prompt labeling; has no runtime routing effect.
+	 * Mirrors `SpaceAgent.role`.
 	 */
-	role: BuiltinAgentRole;
+	role: string;
 	/** Custom system prompt */
 	systemPrompt?: string;
 	/**
@@ -742,7 +744,8 @@ export interface ExportedSpaceAgent {
 /**
  * A Space workflow in the portable export format.
  * Space-specific fields (`id`, `spaceId`, `createdAt`, `updatedAt`) are stripped.
- * Step IDs are stripped; rule `appliesTo` uses step order indices.
+ * Step IDs are stripped; cross-references use step names.
+ * Transition IDs are stripped; `from`/`to` use step names.
  */
 export interface ExportedSpaceWorkflow {
 	/** Format version — always 1 for this revision */
@@ -753,9 +756,13 @@ export interface ExportedSpaceWorkflow {
 	name: string;
 	/** Optional description */
 	description?: string;
-	/** Ordered steps — array position is authoritative for execution order */
+	/** Graph nodes — step order in this array is not significant */
 	steps: ExportedWorkflowStep[];
-	/** Rules with `appliesTo` expressed as step order indices */
+	/** Graph edges — directed transitions between steps */
+	transitions: ExportedWorkflowTransition[];
+	/** Name of the step where execution begins */
+	startStep: string;
+	/** Rules governing agent behavior; `appliesTo` uses step names */
 	rules: ExportedWorkflowRule[];
 	/** Tags for categorization */
 	tags: string[];

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -634,3 +634,133 @@ export interface UpdateSpaceWorkflowParams {
 	tags?: string[] | null;
 	config?: Record<string, unknown> | null;
 }
+
+// ============================================================================
+// Export / Import Format Types (M8)
+// ============================================================================
+
+/**
+ * A single workflow step in the exported format.
+ *
+ * Differences from `WorkflowStep`:
+ * - `id` is stripped (space-specific, regenerated on import)
+ * - For `agentRefType: 'custom'`, `agentRef` holds the agent **name** (not UUID)
+ *   so the export is portable across different Space instances.
+ * - `order` is retained for readability, though array position is authoritative.
+ */
+export type ExportedWorkflowStep =
+	| {
+			agentRefType: 'builtin';
+			agentRef: BuiltinAgentRole;
+			name: string;
+			entryGate?: WorkflowGate;
+			exitGate?: WorkflowGate;
+			instructions?: string;
+			order: number;
+	  }
+	| {
+			agentRefType: 'custom';
+			agentRef: string;
+			name: string;
+			entryGate?: WorkflowGate;
+			exitGate?: WorkflowGate;
+			instructions?: string;
+			order: number;
+	  };
+
+/**
+ * A workflow rule in the exported format.
+ *
+ * Differences from `WorkflowRule`:
+ * - `id` is stripped (space-specific, regenerated on import)
+ * - `appliesTo` contains step **order indices** (numbers) instead of step UUIDs (strings),
+ *   so the reference survives re-import with freshly generated step IDs.
+ */
+export interface ExportedWorkflowRule {
+	/** Human-readable name for display */
+	name: string;
+	/** Rule content — markdown prose describing the constraint or guideline */
+	content: string;
+	/**
+	 * Zero-based order indices of the steps this rule applies to.
+	 * Empty array or omitted means the rule applies to ALL steps.
+	 */
+	appliesTo?: number[];
+}
+
+/**
+ * A Space agent in the portable export format.
+ * Space-specific fields (`id`, `spaceId`, `createdAt`, `updatedAt`) are stripped.
+ */
+export interface ExportedSpaceAgent {
+	/** Format version — always 1 for this revision */
+	version: 1;
+	/** Discriminator for the exported entity type */
+	type: 'agent';
+	/** Human-readable name */
+	name: string;
+	/** Optional description of this agent's specialization */
+	description?: string;
+	/** Model ID override */
+	model?: string;
+	/** Provider name override */
+	provider?: string;
+	/**
+	 * Builtin role preset ('planner' | 'coder' | 'general').
+	 * NOTE: 'leader' is intentionally absent — it is never user-configurable.
+	 */
+	role: BuiltinAgentRole;
+	/** Custom system prompt */
+	systemPrompt?: string;
+	/** Tool configuration */
+	tools?: Record<string, unknown>;
+	/** Additional configuration */
+	config?: Record<string, unknown>;
+}
+
+/**
+ * A Space workflow in the portable export format.
+ * Space-specific fields (`id`, `spaceId`, `createdAt`, `updatedAt`) are stripped.
+ * Step IDs are stripped; rule `appliesTo` uses step order indices.
+ */
+export interface ExportedSpaceWorkflow {
+	/** Format version — always 1 for this revision */
+	version: 1;
+	/** Discriminator for the exported entity type */
+	type: 'workflow';
+	/** Human-readable name */
+	name: string;
+	/** Optional description */
+	description?: string;
+	/** Ordered steps — array position is authoritative for execution order */
+	steps: ExportedWorkflowStep[];
+	/** Rules with `appliesTo` expressed as step order indices */
+	rules: ExportedWorkflowRule[];
+	/** Tags for categorization */
+	tags: string[];
+	/** Additional runtime configuration */
+	config?: Record<string, unknown>;
+}
+
+/**
+ * A bundle containing one or more exported agents and/or workflows.
+ * The bundle is the top-level unit of the export/import file format.
+ */
+export interface SpaceExportBundle {
+	/** Format version — always 1 for this revision */
+	version: 1;
+	/** Discriminator for the top-level type */
+	type: 'bundle';
+	/** Human-readable bundle name */
+	name: string;
+	/** Optional description of the bundle's purpose */
+	description?: string;
+	/** Exported agents (may be empty) */
+	agents: ExportedSpaceAgent[];
+	/** Exported workflows (may be empty) */
+	workflows: ExportedSpaceWorkflow[];
+	/** Export timestamp (milliseconds since epoch) */
+	exportedAt: number;
+	/** Source Space identifier (name or workspace path) for informational purposes */
+	exportedFrom?: string;
+}

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -714,7 +714,14 @@ export interface ExportedSpaceAgent {
 	systemPrompt?: string;
 	/** Tool configuration */
 	tools?: Record<string, unknown>;
-	/** Additional configuration */
+	/**
+	 * Additional agent configuration.
+	 *
+	 * Forward-compatibility stub: `SpaceAgent` does not currently expose a `config`
+	 * field, so `exportAgent()` never populates this. It is reserved here for future
+	 * agent-level configuration that cannot be expressed through the named fields above,
+	 * and for hand-crafted export payloads that need to carry extra metadata.
+	 */
 	config?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
- Add ExportedSpaceAgent, ExportedSpaceWorkflow, SpaceExportBundle,
  ExportedWorkflowStep, ExportedWorkflowTransition, ExportedWorkflowRule types to space.ts
- Create packages/daemon/src/lib/space/export-format.ts with:
  - exportAgent, exportWorkflow, exportBundle functions
  - Remaps agentId UUIDs → agent names (agentRef) on export
  - Remaps transition from/to step UUIDs → step names on export
  - Remaps startStepId UUID → step name (startStep) on export
  - Remaps rule appliesTo step UUIDs → step names on export
  - validateExportedAgent, validateExportedWorkflow, validateExportBundle
    using Zod schemas with clear version error messages (v1 accepted,
    v2+ "requires newer version", missing/invalid → "invalid")
  - Semantic validation: condition type==='condition' requires non-empty expression
  - Referential integrity: duplicate step names, startStep, and transition
    fromStep/toStep must reference known step names
- 79 unit tests covering round-trips, remapping, validation edge cases