### PR TITLE
docs: align Milestone 4 planning docs with transition/condition implementation

### DIFF
--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
@@ -73,10 +73,10 @@ All schema changes are in a **single migration** since everything is new:
 ### 5. Agent Referencing Convention
 
 Unified naming for agent references:
-- `agentRef: string` + `agentRefType: 'builtin' | 'custom'` — used on `WorkflowStep` for workflow definitions
-- `customAgentId?: string` on `SpaceTask` — task-level custom agent assignment
-- `assignedAgent: AgentType` on `SpaceTask` — built-in agent assignment
-- The `agentRef`/`agentRefType` pair is the canonical way to reference agents in workflow definitions. `customAgentId` is the runtime assignment mechanism.
+- `agentId: string` on `WorkflowStep` — UUID of the `SpaceAgent` assigned to this step. All agents (preset and custom) are regular `SpaceAgent` records; there is no separate builtin/custom type distinction.
+- `customAgentId?: string` on `SpaceTask` — task-level custom agent assignment at runtime
+- `assignedAgent: AgentType` on `SpaceTask` — built-in agent assignment at runtime
+- For export/import, `agentId` UUIDs are resolved to agent names and back (see Milestone 8).
 
 ### 6. Space Creation Requires Workspace Path
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/00-overview.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Build a new **Spaces** system — a fully parallel, isolated multi-agent workflow container. Spaces allow users to create custom agents with configurable names, models, providers, tools, and system prompts. These agents can be composed into custom workflows that define agent interactions, runtime gates, and rules. A pure data layer underpins everything, enabling future sharing and marketplace capabilities.
+Build a new **Spaces** system — a fully parallel, isolated multi-agent workflow container. Spaces allow users to create custom agents with configurable names, models, providers, tools, and system prompts. These agents can be composed into custom workflows that define agent interactions, transition conditions, and rules. A pure data layer underpins everything, enabling future sharing and marketplace capabilities.
 
 ## Isolation Principle
 
@@ -33,7 +33,7 @@ The Space system deliberately **does not include goals**. In the existing Room s
 
 2. **Custom Agent Definitions** — a `space_agents` table so users can define agents with arbitrary names, models, tools, and system prompts. Each agent belongs to a Space. Managed by `SpaceAgentManager`.
 
-3. **Custom Workflows** — `space_workflows` and `space_workflow_steps` tables (created in the M1 migration) with `SpaceWorkflowRepository` and `SpaceWorkflowManager` in `packages/daemon/src/lib/space/`. Workflows define sequences of agent steps, runtime gates, and rules. All types in `space.ts`.
+3. **Custom Workflows** — `space_workflows` and `space_workflow_steps` tables (created in the M1 migration) with `SpaceWorkflowRepository` and `SpaceWorkflowManager` in `packages/daemon/src/lib/space/`. Workflows define directed graphs of agent steps connected by transitions with optional conditions, and rules. All types in `space.ts`.
 
 4. **SpaceRuntime** — a new workflow-first orchestration engine in `packages/daemon/src/lib/space/runtime/`. Unlike `RoomRuntime` which has a hardcoded planner→coder→leader flow, `SpaceRuntime` is designed from the ground up for workflow-driven orchestration via `WorkflowExecutor`. Workflow runs are the unit of orchestration — each run tracks step progression through a workflow. Managed by `SpaceRuntimeService`.
 
@@ -51,17 +51,18 @@ The existing `AgentType = 'coder' | 'general'` union is **kept as-is**. Custom a
 
 The `WorkflowExecutor` orchestrates **workflow run** progression within Spaces:
 - A `SpaceWorkflowRun` represents an active execution of a workflow (e.g., Step 1: Planner, Step 2: Coder, Step 3: Security Reviewer)
-- Each workflow step produces one or more `SpaceTask` records. When a step completes, the executor evaluates the exit gate and advances to the next step.
+- Each workflow step produces one or more `SpaceTask` records. When a step completes, the executor evaluates outgoing transition conditions and advances to the next step.
 - **The Leader role is preserved per group.** Every Worker group still gets a Leader session for review. Custom agents with `role: 'reviewer'` are specialized Workers whose output is reviewed by the Leader.
 - The `WorkflowExecutor` hooks into the **task completion** path within `SpaceRuntime`: when all tasks for a step complete (Leader approves), the executor checks whether to advance.
 
-### 3. Gate Security Model
+### 3. Transition Condition Model
 
-Shell-executing gates (`quality_check`, `custom`) pose security risks:
-- **Command allowlisting**: `quality_check` gates only accept predefined commands from a configurable allowlist
-- **Custom gate restrictions**: scripts must be within the workspace directory (no `..`, no absolute paths outside workspace)
-- **Execution timeout**: Default 60s, max 300s, enforced via `Bun.spawn`
-- **Authorization**: Only space owners can define `custom` gates with shell commands
+Transitions connect workflow steps and carry optional conditions that determine whether the transition fires:
+- **`always`** (default when no condition) — transition fires unconditionally
+- **`human`** — transition pauses and waits for explicit human approval before firing
+- **`condition`** — transition fires when a shell `expression` exits with code 0, evaluated via `Bun.spawn`
+- **Execution timeout**: Default 60s, max 300s, enforced per condition evaluation
+- **No allowlist**: condition expressions are arbitrary shell strings; users are responsible for expression content
 
 ### 4. Single Migration Strategy
 
@@ -90,8 +91,8 @@ Spaces require a **workspace path** at creation time — the directory where age
 
 1. **Space Core Data Model & Infrastructure** — All Space types in `space.ts`, single DB migration (all tables including `space_workflow_runs`), repositories, managers, RPC handlers for Space container + tasks + workflow runs + session groups.
 2. **Custom Agent Data & Runtime** — Agent types in `space.ts`, `SpaceAgentRepository`, `SpaceAgentManager`, agent RPC handlers, `createCustomAgentInit()` factory, agent resolution helper.
-3. **Workflow Data Model** — Workflow/step/gate/rule types in `space.ts`, `SpaceWorkflowRepository`, `SpaceWorkflowManager` in `packages/daemon/src/lib/space/`, workflow RPC handlers (`spaceWorkflow.*`), built-in templates.
-4. **Workflow Runtime Engine** — `WorkflowExecutor` in `packages/daemon/src/lib/space/runtime/`, `SpaceRuntime` orchestration engine, `SpaceRuntimeService`, `spaceWorkflowRun.*` RPC handlers, gate evaluation, step advancement, rule injection. Operates on workflow runs and tasks (no goals).
+3. **Workflow Data Model** — Workflow/step/transition/condition/rule types in `space.ts`, `SpaceWorkflowRepository`, `SpaceWorkflowManager` in `packages/daemon/src/lib/space/`, workflow RPC handlers (`spaceWorkflow.*`), built-in templates.
+4. **Workflow Runtime Engine** — `WorkflowExecutor` in `packages/daemon/src/lib/space/runtime/`, `SpaceRuntime` orchestration engine, `SpaceRuntimeService`, `spaceWorkflowRun.*` RPC handlers, transition condition evaluation, step advancement, rule injection. Operates on workflow runs and tasks (no goals).
 5. **Space Frontend Foundation** — Navigation entry point, URL routing, `SpaceStore`, Space creation UX with workspace path picker, minimalist 3-column layout shell (right pane shows placeholder states until M4 provides a running runtime).
 6. **Frontend: Agent & Workflow UI** — Agent creation/editing, visual workflow builder, rules editor — all under `packages/web/src/components/space/`.
 7. **Workflow Selection & Agent Tools** — Two-mode workflow selection (explicit workflowId OR AI auto-select via LLM reasoning), Space agent tools in `packages/daemon/src/lib/space/tools/`, prompt enhancement so the agent can intelligently choose workflows.

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
@@ -201,8 +201,7 @@ Create a single DB migration that creates ALL Space-related tables. Since these 
      id TEXT PRIMARY KEY,
      workflow_id TEXT NOT NULL,
      name TEXT NOT NULL,
