### PR TITLE
feat: workflow selection logic and Space agent tools (Task 7.1)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -31,6 +31,15 @@ export type {
 export { SpaceRuntime } from './runtime/space-runtime';
 export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
 
+export { selectWorkflow } from './runtime/workflow-selector';
+export type { WorkflowSelectionContext } from './runtime/workflow-selector';
+
+export {
+	createSpaceAgentToolHandlers,
+	createSpaceAgentMcpServer,
+} from './tools/space-agent-tools';
+export type { SpaceAgentToolsConfig, SpaceAgentMcpServer } from './tools/space-agent-tools';
+
 export {
 	exportAgent,
 	exportWorkflow,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -34,6 +34,8 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { WorkflowExecutor, WorkflowTransitionError } from './workflow-executor';
+import { selectWorkflow } from './workflow-selector';
+import type { WorkflowSelectionContext } from './workflow-selector';
 import { Logger } from '../../logger';
 
 const log = new Logger('space-runtime');
@@ -309,6 +311,23 @@ export class SpaceRuntime {
 		return workflow.rules.filter(
 			(r) => !r.appliesTo || r.appliesTo.length === 0 || r.appliesTo.includes(stepId)
 		);
+	}
+
+	/**
+	 * Resolve the best workflow for a new run using the workflow selection algorithm.
+	 *
+	 * Accepts an optional explicit `workflowId`. When omitted, auto-selects via
+	 * tag-based and keyword-based heuristics. Returns null when no workflow matches
+	 * (caller should create a standalone task instead).
+	 *
+	 * This is a thin integration point: it loads the available workflows for the
+	 * space and delegates to the pure `selectWorkflow()` function.
+	 */
+	resolveWorkflowForRun(
+		context: Omit<WorkflowSelectionContext, 'availableWorkflows'>
+	): SpaceWorkflow | null {
+		const availableWorkflows = this.config.spaceWorkflowManager.listWorkflows(context.spaceId);
+		return selectWorkflow({ ...context, availableWorkflows });
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -35,7 +35,6 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { WorkflowExecutor, WorkflowTransitionError } from './workflow-executor';
 import { selectWorkflow } from './workflow-selector';
-import type { WorkflowSelectionContext } from './workflow-selector';
 import { Logger } from '../../logger';
 
 const log = new Logger('space-runtime');
@@ -314,20 +313,18 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Resolve the best workflow for a new run using the workflow selection algorithm.
+	 * Resolve a workflow for a new run from an explicit workflowId.
 	 *
-	 * Accepts an optional explicit `workflowId`. When omitted, auto-selects via
-	 * tag-based and keyword-based heuristics. Returns null when no workflow matches
-	 * (caller should create a standalone task instead).
+	 * Returns the workflow if found in this space's workflows, or null when:
+	 *   - No workflowId is provided (LLM agent must call list_workflows first)
+	 *   - The provided workflowId is not found in this space
 	 *
-	 * This is a thin integration point: it loads the available workflows for the
-	 * space and delegates to the pure `selectWorkflow()` function.
+	 * This is a thin integration point: it loads the space's workflows from the
+	 * DB and delegates to the pure `selectWorkflow()` function.
 	 */
-	resolveWorkflowForRun(
-		context: Omit<WorkflowSelectionContext, 'availableWorkflows'>
-	): SpaceWorkflow | null {
-		const availableWorkflows = this.config.spaceWorkflowManager.listWorkflows(context.spaceId);
-		return selectWorkflow({ ...context, availableWorkflows });
+	resolveWorkflowForRun(spaceId: string, workflowId?: string): SpaceWorkflow | null {
+		const availableWorkflows = this.config.spaceWorkflowManager.listWorkflows(spaceId);
+		return selectWorkflow({ spaceId, availableWorkflows, workflowId });
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/workflow-selector.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-selector.ts
@@ -1,19 +1,19 @@
 /**
  * Workflow Selector
  *
- * Pure, deterministic function for selecting a SpaceWorkflow given a context.
+ * Pure function for resolving a SpaceWorkflow from an explicit workflowId.
  * Has no runtime dependencies — takes only data inputs so it can be tested
  * in isolation without any DB or manager instances.
  *
- * Priority chain (first match wins):
- *   1. Explicit workflowId provided → use it
- *   2. Tag-based: match keywords from title/description against workflow tags
- *   3. MVP keyword matching: substring match title/description against workflow descriptions
- *   4. Fall back to null (create standalone task)
+ * Design (per M7 spec):
+ *   - Workflow selection has two modes: explicit workflowId OR AI auto-select.
+ *   - When workflowId is provided, this function finds it in availableWorkflows.
+ *   - When no workflowId is provided, this function returns null — the Space
+ *     agent LLM is expected to call list_workflows first and pick explicitly.
+ *   - There is no tag-based matching, no keyword-based matching, and no
+ *     heuristic fallback. LLM reasoning replaces static heuristics.
  *
- * Note: The "space has default workflow" step was removed in Task 3.2 —
- * the Space system has no isDefault concept. Workflow selection is explicit
- * workflowId OR AI auto-select via this function.
+ * See: docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
  */
 
 import type { SpaceWorkflow } from '@neokai/shared';
@@ -35,33 +35,13 @@ export interface WorkflowSelectionContext {
 	 */
 	availableWorkflows: SpaceWorkflow[];
 	/**
-	 * Optional explicit workflow ID. When provided, the function uses this workflow
-	 * if it exists in availableWorkflows, bypassing all other heuristics.
+	 * Optional explicit workflow ID. When provided, the function returns that
+	 * workflow if found in availableWorkflows, otherwise null.
+	 *
+	 * When omitted, returns null — the caller (LLM agent) must call list_workflows
+	 * and then provide an explicit workflowId.
 	 */
 	workflowId?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Normalise text for comparison: lowercase, collapse whitespace.
- */
-function normalise(text: string): string {
-	return text.toLowerCase().replace(/\s+/g, ' ').trim();
-}
-
-/**
- * Extract candidate keywords from a title + description string.
- * Returns individual words longer than 2 chars (stops words like 'a', 'an', 'to').
- */
-function extractKeywords(title: string, description: string): string[] {
-	const combined = normalise(`${title} ${description}`);
-	return combined
-		.split(/\W+/)
-		.filter((w) => w.length > 2)
-		.filter(Boolean);
 }
 
 // ---------------------------------------------------------------------------
@@ -69,90 +49,23 @@ function extractKeywords(title: string, description: string): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Select a workflow from the available set given the context.
+ * Resolve a workflow from the available set given an explicit workflowId.
  *
- * Returns null when no workflow matches — callers should create a standalone
- * SpaceTask in that case.
+ * Returns null in two cases:
+ *   1. No workflowId provided — the LLM agent must pick one via list_workflows.
+ *   2. workflowId provided but not found in availableWorkflows.
  *
  * The function is pure and deterministic: given the same inputs it always
  * returns the same output.
  */
 export function selectWorkflow(context: WorkflowSelectionContext): SpaceWorkflow | null {
-	const { availableWorkflows, workflowId, title, description } = context;
+	const { availableWorkflows, workflowId } = context;
 
-	if (availableWorkflows.length === 0) return null;
-
-	// -------------------------------------------------------------------------
-	// Step 1: Explicit workflowId provided
-	// -------------------------------------------------------------------------
-	if (workflowId) {
-		const explicit = availableWorkflows.find((w) => w.id === workflowId);
-		if (explicit) return explicit;
-		// Explicit ID was given but not found in the available set — return null
-		// rather than silently falling through to heuristics.
+	if (!workflowId) {
+		// No explicit ID: return null — LLM agent must call list_workflows and pick.
 		return null;
 	}
 
-	// -------------------------------------------------------------------------
-	// Step 2: Tag-based matching
-	// Rank workflows by how many of the input keywords appear in their tag list.
-	// -------------------------------------------------------------------------
-	const keywords = extractKeywords(title, description);
-
-	if (keywords.length > 0) {
-		let bestTagMatch: SpaceWorkflow | null = null;
-		let bestTagScore = 0;
-
-		for (const workflow of availableWorkflows) {
-			if (!workflow.tags || workflow.tags.length === 0) continue;
-
-			const normalisedTags = workflow.tags.map(normalise);
-			let score = 0;
-			for (const kw of keywords) {
-				if (normalisedTags.some((tag) => tag.includes(kw) || kw.includes(tag))) {
-					score++;
-				}
-			}
-
-			if (score > bestTagScore) {
-				bestTagScore = score;
-				bestTagMatch = workflow;
-			}
-		}
-
-		if (bestTagMatch) return bestTagMatch;
-	}
-
-	// -------------------------------------------------------------------------
-	// Step 3: MVP keyword matching — substring match title/description against
-	// workflow descriptions.
-	// -------------------------------------------------------------------------
-	const normalisedInput = normalise(`${title} ${description}`);
-
-	let bestDescMatch: SpaceWorkflow | null = null;
-	let bestDescScore = 0;
-
-	for (const workflow of availableWorkflows) {
-		const workflowDesc = normalise(workflow.description ?? '');
-		if (!workflowDesc) continue;
-
-		// Score: count how many words from the workflow description appear in the input
-		const descWords = workflowDesc.split(/\W+/).filter((w) => w.length > 2);
-		let score = 0;
-		for (const word of descWords) {
-			if (normalisedInput.includes(word)) score++;
-		}
-
-		if (score > bestDescScore) {
-			bestDescScore = score;
-			bestDescMatch = workflow;
-		}
-	}
-
-	if (bestDescMatch) return bestDescMatch;
-
-	// -------------------------------------------------------------------------
-	// Step 4: Fall back to null — caller creates a standalone task
-	// -------------------------------------------------------------------------
-	return null;
+	// Explicit ID provided: find it in the available set (or null if not found).
+	return availableWorkflows.find((w) => w.id === workflowId) ?? null;
 }

--- a/packages/daemon/src/lib/space/runtime/workflow-selector.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-selector.ts
@@ -1,0 +1,158 @@
+/**
+ * Workflow Selector
+ *
+ * Pure, deterministic function for selecting a SpaceWorkflow given a context.
+ * Has no runtime dependencies — takes only data inputs so it can be tested
+ * in isolation without any DB or manager instances.
+ *
+ * Priority chain (first match wins):
+ *   1. Explicit workflowId provided → use it
+ *   2. Tag-based: match keywords from title/description against workflow tags
+ *   3. MVP keyword matching: substring match title/description against workflow descriptions
+ *   4. Fall back to null (create standalone task)
+ *
+ * Note: The "space has default workflow" step was removed in Task 3.2 —
+ * the Space system has no isDefault concept. Workflow selection is explicit
+ * workflowId OR AI auto-select via this function.
+ */
+
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowSelectionContext {
+	/** The space this selection is scoped to. */
+	spaceId: string;
+	/** Human-readable title of the work being requested. */
+	title: string;
+	/** Longer description of the work being requested. May be empty. */
+	description: string;
+	/**
+	 * Available workflows to select from.
+	 * Must all belong to the given spaceId — callers are responsible for pre-filtering.
+	 */
+	availableWorkflows: SpaceWorkflow[];
+	/**
+	 * Optional explicit workflow ID. When provided, the function uses this workflow
+	 * if it exists in availableWorkflows, bypassing all other heuristics.
+	 */
+	workflowId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise text for comparison: lowercase, collapse whitespace.
+ */
+function normalise(text: string): string {
+	return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Extract candidate keywords from a title + description string.
+ * Returns individual words longer than 2 chars (stops words like 'a', 'an', 'to').
+ */
+function extractKeywords(title: string, description: string): string[] {
+	const combined = normalise(`${title} ${description}`);
+	return combined
+		.split(/\W+/)
+		.filter((w) => w.length > 2)
+		.filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Core selection logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Select a workflow from the available set given the context.
+ *
+ * Returns null when no workflow matches — callers should create a standalone
+ * SpaceTask in that case.
+ *
+ * The function is pure and deterministic: given the same inputs it always
+ * returns the same output.
+ */
+export function selectWorkflow(context: WorkflowSelectionContext): SpaceWorkflow | null {
+	const { availableWorkflows, workflowId, title, description } = context;
+
+	if (availableWorkflows.length === 0) return null;
+
+	// -------------------------------------------------------------------------
+	// Step 1: Explicit workflowId provided
+	// -------------------------------------------------------------------------
+	if (workflowId) {
+		const explicit = availableWorkflows.find((w) => w.id === workflowId);
+		if (explicit) return explicit;
+		// Explicit ID was given but not found in the available set — return null
+		// rather than silently falling through to heuristics.
+		return null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 2: Tag-based matching
+	// Rank workflows by how many of the input keywords appear in their tag list.
+	// -------------------------------------------------------------------------
+	const keywords = extractKeywords(title, description);
+
+	if (keywords.length > 0) {
+		let bestTagMatch: SpaceWorkflow | null = null;
+		let bestTagScore = 0;
+
+		for (const workflow of availableWorkflows) {
+			if (!workflow.tags || workflow.tags.length === 0) continue;
+
+			const normalisedTags = workflow.tags.map(normalise);
+			let score = 0;
+			for (const kw of keywords) {
+				if (normalisedTags.some((tag) => tag.includes(kw) || kw.includes(tag))) {
+					score++;
+				}
+			}
+
+			if (score > bestTagScore) {
+				bestTagScore = score;
+				bestTagMatch = workflow;
+			}
+		}
+
+		if (bestTagMatch) return bestTagMatch;
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 3: MVP keyword matching — substring match title/description against
+	// workflow descriptions.
+	// -------------------------------------------------------------------------
+	const normalisedInput = normalise(`${title} ${description}`);
+
+	let bestDescMatch: SpaceWorkflow | null = null;
+	let bestDescScore = 0;
+
+	for (const workflow of availableWorkflows) {
+		const workflowDesc = normalise(workflow.description ?? '');
+		if (!workflowDesc) continue;
+
+		// Score: count how many words from the workflow description appear in the input
+		const descWords = workflowDesc.split(/\W+/).filter((w) => w.length > 2);
+		let score = 0;
+		for (const word of descWords) {
+			if (normalisedInput.includes(word)) score++;
+		}
+
+		if (score > bestDescScore) {
+			bestDescScore = score;
+			bestDescMatch = workflow;
+		}
+	}
+
+	if (bestDescMatch) return bestDescMatch;
+
+	// -------------------------------------------------------------------------
+	// Step 4: Fall back to null — caller creates a standalone task
+	// -------------------------------------------------------------------------
+	return null;
+}

--- a/packages/daemon/src/lib/space/runtime/workflow-selector.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-selector.ts
@@ -25,10 +25,6 @@ import type { SpaceWorkflow } from '@neokai/shared';
 export interface WorkflowSelectionContext {
 	/** The space this selection is scoped to. */
 	spaceId: string;
-	/** Human-readable title of the work being requested. */
-	title: string;
-	/** Longer description of the work being requested. May be empty. */
-	description: string;
 	/**
 	 * Available workflows to select from.
 	 * Must all belong to the given spaceId — callers are responsible for pre-filtering.

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1,0 +1,287 @@
+/**
+ * Space Agent Tools — MCP tools for the Space leader agent session.
+ *
+ * These tools allow the Space agent to start workflow runs, create standalone
+ * tasks, and query Space state. They are in the Space namespace (not Room).
+ *
+ * Tools:
+ *   start_workflow_run — starts a run with optional workflowId (auto-selects if omitted)
+ *   create_task        — creates a standalone SpaceTask (no workflow)
+ *   list_workflows     — returns available SpaceWorkflow records for the space
+ *   list_tasks         — filterable by status and workflowRunId
+ *   list_workflow_runs — returns active/completed runs for the space
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import type { SpaceTaskStatus, SpaceTaskType, SpaceTaskPriority } from '@neokai/shared';
+import type { SpaceRuntime } from '../runtime/space-runtime';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceTaskManager } from '../managers/space-task-manager';
+import { selectWorkflow } from '../runtime/workflow-selector';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface SpaceAgentToolsConfig {
+	/** The Space this agent is operating within. */
+	spaceId: string;
+	/** SpaceRuntime for starting workflow runs. */
+	runtime: SpaceRuntime;
+	/** Workflow manager for listing available workflows. */
+	workflowManager: SpaceWorkflowManager;
+	/** Task repository for read queries (list/filter). */
+	taskRepo: SpaceTaskRepository;
+	/** Workflow run repository for listing runs. */
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Task manager for creating standalone tasks. */
+	taskManager: SpaceTaskManager;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+function jsonResult(data: Record<string, unknown>): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers (separated for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create handler functions that can be tested directly without an MCP server.
+ * Returns a map of tool name → handler function.
+ */
+export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
+	const { spaceId, runtime, workflowManager, taskRepo, workflowRunRepo, taskManager } = config;
+
+	return {
+		/**
+		 * Start a new workflow run.
+		 * If workflowId is not provided, auto-selects a workflow via selectWorkflow().
+		 * Falls back to null (standalone task) if no workflow matches.
+		 */
+		async start_workflow_run(args: {
+			title: string;
+			description?: string;
+			workflow_id?: string;
+		}): Promise<ToolResult> {
+			const availableWorkflows = workflowManager.listWorkflows(spaceId);
+
+			const selected = selectWorkflow({
+				spaceId,
+				title: args.title,
+				description: args.description ?? '',
+				availableWorkflows,
+				workflowId: args.workflow_id,
+			});
+
+			if (!selected) {
+				return jsonResult({
+					success: false,
+					error:
+						'No matching workflow found. Use create_task to create a standalone task instead, or provide an explicit workflow_id.',
+					availableWorkflows: availableWorkflows.map((w) => ({ id: w.id, name: w.name })),
+				});
+			}
+
+			try {
+				const { run, tasks } = await runtime.startWorkflowRun(
+					spaceId,
+					selected.id,
+					args.title,
+					args.description
+				);
+				return jsonResult({ success: true, run, tasks, selectedWorkflowId: selected.id });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Create a standalone SpaceTask (not associated with a workflow run).
+		 */
+		async create_task(args: {
+			title: string;
+			description: string;
+			task_type?: SpaceTaskType;
+			custom_agent_id?: string;
+			priority?: SpaceTaskPriority;
+			depends_on?: string[];
+		}): Promise<ToolResult> {
+			try {
+				const task = await taskManager.createTask({
+					title: args.title,
+					description: args.description,
+					taskType: args.task_type,
+					customAgentId: args.custom_agent_id,
+					priority: args.priority,
+					dependsOn: args.depends_on,
+					status: 'pending',
+				});
+				return jsonResult({ success: true, taskId: task.id, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * List all available SpaceWorkflow records for this space.
+		 */
+		async list_workflows(): Promise<ToolResult> {
+			const workflows = workflowManager.listWorkflows(spaceId);
+			return jsonResult({ success: true, workflows });
+		},
+
+		/**
+		 * List SpaceTasks, optionally filtered by status and/or workflowRunId.
+		 * When workflowRunId is provided, returns only tasks belonging to that run.
+		 * When status is provided, filters by task status.
+		 */
+		async list_tasks(args: {
+			status?: SpaceTaskStatus;
+			workflow_run_id?: string;
+		}): Promise<ToolResult> {
+			let tasks;
+			if (args.workflow_run_id) {
+				tasks = taskRepo.listByWorkflowRun(args.workflow_run_id);
+				if (args.status) {
+					tasks = tasks.filter((t) => t.status === args.status);
+				}
+			} else if (args.status) {
+				tasks = taskRepo.listByStatus(spaceId, args.status);
+			} else {
+				tasks = taskRepo.listBySpace(spaceId);
+			}
+			return jsonResult({ success: true, tasks });
+		},
+
+		/**
+		 * List workflow runs for this space.
+		 * By default returns all runs; optionally filter by status.
+		 */
+		async list_workflow_runs(args: { status?: string }): Promise<ToolResult> {
+			let runs = workflowRunRepo.listBySpace(spaceId);
+			if (args.status) {
+				runs = runs.filter((r) => r.status === args.status);
+			}
+			return jsonResult({ success: true, runs });
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// MCP server factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an MCP server exposing all Space agent tools.
+ * Pass the returned server to the SDK session init.
+ */
+export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
+	const handlers = createSpaceAgentToolHandlers(config);
+
+	const tools = [
+		tool(
+			'start_workflow_run',
+			'Start a new workflow run for the space. Auto-selects the best workflow if workflow_id is not provided.',
+			{
+				title: z.string().describe('Short title for this workflow run'),
+				description: z
+					.string()
+					.optional()
+					.describe(
+						'Detailed description of the work. Used for workflow auto-selection when workflow_id is omitted.'
+					),
+				workflow_id: z
+					.string()
+					.optional()
+					.describe(
+						'Explicit workflow ID to use. When omitted, a workflow is auto-selected based on title/description.'
+					),
+			},
+			(args) => handlers.start_workflow_run(args)
+		),
+		tool(
+			'create_task',
+			'Create a standalone SpaceTask not associated with any workflow run.',
+			{
+				title: z.string().describe('Short title for the task'),
+				description: z.string().describe('Detailed task description and acceptance criteria'),
+				task_type: z
+					.enum(['planning', 'coding', 'research', 'design', 'review'])
+					.optional()
+					.describe('Task type — determines which agent preset runs this task'),
+				custom_agent_id: z
+					.string()
+					.optional()
+					.describe('ID of a custom SpaceAgent to run this task'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.default('normal')
+					.describe('Task priority'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('IDs of tasks that must complete before this task starts'),
+			},
+			(args) => handlers.create_task(args)
+		),
+		tool(
+			'list_workflows',
+			'List all available workflows for this space, including their names, descriptions, and tags.',
+			{},
+			() => handlers.list_workflows()
+		),
+		tool(
+			'list_tasks',
+			'List SpaceTasks for this space. Optionally filter by status or workflow run.',
+			{
+				status: z
+					.enum([
+						'draft',
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+					])
+					.optional()
+					.describe('Filter by task status'),
+				workflow_run_id: z
+					.string()
+					.optional()
+					.describe('Filter to only tasks belonging to a specific workflow run'),
+			},
+			(args) => handlers.list_tasks(args)
+		),
+		tool(
+			'list_workflow_runs',
+			'List workflow runs for this space. Optionally filter by status.',
+			{
+				status: z
+					.enum(['pending', 'in_progress', 'completed', 'cancelled', 'needs_attention'])
+					.optional()
+					.describe('Filter by run status'),
+			},
+			(args) => handlers.list_workflow_runs(args)
+		),
+	];
+
+	return createSdkMcpServer({ name: 'space-agent', tools });
+}
+
+export type SpaceAgentMcpServer = ReturnType<typeof createSpaceAgentMcpServer>;

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -51,7 +51,7 @@ interface ToolResult {
 	content: Array<{ type: 'text'; text: string }>;
 }
 
-function jsonResult(data: Record<string, unknown>): ToolResult {
+function jsonResult(data: unknown): ToolResult {
 	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
 
@@ -148,8 +148,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				});
 			}
 
-			// Switching workflow: cancel current run, start a new one.
+			// Switching workflow: validate the target workflow exists BEFORE cancelling
+			// the old run, so a bad workflow_id never leaves the user with no active run.
 			if (args.workflow_id) {
+				const targetWorkflow = workflowManager.getWorkflow(args.workflow_id);
+				if (!targetWorkflow) {
+					return jsonResult({
+						success: false,
+						error: `Workflow not found: ${args.workflow_id}`,
+					});
+				}
+
 				workflowRunRepo.updateStatus(run.id, 'cancelled');
 
 				try {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1,26 +1,30 @@
 /**
  * Space Agent Tools — MCP tools for the Space leader agent session.
  *
- * These tools allow the Space agent to start workflow runs, create standalone
- * tasks, and query Space state. They are in the Space namespace (not Room).
+ * These tools allow the Space agent to start workflow runs, check status,
+ * change plans, and query Space tasks. They are in the Space namespace (not Room).
  *
- * Tools:
- *   start_workflow_run — starts a run with optional workflowId (auto-selects if omitted)
- *   create_task        — creates a standalone SpaceTask (no workflow)
- *   list_workflows     — returns available SpaceWorkflow records for the space
- *   list_tasks         — filterable by status and workflowRunId
- *   list_workflow_runs — returns active/completed runs for the space
+ * Tools (per M7 spec):
+ *   list_workflows     — show all workflows with their descriptions and steps
+ *   start_workflow_run — begin a workflow run (requires explicit workflowId)
+ *   get_workflow_run   — check the status of a running workflow
+ *   change_plan        — update task description or switch to a different workflow mid-run
+ *   list_tasks         — see current and past tasks
+ *
+ * Design note: workflow selection is LLM-driven. The agent calls list_workflows,
+ * reasons about which workflow fits the request, then calls start_workflow_run
+ * with an explicit workflowId. There are no server-side heuristics.
+ *
+ * See: docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { SpaceTaskStatus, SpaceTaskType, SpaceTaskPriority } from '@neokai/shared';
+import type { SpaceTaskStatus } from '@neokai/shared';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
-import type { SpaceTaskManager } from '../managers/space-task-manager';
-import { selectWorkflow } from '../runtime/workflow-selector';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -29,16 +33,14 @@ import { selectWorkflow } from '../runtime/workflow-selector';
 export interface SpaceAgentToolsConfig {
 	/** The Space this agent is operating within. */
 	spaceId: string;
-	/** SpaceRuntime for starting workflow runs. */
+	/** SpaceRuntime for starting and managing workflow runs. */
 	runtime: SpaceRuntime;
 	/** Workflow manager for listing available workflows. */
 	workflowManager: SpaceWorkflowManager;
 	/** Task repository for read queries (list/filter). */
 	taskRepo: SpaceTaskRepository;
-	/** Workflow run repository for listing runs. */
+	/** Workflow run repository for listing and updating runs. */
 	workflowRunRepo: SpaceWorkflowRunRepository;
-	/** Task manager for creating standalone tasks. */
-	taskManager: SpaceTaskManager;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,82 +64,12 @@ function jsonResult(data: Record<string, unknown>): ToolResult {
  * Returns a map of tool name → handler function.
  */
 export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
-	const { spaceId, runtime, workflowManager, taskRepo, workflowRunRepo, taskManager } = config;
+	const { spaceId, runtime, workflowManager, taskRepo, workflowRunRepo } = config;
 
 	return {
 		/**
-		 * Start a new workflow run.
-		 * If workflowId is not provided, auto-selects a workflow via selectWorkflow().
-		 * Falls back to null (standalone task) if no workflow matches.
-		 */
-		async start_workflow_run(args: {
-			title: string;
-			description?: string;
-			workflow_id?: string;
-		}): Promise<ToolResult> {
-			const availableWorkflows = workflowManager.listWorkflows(spaceId);
-
-			const selected = selectWorkflow({
-				spaceId,
-				title: args.title,
-				description: args.description ?? '',
-				availableWorkflows,
-				workflowId: args.workflow_id,
-			});
-
-			if (!selected) {
-				return jsonResult({
-					success: false,
-					error:
-						'No matching workflow found. Use create_task to create a standalone task instead, or provide an explicit workflow_id.',
-					availableWorkflows: availableWorkflows.map((w) => ({ id: w.id, name: w.name })),
-				});
-			}
-
-			try {
-				const { run, tasks } = await runtime.startWorkflowRun(
-					spaceId,
-					selected.id,
-					args.title,
-					args.description
-				);
-				return jsonResult({ success: true, run, tasks, selectedWorkflowId: selected.id });
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				return jsonResult({ success: false, error: message });
-			}
-		},
-
-		/**
-		 * Create a standalone SpaceTask (not associated with a workflow run).
-		 */
-		async create_task(args: {
-			title: string;
-			description: string;
-			task_type?: SpaceTaskType;
-			custom_agent_id?: string;
-			priority?: SpaceTaskPriority;
-			depends_on?: string[];
-		}): Promise<ToolResult> {
-			try {
-				const task = await taskManager.createTask({
-					title: args.title,
-					description: args.description,
-					taskType: args.task_type,
-					customAgentId: args.custom_agent_id,
-					priority: args.priority,
-					dependsOn: args.depends_on,
-					status: 'pending',
-				});
-				return jsonResult({ success: true, taskId: task.id, task });
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				return jsonResult({ success: false, error: message });
-			}
-		},
-
-		/**
 		 * List all available SpaceWorkflow records for this space.
+		 * The LLM agent calls this first to understand available options.
 		 */
 		async list_workflows(): Promise<ToolResult> {
 			const workflows = workflowManager.listWorkflows(spaceId);
@@ -145,9 +77,116 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		},
 
 		/**
-		 * List SpaceTasks, optionally filtered by status and/or workflowRunId.
-		 * When workflowRunId is provided, returns only tasks belonging to that run.
-		 * When status is provided, filters by task status.
+		 * Start a new workflow run with an explicit workflowId.
+		 * The agent must call list_workflows first and pick the right workflow.
+		 */
+		async start_workflow_run(args: {
+			workflow_id: string;
+			title: string;
+			description?: string;
+		}): Promise<ToolResult> {
+			try {
+				const { run, tasks } = await runtime.startWorkflowRun(
+					spaceId,
+					args.workflow_id,
+					args.title,
+					args.description
+				);
+				return jsonResult({ success: true, run, tasks });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Get the current status of a workflow run, including its current step.
+		 */
+		async get_workflow_run(args: { run_id: string }): Promise<ToolResult> {
+			const run = workflowRunRepo.getRun(args.run_id);
+			if (!run) {
+				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
+			}
+
+			// Include current step info if available
+			let currentStep = null;
+			if (run.currentStepId) {
+				const workflow = workflowManager.getWorkflow(run.workflowId);
+				if (workflow) {
+					currentStep = workflow.steps.find((s) => s.id === run.currentStepId) ?? null;
+				}
+			}
+
+			// Include tasks for this run
+			const tasks = taskRepo.listByWorkflowRun(run.id);
+
+			return jsonResult({ success: true, run, currentStep, tasks });
+		},
+
+		/**
+		 * Update the current workflow run's task description, or switch to a
+		 * different workflow mid-run (cancels the current run and starts a new one).
+		 *
+		 * - Provide `description` to update the run description in place.
+		 * - Provide `workflow_id` to switch workflows: the current run is cancelled
+		 *   and a new run is started with the same title and updated description.
+		 */
+		async change_plan(args: {
+			run_id: string;
+			description?: string;
+			workflow_id?: string;
+		}): Promise<ToolResult> {
+			const run = workflowRunRepo.getRun(args.run_id);
+			if (!run) {
+				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
+			}
+
+			if (run.status === 'completed' || run.status === 'cancelled') {
+				return jsonResult({
+					success: false,
+					error: `Cannot change plan for a ${run.status} run.`,
+				});
+			}
+
+			// Switching workflow: cancel current run, start a new one.
+			if (args.workflow_id) {
+				workflowRunRepo.updateStatus(run.id, 'cancelled');
+
+				try {
+					const newDescription = args.description ?? run.description;
+					const { run: newRun, tasks } = await runtime.startWorkflowRun(
+						spaceId,
+						args.workflow_id,
+						run.title,
+						newDescription
+					);
+					return jsonResult({
+						success: true,
+						previousRunId: run.id,
+						run: newRun,
+						tasks,
+						message: `Switched from workflow "${run.workflowId}" to "${args.workflow_id}". Previous run cancelled.`,
+					});
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					return jsonResult({ success: false, error: message });
+				}
+			}
+
+			// Description-only update.
+			if (args.description !== undefined) {
+				const updated = workflowRunRepo.updateRun(run.id, { description: args.description });
+				return jsonResult({ success: true, run: updated });
+			}
+
+			return jsonResult({
+				success: false,
+				error: 'Provide at least one of: description, workflow_id.',
+			});
+		},
+
+		/**
+		 * List SpaceTasks for this space, optionally filtered by status and/or workflowRunId.
 		 */
 		async list_tasks(args: {
 			status?: SpaceTaskStatus;
@@ -166,18 +205,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 			return jsonResult({ success: true, tasks });
 		},
-
-		/**
-		 * List workflow runs for this space.
-		 * By default returns all runs; optionally filter by status.
-		 */
-		async list_workflow_runs(args: { status?: string }): Promise<ToolResult> {
-			let runs = workflowRunRepo.listBySpace(spaceId);
-			if (args.status) {
-				runs = runs.filter((r) => r.status === args.status);
-			}
-			return jsonResult({ success: true, runs });
-		},
 	};
 }
 
@@ -194,60 +221,49 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 
 	const tools = [
 		tool(
-			'start_workflow_run',
-			'Start a new workflow run for the space. Auto-selects the best workflow if workflow_id is not provided.',
-			{
-				title: z.string().describe('Short title for this workflow run'),
-				description: z
-					.string()
-					.optional()
-					.describe(
-						'Detailed description of the work. Used for workflow auto-selection when workflow_id is omitted.'
-					),
-				workflow_id: z
-					.string()
-					.optional()
-					.describe(
-						'Explicit workflow ID to use. When omitted, a workflow is auto-selected based on title/description.'
-					),
-			},
-			(args) => handlers.start_workflow_run(args)
-		),
-		tool(
-			'create_task',
-			'Create a standalone SpaceTask not associated with any workflow run.',
-			{
-				title: z.string().describe('Short title for the task'),
-				description: z.string().describe('Detailed task description and acceptance criteria'),
-				task_type: z
-					.enum(['planning', 'coding', 'research', 'design', 'review'])
-					.optional()
-					.describe('Task type — determines which agent preset runs this task'),
-				custom_agent_id: z
-					.string()
-					.optional()
-					.describe('ID of a custom SpaceAgent to run this task'),
-				priority: z
-					.enum(['low', 'normal', 'high', 'urgent'])
-					.optional()
-					.default('normal')
-					.describe('Task priority'),
-				depends_on: z
-					.array(z.string())
-					.optional()
-					.describe('IDs of tasks that must complete before this task starts'),
-			},
-			(args) => handlers.create_task(args)
-		),
-		tool(
 			'list_workflows',
-			'List all available workflows for this space, including their names, descriptions, and tags.',
+			'Show all workflows in this space with their descriptions and steps. Call this first to understand available options before starting a run.',
 			{},
 			() => handlers.list_workflows()
 		),
 		tool(
+			'start_workflow_run',
+			'Begin a workflow run. You must call list_workflows first and choose the workflow whose description and steps best match the request.',
+			{
+				workflow_id: z
+					.string()
+					.describe('ID of the workflow to run (required — choose from list_workflows)'),
+				title: z.string().describe('Short title for this workflow run'),
+				description: z.string().optional().describe('Detailed description of the work to be done'),
+			},
+			(args) => handlers.start_workflow_run(args)
+		),
+		tool(
+			'get_workflow_run',
+			'Check the current status of a workflow run, including the current step and associated tasks.',
+			{
+				run_id: z.string().describe('ID of the workflow run to inspect'),
+			},
+			(args) => handlers.get_workflow_run(args)
+		),
+		tool(
+			'change_plan',
+			'Update the task description for an ongoing run, or switch to a different workflow mid-run (cancels the current run and starts a new one).',
+			{
+				run_id: z.string().describe('ID of the current workflow run'),
+				description: z.string().optional().describe('Updated task description'),
+				workflow_id: z
+					.string()
+					.optional()
+					.describe(
+						'New workflow ID to switch to. The current run will be cancelled and a new run started with the same title.'
+					),
+			},
+			(args) => handlers.change_plan(args)
+		),
+		tool(
 			'list_tasks',
-			'List SpaceTasks for this space. Optionally filter by status or workflow run.',
+			'List SpaceTasks for this space. Optionally filter by status or by a specific workflow run.',
 			{
 				status: z
 					.enum([
@@ -267,17 +283,6 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('Filter to only tasks belonging to a specific workflow run'),
 			},
 			(args) => handlers.list_tasks(args)
-		),
-		tool(
-			'list_workflow_runs',
-			'List workflow runs for this space. Optionally filter by status.',
-			{
-				status: z
-					.enum(['pending', 'in_progress', 'completed', 'cancelled', 'needs_attention'])
-					.optional()
-					.describe('Filter by run status'),
-			},
-			(args) => handlers.list_workflow_runs(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -385,6 +385,33 @@ describe('createSpaceAgentToolHandlers — change_plan', () => {
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
 	});
+
+	test('does not cancel the original run when target workflow_id is invalid', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Original WF'
+		);
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'run to keep',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		// Attempt to switch to a non-existent workflow
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: runId,
+			workflow_id: 'wf-does-not-exist',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+
+		// Original run must still be in_progress — not cancelled
+		const originalRun = ctx.workflowRunRepo.getRun(runId);
+		expect(originalRun?.status).toBe('in_progress');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1,12 +1,12 @@
 /**
  * Unit tests for createSpaceAgentToolHandlers()
  *
- * Covers:
- * - start_workflow_run: explicit workflowId, auto-select via tags, no match → error
- * - create_task: creates standalone task (no workflowRunId)
+ * Covers (per M7 spec tools):
  * - list_workflows: returns space workflows
+ * - start_workflow_run: explicit workflowId required; creates run + tasks
+ * - get_workflow_run: returns run status, current step, and tasks
+ * - change_plan: description update; workflow switch (cancel + restart)
  * - list_tasks: filter by status, workflowRunId
- * - list_workflow_runs: filter by status
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -21,13 +21,12 @@ import { SpaceAgentRepository } from '../../../src/storage/repositories/space-ag
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
-import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { createSpaceAgentToolHandlers } from '../../../src/lib/space/tools/space-agent-tools.ts';
 import type { SpaceWorkflow } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
-// DB + space setup helpers (same pattern as space-runtime.test.ts)
+// DB + space setup helpers
 // ---------------------------------------------------------------------------
 
 function makeDb(): { db: BunDatabase; dir: string } {
@@ -67,7 +66,7 @@ function seedAgentRow(
 }
 
 // ---------------------------------------------------------------------------
-// Build a minimal linear workflow (single step — no transitions, immediately terminal)
+// Build a single-step workflow (terminal — no transitions)
 // ---------------------------------------------------------------------------
 
 function buildSingleStepWorkflow(
@@ -75,7 +74,7 @@ function buildSingleStepWorkflow(
 	workflowManager: SpaceWorkflowManager,
 	agentId: string,
 	name: string,
-	tags: string[],
+	tags: string[] = [],
 	description = ''
 ): SpaceWorkflow {
 	const stepId = `step-${Math.random().toString(36).slice(2)}`;
@@ -99,12 +98,10 @@ interface TestCtx {
 	db: BunDatabase;
 	dir: string;
 	spaceId: string;
-	workspacePath: string;
 	agentId: string;
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
-	taskManager: SpaceTaskManager;
 	runtime: SpaceRuntime;
 }
 
@@ -122,7 +119,6 @@ function makeCtx(): TestCtx {
 	const agentManager = new SpaceAgentManager(agentRepo);
 
 	const workflowRepo = new SpaceWorkflowRepository(db);
-	// No agentLookup passed — same pattern as space-runtime.test.ts
 	const workflowManager = new SpaceWorkflowManager(workflowRepo);
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
@@ -138,473 +134,321 @@ function makeCtx(): TestCtx {
 		taskRepo,
 	});
 
-	const taskManager = new SpaceTaskManager(db, spaceId);
+	return { db, dir, spaceId, agentId, workflowManager, workflowRunRepo, taskRepo, runtime };
+}
 
-	return {
-		db,
-		dir,
-		spaceId,
-		workspacePath,
-		agentId,
-		workflowManager,
-		workflowRunRepo,
-		taskRepo,
-		taskManager,
-		runtime,
-	};
+function makeHandlers(ctx: TestCtx) {
+	return createSpaceAgentToolHandlers({
+		spaceId: ctx.spaceId,
+		runtime: ctx.runtime,
+		workflowManager: ctx.workflowManager,
+		taskRepo: ctx.taskRepo,
+		workflowRunRepo: ctx.workflowRunRepo,
+	});
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// list_workflows
 // ---------------------------------------------------------------------------
-
-describe('createSpaceAgentToolHandlers — start_workflow_run', () => {
-	let ctx: TestCtx;
-
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('explicit workflowId starts a run and returns tasks', async () => {
-		const wf = buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'My Workflow',
-			['coding']
-		);
-
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.start_workflow_run({
-			title: 'Test run',
-			description: 'desc',
-			workflow_id: wf.id,
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.run).toBeDefined();
-		expect(parsed.run.workflowId).toBe(wf.id);
-		expect(parsed.tasks).toHaveLength(1);
-		expect(parsed.selectedWorkflowId).toBe(wf.id);
-	});
-
-	test('auto-selects workflow via tag match when no workflowId provided', async () => {
-		const wfCoding = buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Coding Workflow',
-			['coding']
-		);
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Research Workflow', [
-			'research',
-		]);
-
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.start_workflow_run({
-			title: 'implement coding feature',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.selectedWorkflowId).toBe(wfCoding.id);
-	});
-
-	test('returns error when no workflow matches and no workflowId provided', async () => {
-		// No workflows in space
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.start_workflow_run({
-			title: 'some task',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toBeDefined();
-	});
-
-	test('returns error when explicit workflowId not found', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.start_workflow_run({
-			title: 'test',
-			workflow_id: 'wf-does-not-exist',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-	});
-
-	test('creates run record in DB with in_progress status', async () => {
-		const wf = buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'DB Run Workflow',
-			['coding']
-		);
-
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		await handlers.start_workflow_run({ title: 'run title', workflow_id: wf.id });
-
-		const runs = ctx.workflowRunRepo.listBySpace(ctx.spaceId);
-		expect(runs).toHaveLength(1);
-		expect(runs[0].status).toBe('in_progress');
-		expect(runs[0].title).toBe('run title');
-	});
-});
-
-describe('createSpaceAgentToolHandlers — create_task', () => {
-	let ctx: TestCtx;
-
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('creates a standalone task with no workflowRunId', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.create_task({
-			title: 'Standalone task',
-			description: 'Do something useful',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.taskId).toBeDefined();
-		expect(parsed.task.title).toBe('Standalone task');
-		expect(parsed.task.workflowRunId).toBeUndefined();
-	});
-
-	test('creates task with specified task_type', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.create_task({
-			title: 'Research task',
-			description: 'Research something',
-			task_type: 'research',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.task.taskType).toBe('research');
-	});
-
-	test('creates task with custom_agent_id', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.create_task({
-			title: 'Custom agent task',
-			description: 'Use custom agent',
-			custom_agent_id: ctx.agentId,
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.task.customAgentId).toBe(ctx.agentId);
-	});
-
-	test('creates task with pending status by default', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.create_task({
-			title: 'Default status task',
-			description: 'Should be pending',
-		});
-
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.task.status).toBe('pending');
-	});
-});
 
 describe('createSpaceAgentToolHandlers — list_workflows', () => {
 	let ctx: TestCtx;
-
 	beforeEach(() => {
 		ctx = makeCtx();
 	});
-
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty list when no workflows exist', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.list_workflows();
+		const result = await makeHandlers(ctx).list_workflows();
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toEqual([]);
 	});
 
 	test('returns all workflows for the space', async () => {
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Alpha', ['alpha']);
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Beta', ['beta']);
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Alpha');
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Beta');
 
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const result = await handlers.list_workflows();
+		const result = await makeHandlers(ctx).list_workflows();
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toHaveLength(2);
 	});
 });
 
-describe('createSpaceAgentToolHandlers — list_tasks', () => {
-	let ctx: TestCtx;
+// ---------------------------------------------------------------------------
+// start_workflow_run
+// ---------------------------------------------------------------------------
 
+describe('createSpaceAgentToolHandlers — start_workflow_run', () => {
+	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
 	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
 
+	test('starts a run with explicit workflow_id and returns run + tasks', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'My WF');
+
+		const result = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'Test run',
+			description: 'desc',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.run.workflowId).toBe(wf.id);
+		expect(parsed.run.title).toBe('Test run');
+		expect(parsed.tasks).toHaveLength(1);
+	});
+
+	test('creates run record in DB with in_progress status', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'DB WF');
+
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run title' });
+
+		const runs = ctx.workflowRunRepo.listBySpace(ctx.spaceId);
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe('in_progress');
+		expect(runs[0].title).toBe('run title');
+	});
+
+	test('returns error when workflow_id not found', async () => {
+		const result = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: 'wf-does-not-exist',
+			title: 'test',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_workflow_run
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns run with current step and tasks', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Get WF');
+
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'my run',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		const result = await makeHandlers(ctx).get_workflow_run({ run_id: runId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.run.id).toBe(runId);
+		expect(parsed.run.status).toBe('in_progress');
+		expect(parsed.currentStep).toBeDefined();
+		expect(parsed.tasks).toHaveLength(1);
+	});
+
+	test('returns error when run not found', async () => {
+		const result = await makeHandlers(ctx).get_workflow_run({ run_id: 'run-missing' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('run-missing');
+	});
+
+	test('returns run with no currentStep when currentStepId is absent', async () => {
+		// Create a run directly in the DB without a currentStepId
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'NoStep WF');
+		const rawRun = ctx.workflowRunRepo.createRun({
+			spaceId: ctx.spaceId,
+			workflowId: wf.id,
+			title: 'no-step run',
+		});
+		// Leave currentStepId null (pending run — no step assigned)
+
+		const result = await makeHandlers(ctx).get_workflow_run({ run_id: rawRun.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.currentStep).toBeNull();
+		expect(parsed.tasks).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// change_plan
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — change_plan', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('updates description of an in-progress run', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Desc WF');
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'run',
+			description: 'original desc',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: runId,
+			description: 'updated desc',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.run.description).toBe('updated desc');
+	});
+
+	test('switches workflow: cancels current run and starts new one', async () => {
+		const wf1 = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF One');
+		const wf2 = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Two');
+
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf1.id,
+			title: 'switch test',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: runId,
+			workflow_id: wf2.id,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.previousRunId).toBe(runId);
+		expect(parsed.run.workflowId).toBe(wf2.id);
+		expect(parsed.run.title).toBe('switch test');
+
+		// Old run should be cancelled
+		const oldRun = ctx.workflowRunRepo.getRun(runId);
+		expect(oldRun?.status).toBe('cancelled');
+	});
+
+	test('returns error when run not found', async () => {
+		const result = await makeHandlers(ctx).change_plan({ run_id: 'run-missing' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+	});
+
+	test('returns error when trying to change plan on completed run', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Done WF');
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'done run',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		// Mark as completed
+		ctx.workflowRunRepo.updateStatus(runId, 'completed');
+
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: runId,
+			description: 'new desc',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('completed');
+	});
+
+	test('returns error when neither description nor workflow_id provided', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Empty WF');
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'run',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		const result = await makeHandlers(ctx).change_plan({ run_id: runId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// list_tasks
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — list_tasks', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns all tasks when no filter applied', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'List WF');
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 1' });
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 2' });
 
-		await handlers.create_task({ title: 'Task 1', description: 'desc' });
-		await handlers.create_task({ title: 'Task 2', description: 'desc' });
-
-		const result = await handlers.list_tasks({});
+		const result = await makeHandlers(ctx).list_tasks({});
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 		expect(parsed.tasks).toHaveLength(2);
 	});
 
-	test('filters tasks by status', async () => {
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		// Create two tasks — both will be 'pending'
-		const r1 = await handlers.create_task({ title: 'T1', description: 'd' });
-		const p1 = JSON.parse(r1.content[0].text);
-		// Complete the first task via repo update directly
-		ctx.taskRepo.updateTask(p1.taskId, {
-			status: 'completed',
-			completedAt: Date.now(),
-		});
-
-		await handlers.create_task({ title: 'T2', description: 'd' });
-
-		const result = await handlers.list_tasks({ status: 'pending' });
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.tasks).toHaveLength(1);
-		expect(parsed.tasks[0].title).toBe('T2');
-	});
-
 	test('filters tasks by workflow_run_id', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Filter WF', [
-			'coding',
-		]);
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Filter WF');
 
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
+		const r1 = await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run A' });
+		const runId = JSON.parse(r1.content[0].text).run.id;
 
-		// Create a workflow run (produces 1 task)
-		const runResult = await handlers.start_workflow_run({
-			title: 'run for filter test',
-			workflow_id: wf.id,
-		});
-		const runParsed = JSON.parse(runResult.content[0].text);
-		const runId = runParsed.run.id;
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run B' });
 
-		// Create a standalone task
-		await handlers.create_task({ title: 'standalone', description: 'no run' });
-
-		// Filter by run ID
-		const result = await handlers.list_tasks({ workflow_run_id: runId });
+		const result = await makeHandlers(ctx).list_tasks({ workflow_run_id: runId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 		expect(parsed.tasks).toHaveLength(1);
 		expect(parsed.tasks[0].workflowRunId).toBe(runId);
 	});
-});
 
-describe('createSpaceAgentToolHandlers — list_workflow_runs', () => {
-	let ctx: TestCtx;
+	test('filters tasks by status', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Status WF');
 
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
+		const r1 = await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 1' });
+		const taskId = JSON.parse(r1.content[0].text).tasks[0].id;
 
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
+		await makeHandlers(ctx).start_workflow_run({ workflow_id: wf.id, title: 'run 2' });
 
-	test('returns all runs when no filter applied', async () => {
-		const wf = buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Run List WF',
-			['coding']
-		);
+		// Mark first task as completed
+		ctx.taskRepo.updateTask(taskId, { status: 'completed', completedAt: Date.now() });
 
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		await handlers.start_workflow_run({ title: 'run 1', workflow_id: wf.id });
-		await handlers.start_workflow_run({ title: 'run 2', workflow_id: wf.id });
-
-		const result = await handlers.list_workflow_runs({});
+		const result = await makeHandlers(ctx).list_tasks({ status: 'pending' });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		expect(parsed.runs).toHaveLength(2);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].status).toBe('pending');
 	});
 
-	test('filters runs by status', async () => {
-		const wf = buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Status Filter WF',
-			['coding']
-		);
-
-		const handlers = createSpaceAgentToolHandlers({
-			spaceId: ctx.spaceId,
-			runtime: ctx.runtime,
-			workflowManager: ctx.workflowManager,
-			taskRepo: ctx.taskRepo,
-			workflowRunRepo: ctx.workflowRunRepo,
-			taskManager: ctx.taskManager,
-		});
-
-		const r1 = await handlers.start_workflow_run({ title: 'run A', workflow_id: wf.id });
-		const runId = JSON.parse(r1.content[0].text).run.id;
-
-		await handlers.start_workflow_run({ title: 'run B', workflow_id: wf.id });
-
-		// Mark run A as cancelled
-		ctx.workflowRunRepo.updateStatus(runId, 'cancelled');
-
-		const result = await handlers.list_workflow_runs({ status: 'in_progress' });
+	test('returns empty list when no tasks exist', async () => {
+		const result = await makeHandlers(ctx).list_tasks({});
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		expect(parsed.runs).toHaveLength(1);
-		expect(parsed.runs[0].title).toBe('run B');
+		expect(parsed.tasks).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Unit tests for createSpaceAgentToolHandlers()
+ *
+ * Covers:
+ * - start_workflow_run: explicit workflowId, auto-select via tags, no match → error
+ * - create_task: creates standalone task (no workflowRunId)
+ * - list_workflows: returns space workflows
+ * - list_tasks: filter by status, workflowRunId
+ * - list_workflow_runs: filter by status
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import { createSpaceAgentToolHandlers } from '../../../src/lib/space/tools/space-agent-tools.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB + space setup helpers (same pattern as space-runtime.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-agent-tools',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgentRow(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	name: string,
+	role: string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, name, role, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Build a minimal linear workflow (single step — no transitions, immediately terminal)
+// ---------------------------------------------------------------------------
+
+function buildSingleStepWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string,
+	name: string,
+	tags: string[],
+	description = ''
+): SpaceWorkflow {
+	const stepId = `step-${Math.random().toString(36).slice(2)}`;
+	return workflowManager.createWorkflow({
+		spaceId,
+		name,
+		description,
+		steps: [{ id: stepId, name: 'Work', agentId }],
+		transitions: [],
+		startStepId: stepId,
+		rules: [],
+		tags,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Test context
+// ---------------------------------------------------------------------------
+
+interface TestCtx {
+	db: BunDatabase;
+	dir: string;
+	spaceId: string;
+	workspacePath: string;
+	agentId: string;
+	workflowManager: SpaceWorkflowManager;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
+	runtime: SpaceRuntime;
+}
+
+function makeCtx(): TestCtx {
+	const { db, dir } = makeDb();
+	const spaceId = 'space-tools-test';
+	const workspacePath = '/tmp/test-workspace';
+
+	seedSpaceRow(db, spaceId, workspacePath);
+
+	const agentId = 'agent-coder-1';
+	seedAgentRow(db, agentId, spaceId, 'Coder', 'coder');
+
+	const agentRepo = new SpaceAgentRepository(db);
+	const agentManager = new SpaceAgentManager(agentRepo);
+
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	// No agentLookup passed — same pattern as space-runtime.test.ts
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const spaceManager = new SpaceManager(db);
+
+	const runtime = new SpaceRuntime({
+		db,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+	});
+
+	const taskManager = new SpaceTaskManager(db, spaceId);
+
+	return {
+		db,
+		dir,
+		spaceId,
+		workspacePath,
+		agentId,
+		workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		taskManager,
+		runtime,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — start_workflow_run', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('explicit workflowId starts a run and returns tasks', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'My Workflow',
+			['coding']
+		);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.start_workflow_run({
+			title: 'Test run',
+			description: 'desc',
+			workflow_id: wf.id,
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.run).toBeDefined();
+		expect(parsed.run.workflowId).toBe(wf.id);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.selectedWorkflowId).toBe(wf.id);
+	});
+
+	test('auto-selects workflow via tag match when no workflowId provided', async () => {
+		const wfCoding = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Coding Workflow',
+			['coding']
+		);
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Research Workflow', [
+			'research',
+		]);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.start_workflow_run({
+			title: 'implement coding feature',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.selectedWorkflowId).toBe(wfCoding.id);
+	});
+
+	test('returns error when no workflow matches and no workflowId provided', async () => {
+		// No workflows in space
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.start_workflow_run({
+			title: 'some task',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBeDefined();
+	});
+
+	test('returns error when explicit workflowId not found', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.start_workflow_run({
+			title: 'test',
+			workflow_id: 'wf-does-not-exist',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+	});
+
+	test('creates run record in DB with in_progress status', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'DB Run Workflow',
+			['coding']
+		);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		await handlers.start_workflow_run({ title: 'run title', workflow_id: wf.id });
+
+		const runs = ctx.workflowRunRepo.listBySpace(ctx.spaceId);
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe('in_progress');
+		expect(runs[0].title).toBe('run title');
+	});
+});
+
+describe('createSpaceAgentToolHandlers — create_task', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('creates a standalone task with no workflowRunId', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.create_task({
+			title: 'Standalone task',
+			description: 'Do something useful',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBeDefined();
+		expect(parsed.task.title).toBe('Standalone task');
+		expect(parsed.task.workflowRunId).toBeUndefined();
+	});
+
+	test('creates task with specified task_type', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.create_task({
+			title: 'Research task',
+			description: 'Research something',
+			task_type: 'research',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.taskType).toBe('research');
+	});
+
+	test('creates task with custom_agent_id', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.create_task({
+			title: 'Custom agent task',
+			description: 'Use custom agent',
+			custom_agent_id: ctx.agentId,
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe(ctx.agentId);
+	});
+
+	test('creates task with pending status by default', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.create_task({
+			title: 'Default status task',
+			description: 'Should be pending',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+	});
+});
+
+describe('createSpaceAgentToolHandlers — list_workflows', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns empty list when no workflows exist', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.list_workflows();
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflows).toEqual([]);
+	});
+
+	test('returns all workflows for the space', async () => {
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Alpha', ['alpha']);
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Beta', ['beta']);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const result = await handlers.list_workflows();
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflows).toHaveLength(2);
+	});
+});
+
+describe('createSpaceAgentToolHandlers — list_tasks', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns all tasks when no filter applied', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		await handlers.create_task({ title: 'Task 1', description: 'desc' });
+		await handlers.create_task({ title: 'Task 2', description: 'desc' });
+
+		const result = await handlers.list_tasks({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.tasks).toHaveLength(2);
+	});
+
+	test('filters tasks by status', async () => {
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		// Create two tasks — both will be 'pending'
+		const r1 = await handlers.create_task({ title: 'T1', description: 'd' });
+		const p1 = JSON.parse(r1.content[0].text);
+		// Complete the first task via repo update directly
+		ctx.taskRepo.updateTask(p1.taskId, {
+			status: 'completed',
+			completedAt: Date.now(),
+		});
+
+		await handlers.create_task({ title: 'T2', description: 'd' });
+
+		const result = await handlers.list_tasks({ status: 'pending' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].title).toBe('T2');
+	});
+
+	test('filters tasks by workflow_run_id', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Filter WF', [
+			'coding',
+		]);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		// Create a workflow run (produces 1 task)
+		const runResult = await handlers.start_workflow_run({
+			title: 'run for filter test',
+			workflow_id: wf.id,
+		});
+		const runParsed = JSON.parse(runResult.content[0].text);
+		const runId = runParsed.run.id;
+
+		// Create a standalone task
+		await handlers.create_task({ title: 'standalone', description: 'no run' });
+
+		// Filter by run ID
+		const result = await handlers.list_tasks({ workflow_run_id: runId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].workflowRunId).toBe(runId);
+	});
+});
+
+describe('createSpaceAgentToolHandlers — list_workflow_runs', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns all runs when no filter applied', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Run List WF',
+			['coding']
+		);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		await handlers.start_workflow_run({ title: 'run 1', workflow_id: wf.id });
+		await handlers.start_workflow_run({ title: 'run 2', workflow_id: wf.id });
+
+		const result = await handlers.list_workflow_runs({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.runs).toHaveLength(2);
+	});
+
+	test('filters runs by status', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Status Filter WF',
+			['coding']
+		);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+		});
+
+		const r1 = await handlers.start_workflow_run({ title: 'run A', workflow_id: wf.id });
+		const runId = JSON.parse(r1.content[0].text).run.id;
+
+		await handlers.start_workflow_run({ title: 'run B', workflow_id: wf.id });
+
+		// Mark run A as cancelled
+		ctx.workflowRunRepo.updateStatus(runId, 'cancelled');
+
+		const result = await handlers.list_workflow_runs({ status: 'in_progress' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.runs).toHaveLength(1);
+		expect(parsed.runs[0].title).toBe('run B');
+	});
+});

--- a/packages/daemon/tests/unit/space/workflow-selector.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-selector.test.ts
@@ -45,8 +45,6 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 function makeContext(overrides: Partial<WorkflowSelectionContext> = {}): WorkflowSelectionContext {
 	return {
 		spaceId: 'space-1',
-		title: '',
-		description: '',
 		availableWorkflows: [],
 		...overrides,
 	};
@@ -109,42 +107,22 @@ describe('selectWorkflow — explicit workflowId', () => {
 
 describe('selectWorkflow — no workflowId (LLM must pick)', () => {
 	test('returns null when no workflowId and no workflows', () => {
-		const ctx = makeContext({ title: 'do something', availableWorkflows: [] });
+		const ctx = makeContext({ availableWorkflows: [] });
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
 	test('returns null when no workflowId even if workflows are available', () => {
 		const wf = makeWorkflow({ id: 'wf-noworkflowid', tags: ['coding'] });
-		const ctx = makeContext({
-			title: 'implement coding feature',
-			description: 'write some code',
-			availableWorkflows: [wf],
-		});
-		// No workflowId → always null regardless of tags/description
+		const ctx = makeContext({ availableWorkflows: [wf] });
+		// No workflowId → always null (no server-side heuristics)
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
-	test('returns null when no workflowId and multiple workflows with matching names', () => {
-		const wf1 = makeWorkflow({ id: 'wf-nm1', name: 'Coding Workflow', tags: ['coding'] });
-		const wf2 = makeWorkflow({ id: 'wf-nm2', name: 'Research Workflow', tags: ['research'] });
-		const ctx = makeContext({
-			title: 'coding research task',
-			availableWorkflows: [wf1, wf2],
-		});
-		// Still null — no server-side heuristics
-		expect(selectWorkflow(ctx)).toBeNull();
-	});
-
-	test('returns null when no workflowId and workflow descriptions match input', () => {
-		const wf = makeWorkflow({
-			id: 'wf-desc-match',
-			description: 'implement a coding feature',
-		});
-		const ctx = makeContext({
-			title: 'implement a coding feature',
-			availableWorkflows: [wf],
-		});
-		// No keyword matching — return null
+	test('returns null when no workflowId and multiple workflows exist', () => {
+		const wf1 = makeWorkflow({ id: 'wf-nm1', name: 'Coding Workflow' });
+		const wf2 = makeWorkflow({ id: 'wf-nm2', name: 'Research Workflow' });
+		const ctx = makeContext({ availableWorkflows: [wf1, wf2] });
+		// Still null — LLM must choose
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 });

--- a/packages/daemon/tests/unit/space/workflow-selector.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-selector.test.ts
@@ -1,11 +1,11 @@
 /**
  * Unit tests for selectWorkflow()
  *
- * Covers all priority chain levels:
- *   1. Explicit workflowId → use it
- *   2. Tag-based matching
- *   3. Keyword/description matching
- *   4. Null fallback (no match)
+ * Per M7 spec: selection has two modes only:
+ *   1. Explicit workflowId provided → return that workflow (or null if not found)
+ *   2. No workflowId → return null (LLM agent must call list_workflows and pick explicitly)
+ *
+ * There are no heuristics (no tag matching, no keyword matching, no fallback selection).
  *
  * selectWorkflow() is a pure function: no DB, no managers.
  */
@@ -53,7 +53,7 @@ function makeContext(overrides: Partial<WorkflowSelectionContext> = {}): Workflo
 }
 
 // ---------------------------------------------------------------------------
-// Priority 1: Explicit workflowId
+// Explicit workflowId provided
 // ---------------------------------------------------------------------------
 
 describe('selectWorkflow — explicit workflowId', () => {
@@ -67,26 +67,15 @@ describe('selectWorkflow — explicit workflowId', () => {
 		expect(selectWorkflow(ctx)).toBe(wf1);
 	});
 
-	test('explicit wins over tag match', () => {
-		const wfTagMatch = makeWorkflow({ id: 'wf-tag', tags: ['coding'] });
-		const wfExplicit = makeWorkflow({ id: 'wf-explicit-3' });
+	test('returns the correct workflow when multiple are available', () => {
+		const wf1 = makeWorkflow({ id: 'wf-multi-1' });
+		const wf2 = makeWorkflow({ id: 'wf-multi-2' });
+		const wf3 = makeWorkflow({ id: 'wf-multi-3' });
 		const ctx = makeContext({
-			title: 'build a coding feature',
-			workflowId: 'wf-explicit-3',
-			availableWorkflows: [wfTagMatch, wfExplicit],
+			workflowId: 'wf-multi-3',
+			availableWorkflows: [wf1, wf2, wf3],
 		});
-		expect(selectWorkflow(ctx)).toBe(wfExplicit);
-	});
-
-	test('explicit wins over description keyword match', () => {
-		const wfDesc = makeWorkflow({ id: 'wf-desc', description: 'research and analyze data' });
-		const wfExplicit = makeWorkflow({ id: 'wf-explicit-4' });
-		const ctx = makeContext({
-			title: 'research and analyze data',
-			workflowId: 'wf-explicit-4',
-			availableWorkflows: [wfDesc, wfExplicit],
-		});
-		expect(selectWorkflow(ctx)).toBe(wfExplicit);
+		expect(selectWorkflow(ctx)).toBe(wf3);
 	});
 
 	test('returns null when explicit id not found in availableWorkflows', () => {
@@ -98,224 +87,64 @@ describe('selectWorkflow — explicit workflowId', () => {
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
-	test('does NOT fall through to heuristics when explicit id is not found', () => {
-		// Even if a tag would have matched, explicit missing → null (not fallthrough)
-		const wfTag = makeWorkflow({ id: 'wf-tag2', tags: ['coding'] });
+	test('returns null when explicit id not found and list is empty', () => {
 		const ctx = makeContext({
-			title: 'coding task',
-			workflowId: 'wf-does-not-exist',
-			availableWorkflows: [wfTag],
+			workflowId: 'wf-missing',
+			availableWorkflows: [],
 		});
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
-});
 
-// ---------------------------------------------------------------------------
-// Priority 2: Tag-based matching
-// ---------------------------------------------------------------------------
-
-describe('selectWorkflow — tag matching', () => {
-	test('matches a workflow whose tags include a keyword from title', () => {
-		const wfCoding = makeWorkflow({ id: 'wf-coding', tags: ['coding', 'default'] });
-		const wfResearch = makeWorkflow({ id: 'wf-research', tags: ['research'] });
-		const ctx = makeContext({
-			title: 'implement a coding feature',
-			availableWorkflows: [wfCoding, wfResearch],
-		});
-		expect(selectWorkflow(ctx)).toBe(wfCoding);
-	});
-
-	test('matches a workflow whose tags include a keyword from description', () => {
-		const wfResearch = makeWorkflow({ id: 'wf-research2', tags: ['research'] });
-		const wfCoding = makeWorkflow({ id: 'wf-coding2', tags: ['coding'] });
-		const ctx = makeContext({
-			title: 'new initiative',
-			description: 'we need to research the market',
-			availableWorkflows: [wfCoding, wfResearch],
-		});
-		expect(selectWorkflow(ctx)).toBe(wfResearch);
-	});
-
-	test('picks the workflow with most tag matches', () => {
-		const wfA = makeWorkflow({ id: 'wf-a', tags: ['coding'] });
-		const wfB = makeWorkflow({ id: 'wf-b', tags: ['coding', 'review'] });
-		const ctx = makeContext({
-			title: 'code review needed',
-			description: 'coding and review',
-			availableWorkflows: [wfA, wfB],
-		});
-		// wfB matches both 'coding' and 'review' keywords
-		expect(selectWorkflow(ctx)).toBe(wfB);
-	});
-
-	test('tag matching is case-insensitive', () => {
-		const wf = makeWorkflow({ id: 'wf-ci', tags: ['CODING'] });
-		const ctx = makeContext({
-			title: 'coding task',
-			availableWorkflows: [wf],
-		});
-		expect(selectWorkflow(ctx)).toBe(wf);
-	});
-
-	test('skips workflows with empty tags for tag matching', () => {
-		const wfNoTags = makeWorkflow({ id: 'wf-notags', tags: [] });
-		const wfWithTags = makeWorkflow({ id: 'wf-withtags', tags: ['coding'] });
-		const ctx = makeContext({
-			title: 'coding task',
-			availableWorkflows: [wfNoTags, wfWithTags],
-		});
-		expect(selectWorkflow(ctx)).toBe(wfWithTags);
+	test('is deterministic — same input always returns same output', () => {
+		const wf1 = makeWorkflow({ id: 'wf-det-1' });
+		const wf2 = makeWorkflow({ id: 'wf-det-2' });
+		const ctx = makeContext({ workflowId: 'wf-det-1', availableWorkflows: [wf1, wf2] });
+		expect(selectWorkflow(ctx)).toBe(selectWorkflow(ctx));
 	});
 });
 
 // ---------------------------------------------------------------------------
-// Priority 3: Description keyword matching
+// No workflowId — always returns null (LLM must pick)
 // ---------------------------------------------------------------------------
 
-describe('selectWorkflow — description keyword matching', () => {
-	test('matches workflow whose description contains words from the input title', () => {
-		const wfResearch = makeWorkflow({
-			id: 'wf-res',
-			tags: [],
-			description: 'perform research and gather information',
-		});
-		const wfCoding = makeWorkflow({
-			id: 'wf-cod',
-			tags: [],
-			description: 'write and review code changes',
-		});
-		const ctx = makeContext({
-			title: 'need to gather research information',
-			availableWorkflows: [wfCoding, wfResearch],
-		});
-		// 'research', 'gather', 'information' appear in wfResearch description
-		expect(selectWorkflow(ctx)).toBe(wfResearch);
-	});
-
-	test('picks the workflow with more description words matching the input', () => {
-		const wfA = makeWorkflow({
-			id: 'wf-kwa',
-			tags: [],
-			description: 'design user interface components',
-		});
-		const wfB = makeWorkflow({
-			id: 'wf-kwb',
-			tags: [],
-			description: 'design and prototype user interface layouts and components',
-		});
-		const ctx = makeContext({
-			title: 'design user interface and components',
-			availableWorkflows: [wfA, wfB],
-		});
-		// wfB has more overlapping words
-		expect(selectWorkflow(ctx)).toBe(wfB);
-	});
-
-	test('skips workflows with empty description', () => {
-		const wfEmpty = makeWorkflow({ id: 'wf-empty-desc', description: '', tags: [] });
-		const wfDesc = makeWorkflow({
-			id: 'wf-has-desc',
-			description: 'build and test features',
-			tags: [],
-		});
-		const ctx = makeContext({
-			title: 'build new features',
-			availableWorkflows: [wfEmpty, wfDesc],
-		});
-		expect(selectWorkflow(ctx)).toBe(wfDesc);
-	});
-
-	test('tag matching takes priority over description matching', () => {
-		const wfTagOnly = makeWorkflow({ id: 'wf-tag-only', tags: ['coding'], description: '' });
-		const wfDescOnly = makeWorkflow({
-			id: 'wf-desc-only',
-			tags: [],
-			description: 'implement code features for this project',
-		});
-		const ctx = makeContext({
-			title: 'implement coding features',
-			availableWorkflows: [wfDescOnly, wfTagOnly],
-		});
-		// Tag match should win over description match
-		expect(selectWorkflow(ctx)).toBe(wfTagOnly);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Priority 4: Null fallback
-// ---------------------------------------------------------------------------
-
-describe('selectWorkflow — null fallback', () => {
-	test('returns null when no workflows are available', () => {
+describe('selectWorkflow — no workflowId (LLM must pick)', () => {
+	test('returns null when no workflowId and no workflows', () => {
 		const ctx = makeContext({ title: 'do something', availableWorkflows: [] });
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
-	test('returns null when no workflow tags or descriptions match', () => {
-		const wf = makeWorkflow({
-			id: 'wf-nomatch',
-			tags: ['xyz'],
-			description: 'completely unrelated',
-		});
+	test('returns null when no workflowId even if workflows are available', () => {
+		const wf = makeWorkflow({ id: 'wf-noworkflowid', tags: ['coding'] });
 		const ctx = makeContext({
-			title: 'aardvark quantum physics',
-			description: 'something with no overlap',
+			title: 'implement coding feature',
+			description: 'write some code',
 			availableWorkflows: [wf],
 		});
-		// 'aardvark' and 'quantum' don't appear in tags or description words
-		// 'something' may match 'something' but let's use truly unrelated words
-		// Actually 'unrelated', 'completely' might match from description — let's use safer input
-		const ctx2 = makeContext({
-			title: 'zymurgy nomenclature',
-			description: 'foobarbaz quux',
-			availableWorkflows: [wf],
-		});
-		expect(selectWorkflow(ctx2)).toBeNull();
+		// No workflowId → always null regardless of tags/description
+		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
-	test('returns null when all workflows have no tags and no descriptions', () => {
-		const wf1 = makeWorkflow({ id: 'wf-bare1', tags: [], description: '' });
-		const wf2 = makeWorkflow({ id: 'wf-bare2', tags: [], description: '' });
+	test('returns null when no workflowId and multiple workflows with matching names', () => {
+		const wf1 = makeWorkflow({ id: 'wf-nm1', name: 'Coding Workflow', tags: ['coding'] });
+		const wf2 = makeWorkflow({ id: 'wf-nm2', name: 'Research Workflow', tags: ['research'] });
 		const ctx = makeContext({
-			title: 'any title',
-			description: 'any description',
+			title: 'coding research task',
 			availableWorkflows: [wf1, wf2],
 		});
-		expect(selectWorkflow(ctx)).toBeNull();
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Edge cases
-// ---------------------------------------------------------------------------
-
-describe('selectWorkflow — edge cases', () => {
-	test('handles empty title and description with tag match', () => {
-		const wf = makeWorkflow({ id: 'wf-emptyinput', tags: ['default'] });
-		const ctx = makeContext({ title: '', description: '', availableWorkflows: [wf] });
-		// No keywords → no tag match
+		// Still null — no server-side heuristics
 		expect(selectWorkflow(ctx)).toBeNull();
 	});
 
-	test('handles single character words (filtered out)', () => {
-		const wf = makeWorkflow({ id: 'wf-shortwords', tags: ['a', 'b', 'coding'] });
+	test('returns null when no workflowId and workflow descriptions match input', () => {
+		const wf = makeWorkflow({
+			id: 'wf-desc-match',
+			description: 'implement a coding feature',
+		});
 		const ctx = makeContext({
-			title: 'a b coding',
+			title: 'implement a coding feature',
 			availableWorkflows: [wf],
 		});
-		// 'a' and 'b' are 1 char (filtered), 'coding' is 6 chars → matches
-		expect(selectWorkflow(ctx)).toBe(wf);
-	});
-
-	test('is deterministic — same input always returns same output', () => {
-		const workflows = [
-			makeWorkflow({ id: 'wf-det1', tags: ['alpha'] }),
-			makeWorkflow({ id: 'wf-det2', tags: ['beta', 'coding'] }),
-			makeWorkflow({ id: 'wf-det3', tags: ['coding'] }),
-		];
-		const ctx = makeContext({ title: 'alpha beta coding', availableWorkflows: workflows });
-		const first = selectWorkflow(ctx);
-		const second = selectWorkflow(ctx);
-		expect(first).toBe(second);
+		// No keyword matching — return null
+		expect(selectWorkflow(ctx)).toBeNull();
 	});
 });

--- a/packages/daemon/tests/unit/space/workflow-selector.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-selector.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for selectWorkflow()
+ *
+ * Covers all priority chain levels:
+ *   1. Explicit workflowId → use it
+ *   2. Tag-based matching
+ *   3. Keyword/description matching
+ *   4. Null fallback (no match)
+ *
+ * selectWorkflow() is a pure function: no DB, no managers.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { selectWorkflow } from '../../../src/lib/space/runtime/workflow-selector.ts';
+import type { WorkflowSelectionContext } from '../../../src/lib/space/runtime/workflow-selector.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+function makeId(): string {
+	return `wf-${++idCounter}`;
+}
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	const id = makeId();
+	return {
+		id,
+		spaceId: 'space-1',
+		name: `Workflow ${id}`,
+		description: '',
+		steps: [],
+		transitions: [],
+		startStepId: 'step-1',
+		rules: [],
+		tags: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeContext(overrides: Partial<WorkflowSelectionContext> = {}): WorkflowSelectionContext {
+	return {
+		spaceId: 'space-1',
+		title: '',
+		description: '',
+		availableWorkflows: [],
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Priority 1: Explicit workflowId
+// ---------------------------------------------------------------------------
+
+describe('selectWorkflow — explicit workflowId', () => {
+	test('returns the workflow with the matching id', () => {
+		const wf1 = makeWorkflow({ id: 'wf-explicit-1' });
+		const wf2 = makeWorkflow({ id: 'wf-explicit-2' });
+		const ctx = makeContext({
+			workflowId: 'wf-explicit-1',
+			availableWorkflows: [wf1, wf2],
+		});
+		expect(selectWorkflow(ctx)).toBe(wf1);
+	});
+
+	test('explicit wins over tag match', () => {
+		const wfTagMatch = makeWorkflow({ id: 'wf-tag', tags: ['coding'] });
+		const wfExplicit = makeWorkflow({ id: 'wf-explicit-3' });
+		const ctx = makeContext({
+			title: 'build a coding feature',
+			workflowId: 'wf-explicit-3',
+			availableWorkflows: [wfTagMatch, wfExplicit],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfExplicit);
+	});
+
+	test('explicit wins over description keyword match', () => {
+		const wfDesc = makeWorkflow({ id: 'wf-desc', description: 'research and analyze data' });
+		const wfExplicit = makeWorkflow({ id: 'wf-explicit-4' });
+		const ctx = makeContext({
+			title: 'research and analyze data',
+			workflowId: 'wf-explicit-4',
+			availableWorkflows: [wfDesc, wfExplicit],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfExplicit);
+	});
+
+	test('returns null when explicit id not found in availableWorkflows', () => {
+		const wf = makeWorkflow({ id: 'wf-other' });
+		const ctx = makeContext({
+			workflowId: 'wf-missing',
+			availableWorkflows: [wf],
+		});
+		expect(selectWorkflow(ctx)).toBeNull();
+	});
+
+	test('does NOT fall through to heuristics when explicit id is not found', () => {
+		// Even if a tag would have matched, explicit missing → null (not fallthrough)
+		const wfTag = makeWorkflow({ id: 'wf-tag2', tags: ['coding'] });
+		const ctx = makeContext({
+			title: 'coding task',
+			workflowId: 'wf-does-not-exist',
+			availableWorkflows: [wfTag],
+		});
+		expect(selectWorkflow(ctx)).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Priority 2: Tag-based matching
+// ---------------------------------------------------------------------------
+
+describe('selectWorkflow — tag matching', () => {
+	test('matches a workflow whose tags include a keyword from title', () => {
+		const wfCoding = makeWorkflow({ id: 'wf-coding', tags: ['coding', 'default'] });
+		const wfResearch = makeWorkflow({ id: 'wf-research', tags: ['research'] });
+		const ctx = makeContext({
+			title: 'implement a coding feature',
+			availableWorkflows: [wfCoding, wfResearch],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfCoding);
+	});
+
+	test('matches a workflow whose tags include a keyword from description', () => {
+		const wfResearch = makeWorkflow({ id: 'wf-research2', tags: ['research'] });
+		const wfCoding = makeWorkflow({ id: 'wf-coding2', tags: ['coding'] });
+		const ctx = makeContext({
+			title: 'new initiative',
+			description: 'we need to research the market',
+			availableWorkflows: [wfCoding, wfResearch],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfResearch);
+	});
+
+	test('picks the workflow with most tag matches', () => {
+		const wfA = makeWorkflow({ id: 'wf-a', tags: ['coding'] });
+		const wfB = makeWorkflow({ id: 'wf-b', tags: ['coding', 'review'] });
+		const ctx = makeContext({
+			title: 'code review needed',
+			description: 'coding and review',
+			availableWorkflows: [wfA, wfB],
+		});
+		// wfB matches both 'coding' and 'review' keywords
+		expect(selectWorkflow(ctx)).toBe(wfB);
+	});
+
+	test('tag matching is case-insensitive', () => {
+		const wf = makeWorkflow({ id: 'wf-ci', tags: ['CODING'] });
+		const ctx = makeContext({
+			title: 'coding task',
+			availableWorkflows: [wf],
+		});
+		expect(selectWorkflow(ctx)).toBe(wf);
+	});
+
+	test('skips workflows with empty tags for tag matching', () => {
+		const wfNoTags = makeWorkflow({ id: 'wf-notags', tags: [] });
+		const wfWithTags = makeWorkflow({ id: 'wf-withtags', tags: ['coding'] });
+		const ctx = makeContext({
+			title: 'coding task',
+			availableWorkflows: [wfNoTags, wfWithTags],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfWithTags);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Priority 3: Description keyword matching
+// ---------------------------------------------------------------------------
+
+describe('selectWorkflow — description keyword matching', () => {
+	test('matches workflow whose description contains words from the input title', () => {
+		const wfResearch = makeWorkflow({
+			id: 'wf-res',
+			tags: [],
+			description: 'perform research and gather information',
+		});
+		const wfCoding = makeWorkflow({
+			id: 'wf-cod',
+			tags: [],
+			description: 'write and review code changes',
+		});
+		const ctx = makeContext({
+			title: 'need to gather research information',
+			availableWorkflows: [wfCoding, wfResearch],
+		});
+		// 'research', 'gather', 'information' appear in wfResearch description
+		expect(selectWorkflow(ctx)).toBe(wfResearch);
+	});
+
+	test('picks the workflow with more description words matching the input', () => {
+		const wfA = makeWorkflow({
+			id: 'wf-kwa',
+			tags: [],
+			description: 'design user interface components',
+		});
+		const wfB = makeWorkflow({
+			id: 'wf-kwb',
+			tags: [],
+			description: 'design and prototype user interface layouts and components',
+		});
+		const ctx = makeContext({
+			title: 'design user interface and components',
+			availableWorkflows: [wfA, wfB],
+		});
+		// wfB has more overlapping words
+		expect(selectWorkflow(ctx)).toBe(wfB);
+	});
+
+	test('skips workflows with empty description', () => {
+		const wfEmpty = makeWorkflow({ id: 'wf-empty-desc', description: '', tags: [] });
+		const wfDesc = makeWorkflow({
+			id: 'wf-has-desc',
+			description: 'build and test features',
+			tags: [],
+		});
+		const ctx = makeContext({
+			title: 'build new features',
+			availableWorkflows: [wfEmpty, wfDesc],
+		});
+		expect(selectWorkflow(ctx)).toBe(wfDesc);
+	});
+
+	test('tag matching takes priority over description matching', () => {
+		const wfTagOnly = makeWorkflow({ id: 'wf-tag-only', tags: ['coding'], description: '' });
+		const wfDescOnly = makeWorkflow({
+			id: 'wf-desc-only',
+			tags: [],
+			description: 'implement code features for this project',
+		});
+		const ctx = makeContext({
+			title: 'implement coding features',
+			availableWorkflows: [wfDescOnly, wfTagOnly],
+		});
+		// Tag match should win over description match
+		expect(selectWorkflow(ctx)).toBe(wfTagOnly);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Priority 4: Null fallback
+// ---------------------------------------------------------------------------
+
+describe('selectWorkflow — null fallback', () => {
+	test('returns null when no workflows are available', () => {
+		const ctx = makeContext({ title: 'do something', availableWorkflows: [] });
+		expect(selectWorkflow(ctx)).toBeNull();
+	});
+
+	test('returns null when no workflow tags or descriptions match', () => {
+		const wf = makeWorkflow({
+			id: 'wf-nomatch',
+			tags: ['xyz'],
+			description: 'completely unrelated',
+		});
+		const ctx = makeContext({
+			title: 'aardvark quantum physics',
+			description: 'something with no overlap',
+			availableWorkflows: [wf],
+		});
+		// 'aardvark' and 'quantum' don't appear in tags or description words
+		// 'something' may match 'something' but let's use truly unrelated words
+		// Actually 'unrelated', 'completely' might match from description — let's use safer input
+		const ctx2 = makeContext({
+			title: 'zymurgy nomenclature',
+			description: 'foobarbaz quux',
+			availableWorkflows: [wf],
+		});
+		expect(selectWorkflow(ctx2)).toBeNull();
+	});
+
+	test('returns null when all workflows have no tags and no descriptions', () => {
+		const wf1 = makeWorkflow({ id: 'wf-bare1', tags: [], description: '' });
+		const wf2 = makeWorkflow({ id: 'wf-bare2', tags: [], description: '' });
+		const ctx = makeContext({
+			title: 'any title',
+			description: 'any description',
+			availableWorkflows: [wf1, wf2],
+		});
+		expect(selectWorkflow(ctx)).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('selectWorkflow — edge cases', () => {
+	test('handles empty title and description with tag match', () => {
+		const wf = makeWorkflow({ id: 'wf-emptyinput', tags: ['default'] });
+		const ctx = makeContext({ title: '', description: '', availableWorkflows: [wf] });
+		// No keywords → no tag match
+		expect(selectWorkflow(ctx)).toBeNull();
+	});
+
+	test('handles single character words (filtered out)', () => {
+		const wf = makeWorkflow({ id: 'wf-shortwords', tags: ['a', 'b', 'coding'] });
+		const ctx = makeContext({
+			title: 'a b coding',
+			availableWorkflows: [wf],
+		});
+		// 'a' and 'b' are 1 char (filtered), 'coding' is 6 chars → matches
+		expect(selectWorkflow(ctx)).toBe(wf);
+	});
+
+	test('is deterministic — same input always returns same output', () => {
+		const workflows = [
+			makeWorkflow({ id: 'wf-det1', tags: ['alpha'] }),
+			makeWorkflow({ id: 'wf-det2', tags: ['beta', 'coding'] }),
+			makeWorkflow({ id: 'wf-det3', tags: ['coding'] }),
+		];
+		const ctx = makeContext({ title: 'alpha beta coding', availableWorkflows: workflows });
+		const first = selectWorkflow(ctx);
+		const second = selectWorkflow(ctx);
+		expect(first).toBe(second);
+	});
+});


### PR DESCRIPTION
- Add selectWorkflow() pure deterministic function in workflow-selector.ts
  with 4-level priority chain: explicit ID → tag matching → keyword/description
  matching → null fallback
- Add resolveWorkflowForRun() integration point in SpaceRuntime that delegates
  to selectWorkflow() with space workflows loaded from DB
- New space-agent-tools.ts with 5 MCP tools: start_workflow_run (auto-selects
  workflow via selectWorkflow when no explicit ID given), create_task, list_workflows,
  list_tasks (filterable by status/workflowRunId), list_workflow_runs
- Export new modules from space/index.ts
- 36 unit tests covering all selection priority levels and all tool handlers
