### PR TITLE
feat: Space creation UX and 3-column layout (Task 5.3)

### DIFF
--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -43,8 +43,10 @@ test.describe('Space Creation UX', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await waitForWebSocketConnected(page);
-		// Small settle time after connection
-		await page.waitForTimeout(300);
+		// Wait for the NavRail to be visible — deterministic signal that the app is ready
+		await expect(page.getByRole('button', { name: 'Spaces', exact: true })).toBeVisible({
+			timeout: 5000,
+		});
 	});
 
 	test.afterEach(async ({ page }) => {

--- a/packages/e2e/tests/features/space-creation.e2e.ts
+++ b/packages/e2e/tests/features/space-creation.e2e.ts
@@ -1,0 +1,171 @@
+/**
+ * Space Creation E2E Tests
+ *
+ * Verifies:
+ * - Navigating to the Spaces section
+ * - "Create Space" dialog opens
+ * - Workspace path field is required
+ * - Name auto-suggests from workspace path
+ * - Creating a space navigates to it
+ * - Space 3-column layout renders (nav panel, dashboard, no task pane initially)
+ * - Nav panel shows "No runs or tasks yet" for a fresh space
+ *
+ * Setup: creates a space via dialog (UI-only)
+ * Cleanup: deletes the space via RPC in afterEach (infrastructure)
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+async function deleteSpaceByRpc(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	spaceId: string
+): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+test.describe('Space Creation UX', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let createdSpaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		// Small settle time after connection
+		await page.waitForTimeout(300);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (createdSpaceId) {
+			await deleteSpaceByRpc(page, createdSpaceId);
+			createdSpaceId = '';
+		}
+	});
+
+	test('navigates to Spaces section via NavRail', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await expect(spacesButton).toBeVisible({ timeout: 5000 });
+		await spacesButton.click();
+
+		// ContextPanel should show "Spaces" header
+		await expect(page.locator('h2:has-text("Spaces")')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('shows "Create Space" button in Spaces section', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+
+		// Header CTA button
+		await expect(
+			page.getByRole('button', { name: 'Create Space', exact: true }).first()
+		).toBeVisible({
+			timeout: 5000,
+		});
+	});
+
+	test('opens Create Space dialog when button clicked', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+
+		const createButton = page.getByRole('button', { name: 'Create Space', exact: true }).first();
+		await expect(createButton).toBeVisible({ timeout: 5000 });
+		await createButton.click();
+
+		// Dialog should appear
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('text=Workspace Path')).toBeVisible({ timeout: 3000 });
+	});
+
+	test('workspace path is required — shows error on empty submit', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+		await page.getByRole('button', { name: 'Create Space', exact: true }).first().click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+		// Submit without filling workspace path
+		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		await submitButton.click();
+
+		// Should show validation error
+		await expect(page.locator('text=Workspace path is required')).toBeVisible({ timeout: 3000 });
+	});
+
+	test('auto-suggests name from workspace path', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+		await page.getByRole('button', { name: 'Create Space', exact: true }).first().click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+		// Type a workspace path
+		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
+		await pathInput.fill('/projects/my-cool-project');
+
+		// Name should auto-suggest
+		const nameInput = page.locator('input[placeholder="e.g., My App"]');
+		await expect(nameInput).toHaveValue('my-cool-project', { timeout: 2000 });
+	});
+
+	test('creates space and shows 3-column layout', async ({ page }) => {
+		const workspaceRoot = await getWorkspaceRoot(page);
+
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+		await page.getByRole('button', { name: 'Create Space', exact: true }).first().click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+		// Fill workspace path with the server's workspace root (guaranteed to exist)
+		const pathInput = page.locator('input[placeholder*="/Users/you/projects"]');
+		await pathInput.fill(workspaceRoot);
+
+		// Set a unique name to avoid conflicts
+		const nameInput = page.locator('input[placeholder="e.g., My App"]');
+		await nameInput.fill(`E2E Space ${Date.now()}`);
+
+		// Submit
+		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Space' });
+		await submitButton.click();
+
+		// Wait for navigation to the new space
+		await page.waitForURL(/\/space\/[a-f0-9-]+/, { timeout: 10000 });
+
+		// Extract the space ID from the URL for cleanup
+		const url = page.url();
+		const match = url.match(/\/space\/([a-f0-9-]+)/);
+		if (match) {
+			createdSpaceId = match[1];
+		}
+
+		// Space layout should be visible
+		// Left column: nav panel
+		await expect(page.locator('text=No runs or tasks yet')).toBeVisible({ timeout: 5000 });
+		// Middle column: dashboard (quick actions)
+		await expect(page.locator('text=Quick Actions')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('text=Start Workflow Run')).toBeVisible({ timeout: 3000 });
+		await expect(page.locator('text=Create Task')).toBeVisible({ timeout: 3000 });
+	});
+
+	test('dialog can be closed with Cancel button', async ({ page }) => {
+		const spacesButton = page.getByRole('button', { name: 'Spaces', exact: true });
+		await spacesButton.click();
+		await page.getByRole('button', { name: 'Create Space', exact: true }).first().click();
+		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+
+		// Click Cancel
+		await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+
+		// Dialog should close
+		await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 3000 });
+	});
+});

--- a/packages/web/src/components/space/SpaceCreateDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateDialog.tsx
@@ -1,0 +1,166 @@
+/**
+ * SpaceCreateDialog Component
+ *
+ * Modal form for creating a new Space with:
+ * - Workspace Path (required, hero field)
+ * - Name (auto-suggested from directory name)
+ * - Description (optional)
+ * - Form validation and error handling
+ */
+
+import { useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { connectionManager } from '../../lib/connection-manager';
+import { navigateToSpace } from '../../lib/router';
+import type { Space } from '@neokai/shared';
+
+interface SpaceCreateDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Extract directory basename from a path string
+ */
+function basenameFromPath(p: string): string {
+	const normalized = p.replace(/[/\\]+$/, '');
+	const parts = normalized.split(/[/\\]/);
+	return parts[parts.length - 1] ?? '';
+}
+
+export function SpaceCreateDialog({ isOpen, onClose }: SpaceCreateDialogProps) {
+	const [workspacePath, setWorkspacePath] = useState('');
+	const [name, setName] = useState('');
+	const [description, setDescription] = useState('');
+	const [nameTouched, setNameTouched] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handlePathInput = (value: string) => {
+		setWorkspacePath(value);
+		if (!nameTouched) {
+			const suggested = basenameFromPath(value);
+			setName(suggested);
+		}
+	};
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+
+		if (!workspacePath.trim()) {
+			setError('Workspace path is required');
+			return;
+		}
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setError('Not connected to server');
+			return;
+		}
+
+		try {
+			setSubmitting(true);
+			setError(null);
+
+			const space = await hub.request<Space>('space.create', {
+				workspacePath: workspacePath.trim(),
+				name: name.trim() || basenameFromPath(workspacePath.trim()),
+				description: description.trim() || undefined,
+			});
+
+			if (!space) {
+				throw new Error('Server returned no data');
+			}
+
+			navigateToSpace(space.id);
+			handleClose();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to create space');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const handleClose = () => {
+		setWorkspacePath('');
+		setName('');
+		setDescription('');
+		setNameTouched(false);
+		setError(null);
+		onClose();
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Create Space" size="md">
+			<form onSubmit={handleSubmit} class="space-y-5">
+				{error && (
+					<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-3 text-red-400 text-sm">
+						{error}
+					</div>
+				)}
+
+				{/* Workspace Path — hero field */}
+				<div>
+					<label class="block text-sm font-medium text-gray-200 mb-1.5">
+						Workspace Path
+						<span class="text-red-400 ml-1">*</span>
+					</label>
+					<p class="text-xs text-gray-500 mb-2">
+						Absolute path to the project directory this Space operates on.
+					</p>
+					<input
+						type="text"
+						value={workspacePath}
+						onInput={(e) => handlePathInput((e.target as HTMLInputElement).value)}
+						placeholder="/Users/you/projects/my-app"
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-3 text-gray-100
+							placeholder-gray-600 focus:outline-none focus:border-blue-500 font-mono text-sm"
+						autoFocus
+					/>
+				</div>
+
+				{/* Name */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">Name</label>
+					<input
+						type="text"
+						value={name}
+						onInput={(e) => {
+							setName((e.target as HTMLInputElement).value);
+							setNameTouched(true);
+						}}
+						placeholder="e.g., My App"
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500"
+					/>
+				</div>
+
+				{/* Description */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Description
+						<span class="text-gray-500 text-xs ml-2">(optional)</span>
+					</label>
+					<textarea
+						value={description}
+						onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+						placeholder="Briefly describe the purpose of this space..."
+						rows={3}
+						class="w-full bg-dark-800 border border-dark-700 rounded-lg px-4 py-2.5 text-gray-100
+							placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-none text-sm"
+					/>
+				</div>
+
+				<div class="flex gap-3 pt-1">
+					<Button type="button" variant="secondary" onClick={handleClose} fullWidth>
+						Cancel
+					</Button>
+					<Button type="submit" loading={submitting} fullWidth>
+						Create Space
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -146,6 +146,7 @@ export function SpaceDashboard({
 			)}
 
 			{/* Quick actions */}
+			{/* TODO: onStartWorkflow and onCreateTask are unwired scaffolding — will be connected once workflow/task creation dialogs are implemented */}
 			<div>
 				<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
 					Quick Actions

--- a/packages/web/src/components/space/SpaceDashboard.tsx
+++ b/packages/web/src/components/space/SpaceDashboard.tsx
@@ -1,0 +1,203 @@
+/**
+ * SpaceDashboard Component
+ *
+ * Default middle-column view for the Space layout.
+ * Shows space overview, active run progress, and quick-action cards.
+ */
+
+import type { ComponentType } from 'preact';
+import { spaceStore } from '../../lib/space-store';
+
+interface SpaceDashboardProps {
+	spaceId: string;
+	onStartWorkflow?: () => void;
+	onCreateTask?: () => void;
+}
+
+/**
+ * Truncate a long path for display, showing trailing segments
+ */
+function truncatePath(p: string, maxLen = 48): string {
+	if (p.length <= maxLen) return p;
+	return '…' + p.slice(-(maxLen - 1));
+}
+
+interface QuickActionCardProps {
+	title: string;
+	description: string;
+	icon: ComponentType;
+	onClick?: () => void;
+}
+
+function QuickActionCard({ title, description, icon: Icon, onClick }: QuickActionCardProps) {
+	return (
+		<button
+			onClick={onClick}
+			class="flex items-start gap-3 p-4 bg-dark-850 border border-dark-700 rounded-lg
+				hover:bg-dark-800 hover:border-dark-600 transition-colors text-left w-full group"
+		>
+			<div class="mt-0.5 text-gray-500 group-hover:text-gray-300 transition-colors flex-shrink-0">
+				<Icon />
+			</div>
+			<div>
+				<p class="text-sm font-medium text-gray-300 group-hover:text-gray-100 transition-colors">
+					{title}
+				</p>
+				<p class="text-xs text-gray-600 mt-0.5">{description}</p>
+			</div>
+		</button>
+	);
+}
+
+function PlayIcon() {
+	return (
+		<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+			/>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+			/>
+		</svg>
+	);
+}
+
+function PlusIcon() {
+	return (
+		<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2} d="M12 4v16m8-8H4" />
+		</svg>
+	);
+}
+
+export function SpaceDashboard({
+	spaceId: _spaceId,
+	onStartWorkflow,
+	onCreateTask,
+}: SpaceDashboardProps) {
+	const space = spaceStore.space.value;
+	const loading = spaceStore.loading.value;
+	const activeRuns = spaceStore.activeRuns.value;
+	const activeTasks = spaceStore.activeTasks.value;
+	const tasks = spaceStore.tasks.value;
+	const workflowRuns = spaceStore.workflowRuns.value;
+
+	if (loading) {
+		return (
+			<div class="flex items-center justify-center h-full">
+				<div class="text-center">
+					<div class="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+					<p class="text-sm text-gray-500">Loading space...</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!space) {
+		return (
+			<div class="flex items-center justify-center h-full">
+				<p class="text-sm text-gray-500">Space not found</p>
+			</div>
+		);
+	}
+
+	// Recent activity: last 5 items by updatedAt
+	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5);
+
+	const recentRuns = [...workflowRuns].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 3);
+
+	return (
+		<div class="flex flex-col h-full overflow-y-auto p-6 space-y-6">
+			{/* Space header */}
+			<div>
+				<h1 class="text-xl font-semibold text-gray-100">{space.name}</h1>
+				<p class="text-xs text-gray-600 font-mono mt-1 truncate" title={space.workspacePath}>
+					{truncatePath(space.workspacePath)}
+				</p>
+				{space.description && <p class="text-sm text-gray-400 mt-2">{space.description}</p>}
+			</div>
+
+			{/* Active status */}
+			{(activeRuns.length > 0 || activeTasks.length > 0) && (
+				<div class="bg-blue-900/15 border border-blue-800/40 rounded-lg px-4 py-3">
+					<div class="flex items-center gap-2">
+						<span class="w-2 h-2 rounded-full bg-blue-400 animate-pulse flex-shrink-0" />
+						<p class="text-sm text-blue-300">
+							{activeRuns.length > 0 && (
+								<span>
+									{activeRuns.length} active {activeRuns.length === 1 ? 'run' : 'runs'}
+								</span>
+							)}
+							{activeRuns.length > 0 && activeTasks.length > 0 && <span class="mx-1">·</span>}
+							{activeTasks.length > 0 && (
+								<span>
+									{activeTasks.length} {activeTasks.length === 1 ? 'task' : 'tasks'} in progress
+								</span>
+							)}
+						</p>
+					</div>
+				</div>
+			)}
+
+			{/* Quick actions */}
+			<div>
+				<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+					Quick Actions
+				</h2>
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<QuickActionCard
+						title="Start Workflow Run"
+						description="Execute a workflow with agents"
+						icon={PlayIcon}
+						onClick={onStartWorkflow}
+					/>
+					<QuickActionCard
+						title="Create Task"
+						description="Add a standalone task to this space"
+						icon={PlusIcon}
+						onClick={onCreateTask}
+					/>
+				</div>
+			</div>
+
+			{/* Recent activity */}
+			{(recentTasks.length > 0 || recentRuns.length > 0) && (
+				<div>
+					<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+						Recent Activity
+					</h2>
+					<div class="space-y-1">
+						{recentRuns.map((run) => (
+							<div
+								key={run.id}
+								class="flex items-center gap-3 px-3 py-2 rounded-md bg-dark-850 border border-dark-800"
+							>
+								<span class="text-xs text-gray-600 font-medium w-16 flex-shrink-0">Run</span>
+								<span class="text-xs text-gray-300 truncate flex-1">{run.title}</span>
+								<span class="text-xs text-gray-600 capitalize">{run.status.replace('_', ' ')}</span>
+							</div>
+						))}
+						{recentTasks.map((task) => (
+							<div
+								key={task.id}
+								class="flex items-center gap-3 px-3 py-2 rounded-md bg-dark-850 border border-dark-800"
+							>
+								<span class="text-xs text-gray-600 font-medium w-16 flex-shrink-0">Task</span>
+								<span class="text-xs text-gray-300 truncate flex-1">{task.title}</span>
+								<span class="text-xs text-gray-600 capitalize">
+									{task.status.replace('_', ' ')}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceNavPanel.tsx
+++ b/packages/web/src/components/space/SpaceNavPanel.tsx
@@ -1,0 +1,230 @@
+/**
+ * SpaceNavPanel Component
+ *
+ * Left column navigation panel for the Space view.
+ * Shows workflow runs, standalone tasks, and navigation links.
+ */
+
+import type { ComponentType } from 'preact';
+import { spaceStore } from '../../lib/space-store';
+import { cn } from '../../lib/utils';
+import type { SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
+
+interface SpaceNavPanelProps {
+	spaceId: string;
+	activeTaskId?: string | null;
+	activeRunId?: string | null;
+	onRunSelect: (runId: string) => void;
+	onTaskSelect: (taskId: string) => void;
+}
+
+type RunStatus = SpaceWorkflowRun['status'];
+type TaskStatus = SpaceTask['status'];
+
+function StatusDot({ status }: { status: RunStatus | TaskStatus }) {
+	const base = 'w-2 h-2 rounded-full flex-shrink-0';
+	switch (status) {
+		case 'in_progress':
+			return <span class={cn(base, 'bg-blue-400 animate-pulse')} />;
+		case 'completed':
+			return <span class={cn(base, 'bg-green-500')} />;
+		case 'needs_attention':
+			return <span class={cn(base, 'bg-yellow-400')} />;
+		case 'cancelled':
+			return <span class={cn(base, 'bg-gray-600')} />;
+		default:
+			// pending, draft, review
+			return <span class={cn(base, 'bg-gray-500')} />;
+	}
+}
+
+interface RunItemProps {
+	run: SpaceWorkflowRun;
+	taskCount: number;
+	isActive: boolean;
+	onClick: () => void;
+}
+
+function RunItem({ run, taskCount, isActive, onClick }: RunItemProps) {
+	return (
+		<button
+			onClick={onClick}
+			class={cn(
+				'w-full text-left px-3 py-2 rounded-md transition-colors group',
+				isActive
+					? 'bg-dark-700 text-gray-100'
+					: 'text-gray-400 hover:bg-dark-800 hover:text-gray-200'
+			)}
+		>
+			<div class="flex items-center gap-2 min-w-0">
+				<StatusDot status={run.status} />
+				<span class="text-xs font-medium truncate flex-1">{run.title}</span>
+			</div>
+			{taskCount > 0 && (
+				<div class="text-xs text-gray-600 mt-0.5 pl-4">
+					{taskCount} {taskCount === 1 ? 'task' : 'tasks'}
+				</div>
+			)}
+		</button>
+	);
+}
+
+interface TaskItemProps {
+	task: SpaceTask;
+	isActive: boolean;
+	onClick: () => void;
+}
+
+function TaskItem({ task, isActive, onClick }: TaskItemProps) {
+	return (
+		<button
+			onClick={onClick}
+			class={cn(
+				'w-full text-left px-3 py-2 rounded-md transition-colors',
+				isActive
+					? 'bg-dark-700 text-gray-100'
+					: 'text-gray-400 hover:bg-dark-800 hover:text-gray-200'
+			)}
+		>
+			<div class="flex items-center gap-2 min-w-0">
+				<StatusDot status={task.status} />
+				<span class="text-xs font-medium truncate flex-1">{task.title}</span>
+			</div>
+		</button>
+	);
+}
+
+export function SpaceNavPanel({
+	spaceId: _spaceId,
+	activeTaskId,
+	activeRunId,
+	onRunSelect,
+	onTaskSelect,
+}: SpaceNavPanelProps) {
+	const workflowRuns = spaceStore.workflowRuns.value;
+	const standaloneTasks = spaceStore.standaloneTasks.value;
+	const tasksByRun = spaceStore.tasksByRun.value;
+	const loading = spaceStore.loading.value;
+
+	if (loading) {
+		return (
+			<div class="flex items-center justify-center h-24">
+				<span class="text-xs text-gray-600 animate-pulse">Loading...</span>
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex flex-col h-full overflow-y-auto py-2">
+			{/* Workflow Runs */}
+			{workflowRuns.length > 0 && (
+				<div class="mb-4">
+					<div class="px-3 mb-1">
+						<span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+							Workflow Runs
+						</span>
+					</div>
+					<div class="space-y-0.5 px-1">
+						{workflowRuns.map((run) => (
+							<RunItem
+								key={run.id}
+								run={run}
+								taskCount={tasksByRun.get(run.id)?.length ?? 0}
+								isActive={activeRunId === run.id}
+								onClick={() => onRunSelect(run.id)}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Standalone Tasks */}
+			{standaloneTasks.length > 0 && (
+				<div class="mb-4">
+					<div class="px-3 mb-1">
+						<span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Tasks</span>
+					</div>
+					<div class="space-y-0.5 px-1">
+						{standaloneTasks.map((task) => (
+							<TaskItem
+								key={task.id}
+								task={task}
+								isActive={activeTaskId === task.id}
+								onClick={() => onTaskSelect(task.id)}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+
+			{workflowRuns.length === 0 && standaloneTasks.length === 0 && (
+				<div class="px-3 py-4">
+					<p class="text-xs text-gray-600 text-center">No runs or tasks yet</p>
+				</div>
+			)}
+
+			{/* Navigation Links */}
+			<div class="mt-auto pt-4 border-t border-dark-700 px-1">
+				<div class="space-y-0.5">
+					<NavLink label="Agents" icon={AgentIcon} />
+					<NavLink label="Workflows" icon={WorkflowIcon} />
+					<NavLink label="Settings" icon={SettingsIcon} />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function NavLink({ label, icon: Icon }: { label: string; icon: ComponentType }) {
+	return (
+		<div class="flex items-center gap-2 px-3 py-2 rounded-md text-gray-500 hover:bg-dark-800 hover:text-gray-300 cursor-pointer transition-colors">
+			<Icon />
+			<span class="text-xs font-medium">{label}</span>
+		</div>
+	);
+}
+
+function AgentIcon() {
+	return (
+		<svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+			/>
+		</svg>
+	);
+}
+
+function WorkflowIcon() {
+	return (
+		<svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M4 6h16M4 10h16M4 14h16M4 18h16"
+			/>
+		</svg>
+	);
+}
+
+function SettingsIcon() {
+	return (
+		<svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+			/>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+			/>
+		</svg>
+	);
+}

--- a/packages/web/src/components/space/SpaceNavPanel.tsx
+++ b/packages/web/src/components/space/SpaceNavPanel.tsx
@@ -163,7 +163,7 @@ export function SpaceNavPanel({
 				</div>
 			)}
 
-			{/* Navigation Links */}
+			{/* Navigation Links — TODO: wire onClick once Agent/Workflow/Settings routes are implemented */}
 			<div class="mt-auto pt-4 border-t border-dark-700 px-1">
 				<div class="space-y-0.5">
 					<NavLink label="Agents" icon={AgentIcon} />

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,0 +1,282 @@
+/**
+ * SpaceTaskPane Component
+ *
+ * Right column task detail pane for the Space layout.
+ * Shows task details, status, and human input area when needed.
+ */
+
+import { useState } from 'preact/hooks';
+import { spaceStore } from '../../lib/space-store';
+import { cn } from '../../lib/utils';
+import type { SpaceTask, SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
+
+interface SpaceTaskPaneProps {
+	taskId: string | null;
+	onClose?: () => void;
+}
+
+const STATUS_LABELS: Record<SpaceTaskStatus, string> = {
+	draft: 'Draft',
+	pending: 'Pending',
+	in_progress: 'In Progress',
+	review: 'Review',
+	completed: 'Completed',
+	needs_attention: 'Needs Attention',
+	cancelled: 'Cancelled',
+};
+
+const STATUS_CLASSES: Record<SpaceTaskStatus, string> = {
+	draft: 'bg-gray-800 text-gray-400 border-gray-700',
+	pending: 'bg-gray-800 text-gray-300 border-gray-600',
+	in_progress: 'bg-blue-900/30 text-blue-300 border-blue-700/50',
+	review: 'bg-purple-900/30 text-purple-300 border-purple-700/50',
+	completed: 'bg-green-900/30 text-green-300 border-green-700/50',
+	needs_attention: 'bg-yellow-900/30 text-yellow-300 border-yellow-700/50',
+	cancelled: 'bg-gray-800 text-gray-500 border-gray-700',
+};
+
+const PRIORITY_LABELS: Record<SpaceTaskPriority, string> = {
+	low: 'Low',
+	normal: 'Normal',
+	high: 'High',
+	urgent: 'Urgent',
+};
+
+const PRIORITY_CLASSES: Record<SpaceTaskPriority, string> = {
+	low: 'text-gray-500',
+	normal: 'text-gray-400',
+	high: 'text-orange-400',
+	urgent: 'text-red-400',
+};
+
+function StatusBadge({ status }: { status: SpaceTaskStatus }) {
+	return (
+		<span
+			class={cn(
+				'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border',
+				STATUS_CLASSES[status]
+			)}
+		>
+			{STATUS_LABELS[status]}
+		</span>
+	);
+}
+
+interface HumanInputAreaProps {
+	task: SpaceTask;
+}
+
+function HumanInputArea({ task }: HumanInputAreaProps) {
+	const [inputText, setInputText] = useState(task.inputDraft ?? '');
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+		if (!inputText.trim()) return;
+
+		try {
+			setSubmitting(true);
+			setError(null);
+			await spaceStore.updateTask(task.id, {
+				inputDraft: inputText.trim(),
+				status: 'in_progress',
+			});
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to submit response');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div class="mt-4 border border-yellow-800/50 rounded-lg p-4 bg-yellow-900/10">
+			<h3 class="text-sm font-medium text-yellow-300 mb-2">Human Input Required</h3>
+			<p class="text-xs text-gray-400 mb-3">
+				This task needs your attention before it can continue.
+			</p>
+			{error && (
+				<div class="mb-3 text-xs text-red-400 bg-red-900/20 border border-red-800/50 rounded px-3 py-2">
+					{error}
+				</div>
+			)}
+			<form onSubmit={handleSubmit} class="space-y-3">
+				<textarea
+					value={inputText}
+					onInput={(e) => setInputText((e.target as HTMLTextAreaElement).value)}
+					placeholder="Type your response or approval..."
+					rows={3}
+					class="w-full bg-dark-800 border border-dark-600 rounded-md px-3 py-2 text-gray-100
+						placeholder-gray-600 focus:outline-none focus:border-yellow-600 resize-none text-sm"
+				/>
+				<button
+					type="submit"
+					disabled={submitting || !inputText.trim()}
+					class="px-4 py-1.5 text-xs font-medium bg-yellow-700 hover:bg-yellow-600
+						text-yellow-100 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					{submitting ? 'Submitting...' : 'Submit Response'}
+				</button>
+			</form>
+		</div>
+	);
+}
+
+export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
+	const tasks = spaceStore.tasks.value;
+
+	if (!taskId) {
+		return (
+			<div class="flex items-center justify-center h-full p-6">
+				<p class="text-sm text-gray-600 text-center">Select a task to view details</p>
+			</div>
+		);
+	}
+
+	const task = tasks.find((t) => t.id === taskId);
+
+	if (!task) {
+		return (
+			<div class="flex items-center justify-center h-full p-6">
+				<p class="text-sm text-gray-600 text-center">Task not found</p>
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex flex-col h-full overflow-y-auto">
+			{/* Header */}
+			<div class="flex items-start justify-between px-4 py-3 border-b border-dark-700">
+				<h2 class="text-sm font-semibold text-gray-100 flex-1 mr-2 leading-snug">{task.title}</h2>
+				{onClose && (
+					<button
+						onClick={onClose}
+						class="text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0 mt-0.5"
+						aria-label="Close task pane"
+					>
+						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				)}
+			</div>
+
+			{/* Body */}
+			<div class="flex-1 px-4 py-4 space-y-4">
+				{/* Status + Priority row */}
+				<div class="flex items-center gap-3 flex-wrap">
+					<StatusBadge status={task.status} />
+					<span class={cn('text-xs font-medium', PRIORITY_CLASSES[task.priority])}>
+						{PRIORITY_LABELS[task.priority]} priority
+					</span>
+					{task.taskType && <span class="text-xs text-gray-600 capitalize">{task.taskType}</span>}
+				</div>
+
+				{/* Workflow step indicator */}
+				{task.workflowRunId && (
+					<div class="flex items-center gap-2 text-xs text-gray-500">
+						<svg
+							class="w-3.5 h-3.5 flex-shrink-0"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M4 6h16M4 10h16M4 14h16M4 18h16"
+							/>
+						</svg>
+						<span>
+							Workflow Step
+							{task.workflowStepId && (
+								<span class="ml-1 font-mono text-gray-600">{task.workflowStepId.slice(0, 8)}</span>
+							)}
+						</span>
+					</div>
+				)}
+
+				{/* Description */}
+				{task.description && (
+					<div>
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+							Description
+						</h3>
+						<p class="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">
+							{task.description}
+						</p>
+					</div>
+				)}
+
+				{/* Current step */}
+				{task.currentStep && (
+					<div>
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+							Current Step
+						</h3>
+						<p class="text-xs text-gray-400">{task.currentStep}</p>
+					</div>
+				)}
+
+				{/* Progress */}
+				{task.progress != null && task.progress > 0 && (
+					<div>
+						<div class="flex items-center justify-between mb-1">
+							<span class="text-xs text-gray-500">Progress</span>
+							<span class="text-xs text-gray-500">{task.progress}%</span>
+						</div>
+						<div class="w-full bg-dark-700 rounded-full h-1.5">
+							<div
+								class="bg-blue-500 h-1.5 rounded-full transition-all"
+								style={{ width: `${task.progress}%` }}
+							/>
+						</div>
+					</div>
+				)}
+
+				{/* Result */}
+				{task.result && (
+					<div>
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+							Result
+						</h3>
+						<p class="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{task.result}</p>
+					</div>
+				)}
+
+				{/* Error */}
+				{task.error && (
+					<div>
+						<h3 class="text-xs font-semibold text-red-500 uppercase tracking-wider mb-1.5">
+							Error
+						</h3>
+						<p class="text-sm text-red-400 leading-relaxed whitespace-pre-wrap">{task.error}</p>
+					</div>
+				)}
+
+				{/* PR link */}
+				{task.prUrl && (
+					<div class="flex items-center gap-2">
+						<a
+							href={task.prUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+						>
+							{task.prNumber ? `PR #${task.prNumber}` : 'Pull Request'}
+						</a>
+					</div>
+				)}
+
+				{/* Human input area */}
+				{task.status === 'needs_attention' && <HumanInputArea task={task} />}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -78,10 +78,10 @@ function HumanInputArea({ task }: HumanInputAreaProps) {
 		try {
 			setSubmitting(true);
 			setError(null);
-			await spaceStore.updateTask(task.id, {
-				inputDraft: inputText.trim(),
-				status: 'in_progress',
-			});
+			// Persist the draft first so it is never lost even if the status transition fails
+			await spaceStore.updateTask(task.id, { inputDraft: inputText.trim() });
+			// Then attempt to resume the task — the server validates the transition
+			await spaceStore.updateTask(task.id, { status: 'in_progress' });
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to submit response');
 		} finally {

--- a/packages/web/src/components/space/__tests__/SpaceCreateDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateDialog.test.tsx
@@ -1,0 +1,279 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceCreateDialog
+ *
+ * Tests:
+ * - Dialog renders when open
+ * - Workspace path required validation
+ * - Name auto-suggestion from path
+ * - Name can be manually overridden
+ * - Submit calls space.create RPC
+ * - Success: navigates to new space and closes
+ * - Error: shows error message
+ * - Cancel: closes and resets form
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+
+// Mocks must be declared before imports
+const mockRequest = vi.fn();
+const mockGetHubIfConnected = vi.fn();
+const mockNavigateToSpace = vi.fn();
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		get getHubIfConnected() {
+			return mockGetHubIfConnected;
+		},
+	},
+}));
+
+vi.mock('../../../lib/router', () => ({
+	get navigateToSpace() {
+		return mockNavigateToSpace;
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({
+		isOpen,
+		children,
+		title,
+		onClose,
+	}: {
+		isOpen: boolean;
+		children: unknown;
+		title: string;
+		onClose: () => void;
+	}) => {
+		if (!isOpen) return null;
+		return (
+			<div role="dialog" aria-label={title}>
+				<button onClick={onClose} aria-label="Close modal">
+					X
+				</button>
+				{children}
+			</div>
+		);
+	},
+}));
+
+vi.mock('../../ui/Button', () => ({
+	Button: ({
+		children,
+		onClick,
+		type,
+		loading,
+		disabled,
+	}: {
+		children: unknown;
+		onClick?: () => void;
+		type?: string;
+		loading?: boolean;
+		disabled?: boolean;
+	}) => (
+		<button type={type ?? 'button'} onClick={onClick} disabled={disabled || loading}>
+			{loading ? 'Loading...' : children}
+		</button>
+	),
+}));
+
+import { SpaceCreateDialog } from '../SpaceCreateDialog';
+
+const SPACE_MOCK = {
+	id: 'space-abc',
+	name: 'my-app',
+	workspacePath: '/projects/my-app',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active' as const,
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
+describe('SpaceCreateDialog', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+		mockRequest.mockReset();
+		mockGetHubIfConnected.mockReset();
+		mockNavigateToSpace.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when isOpen is false', () => {
+		const { container } = render(<SpaceCreateDialog isOpen={false} onClose={onClose} />);
+		expect(container.querySelector('[role="dialog"]')).toBeNull();
+	});
+
+	it('renders dialog when isOpen is true', () => {
+		const { getByRole } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		expect(getByRole('dialog')).toBeTruthy();
+	});
+
+	it('shows workspace path input with required indicator', () => {
+		const { getByPlaceholderText, getByText } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+		expect(getByPlaceholderText('/Users/you/projects/my-app')).toBeTruthy();
+		expect(getByText('Workspace Path')).toBeTruthy();
+		expect(getByText('*')).toBeTruthy();
+	});
+
+	it('auto-suggests name from workspace path', () => {
+		const { getByPlaceholderText } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		const pathInput = getByPlaceholderText('/Users/you/projects/my-app');
+		fireEvent.input(pathInput, { target: { value: '/projects/my-cool-app' } });
+
+		const nameInput = getByPlaceholderText('e.g., My App') as HTMLInputElement;
+		expect(nameInput.value).toBe('my-cool-app');
+	});
+
+	it('does not override name when user has already typed it', () => {
+		const { getByPlaceholderText } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		const nameInput = getByPlaceholderText('e.g., My App') as HTMLInputElement;
+		// User types a custom name
+		fireEvent.input(nameInput, { target: { value: 'Custom Name' } });
+
+		// Now change the path
+		const pathInput = getByPlaceholderText('/Users/you/projects/my-app');
+		fireEvent.input(pathInput, { target: { value: '/projects/different-dir' } });
+
+		// Name should remain the custom one
+		expect(nameInput.value).toBe('Custom Name');
+	});
+
+	it('shows validation error when workspace path is empty', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		const { getByRole, findByText } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+		expect(await findByText('Workspace path is required')).toBeTruthy();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('shows error when not connected', async () => {
+		mockGetHubIfConnected.mockReturnValue(null);
+		const { getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+		const pathInput = getByPlaceholderText('/Users/you/projects/my-app');
+		fireEvent.input(pathInput, { target: { value: '/projects/foo' } });
+
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+
+		expect(await findByText('Not connected to server')).toBeTruthy();
+	});
+
+	it('calls space.create RPC on submit with correct params', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(SPACE_MOCK);
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('/Users/you/projects/my-app'), {
+			target: { value: '/projects/my-app' },
+		});
+
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('space.create', {
+				workspacePath: '/projects/my-app',
+				name: 'my-app',
+				description: undefined,
+			});
+		});
+	});
+
+	it('navigates to new space and closes on success', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(SPACE_MOCK);
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('/Users/you/projects/my-app'), {
+			target: { value: '/projects/my-app' },
+		});
+
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+
+		await waitFor(() => {
+			expect(mockNavigateToSpace).toHaveBeenCalledWith('space-abc');
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it('shows error message when space.create fails', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockRejectedValue(new Error('Workspace path does not exist'));
+
+		const { getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('/Users/you/projects/my-app'), {
+			target: { value: '/projects/nonexistent' },
+		});
+
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+
+		expect(await findByText('Workspace path does not exist')).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when Cancel is clicked', () => {
+		const { getByText } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		fireEvent.click(getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('includes description in RPC call when provided', async () => {
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue(SPACE_MOCK);
+
+		const { getByPlaceholderText, getByRole } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+
+		fireEvent.input(getByPlaceholderText('/Users/you/projects/my-app'), {
+			target: { value: '/projects/my-app' },
+		});
+
+		fireEvent.input(getByPlaceholderText('Briefly describe the purpose of this space...'), {
+			target: { value: 'My project description' },
+		});
+
+		const form = getByRole('dialog').querySelector('form');
+		fireEvent.submit(form!);
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith(
+				'space.create',
+				expect.objectContaining({
+					description: 'My project description',
+				})
+			);
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceDashboard.test.tsx
@@ -1,0 +1,209 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceDashboard
+ *
+ * Tests:
+ * - Loading state renders spinner
+ * - No space renders "Space not found"
+ * - Space name and workspace path rendered
+ * - Description shown when present
+ * - Active runs banner shown when runs are active
+ * - Active tasks count in banner
+ * - Quick action cards rendered
+ * - onStartWorkflow called from "Start Workflow Run" card
+ * - onCreateTask called from "Create Task" card
+ * - Recent activity section shown when data exists
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { signal, computed } from '@preact/signals';
+import type { Space, SpaceTask, SpaceWorkflowRun } from '@neokai/shared';
+
+// Mock signals
+let mockSpace: ReturnType<typeof signal<Space | null>>;
+let mockLoading: ReturnType<typeof signal<boolean>>;
+let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockActiveRuns: ReturnType<typeof computed<SpaceWorkflowRun[]>>;
+let mockActiveTasks: ReturnType<typeof computed<SpaceTask[]>>;
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			space: mockSpace,
+			loading: mockLoading,
+			tasks: mockTasks,
+			workflowRuns: mockWorkflowRuns,
+			activeRuns: mockActiveRuns,
+			activeTasks: mockActiveTasks,
+		};
+	},
+}));
+
+// Initialize signals before component import
+mockSpace = signal<Space | null>(null);
+mockLoading = signal(false);
+mockTasks = signal<SpaceTask[]>([]);
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockActiveRuns = computed(() =>
+	mockWorkflowRuns.value.filter((r) => r.status === 'pending' || r.status === 'in_progress')
+);
+mockActiveTasks = computed(() => mockTasks.value.filter((t) => t.status === 'in_progress'));
+
+import { SpaceDashboard } from '../SpaceDashboard';
+
+function makeSpace(overrides: Partial<Space> = {}): Space {
+	return {
+		id: 'space-1',
+		name: 'My Space',
+		workspacePath: '/projects/my-space',
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeTask(id: string, status: SpaceTask['status'] = 'pending'): SpaceTask {
+	return {
+		id,
+		spaceId: 'space-1',
+		title: `Task ${id}`,
+		description: '',
+		status,
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeRun(id: string, status: SpaceWorkflowRun['status'] = 'pending'): SpaceWorkflowRun {
+	return {
+		id,
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title: `Run ${id}`,
+		status,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+describe('SpaceDashboard', () => {
+	beforeEach(() => {
+		cleanup();
+		mockSpace.value = null;
+		mockLoading.value = false;
+		mockTasks.value = [];
+		mockWorkflowRuns.value = [];
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders loading spinner when loading', () => {
+		mockLoading.value = true;
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(container.querySelector('.animate-spin')).toBeTruthy();
+	});
+
+	it('renders "Space not found" when no space', () => {
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Space not found')).toBeTruthy();
+	});
+
+	it('renders space name', () => {
+		mockSpace.value = makeSpace({ name: 'Awesome Project' });
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Awesome Project')).toBeTruthy();
+	});
+
+	it('renders workspace path', () => {
+		mockSpace.value = makeSpace({ workspacePath: '/home/user/projects/test' });
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('/home/user/projects/test')).toBeTruthy();
+	});
+
+	it('renders description when provided', () => {
+		mockSpace.value = makeSpace({ description: 'A cool project description' });
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('A cool project description')).toBeTruthy();
+	});
+
+	it('does not show active banner when no active runs or tasks', () => {
+		mockSpace.value = makeSpace();
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		// No blue animated dot
+		expect(container.querySelector('.bg-blue-400')).toBeNull();
+	});
+
+	it('shows active runs in banner', () => {
+		mockSpace.value = makeSpace();
+		mockWorkflowRuns.value = [makeRun('r1', 'in_progress')];
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText(/1 active run/)).toBeTruthy();
+	});
+
+	it('shows active tasks count in banner', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'in_progress'), makeTask('t2', 'in_progress')];
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText(/2 tasks in progress/)).toBeTruthy();
+	});
+
+	it('renders quick action cards', () => {
+		mockSpace.value = makeSpace();
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Start Workflow Run')).toBeTruthy();
+		expect(getByText('Create Task')).toBeTruthy();
+	});
+
+	it('calls onStartWorkflow when "Start Workflow Run" card is clicked', () => {
+		mockSpace.value = makeSpace();
+		const onStartWorkflow = vi.fn();
+		const { getByText } = render(
+			<SpaceDashboard spaceId="space-1" onStartWorkflow={onStartWorkflow} />
+		);
+		fireEvent.click(getByText('Start Workflow Run').closest('button')!);
+		expect(onStartWorkflow).toHaveBeenCalled();
+	});
+
+	it('calls onCreateTask when "Create Task" card is clicked', () => {
+		mockSpace.value = makeSpace();
+		const onCreateTask = vi.fn();
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" onCreateTask={onCreateTask} />);
+		fireEvent.click(getByText('Create Task').closest('button')!);
+		expect(onCreateTask).toHaveBeenCalled();
+	});
+
+	it('shows recent activity section when runs exist', () => {
+		mockSpace.value = makeSpace();
+		mockWorkflowRuns.value = [makeRun('r1', 'completed')];
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Recent Activity')).toBeTruthy();
+		expect(getByText('Run r1')).toBeTruthy();
+	});
+
+	it('shows recent tasks in activity section', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [makeTask('t1', 'completed')];
+		const { getByText } = render(<SpaceDashboard spaceId="space-1" />);
+		expect(getByText('Task t1')).toBeTruthy();
+	});
+
+	it('truncates long workspace paths', () => {
+		const longPath = '/very/long/path/to/some/deeply/nested/project/directory/my-project';
+		mockSpace.value = makeSpace({ workspacePath: longPath });
+		const { container } = render(<SpaceDashboard spaceId="space-1" />);
+		const pathEl = container.querySelector('.font-mono');
+		// Path should be truncated (starts with ellipsis)
+		expect(pathEl?.textContent?.startsWith('…')).toBe(true);
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceNavPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceNavPanel.test.tsx
@@ -1,0 +1,213 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceNavPanel
+ *
+ * Tests:
+ * - Loading state renders skeleton text
+ * - Empty state when no runs or tasks
+ * - Workflow runs section renders runs
+ * - Task count per run displayed
+ * - Standalone tasks section renders tasks
+ * - Status dots render for various statuses
+ * - Active item highlighted
+ * - onRunSelect called when run clicked
+ * - onTaskSelect called when task clicked
+ * - Navigation links rendered
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { signal, computed } from '@preact/signals';
+import type { SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
+
+// Mock signals — define before vi.mock
+let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockLoading: ReturnType<typeof signal<boolean>>;
+let mockStandaloneTasks: ReturnType<typeof computed<SpaceTask[]>>;
+let mockTasksByRun: ReturnType<typeof computed<Map<string, SpaceTask[]>>>;
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			workflowRuns: mockWorkflowRuns,
+			standaloneTasks: mockStandaloneTasks,
+			tasksByRun: mockTasksByRun,
+			loading: mockLoading,
+		};
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Initialize signals
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockTasks = signal<SpaceTask[]>([]);
+mockLoading = signal(false);
+mockStandaloneTasks = computed(() => mockTasks.value.filter((t) => !t.workflowRunId));
+mockTasksByRun = computed(() => {
+	const map = new Map<string, SpaceTask[]>();
+	for (const task of mockTasks.value) {
+		if (task.workflowRunId) {
+			const existing = map.get(task.workflowRunId) ?? [];
+			map.set(task.workflowRunId, [...existing, task]);
+		}
+	}
+	return map;
+});
+
+import { SpaceNavPanel } from '../SpaceNavPanel';
+
+function makeRun(
+	id: string,
+	status: SpaceWorkflowRun['status'] = 'pending',
+	title = `Run ${id}`
+): SpaceWorkflowRun {
+	return {
+		id,
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title,
+		status,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeTask(
+	id: string,
+	status: SpaceTask['status'] = 'pending',
+	workflowRunId?: string
+): SpaceTask {
+	return {
+		id,
+		spaceId: 'space-1',
+		title: `Task ${id}`,
+		description: '',
+		status,
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...(workflowRunId ? { workflowRunId } : {}),
+	};
+}
+
+const defaultProps = {
+	spaceId: 'space-1',
+	activeTaskId: null,
+	activeRunId: null,
+	onRunSelect: vi.fn(),
+	onTaskSelect: vi.fn(),
+};
+
+describe('SpaceNavPanel', () => {
+	beforeEach(() => {
+		cleanup();
+		mockWorkflowRuns.value = [];
+		mockTasks.value = [];
+		mockLoading.value = false;
+		defaultProps.onRunSelect.mockClear();
+		defaultProps.onTaskSelect.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders loading state when loading is true', () => {
+		mockLoading.value = true;
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('Loading...')).toBeTruthy();
+	});
+
+	it('renders empty state when no runs or tasks', () => {
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('No runs or tasks yet')).toBeTruthy();
+	});
+
+	it('renders workflow runs section when runs exist', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'pending', 'My Run')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('Workflow Runs')).toBeTruthy();
+		expect(getByText('My Run')).toBeTruthy();
+	});
+
+	it('shows task count per run', () => {
+		mockWorkflowRuns.value = [makeRun('r1')];
+		mockTasks.value = [makeTask('t1', 'pending', 'r1'), makeTask('t2', 'in_progress', 'r1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('2 tasks')).toBeTruthy();
+	});
+
+	it('shows singular task when count is 1', () => {
+		mockWorkflowRuns.value = [makeRun('r1')];
+		mockTasks.value = [makeTask('t1', 'pending', 'r1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('1 task')).toBeTruthy();
+	});
+
+	it('renders standalone tasks section when tasks exist', () => {
+		mockTasks.value = [makeTask('t1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('Tasks')).toBeTruthy();
+		expect(getByText('Task t1')).toBeTruthy();
+	});
+
+	it('calls onRunSelect when a run is clicked', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'pending', 'Run 1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		fireEvent.click(getByText('Run 1'));
+		expect(defaultProps.onRunSelect).toHaveBeenCalledWith('r1');
+	});
+
+	it('calls onTaskSelect when a task is clicked', () => {
+		mockTasks.value = [makeTask('t1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		fireEvent.click(getByText('Task t1'));
+		expect(defaultProps.onTaskSelect).toHaveBeenCalledWith('t1');
+	});
+
+	it('highlights active run', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'pending', 'Active Run')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} activeRunId="r1" />);
+		const runButton = getByText('Active Run').closest('button');
+		expect(runButton?.className).toContain('bg-dark-700');
+	});
+
+	it('highlights active task', () => {
+		mockTasks.value = [makeTask('t1')];
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} activeTaskId="t1" />);
+		const taskButton = getByText('Task t1').closest('button');
+		expect(taskButton?.className).toContain('bg-dark-700');
+	});
+
+	it('renders navigation links', () => {
+		const { getByText } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(getByText('Agents')).toBeTruthy();
+		expect(getByText('Workflows')).toBeTruthy();
+		expect(getByText('Settings')).toBeTruthy();
+	});
+
+	it('renders in_progress status dot with animation', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'in_progress', 'Active Run')];
+		const { container } = render(<SpaceNavPanel {...defaultProps} />);
+		const dot = container.querySelector('.bg-blue-400');
+		expect(dot).toBeTruthy();
+		expect(dot?.className).toContain('animate-pulse');
+	});
+
+	it('renders completed status dot in green', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'completed', 'Done Run')];
+		const { container } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(container.querySelector('.bg-green-500')).toBeTruthy();
+	});
+
+	it('renders needs_attention status dot in yellow', () => {
+		mockWorkflowRuns.value = [makeRun('r1', 'needs_attention', 'Blocked Run')];
+		const { container } = render(<SpaceNavPanel {...defaultProps} />);
+		expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -1,0 +1,194 @@
+// @ts-nocheck
+/**
+ * Unit tests for SpaceTaskPane
+ *
+ * Tests:
+ * - Empty state when no taskId
+ * - "Task not found" when taskId doesn't match
+ * - Task title rendered
+ * - Status badge rendered
+ * - Priority indicator rendered
+ * - Workflow step indicator shown when workflowRunId present
+ * - Description rendered
+ * - Current step rendered
+ * - Progress bar rendered
+ * - Result section rendered
+ * - Error section rendered
+ * - PR link rendered
+ * - Human input area shown for needs_attention status
+ * - Human input area NOT shown for other statuses
+ * - Close button calls onClose
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { SpaceTask } from '@neokai/shared';
+
+let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			tasks: mockTasks,
+			updateTask: mockUpdateTask,
+		};
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Initialize signals
+mockTasks = signal<SpaceTask[]>([]);
+
+import { SpaceTaskPane } from '../SpaceTaskPane';
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'Fix the bug',
+		description: 'This is the description',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+describe('SpaceTaskPane', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockUpdateTask.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows empty state when taskId is null', () => {
+		const { getByText } = render(<SpaceTaskPane taskId={null} />);
+		expect(getByText('Select a task to view details')).toBeTruthy();
+	});
+
+	it('shows "Task not found" when taskId does not match any task', () => {
+		mockTasks.value = [makeTask()];
+		const { getByText } = render(<SpaceTaskPane taskId="nonexistent" />);
+		expect(getByText('Task not found')).toBeTruthy();
+	});
+
+	it('renders task title', () => {
+		mockTasks.value = [makeTask({ title: 'My Awesome Task' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('My Awesome Task')).toBeTruthy();
+	});
+
+	it('renders status badge', () => {
+		mockTasks.value = [makeTask({ status: 'in_progress' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('In Progress')).toBeTruthy();
+	});
+
+	it('renders priority indicator', () => {
+		mockTasks.value = [makeTask({ priority: 'high' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('High priority')).toBeTruthy();
+	});
+
+	it('shows workflow step indicator when workflowRunId is present', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1', workflowStepId: 'step-abc123' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText(/Workflow Step/)).toBeTruthy();
+		// Should show truncated step ID
+		expect(getByText(/step-ab/)).toBeTruthy();
+	});
+
+	it('does NOT show workflow step indicator without workflowRunId', () => {
+		mockTasks.value = [makeTask()];
+		const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByText(/Workflow Step/)).toBeNull();
+	});
+
+	it('renders description', () => {
+		mockTasks.value = [makeTask({ description: 'Detailed description here' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Detailed description here')).toBeTruthy();
+	});
+
+	it('renders current step when present', () => {
+		mockTasks.value = [makeTask({ currentStep: 'Running linter' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Current Step')).toBeTruthy();
+		expect(getByText('Running linter')).toBeTruthy();
+	});
+
+	it('renders progress bar when progress > 0', () => {
+		mockTasks.value = [makeTask({ progress: 75 })];
+		const { getByText, container } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Progress')).toBeTruthy();
+		expect(getByText('75%')).toBeTruthy();
+		const progressBar = container.querySelector('.bg-blue-500');
+		expect(progressBar).toBeTruthy();
+	});
+
+	it('does NOT render progress bar when progress is null', () => {
+		mockTasks.value = [makeTask({ progress: null })];
+		const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByText('Progress')).toBeNull();
+	});
+
+	it('renders result section when result exists', () => {
+		mockTasks.value = [makeTask({ result: 'Build succeeded' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Result')).toBeTruthy();
+		expect(getByText('Build succeeded')).toBeTruthy();
+	});
+
+	it('renders error section when error exists', () => {
+		mockTasks.value = [makeTask({ error: 'Build failed: syntax error' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Error')).toBeTruthy();
+		expect(getByText('Build failed: syntax error')).toBeTruthy();
+	});
+
+	it('renders PR link when prUrl is set', () => {
+		mockTasks.value = [makeTask({ prUrl: 'https://github.com/owner/repo/pull/42', prNumber: 42 })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('PR #42')).toBeTruthy();
+	});
+
+	it('shows human input area for needs_attention status', () => {
+		mockTasks.value = [makeTask({ status: 'needs_attention' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Human Input Required')).toBeTruthy();
+		expect(getByText('Submit Response')).toBeTruthy();
+	});
+
+	it('does NOT show human input area for non-needs_attention status', () => {
+		mockTasks.value = [makeTask({ status: 'in_progress' })];
+		const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByText('Human Input Required')).toBeNull();
+	});
+
+	it('calls onClose when close button is clicked', () => {
+		mockTasks.value = [makeTask()];
+		const onClose = vi.fn();
+		const { container } = render(<SpaceTaskPane taskId="task-1" onClose={onClose} />);
+		const closeBtn = container.querySelector('[aria-label="Close task pane"]');
+		expect(closeBtn).toBeTruthy();
+		fireEvent.click(closeBtn!);
+		expect(onClose).toHaveBeenCalled();
+	});
+
+	it('does not render close button when onClose is not provided', () => {
+		mockTasks.value = [makeTask()];
+		const { container } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(container.querySelector('[aria-label="Close task pane"]')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceTask } from '@neokai/shared';
 
@@ -190,5 +190,75 @@ describe('SpaceTaskPane', () => {
 		mockTasks.value = [makeTask()];
 		const { container } = render(<SpaceTaskPane taskId="task-1" />);
 		expect(container.querySelector('[aria-label="Close task pane"]')).toBeNull();
+	});
+});
+
+describe('SpaceTaskPane — HumanInputArea submit behavior', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockUpdateTask.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('calls updateTask with inputDraft first, then status second', async () => {
+		mockTasks.value = [makeTask({ status: 'needs_attention' })];
+		const { getByPlaceholderText, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+
+		fireEvent.input(getByPlaceholderText('Type your response or approval...'), {
+			target: { value: 'Looks good to me' },
+		});
+		fireEvent.click(getByText('Submit Response'));
+
+		await waitFor(() => expect(mockUpdateTask).toHaveBeenCalledTimes(2));
+
+		const [firstCall, secondCall] = mockUpdateTask.mock.calls;
+		expect(firstCall).toEqual(['task-1', { inputDraft: 'Looks good to me' }]);
+		expect(secondCall).toEqual(['task-1', { status: 'in_progress' }]);
+	});
+
+	it('does not attempt status transition if inputDraft persistence fails', async () => {
+		mockUpdateTask.mockRejectedValueOnce(new Error('Server error'));
+		mockTasks.value = [makeTask({ status: 'needs_attention' })];
+		const { getByPlaceholderText, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+
+		fireEvent.input(getByPlaceholderText('Type your response or approval...'), {
+			target: { value: 'My response' },
+		});
+		fireEvent.click(getByText('Submit Response'));
+
+		await waitFor(() => expect(mockUpdateTask).toHaveBeenCalledTimes(1));
+		// Only the draft call was attempted — status transition was skipped
+		expect(mockUpdateTask.mock.calls[0]).toEqual(['task-1', { inputDraft: 'My response' }]);
+	});
+
+	it('shows error message when status transition fails', async () => {
+		mockUpdateTask
+			.mockResolvedValueOnce(undefined) // inputDraft succeeds
+			.mockRejectedValueOnce(new Error('Invalid transition')); // status fails
+		mockTasks.value = [makeTask({ status: 'needs_attention' })];
+		const { getByPlaceholderText, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+
+		fireEvent.input(getByPlaceholderText('Type your response or approval...'), {
+			target: { value: 'Approved' },
+		});
+		fireEvent.click(getByText('Submit Response'));
+
+		await waitFor(() => expect(getByText('Invalid transition')).toBeTruthy());
+		// Both calls were made (draft + failed status)
+		expect(mockUpdateTask).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not submit when input text is empty', () => {
+		mockTasks.value = [makeTask({ status: 'needs_attention' })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+
+		// Submit button is disabled when input is empty — click is a no-op
+		fireEvent.click(getByText('Submit Response'));
+
+		expect(mockUpdateTask).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import {
 	navSectionSignal,
 	contextPanelOpenSignal,
@@ -30,6 +30,8 @@ import { SessionList } from './SessionList.tsx';
 import { RoomList } from './RoomList.tsx';
 import { RoomContextPanel } from './RoomContextPanel.tsx';
 import { SpaceContextPanel } from '../components/space/SpaceContextPanel.tsx';
+import { SpaceCreateDialog } from '../components/space/SpaceCreateDialog.tsx';
+import { spaceStore } from '../lib/space-store.ts';
 import { ConnectionNotReadyError } from '../lib/errors.ts';
 
 // Settings section configuration
@@ -116,9 +118,19 @@ function SectionIcon({ type }: { type: string }) {
 
 export function ContextPanel() {
 	const [creatingSession, setCreatingSession] = useState(false);
+	const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
 
 	const navSection = navSectionSignal.value;
 	const isPanelOpen = contextPanelOpenSignal.value;
+
+	// Initialize the global space list when entering the spaces section
+	useEffect(() => {
+		if (navSection === 'spaces') {
+			spaceStore.initGlobalList().catch(() => {
+				// Error tracked inside initGlobalList
+			});
+		}
+	}, [navSection]);
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentRoomId = currentRoomIdSignal.value;
 
@@ -215,6 +227,9 @@ export function ContextPanel() {
 			case 'chats':
 				handleCreateSession();
 				break;
+			case 'spaces':
+				setCreateSpaceOpen(true);
+				break;
 			default:
 				break;
 		}
@@ -253,12 +268,17 @@ export function ContextPanel() {
 
 	const isActionLoading = creatingSession;
 
+	const allSpaces = spaceStore.spaces.value;
+
 	return (
 		<>
 			{/* Mobile backdrop */}
 			{isPanelOpen && (
 				<div class="fixed inset-0 bg-black/50 z-35 md:hidden" onClick={handlePanelClose} />
 			)}
+
+			{/* Space Create Dialog */}
+			<SpaceCreateDialog isOpen={createSpaceOpen} onClose={() => setCreateSpaceOpen(false)} />
 
 			<div
 				class={`
@@ -321,6 +341,7 @@ export function ContextPanel() {
 
 					{(navSection === 'home' ||
 						navSection === 'chats' ||
+						navSection === 'spaces' ||
 						(navSection === 'rooms' && !isRoomDetail)) && (
 						<Button
 							onClick={handleAction}
@@ -360,13 +381,10 @@ export function ContextPanel() {
 					<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
 				)}
 				{navSection === 'spaces' && (
-					// TODO: replace empty array with real space list from state once
-					// the Spaces data layer is wired up (Task 5.x).
-					// onCreateSpace is intentionally omitted here — "Create Space" will be
-					// triggered from the header CTA button once space creation is implemented.
 					<SpaceContextPanel
-						spaces={[]}
+						spaces={allSpaces}
 						onSpaceSelect={() => (contextPanelOpenSignal.value = false)}
+						onCreateSpace={() => setCreateSpaceOpen(true)}
 					/>
 				)}
 				{navSection === 'projects' && (

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -1,21 +1,106 @@
 /**
  * SpaceIsland — main content area for the Space view.
  * Rendered by MainContent when currentSpaceIdSignal is set.
- * Full implementation will follow in subsequent tasks.
+ *
+ * 3-column layout:
+ * - Left (~240px): SpaceNavPanel — workflow runs, tasks, nav links
+ * - Middle (flex-1): SpaceDashboard (default) or other detail views
+ * - Right (~320px, conditional): SpaceTaskPane when a task is selected
  */
+
+import { useState, useEffect } from 'preact/hooks';
+import { spaceStore } from '../lib/space-store';
+import { currentSpaceTaskIdSignal } from '../lib/signals';
+import { navigateToSpaceTask, navigateToSpace } from '../lib/router';
+import { SpaceNavPanel } from '../components/space/SpaceNavPanel';
+import { SpaceDashboard } from '../components/space/SpaceDashboard';
+import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
 
 interface SpaceIslandProps {
 	spaceId: string;
 }
 
 export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
-	return (
-		<div class="flex-1 flex items-center justify-center bg-dark-900">
-			<div class="text-center">
-				<div class="text-4xl mb-3">🚀</div>
-				<p class="text-sm text-gray-400">Space</p>
-				<p class="text-xs text-gray-600 mt-1 font-mono">{spaceId}</p>
+	const [activeRunId, setActiveRunId] = useState<string | null>(null);
+	const loading = spaceStore.loading.value;
+	const error = spaceStore.error.value;
+
+	// Derive active task ID from the global signal
+	const activeTaskId = currentSpaceTaskIdSignal.value;
+
+	// Load space data on mount or when spaceId changes
+	useEffect(() => {
+		spaceStore.selectSpace(spaceId).catch(() => {
+			// Error is tracked in spaceStore.error
+		});
+
+		return () => {
+			// Optionally clear when unmounting; leave it for now so
+			// navigating back is instant (store shows stale-then-fresh data).
+		};
+	}, [spaceId]);
+
+	const handleRunSelect = (runId: string) => {
+		setActiveRunId(runId);
+		// Clear task selection when switching to a run
+		currentSpaceTaskIdSignal.value = null;
+	};
+
+	const handleTaskSelect = (taskId: string) => {
+		setActiveRunId(null);
+		navigateToSpaceTask(spaceId, taskId);
+	};
+
+	const handleTaskPaneClose = () => {
+		navigateToSpace(spaceId);
+	};
+
+	if (loading && !spaceStore.space.value) {
+		return (
+			<div class="flex-1 flex items-center justify-center bg-dark-900">
+				<div class="text-center">
+					<div class="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+					<p class="text-sm text-gray-500">Loading space...</p>
+				</div>
 			</div>
+		);
+	}
+
+	if (error && !spaceStore.space.value) {
+		return (
+			<div class="flex-1 flex items-center justify-center bg-dark-900">
+				<div class="text-center max-w-sm">
+					<p class="text-sm text-red-400 mb-2">Failed to load space</p>
+					<p class="text-xs text-gray-600">{error}</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex-1 flex overflow-hidden bg-dark-900">
+			{/* Left column — navigation panel */}
+			<div class="w-60 flex-shrink-0 border-r border-dark-700 overflow-hidden flex flex-col">
+				<SpaceNavPanel
+					spaceId={spaceId}
+					activeTaskId={activeTaskId}
+					activeRunId={activeRunId}
+					onRunSelect={handleRunSelect}
+					onTaskSelect={handleTaskSelect}
+				/>
+			</div>
+
+			{/* Middle column — main content */}
+			<div class="flex-1 overflow-hidden flex flex-col min-w-0">
+				<SpaceDashboard spaceId={spaceId} />
+			</div>
+
+			{/* Right column — task detail pane (conditionally shown) */}
+			{activeTaskId && (
+				<div class="hidden md:flex w-80 flex-shrink-0 border-l border-dark-700 overflow-hidden flex-col">
+					<SpaceTaskPane taskId={activeTaskId} onClose={handleTaskPaneClose} />
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -121,6 +121,8 @@ function makeMockHub() {
 			// spaceWorkflow handlers return wrapped { workflow }
 			if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
 			if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
+			// space.list returns array of spaces
+			if (method === 'space.list') return [makeSpace('s1'), makeSpace('s2')];
 			return {};
 		}),
 	};
@@ -859,5 +861,147 @@ describe('SpaceStore — CRUD methods', () => {
 			'No space selected'
 		);
 		await expect(spaceStore.createWorkflow({ name: 'W' })).rejects.toThrow('No space selected');
+	});
+});
+
+// -------------------------------------------------------
+// Helper to access/reset private globalListInitialized flag
+// -------------------------------------------------------
+
+type SpaceStorePrivate = {
+	globalListInitialized: boolean;
+};
+
+function resetGlobalListState() {
+	(spaceStore as unknown as SpaceStorePrivate).globalListInitialized = false;
+	spaceStore.spaces.value = [];
+}
+
+describe('SpaceStore — initGlobalList', () => {
+	beforeEach(async () => {
+		await resetStore();
+		resetGlobalListState();
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it('fetches space list and populates spaces signal', async () => {
+		await spaceStore.initGlobalList();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.list', {});
+		expect(spaceStore.spaces.value).toHaveLength(2);
+		expect(spaceStore.spaces.value[0].id).toBe('s1');
+		expect(spaceStore.spaces.value[1].id).toBe('s2');
+	});
+
+	it('is idempotent — second call skips fetch', async () => {
+		await spaceStore.initGlobalList();
+		const callCount = mockHub.request.mock.calls.length;
+
+		await spaceStore.initGlobalList();
+
+		// No additional request calls on the second invocation
+		expect(mockHub.request.mock.calls.length).toBe(callCount);
+	});
+
+	it('adds new space on space.created when not already in list', async () => {
+		await spaceStore.initGlobalList();
+		const newSpace = makeSpace('new-s');
+
+		mockEventHandlers.get('space.created')?.({ spaceId: 'new-s', space: newSpace });
+
+		expect(spaceStore.spaces.value.some((s) => s.id === 'new-s')).toBe(true);
+		expect(spaceStore.spaces.value).toHaveLength(3);
+	});
+
+	it('does not add duplicate on space.created if already in list', async () => {
+		await spaceStore.initGlobalList();
+		const count = spaceStore.spaces.value.length;
+
+		mockEventHandlers.get('space.created')?.({ spaceId: 's1', space: makeSpace('s1') });
+
+		expect(spaceStore.spaces.value).toHaveLength(count);
+	});
+
+	it('updates matching space on space.updated', async () => {
+		await spaceStore.initGlobalList();
+
+		mockEventHandlers.get('space.updated')?.({ spaceId: 's1', space: { name: 'Renamed' } });
+
+		expect(spaceStore.spaces.value.find((s) => s.id === 's1')?.name).toBe('Renamed');
+		// Other spaces unaffected
+		expect(spaceStore.spaces.value.find((s) => s.id === 's2')?.name).toBe('Test Space');
+	});
+
+	it('replaces matching space on space.archived', async () => {
+		await spaceStore.initGlobalList();
+		const archived = { ...makeSpace('s1'), status: 'archived' } as Space;
+
+		mockEventHandlers.get('space.archived')?.({ spaceId: 's1', space: archived });
+
+		expect(spaceStore.spaces.value.find((s) => s.id === 's1')?.status).toBe('archived');
+		expect(spaceStore.spaces.value).toHaveLength(2);
+	});
+
+	it('removes matching space on space.deleted', async () => {
+		await spaceStore.initGlobalList();
+		expect(spaceStore.spaces.value.some((s) => s.id === 's1')).toBe(true);
+
+		mockEventHandlers.get('space.deleted')?.({ spaceId: 's1' });
+
+		expect(spaceStore.spaces.value.some((s) => s.id === 's1')).toBe(false);
+		expect(spaceStore.spaces.value).toHaveLength(1);
+	});
+
+	it('resets globalListInitialized flag on failure so retry works', async () => {
+		mockHub.request.mockRejectedValueOnce(new Error('Network error'));
+		await spaceStore.initGlobalList();
+
+		const priv = spaceStore as unknown as SpaceStorePrivate;
+		expect(priv.globalListInitialized).toBe(false);
+
+		// Retry should succeed and set flag to true
+		await spaceStore.initGlobalList();
+		expect(priv.globalListInitialized).toBe(true);
+		expect(spaceStore.spaces.value).toHaveLength(2);
+	});
+});
+
+describe('SpaceStore — refresh', () => {
+	beforeEach(async () => {
+		await resetStore();
+		resetGlobalListState();
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it('re-initializes global list on reconnect when previously initialized', async () => {
+		await spaceStore.initGlobalList();
+		mockHub.request.mockClear();
+
+		await spaceStore.refresh();
+
+		// space.list should be re-fetched (init ran again)
+		expect(mockHub.request).toHaveBeenCalledWith('space.list', {});
+	});
+
+	it('does not re-init global list when never initialized', async () => {
+		// globalListInitialized is false — never called initGlobalList
+		await spaceStore.refresh();
+
+		expect(mockHub.request).not.toHaveBeenCalledWith('space.list', expect.anything());
+	});
+
+	it('re-fetches space overview when a space is selected', async () => {
+		await spaceStore.selectSpace('space-1');
+		mockHub.request.mockClear();
+
+		await spaceStore.refresh();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.overview', { id: 'space-1' });
+	});
+
+	it('is a no-op for space state when no space is selected', async () => {
+		await spaceStore.refresh();
+
+		expect(mockHub.request).not.toHaveBeenCalledWith('space.overview', expect.anything());
 	});
 });

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -19,7 +19,14 @@ import type { Space, SpaceTask, SpaceWorkflowRun, SpaceAgent, SpaceWorkflow } fr
 // -------------------------------------------------------
 
 let mockEventHandlers: Map<string, (event: unknown) => void>;
+/** Multi-handler map: supports multiple subscribers per event (used in P0 duplicate-subscription tests) */
+let mockEventHandlerSets: Map<string, Set<(event: unknown) => void>>;
 let mockHub: ReturnType<typeof makeMockHub>;
+
+/** Fire all registered handlers for an event (both single and multi-handler maps) */
+function fireMockEvent(eventName: string, data: unknown): void {
+	mockEventHandlerSets.get(eventName)?.forEach((h) => h(data));
+}
 
 function makeSpace(id = 'space-1'): Space {
 	return {
@@ -94,8 +101,17 @@ function makeMockHub() {
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),
 		onEvent: vi.fn((eventName: string, handler: (e: unknown) => void) => {
+			// Single-handler map — last registration wins (used by most existing tests)
 			mockEventHandlers.set(eventName, handler);
-			return () => mockEventHandlers.delete(eventName);
+			// Multi-handler set — tracks all active handlers for P0 duplicate-subscription tests
+			if (!mockEventHandlerSets.has(eventName)) {
+				mockEventHandlerSets.set(eventName, new Set());
+			}
+			mockEventHandlerSets.get(eventName)!.add(handler);
+			return () => {
+				mockEventHandlers.delete(eventName);
+				mockEventHandlerSets.get(eventName)?.delete(handler);
+			};
 		}),
 		request: vi.fn(async (method: string, _params?: unknown) => {
 			if (method === 'space.overview') {
@@ -148,6 +164,7 @@ async function getStore() {
 
 async function resetStore() {
 	mockEventHandlers = new Map();
+	mockEventHandlerSets = new Map();
 	mockHub = makeMockHub();
 	spaceStore = await getStore();
 	// Deselect if a space is selected
@@ -870,10 +887,13 @@ describe('SpaceStore — CRUD methods', () => {
 
 type SpaceStorePrivate = {
 	globalListInitialized: boolean;
+	globalListCleanupFns: Array<() => void>;
 };
 
 function resetGlobalListState() {
-	(spaceStore as unknown as SpaceStorePrivate).globalListInitialized = false;
+	const priv = spaceStore as unknown as SpaceStorePrivate;
+	priv.globalListInitialized = false;
+	priv.globalListCleanupFns = [];
 	spaceStore.spaces.value = [];
 }
 
@@ -952,6 +972,23 @@ describe('SpaceStore — initGlobalList', () => {
 		expect(spaceStore.spaces.value).toHaveLength(1);
 	});
 
+	it('removes stale handlers before re-registering on reconnect re-init', async () => {
+		// Initial registration
+		await spaceStore.initGlobalList();
+		expect(spaceStore.spaces.value).toHaveLength(2);
+
+		// Simulate refresh(): reset flag (stale handlers still on hub)
+		const priv = spaceStore as unknown as SpaceStorePrivate;
+		priv.globalListInitialized = false;
+
+		// Re-init: must call cleanup fns before re-registering
+		await spaceStore.initGlobalList();
+
+		// Fire space.created once — should produce exactly one new entry (not two)
+		fireMockEvent('space.created', { spaceId: 'new-s', space: makeSpace('new-s') });
+		expect(spaceStore.spaces.value.filter((s) => s.id === 'new-s')).toHaveLength(1);
+	});
+
 	it('resets globalListInitialized flag on failure so retry works', async () => {
 		mockHub.request.mockRejectedValueOnce(new Error('Network error'));
 		await spaceStore.initGlobalList();
@@ -979,7 +1016,9 @@ describe('SpaceStore — refresh', () => {
 
 		await spaceStore.refresh();
 
-		// space.list should be re-fetched (init ran again)
+		// refresh() fire-and-forgets initGlobalList() via .catch(). The assertion passes
+		// because all mocks resolve synchronously (vi.fn async), so the microtask queue
+		// drains within the same await tick as refresh() itself.
 		expect(mockHub.request).toHaveBeenCalledWith('space.list', {});
 	});
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -126,6 +126,13 @@ class SpaceStore {
 	/** Whether global list subscriptions have been set up */
 	private globalListInitialized = false;
 
+	/**
+	 * Cleanup functions for global list event subscriptions.
+	 * Stored so re-initialization (on reconnect) can remove old handlers
+	 * before registering new ones on the same hub instance.
+	 */
+	private globalListCleanupFns: Array<() => void> = [];
+
 	// ========================================
 	// Global Space List
 	// ========================================
@@ -134,10 +141,25 @@ class SpaceStore {
 	 * Initialize the global space list.
 	 * Fetches all spaces from the server and subscribes to global create/archive/delete events.
 	 * Safe to call multiple times — idempotent after first call.
+	 *
+	 * On reconnect, refresh() resets `globalListInitialized` so this runs again.
+	 * Before re-registering, any stale handlers from the previous run are removed
+	 * via `globalListCleanupFns` to prevent duplicate subscriptions on the same hub.
 	 */
 	async initGlobalList(): Promise<void> {
 		if (this.globalListInitialized) return;
 		this.globalListInitialized = true;
+
+		// Remove stale handlers from the previous registration (e.g. after a refresh reset).
+		// This prevents duplicate event firings when the same hub instance is reused.
+		for (const cleanup of this.globalListCleanupFns) {
+			try {
+				cleanup();
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+		this.globalListCleanupFns = [];
 
 		try {
 			const hub = await connectionManager.getHub();
@@ -145,30 +167,38 @@ class SpaceStore {
 			this.spaces.value = spaces ?? [];
 
 			// Subscribe to global space events to keep list up-to-date
-			hub.onEvent<{ spaceId: string; space: Space }>('space.created', (event) => {
-				if (event.space) {
-					const exists = this.spaces.value.some((s) => s.id === event.spaceId);
-					if (!exists) {
-						this.spaces.value = [...this.spaces.value, event.space];
+			this.globalListCleanupFns.push(
+				hub.onEvent<{ spaceId: string; space: Space }>('space.created', (event) => {
+					if (event.space) {
+						const exists = this.spaces.value.some((s) => s.id === event.spaceId);
+						if (!exists) {
+							this.spaces.value = [...this.spaces.value, event.space];
+						}
 					}
-				}
-			});
+				})
+			);
 
-			hub.onEvent<{ spaceId: string; space?: Partial<Space> }>('space.updated', (event) => {
-				this.spaces.value = this.spaces.value.map((s) =>
-					s.id === event.spaceId ? ({ ...s, ...event.space } as Space) : s
-				);
-			});
+			this.globalListCleanupFns.push(
+				hub.onEvent<{ spaceId: string; space?: Partial<Space> }>('space.updated', (event) => {
+					this.spaces.value = this.spaces.value.map((s) =>
+						s.id === event.spaceId ? ({ ...s, ...event.space } as Space) : s
+					);
+				})
+			);
 
-			hub.onEvent<{ spaceId: string; space: Space }>('space.archived', (event) => {
-				this.spaces.value = this.spaces.value.map((s) =>
-					s.id === event.spaceId ? event.space : s
-				);
-			});
+			this.globalListCleanupFns.push(
+				hub.onEvent<{ spaceId: string; space: Space }>('space.archived', (event) => {
+					this.spaces.value = this.spaces.value.map((s) =>
+						s.id === event.spaceId ? event.space : s
+					);
+				})
+			);
 
-			hub.onEvent<{ spaceId: string }>('space.deleted', (event) => {
-				this.spaces.value = this.spaces.value.filter((s) => s.id !== event.spaceId);
-			});
+			this.globalListCleanupFns.push(
+				hub.onEvent<{ spaceId: string }>('space.deleted', (event) => {
+					this.spaces.value = this.spaces.value.filter((s) => s.id !== event.spaceId);
+				})
+			);
 		} catch (err) {
 			logger.error('Failed to initialize global space list:', err);
 			// Reset flag so retries work on reconnect

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -567,8 +567,23 @@ class SpaceStore {
 	/**
 	 * Refresh current space state from server.
 	 * Called by the connection manager on WebSocket reconnect.
+	 *
+	 * Also re-initializes the global space list when it was previously set up.
+	 * The old hub connection is closed on disconnect, tearing down any event
+	 * subscriptions registered in initGlobalList(). Resetting the flag here
+	 * ensures initGlobalList() runs again with the new hub connection — either
+	 * immediately (if the global list was active) or lazily (on next Spaces
+	 * section navigation).
 	 */
 	async refresh(): Promise<void> {
+		// Re-initialize global list subscriptions on the new hub if they existed
+		if (this.globalListInitialized) {
+			this.globalListInitialized = false;
+			this.initGlobalList().catch((err) => {
+				logger.error('Failed to re-initialize global space list on reconnect:', err);
+			});
+		}
+
 		const spaceId = this.spaceId.value;
 		if (!spaceId) return;
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -46,6 +46,12 @@ class SpaceStore {
 	// Core Signals
 	// ========================================
 
+	/**
+	 * Global list of all spaces (across all spaces, for the sidebar list).
+	 * Populated by initGlobalList(); not tied to any selected space.
+	 */
+	readonly spaces = signal<Space[]>([]);
+
 	/** Current active space ID */
 	readonly spaceId = signal<string | null>(null);
 
@@ -116,6 +122,59 @@ class SpaceStore {
 
 	/** The space-specific channel that was joined, for cleanup on switch */
 	private activeSpaceChannel: string | null = null;
+
+	/** Whether global list subscriptions have been set up */
+	private globalListInitialized = false;
+
+	// ========================================
+	// Global Space List
+	// ========================================
+
+	/**
+	 * Initialize the global space list.
+	 * Fetches all spaces from the server and subscribes to global create/archive/delete events.
+	 * Safe to call multiple times — idempotent after first call.
+	 */
+	async initGlobalList(): Promise<void> {
+		if (this.globalListInitialized) return;
+		this.globalListInitialized = true;
+
+		try {
+			const hub = await connectionManager.getHub();
+			const spaces = await hub.request<Space[]>('space.list', {});
+			this.spaces.value = spaces ?? [];
+
+			// Subscribe to global space events to keep list up-to-date
+			hub.onEvent<{ spaceId: string; space: Space }>('space.created', (event) => {
+				if (event.space) {
+					const exists = this.spaces.value.some((s) => s.id === event.spaceId);
+					if (!exists) {
+						this.spaces.value = [...this.spaces.value, event.space];
+					}
+				}
+			});
+
+			hub.onEvent<{ spaceId: string; space?: Partial<Space> }>('space.updated', (event) => {
+				this.spaces.value = this.spaces.value.map((s) =>
+					s.id === event.spaceId ? ({ ...s, ...event.space } as Space) : s
+				);
+			});
+
+			hub.onEvent<{ spaceId: string; space: Space }>('space.archived', (event) => {
+				this.spaces.value = this.spaces.value.map((s) =>
+					s.id === event.spaceId ? event.space : s
+				);
+			});
+
+			hub.onEvent<{ spaceId: string }>('space.deleted', (event) => {
+				this.spaces.value = this.spaces.value.filter((s) => s.id !== event.spaceId);
+			});
+		} catch (err) {
+			logger.error('Failed to initialize global space list:', err);
+			// Reset flag so retries work on reconnect
+			this.globalListInitialized = false;
+		}
+	}
 
 	// ========================================
 	// Space Selection (with Promise-Chain Lock)


### PR DESCRIPTION
- SpaceCreateDialog: workspace path as hero field (required), name
  auto-suggests from dir basename, optional description, validates
  client-side + server-side via space.create RPC
- SpaceIsland: full 3-column layout (nav 240px / main flex-1 / task
  pane 320px on md+) replacing the placeholder; loads space via
  spaceStore.selectSpace(); responsive (right pane hidden on mobile)
- SpaceDashboard: default middle-column view — space name, workspace
  path, description, active-run/task status banner, quick-action cards,
  recent activity list
- SpaceNavPanel: left-column panel — workflow runs with status dots and
  task counts, standalone tasks, nav links (Agents, Workflows, Settings)
- SpaceTaskPane: right-column task detail — status badge, priority,
  workflow step indicator, description, progress, result, error, PR link,
  human-input area for needs_attention status
- SpaceStore: add spaces signal + initGlobalList() for the global space
  list (subscribes to space.created/updated/archived/deleted events)
- ContextPanel: wires SpaceCreateDialog + real space list from spaceStore;
  "Create Space" header button now functional in Spaces section
- 58 unit tests + e2e tests for space creation flow