-     agent_ref TEXT NOT NULL,
-     agent_ref_type TEXT NOT NULL DEFAULT 'builtin' CHECK(agent_ref_type IN ('builtin', 'custom')),
+     agent_id TEXT NOT NULL,
      instructions TEXT,
      step_order INTEGER NOT NULL,
      FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/01-space-core-data-model.md
@@ -101,8 +101,8 @@ Create a new shared types file for all Space-related types. These are distinct f
      /** Title/description of what this run is doing */
      title: string;
      description: string;
-     /** Current step index in the workflow */
-     currentStepIndex: number;
+     /** ID of the current step being executed */
+     currentStepId: string;
      status: 'pending' | 'in_progress' | 'completed' | 'cancelled' | 'needs_attention';
      config?: Record<string, unknown>;
      createdAt: number;
@@ -203,8 +203,6 @@ Create a single DB migration that creates ALL Space-related tables. Since these 
      name TEXT NOT NULL,
      agent_ref TEXT NOT NULL,
      agent_ref_type TEXT NOT NULL DEFAULT 'builtin' CHECK(agent_ref_type IN ('builtin', 'custom')),
-     entry_gate TEXT,
-     exit_gate TEXT,
      instructions TEXT,
      step_order INTEGER NOT NULL,
      FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
@@ -218,7 +216,7 @@ Create a single DB migration that creates ALL Space-related tables. Since these 
      workflow_id TEXT NOT NULL,
      title TEXT NOT NULL,
      description TEXT NOT NULL DEFAULT '',
-     current_step_index INTEGER NOT NULL DEFAULT 0,
+     current_step_id TEXT NOT NULL DEFAULT '',
      status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
      config TEXT,
      created_at INTEGER NOT NULL,

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/02-custom-agent-data-runtime.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/02-custom-agent-data-runtime.md
@@ -87,7 +87,7 @@ Define the custom agent types and build the data access + business logic layers 
    - `updateAgent(id: string, params: UpdateSpaceAgentParams): SpaceAgent | null`
    - `deleteAgent(id: string): boolean`
    - `getAgentsByIds(ids: string[]): SpaceAgent[]` — batch lookup for workflow validation
-   - `isAgentReferenced(agentId: string): { workflows: string[] }` — checks if agent is referenced by workflow steps (`space_workflow_steps.agent_ref` where `agent_ref_type = 'custom'`)
+   - `isAgentReferenced(agentId: string): { workflows: string[] }` — checks if agent is referenced by workflow steps (`space_workflow_steps.agent_id = agentId`)
    - Handle JSON serialization for `tools` and `config`
 
 4. Create `packages/daemon/src/lib/space/managers/space-agent-manager.ts`:

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Define the workflow types, repository, manager, RPC handlers, and built-in templates for custom workflows within Spaces. A workflow defines a sequence of agent steps with runtime gates between them and configurable rules. All code lives in the Space namespace — no existing Room code is modified.
+Define the workflow types, repository, manager, RPC handlers, and built-in templates for custom workflows within Spaces. A workflow defines a directed graph of agent steps connected by transitions with optional conditions and configurable rules. All code lives in the Space namespace — no existing Room code is modified.
 
 ## Isolation Checklist
 
@@ -17,7 +17,7 @@ Define the workflow types, repository, manager, RPC handlers, and built-in templ
 
 ## Scope
 
-- Workflow shared types (gates, steps, rules) in `space.ts`
+- Workflow shared types (transitions, conditions, steps, rules) in `space.ts`
 - `SpaceWorkflowRepository` and `SpaceWorkflowManager`
 - RPC handlers for workflow CRUD (`spaceWorkflow.*`)
 - DaemonEventMap registration (`spaceWorkflow.created/updated/deleted`)
