### PR TITLE
fix: fetch real Copilot model IDs dynamically via client.listModels()

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -153,6 +153,17 @@ const COPILOT_ANTHROPIC_MODELS: ModelInfo[] = [
 		available: true,
 	},
 	{
+		id: 'gpt-5.3-codex',
+		name: 'GPT-5.3 Codex (Copilot)',
+		alias: 'copilot-anthropic-codex',
+		family: 'gpt',
+		provider: 'anthropic-copilot',
+		contextWindow: 272000,
+		description: 'GPT-5.3 Codex via GitHub Copilot · Best for coding',
+		releaseDate: '2025-12-01',
+		available: true,
+	},
+	{
 		// Intentionally "gemini-3-pro-preview" (not "gemini-3.1-pro-preview").
 		// The legacy CLI path used "gemini-3.1-pro-preview" because it passed IDs
 		// directly to Copilot CLI. This provider passes IDs as hints to the embedded

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -679,9 +679,10 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 	 * for 5 minutes by `resolveGitHubToken`. Expected latency: 3–15 s (subprocess spawn
 	 * + OAuth exchange). A 20 s hard timeout prevents indefinite hangs on slow networks.
 	 *
-	 * Note: uses `gpt-4o-mini` as the validation model. If Copilot ever removes that
-	 * model, validation will spuriously return false (prompting the user to re-authenticate
-	 * via OAuth rather than silently succeeding).
+	 * Note: uses `gpt-5-mini` as the validation model — the designated free-tier
+	 * Copilot model used across CI. If Copilot ever removes that model, validation
+	 * will spuriously return false (prompting the user to re-authenticate via OAuth
+	 * rather than silently succeeding).
 	 */
 	private async validateCopilotToken(token: string): Promise<boolean> {
 		const TIMEOUT_MS = 20_000;
@@ -694,7 +695,7 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 			let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 			const session = await Promise.race([
 				client.createSession({
-					model: 'gpt-4o-mini',
+					model: 'gpt-5-mini',
 					onPermissionRequest: () => Promise.resolve({ kind: 'approved' as const }),
 				}),
 				new Promise<never>((_, reject) => {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -153,17 +153,6 @@ const COPILOT_ANTHROPIC_MODELS: ModelInfo[] = [
 		available: true,
 	},
 	{
-		id: 'gpt-5.3-codex',
-		name: 'GPT-5.3 Codex (Copilot)',
-		alias: 'copilot-anthropic-codex',
-		family: 'gpt',
-		provider: 'anthropic-copilot',
-		contextWindow: 272000,
-		description: 'GPT-5.3 Codex via GitHub Copilot · Best for coding',
-		releaseDate: '2025-12-01',
-		available: true,
-	},
-	{
 		// Intentionally "gemini-3-pro-preview" (not "gemini-3.1-pro-preview").
 		// The legacy CLI path used "gemini-3.1-pro-preview" because it passed IDs
 		// directly to Copilot CLI. This provider passes IDs as hints to the embedded

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -54,7 +54,7 @@ import type {
 	ProviderOAuthFlowData,
 } from '@neokai/shared/provider';
 import type { ModelInfo } from '@neokai/shared';
-import { CopilotClient } from '@github/copilot-sdk';
+import { CopilotClient, type ModelInfo as CopilotSdkModelInfo } from '@github/copilot-sdk';
 import { startEmbeddedServer, type EmbeddedServer } from './server.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -68,23 +68,35 @@ const execFileAsync = promisify(execFile);
 const logger = new Logger('anthropic-copilot-provider');
 
 /**
- * GitHub Copilot model definitions.
- * Aliases use the `copilot-anthropic-` prefix for backwards compatibility
- * with existing configurations.
+ * Infer the model family from a Copilot SDK model ID.
+ * Returns 'sonnet', 'opus', 'haiku', 'gpt', or 'gemini'.
+ */
+function inferModelFamily(modelId: string): string {
+	const id = modelId.toLowerCase();
+	if (id.includes('claude')) {
+		if (id.includes('opus')) return 'opus';
+		if (id.includes('haiku')) return 'haiku';
+		return 'sonnet';
+	}
+	if (id.includes('gemini')) return 'gemini';
+	return 'gpt';
+}
+
+/**
+ * Static fallback model definitions for the Copilot provider.
  *
- * These model IDs are the identifiers the GitHub Copilot backend recognises
- * and must be passed verbatim to `CopilotClient.createSession({ model })`.
+ * These are used as display-name / alias enrichment when building the model list
+ * from `client.listModels()`. They also serve as a last-resort fallback if the
+ * Copilot API is unreachable at the time `getModels()` is called.
+ *
+ * IMPORTANT — Do NOT rely on these IDs being valid for the user's Copilot account.
+ * The actual available models are fetched dynamically via `client.listModels()` so
+ * that the test model ID matches what the Copilot API actually accepts.
  *
  * NOTE — intentional model ID collision with the Anthropic provider:
- * The `id` fields below (e.g. `claude-opus-4.6`) are also claimed by the
- * Anthropic provider. `registry.detectProvider(modelId)` will therefore
- * return Anthropic (registered first in factory.ts) for these IDs. This is
- * by design: every `anthropic-copilot` session stores its provider ID
- * explicitly in `session.config.provider`, and `applyEnvVarsToProcess` /
- * `getEnvVarsForModel` accept an optional `providerId` argument that
- * bypasses auto-detection. All callers that need Copilot routing MUST pass
- * the explicit provider ID; callers that rely on `detectProvider` alone will
- * silently route to Anthropic.
+ * The `id` fields below (e.g. `claude-opus-4.6`) may also be claimed by the
+ * Anthropic provider. Every `anthropic-copilot` session stores its provider ID
+ * explicitly in `session.config.provider` to avoid ambiguity.
  */
 const COPILOT_ANTHROPIC_MODELS: ModelInfo[] = [
 	{
@@ -206,6 +218,12 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 	private serverStarting: Promise<EmbeddedServer> | undefined = undefined;
 	/** Resolved token cache with TTL */
 	private tokenCache: TokenCacheEntry | null = null;
+	/**
+	 * Dynamically fetched models from the Copilot API (via client.listModels()).
+	 * Populated in getModels() and used by ownsModel() so that real Copilot model
+	 * IDs (which may differ from our static list) are recognised by this provider.
+	 */
+	private dynamicModelsCache: ModelInfo[] | null = null;
 
 	/** Path to stored authentication tokens */
 	private readonly authPath: string;
@@ -250,11 +268,38 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 			logger.error('Failed to start embedded Anthropic server:', err);
 			return [];
 		}
+
+		// Fetch real model IDs from the Copilot API so we only expose models that
+		// the user's account can actually use.  Hardcoded model IDs are used as
+		// display-name / context-window enrichment when a match is found, and as a
+		// last-resort fallback when the API call fails.
+		if (this.clientCache) {
+			try {
+				const sdkModels = await this.clientCache.listModels();
+				const mapped = sdkModels
+					.filter((m) => m.policy?.state !== 'disabled')
+					.map((m) => this.mapCopilotSdkModel(m));
+				if (mapped.length > 0) {
+					this.dynamicModelsCache = mapped;
+					return mapped;
+				}
+			} catch (err) {
+				logger.warn('client.listModels() failed, falling back to static model list:', err);
+			}
+		}
+
 		return COPILOT_ANTHROPIC_MODELS;
 	}
 
 	ownsModel(modelId: string): boolean {
-		return COPILOT_ANTHROPIC_MODELS.some((m) => m.alias === modelId || m.id === modelId);
+		if (COPILOT_ANTHROPIC_MODELS.some((m) => m.alias === modelId || m.id === modelId)) {
+			return true;
+		}
+		// Also check dynamically fetched models (real Copilot SDK model IDs).
+		if (this.dynamicModelsCache) {
+			return this.dynamicModelsCache.some((m) => m.alias === modelId || m.id === modelId);
+		}
+		return false;
 	}
 
 	getModelForTier(tier: ModelTier): string | undefined {
@@ -286,7 +331,8 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 			);
 		}
 
-		const entry = COPILOT_ANTHROPIC_MODELS.find((m) => m.alias === modelId || m.id === modelId);
+		const allKnownModels = this.dynamicModelsCache ?? COPILOT_ANTHROPIC_MODELS;
+		const entry = allKnownModels.find((m) => m.alias === modelId || m.id === modelId);
 		const resolvedId = entry?.id ?? modelId;
 		// Per-session workspace path is encoded in the auth token so the embedded
 		// server (shared singleton) can apply the correct cwd per HTTP request.
@@ -302,10 +348,11 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 				ANTHROPIC_API_KEY: '',
 				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 				API_TIMEOUT_MS: '300000',
-				ANTHROPIC_DEFAULT_OPUS_MODEL:
-					resolvedId === 'claude-opus-4.6' ? 'claude-opus-4.6' : 'claude-sonnet-4.6',
+				// All three tiers route to the same resolved model so the bridge handles
+				// every SDK-internal model request with the one real Copilot model ID.
+				ANTHROPIC_DEFAULT_OPUS_MODEL: resolvedId,
 				ANTHROPIC_DEFAULT_SONNET_MODEL: resolvedId,
-				ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5-mini',
+				ANTHROPIC_DEFAULT_HAIKU_MODEL: resolvedId,
 			},
 			isAnthropicCompatible: true,
 			apiVersion: 'v1',
@@ -766,6 +813,30 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 	// ---------------------------------------------------------------------------
 	// Private helpers
 	// ---------------------------------------------------------------------------
+
+	/**
+	 * Map a Copilot SDK ModelInfo to NeoKai's ModelInfo format.
+	 *
+	 * Uses the static list for display-name and context-window enrichment when a
+	 * matching ID is found, so existing users with static aliases are not affected.
+	 */
+	private mapCopilotSdkModel(m: CopilotSdkModelInfo): ModelInfo {
+		// Look up static entry for enriched display metadata.
+		const staticEntry = COPILOT_ANTHROPIC_MODELS.find((s) => s.id === m.id);
+		const family = inferModelFamily(m.id);
+		return {
+			id: m.id,
+			name: staticEntry?.name ?? `${m.name ?? m.id} (Copilot)`,
+			alias: staticEntry?.alias ?? `copilot-${m.id.replace(/[^a-z0-9]/gi, '-').toLowerCase()}`,
+			family,
+			provider: 'anthropic-copilot',
+			contextWindow:
+				staticEntry?.contextWindow ?? m.capabilities?.limits?.max_context_window_tokens ?? 128000,
+			description: staticEntry?.description ?? `${m.name ?? m.id} via GitHub Copilot`,
+			releaseDate: staticEntry?.releaseDate ?? '2025-01-01',
+			available: m.policy?.state !== 'disabled',
+		};
+	}
 
 	private async createServer(): Promise<EmbeddedServer> {
 		const token = await this.resolveGitHubToken();

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -164,13 +164,8 @@ const COPILOT_ANTHROPIC_MODELS: ModelInfo[] = [
 		available: true,
 	},
 	{
-		// Intentionally "gemini-3-pro-preview" (not "gemini-3.1-pro-preview").
-		// The legacy CLI path used "gemini-3.1-pro-preview" because it passed IDs
-		// directly to Copilot CLI. This provider passes IDs as hints to the embedded
-		// HTTP server, which maps them to Copilot SDK sessions; the version suffix
-		// matters for routing.
-		id: 'gemini-3-pro-preview',
-		name: 'Gemini 3 Pro (Copilot)',
+		id: 'gemini-3.1-pro-preview',
+		name: 'Gemini 3.1 Pro (Copilot)',
 		alias: 'copilot-anthropic-gemini',
 		family: 'gemini',
 		provider: 'anthropic-copilot',

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -170,7 +170,7 @@ const COPILOT_ANTHROPIC_MODELS: ModelInfo[] = [
 		family: 'gemini',
 		provider: 'anthropic-copilot',
 		contextWindow: 128000,
-		description: 'Gemini 3 Pro Preview via GitHub Copilot',
+		description: 'Gemini 3.1 Pro Preview via GitHub Copilot',
 		releaseDate: '2025-11-15',
 		available: true,
 	},
@@ -679,10 +679,11 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 	 * for 5 minutes by `resolveGitHubToken`. Expected latency: 3–15 s (subprocess spawn
 	 * + OAuth exchange). A 20 s hard timeout prevents indefinite hangs on slow networks.
 	 *
-	 * Note: uses `gpt-5-mini` as the validation model — the designated free-tier
-	 * Copilot model used across CI. If Copilot ever removes that model, validation
-	 * will spuriously return false (prompting the user to re-authenticate via OAuth
-	 * rather than silently succeeding).
+	 * Uses `client.listModels()` for validation — a non-empty model list proves the
+	 * token has Copilot API access without depending on any specific model being
+	 * available on the user's plan.  This is intentionally model-agnostic: a user
+	 * on an enterprise plan with a different model catalogue should still be
+	 * authenticated correctly.
 	 */
 	private async validateCopilotToken(token: string): Promise<boolean> {
 		const TIMEOUT_MS = 20_000;
@@ -693,11 +694,8 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 		});
 		try {
 			let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-			const session = await Promise.race([
-				client.createSession({
-					model: 'gpt-5-mini',
-					onPermissionRequest: () => Promise.resolve({ kind: 'approved' as const }),
-				}),
+			const models = await Promise.race([
+				client.listModels(),
 				new Promise<never>((_, reject) => {
 					timeoutHandle = setTimeout(
 						() => reject(new Error('validateCopilotToken timed out')),
@@ -706,8 +704,7 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 				}),
 			]);
 			clearTimeout(timeoutHandle);
-			await session.disconnect();
-			return true;
+			return models.length > 0;
 		} catch {
 			return false;
 		} finally {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -81,8 +81,12 @@ function pickModelForTier(models: ModelInfo[], tier: ModelTier): string | undefi
 
 	const keywordsByTier: Record<ModelTier, string[]> = {
 		opus: ['opus', 'pro', 'ultra'],
-		sonnet: ['sonnet', '4o', 'turbo', 'flash'],
+		// 'flash' is intentionally absent from sonnet — Gemini Flash models are fast/cheap
+		// and should be haiku-tier. Including 'flash' here would shadow the haiku path
+		// whenever a Flash model appears in the account's model list.
+		sonnet: ['sonnet', '4o', 'turbo'],
 		haiku: ['mini', 'haiku', 'flash', 'fast', 'lite'],
+		// 'default' mirrors 'sonnet': a mid-tier capable model is the right default.
 		default: ['sonnet', '4o', 'turbo'],
 	};
 	const keywords = keywordsByTier[tier] ?? [];

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -68,6 +68,33 @@ const execFileAsync = promisify(execFile);
 const logger = new Logger('anthropic-copilot-provider');
 
 /**
+ * Pick the most appropriate model from `models` for a given tier.
+ *
+ * Used by getModelForTier() when the static fallback ID is not in the dynamic
+ * model list.  Prefers models whose ID or name contains keywords associated
+ * with the tier; falls back to the first available model.
+ */
+function pickModelForTier(models: ModelInfo[], tier: ModelTier): string | undefined {
+	if (models.length === 0) return undefined;
+	const available = models.filter((m) => m.available !== false);
+	if (available.length === 0) return undefined;
+
+	const keywordsByTier: Record<ModelTier, string[]> = {
+		opus: ['opus', 'pro', 'ultra'],
+		sonnet: ['sonnet', '4o', 'turbo', 'flash'],
+		haiku: ['mini', 'haiku', 'flash', 'fast', 'lite'],
+		default: ['sonnet', '4o', 'turbo'],
+	};
+	const keywords = keywordsByTier[tier] ?? [];
+	for (const kw of keywords) {
+		const match = available.find((m) => m.id.toLowerCase().includes(kw));
+		if (match) return match.id;
+	}
+	// Fall back to first available model.
+	return available[0].id;
+}
+
+/**
  * Infer the model family from a Copilot SDK model ID.
  * Returns 'sonnet', 'opus', 'haiku', 'gpt', or 'gemini'.
  */
@@ -220,10 +247,24 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 	private tokenCache: TokenCacheEntry | null = null;
 	/**
 	 * Dynamically fetched models from the Copilot API (via client.listModels()).
-	 * Populated in getModels() and used by ownsModel() so that real Copilot model
-	 * IDs (which may differ from our static list) are recognised by this provider.
+	 * Populated in getModels() and used by ownsModel()/getModelForTier() so that
+	 * real Copilot model IDs (which may differ from our static list) are recognised
+	 * by this provider.
+	 *
+	 * NOTE — ownsModel() call-order dependency:
+	 * ownsModel() checks this cache but cannot populate it (the method is synchronous
+	 * while listModels() is async). In the normal lifecycle getModels() is always
+	 * called before a session is created (the UI fetches models before offering them
+	 * to the user), so the cache is populated before ownsModel() is needed for routing.
+	 * Sessions resumed from a restart are looked up via the stored explicit providerId
+	 * (registry.detectProviderForModel), so ownsModel() is not on the critical path
+	 * for those.  If ownsModel() is called before getModels() for a real Copilot SDK
+	 * model ID that is not in the static list, it will return false — a known
+	 * limitation documented here.
 	 */
 	private dynamicModelsCache: ModelInfo[] | null = null;
+	/** Expiry timestamp for dynamicModelsCache (epoch ms). 0 means "not set". */
+	private dynamicModelsCacheExpiresAt = 0;
 
 	/** Path to stored authentication tokens */
 	private readonly authPath: string;
@@ -273,6 +314,13 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 		// the user's account can actually use.  Hardcoded model IDs are used as
 		// display-name / context-window enrichment when a match is found, and as a
 		// last-resort fallback when the API call fails.
+		// The result is cached with a TTL matching the token cache (5 minutes) to
+		// avoid making a listModels() API call on every model-list request.
+		const now = Date.now();
+		if (this.dynamicModelsCache && now < this.dynamicModelsCacheExpiresAt) {
+			return this.dynamicModelsCache;
+		}
+
 		if (this.clientCache) {
 			try {
 				const sdkModels = await this.clientCache.listModels();
@@ -281,6 +329,7 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 					.map((m) => this.mapCopilotSdkModel(m));
 				if (mapped.length > 0) {
 					this.dynamicModelsCache = mapped;
+					this.dynamicModelsCacheExpiresAt = now + TOKEN_CACHE_TTL_MS;
 					return mapped;
 				}
 			} catch (err) {
@@ -309,7 +358,22 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
 			haiku: 'gpt-5-mini',
 			default: 'claude-sonnet-4.6',
 		};
-		return tierMap[tier];
+		const staticId = tierMap[tier];
+
+		// If the dynamic cache is populated, prefer a model from it to avoid
+		// returning an ID that does not exist on the user's Copilot account.
+		const cache = this.dynamicModelsCache;
+		if (cache && cache.length > 0) {
+			// 1. Static ID is in the cache → it is a real Copilot model, use it.
+			if (cache.some((m) => m.id === staticId || m.alias === staticId)) {
+				return staticId;
+			}
+			// 2. Find the best matching model in the cache for this tier.
+			const preferred = pickModelForTier(cache, tier);
+			if (preferred) return preferred;
+		}
+
+		return staticId;
 	}
 
 	/**

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -222,9 +222,8 @@ function hasToolUseBlock(sdkMessages: Array<Record<string, unknown>>, toolName?:
 describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 	let daemon: DaemonServerContext;
 	/**
-	 * The first available anthropic-copilot model ID, fetched dynamically in beforeAll.
-	 * Using a dynamic ID avoids hardcoding model names that may not exist in all
-	 * Copilot plans or that Copilot may deprecate.
+	 * Always 'gpt-5-mini' — the free-tier Copilot model used for all CI tests.
+	 * beforeAll hard-fails if this model is not present in the account's model list.
 	 */
 	let testModelId: string;
 
@@ -255,7 +254,21 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 					'authentication succeeded but the embedded server failed to start.'
 			);
 		}
-		testModelId = copilotModels[0].id;
+
+		// Hard-fail if gpt-5-mini is not available.
+		// gpt-5-mini is the designated CI model: it is free (0x cost) for all Copilot
+		// subscribers, so it must always be present.  A missing gpt-5-mini means the
+		// account's Copilot plan has changed and the CI secret / plan needs attention.
+		const miniModel = copilotModels.find((m) => m.id === 'gpt-5-mini');
+		if (!miniModel) {
+			throw new Error(
+				`gpt-5-mini is not in the anthropic-copilot model list. ` +
+					`Available models: ${copilotModels.map((m) => m.id).join(', ')}. ` +
+					`gpt-5-mini must be present — it is the designated free-tier CI model. ` +
+					`Check that the Copilot account/plan still includes gpt-5-mini.`
+			);
+		}
+		testModelId = 'gpt-5-mini';
 	}, SETUP_TIMEOUT);
 
 	afterAll(async () => {

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -63,6 +63,7 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 		it('owns all copilot-anthropic-* aliases', () => {
 			expect(provider.ownsModel('copilot-anthropic-opus')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-sonnet')).toBe(true);
+			expect(provider.ownsModel('copilot-anthropic-codex')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-gemini')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-mini')).toBe(true);
 		});
@@ -71,6 +72,7 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			// No legacy CLI provider collision — bare IDs are owned by this provider
 			expect(provider.ownsModel('claude-opus-4.6')).toBe(true);
 			expect(provider.ownsModel('claude-sonnet-4.6')).toBe(true);
+			expect(provider.ownsModel('gpt-5.3-codex')).toBe(true);
 			expect(provider.ownsModel('gpt-5-mini')).toBe(true);
 		});
 

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -309,14 +309,16 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			expect(cfg.envVars['ANTHROPIC_API_KEY']).toBe('');
 		});
 
-		it('ANTHROPIC_DEFAULT_HAIKU_MODEL is gpt-5-mini (not a claude-* fallback)', () => {
-			// Regression guard: the haiku tier for Copilot must map to gpt-5-mini (a model
-			// served by the Copilot bridge). Without this env var the Claude Agent SDK
-			// subprocess defaults to claude-haiku-4-5-20251001 for background calls
-			// (summarisation, compaction), which the bridge may not serve correctly.
-			// The .toBe assertion is stricter than .not.toMatch(/^claude-/) and subsumes it.
+		it('ANTHROPIC_DEFAULT_HAIKU_MODEL matches the resolved model ID (all tiers use the same Copilot model)', () => {
+			// All three SDK model tiers (opus/sonnet/haiku) are set to the resolved Copilot
+			// model ID so that every SDK-internal call (summarisation, compaction, etc.)
+			// routes through the same real Copilot model rather than a hardcoded fallback
+			// that might not be available on the user's Copilot account.
 			const cfg = provider.buildSdkConfig('copilot-anthropic-sonnet');
-			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5-mini');
+			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('claude-sonnet-4.6');
+			expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe(
+				cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']
+			);
 		});
 	});
 
@@ -374,6 +376,124 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			);
 			await p.getModels();
 			expect(ensureSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns dynamic models from client.listModels() when clientCache is available', async () => {
+			const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'gho_env' });
+			spyOn(
+				p as unknown as Record<string, unknown>,
+				'loadStoredGitHubToken' as never
+			).mockResolvedValue(undefined as never);
+			spyOn(p, 'ensureServerStarted').mockResolvedValue('http://127.0.0.1:9999' as never);
+
+			// Inject a mock clientCache with listModels()
+			const fakeSdkModels = [
+				{
+					id: 'gpt-4o',
+					name: 'GPT-4o',
+					capabilities: {
+						supports: { vision: true, reasoningEffort: false },
+						limits: { max_context_window_tokens: 128000 },
+					},
+					policy: { state: 'enabled', terms: '' },
+				},
+				{
+					id: 'claude-sonnet-4-5',
+					name: 'Claude Sonnet',
+					capabilities: {
+						supports: { vision: false, reasoningEffort: false },
+						limits: { max_context_window_tokens: 200000 },
+					},
+					policy: { state: 'enabled', terms: '' },
+				},
+				// Disabled model should be filtered out
+				{
+					id: 'gpt-4-turbo',
+					name: 'GPT-4 Turbo',
+					capabilities: {
+						supports: { vision: false, reasoningEffort: false },
+						limits: { max_context_window_tokens: 128000 },
+					},
+					policy: { state: 'disabled', terms: '' },
+				},
+			];
+			(p as unknown as Record<string, unknown>)['clientCache'] = {
+				listModels: async () => fakeSdkModels,
+			};
+
+			const models = await p.getModels();
+
+			// Should return dynamic models (filtering out disabled ones)
+			expect(models.length).toBe(2);
+			expect(models.map((m) => m.id)).toContain('gpt-4o');
+			expect(models.map((m) => m.id)).toContain('claude-sonnet-4-5');
+			expect(models.map((m) => m.id)).not.toContain('gpt-4-turbo');
+			// All should have the correct provider
+			for (const m of models) {
+				expect(m.provider).toBe('anthropic-copilot');
+			}
+		});
+
+		it('falls back to static model list when client.listModels() throws', async () => {
+			const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'gho_env' });
+			spyOn(
+				p as unknown as Record<string, unknown>,
+				'loadStoredGitHubToken' as never
+			).mockResolvedValue(undefined as never);
+			spyOn(p, 'ensureServerStarted').mockResolvedValue('http://127.0.0.1:9999' as never);
+
+			(p as unknown as Record<string, unknown>)['clientCache'] = {
+				listModels: async () => {
+					throw new Error('API error');
+				},
+			};
+
+			const models = await p.getModels();
+			// Should fall back to static list
+			expect(models.length).toBeGreaterThan(0);
+			expect(models.some((m) => m.id === 'claude-sonnet-4.6')).toBe(true);
+		});
+
+		it('falls back to static model list when client.listModels() returns empty', async () => {
+			const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'gho_env' });
+			spyOn(
+				p as unknown as Record<string, unknown>,
+				'loadStoredGitHubToken' as never
+			).mockResolvedValue(undefined as never);
+			spyOn(p, 'ensureServerStarted').mockResolvedValue('http://127.0.0.1:9999' as never);
+
+			(p as unknown as Record<string, unknown>)['clientCache'] = {
+				listModels: async () => [],
+			};
+
+			const models = await p.getModels();
+			// Should fall back to static list
+			expect(models.length).toBeGreaterThan(0);
+			expect(models.some((m) => m.id === 'claude-sonnet-4.6')).toBe(true);
+		});
+	});
+
+	describe('ownsModel() with dynamic models', () => {
+		it('returns true for a model ID in the dynamic cache', () => {
+			const p = new AnthropicToCopilotBridgeProvider('/tmp', {});
+			// Inject a dynamic models cache with a model not in the static list
+			(p as unknown as Record<string, unknown>)['dynamicModelsCache'] = [
+				{
+					id: 'gpt-4o',
+					name: 'GPT-4o (Copilot)',
+					alias: 'copilot-gpt-4o',
+					family: 'gpt',
+					provider: 'anthropic-copilot',
+					contextWindow: 128000,
+					description: 'GPT-4o via GitHub Copilot',
+					releaseDate: '2025-01-01',
+					available: true,
+				},
+			];
+			expect(p.ownsModel('gpt-4o')).toBe(true);
+			expect(p.ownsModel('copilot-gpt-4o')).toBe(true);
+			// Unknown model should still return false
+			expect(p.ownsModel('unknown-model-xyz')).toBe(false);
 		});
 	});
 

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -63,7 +63,6 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 		it('owns all copilot-anthropic-* aliases', () => {
 			expect(provider.ownsModel('copilot-anthropic-opus')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-sonnet')).toBe(true);
-			expect(provider.ownsModel('copilot-anthropic-codex')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-gemini')).toBe(true);
 			expect(provider.ownsModel('copilot-anthropic-mini')).toBe(true);
 		});
@@ -72,7 +71,6 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			// No legacy CLI provider collision — bare IDs are owned by this provider
 			expect(provider.ownsModel('claude-opus-4.6')).toBe(true);
 			expect(provider.ownsModel('claude-sonnet-4.6')).toBe(true);
-			expect(provider.ownsModel('gpt-5.3-codex')).toBe(true);
 			expect(provider.ownsModel('gpt-5-mini')).toBe(true);
 		});
 

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -76,8 +76,8 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			expect(provider.ownsModel('gpt-5-mini')).toBe(true);
 		});
 
