### PR TITLE
feat: add Space export/import RPC handlers (Task 8.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -57,6 +57,7 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceRuntime } from '../space/runtime/space-runtime';
+import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -233,6 +234,16 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		taskRepo: spaceTaskRepo,
 	});
 	spaceRuntime.start();
+
+	// Space export/import handlers
+	setupSpaceExportImportHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceAgentRepo,
+		spaceWorkflowRepo,
+		spaceWorkflowManager,
+		deps.db.getDatabase()
+	);
 
 	// Return cleanup function to stop background services
 	return () => {

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -1,0 +1,523 @@
+/**
+ * Space Export/Import RPC Handlers
+ *
+ * Export namespace (spaceExport.*):
+ *   spaceExport.agents    { spaceId, agentIds? }                       → { bundle: SpaceExportBundle }
+ *   spaceExport.workflows { spaceId, workflowIds? }                    → { bundle: SpaceExportBundle }
+ *   spaceExport.bundle    { spaceId, agentIds?, workflowIds? }         → { bundle: SpaceExportBundle }
+ *
+ * Import namespace (spaceImport.*):
+ *   spaceImport.preview   { bundle, spaceId }                          → ImportPreviewResult
+ *   spaceImport.execute   { spaceId, bundle, conflictResolution? }     → ImportExecuteResult
+ *
+ * Cross-reference rules:
+ * - Exported workflow steps store the agent's display **name** (`agentRef`), not UUID.
+ * - On import, agent names are resolved to UUIDs by checking:
+ *     1. Agents being imported in the same bundle (by original bundle name)
+ *     2. Agents already present in the target space (by name)
+ * - If a name cannot be resolved, preview flags it as a validation error;
+ *   execute throws and aborts import of that workflow.
+ * - Rule `appliesTo` lists step **names** in the exported format and are
+ *   remapped to new step UUIDs on import.
+ */
+
+import { generateUUID } from '@neokai/shared';
+import type {
+	MessageHub,
+	Space,
+	SpaceAgent,
+	CreateSpaceAgentParams,
+	CreateSpaceWorkflowParams,
+	WorkflowStepInput,
+	WorkflowTransitionInput,
+	WorkflowRuleInput,
+	SpaceExportBundle,
+	ExportedSpaceAgent,
+	ExportedSpaceWorkflow,
+} from '@neokai/shared';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
+import type { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
+import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
+import { exportBundle, validateExportBundle } from '../space/export-format';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface ImportPreview {
+	name: string;
+	action: 'create' | 'conflict';
+	existingId?: string;
+}
+
+export interface ImportPreviewResult {
+	agents: ImportPreview[];
+	workflows: ImportPreview[];
+	validationErrors: string[];
+}
+
+export type ConflictResolutionStrategy = 'skip' | 'rename' | 'replace';
+
+export interface ImportConflictResolution {
+	agents?: Record<string, ConflictResolutionStrategy>;
+	workflows?: Record<string, ConflictResolutionStrategy>;
+}
+
+export interface ImportedItem {
+	name: string;
+	id: string;
+	action: 'created' | 'skipped' | 'renamed' | 'replaced';
+}
+
+export interface ImportExecuteResult {
+	agents: ImportedItem[];
+	workflows: ImportedItem[];
+	warnings: string[];
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+async function requireSpace(spaceManager: SpaceManager, spaceId: string): Promise<Space> {
+	if (!spaceId) throw new Error('spaceId is required');
+	const space = await spaceManager.getSpace(spaceId);
+	if (!space) throw new Error(`Space not found: ${spaceId}`);
+	return space;
+}
+
+/** Generate a name that does not collide with anything in `existingNames`. */
+function generateUniqueName(baseName: string, existingNames: Set<string>): string {
+	if (!existingNames.has(baseName)) return baseName;
+	let counter = 1;
+	while (existingNames.has(`${baseName} (${counter})`)) counter++;
+	return `${baseName} (${counter})`;
+}
+
+function buildAgentCreateParams(
+	spaceId: string,
+	name: string,
+	exported: ExportedSpaceAgent
+): CreateSpaceAgentParams {
+	const params: CreateSpaceAgentParams = { spaceId, name, role: exported.role };
+	if (exported.description !== undefined) params.description = exported.description;
+	if (exported.model !== undefined) params.model = exported.model;
+	if (exported.provider !== undefined) params.provider = exported.provider;
+	if (exported.systemPrompt !== undefined) params.systemPrompt = exported.systemPrompt;
+	if (exported.tools !== undefined) params.tools = exported.tools;
+	return params;
+}
+
+/**
+ * Convert an `ExportedSpaceWorkflow` into `CreateSpaceWorkflowParams` suitable
+ * for `SpaceWorkflowRepository.createWorkflow()`.
+ *
+ * Step names are assigned fresh UUIDs; rule `appliesTo` arrays are remapped from
+ * step names to those new UUIDs; agent refs are resolved via the two lookup maps.
+ *
+ * @returns params ready for the repository, the step-name→UUID map (for rule
+ *          appliesTo remapping), and any warnings about unresolved agent refs.
+ */
+function buildWorkflowCreateParams(
+	spaceId: string,
+	name: string,
+	exported: ExportedSpaceWorkflow,
+	importedAgentNameToId: Map<string, string>,
+	existingAgentNameToId: Map<string, string>
+): { params: CreateSpaceWorkflowParams; stepNameToId: Map<string, string>; warnings: string[] } {
+	const warnings: string[] = [];
+
+	// Assign fresh UUIDs to each step (provides stable cross-reference within this import)
+	const stepNameToId = new Map<string, string>();
+	for (const step of exported.steps) {
+		stepNameToId.set(step.name, generateUUID());
+	}
+
+	// Build WorkflowStepInput list — resolve agentRef names → UUIDs
+	const steps: WorkflowStepInput[] = exported.steps.map((exportedStep) => {
+		const agentId =
+			importedAgentNameToId.get(exportedStep.agentRef) ??
+			existingAgentNameToId.get(exportedStep.agentRef) ??
+			null;
+
+		if (!agentId) {
+			warnings.push(
+				`step "${exportedStep.name}" references unknown agent "${exportedStep.agentRef}"`
+			);
+		}
+
+		const step: WorkflowStepInput = {
+			id: stepNameToId.get(exportedStep.name)!,
+			name: exportedStep.name,
+			agentId: agentId ?? '',
+		};
+		if (exportedStep.instructions !== undefined) step.instructions = exportedStep.instructions;
+		return step;
+	});
+
+	// Build WorkflowTransitionInput list — remap step names → new step UUIDs
+	const transitions: WorkflowTransitionInput[] = exported.transitions.map((t) => {
+		const tr: WorkflowTransitionInput = {
+			from: stepNameToId.get(t.fromStep) ?? t.fromStep,
+			to: stepNameToId.get(t.toStep) ?? t.toStep,
+		};
+		if (t.condition !== undefined) tr.condition = t.condition;
+		if (t.order !== undefined) tr.order = t.order;
+		return tr;
+	});
+
+	// Resolve startStep name → new UUID
+	const startStepId = stepNameToId.get(exported.startStep);
+
+	// Build WorkflowRuleInput list — remap appliesTo step names → new step UUIDs
+	const rules: WorkflowRuleInput[] = exported.rules.map((rule) => {
+		const ruleOut: WorkflowRuleInput = { name: rule.name, content: rule.content };
+		if (rule.appliesTo?.length) {
+			const stepIds = rule.appliesTo
+				.map((stepName) => stepNameToId.get(stepName))
+				.filter((id): id is string => id !== undefined);
+			if (stepIds.length > 0) ruleOut.appliesTo = stepIds;
+		}
+		return ruleOut;
+	});
+
+	const params: CreateSpaceWorkflowParams = {
+		spaceId,
+		name,
+		steps,
+		transitions,
+		rules,
+		tags: exported.tags,
+	};
+	if (startStepId) params.startStepId = startStepId;
+	if (exported.description !== undefined) params.description = exported.description;
+	if (exported.config !== undefined) params.config = exported.config;
+
+	return { params, stepNameToId, warnings };
+}
+
+/**
+ * Validate cross-references and condition expressions in an exported workflow.
+ * Returns a list of human-readable error strings (empty = valid).
+ *
+ * @param importedAgentNames - Set of agent names being imported in the same bundle
+ * @param existingAgentNameToId - Map of existing agent names → UUIDs in target space
+ */
+function validateWorkflowForPreview(
+	exported: ExportedSpaceWorkflow,
+	importedAgentNames: Set<string>,
+	existingAgentNameToId: Map<string, string>
+): string[] {
+	const errors: string[] = [];
+
+	// Unresolved agent refs
+	for (const step of exported.steps) {
+		if (!importedAgentNames.has(step.agentRef) && !existingAgentNameToId.has(step.agentRef)) {
+			errors.push(
+				`step "${step.name}" references unknown agent "${step.agentRef}" — not found in bundle or target space`
+			);
+		}
+	}
+
+	// Condition expression validation (mirrors SpaceWorkflowManager.validateCondition)
+	for (let i = 0; i < exported.transitions.length; i++) {
+		const t = exported.transitions[i];
+		if (t.condition?.type === 'condition' && !t.condition.expression?.trim()) {
+			errors.push(`transition[${i}]: 'condition' type requires a non-empty expression`);
+		}
+	}
+
+	return errors;
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+export function setupSpaceExportImportHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager,
+	agentRepo: SpaceAgentRepository,
+	workflowRepo: SpaceWorkflowRepository,
+	workflowManager: SpaceWorkflowManager
+): void {
+	// ─── spaceExport.agents ──────────────────────────────────────────────────
+	messageHub.onRequest('spaceExport.agents', async (data) => {
+		const params = data as { spaceId: string; agentIds?: string[] };
+		const space = await requireSpace(spaceManager, params.spaceId);
+
+		let agents: SpaceAgent[] = agentRepo.getBySpaceId(params.spaceId);
+		if (params.agentIds?.length) {
+			const idSet = new Set(params.agentIds);
+			agents = agents.filter((a) => idSet.has(a.id));
+		}
+
+		const bundle = exportBundle(agents, [], `${space.name} agents`, {
+			exportedFrom: params.spaceId,
+		});
+		return { bundle };
+	});
+
+	// ─── spaceExport.workflows ───────────────────────────────────────────────
+	messageHub.onRequest('spaceExport.workflows', async (data) => {
+		const params = data as { spaceId: string; workflowIds?: string[] };
+		const space = await requireSpace(spaceManager, params.spaceId);
+
+		let workflows = workflowRepo.listWorkflows(params.spaceId);
+		if (params.workflowIds?.length) {
+			const idSet = new Set(params.workflowIds);
+			workflows = workflows.filter((w) => idSet.has(w.id));
+		}
+
+		// All space agents are needed for correct agentId→name resolution inside exportBundle
+		const allAgents = agentRepo.getBySpaceId(params.spaceId);
+
+		// Export with full agent set so step agentRefs resolve to names, then trim the
+		// bundle's agents array to only those actually referenced by the exported workflows.
+		const full = exportBundle(allAgents, workflows, `${space.name} workflows`, {
+			exportedFrom: params.spaceId,
+		});
+
+		const referencedNames = new Set<string>();
+		for (const wf of full.workflows) {
+			for (const step of wf.steps) referencedNames.add(step.agentRef);
+		}
+
+		const bundle: SpaceExportBundle = {
+			...full,
+			agents: full.agents.filter((a) => referencedNames.has(a.name)),
+		};
+
+		return { bundle };
+	});
+
+	// ─── spaceExport.bundle ──────────────────────────────────────────────────
+	messageHub.onRequest('spaceExport.bundle', async (data) => {
+		const params = data as { spaceId: string; agentIds?: string[]; workflowIds?: string[] };
+		const space = await requireSpace(spaceManager, params.spaceId);
+
+		let agents = agentRepo.getBySpaceId(params.spaceId);
+		if (params.agentIds?.length) {
+			const idSet = new Set(params.agentIds);
+			agents = agents.filter((a) => idSet.has(a.id));
+		}
+
+		let workflows = workflowRepo.listWorkflows(params.spaceId);
+		if (params.workflowIds?.length) {
+			const idSet = new Set(params.workflowIds);
+			workflows = workflows.filter((w) => idSet.has(w.id));
+		}
+
+		const bundle = exportBundle(agents, workflows, `${space.name} bundle`, {
+			exportedFrom: params.spaceId,
+		});
+		return { bundle };
+	});
+
+	// ─── spaceImport.preview ─────────────────────────────────────────────────
+	messageHub.onRequest('spaceImport.preview', async (data) => {
+		const params = data as { bundle: unknown; spaceId: string };
+		await requireSpace(spaceManager, params.spaceId);
+
+		// Validate bundle structure and version
+		const validation = validateExportBundle(params.bundle);
+		if (!validation.ok) {
+			const result: ImportPreviewResult = {
+				agents: [],
+				workflows: [],
+				validationErrors: [validation.error],
+			};
+			return result;
+		}
+		const bundle = validation.value;
+
+		// Load existing entities in target space
+		const existingAgents = agentRepo.getBySpaceId(params.spaceId);
+		const existingWorkflows = workflowRepo.listWorkflows(params.spaceId);
+
+		const existingAgentByName = new Map(existingAgents.map((a) => [a.name, a]));
+		const existingWorkflowByName = new Map(existingWorkflows.map((w) => [w.name, w]));
+		const existingAgentNameToId = new Map(existingAgents.map((a) => [a.name, a.id]));
+
+		// Agent previews
+		const agentPreviews: ImportPreview[] = bundle.agents.map((a) => {
+			const existing = existingAgentByName.get(a.name);
+			if (existing) return { name: a.name, action: 'conflict', existingId: existing.id };
+			return { name: a.name, action: 'create' };
+		});
+
+		// Workflow previews + validation
+		const workflowPreviews: ImportPreview[] = [];
+		const validationErrors: string[] = [];
+
+		const importedAgentNames = new Set(bundle.agents.map((a) => a.name));
+
+		for (const wf of bundle.workflows) {
+			const existing = existingWorkflowByName.get(wf.name);
+			if (existing) {
+				workflowPreviews.push({ name: wf.name, action: 'conflict', existingId: existing.id });
+			} else {
+				workflowPreviews.push({ name: wf.name, action: 'create' });
+			}
+
+			// Cross-reference and condition validation
+			const errors = validateWorkflowForPreview(wf, importedAgentNames, existingAgentNameToId);
+			for (const err of errors) {
+				validationErrors.push(`Workflow "${wf.name}": ${err}`);
+			}
+		}
+
+		const result: ImportPreviewResult = {
+			agents: agentPreviews,
+			workflows: workflowPreviews,
+			validationErrors,
+		};
+		return result;
+	});
+
+	// ─── spaceImport.execute ─────────────────────────────────────────────────
+	messageHub.onRequest('spaceImport.execute', async (data) => {
+		const params = data as {
+			spaceId: string;
+			bundle: unknown;
+			conflictResolution?: ImportConflictResolution;
+		};
+		await requireSpace(spaceManager, params.spaceId);
+
+		// Re-validate bundle (guards against stale previews)
+		const validation = validateExportBundle(params.bundle);
+		if (!validation.ok) {
+			throw new Error(`Invalid bundle: ${validation.error}`);
+		}
+		const bundle = validation.value;
+		const resolution = params.conflictResolution ?? {};
+
+		// Snapshot of existing entities (before any mutations)
+		const existingAgents = agentRepo.getBySpaceId(params.spaceId);
+		const existingWorkflows = workflowRepo.listWorkflows(params.spaceId);
+
+		const existingAgentByName = new Map(existingAgents.map((a) => [a.name, a]));
+		const existingWorkflowByName = new Map(existingWorkflows.map((w) => [w.name, w]));
+		const existingAgentNameToId = new Map(existingAgents.map((a) => [a.name, a.id]));
+
+		// Mutable sets for uniqueness tracking across the import batch
+		const usedAgentNames = new Set(existingAgents.map((a) => a.name));
+		const usedWorkflowNames = new Set(existingWorkflows.map((w) => w.name));
+
+		// ── Phase 1: import agents ──────────────────────────────────────────
+		// Maps original bundle agent name → assigned UUID (used for workflow cross-refs)
+		const importedAgentNameToId = new Map<string, string>();
+		const agentResults: ImportedItem[] = [];
+
+		for (const exportedAgent of bundle.agents) {
+			const existing = existingAgentByName.get(exportedAgent.name);
+
+			if (!existing) {
+				// No conflict — create new agent
+				const created = agentRepo.create(
+					buildAgentCreateParams(params.spaceId, exportedAgent.name, exportedAgent)
+				);
+				usedAgentNames.add(exportedAgent.name);
+				importedAgentNameToId.set(exportedAgent.name, created.id);
+				agentResults.push({ name: exportedAgent.name, id: created.id, action: 'created' });
+				continue;
+			}
+
+			// Conflict — apply resolution strategy (default: skip)
+			const strategy: ConflictResolutionStrategy =
+				resolution.agents?.[exportedAgent.name] ?? 'skip';
+
+			if (strategy === 'skip') {
+				importedAgentNameToId.set(exportedAgent.name, existing.id);
+				agentResults.push({ name: exportedAgent.name, id: existing.id, action: 'skipped' });
+			} else if (strategy === 'replace') {
+				// Update existing agent in place (preserve its UUID and spaceId)
+				const updated = agentRepo.update(existing.id, {
+					role: exportedAgent.role,
+					description: exportedAgent.description,
+					model: exportedAgent.model,
+					provider: exportedAgent.provider,
+					systemPrompt: exportedAgent.systemPrompt,
+					tools: exportedAgent.tools,
+				});
+				const id = updated?.id ?? existing.id;
+				importedAgentNameToId.set(exportedAgent.name, id);
+				agentResults.push({ name: exportedAgent.name, id, action: 'replaced' });
+			} else {
+				// rename — create with a unique name, keep original name as the bundle key
+				const finalName = generateUniqueName(exportedAgent.name, usedAgentNames);
+				const created = agentRepo.create(
+					buildAgentCreateParams(params.spaceId, finalName, exportedAgent)
+				);
+				usedAgentNames.add(finalName);
+				importedAgentNameToId.set(exportedAgent.name, created.id);
+				agentResults.push({ name: finalName, id: created.id, action: 'renamed' });
+			}
+		}
+
+		// ── Phase 2: import workflows ────────────────────────────────────────
+		const workflowResults: ImportedItem[] = [];
+		const allWarnings: string[] = [];
+
+		for (const exportedWorkflow of bundle.workflows) {
+			const existing = existingWorkflowByName.get(exportedWorkflow.name);
+
+			let finalName = exportedWorkflow.name;
+			let action: ImportedItem['action'] = 'created';
+
+			if (!existing) {
+				// No conflict — create as-is
+			} else {
+				const strategy: ConflictResolutionStrategy =
+					resolution.workflows?.[exportedWorkflow.name] ?? 'skip';
+
+				if (strategy === 'skip') {
+					workflowResults.push({ name: exportedWorkflow.name, id: existing.id, action: 'skipped' });
+					continue;
+				}
+
+				if (strategy === 'replace') {
+					// Delete the existing workflow so the name becomes available again
+					workflowRepo.deleteWorkflow(existing.id);
+					usedWorkflowNames.delete(exportedWorkflow.name);
+					action = 'replaced';
+				} else {
+					// rename
+					finalName = generateUniqueName(exportedWorkflow.name, usedWorkflowNames);
+					action = 'renamed';
+				}
+			}
+
+			const { params: createParams, warnings } = buildWorkflowCreateParams(
+				params.spaceId,
+				finalName,
+				exportedWorkflow,
+				importedAgentNameToId,
+				existingAgentNameToId
+			);
+
+			// Fail fast on unresolved agent refs — they would produce invalid DB rows
+			if (warnings.length > 0) {
+				for (const w of warnings) {
+					allWarnings.push(`Workflow "${finalName}": ${w}`);
+				}
+				throw new Error(
+					`Cannot import workflow "${finalName}": unresolved agent reference(s) — run spaceImport.preview to see details`
+				);
+			}
+
+			// workflowManager.createWorkflow validates steps/transitions/conditions and writes to DB
+			const created = workflowManager.createWorkflow(createParams);
+			usedWorkflowNames.add(finalName);
+			workflowResults.push({ name: finalName, id: created.id, action });
+		}
+
+		const result: ImportExecuteResult = {
+			agents: agentResults,
+			workflows: workflowResults,
+			warnings: allWarnings,
+		};
+		return result;
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -19,8 +19,27 @@
  *   execute throws and aborts import of that workflow.
  * - Rule `appliesTo` lists step **names** in the exported format and are
  *   remapped to new step UUIDs on import.
+ *
+ * Atomicity:
+ * - `spaceImport.execute` wraps all DB mutations in a single SQLite transaction.
+ *   Any failure (unresolved agent ref, workflow validation error, etc.) rolls back
+ *   the entire operation — no partial state is left in the database.
+ *
+ * Agent `replace` semantics:
+ * - Fields absent from the exported agent (undefined) are explicitly cleared
+ *   (set to null/empty), producing the same result as delete + create.
+ *   This is intentional: `replace` is not a merge; it overwrites the existing
+ *   record with exactly what the export contains.
+ *
+ * Naming uniqueness:
+ * - Agent names in the DB are case-insensitive (SpaceAgentRepository uses LOWER()
+ *   in uniqueness checks). The in-memory `usedAgentNames` set uses exact-case
+ *   matching to track names created within the import batch; this is safe because
+ *   all names that flow through the DB are already lower-case normalized at the
+ *   source. Workflow names are exact-case both in the DB and in the set.
  */
 
+import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type {
 	MessageHub,
@@ -91,7 +110,10 @@ async function requireSpace(spaceManager: SpaceManager, spaceId: string): Promis
 function generateUniqueName(baseName: string, existingNames: Set<string>): string {
 	if (!existingNames.has(baseName)) return baseName;
 	let counter = 1;
-	while (existingNames.has(`${baseName} (${counter})`)) counter++;
+	while (counter < 10_000 && existingNames.has(`${baseName} (${counter})`)) counter++;
+	if (counter >= 10_000) {
+		throw new Error(`Cannot generate a unique name for "${baseName}": too many existing variants`);
+	}
 	return `${baseName} (${counter})`;
 }
 
@@ -111,12 +133,12 @@ function buildAgentCreateParams(
 
 /**
  * Convert an `ExportedSpaceWorkflow` into `CreateSpaceWorkflowParams` suitable
- * for `SpaceWorkflowRepository.createWorkflow()`.
+ * for `SpaceWorkflowManager.createWorkflow()`.
  *
  * Step names are assigned fresh UUIDs; rule `appliesTo` arrays are remapped from
  * step names to those new UUIDs; agent refs are resolved via the two lookup maps.
  *
- * @returns params ready for the repository, the step-name→UUID map (for rule
+ * @returns params ready for the manager, the step-name→UUID map (for rule
  *          appliesTo remapping), and any warnings about unresolved agent refs.
  */
 function buildWorkflowCreateParams(
@@ -198,8 +220,12 @@ function buildWorkflowCreateParams(
 }
 
 /**
- * Validate cross-references and condition expressions in an exported workflow.
+ * Validate cross-references in an exported workflow against the current import context.
  * Returns a list of human-readable error strings (empty = valid).
+ *
+ * Note: condition expression validation is intentionally omitted here — it is
+ * already enforced by the Zod schema in validateExportBundle(), so any bundle
+ * that reaches this function has already had its conditions validated.
  *
  * @param importedAgentNames - Set of agent names being imported in the same bundle
  * @param existingAgentNameToId - Map of existing agent names → UUIDs in target space
@@ -211,20 +237,11 @@ function validateWorkflowForPreview(
 ): string[] {
 	const errors: string[] = [];
 
-	// Unresolved agent refs
 	for (const step of exported.steps) {
 		if (!importedAgentNames.has(step.agentRef) && !existingAgentNameToId.has(step.agentRef)) {
 			errors.push(
 				`step "${step.name}" references unknown agent "${step.agentRef}" — not found in bundle or target space`
 			);
-		}
-	}
-
-	// Condition expression validation (mirrors SpaceWorkflowManager.validateCondition)
-	for (let i = 0; i < exported.transitions.length; i++) {
-		const t = exported.transitions[i];
-		if (t.condition?.type === 'condition' && !t.condition.expression?.trim()) {
-			errors.push(`transition[${i}]: 'condition' type requires a non-empty expression`);
 		}
 	}
 
@@ -240,7 +257,8 @@ export function setupSpaceExportImportHandlers(
 	spaceManager: SpaceManager,
 	agentRepo: SpaceAgentRepository,
 	workflowRepo: SpaceWorkflowRepository,
-	workflowManager: SpaceWorkflowManager
+	workflowManager: SpaceWorkflowManager,
+	db: BunDatabase
 ): void {
 	// ─── spaceExport.agents ──────────────────────────────────────────────────
 	messageHub.onRequest('spaceExport.agents', async (data) => {
@@ -361,7 +379,7 @@ export function setupSpaceExportImportHandlers(
 				workflowPreviews.push({ name: wf.name, action: 'create' });
 			}
 
-			// Cross-reference and condition validation
+			// Cross-reference validation (unresolved agent refs)
 			const errors = validateWorkflowForPreview(wf, importedAgentNames, existingAgentNameToId);
 			for (const err of errors) {
 				validationErrors.push(`Workflow "${wf.name}": ${err}`);
@@ -383,9 +401,10 @@ export function setupSpaceExportImportHandlers(
 			bundle: unknown;
 			conflictResolution?: ImportConflictResolution;
 		};
+		// Space check is async — must happen outside the synchronous transaction
 		await requireSpace(spaceManager, params.spaceId);
 
-		// Re-validate bundle (guards against stale previews)
+		// Re-validate bundle (guards against stale previews or tampered payloads)
 		const validation = validateExportBundle(params.bundle);
 		if (!validation.ok) {
 			throw new Error(`Invalid bundle: ${validation.error}`);
@@ -393,131 +412,150 @@ export function setupSpaceExportImportHandlers(
 		const bundle = validation.value;
 		const resolution = params.conflictResolution ?? {};
 
-		// Snapshot of existing entities (before any mutations)
-		const existingAgents = agentRepo.getBySpaceId(params.spaceId);
-		const existingWorkflows = workflowRepo.listWorkflows(params.spaceId);
+		// All DB mutations are wrapped in a single transaction so that any failure
+		// (unresolved agent ref, workflow validation error, etc.) rolls back the
+		// entire import — no partial state is committed to the database.
+		const executeImport = db.transaction(
+			(spaceId: string, res: ImportConflictResolution): ImportExecuteResult => {
+				// Snapshot of existing entities (before any mutations)
+				const existingAgents = agentRepo.getBySpaceId(spaceId);
+				const existingWorkflows = workflowRepo.listWorkflows(spaceId);
 
-		const existingAgentByName = new Map(existingAgents.map((a) => [a.name, a]));
-		const existingWorkflowByName = new Map(existingWorkflows.map((w) => [w.name, w]));
-		const existingAgentNameToId = new Map(existingAgents.map((a) => [a.name, a.id]));
+				const existingAgentByName = new Map(existingAgents.map((a) => [a.name, a]));
+				const existingWorkflowByName = new Map(existingWorkflows.map((w) => [w.name, w]));
+				const existingAgentNameToId = new Map(existingAgents.map((a) => [a.name, a.id]));
 
-		// Mutable sets for uniqueness tracking across the import batch
-		const usedAgentNames = new Set(existingAgents.map((a) => a.name));
-		const usedWorkflowNames = new Set(existingWorkflows.map((w) => w.name));
+				// Mutable sets for uniqueness tracking across the import batch
+				const usedAgentNames = new Set(existingAgents.map((a) => a.name));
+				const usedWorkflowNames = new Set(existingWorkflows.map((w) => w.name));
 
-		// ── Phase 1: import agents ──────────────────────────────────────────
-		// Maps original bundle agent name → assigned UUID (used for workflow cross-refs)
-		const importedAgentNameToId = new Map<string, string>();
-		const agentResults: ImportedItem[] = [];
+				// ── Phase 1: import agents ──────────────────────────────────────
+				// Maps original bundle agent name → assigned UUID (used for workflow cross-refs)
+				const importedAgentNameToId = new Map<string, string>();
+				const agentResults: ImportedItem[] = [];
 
-		for (const exportedAgent of bundle.agents) {
-			const existing = existingAgentByName.get(exportedAgent.name);
+				for (const exportedAgent of bundle.agents) {
+					const existing = existingAgentByName.get(exportedAgent.name);
 
-			if (!existing) {
-				// No conflict — create new agent
-				const created = agentRepo.create(
-					buildAgentCreateParams(params.spaceId, exportedAgent.name, exportedAgent)
-				);
-				usedAgentNames.add(exportedAgent.name);
-				importedAgentNameToId.set(exportedAgent.name, created.id);
-				agentResults.push({ name: exportedAgent.name, id: created.id, action: 'created' });
-				continue;
-			}
+					if (!existing) {
+						// No conflict — create new agent
+						const created = agentRepo.create(
+							buildAgentCreateParams(spaceId, exportedAgent.name, exportedAgent)
+						);
+						usedAgentNames.add(exportedAgent.name);
+						importedAgentNameToId.set(exportedAgent.name, created.id);
+						agentResults.push({ name: exportedAgent.name, id: created.id, action: 'created' });
+						continue;
+					}
 
-			// Conflict — apply resolution strategy (default: skip)
-			const strategy: ConflictResolutionStrategy =
-				resolution.agents?.[exportedAgent.name] ?? 'skip';
+					// Conflict — apply resolution strategy (default: skip)
+					const strategy: ConflictResolutionStrategy = res.agents?.[exportedAgent.name] ?? 'skip';
 
-			if (strategy === 'skip') {
-				importedAgentNameToId.set(exportedAgent.name, existing.id);
-				agentResults.push({ name: exportedAgent.name, id: existing.id, action: 'skipped' });
-			} else if (strategy === 'replace') {
-				// Update existing agent in place (preserve its UUID and spaceId)
-				const updated = agentRepo.update(existing.id, {
-					role: exportedAgent.role,
-					description: exportedAgent.description,
-					model: exportedAgent.model,
-					provider: exportedAgent.provider,
-					systemPrompt: exportedAgent.systemPrompt,
-					tools: exportedAgent.tools,
-				});
-				const id = updated?.id ?? existing.id;
-				importedAgentNameToId.set(exportedAgent.name, id);
-				agentResults.push({ name: exportedAgent.name, id, action: 'replaced' });
-			} else {
-				// rename — create with a unique name, keep original name as the bundle key
-				const finalName = generateUniqueName(exportedAgent.name, usedAgentNames);
-				const created = agentRepo.create(
-					buildAgentCreateParams(params.spaceId, finalName, exportedAgent)
-				);
-				usedAgentNames.add(finalName);
-				importedAgentNameToId.set(exportedAgent.name, created.id);
-				agentResults.push({ name: finalName, id: created.id, action: 'renamed' });
-			}
-		}
-
-		// ── Phase 2: import workflows ────────────────────────────────────────
-		const workflowResults: ImportedItem[] = [];
-		const allWarnings: string[] = [];
-
-		for (const exportedWorkflow of bundle.workflows) {
-			const existing = existingWorkflowByName.get(exportedWorkflow.name);
-
-			let finalName = exportedWorkflow.name;
-			let action: ImportedItem['action'] = 'created';
-
-			if (!existing) {
-				// No conflict — create as-is
-			} else {
-				const strategy: ConflictResolutionStrategy =
-					resolution.workflows?.[exportedWorkflow.name] ?? 'skip';
-
-				if (strategy === 'skip') {
-					workflowResults.push({ name: exportedWorkflow.name, id: existing.id, action: 'skipped' });
-					continue;
+					if (strategy === 'skip') {
+						importedAgentNameToId.set(exportedAgent.name, existing.id);
+						agentResults.push({ name: exportedAgent.name, id: existing.id, action: 'skipped' });
+					} else if (strategy === 'replace') {
+						// Overwrite existing agent in place (preserve UUID and spaceId).
+						// Fields absent from the export are explicitly cleared (null → empty string
+						// or null) so that replace produces the same result as delete + create.
+						const updated = agentRepo.update(existing.id, {
+							role: exportedAgent.role,
+							description: exportedAgent.description ?? null,
+							model: exportedAgent.model ?? null,
+							provider: exportedAgent.provider ?? null,
+							systemPrompt: exportedAgent.systemPrompt ?? null,
+							tools: exportedAgent.tools ?? null,
+						});
+						const id = updated?.id ?? existing.id;
+						importedAgentNameToId.set(exportedAgent.name, id);
+						agentResults.push({ name: exportedAgent.name, id, action: 'replaced' });
+					} else {
+						// rename — create with a unique name; the original bundle name remains the
+						// cross-reference key so workflow steps still resolve correctly.
+						const finalName = generateUniqueName(exportedAgent.name, usedAgentNames);
+						const created = agentRepo.create(
+							buildAgentCreateParams(spaceId, finalName, exportedAgent)
+						);
+						usedAgentNames.add(finalName);
+						importedAgentNameToId.set(exportedAgent.name, created.id);
+						agentResults.push({ name: finalName, id: created.id, action: 'renamed' });
+					}
 				}
 
-				if (strategy === 'replace') {
-					// Delete the existing workflow so the name becomes available again
-					workflowRepo.deleteWorkflow(existing.id);
-					usedWorkflowNames.delete(exportedWorkflow.name);
-					action = 'replaced';
-				} else {
-					// rename
-					finalName = generateUniqueName(exportedWorkflow.name, usedWorkflowNames);
-					action = 'renamed';
+				// ── Phase 2: import workflows ────────────────────────────────────
+				const workflowResults: ImportedItem[] = [];
+				const allWarnings: string[] = [];
+
+				for (const exportedWorkflow of bundle.workflows) {
+					const existing = existingWorkflowByName.get(exportedWorkflow.name);
+
+					let finalName = exportedWorkflow.name;
+					let action: ImportedItem['action'] = 'created';
+
+					if (!existing) {
+						// No conflict — create as-is
+					} else {
+						const strategy: ConflictResolutionStrategy =
+							res.workflows?.[exportedWorkflow.name] ?? 'skip';
+
+						if (strategy === 'skip') {
+							workflowResults.push({
+								name: exportedWorkflow.name,
+								id: existing.id,
+								action: 'skipped',
+							});
+							continue;
+						}
+
+						if (strategy === 'replace') {
+							// Delete the existing workflow so the name becomes available again.
+							// This happens inside the transaction, so it rolls back on any later error.
+							workflowRepo.deleteWorkflow(existing.id);
+							usedWorkflowNames.delete(exportedWorkflow.name);
+							action = 'replaced';
+						} else {
+							// rename
+							finalName = generateUniqueName(exportedWorkflow.name, usedWorkflowNames);
+							action = 'renamed';
+						}
+					}
+
+					// Reserve the name before calling createWorkflow so that duplicate workflow
+					// names within the same bundle (same strategy = rename) produce different names.
+					usedWorkflowNames.add(finalName);
+
+					const { params: createParams, warnings } = buildWorkflowCreateParams(
+						spaceId,
+						finalName,
+						exportedWorkflow,
+						importedAgentNameToId,
+						existingAgentNameToId
+					);
+
+					// Fail fast on unresolved agent refs — they would produce invalid DB rows.
+					// The transaction ensures the delete (replace strategy) is also rolled back.
+					if (warnings.length > 0) {
+						for (const w of warnings) {
+							allWarnings.push(`Workflow "${finalName}": ${w}`);
+						}
+						throw new Error(
+							`Cannot import workflow "${finalName}": unresolved agent reference(s) — run spaceImport.preview to see details`
+						);
+					}
+
+					// workflowManager.createWorkflow validates steps/transitions/conditions and writes to DB
+					const created = workflowManager.createWorkflow(createParams);
+					workflowResults.push({ name: finalName, id: created.id, action });
 				}
+
+				return {
+					agents: agentResults,
+					workflows: workflowResults,
+					warnings: allWarnings,
+				};
 			}
+		);
 
-			const { params: createParams, warnings } = buildWorkflowCreateParams(
-				params.spaceId,
-				finalName,
-				exportedWorkflow,
-				importedAgentNameToId,
-				existingAgentNameToId
-			);
-
-			// Fail fast on unresolved agent refs — they would produce invalid DB rows
-			if (warnings.length > 0) {
-				for (const w of warnings) {
-					allWarnings.push(`Workflow "${finalName}": ${w}`);
-				}
-				throw new Error(
-					`Cannot import workflow "${finalName}": unresolved agent reference(s) — run spaceImport.preview to see details`
-				);
-			}
-
-			// workflowManager.createWorkflow validates steps/transitions/conditions and writes to DB
-			const created = workflowManager.createWorkflow(createParams);
-			usedWorkflowNames.add(finalName);
-			workflowResults.push({ name: finalName, id: created.id, action });
-		}
-
-		const result: ImportExecuteResult = {
-			agents: agentResults,
-			workflows: workflowResults,
-			warnings: allWarnings,
-		};
-		return result;
+		return executeImport(params.spaceId, resolution);
 	});
 }

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -1,0 +1,1064 @@
+/**
+ * Space Export/Import RPC Handler Unit Tests
+ *
+ * Tests for:
+ * - spaceExport.agents, spaceExport.workflows, spaceExport.bundle
+ * - spaceImport.preview (conflict detection, validation, cross-ref checking)
+ * - spaceImport.execute (all conflict resolutions, agent name→UUID mapping, step ID remapping)
+ *
+ * Uses in-memory SQLite with real repositories and managers so the full
+ * business-logic path (including SpaceWorkflowManager validation) is exercised.
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { MessageHub } from '@neokai/shared';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
+import type { SpaceAgentLookup } from '../../../src/lib/space/managers/space-workflow-manager';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import {
+	setupSpaceExportImportHandlers,
+	type ImportPreviewResult,
+	type ImportExecuteResult,
+} from '../../../src/lib/rpc-handlers/space-export-import-handlers';
+
+// ─── DB schema ────────────────────────────────────────────────────────────────
+
+function createSchema(db: Database): void {
+	db.exec('PRAGMA foreign_keys = ON');
+
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			workspace_path TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			background_context TEXT NOT NULL DEFAULT '',
+			instructions TEXT NOT NULL DEFAULT '',
+			default_model TEXT,
+			allowed_models TEXT NOT NULL DEFAULT '[]',
+			session_ids TEXT NOT NULL DEFAULT '[]',
+			status TEXT NOT NULL DEFAULT 'active',
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE space_agents (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			model TEXT,
+			provider TEXT,
+			tools TEXT NOT NULL DEFAULT '[]',
+			system_prompt TEXT NOT NULL DEFAULT '',
+			role TEXT NOT NULL DEFAULT 'coder',
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			start_step_id TEXT,
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE space_workflow_steps (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			agent_id TEXT,
+			order_index INTEGER NOT NULL,
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE space_workflow_transitions (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			from_step_id TEXT NOT NULL,
+			to_step_id TEXT NOT NULL,
+			condition TEXT,
+			order_index INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+			FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
+			FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+		)
+	`);
+}
+
+function insertSpace(db: Database, id: string, name = `Space ${id}`): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+	).run(id, `/workspace/${id}`, name, now, now);
+}
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockHub(): { hub: MessageHub; handlers: Map<string, RequestHandler> } {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockSpaceManager(spaceId: string, spaceName = 'Test Space'): SpaceManager {
+	return {
+		getSpace: mock(async (id: string) => {
+			if (id === spaceId) {
+				return { id, name: spaceName, workspacePath: '/ws', status: 'active' } as any;
+			}
+			return null;
+		}),
+	} as unknown as SpaceManager;
+}
+
+async function call<T>(
+	handlers: Map<string, RequestHandler>,
+	method: string,
+	params: unknown
+): Promise<T> {
+	const handler = handlers.get(method);
+	if (!handler) throw new Error(`Handler not registered: ${method}`);
+	return (await handler(params, {})) as T;
+}
+
+// ─── Test setup ───────────────────────────────────────────────────────────────
+
+const SPACE_ID = 'space-1';
+const OTHER_SPACE_ID = 'space-2';
+
+describe('Space Export/Import RPC Handlers', () => {
+	let db: Database;
+	let agentRepo: SpaceAgentRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let handlers: Map<string, RequestHandler>;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSchema(db);
+		insertSpace(db, SPACE_ID, 'My Space');
+		insertSpace(db, OTHER_SPACE_ID, 'Other Space');
+
+		agentRepo = new SpaceAgentRepository(db as any);
+		workflowRepo = new SpaceWorkflowRepository(db as any);
+
+		const agentLookup: SpaceAgentLookup = {
+			getAgentById(spaceId: string, id: string) {
+				const agent = agentRepo.getById(id);
+				if (!agent || agent.spaceId !== spaceId) return null;
+				return { id: agent.id, name: agent.name };
+			},
+		};
+		workflowManager = new SpaceWorkflowManager(workflowRepo, agentLookup);
+		spaceManager = createMockSpaceManager(SPACE_ID);
+
+		const mockHub = createMockHub();
+		handlers = mockHub.handlers;
+
+		setupSpaceExportImportHandlers(
+			mockHub.hub,
+			spaceManager,
+			agentRepo,
+			workflowRepo,
+			workflowManager
+		);
+	});
+
+	// ─── Handler registration ────────────────────────────────────────────────
+
+	it('registers all 5 handlers', () => {
+		expect(handlers.has('spaceExport.agents')).toBe(true);
+		expect(handlers.has('spaceExport.workflows')).toBe(true);
+		expect(handlers.has('spaceExport.bundle')).toBe(true);
+		expect(handlers.has('spaceImport.preview')).toBe(true);
+		expect(handlers.has('spaceImport.execute')).toBe(true);
+	});
+
+	// ─── spaceId validation ───────────────────────────────────────────────────
+
+	describe('spaceId validation', () => {
+		it.each([
+			'spaceExport.agents',
+			'spaceExport.workflows',
+			'spaceExport.bundle',
+		])('%s: throws if spaceId missing', async (method) => {
+			await expect(call(handlers, method, {})).rejects.toThrow('spaceId is required');
+		});
+
+		it.each([
+			'spaceExport.agents',
+			'spaceExport.workflows',
+			'spaceExport.bundle',
+		])('%s: throws if space not found', async (method) => {
+			await expect(call(handlers, method, { spaceId: 'nonexistent' })).rejects.toThrow(
+				'Space not found: nonexistent'
+			);
+		});
+
+		it('spaceImport.preview: throws if spaceId missing', async () => {
+			await expect(call(handlers, 'spaceImport.preview', { bundle: {} })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('spaceImport.execute: throws if spaceId missing', async () => {
+			await expect(call(handlers, 'spaceImport.execute', { bundle: {} })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('spaceImport.execute: throws if space not found', async () => {
+			await expect(
+				call(handlers, 'spaceImport.execute', { spaceId: 'ghost', bundle: {} })
+			).rejects.toThrow('Space not found: ghost');
+		});
+	});
+
+	// ─── spaceExport.agents ───────────────────────────────────────────────────
+
+	describe('spaceExport.agents', () => {
+		it('exports all agents when no filter provided', async () => {
+			agentRepo.create({ spaceId: SPACE_ID, name: 'Alpha', role: 'coder' });
+			agentRepo.create({ spaceId: SPACE_ID, name: 'Beta', role: 'planner' });
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.agents', {
+				spaceId: SPACE_ID,
+			});
+
+			expect(bundle.type).toBe('bundle');
+			expect(bundle.agents).toHaveLength(2);
+			expect(bundle.agents.map((a: any) => a.name)).toEqual(
+				expect.arrayContaining(['Alpha', 'Beta'])
+			);
+			expect(bundle.workflows).toHaveLength(0);
+		});
+
+		it('filters agents by agentIds', async () => {
+			const a1 = agentRepo.create({ spaceId: SPACE_ID, name: 'Alpha', role: 'coder' });
+			agentRepo.create({ spaceId: SPACE_ID, name: 'Beta', role: 'planner' });
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.agents', {
+				spaceId: SPACE_ID,
+				agentIds: [a1.id],
+			});
+
+			expect(bundle.agents).toHaveLength(1);
+			expect(bundle.agents[0].name).toBe('Alpha');
+		});
+
+		it('exported agent preserves fields and strips id/spaceId', async () => {
+			agentRepo.create({
+				spaceId: SPACE_ID,
+				name: 'Coder',
+				role: 'coder',
+				model: 'claude-3',
+				systemPrompt: 'You code.',
+				tools: ['read_file'],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.agents', {
+				spaceId: SPACE_ID,
+			});
+
+			const exported = bundle.agents[0];
+			expect(exported.name).toBe('Coder');
+			expect(exported.role).toBe('coder');
+			expect(exported.model).toBe('claude-3');
+			expect(exported.systemPrompt).toBe('You code.');
+			expect(exported.tools).toEqual(['read_file']);
+			expect(exported.id).toBeUndefined();
+			expect(exported.spaceId).toBeUndefined();
+			expect(exported.version).toBe(1);
+			expect(exported.type).toBe('agent');
+		});
+
+		it('sets exportedFrom to spaceId', async () => {
+			agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.agents', {
+				spaceId: SPACE_ID,
+			});
+			expect(bundle.exportedFrom).toBe(SPACE_ID);
+		});
+
+		it('returns empty agents array when no agents exist', async () => {
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.agents', {
+				spaceId: SPACE_ID,
+			});
+			expect(bundle.agents).toHaveLength(0);
+		});
+	});
+
+	// ─── spaceExport.workflows ────────────────────────────────────────────────
+
+	describe('spaceExport.workflows', () => {
+		it('exports workflow with agentRef resolved to agent name', async () => {
+			const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Pipeline',
+				steps: [{ name: 'Code', agentId: agent.id }],
+				transitions: [],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
+				spaceId: SPACE_ID,
+			});
+
+			expect(bundle.workflows).toHaveLength(1);
+			const wf = bundle.workflows[0];
+			expect(wf.name).toBe('Pipeline');
+			expect(wf.steps[0].agentRef).toBe('Coder'); // UUID resolved to name
+			expect(wf.steps[0].name).toBe('Code');
+		});
+
+		it('includes only referenced agents in the bundle', async () => {
+			const coder = agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+			agentRepo.create({ spaceId: SPACE_ID, name: 'Reviewer', role: 'reviewer' });
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Pipeline',
+				steps: [{ name: 'Code', agentId: coder.id }],
+				transitions: [],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
+				spaceId: SPACE_ID,
+			});
+
+			// Only Coder is referenced, Reviewer should NOT be included
+			expect(bundle.agents).toHaveLength(1);
+			expect(bundle.agents[0].name).toBe('Coder');
+		});
+
+		it('filters workflows by workflowIds', async () => {
+			const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+			const wf1 = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'WF1',
+				steps: [{ name: 'S1', agentId: agent.id }],
+				transitions: [],
+			});
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'WF2',
+				steps: [{ name: 'S2', agentId: agent.id }],
+				transitions: [],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
+				spaceId: SPACE_ID,
+				workflowIds: [wf1.id],
+			});
+
+			expect(bundle.workflows).toHaveLength(1);
+			expect(bundle.workflows[0].name).toBe('WF1');
+		});
+
+		it('exports transition step names instead of UUIDs', async () => {
+			const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'TwoStep',
+				steps: [
+					{ id: 'step-1', name: 'First', agentId: agent.id },
+					{ id: 'step-2', name: 'Second', agentId: agent.id },
+				],
+				transitions: [{ from: 'step-1', to: 'step-2' }],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
+				spaceId: SPACE_ID,
+			});
+
+			const wf = bundle.workflows[0];
+			expect(wf.transitions[0].fromStep).toBe('First');
+			expect(wf.transitions[0].toStep).toBe('Second');
+		});
+	});
+
+	// ─── spaceExport.bundle ───────────────────────────────────────────────────
+
+	describe('spaceExport.bundle', () => {
+		it('exports all agents and workflows', async () => {
+			const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'W',
+				steps: [{ name: 'S', agentId: agent.id }],
+				transitions: [],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.bundle', {
+				spaceId: SPACE_ID,
+			});
+
+			expect(bundle.type).toBe('bundle');
+			expect(bundle.agents).toHaveLength(1);
+			expect(bundle.workflows).toHaveLength(1);
+		});
+
+		it('filters by agentIds and workflowIds', async () => {
+			const a1 = agentRepo.create({ spaceId: SPACE_ID, name: 'A1', role: 'coder' });
+			agentRepo.create({ spaceId: SPACE_ID, name: 'A2', role: 'coder' });
+			const wf1 = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'W1',
+				steps: [{ name: 'S', agentId: a1.id }],
+				transitions: [],
+			});
+			workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'W2',
+				steps: [{ name: 'S', agentId: a1.id }],
+				transitions: [],
+			});
+
+			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.bundle', {
+				spaceId: SPACE_ID,
+				agentIds: [a1.id],
+				workflowIds: [wf1.id],
+			});
+
+			expect(bundle.agents).toHaveLength(1);
+			expect(bundle.agents[0].name).toBe('A1');
+			expect(bundle.workflows).toHaveLength(1);
+			expect(bundle.workflows[0].name).toBe('W1');
+		});
+	});
+
+	// ─── spaceImport.preview ─────────────────────────────────────────────────
+
+	describe('spaceImport.preview', () => {
+		it('returns validation error for invalid bundle', async () => {
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle: { not: 'a bundle' },
+			});
+
+			expect(result.agents).toHaveLength(0);
+			expect(result.workflows).toHaveLength(0);
+			expect(result.validationErrors.length).toBeGreaterThan(0);
+		});
+
+		it('returns create action for non-conflicting items', async () => {
+			const bundle = makeBundle([{ name: 'Coder', role: 'coder' }], []);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.agents).toHaveLength(1);
+			expect(result.agents[0]).toEqual({ name: 'Coder', action: 'create' });
+			expect(result.validationErrors).toHaveLength(0);
+		});
+
+		it('detects agent name conflict', async () => {
+			const existing = agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+			const bundle = makeBundle([{ name: 'Coder', role: 'coder' }], []);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.agents[0]).toEqual({
+				name: 'Coder',
+				action: 'conflict',
+				existingId: existing.id,
+			});
+		});
+
+		it('detects workflow name conflict', async () => {
+			const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+			const existing = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Pipeline',
+				steps: [{ name: 'S', agentId: agent.id }],
+				transitions: [],
+			});
+
+			const bundle = makeBundle(
+				[{ name: 'A', role: 'coder' }],
+				[{ name: 'Pipeline', steps: [{ agentRef: 'A', name: 'S' }] }]
+			);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.workflows[0]).toEqual({
+				name: 'Pipeline',
+				action: 'conflict',
+				existingId: existing.id,
+			});
+		});
+
+		it('flags unresolved agent ref as validation error', async () => {
+			const bundle = makeBundle(
+				[],
+				[{ name: 'Pipeline', steps: [{ agentRef: 'Ghost', name: 'S' }] }]
+			);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.validationErrors.length).toBeGreaterThan(0);
+			expect(result.validationErrors[0]).toContain('Ghost');
+			expect(result.validationErrors[0]).toContain('Pipeline');
+		});
+
+		it('resolves agent ref from existing space agents', async () => {
+			agentRepo.create({ spaceId: SPACE_ID, name: 'ExistingAgent', role: 'coder' });
+			// Bundle has no agents but workflow references ExistingAgent (from target space)
+			const bundle = makeBundle(
+				[],
+				[{ name: 'Pipeline', steps: [{ agentRef: 'ExistingAgent', name: 'S' }] }]
+			);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.validationErrors).toHaveLength(0);
+		});
+
+		it('flags condition transition without expression as error', async () => {
+			const bundle = makeBundleWithCondition('condition', ''); // empty expression
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.validationErrors.length).toBeGreaterThan(0);
+			expect(result.validationErrors[0]).toContain('non-empty expression');
+		});
+
+		it('passes validation for always condition', async () => {
+			const bundle = makeBundleWithCondition('always', undefined);
+
+			const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.validationErrors).toHaveLength(0);
+		});
+	});
+
+	// ─── spaceImport.execute ─────────────────────────────────────────────────
+
+	describe('spaceImport.execute', () => {
+		it('throws for invalid bundle', async () => {
+			await expect(
+				call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle: { bad: true } })
+			).rejects.toThrow('Invalid bundle');
+		});
+
+		it('creates agents and workflows with no conflicts', async () => {
+			const bundle = makeBundle(
+				[{ name: 'Coder', role: 'coder', systemPrompt: 'You code.' }],
+				[{ name: 'Pipeline', steps: [{ agentRef: 'Coder', name: 'Code' }] }]
+			);
+
+			const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.agents).toHaveLength(1);
+			expect(result.agents[0]).toMatchObject({ name: 'Coder', action: 'created' });
+			expect(result.workflows).toHaveLength(1);
+			expect(result.workflows[0]).toMatchObject({ name: 'Pipeline', action: 'created' });
+
+			// Verify data persisted
+			const agents = agentRepo.getBySpaceId(SPACE_ID);
+			expect(agents.find((a) => a.name === 'Coder')?.systemPrompt).toBe('You code.');
+			const workflows = workflowRepo.listWorkflows(SPACE_ID);
+			expect(workflows.find((w) => w.name === 'Pipeline')).toBeTruthy();
+		});
+
+		describe('conflict resolution: skip', () => {
+			it('skips conflicting agent and uses existing UUID for workflow cross-refs', async () => {
+				const existing = agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+
+				const bundle = makeBundle(
+					[{ name: 'Coder', role: 'reviewer' }], // different role
+					[{ name: 'Pipeline', steps: [{ agentRef: 'Coder', name: 'Code' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Coder: 'skip' } },
+				});
+
+				expect(result.agents[0]).toMatchObject({
+					name: 'Coder',
+					action: 'skipped',
+					id: existing.id,
+				});
+
+				// Agent role should NOT have changed (skipped)
+				const agent = agentRepo.getById(existing.id)!;
+				expect(agent.role).toBe('coder'); // unchanged
+
+				// Workflow should still be importable and reference the existing agent UUID
+				expect(result.workflows[0].action).toBe('created');
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				expect(wf.steps[0].agentId).toBe(existing.id);
+			});
+
+			it('skips conflicting workflow', async () => {
+				const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+				const existingWf = workflowManager.createWorkflow({
+					spaceId: SPACE_ID,
+					name: 'Pipeline',
+					steps: [{ name: 'S', agentId: agent.id }],
+					transitions: [],
+				});
+
+				const bundle = makeBundle(
+					[{ name: 'A', role: 'coder' }],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'A', name: 'S' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { A: 'skip' }, workflows: { Pipeline: 'skip' } },
+				});
+
+				expect(result.workflows[0]).toMatchObject({
+					name: 'Pipeline',
+					action: 'skipped',
+					id: existingWf.id,
+				});
+
+				// Only one workflow should exist (no duplicate)
+				const all = workflowRepo.listWorkflows(SPACE_ID);
+				expect(all).toHaveLength(1);
+			});
+		});
+
+		describe('conflict resolution: rename', () => {
+			it('renames conflicting agent with unique name', async () => {
+				agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+				agentRepo.create({ spaceId: SPACE_ID, name: 'Coder (1)', role: 'coder' });
+
+				const bundle = makeBundle([{ name: 'Coder', role: 'reviewer' }], []);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Coder: 'rename' } },
+				});
+
+				expect(result.agents[0]).toMatchObject({ name: 'Coder (2)', action: 'renamed' });
+
+				// Both old and new should exist
+				const agents = agentRepo.getBySpaceId(SPACE_ID);
+				expect(agents.map((a) => a.name)).toContain('Coder');
+				expect(agents.map((a) => a.name)).toContain('Coder (2)');
+			});
+
+			it('renames conflicting workflow', async () => {
+				const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+				workflowManager.createWorkflow({
+					spaceId: SPACE_ID,
+					name: 'Pipeline',
+					steps: [{ name: 'S', agentId: agent.id }],
+					transitions: [],
+				});
+
+				const bundle = makeBundle(
+					[{ name: 'A', role: 'coder' }],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'A', name: 'S2' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { A: 'skip' }, workflows: { Pipeline: 'rename' } },
+				});
+
+				expect(result.workflows[0]).toMatchObject({ name: 'Pipeline (1)', action: 'renamed' });
+
+				const all = workflowRepo.listWorkflows(SPACE_ID);
+				expect(all).toHaveLength(2);
+				expect(all.map((w) => w.name)).toContain('Pipeline (1)');
+			});
+		});
+
+		describe('conflict resolution: replace', () => {
+			it('replaces conflicting agent in place (preserves UUID)', async () => {
+				const existing = agentRepo.create({ spaceId: SPACE_ID, name: 'Coder', role: 'coder' });
+
+				const bundle = makeBundle([{ name: 'Coder', role: 'reviewer', model: 'claude-new' }], []);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Coder: 'replace' } },
+				});
+
+				expect(result.agents[0]).toMatchObject({
+					name: 'Coder',
+					action: 'replaced',
+					id: existing.id,
+				});
+
+				const agent = agentRepo.getById(existing.id)!;
+				expect(agent.role).toBe('reviewer');
+				expect(agent.model).toBe('claude-new');
+			});
+
+			it('replaces conflicting workflow (delete + create)', async () => {
+				const agent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+				workflowManager.createWorkflow({
+					spaceId: SPACE_ID,
+					name: 'Pipeline',
+					steps: [{ name: 'OldStep', agentId: agent.id }],
+					transitions: [],
+				});
+
+				const bundle = makeBundle(
+					[{ name: 'A', role: 'coder' }],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'A', name: 'NewStep' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { A: 'skip' }, workflows: { Pipeline: 'replace' } },
+				});
+
+				expect(result.workflows[0]).toMatchObject({ name: 'Pipeline', action: 'replaced' });
+
+				const all = workflowRepo.listWorkflows(SPACE_ID);
+				expect(all).toHaveLength(1);
+				expect(all[0].steps[0].name).toBe('NewStep');
+			});
+		});
+
+		// ─── Cross-reference mapping ───────────────────────────────────────
+
+		describe('cross-reference mapping', () => {
+			it('resolves agent name→UUID from bundle agents', async () => {
+				const bundle = makeBundle(
+					[{ name: 'BundleAgent', role: 'coder' }],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'BundleAgent', name: 'S' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+				});
+
+				const importedAgentId = result.agents[0].id;
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				expect(wf.steps[0].agentId).toBe(importedAgentId);
+			});
+
+			it('resolves agent name→UUID from existing space agents (not in bundle)', async () => {
+				const existing = agentRepo.create({ spaceId: SPACE_ID, name: 'LocalAgent', role: 'coder' });
+
+				// Bundle has workflow referencing LocalAgent but does not include LocalAgent as agent
+				const bundle = makeBundle(
+					[],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'LocalAgent', name: 'S' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+				});
+
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				expect(wf.steps[0].agentId).toBe(existing.id);
+			});
+
+			it('prefers bundle agent over existing space agent of same name', async () => {
+				const existingAgent = agentRepo.create({ spaceId: SPACE_ID, name: 'Agent', role: 'coder' });
+
+				// Bundle includes Agent → will be renamed (conflict resolution: rename)
+				const bundle = makeBundle(
+					[{ name: 'Agent', role: 'reviewer' }],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'Agent', name: 'S' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Agent: 'skip' } },
+				});
+
+				// When Agent is skipped, bundle cross-ref maps to the existing agent UUID
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				expect(wf.steps[0].agentId).toBe(existingAgent.id);
+			});
+
+			it('throws when agent ref cannot be resolved', async () => {
+				const bundle = makeBundle(
+					[],
+					[{ name: 'Pipeline', steps: [{ agentRef: 'GhostAgent', name: 'S' }] }]
+				);
+
+				await expect(
+					call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle })
+				).rejects.toThrow('unresolved agent reference');
+			});
+
+			it('remaps rule appliesTo from step names to new step UUIDs', async () => {
+				const bundleWithRules = makeBundleWithRules();
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle: bundleWithRules,
+				});
+
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				expect(wf.rules).toHaveLength(1);
+				const rule = wf.rules[0];
+				// appliesTo should contain step UUIDs (not step names)
+				expect(rule.appliesTo).toHaveLength(1);
+				// The step UUID should correspond to the 'Code' step
+				const codeStep = wf.steps.find((s) => s.name === 'Code')!;
+				expect(rule.appliesTo![0]).toBe(codeStep.id);
+			});
+
+			it('assigns fresh step UUIDs (not re-using exported names as IDs)', async () => {
+				const bundle = makeBundle(
+					[{ name: 'A', role: 'coder' }],
+					[{ name: 'W', steps: [{ agentRef: 'A', name: 'MyStep' }] }]
+				);
+
+				const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+				});
+
+				const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+				// Step ID should be a UUID (not 'MyStep' or any string from the bundle)
+				const stepId = wf.steps[0].id;
+				expect(stepId).toMatch(/^[0-9a-f-]{36}$/i);
+				expect(stepId).not.toBe('MyStep');
+			});
+		});
+
+		// ─── Multi-agent workflow ──────────────────────────────────────────
+
+		it('imports workflow with multiple steps and transitions', async () => {
+			const bundle = makeTwoStepBundle();
+
+			const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.agents).toHaveLength(2);
+			const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+			expect(wf.steps).toHaveLength(2);
+			expect(wf.transitions).toHaveLength(1);
+
+			// Transition should reference correct step UUIDs
+			const step1 = wf.steps.find((s) => s.name === 'Code')!;
+			const step2 = wf.steps.find((s) => s.name === 'Review')!;
+			expect(wf.transitions[0].from).toBe(step1.id);
+			expect(wf.transitions[0].to).toBe(step2.id);
+		});
+
+		it('returns empty warnings array on clean import', async () => {
+			const bundle = makeBundle(
+				[{ name: 'A', role: 'coder' }],
+				[{ name: 'W', steps: [{ agentRef: 'A', name: 'S' }] }]
+			);
+
+			const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+				spaceId: SPACE_ID,
+				bundle,
+			});
+
+			expect(result.warnings).toHaveLength(0);
+		});
+	});
+});
+
+// ─── Bundle builder helpers ───────────────────────────────────────────────────
+
+type BundleAgent = { name: string; role: string; systemPrompt?: string; model?: string };
+type BundleWorkflow = {
+	name: string;
+	steps: Array<{ agentRef: string; name: string; instructions?: string }>;
+};
+
+function makeBundle(agents: BundleAgent[], workflows: BundleWorkflow[]): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Test Bundle',
+		agents: agents.map((a) => ({
+			version: 1,
+			type: 'agent',
+			name: a.name,
+			role: a.role,
+			...(a.systemPrompt ? { systemPrompt: a.systemPrompt } : {}),
+			...(a.model ? { model: a.model } : {}),
+		})),
+		workflows: workflows.map((w) => ({
+			version: 1,
+			type: 'workflow',
+			name: w.name,
+			steps: w.steps.map((s) => ({
+				agentRef: s.agentRef,
+				name: s.name,
+				...(s.instructions ? { instructions: s.instructions } : {}),
+			})),
+			transitions: [],
+			startStep: w.steps[0]?.name ?? '',
+			rules: [],
+			tags: [],
+		})),
+		exportedAt: Date.now(),
+	};
+}
+
+function makeBundleWithCondition(type: string, expression: string | undefined): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Condition Bundle',
+		agents: [{ version: 1, type: 'agent', name: 'A', role: 'coder' }],
+		workflows: [
+			{
+				version: 1,
+				type: 'workflow',
+				name: 'ConditionWF',
+				steps: [
+					{ agentRef: 'A', name: 'S1' },
+					{ agentRef: 'A', name: 'S2' },
+				],
+				transitions: [
+					{
+						fromStep: 'S1',
+						toStep: 'S2',
+						condition: expression !== undefined ? { type, expression } : { type },
+					},
+				],
+				startStep: 'S1',
+				rules: [],
+				tags: [],
+			},
+		],
+		exportedAt: Date.now(),
+	};
+}
+
+function makeBundleWithRules(): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Rules Bundle',
+		agents: [{ version: 1, type: 'agent', name: 'Coder', role: 'coder' }],
+		workflows: [
+			{
+				version: 1,
+				type: 'workflow',
+				name: 'RulesWF',
+				steps: [{ agentRef: 'Coder', name: 'Code' }],
+				transitions: [],
+				startStep: 'Code',
+				rules: [
+					{
+						name: 'No hacks',
+						content: 'Do not write hacks.',
+						appliesTo: ['Code'], // step name — should be remapped to step UUID
+					},
+				],
+				tags: [],
+			},
+		],
+		exportedAt: Date.now(),
+	};
+}
+
+function makeTwoStepBundle(): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Two Step Bundle',
+		agents: [
+			{ version: 1, type: 'agent', name: 'Coder', role: 'coder' },
+			{ version: 1, type: 'agent', name: 'Reviewer', role: 'reviewer' },
+		],
+		workflows: [
+			{
+				version: 1,
+				type: 'workflow',
+				name: 'CodingPipeline',
+				steps: [
+					{ agentRef: 'Coder', name: 'Code' },
+					{ agentRef: 'Reviewer', name: 'Review' },
+				],
+				transitions: [{ fromStep: 'Code', toStep: 'Review' }],
+				startStep: 'Code',
+				rules: [],
+				tags: [],
+			},
+		],
+		exportedAt: Date.now(),
+	};
+}

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -208,7 +208,8 @@ describe('Space Export/Import RPC Handlers', () => {
 			spaceManager,
 			agentRepo,
 			workflowRepo,
-			workflowManager
+			workflowManager,
+			db as any
 		);
 	});
 
@@ -933,6 +934,134 @@ describe('Space Export/Import RPC Handlers', () => {
 			});
 
 			expect(result.warnings).toHaveLength(0);
+		});
+
+		// ─── Transaction atomicity ─────────────────────────────────────────
+
+		describe('transaction atomicity', () => {
+			it('rolls back agent creation when workflow import fails (unresolved agent ref)', async () => {
+				// Bundle: first workflow imports fine, second has an unresolved agent ref.
+				// After failure, neither agent nor workflow should exist.
+				const bundle = {
+					version: 1,
+					type: 'bundle',
+					name: 'Atomic Test',
+					agents: [{ version: 1, type: 'agent', name: 'NewAgent', role: 'coder' }],
+					workflows: [
+						{
+							version: 1,
+							type: 'workflow',
+							name: 'BadWorkflow',
+							steps: [{ agentRef: 'GhostAgent', name: 'S' }],
+							transitions: [],
+							startStep: 'S',
+							rules: [],
+							tags: [],
+						},
+					],
+					exportedAt: Date.now(),
+				};
+
+				await expect(
+					call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle })
+				).rejects.toThrow('unresolved agent reference');
+
+				// Nothing should have been committed — NewAgent must not exist
+				const agents = agentRepo.getBySpaceId(SPACE_ID);
+				expect(agents.find((a) => a.name === 'NewAgent')).toBeUndefined();
+			});
+
+			it('rolls back workflow deletion when replacement creation fails', async () => {
+				// A workflow that exists in the target space should NOT be deleted
+				// if the replacement creation fails.
+				const existingAgent = agentRepo.create({ spaceId: SPACE_ID, name: 'A', role: 'coder' });
+				const existingWf = workflowManager.createWorkflow({
+					spaceId: SPACE_ID,
+					name: 'ToReplace',
+					steps: [{ name: 'S', agentId: existingAgent.id }],
+					transitions: [],
+				});
+
+				// Bundle: replace "ToReplace" but the replacement references a ghost agent
+				const bundle = {
+					version: 1,
+					type: 'bundle',
+					name: 'Replace Test',
+					agents: [],
+					workflows: [
+						{
+							version: 1,
+							type: 'workflow',
+							name: 'ToReplace',
+							steps: [{ agentRef: 'GhostAgent', name: 'S2' }],
+							transitions: [],
+							startStep: 'S2',
+							rules: [],
+							tags: [],
+						},
+					],
+					exportedAt: Date.now(),
+				};
+
+				await expect(
+					call(handlers, 'spaceImport.execute', {
+						spaceId: SPACE_ID,
+						bundle,
+						conflictResolution: { workflows: { ToReplace: 'replace' } },
+					})
+				).rejects.toThrow('unresolved agent reference');
+
+				// The original workflow must still exist (deletion was rolled back)
+				const wf = workflowRepo.getWorkflow(existingWf.id);
+				expect(wf).not.toBeNull();
+				expect(wf!.name).toBe('ToReplace');
+			});
+		});
+
+		// ─── replace agent field clearing ─────────────────────────────────
+
+		describe('replace agent: unset fields are cleared', () => {
+			it('clears model when not present in exported agent', async () => {
+				const existing = agentRepo.create({
+					spaceId: SPACE_ID,
+					name: 'Coder',
+					role: 'coder',
+					model: 'old-model',
+				});
+
+				// Exported agent has no model field
+				const bundle = makeBundle([{ name: 'Coder', role: 'reviewer' }], []);
+
+				await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Coder: 'replace' } },
+				});
+
+				// model should be cleared (not preserved from the existing agent)
+				const agent = agentRepo.getById(existing.id)!;
+				expect(agent.model).toBeUndefined();
+			});
+
+			it('clears systemPrompt when not present in exported agent', async () => {
+				const existing = agentRepo.create({
+					spaceId: SPACE_ID,
+					name: 'Coder',
+					role: 'coder',
+					systemPrompt: 'Old prompt.',
+				});
+
+				const bundle = makeBundle([{ name: 'Coder', role: 'coder' }], []);
+
+				await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+					spaceId: SPACE_ID,
+					bundle,
+					conflictResolution: { agents: { Coder: 'replace' } },
+				});
+
+				const agent = agentRepo.getById(existing.id)!;
+				expect(agent.systemPrompt).toBeUndefined();
+			});
 		});
 	});
 });


### PR DESCRIPTION
Implements spaceExport.* and spaceImport.* RPC namespaces:
- spaceExport.agents / spaceExport.workflows / spaceExport.bundle
  for exporting Space entities to portable SpaceExportBundle JSON
- spaceImport.preview for dry-run conflict detection, cross-reference
  validation, and SpaceWorkflowManager gate validation
- spaceImport.execute for creating entities with skip/rename/replace
  conflict resolution per item

Cross-reference handling:
- Agent name→UUID resolution: checks bundle agents first, falls back
  to existing space agents
- Step ID remapping: fresh UUIDs assigned to all imported steps;
  rule appliesTo arrays remapped from step names to new step UUIDs
- Transition from/to step names remapped to new step UUIDs

Wired into setupRPCHandlers() in rpc-handlers/index.ts.
45 unit tests covering all handlers, conflict resolutions, and
cross-reference mapping.