@@ -41,32 +41,38 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
 1. Add the following types to `packages/shared/src/types/space.ts`:
 
    ```typescript
-   /** Gate type — runtime checkpoints between workflow steps */
-   type WorkflowGateType =
-     | 'auto'           // Automatically proceed
-     | 'human_approval' // Pause for human approval
-     | 'quality_check'  // Run automated checks from allowlist
-     | 'pr_review'      // PR review gate
-     | 'custom';        // Custom workspace-scoped script
+   /** Condition type for a workflow transition */
+   type WorkflowConditionType = 'always' | 'human' | 'condition';
 
-   /** A gate between workflow steps */
-   interface WorkflowGate {
-     type: WorkflowGateType;
+   /**
+    * A condition that guards a workflow transition.
+    * Conditions determine whether a transition may fire when advance() is called.
+    */
+   interface WorkflowCondition {
+     type: WorkflowConditionType;
      /**
-      * For quality_check: must be an allowlisted command (e.g., 'bun run check').
-      * For custom: relative path to script within workspace (no '..', no absolute paths).
-      * See 00-overview.md "Gate Security Model".
+      * Shell expression to evaluate for the `condition` type.
+      * The transition fires when the expression exits with code 0.
       */
-     command?: string;
+     expression?: string;
      description?: string;
-     /**
-      * Max retries before escalating (0 = no retry).
-      * Retry re-evaluates the gate only, does NOT re-run the agent step.
-      * After retries exhausted, gate fails and task → 'needs_attention'.
-      */
+     /** Max retries on failure (0 = no retry). Retry re-evaluates condition only, NOT re-run agent. */
      maxRetries?: number;
-     /** Timeout in ms for gate command. Default: 60000. Max: 300000. */
+     /** Timeout for condition evaluation in ms (0 = use default 60000ms, max 300000ms) */
      timeoutMs?: number;
+   }
+
+   /**
+    * A directed edge in the workflow graph.
+    * Transitions connect steps and carry optional conditions.
+    */
+   interface WorkflowTransition {
+     id: string;
+     from: string;
+     to: string;
+     condition?: WorkflowCondition;
+     /** Sort order among transitions with the same `from` step. Lower = evaluated first. */
+     order?: number;
    }
 
    /** A single step in a workflow */
@@ -74,16 +80,12 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      id: string;
      name: string;
      /**
-      * Which agent executes this step.
-      * - builtin: 'planner', 'coder', 'general' (NOT 'leader' — Leader is implicit)
-      * - custom: a SpaceAgent ID
+      * ID of the SpaceAgent assigned to execute this step.
+      * Preset agents (coder, general, planner, reviewer) are seeded at Space creation time
+      * as regular SpaceAgent records with well-known role labels.
       */
-     agentRef: string;
-     agentRefType: 'builtin' | 'custom';
-     entryGate?: WorkflowGate | null;
-     exitGate?: WorkflowGate | null;
+     agentId: string;
      instructions?: string;
-     order: number;
    }
 
    /** Rule injected into agent prompts */
@@ -105,6 +107,7 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      name: string;
      description: string;
      steps: WorkflowStep[];
+     transitions: WorkflowTransition[];
      rules: WorkflowRule[];
      /**
       * @deprecated Not used for workflow selection. Workflow selection uses only
@@ -122,6 +125,7 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      name: string;
      description?: string;
      steps: Omit<WorkflowStep, 'id'>[];
+     transitions?: Omit<WorkflowTransition, 'id'>[];
      rules?: Omit<WorkflowRule, 'id'>[];
      /** Organizational tags (not used for automatic selection). */
      tags?: string[];
@@ -132,7 +136,8 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
      name?: string;
      description?: string;
      steps?: Omit<WorkflowStep, 'id'>[];
-     rules?: Omit<WorkflowRule, 'id'>[];
+     transitions?: Omit<WorkflowTransition, 'id'>[] | null;
+     rules?: Omit<WorkflowRule, 'id'>[] | null;
      /** Replaces the tag list. Pass `[]` or `null` to clear. Organizational only. */
      tags?: string[] | null;
      config?: Record<string, unknown>;
@@ -170,7 +175,7 @@ Build the data access and business logic layers for workflows within Spaces. The
    - `deleteWorkflow(id: string): boolean`
    - `getWorkflowsReferencingAgent(agentId: string): SpaceWorkflow[]` — finds workflows referencing a custom agent (used for deletion protection in `SpaceAgentManager`)
    - Handle step CRUD within workflow transactions (replace all steps on update)
-   - JSON serialization for `rules`, `entry_gate`, `exit_gate`
+   - JSON serialization for `rules` and `transitions`
    - `rowToWorkflow()` and `rowToStep()` mapping functions
    - **No `getDefaultWorkflow`/`setDefaultWorkflow`** — workflow selection uses only explicit workflowId or AI auto-select.
 
@@ -180,7 +185,7 @@ Build the data access and business logic layers for workflows within Spaces. The
      - Step agent references valid: builtin must be `'planner'|'coder'|'general'` (NOT `'leader'`); custom must reference existing `SpaceAgent` in same space (query `SpaceAgentManager`)
      - At least one step required
      - Step order contiguous (0, 1, 2, ...)
-     - Gate command validation: `quality_check` → allowlist only; `custom` → relative path, no `..`; `timeoutMs` within range 0–300000
+     - Condition validation: `condition` type requires non-empty `expression`; `timeoutMs` within range 0–300000
    - Business logic: workflow selection is either explicit workflowId (caller-provided) or AI auto-select via `list_workflows` + `start_workflow_run`. No default workflow concept, no `isDefault` flag.
 
 3. Export from `packages/daemon/src/lib/space/index.ts`
@@ -190,13 +195,13 @@ Build the data access and business logic layers for workflows within Spaces. The
    - Step ordering validation
    - Agent reference validation (builtin + custom via `SpaceAgentManager`)
    - Rejection of 'leader' as builtin agent ref
-   - Gate command validation (allowlist, path validation)
-   - JSON round-trip for gates and rules
+   - Condition validation (expression required, timeoutMs range)
+   - JSON round-trip for transitions and rules
    - `getWorkflowsReferencingAgent` returns correct results
 
 **Acceptance criteria:**
 - Repository handles CRUD with proper step management using `space_workflows`/`space_workflow_steps` tables
-- Manager validates workflow integrity including gate security
+- Manager validates workflow integrity including transition/condition validation
 - Agent reference validation queries `SpaceAgentManager` (NOT a nonexistent `CustomAgentManager`)
 - No `isDefault` flag on `SpaceWorkflow` — workflow selection is explicit workflowId or AI auto-select only
 - All files in Space namespace — nothing in `packages/daemon/src/lib/room/`
@@ -261,11 +266,11 @@ Create built-in workflow templates that serve as examples. All files in Space na
 **Subtasks:**
 
 1. Create `packages/daemon/src/lib/space/workflows/built-in-workflows.ts`:
-   - `CODING_WORKFLOW`: Planner → Coder (with `human_approval` exit gate on Planner, `pr_review` exit gate on Coder) — mirrors current multi-agent behavior. Leader is implicit per group, not a step.
-   - `RESEARCH_WORKFLOW`: Planner → General (with `auto` gates)
-   - `REVIEW_ONLY_WORKFLOW`: Coder (single step, `pr_review` exit gate, no planning)
+   - `CODING_WORKFLOW`: Planner → Coder (with `human` condition on Planner→Coder transition) — mirrors current multi-agent behavior. Leader is implicit per group, not a step.
+   - `RESEARCH_WORKFLOW`: Planner → General (with `always` conditions)
+   - `REVIEW_ONLY_WORKFLOW`: Coder (single terminal step, no outgoing transitions)
 
-2. Each template includes appropriate gates with only allowlisted commands
+2. Each template includes appropriate transition conditions
 
 3. `getBuiltInWorkflows(): SpaceWorkflow[]` — returns templates without space-specific IDs (no `isDefault` flag, no seeding logic)
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -148,8 +148,8 @@ Add workflow types to `packages/shared/src/types/space.ts` (alongside the Space/
 
 **Acceptance criteria:**
 - All workflow types defined and exported from `@neokai/shared` via `space.ts`
-- JSDoc on all interfaces with clear semantics for `maxRetries`, `command` constraints, and `agentRef` valid values
-- `leader` explicitly documented as NOT a valid `agentRef`
+- JSDoc on all interfaces with clear semantics for `maxRetries`, `expression` (for `condition` type), and `agentId` (SpaceAgent UUID)
+- `agentId` must reference an existing `SpaceAgent` in the same space; preset roles (`planner`, `coder`, `general`, `reviewer`) are regular `SpaceAgent` records
 - No modifications to `packages/shared/src/types/neo.ts`
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -182,9 +182,9 @@ Build the data access and business logic layers for workflows within Spaces. The
 2. Create `packages/daemon/src/lib/space/managers/space-workflow-manager.ts`:
    - Validation:
      - Name unique within space
-     - Step agent references valid: builtin must be `'planner'|'coder'|'general'` (NOT `'leader'`); custom must reference existing `SpaceAgent` in same space (query `SpaceAgentManager`)
+     - Each step's `agentId` must reference an existing `SpaceAgent` in the same space
      - At least one step required
-     - Step order contiguous (0, 1, 2, ...)
+     - All transition `from`/`to` values must reference step IDs that exist in the workflow
      - Condition validation: `condition` type requires non-empty `expression`; `timeoutMs` within range 0–300000
    - Business logic: workflow selection is either explicit workflowId (caller-provided) or AI auto-select via `list_workflows` + `start_workflow_run`. No default workflow concept, no `isDefault` flag.
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/03-workflow-data-model.md
@@ -192,9 +192,8 @@ Build the data access and business logic layers for workflows within Spaces. The
 
 4. Write unit tests:
    - Full CRUD lifecycle
-   - Step ordering validation
-   - Agent reference validation (builtin + custom via `SpaceAgentManager`)
-   - Rejection of 'leader' as builtin agent ref
+   - Step and transition validation (agentId references valid SpaceAgent, transition from/to reference valid step IDs)
+   - Rejection of unknown `agentId` values (SpaceAgent must exist in same space)
    - Condition validation (expression required, timeoutMs range)
    - JSON round-trip for transitions and rules
    - `getWorkflowsReferencingAgent` returns correct results

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -117,11 +117,11 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 2. **Executor rehydration on startup** (restart safety):
    - Implement `rehydrateExecutors()` async method called **at the start of the first `executeTick()`** (not in constructor — constructor is synchronous, async work deferred to first tick)
    - Query all in-progress `SpaceWorkflowRun` records (status = `in_progress`) from `space_workflow_runs`
-   - Reconstruct executors: load `SpaceWorkflow`, create executor with the persisted `currentStepIndex` from the run record
+   - Reconstruct executors: load `SpaceWorkflow`, create executor with the persisted `currentStepId` from the run record
    - Set `rehydrated: boolean` flag to prevent repeat runs
 
 3. **Starting a workflow run**:
-   - `startWorkflowRun(spaceId, workflowId, title, description?)` → creates `SpaceWorkflowRun` record, creates `WorkflowExecutor`, evaluates entry gate of first step, creates first step's `SpaceTask` records
+   - `startWorkflowRun(spaceId, workflowId, title, description?)` → creates `SpaceWorkflowRun` record with `currentStepId` set to the first step, creates `WorkflowExecutor`, creates first step's `SpaceTask` records
    - `workflowId` is **always required** — either the caller provides it explicitly (UI picker, API) or the Space agent selects it via AI auto-select (`list_workflows` → reason → `start_workflow_run`). There is no default workflow fallback.
    - Store executor in map
 
@@ -136,14 +136,14 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
    - Custom agent (`agentRefType: 'custom'`) → `taskType: 'coding'`, `customAgentId` set, status `pending`
    - Helper: `resolveTaskTypeForStep(step: WorkflowStep): 'planning' | 'coding'`
 
-6. **Step advancement and gate enforcement**:
+6. **Step advancement and transition evaluation**:
    - After task completes (Leader approves), check if task belongs to a workflow run (via `workflowRunId`)
    - If yes: check if all tasks for the current step are complete
-   - If all step tasks complete: `executor.canAdvance()` → evaluate exit gate
-   - Gate passes → `executor.advance()` → creates next step's `SpaceTask` records
-   - Gate requires human approval → pause run with flag
-   - Gate fails after retries → run → `needs_attention`
-   - All steps complete → mark `SpaceWorkflowRun` as complete
+   - If all step tasks complete: call `executor.advance()` — evaluates outgoing transition conditions internally
+   - Transition passes → `advance()` persists the new `currentStepId` and creates next step's `SpaceTask` records
+   - Transition requires human approval → pause run with flag
+   - All transitions fail after retries → run → `needs_attention`
+   - No outgoing transitions (terminal step) → `advance()` marks `SpaceWorkflowRun` as complete
 
 7. **Rule injection** into agent prompts:
    - When building worker config for a workflow task, check current step for rules

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -2,14 +2,13 @@
 
 ## Goal
 
-Build `SpaceRuntime` — a new workflow-first orchestration engine — and `WorkflowExecutor` to manage workflow run step sequences, gate evaluation, and rule injection within Spaces. All code lives in `packages/daemon/src/lib/space/runtime/`. No modifications to `RoomRuntime` or any existing runtime code.
+Build `SpaceRuntime` — a new workflow-first orchestration engine — and `WorkflowExecutor` to manage workflow run step sequences, transition condition evaluation, and rule injection within Spaces. All code lives in `packages/daemon/src/lib/space/runtime/`. No modifications to `RoomRuntime` or any existing runtime code.
 
 ## Isolation Checklist
 
 - `WorkflowExecutor` in `packages/daemon/src/lib/space/runtime/workflow-executor.ts`
 - `SpaceRuntime` in `packages/daemon/src/lib/space/runtime/space-runtime.ts`
 - `SpaceRuntimeService` in `packages/daemon/src/lib/space/runtime/space-runtime-service.ts`
-- Gate allowlist in `packages/daemon/src/lib/space/runtime/gate-allowlist.ts`
 - All types use `SpaceTask`, `SpaceWorkflowRun`, `SpaceWorkflow`, `SpaceAgent` (NOT `NeoTask`, `RoomGoal`, `Workflow`)
 - No modifications to `RoomRuntime`, `TaskGroupManager`, `room-runtime-service.ts`, `room-manager.ts`, or any file under `packages/daemon/src/lib/room/`
 
@@ -21,15 +20,14 @@ The `WorkflowExecutor` operates on **workflow runs** (not goals):
 1. A `SpaceWorkflowRun` represents an active execution of a workflow
 2. Each step produces `SpaceTask` records. `advance()` **creates task DB records only** (pending status) — it does NOT spawn session groups. The tick loop handles group spawning.
 3. Each task still gets a Worker + Leader group pair (using `space_session_groups`/`space_session_group_members`)
-4. When a step's tasks complete (Leader approves), the executor evaluates the exit gate and advances
+4. When a step's tasks complete (Leader approves), the executor evaluates outgoing transition conditions and advances
 5. Custom agents with `role: 'reviewer'` are specialized Workers, NOT Leader replacements
 
 ## Scope
 
-- `WorkflowExecutor` class with gate evaluation and step progression
+- `WorkflowExecutor` class with transition condition evaluation and step progression
 - `SpaceRuntime` class with workflow-driven tick loop
 - `SpaceRuntimeService` for lifecycle management
-- Gate security enforcement
 - Rule injection into agent prompts
 - Backward compatibility for spaces without workflows (standalone tasks)
 - Unit and integration tests
@@ -50,7 +48,7 @@ Create the `WorkflowExecutor` class that manages workflow run progression within
 
 1. Create `packages/daemon/src/lib/space/runtime/workflow-executor.ts`:
    - `WorkflowExecutor` class with:
-     - Constructor takes: `workflow: SpaceWorkflow`, `run: SpaceWorkflowRun`, `taskManager: SpaceTaskManager`, `workflowRunRepo: SpaceWorkflowRunRepository`, `agentManager: SpaceAgentManager`, `workspacePath: string`
+     - Constructor takes: `workflow: SpaceWorkflow`, `run: SpaceWorkflowRun`, `taskManager: SpaceTaskManager`, `workflowRunRepo: SpaceWorkflowRunRepository`, `workspacePath: string`, `commandRunner?: CommandRunner`
      - The `run.currentStepId` enables **restart rehydration**: when creating from persisted state, the run already contains the correct step ID. For new runs, it starts at the first step's ID.
      - `getCurrentStep(): WorkflowStep | null` — returns the step currently being executed, or null if complete/cancelled
      - `getOutgoingTransitions(): WorkflowTransition[]` — returns all outgoing transitions from the current step, sorted ascending by order
@@ -62,36 +60,31 @@ Create the `WorkflowExecutor` class that manages workflow run progression within
    - `space_tasks.workflow_run_id` links tasks to their run
    - `space_tasks.workflow_step_id` links tasks to the specific step that created them
 
-3. Gate evaluation with security enforcement:
-   - `evaluateGate(gate: WorkflowGate, context: GateContext): Promise<GateResult>`
-   - Gate types:
-     - `auto`: always passes
-     - `human_approval`: checks approval flag
-     - `quality_check`: runs **allowlisted command only** with timeout via `Bun.spawn`
-     - `pr_review`: reuses existing PR review pattern (can import utility functions)
-     - `custom`: validates relative path (no `..`, no absolute), runs with timeout
-   - **Timeout**: `gate.timeoutMs` (default: 60000ms, max: 300000ms)
-   - **Retry**: On failure, if `maxRetries > 0` and retries remain, re-evaluate gate only (NOT re-run agent). After exhaustion → `needs_attention`.
+3. Transition condition evaluation:
+   - `evaluateCondition(condition: WorkflowCondition, context: ConditionContext): Promise<ConditionResult>`
+   - Condition types:
+     - `always`: always passes
+     - `human`: passes when `context.humanApproved` is true
+     - `condition`: runs `expression` as a shell command via `sh -c`; passes on exit code 0
+   - **Timeout**: `condition.timeoutMs` (default: 60000ms, max: 300000ms) — applies to `condition` type
+   - **Retry**: On failure, if `maxRetries > 0` and retries remain, re-evaluate condition only (NOT re-run agent). After exhaustion → `needs_attention`. Human conditions are not retried (approval cannot change between retries within one `advance()` call).
+   - Injectable `CommandRunner` (default: `Bun.spawn`) — tests inject a mock to avoid real subprocess calls
 
-4. Quality check command allowlist:
-   - Create `packages/daemon/src/lib/space/runtime/gate-allowlist.ts`
-   - Default: `['bun run check', 'bun test', 'bun run lint', 'bun run typecheck', 'bun run format:check']`
-
-5. Write unit tests:
+4. Write unit tests:
    - Multi-step workflow run progression using `SpaceWorkflowRun`/`SpaceTask`/`SpaceWorkflow` types
-   - All gate types evaluated correctly
-   - Security: reject non-allowlisted commands, reject path traversal
-   - Timeout enforcement (mock Bun.spawn)
-   - Retry logic (re-evaluate gate, not re-run step)
-   - Completion detection, error handling
+   - All condition types evaluated correctly (`always`, `human`, `condition`)
+   - Timeout enforcement (mock CommandRunner)
+   - Retry logic (re-evaluate condition, not re-run step)
+   - Human approval consumed and cleared after use (no stale re-use in cycles)
+   - Completion detection (terminal step with no outgoing transitions)
+   - Error handling (`WorkflowGateError` thrown when all transitions fail)
 
 **Acceptance criteria:**
-- `WorkflowExecutor` advances workflow runs through step sequences
-- All types are Space types (`SpaceTask`, `SpaceWorkflowRun`, `SpaceWorkflow`, `SpaceAgentManager`)
-- All gate types evaluated with security enforcement
-- Non-allowlisted commands rejected, path traversal rejected
-- Timeout enforced on shell-executing gates
-- Retry re-evaluates gate only
+- `WorkflowExecutor` advances workflow runs through step sequences via directed graph transitions
+- All types are Space types (`SpaceTask`, `SpaceWorkflowRun`, `SpaceWorkflow`)
+- All condition types evaluated correctly
+- Timeout enforced on `condition`-type transitions
+- Retry re-evaluates condition only
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 
@@ -105,7 +98,7 @@ Create the `WorkflowExecutor` class that manages workflow run progression within
 
 **Description:**
 
-Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. This is a **new class** in `packages/daemon/src/lib/space/runtime/space-runtime.ts` that manages workflow runs and standalone tasks: creating runs, spawning tasks per step, managing session groups (via `space_session_groups`), advancing steps, and enforcing gates. It does NOT modify `RoomRuntime`.
+Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. This is a **new class** in `packages/daemon/src/lib/space/runtime/space-runtime.ts` that manages workflow runs and standalone tasks: creating runs, spawning tasks per step, managing session groups (via `space_session_groups`), and advancing steps via transition condition evaluation. It does NOT modify `RoomRuntime`.
 
 **Subtasks:**
 
@@ -163,8 +156,8 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
     - Standalone tasks (no workflow) work normally
     - Transition conditions evaluated before moving to the next step
     - Rules injected into agent prompts per step
-    - Human approval gate pauses run correctly
-    - Gate failure → `needs_attention` on run
+    - Human approval transition pauses run correctly
+    - All transitions fail after retries → `needs_attention` on run
     - **Rehydration**: clear map, reinitialize, verify in-progress runs resume from correct step
     - **Cleanup**: executor removed after run completion/failure/cancellation
 
@@ -210,7 +203,7 @@ Build `SpaceRuntimeService` for managing `SpaceRuntime` lifecycle, and configure
 4. Multi-step workflow run lifecycle:
    - `SpaceWorkflowRun` remains `in_progress` until final step completes
    - Track `runId → step → [SpaceTask records]` relationship
-   - Any step failure (gate fails after retries) → run → `needs_attention`
+   - Any step failure (all transitions fail after retries) → run → `needs_attention`
 
 5. Create RPC handler for starting workflow runs in `packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts`:
    - `spaceWorkflowRun.start { spaceId, workflowId, title, description? }` → `{ run: SpaceWorkflowRun }`:

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -51,16 +51,14 @@ Create the `WorkflowExecutor` class that manages workflow run progression within
 1. Create `packages/daemon/src/lib/space/runtime/workflow-executor.ts`:
    - `WorkflowExecutor` class with:
      - Constructor takes: `workflow: SpaceWorkflow`, `run: SpaceWorkflowRun`, `taskManager: SpaceTaskManager`, `workflowRunRepo: SpaceWorkflowRunRepository`, `agentManager: SpaceAgentManager`, `workspacePath: string`
-     - The `run.currentStepIndex` enables **restart rehydration**: when creating from persisted state, the run already contains the correct step index. For new runs, it starts at `0`.
-     - `getCurrentStep(): WorkflowStep | null`
-     - `getNextStep(): WorkflowStep | null`
-     - `canAdvance(): Promise<{ allowed: boolean; reason?: string }>` — evaluates current step's exit gate
-     - `canEnterStep(stepIndex: number): Promise<{ allowed: boolean; reason?: string }>` — evaluates the target step's **entry gate** (if any). Called by `advance()` before entering the next step, and by `SpaceRuntime` before starting the first step of a new run.
-     - `advance(): Promise<{ step: WorkflowStep; tasks: SpaceTask[] }>` — evaluates exit gate of current step, then evaluates **entry gate** of next step; increments step index (persisted on `SpaceWorkflowRun`), **creates `SpaceTask` DB records only** (pending status), sets `workflowRunId` and `workflowStepId` on new tasks. Does NOT spawn session groups.
+     - The `run.currentStepId` enables **restart rehydration**: when creating from persisted state, the run already contains the correct step ID. For new runs, it starts at the first step's ID.
+     - `getCurrentStep(): WorkflowStep | null` — returns the step currently being executed, or null if complete/cancelled
+     - `getOutgoingTransitions(): WorkflowTransition[]` — returns all outgoing transitions from the current step, sorted ascending by order
+     - `advance(): Promise<{ step: WorkflowStep; tasks: SpaceTask[] }>` — evaluates outgoing transitions from current step in order; follows the first whose condition passes; persists `currentStepId` on `SpaceWorkflowRun`, **creates `SpaceTask` DB records only** (pending status), sets `workflowRunId` and `workflowStepId` on new tasks. Does NOT spawn session groups. If no transitions exist, marks run as completed.
      - `isComplete(): boolean`
 
 2. Track workflow state:
-   - `space_workflow_runs.current_step_index` tracks which step the run is on (persisted)
+   - `space_workflow_runs.current_step_id` tracks which step the run is on (persisted)
    - `space_tasks.workflow_run_id` links tasks to their run
    - `space_tasks.workflow_step_id` links tasks to the specific step that created them
 
@@ -163,7 +161,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
     - Coding-step tasks created as pending
     - Custom-agent tasks have `customAgentId` set
     - Standalone tasks (no workflow) work normally
-    - Exit gates checked between steps; entry gates evaluated before entering each step (including first step via `canEnterStep(0)`)
+    - Transition conditions evaluated before moving to the next step
     - Rules injected into agent prompts per step
     - Human approval gate pauses run correctly
     - Gate failure → `needs_attention` on run

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -77,7 +77,7 @@ Create the `WorkflowExecutor` class that manages workflow run progression within
    - Retry logic (re-evaluate condition, not re-run step)
    - Human approval consumed and cleared after use (no stale re-use in cycles)
    - Completion detection (terminal step with no outgoing transitions)
-   - Error handling (`WorkflowGateError` thrown when all transitions fail)
+   - Error handling (`WorkflowTransitionError` thrown when all transitions fail)
 
 **Acceptance criteria:**
 - `WorkflowExecutor` advances workflow runs through step sequences via directed graph transitions
@@ -168,7 +168,7 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
 - Standalone tasks work without a workflow
 - Executors rehydrated on startup, cleaned up on completion
 - `advance()` creates `SpaceTask` DB records only; tick loop handles group spawning
-- No `seedDefaultWorkflow` — workflow selection uses explicit workflowId or AI auto-select only
+- No auto-seeding of default workflows — `seedBuiltInWorkflows()` (Task 3.4) seeds built-in templates as user-selectable options, not as automatic defaults. Workflow selection uses explicit workflowId or AI auto-select only.
 - Integration tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/04-workflow-runtime-engine.md
@@ -124,10 +124,10 @@ Build `SpaceRuntime` — the workflow-first orchestration engine for Spaces. Thi
    - No executor needed — they behave like regular tasks
 
 5. **Task-type assignment for workflow steps**:
-   - `agentRef: 'planner'` → `taskType: 'planning'`, uses planning group path with draft promotion
-   - `agentRef: 'coder'|'general'` → `taskType: 'coding'`, status `pending`, standard execution queue
-   - Custom agent (`agentRefType: 'custom'`) → `taskType: 'coding'`, `customAgentId` set, status `pending`
-   - Helper: `resolveTaskTypeForStep(step: WorkflowStep): 'planning' | 'coding'`
+   - Agent with `role: 'planner'` → `taskType: 'planning'`, uses planning group path with draft promotion
+   - Agent with `role: 'coder'|'general'` → `taskType: 'coding'`, status `pending`, standard execution queue
+   - Custom agent (no preset role) → `taskType: 'coding'`, `customAgentId` set to `step.agentId`, status `pending`
+   - Helper: `resolveTaskTypeForStep(step: WorkflowStep, agent: SpaceAgent): 'planning' | 'coding'`
 
 6. **Step advancement and transition evaluation**:
    - After task completes (Leader approves), check if task belongs to a workflow run (via `workflowRunId`)

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/06-frontend-agent-workflow-ui.md
@@ -74,7 +74,7 @@ Build the UI for listing, creating, and editing custom agents within a Space.
 
 **Description:**
 
-Build the visual workflow editor for composing agent steps with gates.
+Build the visual workflow editor for composing agent steps with transitions and conditions.
 
 **Subtasks:**
 
@@ -92,37 +92,33 @@ Build the visual workflow editor for composing agent steps with gates.
    - Save/Cancel buttons
    - "Start from template" option for new workflows:
      - "Coding (Plan → Code)", "Research (Plan → Research)", "Quick Fix (Code only)"
-     - Templates populate steps and gates with sensible defaults
+     - Templates populate steps and transitions with sensible defaults
 
 3. Create `packages/web/src/components/space/WorkflowStepCard.tsx`:
-   - Collapsed: step number, agent name, gate type icons
+   - Collapsed: step number, agent name, outgoing transition condition indicator
    - Expanded: full configuration
    - Fields:
      - **Name**: text input
-     - **Agent**: dropdown with built-in agents (`planner`, `coder`, `general` — NOT `leader`) + custom agents from SpaceStore
-     - **Entry Gate**: gate type selector
-     - **Exit Gate**: gate type selector
+     - **Agent**: dropdown of all `SpaceAgent` records in the space (preset roles + custom agents)
      - **Instructions**: textarea for step-specific context
-   - Gate sub-forms:
-     - `quality_check`: dropdown of allowlisted commands (not free-text)
-     - `custom`: command input with hint "Relative path to script (e.g., scripts/check.sh)"
-     - `human_approval`, `pr_review`: no additional config needed
-     - Description and optional timeout fields
+   - Transition editor (below each step card):
+     - Add/remove outgoing transitions to other steps
+     - Condition type selector: `always`, `human`, `condition`
+     - For `condition` type: shell expression text input + optional timeout
    - Up/down reorder buttons (drag-and-drop as future enhancement)
    - Remove step button
 
 4. Write unit tests:
    - Step adding, removal, reordering
-   - Agent dropdown excludes 'leader', includes custom agents
-   - Gate config forms render correctly
-   - Quality check gate shows allowlisted commands only
-   - Template selection populates steps
+   - Agent dropdown shows all SpaceAgent records
+   - Transition condition forms render correctly for each condition type
+   - Template selection populates steps and transitions
 
 **Acceptance criteria:**
-- Visual workflow builder allows multi-step composition
+- Visual workflow builder allows multi-step composition with transitions
 - Steps can be added, removed, reordered
-- Agent selection includes builtins (minus 'leader') and custom agents
-- Gate configuration enforces security constraints visually
+- Agent selection shows all SpaceAgent records in the space
+- Transition conditions can be configured per-transition
 - Templates provide quick starts
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
@@ -120,7 +120,7 @@ Define a standardized JSON format for exporting and importing custom agents and 
 
 2. Create `packages/daemon/src/lib/space/data/export-format.ts`:
    - `exportAgent(agent: SpaceAgent): ExportedSpaceAgent`
-   - `exportWorkflow(workflow: SpaceWorkflow, agents: SpaceAgent[]): ExportedSpaceWorkflow` — **must remap**: (1) `rules[].appliesTo` from step UUIDs to step order indices; (2) step `agentId` UUIDs to agent **names** via `agentName` field (lookup in provided agents array)
+   - `exportWorkflow(workflow: SpaceWorkflow, agents: SpaceAgent[]): ExportedSpaceWorkflow` — **must remap**: (1) `rules[].appliesTo` from step UUIDs to step **names**; (2) step `agentId` UUIDs to agent **names** via `agentName` field (lookup in provided agents array); (3) transition `from`/`to` step UUIDs to step **names**
    - `exportBundle(agents: SpaceAgent[], workflows: SpaceWorkflow[], name: string): SpaceExportBundle`
    - Strip space-specific IDs and timestamps
 
@@ -133,7 +133,7 @@ Define a standardized JSON format for exporting and importing custom agents and 
 
 4. Write unit tests:
    - Round-trip: export → serialize → deserialize → validate
-   - **Rule appliesTo round-trip**: export with step-specific rules → verify order indices in JSON → import → verify correct new step IDs
+   - **Rule appliesTo round-trip**: export with step-specific rules → verify step **names** in JSON → import → verify correct new step IDs
    - Validation rejects malformed data
    - Space-specific fields (id, spaceId, timestamps) stripped on export
    - Version validation
@@ -142,7 +142,7 @@ Define a standardized JSON format for exporting and importing custom agents and 
 - Export format well-defined and versioned
 - All types in `space.ts` (NOT `neo.ts`)
 - Type names use Space prefix (`ExportedSpaceAgent`, `SpaceExportBundle`)
-- `appliesTo` correctly remapped between UUIDs and order indices
+- `appliesTo` correctly remapped between step UUIDs and step names
 - Version checking provides clear messages
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
@@ -174,7 +174,7 @@ Add RPC handlers for exporting and importing agents and workflows using `spaceEx
 
 3. Cross-references and ID remapping:
    - **Agent name→UUID remapping**: Exported workflow steps use `agentName` (not UUID). On import, resolve names to `agentId` UUIDs by: (1) checking the bundle's imported agents (if importing both), (2) checking existing agents in target space by name. If agent not found, flag as warning in preview.
