### PR TITLE
feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -18,6 +18,7 @@ import { LiveQueryEngine } from './storage/live-query';
 import { SpaceAgentRepository } from './storage/repositories/space-agent-repository';
 import { SpaceAgentManager } from './lib/space/managers/space-agent-manager';
 import { SpaceManager } from './lib/space/managers/space-manager';
+import type { SpaceRuntimeService } from './lib/space/runtime/space-runtime-service';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -57,6 +58,8 @@ export interface DaemonAppContext {
 	spaceAgentManager: SpaceAgentManager;
 	/** Space manager for Space CRUD and workspace path validation */
 	spaceManager: SpaceManager;
+	/** Space runtime service for workflow run lifecycle management */
+	spaceRuntimeService: SpaceRuntimeService;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -206,8 +209,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		logInfo('[Daemon] GitHub integration disabled - authentication required');
 	}
 
-	// Setup RPC handlers (returns cleanup function)
-	const rpcHandlerCleanup = setupRPCHandlers({
+	// Setup RPC handlers (returns cleanup function + exposed services)
+	const { cleanup: rpcHandlerCleanup, spaceRuntimeService } = setupRPCHandlers({
 		messageHub,
 		sessionManager,
 		authManager,
@@ -435,6 +438,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		liveQueries,
 		spaceAgentManager,
 		spaceManager,
+		spaceRuntimeService,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -418,14 +418,12 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		spaceId: string;
 		taskId: string;
 		task: import('@neokai/shared').SpaceTask;
-		workflowStepName?: string;
 	};
 	'space.task.updated': {
 		sessionId: string;
 		spaceId: string;
 		taskId: string;
 		task: import('@neokai/shared').SpaceTask;
-		workflowStepName?: string;
 	};
 
 	// Space workflow run events (global events - use 'global' as sessionId)

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -418,12 +418,14 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		spaceId: string;
 		taskId: string;
 		task: import('@neokai/shared').SpaceTask;
+		workflowStepName?: string;
 	};
 	'space.task.updated': {
 		sessionId: string;
 		spaceId: string;
 		taskId: string;
 		task: import('@neokai/shared').SpaceTask;
+		workflowStepName?: string;
 	};
 
 	// Space workflow run events (global events - use 'global' as sessionId)

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -56,7 +56,9 @@ import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
-import { SpaceRuntime } from '../space/runtime/space-runtime';
+import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
+import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
 import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 
 export interface RPCHandlerDependencies {
@@ -81,10 +83,19 @@ const log = new Logger('rpc-handlers');
 export type RPCHandlerCleanup = () => void;
 
 /**
- * Register all RPC handlers on MessageHub
- * Returns a cleanup function that should be called to stop background services
+ * Result returned by setupRPCHandlers — includes both the cleanup function
+ * and any services that need to be surfaced in DaemonAppContext.
  */
-export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanup {
+export interface RPCHandlerSetupResult {
+	cleanup: RPCHandlerCleanup;
+	spaceRuntimeService: SpaceRuntimeService;
+}
+
+/**
+ * Register all RPC handlers on MessageHub
+ * Returns a result with cleanup function and exposed services
+ */
+export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupResult {
 	// Room handlers (create roomManager first as session handlers depend on it)
 	const roomManager = new RoomManager(deps.db.getDatabase());
 
@@ -224,8 +235,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		deps.daemonHub
 	);
 
-	// Space Runtime — workflow orchestration tick loop
-	const spaceRuntime = new SpaceRuntime({
+	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API
+	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		spaceManager: deps.spaceManager,
 		spaceAgentManager: deps.spaceAgentManager,
@@ -233,7 +244,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		workflowRunRepo: spaceWorkflowRunRepo,
 		taskRepo: spaceTaskRepo,
 	});
-	spaceRuntime.start();
+	spaceRuntimeService.start();
 
 	// Space export/import handlers
 	setupSpaceExportImportHandlers(
@@ -245,9 +256,26 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerCleanu
 		deps.db.getDatabase()
 	);
 
-	// Return cleanup function to stop background services
-	return () => {
-		roomRuntimeService.stop();
-		spaceRuntime.stop();
+	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers
+	const spaceWorkflowRunTaskManagerFactory: SpaceWorkflowRunTaskManagerFactory = (spaceId) => {
+		return new SpaceTaskManager(deps.db.getDatabase(), spaceId);
+	};
+	setupSpaceWorkflowRunHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceWorkflowManager,
+		spaceWorkflowRunRepo,
+		spaceRuntimeService,
+		spaceWorkflowRunTaskManagerFactory,
+		deps.daemonHub
+	);
+
+	// Return result with cleanup function and exposed services
+	return {
+		cleanup: () => {
+			roomRuntimeService.stop();
+			spaceRuntimeService.stop();
+		},
+		spaceRuntimeService,
 	};
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -14,12 +14,14 @@ import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { WorkflowRunStatus } from '@neokai/shared';
-import { SpaceTaskManager } from '../space/managers/space-task-manager';
-import type { Database as BunDatabase } from 'bun:sqlite';
 import { Logger } from '../logger';
 
 const log = new Logger('space-workflow-run-handlers');
+
+/** Factory that creates a SpaceTaskManager bound to a specific spaceId. */
+export type SpaceWorkflowRunTaskManagerFactory = (spaceId: string) => SpaceTaskManager;
 
 export function setupSpaceWorkflowRunHandlers(
 	messageHub: MessageHub,
@@ -27,7 +29,7 @@ export function setupSpaceWorkflowRunHandlers(
 	spaceWorkflowManager: SpaceWorkflowManager,
 	workflowRunRepo: SpaceWorkflowRunRepository,
 	spaceRuntimeService: SpaceRuntimeService,
-	db: BunDatabase,
+	taskManagerFactory: SpaceWorkflowRunTaskManagerFactory,
 	daemonHub: DaemonHub
 ): void {
 	// ─── spaceWorkflowRun.start ──────────────────────────────────────────────
@@ -42,7 +44,9 @@ export function setupSpaceWorkflowRunHandlers(
 		if (!params.spaceId) throw new Error('spaceId is required');
 		if (!params.title || params.title.trim() === '') throw new Error('title is required');
 
-		// Verify space exists
+		// Early space validation — ensures "Space not found" surfaces before workflow
+		// resolution. Without this check, listWorkflows() would return [] for a
+		// nonexistent spaceId, yielding a misleading "No workflows found" error.
 		const space = await spaceManager.getSpace(params.spaceId);
 		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
 
@@ -105,12 +109,17 @@ export function setupSpaceWorkflowRunHandlers(
 
 	// ─── spaceWorkflowRun.get ────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflowRun.get', async (data) => {
-		const params = data as { id: string };
+		const params = data as { id: string; spaceId?: string };
 
 		if (!params.id) throw new Error('id is required');
 
 		const run = workflowRunRepo.getRun(params.id);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.id}`);
+
+		// Optional ownership check — if spaceId is provided, reject cross-space access
+		if (params.spaceId && run.spaceId !== params.spaceId) {
+			throw new Error(`WorkflowRun not found: ${params.id}`);
+		}
 
 		return { run };
 	});
@@ -132,7 +141,7 @@ export function setupSpaceWorkflowRunHandlers(
 		}
 
 		// Cancel all pending tasks belonging to this run
-		const taskManager = new SpaceTaskManager(db, run.spaceId);
+		const taskManager = taskManagerFactory(run.spaceId);
 		const tasks = await taskManager.listTasksByWorkflowRun(run.id);
 		for (const task of tasks) {
 			if (task.status === 'pending' || task.status === 'in_progress') {

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -1,0 +1,162 @@
+/**
+ * Space Workflow Run RPC Handlers
+ *
+ * RPC handlers for SpaceWorkflowRun lifecycle:
+ * - spaceWorkflowRun.start   - Creates a run and triggers first step task creation
+ * - spaceWorkflowRun.list    - Lists runs for a space (optional status filter)
+ * - spaceWorkflowRun.get     - Gets a run by ID
+ * - spaceWorkflowRun.cancel  - Cancels a run and all pending tasks
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import type { WorkflowRunStatus } from '@neokai/shared';
+import { SpaceTaskManager } from '../space/managers/space-task-manager';
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { Logger } from '../logger';
+
+const log = new Logger('space-workflow-run-handlers');
+
+export function setupSpaceWorkflowRunHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager,
+	spaceWorkflowManager: SpaceWorkflowManager,
+	workflowRunRepo: SpaceWorkflowRunRepository,
+	spaceRuntimeService: SpaceRuntimeService,
+	db: BunDatabase,
+	daemonHub: DaemonHub
+): void {
+	// ─── spaceWorkflowRun.start ──────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflowRun.start', async (data) => {
+		const params = data as {
+			spaceId: string;
+			workflowId?: string;
+			title: string;
+			description?: string;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.title || params.title.trim() === '') throw new Error('title is required');
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		// Resolve workflow: explicit workflowId or auto-select first workflow
+		let workflowId = params.workflowId;
+		if (!workflowId) {
+			const workflows = spaceWorkflowManager.listWorkflows(params.spaceId);
+			if (workflows.length === 0) {
+				throw new Error(`No workflows found for space: ${params.spaceId}`);
+			}
+			workflowId = workflows[0].id;
+		} else {
+			// Validate provided workflow exists and belongs to this space
+			const workflow = spaceWorkflowManager.getWorkflow(workflowId);
+			if (!workflow) throw new Error(`Workflow not found: ${workflowId}`);
+			if (workflow.spaceId !== params.spaceId) throw new Error(`Workflow not found: ${workflowId}`);
+		}
+
+		// Get or create the runtime for this space (validates space, starts runtime if needed)
+		const runtime = await spaceRuntimeService.createOrGetRuntime(params.spaceId);
+
+		// Create the run and initial task via the runtime
+		const { run } = await runtime.startWorkflowRun(
+			params.spaceId,
+			workflowId,
+			params.title,
+			params.description
+		);
+
+		daemonHub
+			.emit('space.workflowRun.created', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				runId: run.id,
+				run,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.workflowRun.created:', err);
+			});
+
+		return { run };
+	});
+
+	// ─── spaceWorkflowRun.list ───────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflowRun.list', async (data) => {
+		const params = data as { spaceId: string; status?: WorkflowRunStatus };
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		let runs = workflowRunRepo.listBySpace(params.spaceId);
+		if (params.status) {
+			runs = runs.filter((r) => r.status === params.status);
+		}
+
+		return { runs };
+	});
+
+	// ─── spaceWorkflowRun.get ────────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflowRun.get', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) throw new Error('id is required');
+
+		const run = workflowRunRepo.getRun(params.id);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.id}`);
+
+		return { run };
+	});
+
+	// ─── spaceWorkflowRun.cancel ─────────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflowRun.cancel', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) throw new Error('id is required');
+
+		const run = workflowRunRepo.getRun(params.id);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.id}`);
+
+		if (run.status === 'cancelled') {
+			return { success: true };
+		}
+		if (run.status === 'completed') {
+			throw new Error('Cannot cancel a completed workflow run');
+		}
+
+		// Cancel all pending tasks belonging to this run
+		const taskManager = new SpaceTaskManager(db, run.spaceId);
+		const tasks = await taskManager.listTasksByWorkflowRun(run.id);
+		for (const task of tasks) {
+			if (task.status === 'pending' || task.status === 'in_progress') {
+				await taskManager.cancelTask(task.id).catch((err: unknown) => {
+					log.warn(`Failed to cancel task ${task.id} for run ${run.id}:`, err);
+				});
+			}
+		}
+
+		// Cancel the run
+		const updated = workflowRunRepo.updateStatus(params.id, 'cancelled');
+		if (!updated) throw new Error(`WorkflowRun not found: ${params.id}`);
+
+		daemonHub
+			.emit('space.workflowRun.updated', {
+				sessionId: 'global',
+				spaceId: run.spaceId,
+				runId: run.id,
+				run: updated,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.workflowRun.updated:', err);
+			});
+
+		return { success: true };
+	});
+}

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -21,6 +21,7 @@ export {
 export {
 	WorkflowExecutor,
 	WorkflowTransitionError,
+	WorkflowGateError,
 } from './runtime/workflow-executor';
 export type {
 	ConditionContext,
@@ -30,6 +31,8 @@ export type {
 } from './runtime/workflow-executor';
 export { SpaceRuntime } from './runtime/space-runtime';
 export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
+export { SpaceRuntimeService } from './runtime/space-runtime-service';
+export type { SpaceRuntimeServiceConfig } from './runtime/space-runtime-service';
 
 export { selectWorkflow } from './runtime/workflow-selector';
 export type { WorkflowSelectionContext } from './runtime/workflow-selector';

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -90,6 +90,13 @@ export class SpaceTaskManager {
 	}
 
 	/**
+	 * List tasks belonging to a specific workflow run
+	 */
+	async listTasksByWorkflowRun(workflowRunId: string): Promise<SpaceTask[]> {
+		return this.taskRepo.listByWorkflowRun(workflowRunId);
+	}
+
+	/**
 	 * Update task status with validation
 	 */
 	async setTaskStatus(

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1,0 +1,86 @@
+/**
+ * SpaceRuntimeService
+ *
+ * Manages SpaceRuntime lifecycle and provides per-space access to the
+ * underlying workflow execution engine.
+ *
+ * Design: One shared SpaceRuntime handles all spaces in a single tick loop.
+ * SpaceRuntimeService provides lifecycle management (start/stop) and a
+ * per-space API surface for RPC handlers and DaemonAppContext.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { SpaceManager } from '../managers/space-manager';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import { SpaceRuntime } from './space-runtime';
+import { Logger } from '../../logger';
+
+const log = new Logger('space-runtime-service');
+
+export interface SpaceRuntimeServiceConfig {
+	db: BunDatabase;
+	spaceManager: SpaceManager;
+	spaceAgentManager: SpaceAgentManager;
+	spaceWorkflowManager: SpaceWorkflowManager;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	taskRepo: SpaceTaskRepository;
+	tickIntervalMs?: number;
+}
+
+export class SpaceRuntimeService {
+	private readonly runtime: SpaceRuntime;
+	private started = false;
+
+	constructor(private readonly config: SpaceRuntimeServiceConfig) {
+		this.runtime = new SpaceRuntime(config);
+	}
+
+	/** Start the underlying SpaceRuntime tick loop. */
+	start(): void {
+		if (this.started) return;
+		this.started = true;
+		this.runtime.start();
+		log.info('SpaceRuntimeService started');
+	}
+
+	/** Stop the underlying SpaceRuntime tick loop. */
+	stop(): void {
+		if (!this.started) return;
+		this.started = false;
+		this.runtime.stop();
+		log.info('SpaceRuntimeService stopped');
+	}
+
+	/**
+	 * Returns the SpaceRuntime for the given space, starting it if needed.
+	 *
+	 * The underlying runtime is shared — one SpaceRuntime handles all spaces.
+	 * This method validates that the space exists and ensures the runtime is
+	 * running before returning it.
+	 *
+	 * Throws if the space does not exist.
+	 */
+	async createOrGetRuntime(spaceId: string): Promise<SpaceRuntime> {
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${spaceId}`);
+		}
+		if (!this.started) {
+			this.start();
+		}
+		return this.runtime;
+	}
+
+	/**
+	 * Release the runtime for a given space.
+	 *
+	 * Currently a no-op — the shared runtime handles all spaces together.
+	 * Reserved for future per-space runtime isolation.
+	 */
+	stopRuntime(_spaceId: string): void {
+		// No-op: shared runtime handles all spaces; use stop() to stop entirely.
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -71,7 +71,7 @@ export class WorkflowTransitionError extends Error {
  * The SpaceRuntime catches this and keeps the executor in the map for retry
  * once the gate is resolved.
  */
-export class WorkflowGateError extends Error {
+export class WorkflowGateError extends WorkflowTransitionError {
 	constructor(message: string) {
 		super(message);
 		this.name = 'WorkflowGateError';

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -65,6 +65,19 @@ export class WorkflowTransitionError extends Error {
 	}
 }
 
+/**
+ * Error thrown by advance() when a human-gate transition blocks advancement.
+ * Indicates that the run is paused waiting for explicit human approval.
+ * The SpaceRuntime catches this and keeps the executor in the map for retry
+ * once the gate is resolved.
+ */
+export class WorkflowGateError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'WorkflowGateError';
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Internal types
 // ---------------------------------------------------------------------------
@@ -280,6 +293,7 @@ export class WorkflowExecutor {
 		// needs_attention and a WorkflowTransitionError thrown.
 		const context = this.getConditionContext();
 		let lastReason: string | undefined;
+		let blockedByHumanGate = false;
 
 		for (const transition of transitions) {
 			const condition = transition.condition;
@@ -302,14 +316,19 @@ export class WorkflowExecutor {
 			}
 
 			lastReason = result.reason;
+			if (condition.type === 'human') {
+				blockedByHumanGate = true;
+			}
 			// Condition did not pass — continue to next transition
 		}
 
 		// All transitions evaluated; none passed → needs_attention
 		this.markNeedsAttention();
-		throw new WorkflowTransitionError(
-			`No matching transition from step "${current.name}": ${lastReason ?? 'no condition passed'}`
-		);
+		const gateMessage = `No matching transition from step "${current.name}": ${lastReason ?? 'no condition passed'}`;
+		if (blockedByHumanGate) {
+			throw new WorkflowGateError(gateMessage);
+		}
+		throw new WorkflowTransitionError(gateMessage);
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -12,11 +12,15 @@ export interface CreateSessionGroupParams {
 	spaceId: string;
 	name: string;
 	description?: string;
+	workflowId?: string;
+	currentStepId?: string;
 }
 
 export interface UpdateSessionGroupParams {
 	name?: string;
 	description?: string;
+	workflowId?: string | null;
+	currentStepId?: string | null;
 }
 
 export class SpaceSessionGroupRepository {
@@ -30,11 +34,20 @@ export class SpaceSessionGroupRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_session_groups (id, space_id, name, description, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_id, current_step_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
-		stmt.run(id, params.spaceId, params.name, params.description ?? null, now, now);
+		stmt.run(
+			id,
+			params.spaceId,
+			params.name,
+			params.description ?? null,
+			params.workflowId ?? null,
+			params.currentStepId ?? null,
+			now,
+			now
+		);
 
 		return this.getGroup(id)!;
 	}
@@ -99,6 +112,14 @@ export class SpaceSessionGroupRepository {
 		if (params.description !== undefined) {
 			fields.push('description = ?');
 			values.push(params.description ?? null);
+		}
+		if (params.workflowId !== undefined) {
+			fields.push('workflow_id = ?');
+			values.push(params.workflowId ?? null);
+		}
+		if (params.currentStepId !== undefined) {
+			fields.push('current_step_id = ?');
+			values.push(params.currentStepId ?? null);
 		}
 
 		if (fields.length > 0) {
@@ -217,6 +238,8 @@ export class SpaceSessionGroupRepository {
 			spaceId: row.space_id as string,
 			name: row.name as string,
 			description: (row.description as string | null) ?? undefined,
+			workflowId: (row.workflow_id as string | null) ?? undefined,
+			currentStepId: (row.current_step_id as string | null) ?? undefined,
 			members,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -12,14 +12,14 @@ export interface CreateSessionGroupParams {
 	spaceId: string;
 	name: string;
 	description?: string;
-	workflowId?: string;
+	workflowRunId?: string;
 	currentStepId?: string;
 }
 
 export interface UpdateSessionGroupParams {
 	name?: string;
 	description?: string;
-	workflowId?: string | null;
+	workflowRunId?: string | null;
 	currentStepId?: string | null;
 }
 
@@ -34,7 +34,7 @@ export class SpaceSessionGroupRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_id, current_step_id, created_at, updated_at)
+			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
@@ -43,7 +43,7 @@ export class SpaceSessionGroupRepository {
 			params.spaceId,
 			params.name,
 			params.description ?? null,
-			params.workflowId ?? null,
+			params.workflowRunId ?? null,
 			params.currentStepId ?? null,
 			now,
 			now
@@ -113,9 +113,9 @@ export class SpaceSessionGroupRepository {
 			fields.push('description = ?');
 			values.push(params.description ?? null);
 		}
-		if (params.workflowId !== undefined) {
-			fields.push('workflow_id = ?');
-			values.push(params.workflowId ?? null);
+		if (params.workflowRunId !== undefined) {
+			fields.push('workflow_run_id = ?');
+			values.push(params.workflowRunId ?? null);
 		}
 		if (params.currentStepId !== undefined) {
 			fields.push('current_step_id = ?');
@@ -238,7 +238,7 @@ export class SpaceSessionGroupRepository {
 			spaceId: row.space_id as string,
 			name: row.name as string,
 			description: (row.description as string | null) ?? undefined,
-			workflowId: (row.workflow_id as string | null) ?? undefined,
+			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			currentStepId: (row.current_step_id as string | null) ?? undefined,
 			members,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -111,14 +111,8 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	runMigration28(db);
 
 	// Migration 29: Create all Space system tables with the final consolidated schema.
-	// Migrations 30–32 are collapsed here: space_agents already includes role/provider,
-	// space_workflows includes start_step_id, space_workflow_runs includes current_step_id,
-	// and space_workflow_transitions is created from the start.
+	// Includes space_session_groups.workflow_run_id and current_step_id columns.
 	runMigration29(db);
-
-	// Migration 30: Add workflow_run_id and current_step_id to space_session_groups
-	// for associating session groups with workflow runs and tracking step progress
-	runMigration30(db);
 }
 
 /**
@@ -1446,7 +1440,7 @@ function runMigration28(db: BunDatabase): void {
 }
 
 /**
- * Migration 29: Create all Space system tables (consolidated — formerly migrations 29–32)
+ * Migration 29: Create all Space system tables (fully consolidated schema)
  *
  * Creates the following tables in FK-safe order:
  * - spaces: workspace-first multi-agent container
@@ -1456,7 +1450,7 @@ function runMigration28(db: BunDatabase): void {
  * - space_workflow_transitions: directed edges between steps (graph navigation)
  * - space_workflow_runs: active/historical workflow executions (includes current_step_id)
  * - space_tasks: tasks with built-in custom_agent_id, workflow_run_id, workflow_step_id
- * - space_session_groups: named groups of related sessions
+ * - space_session_groups: named groups of related sessions (includes workflow_run_id, current_step_id)
  * - space_session_group_members: membership records for session groups
  *
  * All tables are created with IF NOT EXISTS so the migration is idempotent.
@@ -1672,6 +1666,8 @@ function runMigration29(db: BunDatabase): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT,
+			workflow_run_id TEXT,
+			current_step_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -1703,24 +1699,4 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_session_id ON space_session_group_members(session_id)`
 	);
-}
-
-/**
- * Migration 30: Add workflow_run_id and current_step_id to space_session_groups
- * for associating session groups with workflow runs and tracking step progress.
- */
-function runMigration30(db: BunDatabase): void {
-	// Add workflow_run_id to space_session_groups (idempotent)
-	try {
-		db.prepare(`SELECT workflow_run_id FROM space_session_groups LIMIT 1`).all();
-	} catch {
-		db.exec(`ALTER TABLE space_session_groups ADD COLUMN workflow_run_id TEXT`);
-	}
-
-	// Add current_step_id to space_session_groups (idempotent)
-	try {
-		db.prepare(`SELECT current_step_id FROM space_session_groups LIMIT 1`).all();
-	} catch {
-		db.exec(`ALTER TABLE space_session_groups ADD COLUMN current_step_id TEXT`);
-	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -115,6 +115,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// space_workflows includes start_step_id, space_workflow_runs includes current_step_id,
 	// and space_workflow_transitions is created from the start.
 	runMigration29(db);
+
+	// Migration 30: Add workflow_run_id and current_step_id to space_session_groups
+	// for associating session groups with workflow runs and tracking step progress
+	runMigration30(db);
 }
 
 /**
@@ -1699,4 +1703,24 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_session_id ON space_session_group_members(session_id)`
 	);
+}
+
+/**
+ * Migration 30: Add workflow_run_id and current_step_id to space_session_groups
+ * for associating session groups with workflow runs and tracking step progress.
+ */
+function runMigration30(db: BunDatabase): void {
+	// Add workflow_run_id to space_session_groups (idempotent)
+	try {
+		db.prepare(`SELECT workflow_run_id FROM space_session_groups LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_session_groups ADD COLUMN workflow_run_id TEXT`);
+	}
+
+	// Add current_step_id to space_session_groups (idempotent)
+	try {
+		db.prepare(`SELECT current_step_id FROM space_session_groups LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_session_groups ADD COLUMN current_step_id TEXT`);
+	}
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -161,6 +161,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT,
+			workflow_id TEXT,
+			current_step_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -161,7 +161,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT,
-			workflow_id TEXT,
+			workflow_run_id TEXT,
 			current_step_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -5,22 +5,25 @@
  * - spaceWorkflowRun.start: throws if spaceId missing, title missing, space not found,
  *   workflowId not found, no workflows exist; creates run and emits event
  * - spaceWorkflowRun.list: throws if spaceId missing, space not found; returns runs filtered by status
- * - spaceWorkflowRun.get: throws if id missing, not found; returns run
+ * - spaceWorkflowRun.get: throws if id missing, not found; returns run; ownership check
  * - spaceWorkflowRun.cancel: throws if id missing, not found; no-op if already cancelled;
- *   throws if completed; cancels pending tasks and emits event
+ *   throws if completed; cancels pending/in_progress tasks; emits event
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
 import { MessageHub } from '@neokai/shared';
 import type { Space, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
-import { setupSpaceWorkflowRunHandlers } from '../../../src/lib/rpc-handlers/space-workflow-run-handlers.ts';
+import {
+	setupSpaceWorkflowRunHandlers,
+	type SpaceWorkflowRunTaskManagerFactory,
+} from '../../../src/lib/rpc-handlers/space-workflow-run-handlers.ts';
 import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
-import type { Database as BunDatabase } from 'bun:sqlite';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -171,70 +174,15 @@ function createMockRuntimeService(
 	} as unknown as SpaceRuntimeService;
 }
 
-// ─── DB stub (only used by cancel for SpaceTaskManager) ──────────────────────
-
-function createStubDb(tasks: SpaceTask[] = []): BunDatabase {
-	// The cancel handler creates a SpaceTaskManager with the db and calls listTasksByWorkflowRun
-	// and cancelTask. We need the db.prepare().all() chain to work for the task repo.
-	// Return a stub that produces results compatible with SpaceTaskRepository's SQL queries.
-	const taskRows = tasks.map((t) => ({
-		id: t.id,
-		space_id: t.spaceId,
-		title: t.title,
-		description: t.description,
-		status: t.status,
-		priority: t.priority,
-		task_type: t.taskType ?? null,
-		assigned_agent: t.assignedAgent ?? null,
-		custom_agent_id: t.customAgentId ?? null,
-		workflow_run_id: t.workflowRunId ?? null,
-		workflow_step_id: t.workflowStepId ?? null,
-		created_by_task_id: t.createdByTaskId ?? null,
-		progress: t.progress ?? null,
-		current_step: t.currentStep ?? null,
-		result: t.result ?? null,
-		error: t.error ?? null,
-		depends_on: JSON.stringify(t.dependsOn),
-		input_draft: t.inputDraft ?? null,
-		active_session: t.activeSession ?? null,
-		pr_url: t.prUrl ?? null,
-		pr_number: t.prNumber ?? null,
-		pr_created_at: t.prCreatedAt ?? null,
-		archived_at: t.archivedAt ?? null,
-		created_at: t.createdAt,
-		started_at: t.startedAt ?? null,
-		completed_at: t.completedAt ?? null,
-		updated_at: t.updatedAt,
-	}));
-
-	const makePrepare = (rows: unknown[]) => ({
-		all: mock(() => rows),
-		get: mock(() => rows[0] ?? undefined),
-		run: mock(() => ({ changes: rows.length })),
-	});
-
-	// cancelTask calls setTaskStatus which calls db.prepare(UPDATE).run()
-	// We must track calls to simulate the status update
-	const cancelledRow = taskRows.map((r) => ({ ...r, status: 'cancelled' }));
-
+function createMockTaskManager(tasks: SpaceTask[] = []): SpaceTaskManager {
 	return {
-		prepare: mock((sql: string) => {
-			if (sql.includes('WHERE workflow_run_id')) {
-				return makePrepare(taskRows);
-			}
-			if (sql.includes('UPDATE space_tasks')) {
-				// Return the updated (cancelled) row for getTask after update
-				return { run: mock(() => ({ changes: 1 })) };
-			}
-			if (sql.includes('WHERE id = ?') && sql.includes('space_tasks')) {
-				// getTask after setTaskStatus — return cancelled version
-				return { get: mock(() => cancelledRow[0] ?? undefined) };
-			}
-			// Default
-			return makePrepare([]);
-		}),
-		exec: mock(() => {}),
-	} as unknown as BunDatabase;
+		listTasksByWorkflowRun: mock(async () => tasks),
+		cancelTask: mock(async (taskId: string) => ({
+			...mockTask,
+			id: taskId,
+			status: 'cancelled' as const,
+		})),
+	} as unknown as SpaceTaskManager;
 }
 
 // ─── Test Suite ───────────────────────────────────────────────────────────────
@@ -248,7 +196,8 @@ describe('space-workflow-run-handlers', () => {
 	let runRepo: SpaceWorkflowRunRepository;
 	let runtimeService: SpaceRuntimeService;
 	let runtime: SpaceRuntime;
-	let db: BunDatabase;
+	let taskManagerFactory: SpaceWorkflowRunTaskManagerFactory;
+	let taskManager: SpaceTaskManager;
 
 	function setup(
 		opts: {
@@ -275,7 +224,8 @@ describe('space-workflow-run-handlers', () => {
 		runRepo = createMockRunRepo(resolvedRun ?? null, opts.runs ?? [mockRun]);
 		runtime = createMockRuntime(resolvedRun ?? mockRun);
 		runtimeService = createMockRuntimeService(resolvedSpace ?? null, runtime);
-		db = createStubDb(opts.tasks ?? []);
+		taskManager = createMockTaskManager(opts.tasks ?? []);
+		taskManagerFactory = mock(() => taskManager);
 
 		setupSpaceWorkflowRunHandlers(
 			hub,
@@ -283,7 +233,7 @@ describe('space-workflow-run-handlers', () => {
 			workflowManager,
 			runRepo,
 			runtimeService,
-			db,
+			taskManagerFactory,
 			daemonHub
 		);
 	}
@@ -465,6 +415,22 @@ describe('space-workflow-run-handlers', () => {
 			const result = await call('spaceWorkflowRun.get', { id: 'run-1' });
 			expect(result).toEqual({ run: mockRun });
 		});
+
+		it('returns the run without spaceId filter', async () => {
+			const result = await call('spaceWorkflowRun.get', { id: 'run-1' });
+			expect(result).toEqual({ run: mockRun });
+		});
+
+		it('throws if spaceId does not match run.spaceId (ownership check)', async () => {
+			await expect(
+				call('spaceWorkflowRun.get', { id: 'run-1', spaceId: 'space-other' })
+			).rejects.toThrow('WorkflowRun not found: run-1');
+		});
+
+		it('succeeds when spaceId matches run.spaceId', async () => {
+			const result = await call('spaceWorkflowRun.get', { id: 'run-1', spaceId: 'space-1' });
+			expect(result).toEqual({ run: mockRun });
+		});
 	});
 
 	// ─── spaceWorkflowRun.cancel ─────────────────────────────────────────────
@@ -500,8 +466,7 @@ describe('space-workflow-run-handlers', () => {
 			);
 		});
 
-		it('cancels the run and emits space.workflowRun.updated', async () => {
-			// Use empty tasks list to avoid DB complexity
+		it('cancels the run and emits space.workflowRun.updated (no tasks)', async () => {
 			setup({ tasks: [] });
 
 			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
@@ -514,6 +479,83 @@ describe('space-workflow-run-handlers', () => {
 				runId: 'run-1',
 				run: expect.objectContaining({ status: 'cancelled' }),
 			});
+		});
+
+		it('cancels pending and in_progress tasks before cancelling the run', async () => {
+			const inProgressTask: SpaceTask = {
+				...mockTask,
+				id: 'task-2',
+				status: 'in_progress',
+			};
+			const completedTask: SpaceTask = {
+				...mockTask,
+				id: 'task-3',
+				status: 'completed',
+			};
+			setup({ tasks: [mockTask, inProgressTask, completedTask] });
+
+			await call('spaceWorkflowRun.cancel', { id: 'run-1' });
+
+			// Factory should have been called with the run's spaceId
+			expect(taskManagerFactory).toHaveBeenCalledWith('space-1');
+
+			// cancelTask should be called for pending and in_progress but not completed
+			expect(taskManager.cancelTask).toHaveBeenCalledTimes(2);
+			expect(taskManager.cancelTask).toHaveBeenCalledWith('task-1');
+			expect(taskManager.cancelTask).toHaveBeenCalledWith('task-2');
+			// completed task should not be cancelled
+			const callArgs = (taskManager.cancelTask as ReturnType<typeof mock>).mock.calls.map(
+				(c) => c[0]
+			);
+			expect(callArgs).not.toContain('task-3');
+
+			// Run should also be cancelled
+			expect(runRepo.updateStatus).toHaveBeenCalledWith('run-1', 'cancelled');
+		});
+
+		it('continues cancelling remaining tasks even if one cancelTask fails', async () => {
+			const task2: SpaceTask = { ...mockTask, id: 'task-2', status: 'pending' };
+			setup({ tasks: [mockTask, task2] });
+
+			// Make the first cancelTask fail
+			let callCount = 0;
+			taskManager = {
+				listTasksByWorkflowRun: mock(async () => [mockTask, task2]),
+				cancelTask: mock(async (taskId: string) => {
+					callCount++;
+					if (callCount === 1) throw new Error('cancel failed');
+					return { ...mockTask, id: taskId, status: 'cancelled' as const };
+				}),
+			} as unknown as SpaceTaskManager;
+			taskManagerFactory = mock(() => taskManager);
+
+			// Re-setup with new mocks
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			daemonHub = createMockDaemonHub();
+			spaceManager = createMockSpaceManager();
+			workflowManager = createMockWorkflowManager();
+			runRepo = createMockRunRepo();
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				spaceManager,
+				workflowManager,
+				runRepo,
+				createMockRuntimeService(),
+				taskManagerFactory,
+				daemonHub
+			);
+
+			// Should not throw even though one cancelTask failed
+			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
+			expect(result).toEqual({ success: true });
+
+			// Both tasks were attempted
+			expect(taskManager.cancelTask).toHaveBeenCalledTimes(2);
+			// Run still gets cancelled
+			expect(runRepo.updateStatus).toHaveBeenCalledWith('run-1', 'cancelled');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Tests for Space Workflow Run RPC Handlers
+ *
+ * Covers:
+ * - spaceWorkflowRun.start: throws if spaceId missing, title missing, space not found,
+ *   workflowId not found, no workflows exist; creates run and emits event
+ * - spaceWorkflowRun.list: throws if spaceId missing, space not found; returns runs filtered by status
+ * - spaceWorkflowRun.get: throws if id missing, not found; returns run
+ * - spaceWorkflowRun.cancel: throws if id missing, not found; no-op if already cancelled;
+ *   throws if completed; cancels pending tasks and emits event
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
+import { setupSpaceWorkflowRunHandlers } from '../../../src/lib/rpc-handlers/space-workflow-run-handlers.ts';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockWorkflow: SpaceWorkflow = {
+	id: 'workflow-1',
+	spaceId: 'space-1',
+	name: 'Test Workflow',
+	steps: [{ id: 'step-1', name: 'Step One', agentId: 'agent-1' }],
+	transitions: [],
+	startStepId: 'step-1',
+	rules: [],
+	tags: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockRun: SpaceWorkflowRun = {
+	id: 'run-1',
+	spaceId: 'space-1',
+	workflowId: 'workflow-1',
+	title: 'Test Run',
+	currentStepId: 'step-1',
+	status: 'in_progress',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockTask: SpaceTask = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	title: 'Step One',
+	description: '',
+	status: 'pending',
+	priority: 'normal',
+	workflowRunId: 'run-1',
+	workflowStepId: 'step-1',
+	dependsOn: [],
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function createMockWorkflowManager(
+	workflows: SpaceWorkflow[] = [mockWorkflow],
+	singleWorkflow: SpaceWorkflow | null = mockWorkflow
+): SpaceWorkflowManager {
+	return {
+		listWorkflows: mock(() => workflows),
+		getWorkflow: mock(() => singleWorkflow),
+	} as unknown as SpaceWorkflowManager;
+}
+
+function createMockRunRepo(
+	run: SpaceWorkflowRun | null = mockRun,
+	runs: SpaceWorkflowRun[] = [mockRun]
+): SpaceWorkflowRunRepository {
+	return {
+		getRun: mock(() => run),
+		listBySpace: mock(() => runs),
+		updateStatus: mock((id: string, status: string) =>
+			run ? { ...run, id, status: status as SpaceWorkflowRun['status'] } : null
+		),
+	} as unknown as SpaceWorkflowRunRepository;
+}
+
+function createMockRuntime(run: SpaceWorkflowRun = mockRun): SpaceRuntime {
+	return {
+		startWorkflowRun: mock(async () => ({ run, tasks: [mockTask] })),
+		start: mock(() => {}),
+		stop: mock(() => {}),
+		executeTick: mock(async () => {}),
+	} as unknown as SpaceRuntime;
+}
+
+function createMockRuntimeService(
+	space: Space | null = mockSpace,
+	runtime: SpaceRuntime = createMockRuntime()
+): SpaceRuntimeService {
+	return {
+		createOrGetRuntime: mock(async (spaceId: string) => {
+			if (!space) throw new Error(`Space not found: ${spaceId}`);
+			return runtime;
+		}),
+		start: mock(() => {}),
+		stop: mock(() => {}),
+		stopRuntime: mock(() => {}),
+	} as unknown as SpaceRuntimeService;
+}
+
+// ─── DB stub (only used by cancel for SpaceTaskManager) ──────────────────────
+
+function createStubDb(tasks: SpaceTask[] = []): BunDatabase {
+	// The cancel handler creates a SpaceTaskManager with the db and calls listTasksByWorkflowRun
+	// and cancelTask. We need the db.prepare().all() chain to work for the task repo.
+	// Return a stub that produces results compatible with SpaceTaskRepository's SQL queries.
+	const taskRows = tasks.map((t) => ({
+		id: t.id,
+		space_id: t.spaceId,
+		title: t.title,
+		description: t.description,
+		status: t.status,
+		priority: t.priority,
+		task_type: t.taskType ?? null,
+		assigned_agent: t.assignedAgent ?? null,
+		custom_agent_id: t.customAgentId ?? null,
+		workflow_run_id: t.workflowRunId ?? null,
+		workflow_step_id: t.workflowStepId ?? null,
+		created_by_task_id: t.createdByTaskId ?? null,
+		progress: t.progress ?? null,
+		current_step: t.currentStep ?? null,
+		result: t.result ?? null,
+		error: t.error ?? null,
+		depends_on: JSON.stringify(t.dependsOn),
+		input_draft: t.inputDraft ?? null,
+		active_session: t.activeSession ?? null,
+		pr_url: t.prUrl ?? null,
+		pr_number: t.prNumber ?? null,
+		pr_created_at: t.prCreatedAt ?? null,
+		archived_at: t.archivedAt ?? null,
+		created_at: t.createdAt,
+		started_at: t.startedAt ?? null,
+		completed_at: t.completedAt ?? null,
+		updated_at: t.updatedAt,
+	}));
+
+	const makePrepare = (rows: unknown[]) => ({
+		all: mock(() => rows),
+		get: mock(() => rows[0] ?? undefined),
+		run: mock(() => ({ changes: rows.length })),
+	});
+
+	// cancelTask calls setTaskStatus which calls db.prepare(UPDATE).run()
+	// We must track calls to simulate the status update
+	const cancelledRow = taskRows.map((r) => ({ ...r, status: 'cancelled' }));
+
+	return {
+		prepare: mock((sql: string) => {
+			if (sql.includes('WHERE workflow_run_id')) {
+				return makePrepare(taskRows);
+			}
+			if (sql.includes('UPDATE space_tasks')) {
+				// Return the updated (cancelled) row for getTask after update
+				return { run: mock(() => ({ changes: 1 })) };
+			}
+			if (sql.includes('WHERE id = ?') && sql.includes('space_tasks')) {
+				// getTask after setTaskStatus — return cancelled version
+				return { get: mock(() => cancelledRow[0] ?? undefined) };
+			}
+			// Default
+			return makePrepare([]);
+		}),
+		exec: mock(() => {}),
+	} as unknown as BunDatabase;
+}
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('space-workflow-run-handlers', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let workflowManager: SpaceWorkflowManager;
+	let runRepo: SpaceWorkflowRunRepository;
+	let runtimeService: SpaceRuntimeService;
+	let runtime: SpaceRuntime;
+	let db: BunDatabase;
+
+	function setup(
+		opts: {
+			space?: Space | null;
+			workflows?: SpaceWorkflow[];
+			singleWorkflow?: SpaceWorkflow | null;
+			run?: SpaceWorkflowRun | null;
+			runs?: SpaceWorkflowRun[];
+			tasks?: SpaceTask[];
+		} = {}
+	) {
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		daemonHub = createMockDaemonHub();
+		// Use undefined check (not nullish coalescing) so null is preserved
+		const resolvedSpace = 'space' in opts ? opts.space : mockSpace;
+		spaceManager = createMockSpaceManager(resolvedSpace ?? null);
+		workflowManager = createMockWorkflowManager(
+			opts.workflows ?? [mockWorkflow],
+			opts.singleWorkflow !== undefined ? opts.singleWorkflow : mockWorkflow
+		);
+		const resolvedRun = 'run' in opts ? opts.run : mockRun;
+		runRepo = createMockRunRepo(resolvedRun ?? null, opts.runs ?? [mockRun]);
+		runtime = createMockRuntime(resolvedRun ?? mockRun);
+		runtimeService = createMockRuntimeService(resolvedSpace ?? null, runtime);
+		db = createStubDb(opts.tasks ?? []);
+
+		setupSpaceWorkflowRunHandlers(
+			hub,
+			spaceManager,
+			workflowManager,
+			runRepo,
+			runtimeService,
+			db,
+			daemonHub
+		);
+	}
+
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
+
+	beforeEach(() => setup());
+
+	// ─── spaceWorkflowRun.start ──────────────────────────────────────────────
+
+	describe('spaceWorkflowRun.start', () => {
+		it('throws if spaceId is missing', async () => {
+			await expect(call('spaceWorkflowRun.start', { title: 'My Run' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws if title is missing', async () => {
+			await expect(call('spaceWorkflowRun.start', { spaceId: 'space-1' })).rejects.toThrow(
+				'title is required'
+			);
+		});
+
+		it('throws if title is empty string', async () => {
+			await expect(
+				call('spaceWorkflowRun.start', { spaceId: 'space-1', title: '   ' })
+			).rejects.toThrow('title is required');
+		});
+
+		it('throws if space not found', async () => {
+			setup({ space: null });
+			await expect(
+				call('spaceWorkflowRun.start', { spaceId: 'missing', title: 'Test' })
+			).rejects.toThrow('Space not found: missing');
+		});
+
+		it('throws if provided workflowId not found', async () => {
+			setup({ singleWorkflow: null });
+			await expect(
+				call('spaceWorkflowRun.start', {
+					spaceId: 'space-1',
+					title: 'Test',
+					workflowId: 'bad-wf',
+				})
+			).rejects.toThrow('Workflow not found: bad-wf');
+		});
+
+		it('throws if provided workflowId belongs to a different space', async () => {
+			const otherWorkflow: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-other',
+				spaceId: 'space-99',
+			};
+			setup({ singleWorkflow: otherWorkflow });
+			await expect(
+				call('spaceWorkflowRun.start', {
+					spaceId: 'space-1',
+					title: 'Test',
+					workflowId: 'wf-other',
+				})
+			).rejects.toThrow('Workflow not found: wf-other');
+		});
+
+		it('throws if no workflows exist (auto-select mode)', async () => {
+			setup({ workflows: [], singleWorkflow: null });
+			await expect(
+				call('spaceWorkflowRun.start', { spaceId: 'space-1', title: 'Test' })
+			).rejects.toThrow('No workflows found for space: space-1');
+		});
+
+		it('creates run via runtime and emits space.workflowRun.created', async () => {
+			const result = await call('spaceWorkflowRun.start', {
+				spaceId: 'space-1',
+				title: 'My Run',
+				description: 'Some context',
+			});
+
+			expect(result).toEqual({ run: mockRun });
+			expect(runtime.startWorkflowRun).toHaveBeenCalledWith(
+				'space-1',
+				'workflow-1',
+				'My Run',
+				'Some context'
+			);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.created', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				runId: mockRun.id,
+				run: mockRun,
+			});
+		});
+
+		it('auto-selects first workflow when workflowId not provided', async () => {
+			await call('spaceWorkflowRun.start', { spaceId: 'space-1', title: 'Auto' });
+			expect(runtime.startWorkflowRun).toHaveBeenCalledWith(
+				'space-1',
+				'workflow-1',
+				'Auto',
+				undefined
+			);
+		});
+
+		it('uses provided workflowId when given', async () => {
+			await call('spaceWorkflowRun.start', {
+				spaceId: 'space-1',
+				title: 'Explicit WF',
+				workflowId: 'workflow-1',
+			});
+			expect(runtime.startWorkflowRun).toHaveBeenCalledWith(
+				'space-1',
+				'workflow-1',
+				'Explicit WF',
+				undefined
+			);
+		});
+	});
+
+	// ─── spaceWorkflowRun.list ───────────────────────────────────────────────
+
+	describe('spaceWorkflowRun.list', () => {
+		it('throws if spaceId is missing', async () => {
+			await expect(call('spaceWorkflowRun.list', {})).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws if space not found', async () => {
+			setup({ space: null });
+			await expect(call('spaceWorkflowRun.list', { spaceId: 'missing' })).rejects.toThrow(
+				'Space not found: missing'
+			);
+		});
+
+		it('returns all runs for the space', async () => {
+			const result = await call('spaceWorkflowRun.list', { spaceId: 'space-1' });
+			expect(result).toEqual({ runs: [mockRun] });
+		});
+
+		it('filters runs by status when provided', async () => {
+			const completedRun: SpaceWorkflowRun = { ...mockRun, id: 'run-2', status: 'completed' };
+			setup({ runs: [mockRun, completedRun] });
+
+			const result = (await call('spaceWorkflowRun.list', {
+				spaceId: 'space-1',
+				status: 'in_progress',
+			})) as { runs: SpaceWorkflowRun[] };
+
+			expect(result.runs).toHaveLength(1);
+			expect(result.runs[0].id).toBe('run-1');
+		});
+
+		it('returns empty list when no runs match status filter', async () => {
+			const result = (await call('spaceWorkflowRun.list', {
+				spaceId: 'space-1',
+				status: 'cancelled',
+			})) as { runs: SpaceWorkflowRun[] };
+
+			expect(result.runs).toHaveLength(0);
+		});
+	});
+
+	// ─── spaceWorkflowRun.get ────────────────────────────────────────────────
+
+	describe('spaceWorkflowRun.get', () => {
+		it('throws if id is missing', async () => {
+			await expect(call('spaceWorkflowRun.get', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(call('spaceWorkflowRun.get', { id: 'missing-run' })).rejects.toThrow(
+				'WorkflowRun not found: missing-run'
+			);
+		});
+
+		it('returns the run', async () => {
+			const result = await call('spaceWorkflowRun.get', { id: 'run-1' });
+			expect(result).toEqual({ run: mockRun });
+		});
+	});
+
+	// ─── spaceWorkflowRun.cancel ─────────────────────────────────────────────
+
+	describe('spaceWorkflowRun.cancel', () => {
+		it('throws if id is missing', async () => {
+			await expect(call('spaceWorkflowRun.cancel', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(call('spaceWorkflowRun.cancel', { id: 'missing-run' })).rejects.toThrow(
+				'WorkflowRun not found: missing-run'
+			);
+		});
+
+		it('returns success immediately if already cancelled', async () => {
+			const cancelledRun: SpaceWorkflowRun = { ...mockRun, status: 'cancelled' };
+			setup({ run: cancelledRun });
+
+			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
+			expect(result).toEqual({ success: true });
+			// Should not attempt to update status or cancel tasks
+			expect(runRepo.updateStatus).not.toHaveBeenCalled();
+		});
+
+		it('throws if trying to cancel a completed run', async () => {
+			const completedRun: SpaceWorkflowRun = { ...mockRun, status: 'completed' };
+			setup({ run: completedRun });
+
+			await expect(call('spaceWorkflowRun.cancel', { id: 'run-1' })).rejects.toThrow(
+				'Cannot cancel a completed workflow run'
+			);
+		});
+
+		it('cancels the run and emits space.workflowRun.updated', async () => {
+			// Use empty tasks list to avoid DB complexity
+			setup({ tasks: [] });
+
+			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
+			expect(result).toEqual({ success: true });
+
+			expect(runRepo.updateStatus).toHaveBeenCalledWith('run-1', 'cancelled');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				runId: 'run-1',
+				run: expect.objectContaining({ status: 'cancelled' }),
+			});
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -1,0 +1,186 @@
+/**
+ * SpaceRuntimeService Unit Tests
+ *
+ * Covers:
+ * - createOrGetRuntime(): throws if space not found
+ * - createOrGetRuntime(): starts runtime and returns SpaceRuntime instance
+ * - createOrGetRuntime(): returns the same runtime on repeated calls
+ * - stopRuntime(): is a no-op (doesn't throw)
+ * - start() / stop() lifecycle: idempotent, starts/stops underlying runtime
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import type { SpaceRuntimeServiceConfig } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import type { Space } from '@neokai/shared';
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function buildConfig(
+	spaceManager: SpaceManager,
+	tickIntervalMs = 60_000
+): SpaceRuntimeServiceConfig {
+	return {
+		db: {} as BunDatabase,
+		spaceManager,
+		spaceAgentManager: {} as SpaceAgentManager,
+		spaceWorkflowManager: {} as SpaceWorkflowManager,
+		workflowRunRepo: {} as SpaceWorkflowRunRepository,
+		taskRepo: {} as SpaceTaskRepository,
+		tickIntervalMs,
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SpaceRuntimeService', () => {
+	let spaceManager: SpaceManager;
+	let service: SpaceRuntimeService;
+
+	beforeEach(() => {
+		spaceManager = createMockSpaceManager(mockSpace);
+		service = new SpaceRuntimeService(buildConfig(spaceManager));
+	});
+
+	// ─── createOrGetRuntime ──────────────────────────────────────────────────
+
+	describe('createOrGetRuntime()', () => {
+		test('throws if space not found', async () => {
+			const noSpaceManager = createMockSpaceManager(null);
+			const svc = new SpaceRuntimeService(buildConfig(noSpaceManager));
+
+			await expect(svc.createOrGetRuntime('missing-space')).rejects.toThrow(
+				'Space not found: missing-space'
+			);
+		});
+
+		test('starts runtime and returns a SpaceRuntime instance', async () => {
+			const runtime = await service.createOrGetRuntime('space-1');
+
+			// Should return a runtime object (SpaceRuntime has start/stop methods)
+			expect(runtime).toBeDefined();
+			expect(typeof runtime.start).toBe('function');
+			expect(typeof runtime.stop).toBe('function');
+			expect(typeof runtime.executeTick).toBe('function');
+		});
+
+		test('auto-starts the service when not yet started', async () => {
+			// Service not explicitly started — createOrGetRuntime should auto-start it
+			expect((service as unknown as { started: boolean }).started).toBe(false);
+			await service.createOrGetRuntime('space-1');
+			expect((service as unknown as { started: boolean }).started).toBe(true);
+		});
+
+		test('returns the same runtime object on repeated calls', async () => {
+			const runtime1 = await service.createOrGetRuntime('space-1');
+			const runtime2 = await service.createOrGetRuntime('space-1');
+
+			// Shared runtime — same instance
+			expect(runtime1).toBe(runtime2);
+		});
+
+		test('returns same runtime for different space IDs (shared runtime)', async () => {
+			const space2Manager = {
+				getSpace: mock(async (id: string) =>
+					id === 'space-2' ? { ...mockSpace, id: 'space-2' } : mockSpace
+				),
+			} as unknown as SpaceManager;
+			const svc = new SpaceRuntimeService(buildConfig(space2Manager));
+
+			const runtime1 = await svc.createOrGetRuntime('space-1');
+			const runtime2 = await svc.createOrGetRuntime('space-2');
+
+			// One shared runtime handles all spaces
+			expect(runtime1).toBe(runtime2);
+		});
+	});
+
+	// ─── stopRuntime ─────────────────────────────────────────────────────────
+
+	describe('stopRuntime()', () => {
+		test('is a no-op — does not throw', () => {
+			expect(() => service.stopRuntime('space-1')).not.toThrow();
+			expect(() => service.stopRuntime('nonexistent')).not.toThrow();
+		});
+
+		test('does not stop the service (shared runtime remains running)', async () => {
+			service.start();
+			service.stopRuntime('space-1');
+			// Service should still be started
+			expect((service as unknown as { started: boolean }).started).toBe(true);
+		});
+	});
+
+	// ─── start / stop lifecycle ───────────────────────────────────────────────
+
+	describe('start() / stop()', () => {
+		test('start() sets started to true', () => {
+			expect((service as unknown as { started: boolean }).started).toBe(false);
+			service.start();
+			expect((service as unknown as { started: boolean }).started).toBe(true);
+		});
+
+		test('start() is idempotent — calling twice is safe', () => {
+			service.start();
+			service.start(); // should not throw or double-start
+			expect((service as unknown as { started: boolean }).started).toBe(true);
+		});
+
+		test('stop() sets started to false', () => {
+			service.start();
+			service.stop();
+			expect((service as unknown as { started: boolean }).started).toBe(false);
+		});
+
+		test('stop() is idempotent — calling twice is safe', () => {
+			service.start();
+			service.stop();
+			service.stop(); // should not throw
+			expect((service as unknown as { started: boolean }).started).toBe(false);
+		});
+
+		test('stop() on a never-started service is safe', () => {
+			expect(() => service.stop()).not.toThrow();
+		});
+
+		test('can restart after stop', async () => {
+			service.start();
+			service.stop();
+			service.start();
+			expect((service as unknown as { started: boolean }).started).toBe(true);
+
+			// createOrGetRuntime should still work after restart
+			const runtime = await service.createOrGetRuntime('space-1');
+			expect(runtime).toBeDefined();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -42,6 +42,7 @@ const mockSpace: Space = {
 function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
 	return {
 		getSpace: mock(async () => space),
+		listSpaces: mock(async () => []),
 	} as unknown as SpaceManager;
 }
 

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -25,6 +25,7 @@ import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-man
 import {
 	WorkflowExecutor,
 	WorkflowTransitionError,
+	WorkflowGateError,
 } from '../../../src/lib/space/runtime/workflow-executor.ts';
 import type {
 	CommandRunner,
@@ -502,7 +503,7 @@ describe('WorkflowExecutor', () => {
 			// run.config has no humanApproved
 			const executor = makeExecutor(workflow, run);
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
 
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
@@ -769,8 +770,8 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run);
 
-			// First call: condition fails → needs_attention
-			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			// First call: human gate blocks → WorkflowGateError
+			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
 
 			// Second call: must throw immediately (not re-evaluate)
 			await expect(executor.advance()).rejects.toThrow('needs_attention');
@@ -788,7 +789,7 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run);
 
-			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
 
 			const statusBefore = runRepo.getRun(run.id)?.status;
 			await expect(executor.advance()).rejects.toThrow('needs_attention');
@@ -803,8 +804,8 @@ describe('WorkflowExecutor', () => {
 	// WorkflowTransitionError properties
 	// =========================================================================
 
-	describe('WorkflowTransitionError', () => {
-		test('condition failure throws WorkflowTransitionError with descriptive message', async () => {
+	describe('WorkflowGateError', () => {
+		test('human gate throws WorkflowGateError with descriptive message', async () => {
 			const { workflow, run } = createLinearWorkflow([
 				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
 				{
@@ -816,11 +817,11 @@ describe('WorkflowExecutor', () => {
 			]);
 			const executor = makeExecutor(workflow, run);
 
-			let caught: WorkflowTransitionError | undefined;
+			let caught: WorkflowGateError | undefined;
 			try {
 				await executor.advance();
 			} catch (err) {
-				if (err instanceof WorkflowTransitionError) caught = err;
+				if (err instanceof WorkflowGateError) caught = err;
 			}
 
 			expect(caught).toBeDefined();
@@ -938,8 +939,8 @@ describe('WorkflowExecutor', () => {
 
 			const executor = makeExecutor(workflow, run);
 
-			// Both human conditions fail → needs_attention
-			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			// Both human conditions fail → WorkflowGateError + needs_attention
+			await expect(executor.advance()).rejects.toThrow(WorkflowGateError);
 			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
 		});
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -319,8 +319,8 @@ export interface SpaceSessionGroup {
 	name: string;
 	/** Optional description of the group's purpose */
 	description?: string;
-	/** ID of the workflow run this group is associated with (for UI display) */
-	workflowId?: string;
+	/** ID of the workflow run (SpaceWorkflowRun) this group is associated with (for UI display) */
+	workflowRunId?: string;
 	/** ID of the current workflow step being executed by this group */
 	currentStepId?: string;
 	/** Members of this group */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -319,6 +319,10 @@ export interface SpaceSessionGroup {
 	name: string;
 	/** Optional description of the group's purpose */
 	description?: string;
+	/** ID of the workflow run this group is associated with (for UI display) */
+	workflowId?: string;
+	/** ID of the current workflow step being executed by this group */
+	currentStepId?: string;
 	/** Members of this group */
 	members: SpaceSessionGroupMember[];
 	/** Creation timestamp (milliseconds since epoch) */


### PR DESCRIPTION
## Summary

- **SpaceRuntimeService** (`space-runtime-service.ts`): Wraps the shared `SpaceRuntime` with a per-space lifecycle API — `createOrGetRuntime(spaceId)` validates the space, auto-starts the runtime, and returns it; `stopRuntime(spaceId)` is reserved for future per-space isolation
- **`spaceWorkflowRun.*` RPC handlers** (`space-workflow-run-handlers.ts`): `start` creates a run via SpaceRuntimeService + SpaceRuntime, `list` supports optional status filter, `get` fetches by ID, `cancel` cancels pending tasks then the run, emits `space.workflowRun.updated`
- **Migration 33**: Adds `workflow_id` and `current_step_id` columns to `space_session_groups` for UI display of workflow context
- **SpaceSessionGroup type/repo update**: `workflowId` and `currentStepId` fields wired through `CreateSessionGroupParams`, `UpdateSessionGroupParams`, `createGroup()`, `updateGroup()`, and `rowToGroup()`
- **`workflowStepName` in task events**: Added optional `workflowStepName` to `space.task.created` and `space.task.updated` event payloads in `DaemonEventMap`
- **`SpaceTaskManager.listTasksByWorkflowRun()`**: Exposes the task repo's `listByWorkflowRun` at the manager layer
- **`DaemonAppContext.spaceRuntimeService`**: Service surfaced via `RPCHandlerSetupResult` and wired into `app.ts`
- **36 unit tests**: 13 for SpaceRuntimeService lifecycle/createOrGetRuntime, 23 for all 4 `spaceWorkflowRun.*` handlers

## Test plan

- [ ] All pre-commit checks pass (lint, format, typecheck, knip)
- [ ] `bun test packages/daemon/tests/unit/space/space-runtime-service.test.ts` — 13 tests pass
- [ ] `bun test packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts` — 23 tests pass
- [ ] Full unit test suite: `bun test packages/daemon/tests/unit/` — pre-existing failures only (bun-node-wrapper PATH test, unrelated to this PR)