### PR TITLE
feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -179,12 +179,26 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
 	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 
+	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
+	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
+	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
+	const agentLookup: SpaceAgentLookup = {
+		getAgentById(spaceId: string, id: string) {
+			const agent = spaceAgentRepo.getById(id);
+			if (!agent || agent.spaceId !== spaceId) return null;
+			return { id: agent.id, name: agent.name };
+		},
+	};
+	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
+
 	setupSpaceHandlers(
 		deps.messageHub,
 		deps.spaceManager,
 		spaceTaskRepo,
 		spaceWorkflowRunRepo,
-		deps.daemonHub
+		deps.daemonHub,
+		deps.spaceAgentManager,
+		spaceWorkflowManager
 	);
 
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
@@ -200,19 +214,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 
 	// Space agent handlers
 	setupSpaceAgentHandlers(deps.messageHub, deps.daemonHub, deps.spaceAgentManager);
-
-	// Space workflow handlers — wire SpaceAgentRepository as agentLookup so custom
-	// agent refs in workflow steps are validated against actual SpaceAgent records.
-	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
-	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
-	const agentLookup: SpaceAgentLookup = {
-		getAgentById(spaceId: string, id: string) {
-			const agent = spaceAgentRepo.getById(id);
-			if (!agent || agent.spaceId !== spaceId) return null;
-			return { id: agent.id, name: agent.name };
-		},
-	};
-	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
 
 	setupSpaceWorkflowHandlers(
 		deps.messageHub,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -56,6 +56,7 @@ import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
+import { SpaceRuntime } from '../space/runtime/space-runtime';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -222,8 +223,20 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		deps.daemonHub
 	);
 
