### PR TITLE
feat: extend CSS custom properties vocabulary in styles.css

### DIFF
--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -10,6 +10,47 @@
 	--color-dark-850-rgb: 24 24 27;
 	--color-dark-800-rgb: 31 31 35;
 	--color-blue: 59 130 246;
+
+	/* Accent */
+	--color-accent: 99 102 241;
+	--color-accent-hover: 79 70 229;
+
+	/* Surface */
+	--color-surface-0: var(--color-dark-950);
+	--color-surface-1: var(--color-dark-900);
+	--color-surface-2: var(--color-dark-800);
+
+	/* Text scale */
+	--color-text-primary: 243 244 246;
+	--color-text-secondary: 156 163 175;
+	--color-text-muted: 107 114 128;
+
+	/* Border */
+	--color-border-default: 42 42 48;
+	--color-border-subtle: 58 58 66;
+
+	/* Status */
+	--color-status-success: 34 197 94;
+	--color-status-warning: 251 191 36;
+	--color-status-error: 239 68 68;
+	--color-status-info: 99 102 241;
+
+	/* Transition durations — registers Tailwind utilities */
+	--duration-250: 250ms;
+	--duration-instant: 0ms;
+	--duration-deliberate: 400ms;
+
+	/* Border radius */
+	--radius-base: 8px;
+	--radius-lg: 12px;
+	--radius-xl: 20px;
+}
+
+:root {
+	/* Semantic duration aliases for use in raw CSS */
+	--duration-quick: 150ms;
+	--duration-smooth: 250ms;
+	--duration-deliberate: 400ms;
 }
 
 /*


### PR DESCRIPTION
Adds a complete design token vocabulary to the @theme block:
- Accent colors (indigo-500/600)
- Surface hierarchy (surface-0/1/2 aliasing dark-950/900/800)
- Text scale (primary/secondary/muted)
- Border tokens (default/subtle)
- Status colors (success/warning/error/info)
- Transition duration tokens (250ms, instant 0ms, deliberate 400ms)
- Border radius tokens (base 8px, lg 12px, xl 20px)

Adds :root semantic duration aliases for use in raw CSS rules
(--duration-quick, --duration-smooth, --duration-deliberate).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
