### PR TITLE
fix: make CreateWorkflowRunParams.currentStepId optional

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -33,7 +33,7 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { SpaceTaskManager } from '../managers/space-task-manager';
-import { WorkflowExecutor, WorkflowGateError } from './workflow-executor';
+import { WorkflowExecutor, WorkflowTransitionError } from './workflow-executor';
 import { Logger } from '../../logger';
 
 const log = new Logger('space-runtime');
@@ -471,7 +471,7 @@ export class SpaceRuntime {
 				this.executorMeta.delete(runId);
 			}
 		} catch (err) {
-			if (!(err instanceof WorkflowGateError)) {
+			if (!(err instanceof WorkflowTransitionError)) {
 				// Unexpected error — propagate to caller (processCompletedTasks collects it)
 				throw err;
 			}

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -188,7 +188,7 @@ export class SpaceWorkflowRunRepository {
 			workflowId: row.workflow_id as string,
 			title: row.title as string,
 			description: (row.description as string | null) ?? undefined,
-			currentStepId: (row.current_step_id as string | null) ?? '',
+			currentStepId: (row.current_step_id as string | null) ?? undefined,
 			status: row.status as WorkflowRunStatus,
 			config,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -39,7 +39,7 @@ export class SpaceWorkflowRunRepository {
 			params.title,
 			params.description ?? '',
 			0, // keep current_step_index for backward compat
-			params.currentStepId,
+			params.currentStepId ?? null,
 			'pending',
 			null,
 			now,

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -57,7 +57,6 @@ const mockRun: SpaceWorkflowRun = {
 	spaceId: 'space-1',
 	workflowId: 'wf-1',
 	title: 'Run 1',
-	currentStepId: '',
 	status: 'pending',
 	createdAt: NOW,
 	updatedAt: NOW,

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -70,7 +70,6 @@ function makeWorkflowRun(overrides?: Partial<SpaceWorkflowRun>): SpaceWorkflowRu
 		spaceId: 'space-1',
 		workflowId: 'wf-1',
 		title: 'Deploy v1.0',
-		currentStepId: '',
 		status: 'in_progress',
 		createdAt: Date.now(),
 		updatedAt: Date.now(),

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -46,9 +46,17 @@ describe('SpaceWorkflowRunRepository', () => {
 			expect(run.workflowId).toBe(WORKFLOW_ID);
 			expect(run.title).toBe('Run #1');
 			expect(run.status).toBe('pending');
-			expect(run.currentStepId).toBe('');
+			expect(run.currentStepId).toBeUndefined();
 			expect(run.config).toBeUndefined();
 			expect(run.completedAt).toBeUndefined();
+		});
+
+		it('maps NULL currentStepId to undefined (round-trip contract)', () => {
+			// Explicit omission: NULL stored in DB must come back as undefined, not ''
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'No step' });
+			expect(run.currentStepId).toBeUndefined();
+			// Re-fetch from DB to confirm persistence
+			expect(repo.getRun(run.id)!.currentStepId).toBeUndefined();
 		});
 
 		it('creates a run with description', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -253,8 +253,8 @@ export interface SpaceWorkflowRun {
 	title: string;
 	/** Optional description or goal for this run */
 	description?: string;
-	/** ID of the step currently being executed */
-	currentStepId: string;
+	/** ID of the step currently being executed; undefined when the run has not yet been assigned a step */
+	currentStepId?: string;
 	/** Current execution status */
 	status: WorkflowRunStatus;
 	/** Optional runtime configuration for this run */
@@ -275,7 +275,11 @@ export interface CreateWorkflowRunParams {
 	workflowId: string;
 	title: string;
 	description?: string;
-	/** ID of the step to start execution from — should be set to workflow.startStepId */
+	/**
+	 * ID of the step to start execution from — should be set to workflow.startStepId.
+	 * Omit to leave the run without an initial step; the executor must call
+	 * updateCurrentStep() before calling advance().
+	 */
 	currentStepId?: string;
 }
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -276,7 +276,7 @@ export interface CreateWorkflowRunParams {
 	title: string;
 	description?: string;
 	/** ID of the step to start execution from — should be set to workflow.startStepId */
-	currentStepId: string;
+	currentStepId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
The DB column accepts NULL and rowToRun maps it back to ''.
Making the field optional in the type contract allows tests and
callers to omit it, and updates the repository INSERT to use null
instead of undefined to satisfy SQLQueryBindings.