+	// Space Runtime — workflow orchestration tick loop
+	const spaceRuntime = new SpaceRuntime({
+		db: deps.db.getDatabase(),
+		spaceManager: deps.spaceManager,
+		spaceAgentManager: deps.spaceAgentManager,
+		spaceWorkflowManager,
+		workflowRunRepo: spaceWorkflowRunRepo,
+		taskRepo: spaceTaskRepo,
+	});
+	spaceRuntime.start();
+
 	// Return cleanup function to stop background services
 	return () => {
 		roomRuntimeService.stop();
+		spaceRuntime.stop();
 	};
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -21,8 +21,12 @@ import type {
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
+import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import { seedPresetAgents } from '../space/agents/seed-agents';
+import { seedBuiltInWorkflows } from '../space/workflows/built-in-workflows';
 import { Logger } from '../logger';
 
 const log = new Logger('space-handlers');
@@ -39,7 +43,9 @@ export function setupSpaceHandlers(
 	spaceManager: SpaceManager,
 	taskRepo: SpaceTaskRepository,
 	workflowRunRepo: SpaceWorkflowRunRepository,
-	daemonHub: DaemonHub
+	daemonHub: DaemonHub,
+	spaceAgentManager: SpaceAgentManager,
+	spaceWorkflowManager: SpaceWorkflowManager
 ): void {
 	// ─── space.create ───────────────────────────────────────────────────────────
 	messageHub.onRequest('space.create', async (data) => {
@@ -53,6 +59,27 @@ export function setupSpaceHandlers(
 		}
 
 		const space = await spaceManager.createSpace(params);
+
+		// Seed preset agents (Coder, General, Planner, Reviewer) for the new space.
+		// Errors are non-fatal — the space is still usable without preset agents.
+		try {
+			await seedPresetAgents(space.id, spaceAgentManager);
+		} catch (err) {
+			log.warn('Failed to seed preset agents for space', space.id, err);
+		}
+
+		// Seed built-in workflow templates after preset agents are available.
+		// Resolves role names ('planner', 'coder', 'general') to SpaceAgent UUIDs.
+		try {
+			const agents = spaceAgentManager.listBySpaceId(space.id);
+			seedBuiltInWorkflows(
+				space.id,
+				spaceWorkflowManager,
+				(role) => agents.find((a) => a.role === role)?.id
+			);
+		} catch (err) {
+			log.warn('Failed to seed built-in workflows for space', space.id, err);
+		}
 
 		daemonHub
 			.emit('space.created', { sessionId: 'global', spaceId: space.id, space })

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -22,7 +22,12 @@ export {
 	WorkflowExecutor,
 	WorkflowGateError,
 } from './runtime/workflow-executor';
-export type { ConditionContext, ConditionResult, CommandRunner } from './runtime/workflow-executor';
+export type {
+	ConditionContext,
+	ConditionResult,
+	CommandRunner,
+	TaskTypeResolver,
+} from './runtime/workflow-executor';
 export { SpaceRuntime } from './runtime/space-runtime';
 export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
 

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -23,6 +23,8 @@ export {
 	WorkflowGateError,
 } from './runtime/workflow-executor';
 export type { ConditionContext, ConditionResult, CommandRunner } from './runtime/workflow-executor';
+export { SpaceRuntime } from './runtime/space-runtime';
+export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
 
 // Types — re-exported from @neokai/shared for convenience
 export type {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -34,6 +34,9 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { WorkflowExecutor, WorkflowGateError } from './workflow-executor';
+import { Logger } from '../../logger';
+
+const log = new Logger('space-runtime');
 
 // ---------------------------------------------------------------------------
 // Config
@@ -134,13 +137,13 @@ export class SpaceRuntime {
 		const interval = this.config.tickIntervalMs ?? 5_000;
 
 		// Kick off the first tick immediately, then schedule the loop.
-		this.executeTick().catch(() => {
-			// Swallow initial tick error — the loop will retry on the next interval.
+		this.executeTick().catch((err: unknown) => {
+			log.error('SpaceRuntime: initial tick failed:', err);
 		});
 
 		this.tickTimer = setInterval(() => {
-			this.executeTick().catch(() => {
-				// Swallow per-tick errors so the loop stays alive.
+			this.executeTick().catch((err: unknown) => {
+				log.error('SpaceRuntime: tick failed:', err);
 			});
 		}, interval);
 	}
@@ -231,6 +234,7 @@ export class SpaceRuntime {
 		if (!startStep) {
 			this.executors.delete(run.id);
 			this.executorMeta.delete(run.id);
+			this.config.workflowRunRepo.updateStatus(run.id, 'cancelled');
 			throw new Error(`Start step "${workflow.startStepId}" not found in workflow "${workflowId}"`);
 		}
 
@@ -251,6 +255,10 @@ export class SpaceRuntime {
 			// Clean up the executor/meta entries so the run is not orphaned in the map.
 			this.executors.delete(run.id);
 			this.executorMeta.delete(run.id);
+			// Cancel the DB run record so rehydrateExecutors() does not silently loop
+			// over it on next server restart (an in_progress run with no tasks would
+			// sit in the executor map indefinitely, never advancing and never erroring).
+			this.config.workflowRunRepo.updateStatus(run.id, 'cancelled');
 			throw err;
 		}
 
@@ -441,7 +449,10 @@ export class SpaceRuntime {
 			.listByWorkflowRun(runId)
 			.filter((t) => t.workflowStepId === currentStep.id);
 
-		// Only advance when there is at least one task and ALL are completed
+		// Only advance when there is at least one task and ALL are completed.
+		// stepTasks.length === 0 is the normal "waiting" state — the task for this
+		// step has not been spawned yet (session group creation is async and handled
+		// by a separate layer). Silently returning here is intentional.
 		if (stepTasks.length === 0) return;
 		if (!stepTasks.every((t) => t.status === 'completed')) return;
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1,0 +1,422 @@
+/**
+ * SpaceRuntime
+ *
+ * Workflow-first orchestration engine for Spaces.
+ * Manages workflow run lifecycles and standalone task queuing
+ * using Space tables exclusively (not Room tables).
+ *
+ * Responsibilities:
+ * - Maintain a Map<runId, WorkflowExecutor> for active workflow runs
+ * - Rehydrate executors from DB on first executeTick() call
+ * - Start new workflow runs (creates run record + executor + first step task)
+ * - Process completed tasks and advance workflows to the next step
+ * - Resolve task types from agent roles (planner → planning, coder/general → coding, etc.)
+ * - Filter and expose workflow rules applicable to a given step
+ * - Clean up executors when runs reach terminal states
+ *
+ * Note: advance() creates SpaceTask DB records only.
+ * Session group spawning is handled separately and is NOT in scope here.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type {
+	SpaceTask,
+	SpaceTaskType,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+	WorkflowRule,
+	WorkflowStep,
+} from '@neokai/shared';
+import type { SpaceManager } from '../managers/space-manager';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import { SpaceTaskManager } from '../managers/space-task-manager';
+import { WorkflowExecutor, WorkflowGateError } from './workflow-executor';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface SpaceRuntimeConfig {
+	/** Raw Bun SQLite database — used to create per-space SpaceTaskManagers */
+	db: BunDatabase;
+	/** Space manager for listing spaces and fetching workspace paths */
+	spaceManager: SpaceManager;
+	/** Agent manager for resolving agent roles in resolveTaskTypeForStep() */
+	spaceAgentManager: SpaceAgentManager;
+	/** Workflow manager for loading workflow definitions */
+	spaceWorkflowManager: SpaceWorkflowManager;
+	/** Workflow run repository for run CRUD and status updates */
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Task repository for querying tasks by run/step */
+	taskRepo: SpaceTaskRepository;
+}
+
+// ---------------------------------------------------------------------------
+// Return types
+// ---------------------------------------------------------------------------
+
+/** Result of resolveTaskTypeForStep(): taskType + optional customAgentId */
+export interface ResolvedTaskType {
+	/**
+	 * SpaceTaskType derived from the agent's role:
+	 *   planner → 'planning'
+	 *   coder | general → 'coding'
+	 *   custom role → 'coding'
+	 */
+	taskType: SpaceTaskType;
+	/**
+	 * Set for custom-role agents (non-preset) so that the executor knows
+	 * exactly which SpaceAgent to use. Undefined for planner/coder/general
+	 * roles where the step's agentId is the authoritative reference.
+	 */
+	customAgentId: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// SpaceRuntime
+// ---------------------------------------------------------------------------
+
+/** Metadata stored alongside each executor to allow recreation with fresh state */
+interface ExecutorMeta {
+	workflow: SpaceWorkflow;
+	spaceId: string;
+	workspacePath: string;
+}
+
+export class SpaceRuntime {
+	/** Map from workflowRunId → WorkflowExecutor for all active runs */
+	private executors = new Map<string, WorkflowExecutor>();
+
+	/**
+	 * Metadata stored per run so the executor can be recreated with fresh DB
+	 * state when the run has been externally modified (e.g. status reset after
+	 * a human gate approval).
+	 */
+	private executorMeta = new Map<string, ExecutorMeta>();
+
+	/**
+	 * Set to true after the first executeTick() call, after rehydrateExecutors()
+	 * has loaded in-progress runs from the DB. Prevents repeated rehydration.
+	 */
+	private rehydrated = false;
+
+	constructor(private config: SpaceRuntimeConfig) {}
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Main tick method — call on a regular interval.
+	 *
+	 * On the first call, rehydrateExecutors() loads all in-progress workflow
+	 * runs from the DB into the executors map.
+	 *
+	 * On every call:
+	 * 1. Processes completed tasks and advances their workflows
+	 * 2. Cleans up executors for runs that have reached a terminal state
+	 */
+	async executeTick(): Promise<void> {
+		if (!this.rehydrated) {
+			await this.rehydrateExecutors();
+			this.rehydrated = true;
+		}
+
+		await this.processCompletedTasks();
+		this.cleanupTerminalExecutors();
+	}
+
+	/**
+	 * Start a new workflow run for the given space and workflow.
+	 *
+	 * Flow:
+	 * 1. Load the workflow definition
+	 * 2. Create a SpaceWorkflowRun record (status: in_progress)
+	 * 3. Create a WorkflowExecutor and register it in the executors map
+	 * 4. Create a pending SpaceTask for the workflow's start step
+	 *
+	 * Returns the created run and the initial task(s).
+	 */
+	async startWorkflowRun(
+		spaceId: string,
+		workflowId: string,
+		title: string,
+		description?: string
+	): Promise<{ run: SpaceWorkflowRun; tasks: SpaceTask[] }> {
+		const workflow = this.config.spaceWorkflowManager.getWorkflow(workflowId);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${workflowId}`);
+		}
+
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+
+		// Create the run record — starts as 'pending', immediately promoted to 'in_progress'
+		const pendingRun = this.config.workflowRunRepo.createRun({
+			spaceId,
+			workflowId,
+			title,
+			description,
+			currentStepId: workflow.startStepId,
+		});
+
+		const run = this.config.workflowRunRepo.updateStatus(pendingRun.id, 'in_progress')!;
+
+		// Store metadata for future executor recreation with fresh run state
+		const meta: ExecutorMeta = { workflow, spaceId, workspacePath: space.workspacePath };
+		this.executorMeta.set(run.id, meta);
+
+		const executor = this.buildExecutor(workflow, run, spaceId, space.workspacePath);
+		this.executors.set(run.id, executor);
+
+		// Find the start step and create the initial task
+		const startStep = workflow.steps.find((s) => s.id === workflow.startStepId);
+		if (!startStep) {
+			throw new Error(`Start step "${workflow.startStepId}" not found in workflow "${workflowId}"`);
+		}
+
+		const resolved = this.resolveTaskTypeForStep(startStep);
+		const taskManager = new SpaceTaskManager(this.config.db, spaceId);
+		const task = await taskManager.createTask({
+			title: startStep.name,
+			description: startStep.instructions ?? '',
+			workflowRunId: run.id,
+			workflowStepId: startStep.id,
+			taskType: resolved.taskType,
+			customAgentId: resolved.customAgentId ?? startStep.agentId,
+			status: 'pending',
+		});
+
+		return { run, tasks: [task] };
+	}
+
+	/**
+	 * Resolve the appropriate SpaceTaskType (and optional customAgentId) for
+	 * a workflow step, based on the assigned agent's role.
+	 *
+	 * Mapping rules:
+	 *   agent.role === 'planner'          → taskType: 'planning',  customAgentId: undefined
+	 *   agent.role === 'coder'|'general'  → taskType: 'coding',    customAgentId: undefined
+	 *   any other role (custom)           → taskType: 'coding',    customAgentId: step.agentId
+	 *   agent not found                   → taskType: 'coding',    customAgentId: step.agentId
+	 */
+	resolveTaskTypeForStep(step: WorkflowStep): ResolvedTaskType {
+		const agent = this.config.spaceAgentManager.getById(step.agentId);
+
+		if (!agent) {
+			// Unknown agent → treat as custom coding agent
+			return { taskType: 'coding', customAgentId: step.agentId };
+		}
+
+		if (agent.role === 'planner') {
+			return { taskType: 'planning', customAgentId: undefined };
+		}
+
+		if (agent.role === 'coder' || agent.role === 'general') {
+			return { taskType: 'coding', customAgentId: undefined };
+		}
+
+		// Custom role
+		return { taskType: 'coding', customAgentId: step.agentId };
+	}
+
+	/**
+	 * Returns workflow rules applicable to a given workflow step.
+	 *
+	 * A rule applies to a step when:
+	 *   - rule.appliesTo is empty/undefined (applies to ALL steps), OR
+	 *   - rule.appliesTo includes stepId
+	 */
+	getRulesForStep(workflowId: string, stepId: string): WorkflowRule[] {
+		const workflow = this.config.spaceWorkflowManager.getWorkflow(workflowId);
+		if (!workflow) return [];
+
+		return workflow.rules.filter(
+			(r) => !r.appliesTo || r.appliesTo.length === 0 || r.appliesTo.includes(stepId)
+		);
+	}
+
+	/**
+	 * Returns the WorkflowExecutor for a given run ID, or undefined if not tracked.
+	 * Useful for testing and external inspection.
+	 */
+	getExecutor(runId: string): WorkflowExecutor | undefined {
+		return this.executors.get(runId);
+	}
+
+	/**
+	 * Returns the number of executors currently tracked (active runs).
+	 */
+	get executorCount(): number {
+		return this.executors.size;
+	}
+
+	// -------------------------------------------------------------------------
+	// Private — rehydration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Rehydrates WorkflowExecutors from the DB for all in-progress workflow runs.
+	 *
+	 * Called once at the start of the first executeTick(). Reconstructs
+	 * executors with the run's persisted currentStepId so the tick loop can
+	 * resume advancement from where it left off.
+	 *
+	 * Runs that reference a missing workflow are skipped (logged as a warning).
+	 */
+	async rehydrateExecutors(): Promise<void> {
+		const spaces = await this.config.spaceManager.listSpaces(false);
+
+		for (const space of spaces) {
+			const activeRuns = this.config.workflowRunRepo.getActiveRuns(space.id);
+
+			for (const run of activeRuns) {
+				// Skip if executor already registered (e.g. called twice)
+				if (this.executors.has(run.id)) continue;
+
+				const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
+				if (!workflow) {
+					// Workflow was deleted while a run was in-progress — skip silently.
+					// The run will remain in_progress in the DB; it will need manual cleanup.
+					continue;
+				}
+
+				const meta: ExecutorMeta = {
+					workflow,
+					spaceId: space.id,
+					workspacePath: space.workspacePath,
+				};
+				this.executorMeta.set(run.id, meta);
+
+				const executor = this.buildExecutor(workflow, run, space.id, space.workspacePath);
+				this.executors.set(run.id, executor);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Private — tick helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * For each active executor, checks whether the current step's tasks have all
+	 * completed. If so, calls advance() to move to the next step (creating a new
+	 * pending SpaceTask) or marks the run as completed when the terminal step is
+	 * reached.
+	 *
+	 * If a gate condition fails, the run status becomes 'needs_attention'.
+	 * The executor is retained so the run can be re-examined after the gate is
+	 * manually resolved (e.g., humanApproved set in run.config).
+	 */
+	private async processCompletedTasks(): Promise<void> {
+		for (const [runId] of this.executors) {
+			// Always re-read run from DB to pick up external status changes (e.g. human
+			// approval reset, external cancellation).
+			const run = this.config.workflowRunRepo.getRun(runId);
+			if (!run) continue;
+			if (
+				run.status === 'needs_attention' ||
+				run.status === 'cancelled' ||
+				run.status === 'completed'
+			) {
+				continue;
+			}
+
+			// Recreate the executor with the fresh run from DB. This ensures that
+			// external run mutations (e.g. status reset after human approval) are
+			// reflected in the executor's advance() guard checks. The executor is
+			// stateless beyond this.run (all workflow state is in the DB), so
+			// recreation is safe and cheap.
+			const meta = this.executorMeta.get(runId);
+			if (!meta) continue;
+
+			const freshExecutor = this.buildExecutor(
+				meta.workflow,
+				run,
+				meta.spaceId,
+				meta.workspacePath
+			);
+			this.executors.set(runId, freshExecutor);
+
+			const currentStep = freshExecutor.getCurrentStep();
+			if (!currentStep) continue;
+
+			// Find tasks that belong to the current step
+			const stepTasks = this.config.taskRepo
+				.listByWorkflowRun(runId)
+				.filter((t) => t.workflowStepId === currentStep.id);
+
+			// Only advance when there is at least one task and ALL are completed
+			if (stepTasks.length === 0) continue;
+			if (!stepTasks.every((t) => t.status === 'completed')) continue;
+
+			try {
+				const { step: nextStep, tasks: newTasks } = await freshExecutor.advance();
+
+				// Apply task-type assignment to tasks created by advance()
+				for (const task of newTasks) {
+					const resolved = this.resolveTaskTypeForStep(nextStep);
+					this.config.taskRepo.updateTask(task.id, {
+						taskType: resolved.taskType,
+						customAgentId: resolved.customAgentId ?? nextStep.agentId,
+					});
+				}
+
+				if (newTasks.length === 0) {
+					// Terminal step reached — run marked completed by advance(); clean up executor.
+					this.executors.delete(runId);
+					this.executorMeta.delete(runId);
+				}
+			} catch (err) {
+				if (!(err instanceof WorkflowGateError)) {
+					// Unexpected error — re-throw so the caller's error boundary handles it
+					throw err;
+				}
+				// Gate blocked: run status already set to 'needs_attention' by the executor.
+				// Keep executor and meta in map — will be retried after gate is resolved.
+			}
+		}
+	}
+
+	/**
+	 * Removes from the executors map any executor whose run has reached a
+	 * terminal state (completed or cancelled).
+	 *
+	 * Reads run status from DB rather than relying on the executor's cached
+	 * this.run, so external status changes (e.g. cancellation via API) are
+	 * picked up without requiring executor recreation.
+	 */
+	private cleanupTerminalExecutors(): void {
+		for (const [runId] of this.executors) {
+			const run = this.config.workflowRunRepo.getRun(runId);
+			if (!run || run.status === 'completed' || run.status === 'cancelled') {
+				this.executors.delete(runId);
+				this.executorMeta.delete(runId);
+			}
+		}
+	}
+
+	/**
+	 * Builds a WorkflowExecutor for the given run with fresh state.
+	 */
+	private buildExecutor(
+		workflow: SpaceWorkflow,
+		run: SpaceWorkflowRun,
+		spaceId: string,
+		workspacePath: string
+	): WorkflowExecutor {
+		const taskManager = new SpaceTaskManager(this.config.db, spaceId);
+		return new WorkflowExecutor(
+			workflow,
+			run,
+			taskManager,
+			this.config.workflowRunRepo,
+			workspacePath
+		);
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -52,6 +52,11 @@ export interface SpaceRuntimeConfig {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	/** Task repository for querying tasks by run/step */
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Interval between executeTick() calls in milliseconds.
+	 * Used by start(). Default: 5000 (5 seconds).
+	 */
+	tickIntervalMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -98,12 +103,59 @@ export class SpaceRuntime {
 	private executorMeta = new Map<string, ExecutorMeta>();
 
 	/**
+	 * Per-space SpaceTaskManager instances, cached to avoid creating a new
+	 * manager + repository on every executor build.
+	 */
+	private taskManagers = new Map<string, SpaceTaskManager>();
+
+	/**
 	 * Set to true after the first executeTick() call, after rehydrateExecutors()
 	 * has loaded in-progress runs from the DB. Prevents repeated rehydration.
 	 */
 	private rehydrated = false;
 
+	/** Handle returned by setInterval when the tick loop is running */
+	private tickTimer: ReturnType<typeof setInterval> | null = null;
+
 	constructor(private config: SpaceRuntimeConfig) {}
+
+	// -------------------------------------------------------------------------
+	// Lifecycle — start / stop
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Starts the periodic tick loop.
+	 * Calls executeTick() immediately and then every `tickIntervalMs` ms.
+	 * Errors from executeTick() are caught and logged so the loop keeps running.
+	 */
+	start(): void {
+		if (this.tickTimer !== null) return; // already running
+
+		const interval = this.config.tickIntervalMs ?? 5_000;
+
+		// Kick off the first tick immediately, then schedule the loop.
+		this.executeTick().catch(() => {
+			// Swallow initial tick error — the loop will retry on the next interval.
+		});
+
+		this.tickTimer = setInterval(() => {
+			this.executeTick().catch(() => {
+				// Swallow per-tick errors so the loop stays alive.
+			});
+		}, interval);
+	}
+
+	/**
+	 * Stops the periodic tick loop.
+	 * Does not affect in-progress executors — they remain in the map and can
+	 * be resumed by calling start() again.
+	 */
+	stop(): void {
+		if (this.tickTimer !== null) {
+			clearInterval(this.tickTimer);
+			this.tickTimer = null;
+		}
+	}
 
 	// -------------------------------------------------------------------------
 	// Public API
@@ -139,6 +191,7 @@ export class SpaceRuntime {
 	 * 4. Create a pending SpaceTask for the workflow's start step
 	 *
 	 * Returns the created run and the initial task(s).
+	 * Cleans up maps if task creation fails to prevent orphaned executor entries.
 	 */
 	async startWorkflowRun(
 		spaceId: string,
@@ -167,30 +220,39 @@ export class SpaceRuntime {
 
 		const run = this.config.workflowRunRepo.updateStatus(pendingRun.id, 'in_progress')!;
 
-		// Store metadata for future executor recreation with fresh run state
+		// Register executor and meta. If a later step fails, we must clean these up.
 		const meta: ExecutorMeta = { workflow, spaceId, workspacePath: space.workspacePath };
 		this.executorMeta.set(run.id, meta);
-
 		const executor = this.buildExecutor(workflow, run, spaceId, space.workspacePath);
 		this.executors.set(run.id, executor);
 
-		// Find the start step and create the initial task
+		// Find the start step and create the initial task. Roll back map entries if this fails.
 		const startStep = workflow.steps.find((s) => s.id === workflow.startStepId);
 		if (!startStep) {
+			this.executors.delete(run.id);
+			this.executorMeta.delete(run.id);
 			throw new Error(`Start step "${workflow.startStepId}" not found in workflow "${workflowId}"`);
 		}
 
 		const resolved = this.resolveTaskTypeForStep(startStep);
-		const taskManager = new SpaceTaskManager(this.config.db, spaceId);
-		const task = await taskManager.createTask({
-			title: startStep.name,
-			description: startStep.instructions ?? '',
-			workflowRunId: run.id,
-			workflowStepId: startStep.id,
-			taskType: resolved.taskType,
-			customAgentId: resolved.customAgentId ?? startStep.agentId,
-			status: 'pending',
-		});
+		const taskManager = this.getOrCreateTaskManager(spaceId);
+		let task: SpaceTask;
+		try {
+			task = await taskManager.createTask({
+				title: startStep.name,
+				description: startStep.instructions ?? '',
+				workflowRunId: run.id,
+				workflowStepId: startStep.id,
+				taskType: resolved.taskType,
+				customAgentId: resolved.customAgentId,
+				status: 'pending',
+			});
+		} catch (err) {
+			// Clean up the executor/meta entries so the run is not orphaned in the map.
+			this.executors.delete(run.id);
+			this.executorMeta.delete(run.id);
+			throw err;
+		}
 
 		return { run, tasks: [task] };
 	}
@@ -267,13 +329,17 @@ export class SpaceRuntime {
 	 * executors with the run's persisted currentStepId so the tick loop can
 	 * resume advancement from where it left off.
 	 *
-	 * Runs that reference a missing workflow are skipped (logged as a warning).
+	 * Runs that reference a missing workflow are skipped silently.
 	 */
 	async rehydrateExecutors(): Promise<void> {
 		const spaces = await this.config.spaceManager.listSpaces(false);
 
 		for (const space of spaces) {
-			const activeRuns = this.config.workflowRunRepo.getActiveRuns(space.id);
+			// getRehydratableRuns returns 'in_progress' AND 'needs_attention' runs.
+			// 'pending' is still excluded — it's transient (task creation may have failed).
+			// 'needs_attention' runs are included so a human-gate-blocked run gets its
+			// executor reloaded on restart, allowing it to advance once the gate is resolved.
+			const activeRuns = this.config.workflowRunRepo.getRehydratableRuns(space.id);
 
 			for (const run of activeRuns) {
 				// Skip if executor already registered (e.g. called twice)
@@ -312,74 +378,91 @@ export class SpaceRuntime {
 	 * If a gate condition fails, the run status becomes 'needs_attention'.
 	 * The executor is retained so the run can be re-examined after the gate is
 	 * manually resolved (e.g., humanApproved set in run.config).
+	 *
+	 * Errors from individual runs are caught and re-thrown after all runs have
+	 * been processed, so a single bad run cannot starve subsequent ones.
 	 */
 	private async processCompletedTasks(): Promise<void> {
+		let firstError: unknown = null;
+
 		for (const [runId] of this.executors) {
-			// Always re-read run from DB to pick up external status changes (e.g. human
-			// approval reset, external cancellation).
-			const run = this.config.workflowRunRepo.getRun(runId);
-			if (!run) continue;
-			if (
-				run.status === 'needs_attention' ||
-				run.status === 'cancelled' ||
-				run.status === 'completed'
-			) {
-				continue;
-			}
-
-			// Recreate the executor with the fresh run from DB. This ensures that
-			// external run mutations (e.g. status reset after human approval) are
-			// reflected in the executor's advance() guard checks. The executor is
-			// stateless beyond this.run (all workflow state is in the DB), so
-			// recreation is safe and cheap.
-			const meta = this.executorMeta.get(runId);
-			if (!meta) continue;
-
-			const freshExecutor = this.buildExecutor(
-				meta.workflow,
-				run,
-				meta.spaceId,
-				meta.workspacePath
-			);
-			this.executors.set(runId, freshExecutor);
-
-			const currentStep = freshExecutor.getCurrentStep();
-			if (!currentStep) continue;
-
-			// Find tasks that belong to the current step
-			const stepTasks = this.config.taskRepo
-				.listByWorkflowRun(runId)
-				.filter((t) => t.workflowStepId === currentStep.id);
-
-			// Only advance when there is at least one task and ALL are completed
-			if (stepTasks.length === 0) continue;
-			if (!stepTasks.every((t) => t.status === 'completed')) continue;
-
 			try {
-				const { step: nextStep, tasks: newTasks } = await freshExecutor.advance();
-
-				// Apply task-type assignment to tasks created by advance()
-				for (const task of newTasks) {
-					const resolved = this.resolveTaskTypeForStep(nextStep);
-					this.config.taskRepo.updateTask(task.id, {
-						taskType: resolved.taskType,
-						customAgentId: resolved.customAgentId ?? nextStep.agentId,
-					});
-				}
-
-				if (newTasks.length === 0) {
-					// Terminal step reached — run marked completed by advance(); clean up executor.
-					this.executors.delete(runId);
-					this.executorMeta.delete(runId);
-				}
+				await this.processRunTick(runId);
 			} catch (err) {
-				if (!(err instanceof WorkflowGateError)) {
-					// Unexpected error — re-throw so the caller's error boundary handles it
-					throw err;
-				}
-				// Gate blocked: run status already set to 'needs_attention' by the executor.
-				// Keep executor and meta in map — will be retried after gate is resolved.
+				// Capture first unexpected error; continue processing remaining runs.
+				if (firstError === null) firstError = err;
 			}
+		}
+
+		// Re-throw after all runs processed so callers see the error.
+		if (firstError !== null) throw firstError;
+	}
+
+	/**
+	 * Process a single workflow run tick: re-read from DB, recreate executor
+	 * with fresh state, check for completed step tasks, and advance if ready.
+	 */
+	private async processRunTick(runId: string): Promise<void> {
+		// Always re-read run from DB to pick up external status changes (e.g. human
+		// approval reset, external cancellation).
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) return;
+		if (
+			run.status === 'needs_attention' ||
+			run.status === 'cancelled' ||
+			run.status === 'completed'
+		) {
+			return;
+		}
+
+		// Recreate the executor with the fresh run from DB. This ensures that
+		// external run mutations (e.g. status reset after human approval) are
+		// reflected in the executor's advance() guard checks. The executor is
+		// stateless beyond this.run (all workflow state is in the DB), so
+		// recreation is safe and cheap.
+		const meta = this.executorMeta.get(runId);
+		if (!meta) return;
+
+		const freshExecutor = this.buildExecutor(meta.workflow, run, meta.spaceId, meta.workspacePath);
+		this.executors.set(runId, freshExecutor);
+
+		const currentStep = freshExecutor.getCurrentStep();
+		if (!currentStep) {
+			// Run is in_progress but currentStepId references a step that doesn't exist in
+			// the workflow. This is a data inconsistency — throw so the error surfaces rather
+			// than the run silently hanging forever.
+			throw new Error(
+				`Run "${runId}" has currentStepId "${run.currentStepId}" not found in workflow "${run.workflowId}"`
+			);
+		}
+
+		// Find tasks that belong to the current step
+		const stepTasks = this.config.taskRepo
+			.listByWorkflowRun(runId)
+			.filter((t) => t.workflowStepId === currentStep.id);
+
+		// Only advance when there is at least one task and ALL are completed
+		if (stepTasks.length === 0) return;
+		if (!stepTasks.every((t) => t.status === 'completed')) return;
+
+		try {
+			const { tasks: newTasks } = await freshExecutor.advance();
+
+			// Tasks are created with taskType already set by the TaskTypeResolver
+			// injected into the executor via buildExecutor(). No second update needed.
+
+			if (newTasks.length === 0) {
+				// Terminal step reached — run marked completed by advance(); clean up executor.
+				this.executors.delete(runId);
+				this.executorMeta.delete(runId);
+			}
+		} catch (err) {
+			if (!(err instanceof WorkflowGateError)) {
+				// Unexpected error — propagate to caller (processCompletedTasks collects it)
+				throw err;
+			}
+			// Gate blocked: run status already set to 'needs_attention' by the executor.
+			// Keep executor and meta in map — will be retried after gate is resolved.
 		}
 	}
 
@@ -402,7 +485,22 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Returns the cached SpaceTaskManager for a space, creating it if needed.
+	 * Caching avoids creating a new manager + repository on every executor build.
+	 */
+	private getOrCreateTaskManager(spaceId: string): SpaceTaskManager {
+		let manager = this.taskManagers.get(spaceId);
+		if (!manager) {
+			manager = new SpaceTaskManager(this.config.db, spaceId);
+			this.taskManagers.set(spaceId, manager);
+		}
+		return manager;
+	}
+
+	/**
 	 * Builds a WorkflowExecutor for the given run with fresh state.
+	 * Injects the TaskTypeResolver so tasks are created with correct taskType
+	 * in a single atomic DB write.
 	 */
 	private buildExecutor(
 		workflow: SpaceWorkflow,
@@ -410,13 +508,15 @@ export class SpaceRuntime {
 		spaceId: string,
 		workspacePath: string
 	): WorkflowExecutor {
-		const taskManager = new SpaceTaskManager(this.config.db, spaceId);
+		const taskManager = this.getOrCreateTaskManager(spaceId);
 		return new WorkflowExecutor(
 			workflow,
 			run,
 			taskManager,
 			this.config.workflowRunRepo,
-			workspacePath
+			workspacePath,
+			undefined, // use default commandRunner
+			(step) => this.resolveTaskTypeForStep(step) // inject TaskTypeResolver
 		);
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -437,8 +437,11 @@ export class SpaceRuntime {
 		const currentStep = freshExecutor.getCurrentStep();
 		if (!currentStep) {
 			// Run is in_progress but currentStepId references a step that doesn't exist in
-			// the workflow. This is a data inconsistency — throw so the error surfaces rather
-			// than the run silently hanging forever.
+			// the workflow. This is a data inconsistency — cancel the run and clean up maps
+			// so it is not rehydrated on every subsequent restart into the same throw loop.
+			this.executors.delete(runId);
+			this.executorMeta.delete(runId);
+			this.config.workflowRunRepo.updateStatus(runId, 'cancelled');
 			throw new Error(
 				`Run "${runId}" has currentStepId "${run.currentStepId}" not found in workflow "${run.workflowId}"`
 			);

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -79,6 +79,16 @@ export type CommandRunner = (
 	timeoutMs: number
 ) => Promise<{ exitCode: number | null; timedOut?: boolean; stderr?: string }>;
 
+/**
+ * Optional resolver injected by SpaceRuntime to set task metadata (taskType,
+ * customAgentId) at task-creation time. When provided, the task is created
+ * complete in a single DB write — no second update required.
+ */
+export type TaskTypeResolver = (step: WorkflowStep) => {
+	taskType?: string;
+	customAgentId?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Default timeout constants
 // ---------------------------------------------------------------------------
@@ -135,7 +145,8 @@ export class WorkflowExecutor {
 		private taskManager: SpaceTaskManager,
 		private workflowRunRepo: SpaceWorkflowRunRepository,
 		private workspacePath: string,
-		private commandRunner: CommandRunner = defaultCommandRunner
+		private commandRunner: CommandRunner = defaultCommandRunner,
+		private taskTypeResolver?: TaskTypeResolver
 	) {}
 
 	// -------------------------------------------------------------------------
@@ -328,13 +339,20 @@ export class WorkflowExecutor {
 		if (!updatedRun) throw new Error('Failed to persist step ID update');
 		this.run = updatedRun;
 
+		// Resolve task metadata so the task is created complete in a single write.
+		// When a taskTypeResolver is provided it fully controls taskType AND customAgentId —
+		// customAgentId: undefined means "no custom agent" for preset roles (planner/coder/general).
+		// Without a resolver (backward-compat), fall back to nextStep.agentId.
+		const resolved = this.taskTypeResolver?.(nextStep);
+
 		// Create a pending SpaceTask for the new step
 		const task = await this.taskManager.createTask({
 			title: nextStep.name,
 			description: nextStep.instructions ?? '',
 			workflowRunId: this.run.id,
 			workflowStepId: nextStep.id,
-			customAgentId: nextStep.agentId,
+			taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
+			customAgentId: resolved !== undefined ? resolved.customAgentId : nextStep.agentId,
 			status: 'pending',
 		});
 

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -72,11 +72,35 @@ export class SpaceWorkflowRunRepository {
 	}
 
 	/**
-	 * List active (non-terminal) workflow runs for a space
+	 * List in-progress workflow runs for a space.
+	 *
+	 * Only `in_progress` runs are returned — `pending` is a transient state that
+	 * exists only briefly inside `startWorkflowRun` between `createRun` and the
+	 * `updateStatus('in_progress')` call. Including `pending` here would cause
+	 * a run that failed mid-creation to be rehydrated without a task and silently
+	 * loop forever in the executor map.
 	 */
 	getActiveRuns(spaceId: string): SpaceWorkflowRun[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status IN ('pending', 'in_progress') ORDER BY created_at ASC`
+			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status = 'in_progress' ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToRun(r));
+	}
+
+	/**
+	 * List runs that need an executor on startup: in_progress and needs_attention.
+	 *
+	 * This superset of getActiveRuns() is used exclusively by rehydrateExecutors()
+	 * so that runs blocked at a human gate (needs_attention) get an executor
+	 * reloaded on restart. Without this, a run waiting for human approval would
+	 * be permanently stuck after a process restart.
+	 *
+	 * `pending` is still excluded for the same reason as in getActiveRuns().
+	 */
+	getRehydratableRuns(spaceId: string): SpaceWorkflowRun[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_workflow_runs WHERE space_id = ? AND status IN ('in_progress', 'needs_attention') ORDER BY created_at ASC`
 		);
 		const rows = stmt.all(spaceId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToRun(r));

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1,0 +1,888 @@
+/**
+ * SpaceRuntime Integration Tests
+ *
+ * Covers:
+ * - startWorkflowRun(): creates run, executor, first task with correct taskType
+ * - executeTick(): advances completed tasks to next step
+ * - Gate enforcement: human gate blocks advancement, needs_attention set
+ * - Standalone tasks: tasks without workflowRunId are not processed by executor map
+ * - Rule injection: getRulesForStep() filters correctly
+ * - Rehydration: executors reconstructed from DB on startup
+ * - Executor cleanup: removed from map on run complete/cancel
+ * - resolveTaskTypeForStep(): correct mapping for planner, coder, general, custom roles
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-runtime',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgentRow(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	name: string,
+	role: string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, name, role, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function buildLinearWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	steps: Array<{ id: string; name: string; agentId: string; instructions?: string }>,
+	conditions: Array<{ type: 'always' | 'human'; description?: string }> = []
+): SpaceWorkflow {
+	// Build transitions: step[i] → step[i+1] with conditions[i]
+	const transitions = steps.slice(0, -1).map((step, i) => ({
+		from: step.id,
+		to: steps[i + 1].id,
+		condition: conditions[i] ?? { type: 'always' as const },
+		order: 0,
+	}));
+
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: `Test Workflow ${Date.now()}-${Math.random()}`,
+		description: 'Test',
+		steps,
+		transitions,
+		startStepId: steps[0].id,
+		rules: [],
+		tags: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Test suite setup
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let runtime: SpaceRuntime;
+
+	const SPACE_ID = 'space-rt-1';
+	const WORKSPACE = '/tmp/runtime-ws';
+
+	// Agent IDs for preset roles
+	const AGENT_PLANNER = 'agent-planner';
+	const AGENT_CODER = 'agent-coder';
+	const AGENT_GENERAL = 'agent-general';
+	const AGENT_CUSTOM = 'agent-custom';
+
+	// Step ID constants
+	const STEP_A = 'step-a';
+	const STEP_B = 'step-b';
+	const STEP_C = 'step-c';
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+
+		// Seed space
+		seedSpaceRow(db, SPACE_ID, WORKSPACE);
+
+		// Seed agents with different roles
+		seedAgentRow(db, AGENT_PLANNER, SPACE_ID, 'Planner', 'planner');
+		seedAgentRow(db, AGENT_CODER, SPACE_ID, 'Coder', 'coder');
+		seedAgentRow(db, AGENT_GENERAL, SPACE_ID, 'General', 'general');
+		seedAgentRow(db, AGENT_CUSTOM, SPACE_ID, 'Custom', 'my-custom-role');
+
+		// Build managers and repos
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+		spaceManager = new SpaceManager(db);
+
+		const config: SpaceRuntimeConfig = {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+		};
+		runtime = new SpaceRuntime(config);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// resolveTaskTypeForStep
+	// -------------------------------------------------------------------------
+
+	describe('resolveTaskTypeForStep()', () => {
+		test('planner role → planning taskType, no customAgentId', () => {
+			const step = { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER };
+			const result = runtime.resolveTaskTypeForStep(step);
+			expect(result.taskType).toBe('planning');
+			expect(result.customAgentId).toBeUndefined();
+		});
+
+		test('coder role → coding taskType, no customAgentId', () => {
+			const step = { id: STEP_A, name: 'Code', agentId: AGENT_CODER };
+			const result = runtime.resolveTaskTypeForStep(step);
+			expect(result.taskType).toBe('coding');
+			expect(result.customAgentId).toBeUndefined();
+		});
+
+		test('general role → coding taskType, no customAgentId', () => {
+			const step = { id: STEP_A, name: 'Research', agentId: AGENT_GENERAL };
+			const result = runtime.resolveTaskTypeForStep(step);
+			expect(result.taskType).toBe('coding');
+			expect(result.customAgentId).toBeUndefined();
+		});
+
+		test('custom role → coding taskType + customAgentId = step.agentId', () => {
+			const step = { id: STEP_A, name: 'Custom', agentId: AGENT_CUSTOM };
+			const result = runtime.resolveTaskTypeForStep(step);
+			expect(result.taskType).toBe('coding');
+			expect(result.customAgentId).toBe(AGENT_CUSTOM);
+		});
+
+		test('unknown agentId → coding taskType + customAgentId = step.agentId', () => {
+			const step = { id: STEP_A, name: 'Unknown', agentId: 'non-existent-uuid' };
+			const result = runtime.resolveTaskTypeForStep(step);
+			expect(result.taskType).toBe('coding');
+			expect(result.customAgentId).toBe('non-existent-uuid');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getRulesForStep
+	// -------------------------------------------------------------------------
+
+	describe('getRulesForStep()', () => {
+		test('returns empty array when workflow not found', () => {
+			const rules = runtime.getRulesForStep('nonexistent-workflow-id', STEP_A);
+			expect(rules).toEqual([]);
+		});
+
+		test('returns all rules when appliesTo is empty (applies to all steps)', () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Rules Test Workflow',
+				steps: [{ id: STEP_A, name: 'Step A', agentId: AGENT_CODER }],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [
+					{ name: 'Global Rule', content: 'Always be concise', appliesTo: [] },
+					{ name: 'Another Global', content: 'Write tests', appliesTo: undefined as never },
+				],
+				tags: [],
+			});
+
+			const rules = runtime.getRulesForStep(workflow.id, STEP_A);
+			expect(rules).toHaveLength(2);
+		});
+
+		test('filters rules by step ID when appliesTo is set', () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Filtered Rules Workflow',
+				steps: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT_PLANNER },
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+				rules: [
+					{ name: 'Step A Rule', content: 'Rule for step A only', appliesTo: [STEP_A] },
+					{ name: 'Step B Rule', content: 'Rule for step B only', appliesTo: [STEP_B] },
+					{ name: 'Global Rule', content: 'Rule for all steps', appliesTo: [] },
+				],
+				tags: [],
+			});
+
+			// Rules for step A: step A rule + global
+			const rulesForA = runtime.getRulesForStep(workflow.id, STEP_A);
+			expect(rulesForA).toHaveLength(2);
+			expect(rulesForA.map((r) => r.name)).toEqual(
+				expect.arrayContaining(['Step A Rule', 'Global Rule'])
+			);
+
+			// Rules for step B: step B rule + global
+			const rulesForB = runtime.getRulesForStep(workflow.id, STEP_B);
+			expect(rulesForB).toHaveLength(2);
+			expect(rulesForB.map((r) => r.name)).toEqual(
+				expect.arrayContaining(['Step B Rule', 'Global Rule'])
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// startWorkflowRun()
+	// -------------------------------------------------------------------------
+
+	describe('startWorkflowRun()', () => {
+		test('creates run record with in_progress status', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Test Run');
+
+			expect(run.spaceId).toBe(SPACE_ID);
+			expect(run.workflowId).toBe(workflow.id);
+			expect(run.status).toBe('in_progress');
+			expect(run.currentStepId).toBe(STEP_A);
+		});
+
+		test('creates initial SpaceTask for the start step', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'My Run');
+
+			expect(tasks).toHaveLength(1);
+			const task = tasks[0];
+			expect(task.workflowRunId).toBe(tasks[0].workflowRunId);
+			expect(task.workflowStepId).toBe(STEP_A);
+			expect(task.status).toBe('pending');
+			expect(task.title).toBe('Plan');
+		});
+
+		test('assigns correct taskType for planner start step', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(tasks[0].taskType).toBe('planning');
+		});
+
+		test('assigns correct taskType for coder start step', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Code', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(tasks[0].taskType).toBe('coding');
+		});
+
+		test('registers executor in executors map', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(runtime.executorCount).toBe(1);
+			expect(runtime.getExecutor(run.id)).toBeDefined();
+		});
+
+		test('throws for unknown workflow', async () => {
+			await expect(runtime.startWorkflowRun(SPACE_ID, 'nonexistent-wf-id', 'Run')).rejects.toThrow(
+				'Workflow not found'
+			);
+		});
+
+		test('throws for unknown space', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			await expect(
+				runtime.startWorkflowRun('nonexistent-space', workflow.id, 'Run')
+			).rejects.toThrow('Space not found');
+		});
+
+		test('stores description on run record', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'My Run',
+				'Some description'
+			);
+
+			expect(run.description).toBe('Some description');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// executeTick() — advancement
+	// -------------------------------------------------------------------------
+
+	describe('executeTick() — workflow advancement', () => {
+		test('advances run when start step task is completed (always condition)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Complete the first step task
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// Tick — should advance to step B
+			await runtime.executeTick();
+
+			// A new task for step B should exist
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(2);
+
+			const stepBTask = allTasks.find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+			expect(stepBTask!.status).toBe('pending');
+			expect(stepBTask!.taskType).toBe('coding');
+		});
+
+		test('does not advance when step task is still in_progress', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+
+			await runtime.executeTick();
+
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(1); // no new task created
+		});
+
+		test('marks run as completed when terminal step is advanced past', async () => {
+			// Single step workflow — advancing past it completes the run
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			const updatedRun = workflowRunRepo.getRun(run.id);
+			expect(updatedRun!.status).toBe('completed');
+
+			// Executor should be cleaned up
+			expect(runtime.getExecutor(run.id)).toBeUndefined();
+		});
+
+		test('three-step workflow advances through all steps', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+					{ id: STEP_C, name: 'Review', agentId: AGENT_GENERAL },
+				],
+				[{ type: 'always' }, { type: 'always' }]
+			);
+
+			const { run, tasks: initialTasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Run'
+			);
+
+			// Complete step A task → tick → step B task created
+			taskRepo.updateTask(initialTasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+
+			// Complete step B task → tick → step C task created
+			taskRepo.updateTask(stepBTask!.id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const stepCTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_C);
+			expect(stepCTask).toBeDefined();
+
+			// Complete step C task → tick → run completes (terminal step)
+			taskRepo.updateTask(stepCTask!.id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const finalRun = workflowRunRepo.getRun(run.id);
+			expect(finalRun!.status).toBe('completed');
+			expect(runtime.getExecutor(run.id)).toBeUndefined();
+		});
+
+		test('assigns correct taskType to tasks created by advance()', async () => {
+			// Plan → Code (planner → coder)
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			const stepBTask = taskRepo
+				.listByWorkflowRun(run.id)
+				.find((t) => t.workflowStepId === STEP_B)!;
+
+			expect(stepBTask.taskType).toBe('coding');
+		});
+
+		test('sets customAgentId for custom-role agent in advance() result', async () => {
+			// Coder → Custom
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Code', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Custom Step', agentId: AGENT_CUSTOM },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			const stepBTask = taskRepo
+				.listByWorkflowRun(run.id)
+				.find((t) => t.workflowStepId === STEP_B)!;
+
+			expect(stepBTask.taskType).toBe('coding');
+			expect(stepBTask.customAgentId).toBe(AGENT_CUSTOM);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Gate enforcement — human condition
+	// -------------------------------------------------------------------------
+
+	describe('gate enforcement', () => {
+		test('human gate blocks advancement and sets run to needs_attention', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// Tick — human gate should block advancement
+			await runtime.executeTick();
+
+			const updatedRun = workflowRunRepo.getRun(run.id);
+			expect(updatedRun!.status).toBe('needs_attention');
+
+			// No new task should be created for step B
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(1);
+		});
+
+		test('executor is retained after gate block (can be retried)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			// Executor should still be in the map
+			expect(runtime.getExecutor(run.id)).toBeDefined();
+		});
+
+		test('advances after human approval is set in run.config', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// First tick — gate blocks
+			await runtime.executeTick();
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('needs_attention');
+
+			// External approval: reset status and set humanApproved flag
+			workflowRunRepo.updateRun(run.id, {
+				status: 'in_progress',
+				config: { humanApproved: true },
+			});
+
+			// Second tick — gate passes
+			await runtime.executeTick();
+
+			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Standalone tasks
+	// -------------------------------------------------------------------------
+
+	describe('standalone tasks', () => {
+		test('standalone task (no workflowRunId) is not processed by executor map', async () => {
+			// Create a standalone task directly via repo
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone Task',
+				description: 'No workflow',
+				status: 'pending',
+			});
+
+			// Tick should not throw and executor count stays 0
+			await runtime.executeTick();
+
+			expect(runtime.executorCount).toBe(0);
+
+			// Task status unchanged
+			const unchanged = taskRepo.getTask(task.id)!;
+			expect(unchanged.status).toBe('pending');
+		});
+
+		test('multiple workflow runs can coexist without interference', async () => {
+			const wf1 = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_CODER },
+			]);
+			const wf2 = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_B, name: 'Step B', agentId: AGENT_PLANNER },
+			]);
+
+			const { run: run1, tasks: tasks1 } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				wf1.id,
+				'Run 1'
+			);
+			const { run: run2, tasks: tasks2 } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				wf2.id,
+				'Run 2'
+			);
+
+			expect(runtime.executorCount).toBe(2);
+
+			// Complete run1's task only
+			taskRepo.updateTask(tasks1[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			// run1 should complete (terminal step), run2 still active
+			expect(workflowRunRepo.getRun(run1.id)!.status).toBe('completed');
+			expect(workflowRunRepo.getRun(run2.id)!.status).toBe('in_progress');
+			expect(runtime.executorCount).toBe(1);
+			expect(runtime.getExecutor(run1.id)).toBeUndefined();
+			expect(runtime.getExecutor(run2.id)).toBeDefined();
+
+			// Complete run2's task
+			taskRepo.updateTask(tasks2[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			expect(workflowRunRepo.getRun(run2.id)!.status).toBe('completed');
+			expect(runtime.executorCount).toBe(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Rehydration
+	// -------------------------------------------------------------------------
+
+	describe('rehydrateExecutors()', () => {
+		test('rehydrates in-progress runs on first executeTick() call', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			// Create a run and initial task using repo directly (simulating prior server run)
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Rehydration Run',
+				currentStepId: STEP_A,
+			});
+			const run = workflowRunRepo.updateStatus(pendingRun.id, 'in_progress')!;
+
+			// Create and complete the start step task
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Plan',
+				description: '',
+				workflowRunId: run.id,
+				workflowStepId: STEP_A,
+				status: 'completed',
+			});
+			expect(task.status).toBe('completed');
+
+			// Build a fresh runtime (no executors loaded yet)
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			expect(freshRuntime.executorCount).toBe(0);
+
+			// executeTick() should rehydrate the executor and advance the run
+			await freshRuntime.executeTick();
+
+			// Executor for the run should now exist
+			// The completed step A task should trigger advancement to step B
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			const stepBTask = allTasks.find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+		});
+
+		test('rehydration is idempotent (second executeTick does not double-rehydrate)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// First tick — triggers rehydration check (rehydrated already set)
+			await runtime.executeTick();
+
+			// Second tick — should not duplicate executors
+			await runtime.executeTick();
+
+			expect(runtime.executorCount).toBeLessThanOrEqual(1);
+		});
+
+		test('skips runs whose workflow was deleted', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Orphaned Run',
+				currentStepId: STEP_A,
+			});
+			workflowRunRepo.updateStatus(pendingRun.id, 'in_progress');
+
+			// Delete the workflow
+			workflowManager.deleteWorkflow(workflow.id);
+
+			// Fresh runtime — should not throw, should skip the orphaned run
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			await expect(freshRuntime.executeTick()).resolves.toBeUndefined();
+			expect(freshRuntime.executorCount).toBe(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Executor cleanup
+	// -------------------------------------------------------------------------
+
+	describe('executor cleanup', () => {
+		test('executor removed from map when run completes', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(runtime.executorCount).toBe(1);
+
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			expect(runtime.getExecutor(run.id)).toBeUndefined();
+			expect(runtime.executorCount).toBe(0);
+		});
+
+		test('cleanupTerminalExecutors() removes cancelled runs', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(runtime.executorCount).toBe(1);
+
+			// Externally cancel the run
+			workflowRunRepo.updateStatus(run.id, 'cancelled');
+
+			// executeTick → processCompletedTasks skips cancelled, cleanupTerminalExecutors removes it
+			await runtime.executeTick();
+
+			expect(runtime.getExecutor(run.id)).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// seedPresetAgents + seedBuiltInWorkflows wiring (space-handlers)
+	// -------------------------------------------------------------------------
+
+	describe('space.create seeding (unit-level check)', () => {
+		test('seedBuiltInWorkflows can be called after seedPresetAgents successfully', async () => {
+			// Create a new space DB row
+			const newSpaceId = 'space-seed-test';
+			const newWorkspacePath = '/tmp/seed-test';
+			seedSpaceRow(db, newSpaceId, newWorkspacePath);
+
+			const { seedPresetAgents } = await import('../../../src/lib/space/agents/seed-agents.ts');
+			const { seedBuiltInWorkflows } = await import(
+				'../../../src/lib/space/workflows/built-in-workflows.ts'
+			);
+
+			// Seed agents
+			const result = await seedPresetAgents(newSpaceId, agentManager);
+			expect(result.errors).toHaveLength(0);
+			expect(result.seeded.length).toBeGreaterThan(0);
+
+			// Seed workflows using role resolver
+			const agents = agentManager.listBySpaceId(newSpaceId);
+			expect(() =>
+				seedBuiltInWorkflows(
+					newSpaceId,
+					workflowManager,
+					(role) => agents.find((a) => a.role === role)?.id
+				)
+			).not.toThrow();
+
+			// Three built-in workflows should exist
+			const workflows = workflowManager.listWorkflows(newSpaceId);
+			expect(workflows).toHaveLength(3);
+		});
+
+		test('seedBuiltInWorkflows is idempotent (calling twice is a no-op)', async () => {
+			const newSpaceId = 'space-seed-idempotent';
+			const newWorkspacePath = '/tmp/seed-idempotent';
+			seedSpaceRow(db, newSpaceId, newWorkspacePath);
+
+			const { seedPresetAgents } = await import('../../../src/lib/space/agents/seed-agents.ts');
+			const { seedBuiltInWorkflows } = await import(
+				'../../../src/lib/space/workflows/built-in-workflows.ts'
+			);
+
+			await seedPresetAgents(newSpaceId, agentManager);
+			const agents = agentManager.listBySpaceId(newSpaceId);
+			const resolver = (role: string) => agents.find((a) => a.role === role)?.id;
+
+			seedBuiltInWorkflows(newSpaceId, workflowManager, resolver);
+			seedBuiltInWorkflows(newSpaceId, workflowManager, resolver); // second call is no-op
+
+			const workflows = workflowManager.listWorkflows(newSpaceId);
+			expect(workflows).toHaveLength(3); // still 3, not 6
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -348,6 +348,47 @@ describe('SpaceRuntime', () => {
 			);
 		});
 
+		test('cancels DB run record when task creation fails (prevents silent rehydration loop)', async () => {
+			// Create a workflow where the startStepId references a valid step but the
+			// agentId references an agent that is then deleted, causing createTask to fail
+			// due to the foreign key constraint on space_tasks.agent_id.
+			// Instead, use FK-bypass to create a workflow with a bogus startStepId to
+			// trigger the "Start step not found" path which also exercises the cleanup.
+			db.exec('PRAGMA foreign_keys = OFF');
+			let workflow: SpaceWorkflow;
+			try {
+				const repo = new SpaceWorkflowRepository(db);
+				workflow = repo.createWorkflow({
+					spaceId: SPACE_ID,
+					name: `Broken Start ${Date.now()}`,
+					description: '',
+					steps: [{ id: 'step-bad', name: 'Step', agentId: AGENT_PLANNER }],
+					transitions: [],
+					startStepId: 'nonexistent-start-step-id',
+					rules: [],
+					tags: [],
+				});
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+
+			// Count runs before
+			const runsBefore = workflowRunRepo.listBySpace(SPACE_ID);
+
+			await expect(runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Bad Run')).rejects.toThrow(
+				'Start step'
+			);
+
+			// The newly created run should be cancelled, not left as in_progress
+			const runsAfter = workflowRunRepo.listBySpace(SPACE_ID);
+			const newRun = runsAfter.find((r) => !runsBefore.some((b) => b.id === r.id));
+			expect(newRun).toBeDefined();
+			expect(newRun!.status).toBe('cancelled');
+
+			// Executor map should not retain the failed run
+			expect(runtime.executorCount).toBe(0);
+		});
+
 		test('throws for unknown space', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -301,11 +301,11 @@ describe('SpaceRuntime', () => {
 				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
 			]);
 
-			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'My Run');
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'My Run');
 
 			expect(tasks).toHaveLength(1);
 			const task = tasks[0];
-			expect(task.workflowRunId).toBe(tasks[0].workflowRunId);
+			expect(task.workflowRunId).toBe(run.id);
 			expect(task.workflowStepId).toBe(STEP_A);
 			expect(task.status).toBe('pending');
 			expect(task.title).toBe('Plan');
@@ -534,6 +534,75 @@ describe('SpaceRuntime', () => {
 
 			expect(stepBTask.taskType).toBe('coding');
 			expect(stepBTask.customAgentId).toBe(AGENT_CUSTOM);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Non-gate error propagation
+	// -------------------------------------------------------------------------
+
+	describe('non-gate error propagation', () => {
+		test('executeTick() re-throws non-WorkflowGateError from a run tick', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// Corrupt the executor meta so buildExecutor() throws a non-gate error on next tick
+			// by pointing the workflow to a non-existent target step.
+			workflowRunRepo.updateRun(run.id, { currentStepId: 'nonexistent-step' });
+
+			await expect(runtime.executeTick()).rejects.toThrow();
+		});
+
+		test('executeTick() processes remaining runs after one run throws a non-gate error', async () => {
+			// Run 1: will be set to an invalid step to cause a non-gate error
+			const wf1 = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Step A', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+			// Run 2: normal single-step workflow that should complete normally
+			const wf2 = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_C, name: 'Only Step', agentId: AGENT_PLANNER },
+			]);
+
+			const { run: run1, tasks: tasks1 } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				wf1.id,
+				'Run 1'
+			);
+			const { run: run2, tasks: tasks2 } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				wf2.id,
+				'Run 2'
+			);
+
+			// Complete both initial tasks
+			taskRepo.updateTask(tasks1[0].id, { status: 'completed' });
+			taskRepo.updateTask(tasks2[0].id, { status: 'completed' });
+
+			// Force run1 to an invalid step so the tick throws a non-gate error
+			workflowRunRepo.updateRun(run1.id, { currentStepId: 'nonexistent-step' });
+
+			// The tick should throw (from run1) but still process run2 first
+			await expect(runtime.executeTick()).rejects.toThrow();
+
+			// run2 should have completed despite run1's error
+			const run2State = workflowRunRepo.getRun(run2.id)!;
+			expect(run2State.status).toBe('completed');
 		});
 	});
 
@@ -787,6 +856,62 @@ describe('SpaceRuntime', () => {
 
 			await expect(freshRuntime.executeTick()).resolves.toBeUndefined();
 			expect(freshRuntime.executorCount).toBe(0);
+		});
+
+		test('rehydrates needs_attention runs so they can resume after gate resolved', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			// Simulate a run that was blocked at a human gate before restart
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Gate Run',
+				currentStepId: STEP_A,
+			});
+			const run = workflowRunRepo.updateStatus(pendingRun.id, 'needs_attention')!;
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Plan',
+				description: '',
+				workflowRunId: run.id,
+				workflowStepId: STEP_A,
+				status: 'completed',
+			});
+
+			// Fresh runtime rehydrates the needs_attention run
+			const freshRuntime = new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+			});
+
+			// First tick: rehydrates executor but run is needs_attention — no advancement
+			await freshRuntime.executeTick();
+			expect(freshRuntime.getExecutor(run.id)).toBeDefined();
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('needs_attention');
+
+			// Resolve the gate externally
+			workflowRunRepo.updateRun(run.id, {
+				status: 'in_progress',
+				config: { humanApproved: true },
+			});
+
+			// Second tick: gate now passes, run advances to step B
+			await freshRuntime.executeTick();
+
+			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
 		});
 	});
 

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -542,41 +542,52 @@ describe('SpaceRuntime', () => {
 	// -------------------------------------------------------------------------
 
 	describe('non-gate error propagation', () => {
+		/**
+		 * Creates a workflow directly via the repository (bypassing manager validation)
+		 * with a transition whose target step does not exist in the workflow's step list.
+		 * When advance() is called, followTransition() throws a non-gate Error.
+		 *
+		 * FK checks are temporarily disabled to allow the broken transition row to be
+		 * inserted. They are always re-enabled in a finally block.
+		 */
+		function buildWorkflowWithBrokenTransition(stepId: string, stepName: string): SpaceWorkflow {
+			db.exec('PRAGMA foreign_keys = OFF');
+			try {
+				const repo = new SpaceWorkflowRepository(db);
+				return repo.createWorkflow({
+					spaceId: SPACE_ID,
+					name: `Broken ${Date.now()}-${Math.random()}`,
+					description: '',
+					steps: [{ id: stepId, name: stepName, agentId: AGENT_PLANNER }],
+					transitions: [
+						{ from: stepId, to: 'ghost-step-that-does-not-exist', condition: { type: 'always' } },
+					],
+					startStepId: stepId,
+					rules: [],
+					tags: [],
+				});
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+
 		test('executeTick() re-throws non-WorkflowGateError from a run tick', async () => {
-			const workflow = buildLinearWorkflow(
-				SPACE_ID,
-				workflowManager,
-				[
-					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
-					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
-				],
-				[{ type: 'always' }]
-			);
+			// Use a workflow with a broken transition so advance() throws a non-gate Error:
+			// "Target step 'ghost-step-that-does-not-exist' not found in workflow ..."
+			const workflow = buildWorkflowWithBrokenTransition('step-err1', 'Plan');
 
-			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
-
-			// Corrupt the executor meta so buildExecutor() throws a non-gate error on next tick
-			// by pointing the workflow to a non-existent target step.
-			workflowRunRepo.updateRun(run.id, { currentStepId: 'nonexistent-step' });
 
 			await expect(runtime.executeTick()).rejects.toThrow();
 		});
 
 		test('executeTick() processes remaining runs after one run throws a non-gate error', async () => {
-			// Run 1: will be set to an invalid step to cause a non-gate error
-			const wf1 = buildLinearWorkflow(
-				SPACE_ID,
-				workflowManager,
-				[
-					{ id: STEP_A, name: 'Step A', agentId: AGENT_PLANNER },
-					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
-				],
-				[{ type: 'always' }]
-			);
-			// Run 2: normal single-step workflow that should complete normally
+			// Run 1: broken transition → advance() will throw a non-gate error
+			const wf1 = buildWorkflowWithBrokenTransition('step-err2', 'Plan Broken');
+			// Run 2: normal single-step workflow (terminal step → completes immediately)
 			const wf2 = buildLinearWorkflow(SPACE_ID, workflowManager, [
-				{ id: STEP_C, name: 'Only Step', agentId: AGENT_PLANNER },
+				{ id: 'step-err3', name: 'Only Step', agentId: AGENT_PLANNER },
 			]);
 
 			const { run: run1, tasks: tasks1 } = await runtime.startWorkflowRun(
@@ -594,10 +605,7 @@ describe('SpaceRuntime', () => {
 			taskRepo.updateTask(tasks1[0].id, { status: 'completed' });
 			taskRepo.updateTask(tasks2[0].id, { status: 'completed' });
 
-			// Force run1 to an invalid step so the tick throws a non-gate error
-			workflowRunRepo.updateRun(run1.id, { currentStepId: 'nonexistent-step' });
-
-			// The tick should throw (from run1) but still process run2 first
+			// The tick should throw (from run1's broken transition) but still process run2
 			await expect(runtime.executeTick()).rejects.toThrow();
 
 			// run2 should have completed despite run1's error

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -623,6 +623,31 @@ describe('SpaceRuntime', () => {
 			await expect(runtime.executeTick()).rejects.toThrow();
 		});
 
+		test('processRunTick cancels and removes run when currentStepId is inconsistent with workflow', async () => {
+			// Create a valid workflow and start a run normally
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(runtime.executorCount).toBe(1);
+
+			// Externally corrupt the run's currentStepId to a step that doesn't exist
+			// in the workflow (simulates data inconsistency, e.g. a workflow was updated
+			// after a run was started).
+			workflowRunRepo.updateRun(run.id, { currentStepId: 'step-that-does-not-exist' });
+
+			// executeTick() should throw (data inconsistency error), but also:
+			// 1. cancel the DB run record so it is not rehydrated on next restart
+			// 2. remove the executor and meta from the in-memory maps
+			await expect(runtime.executeTick()).rejects.toThrow('not found in workflow');
+
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			expect(updatedRun.status).toBe('cancelled');
+			expect(runtime.executorCount).toBe(0);
+			expect(runtime.getExecutor(run.id)).toBeUndefined();
+		});
+
 		test('executeTick() processes remaining runs after one run throws a non-gate error', async () => {
 			// Run 1: broken transition → advance() will throw a non-gate error
 			const wf1 = buildWorkflowWithBrokenTransition('step-err2', 'Plan Broken');

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -88,14 +88,21 @@ describe('SpaceWorkflowRunRepository', () => {
 	});
 
 	describe('getActiveRuns', () => {
-		it('returns only pending/in_progress runs', () => {
+		it('returns only in_progress runs (excludes pending and completed)', () => {
+			// 'pending' is a transient state that should NOT appear in active runs
 			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Pending' });
-			const r2 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Completed' });
-			repo.updateStatus(r2.id, 'completed');
+
+			// 'in_progress' — should appear
+			const r2 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Active' });
+			repo.updateStatus(r2.id, 'in_progress');
+
+			// 'completed' — should not appear
+			const r3 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Completed' });
+			repo.updateStatus(r3.id, 'completed');
 
 			const active = repo.getActiveRuns(spaceId);
 			expect(active).toHaveLength(1);
-			expect(active[0].title).toBe('Pending');
+			expect(active[0].title).toBe('Active');
 		});
 	});
 

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -106,6 +106,34 @@ describe('SpaceWorkflowRunRepository', () => {
 		});
 	});
 
+	describe('getRehydratableRuns', () => {
+		it('returns in_progress and needs_attention runs; excludes pending, completed, cancelled', () => {
+			// 'pending' — excluded (transient creation state)
+			repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Pending' });
+
+			// 'in_progress' — included
+			const r2 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'InProgress' });
+			repo.updateStatus(r2.id, 'in_progress');
+
+			// 'needs_attention' (human gate blocked) — included so gate can be resolved after restart
+			const r3 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'NeedsAttention' });
+			repo.updateStatus(r3.id, 'needs_attention');
+
+			// 'completed' — excluded
+			const r4 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Completed' });
+			repo.updateStatus(r4.id, 'completed');
+
+			// 'cancelled' — excluded
+			const r5 = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'Cancelled' });
+			repo.updateStatus(r5.id, 'cancelled');
+
+			const rehydratable = repo.getRehydratableRuns(spaceId);
+			expect(rehydratable).toHaveLength(2);
+			const titles = rehydratable.map((r) => r.title).sort();
+			expect(titles).toEqual(['InProgress', 'NeedsAttention']);
+		});
+	});
+
 	describe('updateRun', () => {
 		it('updates title and description', () => {
 			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });


### PR DESCRIPTION
## Summary

- **SpaceRuntime** — new workflow-first orchestration engine for Spaces (`packages/daemon/src/lib/space/runtime/space-runtime.ts`):
  - `Map<runId, WorkflowExecutor>` manages all active workflow runs
  - `executeTick()` — rehydrates on first call, processes completed tasks, cleans up terminal runs
  - `rehydrateExecutors()` — loads in-progress runs from DB and reconstructs executors on startup
  - `startWorkflowRun()` — creates `SpaceWorkflowRun` + executor + initial `SpaceTask` for the start step
  - `resolveTaskTypeForStep()` — planner→planning, coder/general→coding, custom→coding+customAgentId
  - `getRulesForStep()` — filters workflow rules by `appliesTo` step ID (empty = global)
  - Executors recreated with fresh DB state on each tick to pick up external run mutations (e.g. human approval reset)
  - `cleanupTerminalExecutors()` reads run status from DB directly to handle external cancellations

- **`seedDefaultWorkflow` wired into `space.create` RPC handler** (`space-handlers.ts`):
  - After `SpaceManager.createSpace()`, calls `seedPresetAgents()` then `seedBuiltInWorkflows()`
  - Errors are non-fatal — logged as warnings, space remains usable
  - `spaceAgentManager` and `spaceWorkflowManager` added to `setupSpaceHandlers()` params

- **`rpc-handlers/index.ts`**: moved `SpaceWorkflowManager` creation before `setupSpaceHandlers()` call to fix forward-reference TypeScript error

- **Exports**: `SpaceRuntime`, `SpaceRuntimeConfig`, `ResolvedTaskType` added to `space/index.ts`

## Test plan

- [x] 34 integration tests covering:
  - `startWorkflowRun()`: creates run, executor, initial task with correct `taskType`
  - `executeTick()`: advances completed tasks through all steps of a 3-step workflow
  - Gate enforcement: human gate blocks advancement, sets `needs_attention`; advances after external approval reset
  - Standalone tasks: not processed by executor map
  - Rules filtering: `getRulesForStep()` respects `appliesTo` vs global rules
  - Rehydration: executors reconstructed from DB on fresh runtime startup
  - Executor cleanup: removed on run complete and external cancellation
  - `resolveTaskTypeForStep()`: correct mapping for planner/coder/general/custom/unknown roles
  - `seedPresetAgents` + `seedBuiltInWorkflows` idempotency
- [x] Full space test suite: 238 pass, 0 fail
- [x] All pre-commit checks pass (lint, format, typecheck, knip)