### PR TITLE
fix: thread explicit provider through room-spawned agent sessions

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -83,6 +83,7 @@ import type {
 	SelectiveRewindResult,
 	SystemPromptConfig,
 	McpServerConfig,
+	Provider,
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import type { DaemonHub } from '../daemon-hub';
@@ -130,7 +131,7 @@ export interface AgentSessionInit {
 	 * multiple providers (e.g. claude-opus-4.6 owned by both Anthropic and Copilot)
 	 * are routed to the correct provider.
 	 */
-	provider?: string;
+	provider?: Provider;
 
 	/** Enable coordinator mode — main agent orchestrates specialist sub-agents */
 	coordinatorMode?: boolean;
@@ -497,7 +498,7 @@ export class AgentSession
 			// Room-spawned sessions (leader, coder, general) pass this from the model cache
 			// so providers that share canonical model IDs (e.g. anthropic vs anthropic-copilot
 			// for 'claude-opus-4.6') are routed deterministically.
-			provider: init.provider as import('@neokai/shared').Provider | undefined,
+			provider: init.provider,
 		};
 
 		const metadata: SessionMetadata = {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -417,6 +417,18 @@ export class AgentSession
 				hasUpdates = true;
 			}
 
+			// Update config.provider if it changed since the session was first persisted.
+			// Room-spawned agent sessions use per-UUID IDs so this path is not reached for
+			// them today. Long-lived sessions (room chat, lobby) set their provider through
+			// the UI model picker, not init.provider. The update is included defensively so
+			// that if stable IDs are ever used for agent sessions the provider stays current.
+			if (init.provider !== undefined && session.config.provider !== init.provider) {
+				const nextConfig = { ...session.config, provider: init.provider };
+				updates.config = nextConfig;
+				session = { ...session, config: nextConfig };
+				hasUpdates = true;
+			}
+
 			if (hasUpdates) {
 				db.updateSession(init.sessionId, updates);
 			}

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -123,6 +123,15 @@ export interface AgentSessionInit {
 	/** Model ID - defaults to default model */
 	model?: string;
 
+	/**
+	 * Provider ID for this session (e.g. 'anthropic', 'anthropic-copilot', 'glm').
+	 * When set, provider routing is deterministic (no deprecated detectProvider fallback).
+	 * Room-spawned sessions (leader, worker) must set this so models shared between
+	 * multiple providers (e.g. claude-opus-4.6 owned by both Anthropic and Copilot)
+	 * are routed to the correct provider.
+	 */
+	provider?: string;
+
 	/** Enable coordinator mode — main agent orchestrates specialist sub-agents */
 	coordinatorMode?: boolean;
 
@@ -484,6 +493,11 @@ export class AgentSession
 			coordinatorMode: init.coordinatorMode,
 			agent: init.agent,
 			agents: init.agents,
+			// Explicit provider — prevents deprecated detectProvider() fallback in query-runner.
+			// Room-spawned sessions (leader, coder, general) pass this from the model cache
+			// so providers that share canonical model IDs (e.g. anthropic vs anthropic-copilot
+			// for 'claude-opus-4.6') are routed deterministically.
+			provider: init.provider as import('@neokai/shared').Provider | undefined,
 		};
 
 		const metadata: SessionMetadata = {

--- a/packages/daemon/src/lib/providers/anthropic-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-provider.ts
@@ -23,13 +23,22 @@ import { resolveSDKCliPath, isRunningUnderBun } from '../agent/sdk-cli-resolver.
 const CANONICAL_SDK_IDS = new Set(['default', 'sonnet', 'opus', 'haiku', 'sonnet[1m]']);
 
 /**
- * Detect if a model ID is a full version-specific ID (e.g., claude-sonnet-4-5-20250929)
- * vs a canonical short ID (e.g., sonnet, opus, haiku)
+ * Detect if a model ID is a full version-specific ID vs a canonical short ID.
+ *
+ * Recognises two formats:
+ * - Dash-separated: claude-sonnet-4-5-20250929, claude-opus-4-5-20251101
+ * - Dot-notation: claude-opus-4.6, claude-sonnet-4.6 (newer SDK format)
  */
 function isFullVersionId(modelId: string): boolean {
-	// Full IDs match pattern: claude-{family}-{version}-{date}
-	// e.g., claude-sonnet-4-5-20250929, claude-opus-4-5-20251101
-	return /^claude-(sonnet|opus|haiku)-[\d-]+$/.test(modelId);
+	// Dash-separated: claude-{family}-{major}-{minor}[-{date}]
+	if (/^claude-(sonnet|opus|haiku)-[\d-]+$/.test(modelId)) {
+		return true;
+	}
+	// Dot-notation: claude-{family}-{major}.{minor}
+	if (/^claude-(sonnet|opus|haiku)-\d+\.\d+$/.test(modelId)) {
+		return true;
+	}
+	return false;
 }
 
 /**
@@ -76,16 +85,23 @@ function parseModelId(
 		};
 	}
 
-	// Full version IDs: claude-{family}-{major}-{minor}-{date}
-	// Example: claude-sonnet-4-5-20250929
-	const match = modelId.match(/^claude-(sonnet|opus|haiku)-(\d+)-(\d+)(?:-\d{8})?$/);
-	if (match) {
-		const family = match[1];
-		const major = match[2];
-		const minor = match[3];
+	// Full version IDs: claude-{family}-{major}-{minor}[-{date}]
+	// Example: claude-sonnet-4-5-20250929, claude-opus-4-5-20251101
+	const dashMatch = modelId.match(/^claude-(sonnet|opus|haiku)-(\d+)-(\d+)(?:-\d{8})?$/);
+	if (dashMatch) {
 		return {
-			family,
-			version: `${major}.${minor}`, // Extract version as "4.5"
+			family: dashMatch[1],
+			version: `${dashMatch[2]}.${dashMatch[3]}`, // e.g. "4.5"
+		};
+	}
+
+	// Dot-notation IDs: claude-{family}-{major}.{minor}
+	// Example: claude-opus-4.6, claude-sonnet-4.6
+	const dotMatch = modelId.match(/^claude-(sonnet|opus|haiku)-(\d+)\.(\d+)$/);
+	if (dotMatch) {
+		return {
+			family: dotMatch[1],
+			version: `${dotMatch[2]}.${dotMatch[3]}`, // e.g. "4.6"
 		};
 	}
 

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -18,6 +18,7 @@ import type {
 	SessionFeatures,
 	AgentDefinition,
 	SubagentConfig,
+	Provider,
 } from '@neokai/shared';
 
 const DEFAULT_CODER_MODEL = 'claude-sonnet-4-5-20250929';
@@ -39,7 +40,7 @@ export interface CoderAgentConfig {
 	model?: string;
 	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
 	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
-	provider?: string;
+	provider?: Provider;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -37,6 +37,9 @@ export interface CoderAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
+	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
+	provider?: string;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }
@@ -455,6 +458,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 			context: { roomId: config.room.id },
 			type: 'coder',
 			model: config.model ?? DEFAULT_CODER_MODEL,
+			provider: config.provider,
 			agent: 'Coder',
 			agents: {
 				Coder: coderAgentDef,
@@ -478,6 +482,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 		context: { roomId: config.room.id },
 		type: 'coder',
 		model: config.model ?? DEFAULT_CODER_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/general-agent.ts
+++ b/packages/daemon/src/lib/room/agents/general-agent.ts
@@ -9,7 +9,7 @@
  */
 
 import type { AgentSessionInit } from '../../agent/agent-session';
-import type { Room, RoomGoal, NeoTask, SessionFeatures } from '@neokai/shared';
+import type { Room, RoomGoal, NeoTask, SessionFeatures, Provider } from '@neokai/shared';
 
 const DEFAULT_GENERAL_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -30,7 +30,7 @@ export interface GeneralAgentConfig {
 	model?: string;
 	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
 	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
-	provider?: string;
+	provider?: Provider;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }

--- a/packages/daemon/src/lib/room/agents/general-agent.ts
+++ b/packages/daemon/src/lib/room/agents/general-agent.ts
@@ -28,6 +28,9 @@ export interface GeneralAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
+	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
+	provider?: string;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }
@@ -199,6 +202,7 @@ export function createGeneralAgentInit(config: GeneralAgentConfig): AgentSession
 		context: { roomId: config.room.id },
 		type: 'general',
 		model: config.model ?? DEFAULT_GENERAL_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -24,6 +24,7 @@ import type {
 	McpServerConfig,
 	AgentDefinition,
 	SubagentConfig,
+	Provider,
 } from '@neokai/shared';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
@@ -82,7 +83,7 @@ export interface LeaderAgentConfig {
 	model?: string;
 	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
 	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
-	provider?: string;
+	provider?: Provider;
 	/** What type of work is being reviewed */
 	reviewContext?: ReviewContext;
 	/** Dependencies for the leader context MCP server (optional - only needed when creating MCP server) */

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -80,6 +80,9 @@ export interface LeaderAgentConfig {
 	workspacePath: string;
 	groupId: string;
 	model?: string;
+	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
+	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
+	provider?: string;
 	/** What type of work is being reviewed */
 	reviewContext?: ReviewContext;
 	/** Dependencies for the leader context MCP server (optional - only needed when creating MCP server) */
@@ -1150,6 +1153,7 @@ export function createLeaderAgentInit(
 			context: { roomId: config.room.id },
 			type: 'leader' as const,
 			model: config.model ?? DEFAULT_LEADER_MODEL,
+			provider: config.provider,
 			agent: 'Leader',
 			agents: allAgents,
 			contextAutoQueue: false,
@@ -1173,6 +1177,7 @@ export function createLeaderAgentInit(
 		context: { roomId: config.room.id },
 		type: 'leader',
 		model: config.model ?? DEFAULT_LEADER_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -29,6 +29,7 @@ import type {
 	TaskPriority,
 	AgentType,
 	AgentDefinition,
+	Provider,
 } from '@neokai/shared';
 
 const DEFAULT_PLANNER_MODEL = 'claude-sonnet-4-5-20250929';
@@ -84,7 +85,7 @@ export interface PlannerAgentConfig {
 	model?: string;
 	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
 	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
-	provider?: string;
+	provider?: Provider;
 	/** Callback to create a draft task linked to this planning task */
 	createDraftTask: (params: PlannerCreateTaskParams) => Promise<{ id: string; title: string }>;
 	/** Callback to update an existing draft task */

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -82,6 +82,9 @@ export interface PlannerAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID resolved from the model (e.g. 'anthropic', 'anthropic-copilot').
+	 *  When set, routing is deterministic — no deprecated detectProvider fallback. */
+	provider?: string;
 	/** Callback to create a draft task linked to this planning task */
 	createDraftTask: (params: PlannerCreateTaskParams) => Promise<{ id: string; title: string }>;
 	/** Callback to update an existing draft task */
@@ -607,6 +610,7 @@ export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSession
 		context: { roomId: config.room.id },
 		type: 'planner',
 		model: config.model ?? DEFAULT_PLANNER_MODEL,
+		provider: config.provider,
 		agent: 'Planner',
 		agents: {
 			Planner: plannerAgentDef,

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -73,6 +73,7 @@ import {
 } from './lifecycle-hooks';
 import { checkDeadLoop, DEFAULT_DEAD_LOOP_CONFIG, type DeadLoopConfig } from './dead-loop-detector';
 import { getNextRunAt } from './cron-utils';
+import { getAvailableModels } from '../../model-service';
 
 const log = new Logger('room-runtime');
 
@@ -286,7 +287,11 @@ export class RoomRuntime {
 		// Keep test and direct-runtime usage predictable: when no explicit leader model
 		// is provided, derive it from the initial room config.
 		if (!config.model || config.model.trim() === '') {
-			this.taskGroupManager.updateModel(this.resolveAgentModel(config.room, 'leader'));
+			const { model: leaderModel, provider: leaderProvider } = this.resolveAgentModelWithProvider(
+				config.room,
+				'leader'
+			);
+			this.taskGroupManager.updateModel(leaderModel, leaderProvider);
 		}
 	}
 
@@ -332,16 +337,39 @@ export class RoomRuntime {
 	 * Priority: room.config.agentModels[role] > room.defaultModel > global default.
 	 */
 	private resolveAgentModel(room: Room, role: 'leader' | 'planner' | 'coder' | 'general'): string {
+		return this.resolveAgentModelWithProvider(room, role).model;
+	}
+
+	/**
+	 * Resolve both the model ID and its provider for a given agent role.
+	 *
+	 * Looks up the model in the global model cache so that providers sharing the
+	 * same canonical model ID (e.g. anthropic and anthropic-copilot both expose
+	 * 'claude-opus-4.6') are distinguished correctly. Without an explicit provider,
+	 * query-runner.ts falls back to the deprecated detectProvider() heuristic which
+	 * always returns Anthropic first — causing Copilot-targeted sessions to be
+	 * misrouted to Anthropic.
+	 */
+	private resolveAgentModelWithProvider(
+		room: Room,
+		role: 'leader' | 'planner' | 'coder' | 'general'
+	): { model: string; provider: string | undefined } {
 		const config = (room.config ?? {}) as Record<string, unknown>;
 		const agentModels = config.agentModels as Record<string, string> | undefined;
 		const roleModel = agentModels?.[role];
+		let modelId: string;
 		if (typeof roleModel === 'string' && roleModel.trim() !== '') {
-			return roleModel;
+			modelId = roleModel;
+		} else if (typeof room.defaultModel === 'string' && room.defaultModel.trim() !== '') {
+			modelId = room.defaultModel;
+		} else {
+			modelId = this.defaultModel;
 		}
-		if (typeof room.defaultModel === 'string' && room.defaultModel.trim() !== '') {
-			return room.defaultModel;
-		}
-		return this.defaultModel;
+		// Look up provider from the global model cache. getAvailableModels() is sync
+		// and safe to call here (cache is pre-warmed at startup via initializeModels).
+		const availableModels = getAvailableModels('global');
+		const modelInfo = availableModels.find((m) => m.id === modelId || m.alias === modelId);
+		return { model: modelId, provider: modelInfo?.provider };
 	}
 
 	/**
@@ -375,8 +403,10 @@ export class RoomRuntime {
 		this.room = currentRoom;
 		const config = (currentRoom.config ?? {}) as Record<string, unknown>;
 
-		// Keep TaskGroupManager model aligned to the current Leader model.
-		this.taskGroupManager.updateModel(this.resolveAgentModel(currentRoom, 'leader'));
+		// Keep TaskGroupManager model+provider aligned to the current Leader model.
+		const { model: updatedLeaderModel, provider: updatedLeaderProvider } =
+			this.resolveAgentModelWithProvider(currentRoom, 'leader');
+		this.taskGroupManager.updateModel(updatedLeaderModel, updatedLeaderProvider);
 
 		const rawGroups = config.maxConcurrentGroups;
 		this.maxConcurrentGroups =
@@ -2778,8 +2808,14 @@ export class RoomRuntime {
 			await this.emitTaskUpdateById(planningTask.id);
 			return;
 		}
-		const plannerModel = this.resolveAgentModel(currentRoom, 'planner');
-		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
+		const { model: plannerModel, provider: plannerProvider } = this.resolveAgentModelWithProvider(
+			currentRoom,
+			'planner'
+		);
+		const { model: leaderModel, provider: leaderProvider } = this.resolveAgentModelWithProvider(
+			currentRoom,
+			'leader'
+		);
 
 		// Build WorkerConfig for the Planner agent
 		// isPlanApproved uses a mutable ref — groupId is set after spawn() returns
@@ -2795,6 +2831,7 @@ export class RoomRuntime {
 			sessionId: '', // placeholder — overwritten by initFactory
 			workspacePath: this.taskGroupManager.workspacePath,
 			model: plannerModel,
+			provider: plannerProvider,
 			createDraftTask,
 			updateDraftTask,
 			removeDraftTask,
@@ -2814,6 +2851,7 @@ export class RoomRuntime {
 				workspacePath: this.taskGroupManager.workspacePath,
 				groupId: '', // not used by buildLeaderTaskContext
 				model: leaderModel,
+				provider: leaderProvider,
 				reviewContext: 'plan_review',
 			}),
 		};
@@ -2904,8 +2942,14 @@ export class RoomRuntime {
 		// Determine worker config based on assigned agent type
 		const agentType = task.assignedAgent ?? 'coder';
 		const workerRole = agentType === 'general' ? 'general' : 'coder';
-		const workerModel = this.resolveAgentModel(currentRoom, workerRole);
-		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
+		const { model: workerModel, provider: workerProvider } = this.resolveAgentModelWithProvider(
+			currentRoom,
+			workerRole
+		);
+		const { model: leaderModel, provider: leaderProvider } = this.resolveAgentModelWithProvider(
+			currentRoom,
+			'leader'
+		);
 		let workerConfig: WorkerConfig;
 
 		// Shared leader context config (groupId not used by buildLeaderTaskContext)
@@ -2917,6 +2961,7 @@ export class RoomRuntime {
 			workspacePath: this.taskGroupManager.workspacePath,
 			groupId: '',
 			model: leaderModel,
+			provider: leaderProvider,
 			reviewContext: 'code_review' as const,
 		};
 
@@ -2928,6 +2973,7 @@ export class RoomRuntime {
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
 				model: workerModel,
+				provider: workerProvider,
 				previousTaskSummaries,
 			};
 			workerConfig = {
@@ -2946,6 +2992,7 @@ export class RoomRuntime {
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
 				model: workerModel,
+				provider: workerProvider,
 				previousTaskSummaries,
 			};
 			workerConfig = {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -22,6 +22,7 @@ import {
 	type TaskPriority,
 	type AgentType,
 	type RuntimeState,
+	type Provider,
 	MAX_CONCURRENT_GROUPS_LIMIT,
 	MAX_REVIEW_ROUNDS_LIMIT,
 } from '@neokai/shared';
@@ -74,6 +75,7 @@ import {
 import { checkDeadLoop, DEFAULT_DEAD_LOOP_CONFIG, type DeadLoopConfig } from './dead-loop-detector';
 import { getNextRunAt } from './cron-utils';
 import { getAvailableModels } from '../../model-service';
+import { getProviderRegistry } from '../../providers/registry';
 
 const log = new Logger('room-runtime');
 
@@ -333,14 +335,6 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Resolve model for a room agent role.
-	 * Priority: room.config.agentModels[role] > room.defaultModel > global default.
-	 */
-	private resolveAgentModel(room: Room, role: 'leader' | 'planner' | 'coder' | 'general'): string {
-		return this.resolveAgentModelWithProvider(room, role).model;
-	}
-
-	/**
 	 * Resolve both the model ID and its provider for a given agent role.
 	 *
 	 * Looks up the model in the global model cache so that providers sharing the
@@ -349,11 +343,17 @@ export class RoomRuntime {
 	 * query-runner.ts falls back to the deprecated detectProvider() heuristic which
 	 * always returns Anthropic first — causing Copilot-targeted sessions to be
 	 * misrouted to Anthropic.
+	 *
+	 * Fallback: when the model is absent from the cache (e.g. cache not yet warmed,
+	 * or Anthropic provider deduped the dot-notation ID behind its canonical alias),
+	 * the registry's detectProvider() is used. detectProvider iterates providers in
+	 * registration order (Anthropic first) and returns the first owner — so
+	 * `claude-opus-4.6` correctly resolves to 'anthropic'.
 	 */
 	private resolveAgentModelWithProvider(
 		room: Room,
 		role: 'leader' | 'planner' | 'coder' | 'general'
-	): { model: string; provider: string | undefined } {
+	): { model: string; provider: Provider | undefined } {
 		const config = (room.config ?? {}) as Record<string, unknown>;
 		const agentModels = config.agentModels as Record<string, string> | undefined;
 		const roleModel = agentModels?.[role];
@@ -367,9 +367,18 @@ export class RoomRuntime {
 		}
 		// Look up provider from the global model cache. getAvailableModels() is sync
 		// and safe to call here (cache is pre-warmed at startup via initializeModels).
+		// ModelInfo.provider is string; cast to the Provider union at this boundary.
 		const availableModels = getAvailableModels('global');
 		const modelInfo = availableModels.find((m) => m.id === modelId || m.alias === modelId);
-		return { model: modelId, provider: modelInfo?.provider };
+		if (modelInfo) {
+			return { model: modelId, provider: modelInfo.provider as Provider };
+		}
+		// Model not found in cache — fall back to registry's heuristic detectProvider().
+		// This covers: cache not yet warmed, or the Anthropic provider deduplicated the
+		// dot-notation ID behind its canonical short alias (e.g. 'claude-opus-4.6' → 'opus').
+		// detectProvider returns Anthropic first for any 'claude-*' model ID.
+		const detectedProvider = getProviderRegistry().detectProvider(modelId);
+		return { model: modelId, provider: detectedProvider?.id as Provider | undefined };
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -376,7 +376,13 @@ export class RoomRuntime {
 		// Model not found in cache — fall back to registry's heuristic detectProvider().
 		// This covers: cache not yet warmed, or the Anthropic provider deduplicated the
 		// dot-notation ID behind its canonical short alias (e.g. 'claude-opus-4.6' → 'opus').
-		// detectProvider returns Anthropic first for any 'claude-*' model ID.
+		//
+		// Limitation: detectProvider iterates providers in registration order (Anthropic
+		// first) and returns the first owner. For 'claude-*' IDs this resolves to Anthropic,
+		// which is correct in the common case. However, if a room explicitly configured a
+		// Copilot-hosted claude-* model AND the cache is unavailable (e.g. cleared mid-run),
+		// this fallback will misroute that session to Anthropic. Cache misses at runtime are
+		// expected to be transient — models are pre-warmed at startup via initializeModels().
 		const detectedProvider = getProviderRegistry().detectProvider(modelId);
 		return { model: modelId, provider: detectedProvider?.id as Provider | undefined };
 	}

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -154,6 +154,9 @@ export interface TaskGroupManagerConfig {
 	workspacePath: string;
 	/** Leader model */
 	model?: string;
+	/** Provider ID for the leader model (e.g. 'anthropic', 'anthropic-copilot').
+	 *  Resolved from the model cache so routing is deterministic. */
+	provider?: string;
 	/** Worker model (defaults to model if not set) */
 	workerModel?: string;
 	/** Fetch room from DB by ID. Used to get CURRENT room config at route time. */
@@ -178,6 +181,7 @@ export class TaskGroupManager {
 	private readonly daemonHub?: DaemonHub;
 	readonly workspacePath: string;
 	private _model?: string;
+	private _provider?: string;
 	readonly workerModel?: string;
 
 	constructor(config: TaskGroupManagerConfig) {
@@ -191,6 +195,7 @@ export class TaskGroupManager {
 		this.getGoalById = config.getGoal;
 		this.workspacePath = config.workspacePath;
 		this._model = config.model;
+		this._provider = config.provider;
 		this.workerModel = config.workerModel;
 		this.daemonHub = config.daemonHub;
 	}
@@ -200,9 +205,15 @@ export class TaskGroupManager {
 		return this._model;
 	}
 
-	/** Update the model for new leader sessions (e.g., when room settings change) */
-	updateModel(model: string | undefined): void {
+	/** Get the current provider for leader sessions */
+	get provider(): string | undefined {
+		return this._provider;
+	}
+
+	/** Update the model and provider for new leader sessions (e.g., when room settings change) */
+	updateModel(model: string | undefined, provider?: string): void {
 		this._model = model;
+		this._provider = provider;
 	}
 
 	/**
@@ -308,6 +319,7 @@ export class TaskGroupManager {
 			workspacePath: groupWorkspacePath,
 			groupId: group.id,
 			model: this._model,
+			provider: this._provider,
 			reviewContext,
 			goalManager: this.goalManager,
 			taskManager: this.taskManager,
@@ -429,6 +441,7 @@ export class TaskGroupManager {
 				workspacePath: group.workspacePath ?? this.workspacePath,
 				groupId: group.id,
 				model: this.model,
+				provider: this.provider,
 				reviewContext: deferredLeader.reviewContext,
 				goalManager: this.goalManager,
 				taskManager: this.taskManager,

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -12,7 +12,7 @@
  */
 
 import { generateUUID } from '@neokai/shared';
-import type { Room, RoomGoal, NeoTask, MessageDeliveryMode } from '@neokai/shared';
+import type { Room, RoomGoal, NeoTask, MessageDeliveryMode, Provider } from '@neokai/shared';
 import type { AgentSessionInit } from '../../agent/agent-session';
 import { Logger } from '../../logger';
 import type {
@@ -156,7 +156,7 @@ export interface TaskGroupManagerConfig {
 	model?: string;
 	/** Provider ID for the leader model (e.g. 'anthropic', 'anthropic-copilot').
 	 *  Resolved from the model cache so routing is deterministic. */
-	provider?: string;
+	provider?: Provider;
 	/** Worker model (defaults to model if not set) */
 	workerModel?: string;
 	/** Fetch room from DB by ID. Used to get CURRENT room config at route time. */
@@ -181,7 +181,7 @@ export class TaskGroupManager {
 	private readonly daemonHub?: DaemonHub;
 	readonly workspacePath: string;
 	private _model?: string;
-	private _provider?: string;
+	private _provider?: Provider;
 	readonly workerModel?: string;
 
 	constructor(config: TaskGroupManagerConfig) {
@@ -206,12 +206,12 @@ export class TaskGroupManager {
 	}
 
 	/** Get the current provider for leader sessions */
-	get provider(): string | undefined {
+	get provider(): Provider | undefined {
 		return this._provider;
 	}
 
 	/** Update the model and provider for new leader sessions (e.g., when room settings change) */
-	updateModel(model: string | undefined, provider?: string): void {
+	updateModel(model: string | undefined, provider?: Provider): void {
 		this._model = model;
 		this._provider = provider;
 	}

--- a/packages/daemon/tests/unit/providers/anthropic-provider.test.ts
+++ b/packages/daemon/tests/unit/providers/anthropic-provider.test.ts
@@ -192,6 +192,101 @@ describe('AnthropicProvider', () => {
 		});
 	});
 
+	describe('convertSdkModels — dot-notation model IDs', () => {
+		/**
+		 * Regression tests for the provider routing bug:
+		 * claude-opus-4.6 (dot-notation) was not recognised as a full-version ID by
+		 * isFullVersionId(), so it was never deduplicated against the canonical 'opus'
+		 * alias when both appeared in the SDK response.
+		 */
+		it('recognises claude-opus-4.6 as a full-version ID (dot notation)', () => {
+			// Canonical 'opus' is returned first with description that encodes version 4.6
+			const sdkModels = [
+				{ value: 'opus', displayName: 'Opus', description: 'Opus 4.6 · Most capable' },
+				{
+					value: 'claude-opus-4.6',
+					displayName: 'Claude Opus 4.6',
+					description: 'Opus 4.6 · Most capable',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			// claude-opus-4.6 should be deduplicated away because canonical 'opus' exists for version 4.6
+			const opusIds = result.map((m) => m.id);
+			expect(opusIds).toContain('opus');
+			expect(opusIds).not.toContain('claude-opus-4.6');
+		});
+
+		it('keeps claude-opus-4.6 when no canonical opus alias is present', () => {
+			// Only the full dot-notation ID is returned (no canonical alias)
+			const sdkModels = [
+				{
+					value: 'claude-opus-4.6',
+					displayName: 'Claude Opus 4.6',
+					description: 'Opus 4.6 · Most capable',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			const opusIds = result.map((m) => m.id);
+			expect(opusIds).toContain('claude-opus-4.6');
+		});
+
+		it('keeps claude-sonnet-4.6 when no canonical sonnet alias is present', () => {
+			const sdkModels = [
+				{
+					value: 'claude-sonnet-4.6',
+					displayName: 'Claude Sonnet 4.6',
+					description: 'Sonnet 4.6 · Best balance',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			expect(result.map((m) => m.id)).toContain('claude-sonnet-4.6');
+		});
+
+		it('deduplicates claude-sonnet-4.6 when canonical sonnet alias exists for same version', () => {
+			const sdkModels = [
+				{ value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6 · Best balance' },
+				{
+					value: 'claude-sonnet-4.6',
+					displayName: 'Claude Sonnet 4.6',
+					description: 'Sonnet 4.6 · Best balance',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			const ids = result.map((m) => m.id);
+			expect(ids).toContain('sonnet');
+			expect(ids).not.toContain('claude-sonnet-4.6');
+		});
+
+		it('correctly sets provider to anthropic for kept dot-notation models', () => {
+			const sdkModels = [
+				{
+					value: 'claude-opus-4.6',
+					displayName: 'Claude Opus 4.6',
+					description: 'Opus 4.6 · Most capable',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			const model = result.find((m) => m.id === 'claude-opus-4.6');
+			expect(model?.provider).toBe('anthropic');
+			expect(model?.family).toBe('opus');
+		});
+
+		it('continues to handle dash-notation IDs correctly (regression guard)', () => {
+			const sdkModels = [
+				{ value: 'opus', displayName: 'Opus', description: 'Opus 4.5 · Most capable' },
+				{
+					value: 'claude-opus-4-5-20251101',
+					displayName: 'Opus',
+					description: 'Opus 4.5 · Most capable',
+				},
+			];
+			const result = provider.convertSdkModels(sdkModels);
+			const ids = result.map((m) => m.id);
+			expect(ids).toContain('opus');
+			expect(ids).not.toContain('claude-opus-4-5-20251101');
+		});
+	});
+
 	describe('model cache', () => {
 		it('should allow setting model cache', async () => {
 			const customModels = [

--- a/packages/daemon/tests/unit/room/agent-provider-routing.test.ts
+++ b/packages/daemon/tests/unit/room/agent-provider-routing.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for provider routing through agent session init factories.
+ *
+ * Bug: When selecting 'anthropic opus-4.6' as the leader subagent, traffic was
+ * being sent to GitHub Copilot instead of Anthropic. Root cause: AgentSessionInit
+ * was missing a `provider` field, so query-runner.ts fell back to the deprecated
+ * detectProvider() heuristic which always returns Anthropic first for any claude-*
+ * model — causing Copilot-targeted sessions to be misrouted.
+ *
+ * Fix: Thread explicit provider from model cache through the full creation chain:
+ *   resolveAgentModelWithProvider → agent config → AgentSessionInit → SessionConfig
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+	createPlannerAgentInit,
+	type PlannerAgentConfig,
+} from '../../../src/lib/room/agents/planner-agent';
+import {
+	createCoderAgentInit,
+	type CoderAgentConfig,
+} from '../../../src/lib/room/agents/coder-agent';
+import {
+	createGeneralAgentInit,
+	type GeneralAgentConfig,
+} from '../../../src/lib/room/agents/general-agent';
+import {
+	createLeaderAgentInit,
+	type LeaderAgentConfig,
+	type LeaderToolCallbacks,
+	type LeaderToolResult,
+} from '../../../src/lib/room/agents/leader-agent';
+import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+function makeRoom(overrides?: Partial<Room>): Room {
+	return {
+		id: 'room-1',
+		name: 'Test Room',
+		allowedPaths: [{ path: '/workspace', label: 'ws' }],
+		defaultPath: '/workspace',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeGoal(overrides?: Partial<RoomGoal>): RoomGoal {
+	return {
+		id: 'goal-1',
+		roomId: 'room-1',
+		title: 'Build health check',
+		description: 'Add a health check endpoint',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<NeoTask>): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Add GET /health endpoint',
+		description: 'Create health endpoint',
+		status: 'pending',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+const noop = async (): Promise<LeaderToolResult> => ({ content: [{ type: 'text', text: 'ok' }] });
+const leaderCallbacks: LeaderToolCallbacks = {
+	sendToWorker: noop,
+	completeTask: noop,
+	failTask: noop,
+	replanGoal: noop,
+	submitForReview: noop,
+};
+
+// ─── createPlannerAgentInit ───────────────────────────────────────────────────
+
+describe('createPlannerAgentInit — provider routing', () => {
+	const baseConfig: PlannerAgentConfig = {
+		task: makeTask({ taskType: 'planning', status: 'in_progress' }),
+		goal: makeGoal(),
+		room: makeRoom(),
+		sessionId: 'session-1',
+		workspacePath: '/workspace',
+		createDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+		updateDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+		removeDraftTask: async () => true,
+	};
+
+	it('sets provider to undefined when not specified', () => {
+		const init = createPlannerAgentInit(baseConfig);
+		expect(init.provider).toBeUndefined();
+	});
+
+	it('passes explicit anthropic provider through to AgentSessionInit', () => {
+		const init = createPlannerAgentInit({ ...baseConfig, provider: 'anthropic' });
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('passes explicit anthropic-copilot provider through to AgentSessionInit', () => {
+		const init = createPlannerAgentInit({ ...baseConfig, provider: 'anthropic-copilot' });
+		expect(init.provider).toBe('anthropic-copilot');
+	});
+});
+
+// ─── createCoderAgentInit ─────────────────────────────────────────────────────
+
+describe('createCoderAgentInit — provider routing', () => {
+	const baseConfig: CoderAgentConfig = {
+		task: makeTask(),
+		goal: makeGoal(),
+		room: makeRoom(),
+		sessionId: 'session-2',
+		workspacePath: '/workspace',
+	};
+
+	it('sets provider to undefined when not specified', () => {
+		const init = createCoderAgentInit(baseConfig);
+		expect(init.provider).toBeUndefined();
+	});
+
+	it('passes explicit anthropic provider through to AgentSessionInit', () => {
+		const init = createCoderAgentInit({ ...baseConfig, provider: 'anthropic' });
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('passes explicit anthropic-copilot provider through to AgentSessionInit', () => {
+		const init = createCoderAgentInit({ ...baseConfig, provider: 'anthropic-copilot' });
+		expect(init.provider).toBe('anthropic-copilot');
+	});
+
+	it('passes explicit glm provider through to AgentSessionInit', () => {
+		const init = createCoderAgentInit({ ...baseConfig, provider: 'glm' });
+		expect(init.provider).toBe('glm');
+	});
+});
+
+// ─── createGeneralAgentInit ───────────────────────────────────────────────────
+
+describe('createGeneralAgentInit — provider routing', () => {
+	const baseConfig: GeneralAgentConfig = {
+		task: makeTask(),
+		goal: makeGoal(),
+		room: makeRoom(),
+		sessionId: 'session-3',
+		workspacePath: '/workspace',
+	};
+
+	it('sets provider to undefined when not specified', () => {
+		const init = createGeneralAgentInit(baseConfig);
+		expect(init.provider).toBeUndefined();
+	});
+
+	it('passes explicit anthropic provider through to AgentSessionInit', () => {
+		const init = createGeneralAgentInit({ ...baseConfig, provider: 'anthropic' });
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('passes explicit anthropic-copilot provider through to AgentSessionInit', () => {
+		const init = createGeneralAgentInit({ ...baseConfig, provider: 'anthropic-copilot' });
+		expect(init.provider).toBe('anthropic-copilot');
+	});
+});
+
+// ─── createLeaderAgentInit ────────────────────────────────────────────────────
+
+describe('createLeaderAgentInit — provider routing', () => {
+	const baseConfig: LeaderAgentConfig = {
+		task: makeTask(),
+		goal: makeGoal(),
+		room: makeRoom(),
+		sessionId: 'session-4',
+		workspacePath: '/workspace',
+		groupId: 'group-1',
+	};
+
+	it('sets provider to undefined when not specified', () => {
+		const init = createLeaderAgentInit(baseConfig, leaderCallbacks);
+		expect(init.provider).toBeUndefined();
+	});
+
+	it('passes explicit anthropic provider through to AgentSessionInit', () => {
+		const init = createLeaderAgentInit({ ...baseConfig, provider: 'anthropic' }, leaderCallbacks);
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('passes explicit anthropic-copilot provider through to AgentSessionInit', () => {
+		const init = createLeaderAgentInit(
+			{ ...baseConfig, provider: 'anthropic-copilot' },
+			leaderCallbacks
+		);
+		expect(init.provider).toBe('anthropic-copilot');
+	});
+
+	it('passes provider when leader has reviewer sub-agents configured', () => {
+		const roomWithReviewers = makeRoom({
+			config: {
+				agentSubagents: [{ model: 'claude-sonnet-4-5-20250929', role: 'reviewer' }],
+			},
+		});
+		const configWithReviewers: LeaderAgentConfig = {
+			...baseConfig,
+			room: roomWithReviewers,
+			provider: 'anthropic-copilot',
+		};
+		const init = createLeaderAgentInit(configWithReviewers, leaderCallbacks);
+		expect(init.provider).toBe('anthropic-copilot');
+	});
+});
+
+// ─── Provider consistency across agent types ──────────────────────────────────
+
+describe('Provider propagation — same provider is preserved across agent types', () => {
+	const copilotProvider = 'anthropic-copilot';
+	const copilotModel = 'claude-opus-4.6';
+
+	it('coder, general, and planner all receive the same provider', () => {
+		const task = makeTask();
+		const goal = makeGoal();
+		const room = makeRoom();
+
+		const baseArgs = {
+			task,
+			goal,
+			room,
+			sessionId: 'session-x',
+			workspacePath: '/workspace',
+			model: copilotModel,
+			provider: copilotProvider,
+		};
+
+		const coderInit = createCoderAgentInit(baseArgs);
+		const generalInit = createGeneralAgentInit(baseArgs);
+		const plannerInit = createPlannerAgentInit({
+			...baseArgs,
+			taskType: undefined,
+			createDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+			updateDraftTask: async () => ({ id: 'draft-1', title: 'Draft' }),
+			removeDraftTask: async () => true,
+		} as PlannerAgentConfig);
+
+		expect(coderInit.provider).toBe(copilotProvider);
+		expect(generalInit.provider).toBe(copilotProvider);
+		expect(plannerInit.provider).toBe(copilotProvider);
+	});
+
+	it('model is preserved alongside provider', () => {
+		const init = createCoderAgentInit({
+			task: makeTask(),
+			goal: makeGoal(),
+			room: makeRoom(),
+			sessionId: 'session-y',
+			workspacePath: '/workspace',
+			model: copilotModel,
+			provider: copilotProvider,
+		});
+
+		expect(init.model).toBe(copilotModel);
+		expect(init.provider).toBe(copilotProvider);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-provider-resolution.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-provider-resolution.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for RoomRuntime.resolveAgentModelWithProvider()
+ *
+ * Regression coverage for the bug where `claude-opus-4.6` resolved to
+ * `provider: 'anthropic-copilot'` instead of `'anthropic'`.
+ *
+ * The fix has two parts:
+ * 1. anthropic-provider.ts: isFullVersionId() now recognises dot-notation IDs
+ *    (claude-opus-4.6) so they are correctly deduplicated when the SDK also
+ *    returns the canonical 'opus' alias.
+ * 2. room-runtime.ts: resolveAgentModelWithProvider() falls back to the
+ *    registry's detectProvider() when the model is absent from the model cache,
+ *    ensuring 'claude-*' models always resolve to 'anthropic' rather than to
+ *    whichever provider happens to claim them first in the cache.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { clearModelsCache, setModelsCache } from '../../../src/lib/model-service';
+import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
+import type { ModelInfo } from '@neokai/shared';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeModelInfo(
+	overrides: Partial<ModelInfo> & Pick<ModelInfo, 'id' | 'provider'>
+): ModelInfo {
+	return {
+		name: overrides.id,
+		alias: overrides.id,
+		family: 'opus',
+		contextWindow: 200000,
+		description: '',
+		releaseDate: '',
+		available: true,
+		...overrides,
+	};
+}
+
+function setTestModelsCache(models: ModelInfo[]): void {
+	const cache = new Map<string, ModelInfo[]>();
+	cache.set('global', models);
+	setModelsCache(cache);
+}
+
+async function spawnTask(ctx: RuntimeTestContext) {
+	const goal = await ctx.goalManager.createGoal({
+		title: 'Test goal',
+		description: 'desc',
+		status: 'active',
+		priority: 'normal',
+		linkedTaskIds: [],
+	});
+	await ctx.taskManager.createTask({
+		title: 'Test task',
+		description: 'desc',
+		status: 'pending',
+		priority: 'normal',
+		goalId: goal.id,
+	});
+	ctx.runtime.start();
+	await ctx.runtime.tick();
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('RoomRuntime.resolveAgentModelWithProvider — model cache lookup', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		clearModelsCache();
+	});
+
+	afterEach(() => {
+		ctx?.runtime.stop();
+		ctx?.db.close();
+		clearModelsCache();
+	});
+
+	it('resolves provider from cache — Anthropic entry found first for claude-opus-4.6', async () => {
+		// Both Anthropic and Copilot have the same model ID in cache.
+		// Anthropic's entry is first (providers are registered/loaded in that order).
+		setTestModelsCache([
+			makeModelInfo({ id: 'claude-opus-4.6', provider: 'anthropic' }),
+			makeModelInfo({ id: 'claude-opus-4.6', provider: 'anthropic-copilot' }),
+		]);
+
+		ctx = createRuntimeTestContext({
+			room: { defaultModel: 'claude-opus-4.6' },
+		});
+
+		await spawnTask(ctx);
+
+		const leaderCall = ctx.sessionFactory.calls.find(
+			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+		);
+		expect(leaderCall).toBeDefined();
+		const leaderInit = leaderCall!.args[0] as { provider?: string };
+		// First match in cache is Anthropic's entry → routes to anthropic
+		expect(leaderInit.provider).toBe('anthropic');
+	});
+
+	it('falls back to undefined provider when model is absent from cache', async () => {
+		// Cache has no entry for 'claude-opus-4.6'.
+		// In unit tests the provider registry is empty (setup.ts resets it),
+		// so detectProvider() returns undefined. The important thing is that the
+		// code reaches the fallback path rather than crashing.
+		setTestModelsCache([
+			makeModelInfo({ id: 'opus', provider: 'anthropic' }),
+			makeModelInfo({ id: 'sonnet', provider: 'anthropic' }),
+		]);
+
+		ctx = createRuntimeTestContext({
+			room: { defaultModel: 'claude-opus-4.6' },
+		});
+
+		await spawnTask(ctx);
+
+		const leaderCall = ctx.sessionFactory.calls.find(
+			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+		);
+		expect(leaderCall).toBeDefined();
+		// In unit tests, registry is empty → detectProvider returns undefined.
+		// The spawn still succeeds (provider is optional in AgentSessionInit).
+		const leaderInit = leaderCall!.args[0] as { provider?: string };
+		expect(leaderInit.provider).toBeUndefined();
+	});
+
+	it('resolves anthropic-copilot when only Copilot has the model in cache', async () => {
+		// Only Copilot has 'claude-opus-4.6' in cache → should route to copilot
+		setTestModelsCache([
+			makeModelInfo({ id: 'opus', provider: 'anthropic' }),
+			makeModelInfo({ id: 'claude-opus-4.6', provider: 'anthropic-copilot' }),
+		]);
+
+		ctx = createRuntimeTestContext({
+			room: { defaultModel: 'claude-opus-4.6' },
+		});
+
+		await spawnTask(ctx);
+
+		const leaderCall = ctx.sessionFactory.calls.find(
+			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+		);
+		expect(leaderCall).toBeDefined();
+		const leaderInit = leaderCall!.args[0] as { provider?: string };
+		expect(leaderInit.provider).toBe('anthropic-copilot');
+	});
+
+	it('resolves anthropic for canonical opus model', async () => {
+		setTestModelsCache([makeModelInfo({ id: 'opus', provider: 'anthropic' })]);
+
+		ctx = createRuntimeTestContext({
+			room: { defaultModel: 'opus' },
+		});
+
+		await spawnTask(ctx);
+
+		const leaderCall = ctx.sessionFactory.calls.find(
+			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
+		);
+		expect(leaderCall).toBeDefined();
+		const leaderInit = leaderCall!.args[0] as { provider?: string };
+		expect(leaderInit.provider).toBe('anthropic');
+	});
+
+	it('provider propagates to both worker and leader sessions', async () => {
+		setTestModelsCache([makeModelInfo({ id: 'claude-opus-4.6', provider: 'anthropic' })]);
+
+		ctx = createRuntimeTestContext({
+			room: {
+				defaultModel: 'claude-opus-4.6',
+				config: {
+					agentModels: {
+						leader: 'claude-opus-4.6',
+						coder: 'claude-opus-4.6',
+					},
+				},
+			},
+		});
+
+		await spawnTask(ctx);
+
+		const sessionInits = ctx.sessionFactory.calls
+			.filter((c) => c.method === 'createAndStartSession')
+			.map((c) => c.args[0] as { provider?: string });
+
+		expect(sessionInits.length).toBeGreaterThanOrEqual(2); // at least worker + leader
+		for (const init of sessionInits) {
+			expect(init.provider).toBe('anthropic');
+		}
+	});
+});


### PR DESCRIPTION
Root cause: AgentSessionInit was missing a `provider` field, so all
room-spawned sessions (leader, coder, general, planner) had
session.config.provider = undefined. query-runner.ts then fell back to
the deprecated detectProvider() heuristic which iterates providers in
registration order and returns Anthropic first for any claude-* model —
misrouting Copilot-targeted sessions to Anthropic.

Fix: Thread the provider resolved from the global model cache through
the full creation chain:
  resolveAgentModelWithProvider() → TaskGroupManager._provider →
  AgentSessionConfig.provider → AgentSessionInit.provider →
  createSessionFromInit → session.config.provider

Changes:
- AgentSessionInit: add provider?: string field
- createSessionFromInit: pass init.provider into SessionConfig
- LeaderAgentConfig / CoderAgentConfig / GeneralAgentConfig /
  PlannerAgentConfig: add provider?: string field
- createLeaderAgentInit, createCoderAgentInit, createGeneralAgentInit,
  createPlannerAgentInit: pass config.provider into AgentSessionInit
- TaskGroupManager: add _provider field, provider getter, update
  updateModel(model, provider?) to set both
- room-runtime.ts: use resolveAgentModelWithProvider() when building
  planner/worker/leader configs in spawnPlanningGroup and spawnGroupForTask