-   - **Step ID remapping for rules**: new step UUIDs generated on import; remap `rules[].appliesTo` from order indices back to new step UUIDs using `Map<order, newStepId>`
+   - **Step ID remapping for rules and transitions**: new step UUIDs generated on import; remap `rules[].appliesTo` from step names back to new step UUIDs using `Map<stepName, newStepId>`; remap transition `from`/`to` step names back to new step UUIDs using the same map
 
 4. Wire handlers in `packages/daemon/src/lib/rpc-handlers/index.ts` (via `setupRPCHandlers()` — add new registration only)
 

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
@@ -78,16 +78,28 @@ Define a standardized JSON format for exporting and importing custom agents and 
        agentName: string;
        instructions?: string;
      }>;
+     transitions: Array<{
+       /** Source step name (step names must be unique within a workflow — used instead of UUID) */
+       from: string;
+       to: string;
+       condition?: {
+         type: 'always' | 'human' | 'condition';
+         expression?: string;
+         description?: string;
+         maxRetries?: number;
+         timeoutMs?: number;
+       };
+       order?: number;
+     }>;
      rules: Array<{
        name: string;
        content: string;
        /**
-        * Step references use step **order indices** (0, 1, 2, ...), NOT UUIDs.
-        * UUIDs are space-specific and stripped on export.
-        * exportWorkflow() remaps appliesTo from step IDs to order indices.
-        * importWorkflow() remaps order indices back to newly generated step IDs.
+        * Step references use step **names** (NOT UUIDs — step names must be unique within a workflow).
+        * exportWorkflow() remaps appliesTo from step IDs to step names.
+        * importWorkflow() remaps step names back to newly generated step IDs.
         */
-       appliesTo?: number[];
+       appliesTo?: string[];
      }>;
      tags: string[];
      config?: Record<string, unknown>;

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
@@ -69,17 +69,14 @@ Define a standardized JSON format for exporting and importing custom agents and 
      steps: Array<{
        name: string;
        /**
-        * For builtin agents: the agent type string ('planner', 'coder', 'general').
-        * For custom agents: the agent **name** (NOT the UUID).
-        * Custom agent UUIDs are space-specific and stripped on export.
-        * exportWorkflow() resolves custom agent UUIDs to names via SpaceAgentManager.
-        * importWorkflow() resolves names back to UUIDs by looking up agents in the
+        * The agent name used for import resolution (NOT the UUID).
+        * SpaceAgent UUIDs are space-specific and stripped on export.
+        * exportWorkflow() resolves agentId UUIDs to SpaceAgent names via SpaceAgentManager.
+        * importWorkflow() resolves names back to agentId UUIDs by looking up agents in the
         * target space (or in the bundle if importing both agents and workflows together).
         */
-       agentRef: string;
-       agentRefType: 'builtin' | 'custom';
+       agentName: string;
        instructions?: string;
-       order: number;
      }>;
      rules: Array<{
        name: string;
@@ -111,7 +108,7 @@ Define a standardized JSON format for exporting and importing custom agents and 
 
 2. Create `packages/daemon/src/lib/space/data/export-format.ts`:
    - `exportAgent(agent: SpaceAgent): ExportedSpaceAgent`
-   - `exportWorkflow(workflow: SpaceWorkflow, agents: SpaceAgent[]): ExportedSpaceWorkflow` — **must remap**: (1) `rules[].appliesTo` from step UUIDs to step order indices; (2) custom agent `agentRef` from UUIDs to agent **names** (lookup in provided agents array)
+   - `exportWorkflow(workflow: SpaceWorkflow, agents: SpaceAgent[]): ExportedSpaceWorkflow` — **must remap**: (1) `rules[].appliesTo` from step UUIDs to step order indices; (2) step `agentId` UUIDs to agent **names** via `agentName` field (lookup in provided agents array)
    - `exportBundle(agents: SpaceAgent[], workflows: SpaceWorkflow[], name: string): SpaceExportBundle`
    - Strip space-specific IDs and timestamps
 
@@ -164,7 +161,7 @@ Add RPC handlers for exporting and importing agents and workflows using `spaceEx
    - `conflictResolution`: `'skip' | 'rename' | 'replace'` per item
 
 3. Cross-references and ID remapping:
-   - **Custom agent name→UUID remapping**: Exported workflow steps with `agentRefType: 'custom'` have agent **names** (not UUIDs). On import, resolve names to UUIDs by: (1) checking the bundle's imported agents (if importing both), (2) checking existing agents in target space by name. If agent not found, flag as warning in preview.
+   - **Agent name→UUID remapping**: Exported workflow steps use `agentName` (not UUID). On import, resolve names to `agentId` UUIDs by: (1) checking the bundle's imported agents (if importing both), (2) checking existing agents in target space by name. If agent not found, flag as warning in preview.
    - **Step ID remapping for rules**: new step UUIDs generated on import; remap `rules[].appliesTo` from order indices back to new step UUIDs using `Map<order, newStepId>`
 
 4. Wire handlers in `packages/daemon/src/lib/rpc-handlers/index.ts` (via `setupRPCHandlers()` — add new registration only)

--- a/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
+++ b/docs/plans/multi-agent-v2-customizable-agents-workflows/08-export-import-sharing-foundation.md
@@ -78,8 +78,6 @@ Define a standardized JSON format for exporting and importing custom agents and 
         */
        agentRef: string;
        agentRefType: 'builtin' | 'custom';
-       entryGate?: WorkflowGate | null;
-       exitGate?: WorkflowGate | null;
        instructions?: string;
        order: number;
      }>;
@@ -158,7 +156,7 @@ Add RPC handlers for exporting and importing agents and workflows using `spaceEx
    - `spaceExport.agents { spaceId, agentIds? }` → `{ bundle: SpaceExportBundle }`
    - `spaceExport.workflows { spaceId, workflowIds? }` → `{ bundle: SpaceExportBundle }`
    - `spaceExport.bundle { spaceId, agentIds?, workflowIds? }` → full bundle
-   - `spaceImport.preview { bundle, spaceId }` → `{ agents: ImportPreview[], workflows: ImportPreview[], validationErrors }` — dry run with conflict detection AND full `SpaceWorkflowManager` validation (gate security checks)
+   - `spaceImport.preview { bundle, spaceId }` → `{ agents: ImportPreview[], workflows: ImportPreview[], validationErrors }` — dry run with conflict detection AND full `SpaceWorkflowManager` validation (transition/condition validation)
    - `spaceImport.execute { spaceId, bundle, conflictResolution }` → creates entities (re-validates)
 
 2. Conflict resolution:
@@ -173,7 +171,7 @@ Add RPC handlers for exporting and importing agents and workflows using `spaceEx
 
 5. Write unit tests:
    - Export includes correct data from `space_agents`/`space_workflows` tables
-   - Preview detects conflicts and gate validation errors
+   - Preview detects conflicts and validation errors
    - All conflict resolutions work
    - Cross-reference mapping (agent name→UUID remapping for custom steps + step ID remapping for rules.appliesTo)
    - All handlers use `spaceId` (NOT `roomId`)
@@ -183,7 +181,7 @@ Add RPC handlers for exporting and importing agents and workflows using `spaceEx
 - All handlers use `spaceId` context (NOT `roomId`)
 - Export reads from `space_agents`/`space_workflows` tables
 - Import writes to `space_agents`/`space_workflows` tables
-- Preview detects conflicts, missing references, AND gate validation errors
+- Preview detects conflicts, missing references, AND validation errors
 - Unit tests pass
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`
 

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -20,7 +20,7 @@ export {
 } from './workflows/built-in-workflows';
 export {
 	WorkflowExecutor,
-	WorkflowGateError,
+	WorkflowTransitionError,
 } from './runtime/workflow-executor';
 export type { ConditionContext, ConditionResult, CommandRunner } from './runtime/workflow-executor';
 

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -58,10 +58,10 @@ export interface ConditionResult {
  * Error thrown by advance() when all outgoing transition conditions fail after retries.
  * The run's status will already be set to 'needs_attention' when this is thrown.
  */
-export class WorkflowGateError extends Error {
+export class WorkflowTransitionError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = 'WorkflowGateError';
+		this.name = 'WorkflowTransitionError';
 	}
 }
 
@@ -232,7 +232,7 @@ export class WorkflowExecutor {
 	 *   6. Create a pending SpaceTask for the target step
 	 *
 	 * If no transition's condition passes, the run is set to 'needs_attention'
-	 * and a WorkflowGateError is thrown.
+	 * and a WorkflowTransitionError is thrown.
 	 *
 	 * Does NOT spawn session groups — that is SpaceRuntime's responsibility.
 	 */
@@ -266,7 +266,7 @@ export class WorkflowExecutor {
 		// Evaluate transitions in order; follow the first one whose condition passes.
 		// A failing condition does NOT stop evaluation — the next transition is tried.
 		// Only when every transition has been evaluated and none passed is the run marked
-		// needs_attention and a WorkflowGateError thrown.
+		// needs_attention and a WorkflowTransitionError thrown.
 		const context = this.getConditionContext();
 		let lastReason: string | undefined;
 
@@ -296,7 +296,7 @@ export class WorkflowExecutor {
 
 		// All transitions evaluated; none passed → needs_attention
 		this.markNeedsAttention();
-		throw new WorkflowGateError(
+		throw new WorkflowTransitionError(
 			`No matching transition from step "${current.name}": ${lastReason ?? 'no condition passed'}`
 		);
 	}

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -281,7 +281,7 @@ export class WorkflowExecutor {
 			const result = await this.evaluateConditionWithRetry(condition, context);
 			if (result.passed) {
 				const advanced = await this.followTransition(transition);
-				// Clear humanApproved after consuming a human gate to prevent stale re-use
+				// Clear humanApproved after consuming a human transition to prevent stale re-use
 				// in cycles: the next time a human transition is reached the user must
 				// explicitly approve again.
 				if (condition.type === 'human') {
@@ -374,7 +374,7 @@ export class WorkflowExecutor {
 
 	/**
 	 * Clears the humanApproved flag from run.config after it has been consumed.
-	 * This prevents a stale approval from auto-passing subsequent human gates in cycles.
+	 * This prevents a stale approval from auto-passing subsequent human transitions in cycles.
 	 */
 	private clearHumanApproval(): void {
 		const config = (this.run.config ?? {}) as Record<string, unknown>;

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -57,7 +57,7 @@ const mockRun: SpaceWorkflowRun = {
 	spaceId: 'space-1',
 	workflowId: 'wf-1',
 	title: 'Run 1',
-	currentStepIndex: 0,
+	currentStepId: '',
 	status: 'pending',
 	createdAt: NOW,
 	updatedAt: NOW,

--- a/packages/daemon/tests/unit/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/space/built-in-workflows.test.ts
@@ -2,7 +2,7 @@
  * Built-in Workflow Templates Unit Tests
  *
  * Covers:
- * - Template structure: correct agentId placeholders, gate types, step count
+ * - Template structure: correct agentId placeholders, transition conditions, step count
  * - agentId placeholders are valid builtin role names (no 'leader')
  * - getBuiltInWorkflows() returns all three templates
  * - seedBuiltInWorkflows(): seeds all three templates with real agent IDs

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -70,7 +70,7 @@ function makeWorkflowRun(overrides?: Partial<SpaceWorkflowRun>): SpaceWorkflowRu
 		spaceId: 'space-1',
 		workflowId: 'wf-1',
 		title: 'Deploy v1.0',
-		currentStepIndex: 0,
+		currentStepId: '',
 		status: 'in_progress',
 		createdAt: Date.now(),
 		updatedAt: Date.now(),

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -879,7 +879,7 @@ describe('WorkflowExecutor', () => {
 	describe('multiple transitions — first matching wins', () => {
 		test('skips failing human condition and follows always fallback', async () => {
 			// Step A has two transitions: order 0 is human (blocked), order 1 is always (fallback).
-			// The executor should skip the failing human gate and follow the always fallback.
+			// The executor should skip the unapproved human transition and follow the always fallback.
 			const workflow = workflowRepo.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Trans-${Date.now()}`,
@@ -1003,7 +1003,7 @@ describe('WorkflowExecutor', () => {
 
 			await executor.advance();
 
-			// humanApproved should be cleared so a future human gate in a cycle is not auto-passed
+			// humanApproved should be cleared so a future human transition in a cycle is not auto-passed
 			const updated = runRepo.getRun(run.id)!;
 			expect(
 				(updated.config as Record<string, unknown> | undefined)?.humanApproved

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -11,7 +11,7 @@
  * - Completion detection (isComplete after last step)
  * - needs_attention guard (advance() blocked after condition failure)
  * - Cycle support (A → B → A loops)
- * - WorkflowGateError properties
+ * - WorkflowTransitionError properties
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -24,7 +24,7 @@ import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/sp
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import {
 	WorkflowExecutor,
-	WorkflowGateError,
+	WorkflowTransitionError,
 } from '../../../src/lib/space/runtime/workflow-executor.ts';
 import type {
 	CommandRunner,
@@ -502,7 +502,7 @@ describe('WorkflowExecutor', () => {
 			// run.config has no humanApproved
 			const executor = makeExecutor(workflow, run);
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
@@ -596,7 +596,7 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run, makeFailRunner(1));
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
@@ -649,7 +649,7 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run, makeTimeoutRunner());
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
@@ -698,7 +698,7 @@ describe('WorkflowExecutor', () => {
 			// Fails 3 times — more than allowed
 			const executor = makeExecutor(workflow, run, makeRetryRunner(3));
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
@@ -748,7 +748,7 @@ describe('WorkflowExecutor', () => {
 			// Fails on first attempt only
 			const executor = makeExecutor(workflow, run, makeRetryRunner(1));
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 		});
 	});
 
@@ -770,7 +770,7 @@ describe('WorkflowExecutor', () => {
 			const executor = makeExecutor(workflow, run);
 
 			// First call: condition fails → needs_attention
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			// Second call: must throw immediately (not re-evaluate)
 			await expect(executor.advance()).rejects.toThrow('needs_attention');
@@ -788,7 +788,7 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run);
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 
 			const statusBefore = runRepo.getRun(run.id)?.status;
 			await expect(executor.advance()).rejects.toThrow('needs_attention');
@@ -800,11 +800,11 @@ describe('WorkflowExecutor', () => {
 	});
 
 	// =========================================================================
-	// WorkflowGateError properties
+	// WorkflowTransitionError properties
 	// =========================================================================
 
-	describe('WorkflowGateError', () => {
-		test('condition failure throws WorkflowGateError with descriptive message', async () => {
+	describe('WorkflowTransitionError', () => {
+		test('condition failure throws WorkflowTransitionError with descriptive message', async () => {
 			const { workflow, run } = createLinearWorkflow([
 				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
 				{
@@ -816,11 +816,11 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run);
 
-			let caught: WorkflowGateError | undefined;
+			let caught: WorkflowTransitionError | undefined;
 			try {
 				await executor.advance();
 			} catch (err) {
-				if (err instanceof WorkflowGateError) caught = err;
+				if (err instanceof WorkflowTransitionError) caught = err;
 			}
 
 			expect(caught).toBeDefined();
@@ -939,7 +939,7 @@ describe('WorkflowExecutor', () => {
 			const executor = makeExecutor(workflow, run);
 
 			// Both human conditions fail → needs_attention
-			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
 


### PR DESCRIPTION
## Summary

This PR comprehensively updates the Milestone 4 planning documentation to match the actual implementation, which uses a graph-based transition/condition model instead of the original index-based gate model.

### What changed

- **`04-workflow-runtime-engine.md`** (Tasks 4.1–4.3 + header sections): Removed `getNextStep()`, `canEnterStep()`, `canAdvance()`, and all gate model references; updated to reflect the actual `WorkflowExecutor` API (`getCurrentStep`, `getOutgoingTransitions`, `isComplete`, `advance()`); replaced `evaluateGate`/`WorkflowGate`/`GateContext`/`GateResult` with `evaluateCondition`/`WorkflowCondition`/`ConditionContext`/`ConditionResult`; fixed `currentStepIndex` → `currentStepId`; removed `gate-allowlist.ts` from isolation checklist; clarified `seedBuiltInWorkflows` vs auto-seeding

- **`03-workflow-data-model.md`** (Task 3.1–3.4): Replaced `WorkflowGateType`/`WorkflowGate` with `WorkflowConditionType`/`WorkflowCondition`/`WorkflowTransition`; updated `WorkflowStep` to use `agentId` (not `agentRef`/`agentRefType`/gates); added `transitions` field to `SpaceWorkflow`; updated validation, test, and acceptance criteria language throughout; updated built-in template descriptions

- **`01-space-core-data-model.md`**: Fixed `SpaceWorkflowRun.currentStepIndex: number` → `currentStepId: string`; removed stale `entry_gate`/`exit_gate` DB columns from `space_workflow_steps` schema

- **`08-export-import-sharing-foundation.md`**: Removed `entryGate`/`exitGate` from exported workflow step shape; updated validation error descriptions

### Code change

- Renamed `WorkflowGateError` → `WorkflowTransitionError` in `workflow-executor.ts` and tests (the class name was a conceptual leftover from the gate model)

## Test plan

- No logic changes — documentation and one class rename
- `bun test packages/daemon/tests/unit/space/workflow-executor.test.ts` passes with the renamed error class