-		it('owns gemini-3-pro-preview bare ID', () => {
-			expect(provider.ownsModel('gemini-3-pro-preview')).toBe(true);
+		it('owns gemini-3.1-pro-preview bare ID', () => {
+			expect(provider.ownsModel('gemini-3.1-pro-preview')).toBe(true);
 		});
 
 		it('does not own unknown models', () => {

--- a/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-copilot/provider.test.ts
@@ -87,20 +87,88 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 	});
 
 	describe('getModelForTier', () => {
-		it('maps opus tier to claude-opus-4.6', () => {
+		it('maps opus tier to claude-opus-4.6 (no dynamic cache)', () => {
 			expect(provider.getModelForTier('opus')).toBe('claude-opus-4.6');
 		});
 
-		it('maps sonnet tier to claude-sonnet-4.6', () => {
+		it('maps sonnet tier to claude-sonnet-4.6 (no dynamic cache)', () => {
 			expect(provider.getModelForTier('sonnet')).toBe('claude-sonnet-4.6');
 		});
 
-		it('maps haiku tier to gpt-5-mini', () => {
+		it('maps haiku tier to gpt-5-mini (no dynamic cache)', () => {
 			expect(provider.getModelForTier('haiku')).toBe('gpt-5-mini');
 		});
 
-		it('maps default tier to claude-sonnet-4.6', () => {
+		it('maps default tier to claude-sonnet-4.6 (no dynamic cache)', () => {
 			expect(provider.getModelForTier('default')).toBe('claude-sonnet-4.6');
+		});
+
+		it('returns static ID when dynamic cache contains a matching model', () => {
+			// Inject dynamic cache that includes the static haiku ID
+			(provider as unknown as Record<string, unknown>)['dynamicModelsCache'] = [
+				{
+					id: 'gpt-5-mini',
+					name: 'GPT-5 Mini (Copilot)',
+					alias: 'copilot-anthropic-mini',
+					family: 'gpt',
+					provider: 'anthropic-copilot',
+					contextWindow: 128000,
+					description: 'test',
+					releaseDate: '2025-01-01',
+					available: true,
+				},
+			];
+			expect(provider.getModelForTier('haiku')).toBe('gpt-5-mini');
+		});
+
+		it('returns an available model from dynamic cache when static ID is not present', () => {
+			// Dynamic cache has gpt-4o-mini (fits haiku keywords) but NOT gpt-5-mini
+			(provider as unknown as Record<string, unknown>)['dynamicModelsCache'] = [
+				{
+					id: 'gpt-4o',
+					name: 'GPT-4o (Copilot)',
+					alias: 'copilot-gpt-4o',
+					family: 'gpt',
+					provider: 'anthropic-copilot',
+					contextWindow: 128000,
+					description: 'test',
+					releaseDate: '2025-01-01',
+					available: true,
+				},
+				{
+					id: 'gpt-4o-mini',
+					name: 'GPT-4o Mini (Copilot)',
+					alias: 'copilot-gpt-4o-mini',
+					family: 'gpt',
+					provider: 'anthropic-copilot',
+					contextWindow: 128000,
+					description: 'test',
+					releaseDate: '2025-01-01',
+					available: true,
+				},
+			];
+			// haiku tier should find gpt-4o-mini (contains 'mini' keyword)
+			expect(provider.getModelForTier('haiku')).toBe('gpt-4o-mini');
+			// sonnet tier should find gpt-4o (contains '4o' keyword)
+			expect(provider.getModelForTier('sonnet')).toBe('gpt-4o');
+		});
+
+		it('returns first available model from dynamic cache when no keyword match', () => {
+			// Dynamic cache has only an unusual model ID
+			(provider as unknown as Record<string, unknown>)['dynamicModelsCache'] = [
+				{
+					id: 'some-custom-model',
+					name: 'Custom (Copilot)',
+					alias: 'copilot-custom',
+					family: 'gpt',
+					provider: 'anthropic-copilot',
+					contextWindow: 128000,
+					description: 'test',
+					releaseDate: '2025-01-01',
+					available: true,
+				},
+			];
+			expect(provider.getModelForTier('haiku')).toBe('some-custom-model');
 		});
 	});
 
@@ -452,6 +520,48 @@ describe('AnthropicToCopilotBridgeProvider', () => {
 			// Should fall back to static list
 			expect(models.length).toBeGreaterThan(0);
 			expect(models.some((m) => m.id === 'claude-sonnet-4.6')).toBe(true);
+		});
+
+		it('returns cached models within TTL without calling listModels() again', async () => {
+			const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'gho_env' });
+			spyOn(
+				p as unknown as Record<string, unknown>,
+				'loadStoredGitHubToken' as never
+			).mockResolvedValue(undefined as never);
+			spyOn(p, 'ensureServerStarted').mockResolvedValue('http://127.0.0.1:9999' as never);
+
+			let callCount = 0;
+			(p as unknown as Record<string, unknown>)['clientCache'] = {
+				listModels: async () => {
+					callCount++;
+					return [
+						{
+							id: 'gpt-4o',
+							name: 'GPT-4o',
+							capabilities: {
+								supports: { vision: true, reasoningEffort: false },
+								limits: { max_context_window_tokens: 128000 },
+							},
+							policy: { state: 'enabled', terms: '' },
+						},
+					];
+				},
+			};
+
+			// First call — should invoke listModels()
+			await p.getModels();
+			expect(callCount).toBe(1);
+
+			// Second call within TTL — should return cached result
+			await p.getModels();
+			expect(callCount).toBe(1); // listModels NOT called again
+
+			// Force expiry
+			(p as unknown as Record<string, unknown>)['dynamicModelsCacheExpiresAt'] = Date.now() - 1;
+
+			// Third call after expiry — should invoke listModels() again
+			await p.getModels();
+			expect(callCount).toBe(2);
 		});
 
 		it('falls back to static model list when client.listModels() returns empty', async () => {

--- a/packages/daemon/tests/unit/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/providers/context-manager.test.ts
@@ -1062,10 +1062,10 @@ describe('ProviderContextManager', () => {
 // The invariant differs per provider:
 //   Codex bridge:   all three tier slots must be gpt-* model IDs — the bridge
 //                   rejects any claude-* name with "model does not exist".
-//   Copilot bridge: only the haiku slot is at risk. Copilot intentionally routes
-//                   claude-sonnet-4.6 / claude-opus-4.6 for those tiers, but
-//                   gpt-5-mini is required for haiku — a claude-haiku fallback
-//                   would not be served correctly by the Copilot bridge.
+//   Copilot bridge: all three tier slots must be set to the same resolved model ID
+//                   so the SDK's internal haiku/opus calls also go through a real
+//                   Copilot model.  The SDK's default claude-haiku-4-5-20251001
+//                   is an Anthropic API ID that the Copilot bridge cannot serve.
 // ---------------------------------------------------------------------------
 
 describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()', () => {
@@ -1095,7 +1095,7 @@ describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()',
 		expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).not.toMatch(/^claude-/);
 	});
 
-	it('Copilot provider: ANTHROPIC_DEFAULT_HAIKU_MODEL does not start with claude-', () => {
+	it('Copilot provider: all three DEFAULT_*_MODEL slots are set to the resolved model ID', () => {
 		const p = new AnthropicToCopilotBridgeProvider('/tmp', { COPILOT_GITHUB_TOKEN: 'tok' });
 		// Inject a fake server URL — buildSdkConfig() requires the embedded server to be
 		// started, but for this assertion we only care about the env var values it returns.
@@ -1104,9 +1104,20 @@ describe('no-Anthropic-model-leak invariant — real provider buildSdkConfig()',
 			stop: async () => {},
 		};
 		const cfg = p.buildSdkConfig('copilot-anthropic-sonnet');
-		// Only the haiku slot must be non-claude-*. Sonnet/opus intentionally use
-		// claude-sonnet-4.6 / claude-opus-4.6 (the Copilot bridge serves those).
-		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toMatch(/^claude-/);
+		// All three tiers must use the same resolved model ID so that every SDK-internal
+		// call (summarisation, compaction, etc.) routes through the real Copilot model
+		// the user selected, rather than a hardcoded fallback that might be unavailable.
+		// This prevents the original bug where the haiku slot defaulted to
+		// claude-haiku-4-5-20251001, which is an Anthropic API ID that the Copilot bridge
+		// cannot serve.
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe(
+			cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']
+		);
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).toBe(
+			cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']
+		);
+		// The resolved model must NOT be the SDK's default haiku fallback.
+		expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).not.toBe('claude-haiku-4-5-20251001');
 		// p.shutdown() intentionally omitted: serverCache.stop is a no-op and no
 		// real embedded server was started, so there is nothing to clean up.
 	});


### PR DESCRIPTION
The anthropic-copilot provider previously returned a hardcoded static model
list. If any of those IDs (e.g. claude-opus-4.6, claude-sonnet-4.6) are not
valid Copilot SDK model IDs for the authenticated account, createSession()
hangs without emitting session.idle — causing all inference tests to time out
after 120 s.

Fix: call client.listModels() in getModels() to get the actual available
model IDs for the user's Copilot account. The static list is now used only as
display-name/context-window enrichment (when an ID matches) and as a last-
resort fallback when listModels() fails or returns empty.

Also route all three SDK model tiers (opus/sonnet/haiku) to the same resolved
model ID so every SDK-internal call (summarisation, compaction, etc.) routes
through the real Copilot model the user selected, rather than a hardcoded
fallback that might be unavailable.

Addresses: https://github.com/lsm/neokai/actions/runs/23327807694
