### PR TITLE
feat: workflow step builder (Task 6.2)

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -319,6 +319,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 
 	const server = Bun.serve({
 		port: 0, // random available port
+		idleTimeout: 0, // disable idle timeout — bridge server handles long-running SSE streams
 		async fetch(req: Request): Promise<Response> {
 			const url = new URL(req.url);
 

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -1,0 +1,469 @@
+/**
+ * WorkflowEditor Component
+ *
+ * Create or edit a workflow definition.
+ *
+ * Features:
+ * - Name and description fields
+ * - Vertical step list with expandable WorkflowStepCards
+ * - Add Step button
+ * - "Start from template" options
+ * - Save / Cancel
+ */
+
+import { useState } from 'preact/hooks';
+import type { SpaceWorkflow, SpaceAgent } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { WorkflowStepCard } from './WorkflowStepCard';
+import type { StepDraft, ConditionDraft } from './WorkflowStepCard';
+
+// ============================================================================
+// Template Definitions
+// ============================================================================
+
+interface WorkflowTemplate {
+	label: string;
+	description: string;
+	stepRoles: string[]; // agent role names to look up from agent list
+}
+
+const TEMPLATES: WorkflowTemplate[] = [
+	{
+		label: 'Coding (Plan → Code)',
+		description: 'Planner agent designs the approach, then coder implements.',
+		stepRoles: ['planner', 'coder'],
+	},
+	{
+		label: 'Research (Plan → Research)',
+		description: 'Planner agent scopes the research, then general agent executes it.',
+		stepRoles: ['planner', 'general'],
+	},
+	{
+		label: 'Quick Fix (Code only)',
+		description: 'Single coder step for focused, scope-limited changes.',
+		stepRoles: ['coder'],
+	},
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeLocalId(): string {
+	return Math.random().toString(36).slice(2);
+}
+
+function makeEmptyStep(): StepDraft {
+	return { localId: makeLocalId(), name: '', agentId: '', instructions: '' };
+}
+
+function makeDefaultCondition(): ConditionDraft {
+	return { type: 'always' };
+}
+
+/** Filter agents: exclude any agent named 'leader' (case-insensitive) */
+export function filterAgents(agents: SpaceAgent[]): SpaceAgent[] {
+	return agents.filter((a) => a.name.toLowerCase() !== 'leader');
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface WorkflowEditorProps {
+	/** Existing workflow to edit. Undefined = create new. */
+	workflow?: SpaceWorkflow;
+	onSave: () => void;
+	onCancel: () => void;
+}
+
+export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorProps) {
+	const isEditing = !!workflow;
+
+	// Derive initial steps and transitions from an existing workflow (linear model)
+	function initFromWorkflow(wf: SpaceWorkflow): {
+		steps: StepDraft[];
+		transitions: ConditionDraft[];
+	} {
+		// Build ordered step list by following startStepId → transitions
+		const stepMap = new Map(wf.steps.map((s) => [s.id, s]));
+		const ordered: StepDraft[] = [];
+		const visited = new Set<string>();
+		let currentId: string | undefined = wf.startStepId;
+
+		while (currentId && !visited.has(currentId)) {
+			visited.add(currentId);
+			const s = stepMap.get(currentId);
+			if (s) {
+				ordered.push({
+					localId: makeLocalId(),
+					id: s.id,
+					name: s.name,
+					agentId: s.agentId,
+					instructions: s.instructions ?? '',
+				});
+			}
+			// Find the next step via transitions (lowest order first)
+			const outgoing = wf.transitions
+				.filter((t) => t.from === currentId)
+				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+			currentId = outgoing[0]?.to;
+		}
+
+		// Remaining steps not reachable from startStepId
+		for (const s of wf.steps) {
+			if (!visited.has(s.id)) {
+				ordered.push({
+					localId: makeLocalId(),
+					id: s.id,
+					name: s.name,
+					agentId: s.agentId,
+					instructions: s.instructions ?? '',
+				});
+			}
+		}
+
+		// Build transition conditions in step order
+		const conditions: ConditionDraft[] = [];
+		for (let i = 0; i < ordered.length - 1; i++) {
+			const fromId = ordered[i].id;
+			const toId = ordered[i + 1].id;
+			const t = wf.transitions.find((tr) => tr.from === fromId && tr.to === toId);
+			conditions.push(
+				t?.condition
+					? { type: t.condition.type, expression: t.condition.expression }
+					: { type: 'always' }
+			);
+		}
+
+		return { steps: ordered, transitions: conditions };
+	}
+
+	const initial = workflow ? initFromWorkflow(workflow) : null;
+
+	const [name, setName] = useState(workflow?.name ?? '');
+	const [description, setDescription] = useState(workflow?.description ?? '');
+	const [steps, setSteps] = useState<StepDraft[]>(initial?.steps ?? [makeEmptyStep()]);
+	const [transitions, setTransitions] = useState<ConditionDraft[]>(initial?.transitions ?? []);
+	const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showTemplates, setShowTemplates] = useState(false);
+
+	const agents = filterAgents(spaceStore.agents.value);
+
+	// ---- Step operations ----
+
+	function addStep() {
+		setSteps((prev) => [...prev, makeEmptyStep()]);
+		setTransitions((prev) => [...prev, makeDefaultCondition()]);
+		setExpandedIndex(steps.length); // expand the new step
+	}
+
+	function removeStep(index: number) {
+		setSteps((prev) => prev.filter((_, i) => i !== index));
+		setTransitions((prev) => {
+			// When removing step[i]:
+			// - transition[i-1] (incoming) and transition[i] (outgoing) both need to go
+			// - For first step: remove transition[0] only
+			// - For last step: remove transition[n-2] only
+			// - For middle: remove transition[i-1] (we keep the outgoing, dropping incoming)
+			if (prev.length === 0) return prev;
+			if (index === 0) return prev.slice(1);
+			return prev.filter((_, ti) => ti !== index - 1);
+		});
+		setExpandedIndex((prev) => {
+			if (prev === null) return null;
+			if (prev === index) return null;
+			if (prev > index) return prev - 1;
+			return prev;
+		});
+	}
+
+	function moveStep(index: number, direction: 'up' | 'down') {
+		const other = direction === 'up' ? index - 1 : index + 1;
+		if (other < 0 || other >= steps.length) return;
+
+		setSteps((prev) => {
+			const next = [...prev];
+			[next[index], next[other]] = [next[other], next[index]];
+			return next;
+		});
+
+		// Swap adjacent transition: when swapping steps[i] ↔ steps[i+1],
+		// the transition between them stays; but the transitions on the other
+		// sides are unaffected. Only the transition between the two swapped
+		// steps (at index min(i, other)) needs no change — it still connects them.
+		// However if we conceptually track transition[i] as "after step[i]",
+		// swapping steps means we swap transition[i-1] and transition[i] (the
+		// incoming transitions). For simplicity just swap the two relevant entries.
+		const minIdx = Math.min(index, other);
+		if (minIdx < transitions.length && minIdx > 0) {
+			setTransitions((prev) => {
+				const next = [...prev];
+				[next[minIdx - 1], next[minIdx]] = [next[minIdx], next[minIdx - 1]];
+				return next;
+			});
+		}
+
+		setExpandedIndex(other);
+	}
+
+	function updateStep(index: number, step: StepDraft) {
+		setSteps((prev) => prev.map((s, i) => (i === index ? step : s)));
+	}
+
+	function updateEntryCondition(index: number, cond: ConditionDraft) {
+		// entry condition of step[i] = transitions[i-1]
+		if (index === 0) return;
+		setTransitions((prev) => prev.map((t, i) => (i === index - 1 ? cond : t)));
+	}
+
+	function updateExitCondition(index: number, cond: ConditionDraft) {
+		// exit condition of step[i] = transitions[i]
+		if (index === steps.length - 1) return;
+		setTransitions((prev) => prev.map((t, i) => (i === index ? cond : t)));
+	}
+
+	// ---- Template ----
+
+	function applyTemplate(template: WorkflowTemplate) {
+		const newSteps: StepDraft[] = template.stepRoles.map((role) => {
+			const found = agents.find(
+				(a) => a.name.toLowerCase() === role || a.role?.toLowerCase() === role
+			);
+			return {
+				localId: makeLocalId(),
+				name: role.charAt(0).toUpperCase() + role.slice(1),
+				agentId: found?.id ?? '',
+				instructions: '',
+			};
+		});
+
+		setSteps(newSteps);
+		setTransitions(newSteps.slice(1).map(() => makeDefaultCondition()));
+		setExpandedIndex(0);
+		setShowTemplates(false);
+		if (!name) setName(template.label);
+	}
+
+	// ---- Save ----
+
+	async function handleSave() {
+		if (!name.trim()) {
+			setError('Workflow name is required.');
+			return;
+		}
+		if (steps.length === 0) {
+			setError('A workflow must have at least one step.');
+			return;
+		}
+
+		setSaving(true);
+		setError(null);
+
+		try {
+			// Generate IDs for new steps
+			const stepIds = steps.map((s) => s.id ?? crypto.randomUUID());
+
+			const builtSteps = steps.map((s, i) => ({
+				id: stepIds[i],
+				name: s.name || `Step ${i + 1}`,
+				agentId: s.agentId,
+				instructions: s.instructions || undefined,
+			}));
+
+			const builtTransitions = transitions.map((cond, i) => ({
+				from: stepIds[i],
+				to: stepIds[i + 1],
+				condition:
+					cond.type === 'always'
+						? undefined
+						: {
+								type: cond.type,
+								expression: cond.expression,
+							},
+				order: i,
+			}));
+
+			if (isEditing && workflow) {
+				await spaceStore.updateWorkflow(workflow.id, {
+					name: name.trim(),
+					description: description.trim() || null,
+					steps: builtSteps,
+					transitions: builtTransitions,
+					startStepId: stepIds[0],
+				});
+			} else {
+				await spaceStore.createWorkflow({
+					name: name.trim(),
+					description: description.trim() || undefined,
+					steps: builtSteps,
+					transitions: builtTransitions,
+					startStepId: stepIds[0],
+				});
+			}
+
+			onSave();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to save workflow.');
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div class="flex flex-col h-full overflow-hidden">
+			{/* Header */}
+			<div class="flex items-center gap-3 px-6 py-4 border-b border-dark-700 flex-shrink-0">
+				<button
+					onClick={onCancel}
+					class="text-gray-500 hover:text-gray-300 transition-colors"
+					title="Back"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M15 19l-7-7 7-7"
+						/>
+					</svg>
+				</button>
+				<h1 class="text-sm font-semibold text-gray-100">
+					{isEditing ? 'Edit Workflow' : 'New Workflow'}
+				</h1>
+				<div class="flex-1" />
+				<button
+					onClick={onCancel}
+					class="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors"
+				>
+					Cancel
+				</button>
+				<button
+					onClick={handleSave}
+					disabled={saving}
+					class="px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition-colors"
+				>
+					{saving ? 'Saving…' : isEditing ? 'Save Changes' : 'Create Workflow'}
+				</button>
+			</div>
+
+			{/* Scrollable body */}
+			<div class="flex-1 overflow-y-auto p-6 space-y-6">
+				{/* Error */}
+				{error && (
+					<div class="bg-red-900/20 border border-red-800/40 rounded-lg px-4 py-3">
+						<p class="text-xs text-red-300">{error}</p>
+					</div>
+				)}
+
+				{/* Name & Description */}
+				<div class="space-y-4">
+					<div class="space-y-1.5">
+						<label class="text-xs font-medium text-gray-400">Workflow Name</label>
+						<input
+							type="text"
+							value={name}
+							onInput={(e) => setName((e.currentTarget as HTMLInputElement).value)}
+							placeholder="e.g. Feature Development"
+							class="w-full text-sm bg-dark-850 border border-dark-700 rounded-lg px-3 py-2 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+						/>
+					</div>
+					<div class="space-y-1.5">
+						<label class="text-xs font-medium text-gray-400">
+							Description <span class="font-normal text-gray-600">(optional)</span>
+						</label>
+						<textarea
+							value={description}
+							onInput={(e) => setDescription((e.currentTarget as HTMLTextAreaElement).value)}
+							placeholder="What does this workflow accomplish?"
+							rows={2}
+							class="w-full text-sm bg-dark-850 border border-dark-700 rounded-lg px-3 py-2 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+						/>
+					</div>
+				</div>
+
+				{/* Template picker */}
+				{!isEditing && (
+					<div>
+						<button
+							onClick={() => setShowTemplates((v) => !v)}
+							class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+						>
+							{showTemplates ? 'Hide templates ↑' : 'Start from template ↓'}
+						</button>
+						{showTemplates && (
+							<div class="mt-3 grid grid-cols-1 gap-2">
+								{TEMPLATES.map((tpl) => (
+									<button
+										key={tpl.label}
+										onClick={() => applyTemplate(tpl)}
+										class="text-left px-4 py-3 bg-dark-850 border border-dark-700 rounded-lg hover:border-dark-600 hover:bg-dark-800 transition-colors"
+									>
+										<p class="text-xs font-medium text-gray-200">{tpl.label}</p>
+										<p class="text-xs text-gray-600 mt-0.5">{tpl.description}</p>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+
+				{/* Steps */}
+				<div>
+					<div class="flex items-center justify-between mb-3">
+						<h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Steps</h2>
+						<span class="text-xs text-gray-600">
+							{steps.length} step{steps.length !== 1 ? 's' : ''}
+						</span>
+					</div>
+
+					{steps.length === 0 && (
+						<p class="text-xs text-gray-600 text-center py-6">
+							No steps yet. Add a step or start from a template.
+						</p>
+					)}
+
+					<div class="space-y-2">
+						{steps.map((step, i) => (
+							<WorkflowStepCard
+								key={step.localId}
+								step={step}
+								stepIndex={i}
+								isFirst={i === 0}
+								isLast={i === steps.length - 1}
+								expanded={expandedIndex === i}
+								entryCondition={i > 0 ? (transitions[i - 1] ?? { type: 'always' }) : null}
+								exitCondition={i < steps.length - 1 ? (transitions[i] ?? { type: 'always' }) : null}
+								agents={agents}
+								onToggleExpand={() => setExpandedIndex((prev) => (prev === i ? null : i))}
+								onUpdate={(s) => updateStep(i, s)}
+								onUpdateEntryCondition={(c) => updateEntryCondition(i, c)}
+								onUpdateExitCondition={(c) => updateExitCondition(i, c)}
+								onMoveUp={() => moveStep(i, 'up')}
+								onMoveDown={() => moveStep(i, 'down')}
+								onRemove={() => removeStep(i)}
+							/>
+						))}
+					</div>
+
+					<button
+						onClick={addStep}
+						class="mt-3 w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-dashed border-dark-600 rounded-lg text-xs text-gray-500 hover:text-gray-300 hover:border-dark-500 transition-colors"
+					>
+						<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M12 4v16m8-8H4"
+							/>
+						</svg>
+						Add Step
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -226,7 +226,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 	function applyTemplate(template: WorkflowTemplate) {
 		const newSteps: StepDraft[] = template.stepRoles.map((role) => {
 			const found = agents.find(
-				(a) => a.name.toLowerCase() === role || a.role?.toLowerCase() === role
+				(a) => a.name.toLowerCase() === role || a.role.toLowerCase() === role
 			);
 			return {
 				localId: makeLocalId(),

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -50,7 +50,7 @@ const TEMPLATES: WorkflowTemplate[] = [
 // ============================================================================
 
 function makeLocalId(): string {
-	return Math.random().toString(36).slice(2);
+	return crypto.randomUUID();
 }
 
 function makeEmptyStep(): StepDraft {
@@ -61,9 +61,77 @@ function makeDefaultCondition(): ConditionDraft {
 	return { type: 'always' };
 }
 
-/** Filter agents: exclude any agent named 'leader' (case-insensitive) */
+/**
+ * Filter agents for step assignment: exclude any agent whose name or role is
+ * 'leader' (case-insensitive). The 'leader' role is reserved for the
+ * orchestration layer and must not be assigned to workflow steps.
+ */
 export function filterAgents(agents: SpaceAgent[]): SpaceAgent[] {
-	return agents.filter((a) => a.name.toLowerCase() !== 'leader');
+	return agents.filter(
+		(a) => a.name.toLowerCase() !== 'leader' && a.role?.toLowerCase() !== 'leader'
+	);
+}
+
+/**
+ * Derive ordered steps and positional transition conditions from an existing
+ * workflow. Graph traversal follows startStepId through outgoing transitions.
+ * Orphaned steps (not reachable from startStepId) are appended at the end.
+ *
+ * Defined outside the component so it is not recreated on each render and
+ * is clearly a pure initialization helper, not a reactive dependency.
+ */
+export function initFromWorkflow(wf: SpaceWorkflow): {
+	steps: StepDraft[];
+	transitions: ConditionDraft[];
+} {
+	const stepMap = new Map(wf.steps.map((s) => [s.id, s]));
+	const ordered: StepDraft[] = [];
+	const visited = new Set<string>();
+	let currentId: string | undefined = wf.startStepId;
+
+	while (currentId && !visited.has(currentId)) {
+		visited.add(currentId);
+		const s = stepMap.get(currentId);
+		if (s) {
+			ordered.push({
+				localId: makeLocalId(),
+				id: s.id,
+				name: s.name,
+				agentId: s.agentId,
+				instructions: s.instructions ?? '',
+			});
+		}
+		const outgoing = wf.transitions
+			.filter((t) => t.from === currentId)
+			.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+		currentId = outgoing[0]?.to;
+	}
+
+	for (const s of wf.steps) {
+		if (!visited.has(s.id)) {
+			ordered.push({
+				localId: makeLocalId(),
+				id: s.id,
+				name: s.name,
+				agentId: s.agentId,
+				instructions: s.instructions ?? '',
+			});
+		}
+	}
+
+	const conditions: ConditionDraft[] = [];
+	for (let i = 0; i < ordered.length - 1; i++) {
+		const fromId = ordered[i].id;
+		const toId = ordered[i + 1].id;
+		const t = wf.transitions.find((tr) => tr.from === fromId && tr.to === toId);
+		conditions.push(
+			t?.condition
+				? { type: t.condition.type, expression: t.condition.expression }
+				: { type: 'always' }
+		);
+	}
+
+	return { steps: ordered, transitions: conditions };
 }
 
 // ============================================================================
@@ -79,65 +147,6 @@ interface WorkflowEditorProps {
 
 export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorProps) {
 	const isEditing = !!workflow;
-
-	// Derive initial steps and transitions from an existing workflow (linear model)
-	function initFromWorkflow(wf: SpaceWorkflow): {
-		steps: StepDraft[];
-		transitions: ConditionDraft[];
-	} {
-		// Build ordered step list by following startStepId → transitions
-		const stepMap = new Map(wf.steps.map((s) => [s.id, s]));
-		const ordered: StepDraft[] = [];
-		const visited = new Set<string>();
-		let currentId: string | undefined = wf.startStepId;
-
-		while (currentId && !visited.has(currentId)) {
-			visited.add(currentId);
-			const s = stepMap.get(currentId);
-			if (s) {
-				ordered.push({
-					localId: makeLocalId(),
-					id: s.id,
-					name: s.name,
-					agentId: s.agentId,
-					instructions: s.instructions ?? '',
-				});
-			}
-			// Find the next step via transitions (lowest order first)
-			const outgoing = wf.transitions
-				.filter((t) => t.from === currentId)
-				.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-			currentId = outgoing[0]?.to;
-		}
-
-		// Remaining steps not reachable from startStepId
-		for (const s of wf.steps) {
-			if (!visited.has(s.id)) {
-				ordered.push({
-					localId: makeLocalId(),
-					id: s.id,
-					name: s.name,
-					agentId: s.agentId,
-					instructions: s.instructions ?? '',
-				});
-			}
-		}
-
-		// Build transition conditions in step order
-		const conditions: ConditionDraft[] = [];
-		for (let i = 0; i < ordered.length - 1; i++) {
-			const fromId = ordered[i].id;
-			const toId = ordered[i + 1].id;
-			const t = wf.transitions.find((tr) => tr.from === fromId && tr.to === toId);
-			conditions.push(
-				t?.condition
-					? { type: t.condition.type, expression: t.condition.expression }
-					: { type: 'always' }
-			);
-		}
-
-		return { steps: ordered, transitions: conditions };
-	}
 
 	const initial = workflow ? initFromWorkflow(workflow) : null;
 
@@ -164,10 +173,8 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 		setSteps((prev) => prev.filter((_, i) => i !== index));
 		setTransitions((prev) => {
 			// When removing step[i]:
-			// - transition[i-1] (incoming) and transition[i] (outgoing) both need to go
-			// - For first step: remove transition[0] only
-			// - For last step: remove transition[n-2] only
-			// - For middle: remove transition[i-1] (we keep the outgoing, dropping incoming)
+			// - For first step (index=0): remove transition[0] — drop the gate after it
+			// - For any other step: remove transition[i-1] — drop the gate before it
 			if (prev.length === 0) return prev;
 			if (index === 0) return prev.slice(1);
 			return prev.filter((_, ti) => ti !== index - 1);
@@ -190,21 +197,10 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 			return next;
 		});
 
-		// Swap adjacent transition: when swapping steps[i] ↔ steps[i+1],
-		// the transition between them stays; but the transitions on the other
-		// sides are unaffected. Only the transition between the two swapped
-		// steps (at index min(i, other)) needs no change — it still connects them.
-		// However if we conceptually track transition[i] as "after step[i]",
-		// swapping steps means we swap transition[i-1] and transition[i] (the
-		// incoming transitions). For simplicity just swap the two relevant entries.
-		const minIdx = Math.min(index, other);
-		if (minIdx < transitions.length && minIdx > 0) {
-			setTransitions((prev) => {
-				const next = [...prev];
-				[next[minIdx - 1], next[minIdx]] = [next[minIdx], next[minIdx - 1]];
-				return next;
-			});
-		}
+		// Gate conditions are positional — transitions[i] represents the gate
+		// between position i and position i+1. Reordering adjacent steps does
+		// not change which positions exist, so transitions stay in place.
+		// This is consistent regardless of which positions are swapped.
 
 		setExpandedIndex(other);
 	}
@@ -257,6 +253,15 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 		if (steps.length === 0) {
 			setError('A workflow must have at least one step.');
 			return;
+		}
+
+		// Validate each step has an agent assigned
+		for (let i = 0; i < steps.length; i++) {
+			if (!steps[i].agentId) {
+				setError(`Step ${i + 1} requires an agent.`);
+				setExpandedIndex(i);
+				return;
+			}
 		}
 
 		setSaving(true);

--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -68,7 +68,7 @@ function makeDefaultCondition(): ConditionDraft {
  */
 export function filterAgents(agents: SpaceAgent[]): SpaceAgent[] {
 	return agents.filter(
-		(a) => a.name.toLowerCase() !== 'leader' && a.role?.toLowerCase() !== 'leader'
+		(a) => a.name.toLowerCase() !== 'leader' && a.role.toLowerCase() !== 'leader'
 	);
 }
 
@@ -264,6 +264,17 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 			}
 		}
 
+		// Validate condition-type transitions have a non-empty shell expression
+		for (let i = 0; i < transitions.length; i++) {
+			if (transitions[i].type === 'condition' && !transitions[i].expression?.trim()) {
+				setError(
+					`Transition after step ${i + 1} requires a shell expression when using Shell Condition type.`
+				);
+				setExpandedIndex(i); // expand the step whose exit gate is the problem
+				return;
+			}
+		}
+
 		setSaving(true);
 		setError(null);
 
@@ -449,6 +460,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 								onMoveUp={() => moveStep(i, 'up')}
 								onMoveDown={() => moveStep(i, 'down')}
 								onRemove={() => removeStep(i)}
+								disableRemove={steps.length === 1}
 							/>
 						))}
 					</div>

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -140,10 +140,10 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 			return;
 		}
 		try {
-			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>(
-				'spaceExport.workflows',
-				{ spaceId, workflowIds: [workflow.id] }
-			);
+			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>('spaceExport.workflows', {
+				spaceId,
+				workflowIds: [workflow.id],
+			});
 			downloadBundle(bundle, spaceName, 'workflows');
 			toast.success(`Exported "${workflow.name}"`);
 		} catch (err) {
@@ -288,10 +288,9 @@ export function WorkflowList({
 			return;
 		}
 		try {
-			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>(
-				'spaceExport.workflows',
-				{ spaceId }
-			);
+			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>('spaceExport.workflows', {
+				spaceId,
+			});
 			downloadBundle(bundle, spaceName, 'workflows');
 			toast.success(`Exported ${workflows.length} workflow${workflows.length === 1 ? '' : 's'}`);
 		} catch (err) {
@@ -366,8 +365,7 @@ export function WorkflowList({
 			{/* Header */}
 			<div class="flex items-center justify-between px-6 py-4 border-b border-dark-700 flex-shrink-0">
 				<h1 class="text-sm font-semibold text-gray-100">
-					Workflows{' '}
-					<span class="text-xs text-gray-500 font-normal">({workflows.length})</span>
+					Workflows <span class="text-xs text-gray-500 font-normal">({workflows.length})</span>
 				</h1>
 				<div class="flex items-center gap-2">
 					<button

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -1,46 +1,285 @@
 /**
- * WorkflowList — displays workflow definitions in a Space, with per-workflow
- * export and list-level Export All / Import actions.
+ * WorkflowList Component
+ *
+ * Displays all workflows in the space with:
+ * - Workflow cards: name, description, step count, tag chips
+ * - Mini step visualization (horizontal dots showing step sequence)
+ * - "Create Workflow" button and template options
+ * - Edit, Delete, and Export actions per card
+ * - Import and Export All toolbar actions
+ * - Real-time updates via SpaceStore
  */
 
 import { useState } from 'preact/hooks';
-import type { SpaceWorkflow, SpaceExportBundle } from '@neokai/shared';
+import type { SpaceWorkflow, SpaceExportBundle, WorkflowConditionType } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
 import { connectionManager } from '../../lib/connection-manager.ts';
 import { toast } from '../../lib/toast.ts';
 import { ImportPreviewDialog } from './ImportPreviewDialog.tsx';
 import type { ImportPreviewResult, ImportConflictResolution } from './ImportPreviewDialog.tsx';
 import { downloadBundle, pickImportFile } from './export-import-utils.ts';
 
-interface WorkflowListProps {
-	spaceId: string;
-	spaceName: string;
-	workflows: SpaceWorkflow[];
+// ============================================================================
+// Mini Step Visualization
+// ============================================================================
+
+const GATE_COLORS: Record<WorkflowConditionType, string> = {
+	always: 'bg-blue-500',
+	human: 'bg-yellow-400',
+	condition: 'bg-purple-400',
+};
+
+function MiniStepDot({ isStart }: { isStart: boolean }) {
+	return (
+		<span
+			class={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${isStart ? 'bg-blue-500' : 'bg-blue-400'}`}
+		/>
+	);
 }
 
-export function WorkflowList({ spaceId, spaceName, workflows }: WorkflowListProps) {
-	const [importBundle, setImportBundle] = useState<SpaceExportBundle | null>(null);
-	const [importPreview, setImportPreview] = useState<ImportPreviewResult | null>(null);
-	const [isExecuting, setIsExecuting] = useState(false);
+function MiniConnector({ conditionType }: { conditionType?: WorkflowConditionType }) {
+	const color = conditionType ? GATE_COLORS[conditionType] : 'bg-gray-700';
+	return (
+		<div class="flex items-center gap-0.5 flex-shrink-0">
+			<div class="w-4 h-px bg-gray-700" />
+			{conditionType && conditionType !== 'always' && (
+				<span class={`w-1.5 h-1.5 rounded-full ${color}`} />
+			)}
+			<div class="w-4 h-px bg-gray-700" />
+		</div>
+	);
+}
 
-	// ─── Export helpers ──────────────────────────────────────────────────────
+// Show at most MAX_DOTS dots; if there are more steps, show a "+N" overflow label.
+const MAX_DOTS = 6;
 
-	async function exportWorkflow(workflow: SpaceWorkflow) {
+function MiniStepViz({ workflow }: { workflow: SpaceWorkflow }) {
+	if (workflow.steps.length === 0) {
+		return <span class="text-xs text-gray-700 italic">No steps</span>;
+	}
+
+	// Build ordered step list following startStepId
+	const stepMap = new Map(workflow.steps.map((s) => [s.id, s]));
+	const ordered: string[] = [];
+	const visited = new Set<string>();
+	let currentId: string | undefined = workflow.startStepId;
+
+	while (currentId && !visited.has(currentId)) {
+		visited.add(currentId);
+		ordered.push(currentId);
+		const outgoing = workflow.transitions
+			.filter((t) => t.from === currentId)
+			.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+		currentId = outgoing[0]?.to;
+	}
+
+	// Append orphaned steps (not reachable from startStepId)
+	for (const s of workflow.steps) {
+		if (!visited.has(s.id)) {
+			ordered.push(s.id);
+		}
+	}
+
+	// Cap display at MAX_DOTS; show overflow count if needed
+	const overflow = ordered.length > MAX_DOTS ? ordered.length - MAX_DOTS : 0;
+	const display = overflow > 0 ? ordered.slice(0, MAX_DOTS) : ordered;
+
+	return (
+		<div class="flex items-center gap-0 overflow-hidden">
+			{display.map((id, i) => {
+				const step = stepMap.get(id);
+				const nextId = i + 1 < display.length ? display[i + 1] : undefined;
+				const transition = nextId
+					? workflow.transitions.find((t) => t.from === id && t.to === nextId)
+					: undefined;
+
+				return (
+					<div key={id} class="flex items-center" title={step?.name ?? id}>
+						<MiniStepDot isStart={i === 0} />
+						{nextId && <MiniConnector conditionType={transition?.condition?.type} />}
+					</div>
+				);
+			})}
+			{overflow > 0 && <span class="text-xs text-gray-600 ml-1">+{overflow}</span>}
+		</div>
+	);
+}
+
+// ============================================================================
+// Workflow Card
+// ============================================================================
+
+interface WorkflowCardProps {
+	workflow: SpaceWorkflow;
+	spaceId: string;
+	spaceName: string;
+	onEdit: () => void;
+}
+
+function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProps) {
+	const [confirmDelete, setConfirmDelete] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const [deleteError, setDeleteError] = useState<string | null>(null);
+
+	async function handleDelete() {
+		setDeleting(true);
+		setDeleteError(null);
+		try {
+			await spaceStore.deleteWorkflow(workflow.id);
+		} catch (err) {
+			setDeleteError(err instanceof Error ? err.message : 'Failed to delete workflow.');
+			setDeleting(false);
+			setConfirmDelete(false);
+		}
+	}
+
+	async function handleExport() {
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) {
 			toast.error('Connection lost.');
 			return;
 		}
 		try {
-			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>('spaceExport.workflows', {
-				spaceId,
-				workflowIds: [workflow.id],
-			});
+			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>(
+				'spaceExport.workflows',
+				{ spaceId, workflowIds: [workflow.id] }
+			);
 			downloadBundle(bundle, spaceName, 'workflows');
 			toast.success(`Exported "${workflow.name}"`);
 		} catch (err) {
 			toast.error(`Export failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
+
+	return (
+		<div class="bg-dark-850 border border-dark-700 rounded-lg p-4 hover:border-dark-600 transition-colors group">
+			{deleteError && (
+				<div class="mb-2 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
+					{deleteError}
+				</div>
+			)}
+
+			<div class="flex items-start justify-between gap-3">
+				<div class="flex-1 min-w-0">
+					<h3 class="text-sm font-medium text-gray-200 truncate">{workflow.name}</h3>
+					{workflow.description && (
+						<p class="text-xs text-gray-500 mt-0.5 line-clamp-2">{workflow.description}</p>
+					)}
+				</div>
+
+				{/* Action buttons */}
+				<div class="flex items-center gap-1.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+					{confirmDelete ? (
+						<>
+							<span class="text-xs text-red-400">Delete?</span>
+							<button
+								onClick={handleDelete}
+								disabled={deleting}
+								class="px-2 py-1 text-xs text-red-300 bg-red-900/30 hover:bg-red-900/50 border border-red-800/50 rounded disabled:opacity-50 transition-colors"
+							>
+								{deleting ? '…' : 'Confirm'}
+							</button>
+							<button
+								onClick={() => setConfirmDelete(false)}
+								class="px-2 py-1 text-xs text-gray-400 hover:text-gray-200 transition-colors"
+							>
+								Cancel
+							</button>
+						</>
+					) : (
+						<>
+							<button
+								onClick={onEdit}
+								class="px-2.5 py-1 text-xs text-gray-500 hover:text-gray-200 bg-dark-800 hover:bg-dark-700 rounded border border-dark-600 hover:border-dark-500 transition-colors"
+							>
+								Edit
+							</button>
+							<button
+								onClick={handleExport}
+								class="px-2.5 py-1 text-xs text-gray-500 hover:text-gray-200 bg-dark-800 hover:bg-dark-700 rounded border border-dark-600 hover:border-dark-500 transition-colors"
+								title="Export workflow"
+							>
+								<svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+									/>
+								</svg>
+							</button>
+							<button
+								onClick={() => setConfirmDelete(true)}
+								class="px-2.5 py-1 text-xs text-gray-500 hover:text-red-400 bg-dark-800 hover:bg-dark-700 rounded border border-dark-600 hover:border-dark-500 transition-colors"
+								title="Delete workflow"
+							>
+								<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+									/>
+								</svg>
+							</button>
+						</>
+					)}
+				</div>
+			</div>
+
+			{/* Mini step viz */}
+			<div class="mt-3">
+				<MiniStepViz workflow={workflow} />
+			</div>
+
+			{/* Step count + tags footer */}
+			<div class="mt-2.5 flex items-center gap-2 flex-wrap">
+				<span class="text-xs text-gray-600">
+					{workflow.steps.length} {workflow.steps.length === 1 ? 'step' : 'steps'}
+				</span>
+				{workflow.tags.length > 0 && (
+					<>
+						<span class="text-gray-700">·</span>
+						{workflow.tags.map((tag) => (
+							<span
+								key={tag}
+								class="px-1.5 py-0.5 text-xs bg-dark-800 border border-dark-700 rounded text-gray-500"
+							>
+								{tag}
+							</span>
+						))}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+interface WorkflowListProps {
+	spaceId: string;
+	spaceName: string;
+	workflows: SpaceWorkflow[];
+	onCreateWorkflow: () => void;
+	onEditWorkflow: (workflowId: string) => void;
+}
+
+export function WorkflowList({
+	spaceId,
+	spaceName,
+	workflows,
+	onCreateWorkflow,
+	onEditWorkflow,
+}: WorkflowListProps) {
+	const loading = spaceStore.loading.value;
+	const [importBundle, setImportBundle] = useState<SpaceExportBundle | null>(null);
+	const [importPreview, setImportPreview] = useState<ImportPreviewResult | null>(null);
+	const [isExecuting, setIsExecuting] = useState(false);
+
+	// ─── Import/Export helpers ──────────────────────────────────────────────
 
 	async function exportAll() {
 		const hub = connectionManager.getHubIfConnected();
@@ -49,17 +288,16 @@ export function WorkflowList({ spaceId, spaceName, workflows }: WorkflowListProp
 			return;
 		}
 		try {
-			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>('spaceExport.workflows', {
-				spaceId,
-			});
+			const { bundle } = await hub.request<{ bundle: SpaceExportBundle }>(
+				'spaceExport.workflows',
+				{ spaceId }
+			);
 			downloadBundle(bundle, spaceName, 'workflows');
 			toast.success(`Exported ${workflows.length} workflow${workflows.length === 1 ? '' : 's'}`);
 		} catch (err) {
 			toast.error(`Export failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
-
-	// ─── Import helpers ──────────────────────────────────────────────────────
 
 	async function startImport() {
 		const bundle = await pickImportFile();
@@ -97,13 +335,12 @@ export function WorkflowList({ spaceId, spaceName, workflows }: WorkflowListProp
 				warnings: string[];
 			}>('spaceImport.execute', { spaceId, bundle: importBundle, conflictResolution: resolution });
 
-			const createdAgents = result.agents.filter((a) => a.action !== 'skipped').length;
 			const createdWorkflows = result.workflows.filter((w) => w.action !== 'skipped').length;
-			const parts: string[] = [];
-			if (createdAgents > 0) parts.push(`${createdAgents} agent${createdAgents === 1 ? '' : 's'}`);
-			if (createdWorkflows > 0)
-				parts.push(`${createdWorkflows} workflow${createdWorkflows === 1 ? '' : 's'}`);
-			toast.success(parts.length > 0 ? `Imported ${parts.join(' and ')}` : 'Nothing imported');
+			toast.success(
+				createdWorkflows > 0
+					? `Imported ${createdWorkflows} workflow${createdWorkflows === 1 ? '' : 's'}`
+					: 'Nothing imported'
+			);
 			if (result.warnings.length) {
 				toast.warning(result.warnings[0]);
 			}
@@ -116,15 +353,22 @@ export function WorkflowList({ spaceId, spaceName, workflows }: WorkflowListProp
 		}
 	}
 
-	// ─── Render ─────────────────────────────────────────────────────────────
+	if (loading) {
+		return (
+			<div class="flex items-center justify-center h-32">
+				<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+			</div>
+		);
+	}
 
 	return (
-		<div class="flex flex-col h-full">
-			{/* Toolbar */}
-			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700">
-				<h2 class="text-sm font-semibold text-gray-200">
-					Workflows <span class="ml-1 text-xs text-gray-500 font-normal">({workflows.length})</span>
-				</h2>
+		<div class="flex flex-col h-full overflow-hidden">
+			{/* Header */}
+			<div class="flex items-center justify-between px-6 py-4 border-b border-dark-700 flex-shrink-0">
+				<h1 class="text-sm font-semibold text-gray-100">
+					Workflows{' '}
+					<span class="text-xs text-gray-500 font-normal">({workflows.length})</span>
+				</h1>
 				<div class="flex items-center gap-2">
 					<button
 						type="button"
@@ -158,67 +402,69 @@ export function WorkflowList({ spaceId, spaceName, workflows }: WorkflowListProp
 							Export All
 						</button>
 					)}
+					<button
+						onClick={onCreateWorkflow}
+						class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+					>
+						<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M12 4v16m8-8H4"
+							/>
+						</svg>
+						Create Workflow
+					</button>
 				</div>
 			</div>
 
 			{/* List */}
-			<div class="flex-1 overflow-y-auto">
+			<div class="flex-1 overflow-y-auto p-6">
 				{workflows.length === 0 ? (
-					<div class="flex flex-col items-center justify-center p-10 text-center">
-						<div class="text-3xl mb-3">⚡</div>
-						<p class="text-sm text-gray-400">No workflows yet</p>
-						<p class="text-xs text-gray-500 mt-1">Create workflows or import from a file</p>
+					<div class="text-center py-12">
+						<div class="w-10 h-10 mx-auto mb-3 rounded-lg bg-dark-800 border border-dark-700 flex items-center justify-center">
+							<svg
+								class="w-5 h-5 text-gray-600"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M4 6h16M4 10h16M4 14h16M4 18h16"
+								/>
+							</svg>
+						</div>
+						<p class="text-sm text-gray-500">No workflows yet</p>
+						<p class="text-xs text-gray-600 mt-1">
+							Create a workflow to define multi-agent pipelines.
+						</p>
+						<button
+							onClick={onCreateWorkflow}
+							class="mt-4 px-4 py-2 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+						>
+							Create your first workflow
+						</button>
 					</div>
 				) : (
-					<ul class="divide-y divide-dark-700/50">
-						{workflows.map((workflow) => (
-							<li key={workflow.id} class="flex items-center justify-between px-4 py-3 group">
-								<div class="min-w-0">
-									<p class="text-sm font-medium text-gray-200 truncate">{workflow.name}</p>
-									<div class="flex items-center gap-2 mt-0.5">
-										<span class="text-xs text-gray-500">
-											{workflow.steps.length} step{workflow.steps.length === 1 ? '' : 's'}
-										</span>
-										{workflow.tags.length > 0 && (
-											<div class="flex gap-1">
-												{workflow.tags.slice(0, 2).map((tag) => (
-													<span
-														key={tag}
-														class="text-xs bg-dark-700 text-gray-400 px-1.5 py-0.5 rounded"
-													>
-														{tag}
-													</span>
-												))}
-											</div>
-										)}
-									</div>
-									{workflow.description && (
-										<p class="text-xs text-gray-500 mt-0.5 truncate">{workflow.description}</p>
-									)}
-								</div>
-								<button
-									type="button"
-									onClick={() => exportWorkflow(workflow)}
-									class="opacity-0 group-hover:opacity-100 flex items-center gap-1 px-2 py-1 text-xs text-gray-400 hover:text-gray-100 hover:bg-dark-800 rounded transition-all"
-									title="Export workflow"
-								>
-									<svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width={2}
-											d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-										/>
-									</svg>
-									Export
-								</button>
-							</li>
+					<div class="space-y-3">
+						{workflows.map((wf) => (
+							<WorkflowCard
+								key={wf.id}
+								workflow={wf}
+								spaceId={spaceId}
+								spaceName={spaceName}
+								onEdit={() => onEditWorkflow(wf.id)}
+							/>
 						))}
-					</ul>
+					</div>
 				)}
 			</div>
 
-			{/* Import Preview Dialog — key on exportedAt so state resets for each new bundle */}
+			{/* Import Preview Dialog */}
 			{importPreview && importBundle && (
 				<ImportPreviewDialog
 					key={importBundle.exportedAt}

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -1,0 +1,381 @@
+/**
+ * WorkflowStepCard Component
+ *
+ * A single step card in the workflow editor.
+ * Supports collapsed (summary) and expanded (edit) modes.
+ *
+ * Collapsed: step number, agent name, gate type icons
+ * Expanded: name input, agent dropdown, entry/exit gate selectors, instructions
+ */
+
+import type { SpaceAgent } from '@neokai/shared';
+import type { WorkflowConditionType } from '@neokai/shared';
+import { cn } from '../../lib/utils';
+
+// ============================================================================
+// Draft Types (used by WorkflowEditor + WorkflowStepCard)
+// ============================================================================
+
+export interface StepDraft {
+	/** Stable local key for React rendering — not sent to the server */
+	localId: string;
+	/** Existing step ID when editing an existing workflow */
+	id?: string;
+	name: string;
+	agentId: string;
+	instructions: string;
+}
+
+export interface ConditionDraft {
+	type: WorkflowConditionType;
+	/** Shell expression for 'condition' type */
+	expression?: string;
+}
+
+// ============================================================================
+// Gate Config Sub-Form
+// ============================================================================
+
+interface GateConfigProps {
+	condition: ConditionDraft;
+	onChange: (cond: ConditionDraft) => void;
+	label: string;
+	disabled?: boolean;
+}
+
+const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
+	always: 'Automatic',
+	human: 'Human Approval',
+	condition: 'Shell Condition',
+};
+
+function GateConfig({ condition, onChange, label, disabled }: GateConfigProps) {
+	return (
+		<div class="space-y-1.5">
+			<label class="text-xs font-medium text-gray-400">{label}</label>
+			{disabled ? (
+				<p class="text-xs text-gray-600 italic">
+					{label === 'Entry Gate' ? 'Workflow starts here' : 'Workflow ends here'}
+				</p>
+			) : (
+				<>
+					<select
+						value={condition.type}
+						onChange={(e) => {
+							const type = (e.currentTarget as HTMLSelectElement).value as WorkflowConditionType;
+							onChange({ type, expression: type === 'condition' ? '' : undefined });
+						}}
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+					>
+						{(Object.keys(CONDITION_LABELS) as WorkflowConditionType[]).map((t) => (
+							<option key={t} value={t}>
+								{CONDITION_LABELS[t]}
+							</option>
+						))}
+					</select>
+
+					{condition.type === 'condition' && (
+						<div class="space-y-1">
+							<input
+								type="text"
+								placeholder="e.g. bun test && git diff --quiet"
+								value={condition.expression ?? ''}
+								onInput={(e) =>
+									onChange({
+										...condition,
+										expression: (e.currentTarget as HTMLInputElement).value,
+									})
+								}
+								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 font-mono focus:outline-none focus:border-blue-500 placeholder-gray-700"
+							/>
+							<p class="text-xs text-gray-600">
+								Transition fires when the shell command exits with code 0.
+							</p>
+						</div>
+					)}
+
+					{condition.type === 'human' && (
+						<p class="text-xs text-gray-600">Transition requires explicit human approval.</p>
+					)}
+
+					{condition.type === 'always' && (
+						<p class="text-xs text-gray-600">Transition fires automatically.</p>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// Icon Components
+// ============================================================================
+
+function GateIcon({ type }: { type: WorkflowConditionType }) {
+	if (type === 'human') {
+		return (
+			<svg
+				class="w-3 h-3"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				title="Human Approval"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+				/>
+			</svg>
+		);
+	}
+	if (type === 'condition') {
+		return (
+			<svg
+				class="w-3 h-3"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				title="Shell Condition"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+				/>
+			</svg>
+		);
+	}
+	// always
+	return (
+		<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Automatic">
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width={2}
+				d="M13 5l7 7-7 7M5 5l7 7-7 7"
+			/>
+		</svg>
+	);
+}
+
+function ChevronDown() {
+	return (
+		<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2} d="M19 9l-7 7-7-7" />
+		</svg>
+	);
+}
+
+function ChevronUp() {
+	return (
+		<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2} d="M5 15l7-7 7 7" />
+		</svg>
+	);
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+interface WorkflowStepCardProps {
+	step: StepDraft;
+	stepIndex: number;
+	isFirst: boolean;
+	isLast: boolean;
+	expanded: boolean;
+	/** Condition on the transition coming INTO this step. Null for the first step. */
+	entryCondition: ConditionDraft | null;
+	/** Condition on the transition going OUT from this step. Null for the last step. */
+	exitCondition: ConditionDraft | null;
+	/** All space agents, excluding 'leader' */
+	agents: SpaceAgent[];
+	onToggleExpand: () => void;
+	onUpdate: (step: StepDraft) => void;
+	/** Called when entry condition changes — updates transition[stepIndex-1] */
+	onUpdateEntryCondition: (cond: ConditionDraft) => void;
+	/** Called when exit condition changes — updates transition[stepIndex] */
+	onUpdateExitCondition: (cond: ConditionDraft) => void;
+	onMoveUp: () => void;
+	onMoveDown: () => void;
+	onRemove: () => void;
+}
+
+export function WorkflowStepCard({
+	step,
+	stepIndex,
+	isFirst,
+	isLast,
+	expanded,
+	entryCondition,
+	exitCondition,
+	agents,
+	onToggleExpand,
+	onUpdate,
+	onUpdateEntryCondition,
+	onUpdateExitCondition,
+	onMoveUp,
+	onMoveDown,
+	onRemove,
+}: WorkflowStepCardProps) {
+	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
+
+	return (
+		<div class="border border-dark-700 rounded-lg overflow-hidden">
+			{/* Collapsed header — always visible */}
+			<div
+				class={cn(
+					'flex items-center gap-2 px-3 py-2.5 cursor-pointer select-none',
+					expanded ? 'bg-dark-800 border-b border-dark-700' : 'bg-dark-850 hover:bg-dark-800'
+				)}
+				onClick={onToggleExpand}
+			>
+				{/* Step number */}
+				<span class="w-5 h-5 flex items-center justify-center rounded-full bg-dark-700 text-xs font-semibold text-gray-400 flex-shrink-0">
+					{stepIndex + 1}
+				</span>
+
+				{/* Step info */}
+				<div class="flex-1 min-w-0">
+					<div class="flex items-center gap-1.5 min-w-0">
+						<span class="text-xs font-medium text-gray-200 truncate">
+							{step.name || 'Unnamed Step'}
+						</span>
+						<span class="text-xs text-gray-600 flex-shrink-0">·</span>
+						<span class="text-xs text-gray-500 truncate flex-shrink-0">{agentName || '—'}</span>
+					</div>
+				</div>
+
+				{/* Gate icons */}
+				<div class="flex items-center gap-1 text-gray-600 flex-shrink-0">
+					{entryCondition && entryCondition.type !== 'always' && (
+						<span title={`Entry: ${CONDITION_LABELS[entryCondition.type]}`}>
+							<GateIcon type={entryCondition.type} />
+						</span>
+					)}
+					{exitCondition && exitCondition.type !== 'always' && (
+						<span title={`Exit: ${CONDITION_LABELS[exitCondition.type]}`}>
+							<GateIcon type={exitCondition.type} />
+						</span>
+					)}
+				</div>
+
+				{/* Controls */}
+				<div class="flex items-center gap-0.5 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+					<button
+						onClick={onMoveUp}
+						disabled={isFirst}
+						class="p-1 rounded text-gray-600 hover:text-gray-300 hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+						title="Move up"
+					>
+						<ChevronUp />
+					</button>
+					<button
+						onClick={onMoveDown}
+						disabled={isLast}
+						class="p-1 rounded text-gray-600 hover:text-gray-300 hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+						title="Move down"
+					>
+						<ChevronDown />
+					</button>
+					<button
+						onClick={onRemove}
+						class="p-1 rounded text-gray-600 hover:text-red-400 hover:bg-dark-700 transition-colors"
+						title="Remove step"
+					>
+						<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				{/* Expand chevron */}
+				<span class="text-gray-600 flex-shrink-0">
+					{expanded ? <ChevronUp /> : <ChevronDown />}
+				</span>
+			</div>
+
+			{/* Expanded body */}
+			{expanded && (
+				<div class="px-4 py-4 bg-dark-900 space-y-4">
+					{/* Name */}
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-gray-400">Step Name</label>
+						<input
+							type="text"
+							value={step.name}
+							onInput={(e) =>
+								onUpdate({ ...step, name: (e.currentTarget as HTMLInputElement).value })
+							}
+							placeholder="e.g. Plan the approach"
+							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+						/>
+					</div>
+
+					{/* Agent */}
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-gray-400">Agent</label>
+						<select
+							value={step.agentId}
+							onChange={(e) =>
+								onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
+							}
+							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+						>
+							<option value="">— Select agent —</option>
+							{agents.map((a) => (
+								<option key={a.id} value={a.id}>
+									{a.name}
+									{a.role ? ` (${a.role})` : ''}
+								</option>
+							))}
+						</select>
+					</div>
+
+					{/* Entry Gate */}
+					<GateConfig
+						label="Entry Gate"
+						condition={entryCondition ?? { type: 'always' }}
+						onChange={onUpdateEntryCondition}
+						disabled={isFirst}
+					/>
+
+					{/* Exit Gate */}
+					<GateConfig
+						label="Exit Gate"
+						condition={exitCondition ?? { type: 'always' }}
+						onChange={onUpdateExitCondition}
+						disabled={isLast}
+					/>
+
+					{/* Instructions */}
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-gray-400">
+							Instructions <span class="font-normal text-gray-600">(optional)</span>
+						</label>
+						<textarea
+							value={step.instructions}
+							onInput={(e) =>
+								onUpdate({
+									...step,
+									instructions: (e.currentTarget as HTMLTextAreaElement).value,
+								})
+							}
+							placeholder="Step-specific instructions appended to the agent's system prompt…"
+							rows={4}
+							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+						/>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -201,6 +201,8 @@ interface WorkflowStepCardProps {
 	onMoveUp: () => void;
 	onMoveDown: () => void;
 	onRemove: () => void;
+	/** When true, the Remove button is disabled (e.g. only one step remains) */
+	disableRemove?: boolean;
 }
 
 export function WorkflowStepCard({
@@ -219,6 +221,7 @@ export function WorkflowStepCard({
 	onMoveUp,
 	onMoveDown,
 	onRemove,
+	disableRemove = false,
 }: WorkflowStepCardProps) {
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
 
@@ -282,7 +285,8 @@ export function WorkflowStepCard({
 					</button>
 					<button
 						onClick={onRemove}
-						class="p-1 rounded text-gray-600 hover:text-red-400 hover:bg-dark-700 transition-colors"
+						disabled={disableRemove}
+						class="p-1 rounded text-gray-600 hover:text-red-400 hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
 						title="Remove step"
 					>
 						<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -333,7 +337,7 @@ export function WorkflowStepCard({
 							{agents.map((a) => (
 								<option key={a.id} value={a.id}>
 									{a.name}
-									{a.role ? ` (${a.role})` : ''}
+									{` (${a.role})`}
 								</option>
 							))}
 						</select>

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -40,7 +40,8 @@ interface GateConfigProps {
 	condition: ConditionDraft;
 	onChange: (cond: ConditionDraft) => void;
 	label: string;
-	disabled?: boolean;
+	/** Message shown when the gate is not configurable (first/last step boundary) */
+	terminalMessage?: string;
 }
 
 const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
@@ -49,14 +50,12 @@ const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
 	condition: 'Shell Condition',
 };
 
-function GateConfig({ condition, onChange, label, disabled }: GateConfigProps) {
+function GateConfig({ condition, onChange, label, terminalMessage }: GateConfigProps) {
 	return (
 		<div class="space-y-1.5">
 			<label class="text-xs font-medium text-gray-400">{label}</label>
-			{disabled ? (
-				<p class="text-xs text-gray-600 italic">
-					{label === 'Entry Gate' ? 'Workflow starts here' : 'Workflow ends here'}
-				</p>
+			{terminalMessage ? (
+				<p class="text-xs text-gray-600 italic">{terminalMessage}</p>
 			) : (
 				<>
 					<select
@@ -345,7 +344,7 @@ export function WorkflowStepCard({
 						label="Entry Gate"
 						condition={entryCondition ?? { type: 'always' }}
 						onChange={onUpdateEntryCondition}
-						disabled={isFirst}
+						terminalMessage={isFirst ? 'Workflow starts here' : undefined}
 					/>
 
 					{/* Exit Gate */}
@@ -353,7 +352,7 @@ export function WorkflowStepCard({
 						label="Exit Gate"
 						condition={exitCondition ?? { type: 'always' }}
 						onChange={onUpdateExitCondition}
-						disabled={isLast}
+						terminalMessage={isLast ? 'Workflow ends here' : undefined}
 					/>
 
 					{/* Instructions */}

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -77,6 +77,7 @@ function GateConfig({ condition, onChange, label, terminalMessage }: GateConfigP
 						<div class="space-y-1">
 							<input
 								type="text"
+								required
 								placeholder="e.g. bun test && git diff --quiet"
 								value={condition.expression ?? ''}
 								onInput={(e) =>

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -1,0 +1,372 @@
+// @ts-nocheck
+/**
+ * Unit tests for WorkflowEditor
+ *
+ * Tests:
+ * - Renders name and description fields
+ * - Add step button adds a new step card
+ * - Remove step removes the card
+ * - Reorder: move up / move down
+ * - Agent dropdown (via WorkflowStepCard) excludes 'leader' agent
+ * - Template selection pre-fills steps
+ * - Save calls spaceStore.createWorkflow with correct params
+ * - Save calls spaceStore.updateWorkflow when editing
+ * - Error shown when name is empty on save
+ * - Cancel fires onCancel
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+
+// ---- Mocks ----
+
+let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
+let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+
+const mockCreateWorkflow = vi.fn();
+const mockUpdateWorkflow = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			agents: mockAgents,
+			workflows: mockWorkflows,
+			createWorkflow: mockCreateWorkflow,
+			updateWorkflow: mockUpdateWorkflow,
+		};
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Initialize signals before import
+mockAgents = signal<SpaceAgent[]>([]);
+mockWorkflows = signal<SpaceWorkflow[]>([]);
+
+import { WorkflowEditor, filterAgents } from '../WorkflowEditor';
+
+function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
+	return {
+		id,
+		spaceId: 'space-1',
+		name,
+		role,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	const step1Id = 'step-1';
+	const step2Id = 'step-2';
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'Existing Workflow',
+		description: 'A description',
+		steps: [
+			{ id: step1Id, name: 'Plan', agentId: 'agent-1', instructions: 'Plan things' },
+			{ id: step2Id, name: 'Code', agentId: 'agent-2', instructions: '' },
+		],
+		transitions: [{ id: 'tr-1', from: step1Id, to: step2Id, order: 0 }],
+		startStepId: step1Id,
+		rules: [],
+		tags: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+const defaultProps = {
+	onSave: vi.fn(),
+	onCancel: vi.fn(),
+};
+
+describe('WorkflowEditor', () => {
+	beforeEach(() => {
+		cleanup();
+		mockAgents.value = [
+			makeAgent('agent-1', 'planner', 'planner'),
+			makeAgent('agent-2', 'coder', 'coder'),
+			makeAgent('agent-3', 'general', 'general'),
+			makeAgent('agent-leader', 'leader', 'leader'),
+		];
+		mockWorkflows.value = [];
+		mockCreateWorkflow.mockResolvedValue({ id: 'new-wf', steps: [], transitions: [], tags: [] });
+		mockUpdateWorkflow.mockResolvedValue({ id: 'wf-1', steps: [], transitions: [], tags: [] });
+		defaultProps.onSave.mockClear();
+		defaultProps.onCancel.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders name and description fields', () => {
+		const { getByPlaceholderText } = render(<WorkflowEditor {...defaultProps} />);
+		expect(getByPlaceholderText('e.g. Feature Development')).toBeTruthy();
+		expect(getByPlaceholderText('What does this workflow accomplish?')).toBeTruthy();
+	});
+
+	it('renders "New Workflow" title for create mode', () => {
+		const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+		expect(getByText('New Workflow')).toBeTruthy();
+	});
+
+	it('renders "Edit Workflow" title for edit mode', () => {
+		const { getByText } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
+		expect(getByText('Edit Workflow')).toBeTruthy();
+	});
+
+	it('pre-fills name and description when editing', () => {
+		const { container } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
+		const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+		expect(nameInput.value).toBe('Existing Workflow');
+	});
+
+	it('calls onCancel when Cancel button clicked', () => {
+		const { getAllByText } = render(<WorkflowEditor {...defaultProps} />);
+		const cancelBtns = getAllByText('Cancel');
+		fireEvent.click(cancelBtns[0]);
+		expect(defaultProps.onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('renders initial empty step', () => {
+		const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+		expect(getByText('1 step')).toBeTruthy();
+	});
+
+	it('adds a new step when Add Step clicked', () => {
+		const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+		fireEvent.click(getByText('Add Step'));
+		expect(getByText('2 steps')).toBeTruthy();
+	});
+
+	it('removes a step when Remove button clicked (expanded card)', async () => {
+		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
+		// Initially 1 step
+		expect(getByText('1 step')).toBeTruthy();
+		// Add one more
+		fireEvent.click(getByText('Add Step'));
+		expect(getByText('2 steps')).toBeTruthy();
+		// Remove the first step
+		const removeButtons = getAllByTitle('Remove step');
+		fireEvent.click(removeButtons[0]);
+		expect(getByText('1 step')).toBeTruthy();
+	});
+
+	it('moves step up when Move Up clicked', () => {
+		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
+		// Start with 1 step, add another
+		fireEvent.click(getByText('Add Step'));
+		// Both move buttons
+		const moveUpButtons = getAllByTitle('Move up');
+		// The second step (index 1) has move-up enabled; first step has it disabled
+		expect(moveUpButtons[0].disabled).toBe(true); // first step
+		expect(moveUpButtons[1].disabled).toBe(false); // second step
+		fireEvent.click(moveUpButtons[1]);
+		// After move up, the second step becomes first (no assertion on content since names are empty)
+	});
+
+	it('moves step down when Move Down clicked', () => {
+		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
+		fireEvent.click(getByText('Add Step'));
+		const moveDownButtons = getAllByTitle('Move down');
+		expect(moveDownButtons[0].disabled).toBe(false); // first can move down
+		expect(moveDownButtons[1].disabled).toBe(true); // last cannot
+		fireEvent.click(moveDownButtons[0]);
+		// Step moved down successfully
+	});
+
+	describe('filterAgents', () => {
+		it('excludes agents named "leader" (case-insensitive)', () => {
+			const agents: SpaceAgent[] = [
+				makeAgent('1', 'planner', 'planner'),
+				makeAgent('2', 'leader', 'leader'),
+				makeAgent('3', 'Leader', 'leader'),
+				makeAgent('4', 'coder', 'coder'),
+			];
+			const filtered = filterAgents(agents);
+			expect(filtered.map((a) => a.name)).toEqual(['planner', 'coder']);
+		});
+
+		it('preserves all non-leader agents', () => {
+			const agents: SpaceAgent[] = [
+				makeAgent('1', 'planner'),
+				makeAgent('2', 'coder'),
+				makeAgent('3', 'general'),
+				makeAgent('4', 'reviewer'),
+			];
+			const filtered = filterAgents(agents);
+			expect(filtered).toHaveLength(4);
+		});
+	});
+
+	describe('template selection', () => {
+		it('shows template toggle button in create mode', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			expect(getByText(/Start from template/)).toBeTruthy();
+		});
+
+		it('does not show template toggle in edit mode', () => {
+			const { queryByText } = render(
+				<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />
+			);
+			expect(queryByText(/Start from template/)).toBeNull();
+		});
+
+		it('shows template options when toggle clicked', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			expect(getByText('Coding (Plan → Code)')).toBeTruthy();
+			expect(getByText('Research (Plan → Research)')).toBeTruthy();
+			expect(getByText('Quick Fix (Code only)')).toBeTruthy();
+		});
+
+		it('applying Coding template creates 2 steps', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Coding (Plan → Code)'));
+			expect(getByText('2 steps')).toBeTruthy();
+		});
+
+		it('applying Quick Fix template creates 1 step', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Quick Fix (Code only)'));
+			expect(getByText('1 step')).toBeTruthy();
+		});
+
+		it('applying Research template creates 2 steps', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Research (Plan → Research)'));
+			expect(getByText('2 steps')).toBeTruthy();
+		});
+
+		it('template sets workflow name if name is empty', () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Quick Fix (Code only)'));
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			expect(nameInput.value).toBe('Quick Fix (Code only)');
+		});
+
+		it('template does not override existing name', () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			// Set name first
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'My Custom Name' } });
+			// Apply template
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Quick Fix (Code only)'));
+			expect(nameInput.value).toBe('My Custom Name');
+		});
+
+		it('template looks up agents by name matching role', () => {
+			// The planner agent should be pre-selected in Coding template step 1
+			// We can verify via the step card expanded view
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			fireEvent.click(getByText(/Start from template/));
+			fireEvent.click(getByText('Coding (Plan → Code)'));
+			// Expand first step (should be expanded by default after template apply)
+			const agentSelects = container.querySelectorAll('select');
+			// First select in expanded card is the agent dropdown
+			if (agentSelects.length > 0) {
+				expect(agentSelects[0].value).toBe('agent-1'); // planner agent
+			}
+		});
+	});
+
+	describe('save', () => {
+		it('shows error when name is empty on save attempt', async () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
+			const saveBtn = getByText('Create Workflow');
+			fireEvent.click(saveBtn);
+			await waitFor(() => {
+				expect(getByText('Workflow name is required.')).toBeTruthy();
+			});
+		});
+
+		it('calls createWorkflow on save in create mode', async () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(mockCreateWorkflow).toHaveBeenCalledWith(
+					expect.objectContaining({ name: 'My Workflow' })
+				);
+			});
+		});
+
+		it('calls updateWorkflow on save in edit mode', async () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
+			fireEvent.click(getByText('Save Changes'));
+			await waitFor(() => {
+				expect(mockUpdateWorkflow).toHaveBeenCalledWith(
+					'wf-1',
+					expect.objectContaining({ name: 'Existing Workflow' })
+				);
+			});
+		});
+
+		it('calls onSave after successful createWorkflow', async () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(defaultProps.onSave).toHaveBeenCalledOnce();
+			});
+		});
+
+		it('shows error message when createWorkflow throws', async () => {
+			mockCreateWorkflow.mockRejectedValueOnce(new Error('Server error'));
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(getByText('Server error')).toBeTruthy();
+			});
+		});
+
+		it('sends steps with generated IDs and transitions', async () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'Test' } });
+			// Add a second step
+			fireEvent.click(getByText('Add Step'));
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(mockCreateWorkflow).toHaveBeenCalledWith(
+					expect.objectContaining({
+						steps: expect.arrayContaining([expect.objectContaining({ name: expect.any(String) })]),
+						transitions: expect.arrayContaining([
+							expect.objectContaining({ from: expect.any(String), to: expect.any(String) }),
+						]),
+					})
+				);
+			});
+		});
+	});
+
+	describe('edit mode initialization', () => {
+		it('loads steps from existing workflow', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
+			expect(getByText('2 steps')).toBeTruthy();
+		});
+
+		it('loads step names from existing workflow', () => {
+			const { getByText } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
+			// First step is expanded by default
+			expect(getByText('Plan')).toBeTruthy();
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -12,6 +12,7 @@
  * - Save calls spaceStore.createWorkflow with correct params
  * - Save calls spaceStore.updateWorkflow when editing
  * - Error shown when name is empty on save
+ * - Error shown when a step has no agent assigned
  * - Cancel fires onCancel
  */
 
@@ -47,7 +48,7 @@ vi.mock('../../../lib/utils', () => ({
 mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 
-import { WorkflowEditor, filterAgents } from '../WorkflowEditor';
+import { WorkflowEditor, filterAgents, initFromWorkflow } from '../WorkflowEditor';
 
 function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
 	return {
@@ -86,6 +87,12 @@ const defaultProps = {
 	onSave: vi.fn(),
 	onCancel: vi.fn(),
 };
+
+/** Select an agent on the currently-expanded step card */
+function selectAgent(container: HTMLElement, agentId: string) {
+	const agentSelect = container.querySelectorAll('select')[0];
+	fireEvent.change(agentSelect, { target: { value: agentId } });
+}
 
 describe('WorkflowEditor', () => {
 	beforeEach(() => {
@@ -195,6 +202,16 @@ describe('WorkflowEditor', () => {
 			expect(filtered.map((a) => a.name)).toEqual(['planner', 'coder']);
 		});
 
+		it('excludes agents with role "leader" regardless of name', () => {
+			const agents: SpaceAgent[] = [
+				makeAgent('1', 'orchestrator', 'leader'),
+				makeAgent('2', 'coordinator', 'Leader'),
+				makeAgent('3', 'coder', 'coder'),
+			];
+			const filtered = filterAgents(agents);
+			expect(filtered.map((a) => a.name)).toEqual(['coder']);
+		});
+
 		it('preserves all non-leader agents', () => {
 			const agents: SpaceAgent[] = [
 				makeAgent('1', 'planner'),
@@ -204,6 +221,45 @@ describe('WorkflowEditor', () => {
 			];
 			const filtered = filterAgents(agents);
 			expect(filtered).toHaveLength(4);
+		});
+	});
+
+	describe('initFromWorkflow', () => {
+		it('returns ordered steps following startStepId', () => {
+			const wf = makeWorkflow();
+			const { steps } = initFromWorkflow(wf);
+			expect(steps.map((s) => s.name)).toEqual(['Plan', 'Code']);
+		});
+
+		it('returns transitions between sequential steps', () => {
+			const wf = makeWorkflow();
+			const { transitions } = initFromWorkflow(wf);
+			expect(transitions).toHaveLength(1);
+			expect(transitions[0].type).toBe('always');
+		});
+
+		it('preserves transition condition type', () => {
+			const s1 = 'step-1';
+			const s2 = 'step-2';
+			const wf = makeWorkflow({
+				transitions: [{ id: 'tr-1', from: s1, to: s2, condition: { type: 'human' }, order: 0 }],
+			});
+			const { transitions } = initFromWorkflow(wf);
+			expect(transitions[0].type).toBe('human');
+		});
+
+		it('appends orphaned steps not reachable from startStepId', () => {
+			const wf = makeWorkflow({
+				steps: [
+					{ id: 'step-1', name: 'Plan', agentId: 'a1' },
+					{ id: 'step-2', name: 'Code', agentId: 'a2' },
+					{ id: 'orphan', name: 'Orphan', agentId: 'a3' },
+				],
+				transitions: [{ id: 'tr-1', from: 'step-1', to: 'step-2', order: 0 }],
+				startStepId: 'step-1',
+			});
+			const { steps } = initFromWorkflow(wf);
+			expect(steps.map((s) => s.name)).toEqual(['Plan', 'Code', 'Orphan']);
 		});
 	});
 
@@ -293,10 +349,24 @@ describe('WorkflowEditor', () => {
 			});
 		});
 
+		it('shows error when a step has no agent assigned', async () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			// Do NOT select an agent — step.agentId stays empty
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(getByText('Step 1 requires an agent.')).toBeTruthy();
+			});
+			expect(mockCreateWorkflow).not.toHaveBeenCalled();
+		});
+
 		it('calls createWorkflow on save in create mode', async () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			// Select an agent so validation passes
+			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
 				expect(mockCreateWorkflow).toHaveBeenCalledWith(
@@ -320,6 +390,7 @@ describe('WorkflowEditor', () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
 				expect(defaultProps.onSave).toHaveBeenCalledOnce();
@@ -331,6 +402,7 @@ describe('WorkflowEditor', () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
 				expect(getByText('Server error')).toBeTruthy();
@@ -341,8 +413,12 @@ describe('WorkflowEditor', () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
 			fireEvent.input(nameInput, { target: { value: 'Test' } });
+			// Select agent for first step
+			selectAgent(container, 'agent-1');
 			// Add a second step
 			fireEvent.click(getByText('Add Step'));
+			// Select agent for second step (it becomes expanded)
+			selectAgent(container, 'agent-2');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
 				expect(mockCreateWorkflow).toHaveBeenCalledWith(

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Unit tests for WorkflowEditor
  *
@@ -13,18 +12,20 @@
  * - Save calls spaceStore.updateWorkflow when editing
  * - Error shown when name is empty on save
  * - Error shown when a step has no agent assigned
+ * - Error shown when a condition transition has empty shell expression
  * - Cancel fires onCancel
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
-import { signal } from '@preact/signals';
+import { signal, type Signal } from '@preact/signals';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 // ---- Mocks ----
+// Signals are initialized immediately so vi.mock's lazy getter can reference them safely.
 
-let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
-let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+const mockAgents: Signal<SpaceAgent[]> = signal([]);
+const mockWorkflows: Signal<SpaceWorkflow[]> = signal([]);
 
 const mockCreateWorkflow = vi.fn();
 const mockUpdateWorkflow = vi.fn();
@@ -43,10 +44,6 @@ vi.mock('../../../lib/space-store', () => ({
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }));
-
-// Initialize signals before import
-mockAgents = signal<SpaceAgent[]>([]);
-mockWorkflows = signal<SpaceWorkflow[]>([]);
 
 import { WorkflowEditor, filterAgents, initFromWorkflow } from '../WorkflowEditor';
 
@@ -89,8 +86,8 @@ const defaultProps = {
 };
 
 /** Select an agent on the currently-expanded step card */
-function selectAgent(container: HTMLElement, agentId: string) {
-	const agentSelect = container.querySelectorAll('select')[0];
+function selectAgent(container: Element, agentId: string) {
+	const agentSelect = container.querySelectorAll('select')[0] as HTMLSelectElement;
 	fireEvent.change(agentSelect, { target: { value: agentId } });
 }
 
@@ -106,6 +103,8 @@ describe('WorkflowEditor', () => {
 		mockWorkflows.value = [];
 		mockCreateWorkflow.mockResolvedValue({ id: 'new-wf', steps: [], transitions: [], tags: [] });
 		mockUpdateWorkflow.mockResolvedValue({ id: 'wf-1', steps: [], transitions: [], tags: [] });
+		mockCreateWorkflow.mockClear();
+		mockUpdateWorkflow.mockClear();
 		defaultProps.onSave.mockClear();
 		defaultProps.onCancel.mockClear();
 	});
@@ -132,7 +131,9 @@ describe('WorkflowEditor', () => {
 
 	it('pre-fills name and description when editing', () => {
 		const { container } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
-		const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+		const nameInput = container.querySelector(
+			'input[placeholder="e.g. Feature Development"]'
+		) as HTMLInputElement;
 		expect(nameInput.value).toBe('Existing Workflow');
 	});
 
@@ -156,38 +157,44 @@ describe('WorkflowEditor', () => {
 
 	it('removes a step when Remove button clicked (expanded card)', async () => {
 		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
-		// Initially 1 step
 		expect(getByText('1 step')).toBeTruthy();
-		// Add one more
 		fireEvent.click(getByText('Add Step'));
 		expect(getByText('2 steps')).toBeTruthy();
-		// Remove the first step
 		const removeButtons = getAllByTitle('Remove step');
 		fireEvent.click(removeButtons[0]);
 		expect(getByText('1 step')).toBeTruthy();
 	});
 
+	it('disables Remove button when only one step remains', () => {
+		const { getByTitle } = render(<WorkflowEditor {...defaultProps} />);
+		const removeBtn = getByTitle('Remove step') as HTMLButtonElement;
+		expect(removeBtn.disabled).toBe(true);
+	});
+
+	it('enables Remove button when more than one step exists', () => {
+		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
+		fireEvent.click(getByText('Add Step'));
+		const removeBtns = getAllByTitle('Remove step') as HTMLButtonElement[];
+		expect(removeBtns[0].disabled).toBe(false);
+		expect(removeBtns[1].disabled).toBe(false);
+	});
+
 	it('moves step up when Move Up clicked', () => {
 		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
-		// Start with 1 step, add another
 		fireEvent.click(getByText('Add Step'));
-		// Both move buttons
-		const moveUpButtons = getAllByTitle('Move up');
-		// The second step (index 1) has move-up enabled; first step has it disabled
+		const moveUpButtons = getAllByTitle('Move up') as HTMLButtonElement[];
 		expect(moveUpButtons[0].disabled).toBe(true); // first step
 		expect(moveUpButtons[1].disabled).toBe(false); // second step
 		fireEvent.click(moveUpButtons[1]);
-		// After move up, the second step becomes first (no assertion on content since names are empty)
 	});
 
 	it('moves step down when Move Down clicked', () => {
 		const { getByText, getAllByTitle } = render(<WorkflowEditor {...defaultProps} />);
 		fireEvent.click(getByText('Add Step'));
-		const moveDownButtons = getAllByTitle('Move down');
-		expect(moveDownButtons[0].disabled).toBe(false); // first can move down
-		expect(moveDownButtons[1].disabled).toBe(true); // last cannot
+		const moveDownButtons = getAllByTitle('Move down') as HTMLButtonElement[];
+		expect(moveDownButtons[0].disabled).toBe(false);
+		expect(moveDownButtons[1].disabled).toBe(true);
 		fireEvent.click(moveDownButtons[0]);
-		// Step moved down successfully
 	});
 
 	describe('filterAgents', () => {
@@ -309,32 +316,30 @@ describe('WorkflowEditor', () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			fireEvent.click(getByText(/Start from template/));
 			fireEvent.click(getByText('Quick Fix (Code only)'));
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			expect(nameInput.value).toBe('Quick Fix (Code only)');
 		});
 
 		it('template does not override existing name', () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			// Set name first
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'My Custom Name' } });
-			// Apply template
 			fireEvent.click(getByText(/Start from template/));
 			fireEvent.click(getByText('Quick Fix (Code only)'));
 			expect(nameInput.value).toBe('My Custom Name');
 		});
 
 		it('template looks up agents by name matching role', () => {
-			// The planner agent should be pre-selected in Coding template step 1
-			// We can verify via the step card expanded view
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
 			fireEvent.click(getByText(/Start from template/));
 			fireEvent.click(getByText('Coding (Plan → Code)'));
-			// Expand first step (should be expanded by default after template apply)
 			const agentSelects = container.querySelectorAll('select');
-			// First select in expanded card is the agent dropdown
 			if (agentSelects.length > 0) {
-				expect(agentSelects[0].value).toBe('agent-1'); // planner agent
+				expect((agentSelects[0] as HTMLSelectElement).value).toBe('agent-1');
 			}
 		});
 	});
@@ -342,8 +347,7 @@ describe('WorkflowEditor', () => {
 	describe('save', () => {
 		it('shows error when name is empty on save attempt', async () => {
 			const { getByText } = render(<WorkflowEditor {...defaultProps} />);
-			const saveBtn = getByText('Create Workflow');
-			fireEvent.click(saveBtn);
+			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
 				expect(getByText('Workflow name is required.')).toBeTruthy();
 			});
@@ -351,7 +355,9 @@ describe('WorkflowEditor', () => {
 
 		it('shows error when a step has no agent assigned', async () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
 			// Do NOT select an agent — step.agentId stays empty
 			fireEvent.click(getByText('Create Workflow'));
@@ -361,11 +367,42 @@ describe('WorkflowEditor', () => {
 			expect(mockCreateWorkflow).not.toHaveBeenCalled();
 		});
 
+		it('shows error when a condition transition has empty shell expression', async () => {
+			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
+			// Set name
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
+			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
+			// Select agent for step 1
+			selectAgent(container, 'agent-1');
+			// Add step 2
+			fireEvent.click(getByText('Add Step'));
+			selectAgent(container, 'agent-2');
+			// Change exit gate of step 1 to 'condition' with empty expression
+			// Step 1 was previously expanded, but after Add Step, step 2 is expanded.
+			// Click step 1 header to expand it
+			const stepHeaders = container.querySelectorAll('.cursor-pointer');
+			fireEvent.click(stepHeaders[0]);
+			// Now find the exit gate select (selects[2] = exit gate when entry+agent are visible)
+			const selects = container.querySelectorAll('select');
+			// Find exit gate select — it's labeled 'Exit Gate', the last condition select
+			const exitGateSelect = selects[selects.length - 1] as HTMLSelectElement;
+			fireEvent.change(exitGateSelect, { target: { value: 'condition' } });
+			// Leave expression empty and try to save
+			fireEvent.click(getByText('Create Workflow'));
+			await waitFor(() => {
+				expect(getByText(/Transition after step 1 requires a shell expression/)).toBeTruthy();
+			});
+			expect(mockCreateWorkflow).not.toHaveBeenCalled();
+		});
+
 		it('calls createWorkflow on save in create mode', async () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
-			// Select an agent so validation passes
 			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
@@ -388,7 +425,9 @@ describe('WorkflowEditor', () => {
 
 		it('calls onSave after successful createWorkflow', async () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
 			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
@@ -400,7 +439,9 @@ describe('WorkflowEditor', () => {
 		it('shows error message when createWorkflow throws', async () => {
 			mockCreateWorkflow.mockRejectedValueOnce(new Error('Server error'));
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'My Workflow' } });
 			selectAgent(container, 'agent-1');
 			fireEvent.click(getByText('Create Workflow'));
@@ -411,13 +452,12 @@ describe('WorkflowEditor', () => {
 
 		it('sends steps with generated IDs and transitions', async () => {
 			const { getByText, container } = render(<WorkflowEditor {...defaultProps} />);
-			const nameInput = container.querySelector('input[placeholder="e.g. Feature Development"]');
+			const nameInput = container.querySelector(
+				'input[placeholder="e.g. Feature Development"]'
+			) as HTMLInputElement;
 			fireEvent.input(nameInput, { target: { value: 'Test' } });
-			// Select agent for first step
 			selectAgent(container, 'agent-1');
-			// Add a second step
 			fireEvent.click(getByText('Add Step'));
-			// Select agent for second step (it becomes expanded)
 			selectAgent(container, 'agent-2');
 			fireEvent.click(getByText('Create Workflow'));
 			await waitFor(() => {
@@ -441,7 +481,6 @@ describe('WorkflowEditor', () => {
 
 		it('loads step names from existing workflow', () => {
 			const { getByText } = render(<WorkflowEditor {...defaultProps} workflow={makeWorkflow()} />);
-			// First step is expanded by default
 			expect(getByText('Plan')).toBeTruthy();
 		});
 	});

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -10,11 +10,12 @@
  * - Mini step visualization renders dots
  * - "Create Workflow" header button fires onCreateWorkflow
  * - Edit button on card fires onEditWorkflow with correct ID
+ * - Delete confirmation flow (inline confirm pattern)
  * - Real-time updates via SpaceStore signal
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceWorkflow } from '@neokai/shared';
 
@@ -23,11 +24,14 @@ import type { SpaceWorkflow } from '@neokai/shared';
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 
+const mockDeleteWorkflow = vi.fn();
+
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
 		return {
 			workflows: mockWorkflows,
 			loading: mockLoading,
+			deleteWorkflow: mockDeleteWorkflow,
 		};
 	},
 }));
@@ -70,6 +74,7 @@ describe('WorkflowList', () => {
 		cleanup();
 		mockWorkflows.value = [];
 		mockLoading.value = false;
+		mockDeleteWorkflow.mockResolvedValue(undefined);
 		defaultProps.onCreateWorkflow.mockClear();
 		defaultProps.onEditWorkflow.mockClear();
 	});
@@ -160,14 +165,8 @@ describe('WorkflowList', () => {
 
 	it('calls onEditWorkflow with workflow ID when Edit clicked', async () => {
 		mockWorkflows.value = [makeWorkflow({ id: 'wf-abc' })];
-		const { container } = render(<WorkflowList {...defaultProps} />);
-		const card = container.querySelector('.group');
-		// Hover to reveal edit button (opacity-0 group-hover:opacity-100)
-		// In tests, we just query for the button text
-		const editBtn = container.querySelector('button.opacity-0');
-		// fireEvent.click won't work on opacity-0 element if it's not visible,
-		// but happy-dom doesn't respect CSS visibility so click should still work
-		fireEvent.click(editBtn);
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		fireEvent.click(getByText('Edit'));
 		expect(defaultProps.onEditWorkflow).toHaveBeenCalledWith('wf-abc');
 	});
 
@@ -203,5 +202,40 @@ describe('WorkflowList', () => {
 		const { container } = render(<WorkflowList {...defaultProps} />);
 		// Human gate indicator: bg-yellow-400 class on mini connector dot
 		expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+	});
+
+	describe('delete workflow', () => {
+		it('shows inline Delete? confirmation when trash icon clicked', () => {
+			mockWorkflows.value = [makeWorkflow()];
+			const { getByText, container } = render(<WorkflowList {...defaultProps} />);
+			// Find the delete button (trash icon button, second action button)
+			const actionBtns = container.querySelectorAll('button[title="Delete workflow"]');
+			expect(actionBtns.length).toBe(1);
+			fireEvent.click(actionBtns[0]);
+			expect(getByText('Delete?')).toBeTruthy();
+			expect(getByText('Confirm')).toBeTruthy();
+			expect(getByText('Cancel')).toBeTruthy();
+		});
+
+		it('calls deleteWorkflow when Confirm clicked', async () => {
+			mockWorkflows.value = [makeWorkflow({ id: 'wf-del' })];
+			const { getByText, container } = render(<WorkflowList {...defaultProps} />);
+			const trashBtn = container.querySelector('button[title="Delete workflow"]');
+			fireEvent.click(trashBtn);
+			fireEvent.click(getByText('Confirm'));
+			await waitFor(() => {
+				expect(mockDeleteWorkflow).toHaveBeenCalledWith('wf-del');
+			});
+		});
+
+		it('hides confirmation when Cancel clicked', () => {
+			mockWorkflows.value = [makeWorkflow()];
+			const { getByText, queryByText, container } = render(<WorkflowList {...defaultProps} />);
+			const trashBtn = container.querySelector('button[title="Delete workflow"]');
+			fireEvent.click(trashBtn);
+			expect(getByText('Delete?')).toBeTruthy();
+			fireEvent.click(getByText('Cancel'));
+			expect(queryByText('Delete?')).toBeNull();
+		});
 	});
 });

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Unit tests for WorkflowList
  *
@@ -11,34 +10,42 @@
  * - "Create Workflow" header button fires onCreateWorkflow
  * - Edit button on card fires onEditWorkflow with correct ID
  * - Delete confirmation flow (inline confirm pattern)
+ * - Delete failure shows error banner
  * - Real-time updates via SpaceStore signal
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
-import { signal } from '@preact/signals';
+import { signal, type Signal } from '@preact/signals';
 import type { SpaceWorkflow } from '@neokai/shared';
 
 // ---- Mocks ----
+// Signals are initialized immediately so vi.mock's lazy getter can reference them safely.
 
-let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
-let mockLoading: ReturnType<typeof signal<boolean>>;
+const mockLoading: Signal<boolean> = signal(false);
 
 const mockDeleteWorkflow = vi.fn();
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
 		return {
-			workflows: mockWorkflows,
 			loading: mockLoading,
 			deleteWorkflow: mockDeleteWorkflow,
 		};
 	},
 }));
 
-// Initialize signals before import
-mockWorkflows = signal<SpaceWorkflow[]>([]);
-mockLoading = signal(false);
+vi.mock('../../../lib/connection-manager.ts', () => ({
+	connectionManager: { getHubIfConnected: vi.fn() },
+}));
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+vi.mock('../ImportPreviewDialog.tsx', () => ({ ImportPreviewDialog: () => null }));
+vi.mock('../export-import-utils.ts', () => ({
+	downloadBundle: vi.fn(),
+	pickImportFile: vi.fn(),
+}));
 
 import { WorkflowList } from '../WorkflowList';
 
@@ -65,6 +72,9 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 }
 
 const defaultProps = {
+	spaceId: 'space-1',
+	spaceName: 'Test Space',
+	workflows: [] as SpaceWorkflow[],
 	onCreateWorkflow: vi.fn(),
 	onEditWorkflow: vi.fn(),
 };
@@ -72,9 +82,9 @@ const defaultProps = {
 describe('WorkflowList', () => {
 	beforeEach(() => {
 		cleanup();
-		mockWorkflows.value = [];
 		mockLoading.value = false;
 		mockDeleteWorkflow.mockResolvedValue(undefined);
+		defaultProps.workflows = [];
 		defaultProps.onCreateWorkflow.mockClear();
 		defaultProps.onEditWorkflow.mockClear();
 	});
@@ -97,7 +107,7 @@ describe('WorkflowList', () => {
 
 	it('renders Workflows heading', () => {
 		const { getByText } = render(<WorkflowList {...defaultProps} />);
-		expect(getByText('Workflows')).toBeTruthy();
+		expect(getByText(/Workflows/)).toBeTruthy();
 	});
 
 	it('renders Create Workflow button in header', () => {
@@ -118,109 +128,127 @@ describe('WorkflowList', () => {
 	});
 
 	it('renders workflow card with name', () => {
-		mockWorkflows.value = [makeWorkflow({ name: 'Feature Pipeline' })];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = { ...defaultProps, workflows: [makeWorkflow({ name: 'Feature Pipeline' })] };
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('Feature Pipeline')).toBeTruthy();
 	});
 
 	it('renders workflow description', () => {
-		mockWorkflows.value = [makeWorkflow({ description: 'Runs features end-to-end' })];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = {
+			...defaultProps,
+			workflows: [makeWorkflow({ description: 'Runs features end-to-end' })],
+		};
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('Runs features end-to-end')).toBeTruthy();
 	});
 
 	it('renders step count', () => {
-		mockWorkflows.value = [makeWorkflow()];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = { ...defaultProps, workflows: [makeWorkflow()] };
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('2 steps')).toBeTruthy();
 	});
 
 	it('renders singular "1 step"', () => {
 		const s1 = 'step-1';
-		mockWorkflows.value = [
-			makeWorkflow({
-				steps: [{ id: s1, name: 'Plan', agentId: 'a1' }],
-				transitions: [],
-				startStepId: s1,
-			}),
-		];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = {
+			...defaultProps,
+			workflows: [
+				makeWorkflow({
+					steps: [{ id: s1, name: 'Plan', agentId: 'a1' }],
+					transitions: [],
+					startStepId: s1,
+				}),
+			],
+		};
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('1 step')).toBeTruthy();
 	});
 
 	it('renders tag chips', () => {
-		mockWorkflows.value = [makeWorkflow({ tags: ['ci', 'dev'] })];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = { ...defaultProps, workflows: [makeWorkflow({ tags: ['ci', 'dev'] })] };
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('ci')).toBeTruthy();
 		expect(getByText('dev')).toBeTruthy();
 	});
 
 	it('renders mini step dots (one per step)', () => {
-		mockWorkflows.value = [makeWorkflow()]; // 2 steps
-		const { container } = render(<WorkflowList {...defaultProps} />);
-		// Each step dot has bg-blue-400 or bg-blue-500 class
+		const props = { ...defaultProps, workflows: [makeWorkflow()] };
+		const { container } = render(<WorkflowList {...props} />);
 		const dots = container.querySelectorAll('.bg-blue-400, .bg-blue-500');
 		expect(dots.length).toBeGreaterThanOrEqual(2);
 	});
 
-	it('calls onEditWorkflow with workflow ID when Edit clicked', async () => {
-		mockWorkflows.value = [makeWorkflow({ id: 'wf-abc' })];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+	it('calls onEditWorkflow with workflow ID when Edit clicked', () => {
+		const props = { ...defaultProps, workflows: [makeWorkflow({ id: 'wf-abc' })] };
+		const { getByText } = render(<WorkflowList {...props} />);
 		fireEvent.click(getByText('Edit'));
 		expect(defaultProps.onEditWorkflow).toHaveBeenCalledWith('wf-abc');
 	});
 
 	it('renders multiple workflows', () => {
-		mockWorkflows.value = [
-			makeWorkflow({ id: 'wf-1', name: 'Alpha' }),
-			makeWorkflow({ id: 'wf-2', name: 'Beta' }),
-		];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = {
+			...defaultProps,
+			workflows: [
+				makeWorkflow({ id: 'wf-1', name: 'Alpha' }),
+				makeWorkflow({ id: 'wf-2', name: 'Beta' }),
+			],
+		};
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('Alpha')).toBeTruthy();
 		expect(getByText('Beta')).toBeTruthy();
 	});
 
 	it('handles workflow with no steps in mini viz', () => {
-		mockWorkflows.value = [makeWorkflow({ steps: [], transitions: [], startStepId: '' })];
-		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		const props = {
+			...defaultProps,
+			workflows: [makeWorkflow({ steps: [], transitions: [], startStepId: '' })],
+		};
+		const { getByText } = render(<WorkflowList {...props} />);
 		expect(getByText('No steps')).toBeTruthy();
 	});
 
 	it('renders human gate connector for human condition transition', () => {
 		const s1 = 'step-1';
 		const s2 = 'step-2';
-		mockWorkflows.value = [
-			makeWorkflow({
-				steps: [
-					{ id: s1, name: 'Plan', agentId: 'a1' },
-					{ id: s2, name: 'Code', agentId: 'a2' },
-				],
-				transitions: [{ id: 'tr-1', from: s1, to: s2, condition: { type: 'human' }, order: 0 }],
-				startStepId: s1,
-			}),
-		];
-		const { container } = render(<WorkflowList {...defaultProps} />);
-		// Human gate indicator: bg-yellow-400 class on mini connector dot
+		const props = {
+			...defaultProps,
+			workflows: [
+				makeWorkflow({
+					steps: [
+						{ id: s1, name: 'Plan', agentId: 'a1' },
+						{ id: s2, name: 'Code', agentId: 'a2' },
+					],
+					transitions: [
+						{ id: 'tr-1', from: s1, to: s2, condition: { type: 'human' as const }, order: 0 },
+					],
+					startStepId: s1,
+				}),
+			],
+		};
+		const { container } = render(<WorkflowList {...props} />);
 		expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
 	});
 
 	describe('delete workflow', () => {
 		it('shows inline Delete? confirmation when trash icon clicked', () => {
-			mockWorkflows.value = [makeWorkflow()];
-			const { getByText, container } = render(<WorkflowList {...defaultProps} />);
-			// Find the delete button (trash icon button, second action button)
-			const actionBtns = container.querySelectorAll('button[title="Delete workflow"]');
-			expect(actionBtns.length).toBe(1);
-			fireEvent.click(actionBtns[0]);
+			const props = { ...defaultProps, workflows: [makeWorkflow()] };
+			const { getByText, container } = render(<WorkflowList {...props} />);
+			const trashBtn = container.querySelector(
+				'button[title="Delete workflow"]'
+			) as HTMLButtonElement;
+			expect(trashBtn).toBeTruthy();
+			fireEvent.click(trashBtn);
 			expect(getByText('Delete?')).toBeTruthy();
 			expect(getByText('Confirm')).toBeTruthy();
 			expect(getByText('Cancel')).toBeTruthy();
 		});
 
 		it('calls deleteWorkflow when Confirm clicked', async () => {
-			mockWorkflows.value = [makeWorkflow({ id: 'wf-del' })];
-			const { getByText, container } = render(<WorkflowList {...defaultProps} />);
-			const trashBtn = container.querySelector('button[title="Delete workflow"]');
+			const props = { ...defaultProps, workflows: [makeWorkflow({ id: 'wf-del' })] };
+			const { getByText, container } = render(<WorkflowList {...props} />);
+			const trashBtn = container.querySelector(
+				'button[title="Delete workflow"]'
+			) as HTMLButtonElement;
 			fireEvent.click(trashBtn);
 			fireEvent.click(getByText('Confirm'));
 			await waitFor(() => {
@@ -229,13 +257,29 @@ describe('WorkflowList', () => {
 		});
 
 		it('hides confirmation when Cancel clicked', () => {
-			mockWorkflows.value = [makeWorkflow()];
-			const { getByText, queryByText, container } = render(<WorkflowList {...defaultProps} />);
-			const trashBtn = container.querySelector('button[title="Delete workflow"]');
+			const props = { ...defaultProps, workflows: [makeWorkflow()] };
+			const { getByText, queryByText, container } = render(<WorkflowList {...props} />);
+			const trashBtn = container.querySelector(
+				'button[title="Delete workflow"]'
+			) as HTMLButtonElement;
 			fireEvent.click(trashBtn);
 			expect(getByText('Delete?')).toBeTruthy();
 			fireEvent.click(getByText('Cancel'));
 			expect(queryByText('Delete?')).toBeNull();
+		});
+
+		it('shows error banner when deleteWorkflow fails', async () => {
+			mockDeleteWorkflow.mockRejectedValueOnce(new Error('Delete failed'));
+			const props = { ...defaultProps, workflows: [makeWorkflow()] };
+			const { getByText, container } = render(<WorkflowList {...props} />);
+			const trashBtn = container.querySelector(
+				'button[title="Delete workflow"]'
+			) as HTMLButtonElement;
+			fireEvent.click(trashBtn);
+			fireEvent.click(getByText('Confirm'));
+			await waitFor(() => {
+				expect(getByText('Delete failed')).toBeTruthy();
+			});
 		});
 	});
 });

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -1,0 +1,207 @@
+// @ts-nocheck
+/**
+ * Unit tests for WorkflowList
+ *
+ * Tests:
+ * - Loading state shows spinner
+ * - Empty state with create CTA
+ * - Renders workflow cards with name, description, step count
+ * - Tag chips rendered
+ * - Mini step visualization renders dots
+ * - "Create Workflow" header button fires onCreateWorkflow
+ * - Edit button on card fires onEditWorkflow with correct ID
+ * - Real-time updates via SpaceStore signal
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---- Mocks ----
+
+let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+let mockLoading: ReturnType<typeof signal<boolean>>;
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			workflows: mockWorkflows,
+			loading: mockLoading,
+		};
+	},
+}));
+
+// Initialize signals before import
+mockWorkflows = signal<SpaceWorkflow[]>([]);
+mockLoading = signal(false);
+
+import { WorkflowList } from '../WorkflowList';
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	const s1 = 'step-1';
+	const s2 = 'step-2';
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'My Workflow',
+		description: 'Does stuff',
+		steps: [
+			{ id: s1, name: 'Plan', agentId: 'a1' },
+			{ id: s2, name: 'Code', agentId: 'a2' },
+		],
+		transitions: [{ id: 'tr-1', from: s1, to: s2, order: 0 }],
+		startStepId: s1,
+		rules: [],
+		tags: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+const defaultProps = {
+	onCreateWorkflow: vi.fn(),
+	onEditWorkflow: vi.fn(),
+};
+
+describe('WorkflowList', () => {
+	beforeEach(() => {
+		cleanup();
+		mockWorkflows.value = [];
+		mockLoading.value = false;
+		defaultProps.onCreateWorkflow.mockClear();
+		defaultProps.onEditWorkflow.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders loading spinner when loading', () => {
+		mockLoading.value = true;
+		const { container } = render(<WorkflowList {...defaultProps} />);
+		expect(container.querySelector('.animate-spin')).toBeTruthy();
+	});
+
+	it('renders empty state when no workflows', () => {
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('No workflows yet')).toBeTruthy();
+		expect(getByText('Create your first workflow')).toBeTruthy();
+	});
+
+	it('renders Workflows heading', () => {
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('Workflows')).toBeTruthy();
+	});
+
+	it('renders Create Workflow button in header', () => {
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('Create Workflow')).toBeTruthy();
+	});
+
+	it('calls onCreateWorkflow when header Create button clicked', () => {
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		fireEvent.click(getByText('Create Workflow'));
+		expect(defaultProps.onCreateWorkflow).toHaveBeenCalledOnce();
+	});
+
+	it('calls onCreateWorkflow when empty-state CTA clicked', () => {
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		fireEvent.click(getByText('Create your first workflow'));
+		expect(defaultProps.onCreateWorkflow).toHaveBeenCalled();
+	});
+
+	it('renders workflow card with name', () => {
+		mockWorkflows.value = [makeWorkflow({ name: 'Feature Pipeline' })];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('Feature Pipeline')).toBeTruthy();
+	});
+
+	it('renders workflow description', () => {
+		mockWorkflows.value = [makeWorkflow({ description: 'Runs features end-to-end' })];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('Runs features end-to-end')).toBeTruthy();
+	});
+
+	it('renders step count', () => {
+		mockWorkflows.value = [makeWorkflow()];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('2 steps')).toBeTruthy();
+	});
+
+	it('renders singular "1 step"', () => {
+		const s1 = 'step-1';
+		mockWorkflows.value = [
+			makeWorkflow({
+				steps: [{ id: s1, name: 'Plan', agentId: 'a1' }],
+				transitions: [],
+				startStepId: s1,
+			}),
+		];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('1 step')).toBeTruthy();
+	});
+
+	it('renders tag chips', () => {
+		mockWorkflows.value = [makeWorkflow({ tags: ['ci', 'dev'] })];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('ci')).toBeTruthy();
+		expect(getByText('dev')).toBeTruthy();
+	});
+
+	it('renders mini step dots (one per step)', () => {
+		mockWorkflows.value = [makeWorkflow()]; // 2 steps
+		const { container } = render(<WorkflowList {...defaultProps} />);
+		// Each step dot has bg-blue-400 or bg-blue-500 class
+		const dots = container.querySelectorAll('.bg-blue-400, .bg-blue-500');
+		expect(dots.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('calls onEditWorkflow with workflow ID when Edit clicked', async () => {
+		mockWorkflows.value = [makeWorkflow({ id: 'wf-abc' })];
+		const { container } = render(<WorkflowList {...defaultProps} />);
+		const card = container.querySelector('.group');
+		// Hover to reveal edit button (opacity-0 group-hover:opacity-100)
+		// In tests, we just query for the button text
+		const editBtn = container.querySelector('button.opacity-0');
+		// fireEvent.click won't work on opacity-0 element if it's not visible,
+		// but happy-dom doesn't respect CSS visibility so click should still work
+		fireEvent.click(editBtn);
+		expect(defaultProps.onEditWorkflow).toHaveBeenCalledWith('wf-abc');
+	});
+
+	it('renders multiple workflows', () => {
+		mockWorkflows.value = [
+			makeWorkflow({ id: 'wf-1', name: 'Alpha' }),
+			makeWorkflow({ id: 'wf-2', name: 'Beta' }),
+		];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('Alpha')).toBeTruthy();
+		expect(getByText('Beta')).toBeTruthy();
+	});
+
+	it('handles workflow with no steps in mini viz', () => {
+		mockWorkflows.value = [makeWorkflow({ steps: [], transitions: [], startStepId: '' })];
+		const { getByText } = render(<WorkflowList {...defaultProps} />);
+		expect(getByText('No steps')).toBeTruthy();
+	});
+
+	it('renders human gate connector for human condition transition', () => {
+		const s1 = 'step-1';
+		const s2 = 'step-2';
+		mockWorkflows.value = [
+			makeWorkflow({
+				steps: [
+					{ id: s1, name: 'Plan', agentId: 'a1' },
+					{ id: s2, name: 'Code', agentId: 'a2' },
+				],
+				transitions: [{ id: 'tr-1', from: s1, to: s2, condition: { type: 'human' }, order: 0 }],
+				startStepId: s1,
+			}),
+		];
+		const { container } = render(<WorkflowList {...defaultProps} />);
+		// Human gate indicator: bg-yellow-400 class on mini connector dot
+		expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx
@@ -1,0 +1,339 @@
+// @ts-nocheck
+/**
+ * Unit tests for WorkflowStepCard
+ *
+ * Tests:
+ * - Collapsed view: step number, agent name, gate icons
+ * - Expanded view: name input, agent dropdown, gate selectors, instructions
+ * - Agent dropdown excludes 'leader' (enforced by filterAgents in WorkflowEditor)
+ * - Gate config forms: always/human/condition types
+ * - Shell expression input shown only for 'condition' type
+ * - Up/down reorder buttons disabled at boundaries
+ * - Remove button fires onRemove
+ * - Expand/collapse toggle
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import type { SpaceAgent } from '@neokai/shared';
+import { WorkflowStepCard } from '../WorkflowStepCard';
+import type { StepDraft, ConditionDraft } from '../WorkflowStepCard';
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
+	return {
+		id,
+		spaceId: 'space-1',
+		name,
+		role,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeStep(overrides: Partial<StepDraft> = {}): StepDraft {
+	return {
+		localId: 'local-1',
+		name: 'My Step',
+		agentId: 'agent-1',
+		instructions: '',
+		...overrides,
+	};
+}
+
+const defaultAgents: SpaceAgent[] = [
+	makeAgent('agent-1', 'planner', 'planner'),
+	makeAgent('agent-2', 'coder', 'coder'),
+	makeAgent('agent-3', 'general', 'general'),
+];
+
+function makeProps(overrides: Partial<Parameters<typeof WorkflowStepCard>[0]> = {}) {
+	return {
+		step: makeStep(),
+		stepIndex: 1,
+		isFirst: false,
+		isLast: false,
+		expanded: false,
+		entryCondition: { type: 'always' } as ConditionDraft,
+		exitCondition: { type: 'always' } as ConditionDraft,
+		agents: defaultAgents,
+		onToggleExpand: vi.fn(),
+		onUpdate: vi.fn(),
+		onUpdateEntryCondition: vi.fn(),
+		onUpdateExitCondition: vi.fn(),
+		onMoveUp: vi.fn(),
+		onMoveDown: vi.fn(),
+		onRemove: vi.fn(),
+		...overrides,
+	};
+}
+
+describe('WorkflowStepCard', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('collapsed view', () => {
+		it('renders step number (1-based)', () => {
+			const { getByText } = render(<WorkflowStepCard {...makeProps({ stepIndex: 2 })} />);
+			expect(getByText('3')).toBeTruthy();
+		});
+
+		it('renders agent name in collapsed view', () => {
+			const { getByText } = render(<WorkflowStepCard {...makeProps()} />);
+			expect(getByText('planner')).toBeTruthy();
+		});
+
+		it('renders step name in collapsed view', () => {
+			const { getByText } = render(
+				<WorkflowStepCard {...makeProps({ step: makeStep({ name: 'My Awesome Step' }) })} />
+			);
+			expect(getByText('My Awesome Step')).toBeTruthy();
+		});
+
+		it('shows "Unnamed Step" when name is empty', () => {
+			const { getByText } = render(
+				<WorkflowStepCard {...makeProps({ step: makeStep({ name: '' }) })} />
+			);
+			expect(getByText('Unnamed Step')).toBeTruthy();
+		});
+
+		it('calls onToggleExpand when header clicked', () => {
+			const onToggleExpand = vi.fn();
+			const { container } = render(<WorkflowStepCard {...makeProps({ onToggleExpand })} />);
+			const header = container.querySelector('.cursor-pointer');
+			fireEvent.click(header);
+			expect(onToggleExpand).toHaveBeenCalledOnce();
+		});
+
+		it('calls onMoveUp when up button clicked', () => {
+			const onMoveUp = vi.fn();
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onMoveUp })} />);
+			fireEvent.click(getByTitle('Move up'));
+			expect(onMoveUp).toHaveBeenCalledOnce();
+		});
+
+		it('calls onMoveDown when down button clicked', () => {
+			const onMoveDown = vi.fn();
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onMoveDown })} />);
+			fireEvent.click(getByTitle('Move down'));
+			expect(onMoveDown).toHaveBeenCalledOnce();
+		});
+
+		it('disables move up button for first step', () => {
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isFirst: true })} />);
+			expect(getByTitle('Move up').disabled).toBe(true);
+		});
+
+		it('disables move down button for last step', () => {
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isLast: true })} />);
+			expect(getByTitle('Move down').disabled).toBe(true);
+		});
+
+		it('calls onRemove when remove button clicked', () => {
+			const onRemove = vi.fn();
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onRemove })} />);
+			fireEvent.click(getByTitle('Remove step'));
+			expect(onRemove).toHaveBeenCalledOnce();
+		});
+
+		it('shows human gate icon when entry condition is human', () => {
+			const { getByTitle } = render(
+				<WorkflowStepCard {...makeProps({ entryCondition: { type: 'human' } })} />
+			);
+			expect(getByTitle('Entry: Human Approval')).toBeTruthy();
+		});
+
+		it('shows condition gate icon when exit condition is shell condition', () => {
+			const { getByTitle } = render(
+				<WorkflowStepCard {...makeProps({ exitCondition: { type: 'condition' } })} />
+			);
+			expect(getByTitle('Exit: Shell Condition')).toBeTruthy();
+		});
+
+		it('does not show gate icons for always conditions', () => {
+			const { container } = render(
+				<WorkflowStepCard
+					{...makeProps({
+						entryCondition: { type: 'always' },
+						exitCondition: { type: 'always' },
+					})}
+				/>
+			);
+			// No gate icons for 'always' type
+			expect(container.querySelector('[title*="Entry:"]')).toBeNull();
+			expect(container.querySelector('[title*="Exit:"]')).toBeNull();
+		});
+	});
+
+	describe('expanded view', () => {
+		it('shows expanded body when expanded=true', () => {
+			const { getByPlaceholderText } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true })} />
+			);
+			expect(getByPlaceholderText('e.g. Plan the approach')).toBeTruthy();
+		});
+
+		it('does not show expanded body when expanded=false', () => {
+			const { container } = render(<WorkflowStepCard {...makeProps({ expanded: false })} />);
+			const textarea = container.querySelector('textarea');
+			expect(textarea).toBeNull();
+		});
+
+		it('renders agent dropdown with all passed agents', () => {
+			const { container } = render(<WorkflowStepCard {...makeProps({ expanded: true })} />);
+			const selects = container.querySelectorAll('select');
+			// Agent select + entry gate select + exit gate select = 3 selects
+			const agentSelect = selects[0];
+			const options = Array.from(agentSelect.querySelectorAll('option')).map((o) => o.textContent);
+			expect(options).toContain('planner (planner)');
+			expect(options).toContain('coder (coder)');
+			expect(options).toContain('general (general)');
+		});
+
+		it('shows currently selected agent in dropdown', () => {
+			const step = makeStep({ agentId: 'agent-2' });
+			const { container } = render(<WorkflowStepCard {...makeProps({ step, expanded: true })} />);
+			const agentSelect = container.querySelectorAll('select')[0];
+			expect(agentSelect.value).toBe('agent-2');
+		});
+
+		it('calls onUpdate when agent changed', () => {
+			const onUpdate = vi.fn();
+			const { container } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+			);
+			const agentSelect = container.querySelectorAll('select')[0];
+			fireEvent.change(agentSelect, { target: { value: 'agent-2' } });
+			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ agentId: 'agent-2' }));
+		});
+
+		it('calls onUpdate when name changed', () => {
+			const onUpdate = vi.fn();
+			const { getByPlaceholderText } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+			);
+			const nameInput = getByPlaceholderText('e.g. Plan the approach');
+			fireEvent.input(nameInput, { target: { value: 'New Name' } });
+			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Name' }));
+		});
+
+		it('calls onUpdate when instructions changed', () => {
+			const onUpdate = vi.fn();
+			const { container } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
+			);
+			const textarea = container.querySelector('textarea');
+			fireEvent.input(textarea, { target: { value: 'Do the thing.' } });
+			expect(onUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ instructions: 'Do the thing.' })
+			);
+		});
+
+		it('renders "Workflow starts here" for first step entry gate', () => {
+			const { getByText } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true, isFirst: true, entryCondition: null })} />
+			);
+			expect(getByText('Workflow starts here')).toBeTruthy();
+		});
+
+		it('renders "Workflow ends here" for last step exit gate', () => {
+			const { getByText } = render(
+				<WorkflowStepCard {...makeProps({ expanded: true, isLast: true, exitCondition: null })} />
+			);
+			expect(getByText('Workflow ends here')).toBeTruthy();
+		});
+
+		describe('gate config — condition type', () => {
+			it('shows shell expression input when condition type is "condition"', () => {
+				const { getByPlaceholderText } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							entryCondition: { type: 'condition', expression: '' },
+						})}
+					/>
+				);
+				expect(getByPlaceholderText('e.g. bun test && git diff --quiet')).toBeTruthy();
+			});
+
+			it('does not show shell expression input for "always" type', () => {
+				const { container } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							entryCondition: { type: 'always' },
+						})}
+					/>
+				);
+				const inputs = container.querySelectorAll('input[type="text"]');
+				// Only the step name input, no expression input
+				expect(inputs.length).toBe(1);
+			});
+
+			it('calls onUpdateEntryCondition when entry gate type changed', () => {
+				const onUpdateEntryCondition = vi.fn();
+				const { container } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							entryCondition: { type: 'always' },
+							onUpdateEntryCondition,
+						})}
+					/>
+				);
+				const selects = container.querySelectorAll('select');
+				// selects[0] = agent, selects[1] = entry gate, selects[2] = exit gate
+				fireEvent.change(selects[1], { target: { value: 'human' } });
+				expect(onUpdateEntryCondition).toHaveBeenCalledWith({
+					type: 'human',
+					expression: undefined,
+				});
+			});
+
+			it('calls onUpdateExitCondition when exit gate type changed', () => {
+				const onUpdateExitCondition = vi.fn();
+				const { container } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							exitCondition: { type: 'always' },
+							onUpdateExitCondition,
+						})}
+					/>
+				);
+				const selects = container.querySelectorAll('select');
+				// selects[2] = exit gate
+				fireEvent.change(selects[2], { target: { value: 'condition' } });
+				expect(onUpdateExitCondition).toHaveBeenCalledWith({ type: 'condition', expression: '' });
+			});
+
+			it('shows "Requires human approval" hint for human type', () => {
+				const { getByText } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							entryCondition: { type: 'human' },
+						})}
+					/>
+				);
+				expect(getByText('Transition requires explicit human approval.')).toBeTruthy();
+			});
+
+			it('shows "fires automatically" hint for always type', () => {
+				const { getAllByText } = render(
+					<WorkflowStepCard
+						{...makeProps({
+							expanded: true,
+							entryCondition: { type: 'always' },
+						})}
+					/>
+				);
+				expect(getAllByText('Transition fires automatically.').length).toBeGreaterThan(0);
+			});
+		});
+	});
+});

--- a/packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Unit tests for WorkflowStepCard
  *
@@ -104,7 +103,7 @@ describe('WorkflowStepCard', () => {
 		it('calls onToggleExpand when header clicked', () => {
 			const onToggleExpand = vi.fn();
 			const { container } = render(<WorkflowStepCard {...makeProps({ onToggleExpand })} />);
-			const header = container.querySelector('.cursor-pointer');
+			const header = container.querySelector('.cursor-pointer') as HTMLElement;
 			fireEvent.click(header);
 			expect(onToggleExpand).toHaveBeenCalledOnce();
 		});
@@ -125,12 +124,12 @@ describe('WorkflowStepCard', () => {
 
 		it('disables move up button for first step', () => {
 			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isFirst: true })} />);
-			expect(getByTitle('Move up').disabled).toBe(true);
+			expect((getByTitle('Move up') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('disables move down button for last step', () => {
 			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ isLast: true })} />);
-			expect(getByTitle('Move down').disabled).toBe(true);
+			expect((getByTitle('Move down') as HTMLButtonElement).disabled).toBe(true);
 		});
 
 		it('calls onRemove when remove button clicked', () => {
@@ -138,6 +137,16 @@ describe('WorkflowStepCard', () => {
 			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ onRemove })} />);
 			fireEvent.click(getByTitle('Remove step'));
 			expect(onRemove).toHaveBeenCalledOnce();
+		});
+
+		it('disables Remove button when disableRemove is true', () => {
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ disableRemove: true })} />);
+			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(true);
+		});
+
+		it('enables Remove button when disableRemove is false', () => {
+			const { getByTitle } = render(<WorkflowStepCard {...makeProps({ disableRemove: false })} />);
+			expect((getByTitle('Remove step') as HTMLButtonElement).disabled).toBe(false);
 		});
 
 		it('shows human gate icon when entry condition is human', () => {
@@ -187,7 +196,7 @@ describe('WorkflowStepCard', () => {
 			const { container } = render(<WorkflowStepCard {...makeProps({ expanded: true })} />);
 			const selects = container.querySelectorAll('select');
 			// Agent select + entry gate select + exit gate select = 3 selects
-			const agentSelect = selects[0];
+			const agentSelect = selects[0] as HTMLSelectElement;
 			const options = Array.from(agentSelect.querySelectorAll('option')).map((o) => o.textContent);
 			expect(options).toContain('planner (planner)');
 			expect(options).toContain('coder (coder)');
@@ -226,7 +235,7 @@ describe('WorkflowStepCard', () => {
 			const { container } = render(
 				<WorkflowStepCard {...makeProps({ expanded: true, onUpdate })} />
 			);
-			const textarea = container.querySelector('textarea');
+			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 			fireEvent.input(textarea, { target: { value: 'Do the thing.' } });
 			expect(onUpdate).toHaveBeenCalledWith(
 				expect.objectContaining({ instructions: 'Do the thing.' })

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -16,6 +16,7 @@ import { SpaceDashboard } from '../components/space/SpaceDashboard';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
 import { SpaceAgentList } from '../components/space/SpaceAgentList';
 import { WorkflowList } from '../components/space/WorkflowList';
+import { WorkflowEditor } from '../components/space/WorkflowEditor';
 import { SpaceSettings } from '../components/space/SpaceSettings';
 import { cn } from '../lib/utils';
 
@@ -35,6 +36,8 @@ const TABS: { id: SpaceTab; label: string }[] = [
 export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 	const [activeTab, setActiveTab] = useState<SpaceTab>('dashboard');
 	const [activeRunId, setActiveRunId] = useState<string | null>(null);
+	/** null = list view; 'new' = create editor; <id> = edit editor */
+	const [workflowEditId, setWorkflowEditId] = useState<string | null>(null);
 	const loading = spaceStore.loading.value;
 	const error = spaceStore.error.value;
 
@@ -52,6 +55,13 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 			// navigating back is instant (store shows stale-then-fresh data).
 		};
 	}, [spaceId]);
+
+	// Reset workflow edit state when switching away from workflows tab
+	useEffect(() => {
+		if (activeTab !== 'workflows') {
+			setWorkflowEditId(null);
+		}
+	}, [activeTab]);
 
 	const handleRunSelect = (runId: string) => {
 		setActiveRunId(runId);
@@ -95,6 +105,13 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 	const space = spaceStore.space.value;
 	const workflows = spaceStore.workflows.value;
 
+	const editingWorkflow =
+		workflowEditId && workflowEditId !== 'new'
+			? workflows.find((w) => w.id === workflowEditId)
+			: undefined;
+
+	const showWorkflowEditor = activeTab === 'workflows' && workflowEditId !== null;
+
 	return (
 		<div class="flex-1 flex overflow-hidden bg-dark-900">
 			{/* Left column — navigation panel */}
@@ -112,33 +129,51 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 
 			{/* Middle column — tabbed content */}
 			<div class="flex-1 overflow-hidden flex flex-col min-w-0">
-				{/* Tab bar */}
-				<div class="flex border-b border-dark-700 px-4 flex-shrink-0">
-					{TABS.map((tab) => (
-						<button
-							key={tab.id}
-							type="button"
-							onClick={() => setActiveTab(tab.id)}
-							class={cn(
-								'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
-								activeTab === tab.id
-									? 'text-gray-100 border-blue-400'
-									: 'text-gray-400 border-transparent hover:text-gray-200'
-							)}
-						>
-							{tab.label}
-						</button>
-					))}
-				</div>
+				{/* Tab bar — hidden when workflow editor is open (editor has its own back button) */}
+				{!showWorkflowEditor && (
+					<div class="flex border-b border-dark-700 px-4 flex-shrink-0">
+						{TABS.map((tab) => (
+							<button
+								key={tab.id}
+								type="button"
+								onClick={() => setActiveTab(tab.id)}
+								class={cn(
+									'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px',
+									activeTab === tab.id
+										? 'text-gray-100 border-blue-400'
+										: 'text-gray-400 border-transparent hover:text-gray-200'
+								)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
+				)}
 
 				{/* Tab content */}
 				<div class="flex-1 overflow-hidden">
-					{activeTab === 'dashboard' && <SpaceDashboard spaceId={spaceId} />}
-					{activeTab === 'agents' && <SpaceAgentList />}
-					{activeTab === 'workflows' && space && (
-						<WorkflowList spaceId={spaceId} spaceName={space.name} workflows={workflows} />
-					)}
-					{activeTab === 'settings' && space && <SpaceSettings space={space} />}
+				{showWorkflowEditor ? (
+					<WorkflowEditor
+						workflow={editingWorkflow}
+						onSave={() => setWorkflowEditId(null)}
+						onCancel={() => setWorkflowEditId(null)}
+					/>
+				) : (
+					<>
+						{activeTab === 'dashboard' && <SpaceDashboard spaceId={spaceId} />}
+						{activeTab === 'agents' && <SpaceAgentList />}
+						{activeTab === 'workflows' && space && (
+							<WorkflowList
+								spaceId={spaceId}
+								spaceName={space.name}
+								workflows={workflows}
+								onCreateWorkflow={() => setWorkflowEditId('new')}
+								onEditWorkflow={(id) => setWorkflowEditId(id)}
+							/>
+						)}
+						{activeTab === 'settings' && space && <SpaceSettings space={space} />}
+					</>
+				)}
 				</div>
 			</div>
 

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -152,28 +152,28 @@ export default function SpaceIsland({ spaceId }: SpaceIslandProps) {
 
 				{/* Tab content */}
 				<div class="flex-1 overflow-hidden">
-				{showWorkflowEditor ? (
-					<WorkflowEditor
-						workflow={editingWorkflow}
-						onSave={() => setWorkflowEditId(null)}
-						onCancel={() => setWorkflowEditId(null)}
-					/>
-				) : (
-					<>
-						{activeTab === 'dashboard' && <SpaceDashboard spaceId={spaceId} />}
-						{activeTab === 'agents' && <SpaceAgentList />}
-						{activeTab === 'workflows' && space && (
-							<WorkflowList
-								spaceId={spaceId}
-								spaceName={space.name}
-								workflows={workflows}
-								onCreateWorkflow={() => setWorkflowEditId('new')}
-								onEditWorkflow={(id) => setWorkflowEditId(id)}
-							/>
-						)}
-						{activeTab === 'settings' && space && <SpaceSettings space={space} />}
-					</>
-				)}
+					{showWorkflowEditor ? (
+						<WorkflowEditor
+							workflow={editingWorkflow}
+							onSave={() => setWorkflowEditId(null)}
+							onCancel={() => setWorkflowEditId(null)}
+						/>
+					) : (
+						<>
+							{activeTab === 'dashboard' && <SpaceDashboard spaceId={spaceId} />}
+							{activeTab === 'agents' && <SpaceAgentList />}
+							{activeTab === 'workflows' && space && (
+								<WorkflowList
+									spaceId={spaceId}
+									spaceName={space.name}
+									workflows={workflows}
+									onCreateWorkflow={() => setWorkflowEditId('new')}
+									onEditWorkflow={(id) => setWorkflowEditId(id)}
+								/>
+							)}
+							{activeTab === 'settings' && space && <SpaceSettings space={space} />}
+						</>
+					)}
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary

- **WorkflowList**: lists all space workflows with name, description, step count, tag chips, and a mini step visualization (horizontal dots with gate-colored connectors for human/condition transitions); includes delete with inline confirm and error banner on failure; includes import/export toolbar
- **WorkflowEditor**: create/edit form with name+description fields, vertical step list with WorkflowStepCard, Add Step button, Save/Cancel, and "Start from template" picker (Coding / Research / Quick Fix); validates name, per-step agent assignment, and non-empty shell expressions on save
- **WorkflowStepCard**: collapsed view (step number, agent name, gate type icons) and expanded form (name input, agent dropdown, entry/exit gate selectors, shell expression input with `required` attribute for `condition` type, instructions textarea, up/down/remove buttons); Remove button disabled when only 1 step remains
- **filterAgents()**: excludes agents with `role === 'leader'` (case-insensitive) from the agent dropdown; exported for direct testing
- **SpaceIsland**: Workflow navigation is handled by the tab bar. The Workflows tab has a sub-view state (`workflowEditId: string | null`) that switches between WorkflowList (list view) and WorkflowEditor (create/edit view). SpaceNavPanel nav links remain non-interactive since tab selection is the navigation mechanism.

## Gate types

Maps to the three real `WorkflowConditionType` values:
- `always` → Automatic (no config)
- `human` → Human Approval (no config, informational hint)
- `condition` → Shell Condition (expression text input with `required` attribute + hint about exit code 0)

## Test plan

- [x] 167 unit tests across 9 test files (73 new tests across WorkflowEditor/WorkflowStepCard/WorkflowList)
- [x] `WorkflowStepCard`: collapsed/expanded toggle, step add/remove/reorder boundary conditions, gate config forms for all three types, expression input visibility, onUpdate/onUpdateEntryCondition/onUpdateExitCondition callbacks, disableRemove prop
- [x] `WorkflowEditor`: filterAgents excludes leader by role, template selection (3 templates), step count after add/remove/reorder, save calls createWorkflow/updateWorkflow with correct params, error shown on empty name/missing agent/empty shell expression, edit mode pre-fills from workflow, initFromWorkflow handles orphaned steps and condition types
- [x] `WorkflowList`: empty state, card rendering (name/desc/step count/tags), mini step viz dots, gate connector colors, create/edit callbacks, delete confirm/cancel/error flows
- [x] No `@ts-nocheck` — all type errors resolved with explicit casts
- [x] Lint + typecheck + format clean