### PR TITLE
feat: Button/IconButton/NavIconButton unification (Task 2.1)

### DIFF
--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -1,9 +1,16 @@
 import { ComponentChildren, JSX } from 'preact';
 import { cn } from '../../lib/utils.ts';
-import { borderColors } from '../../lib/design-tokens.ts';
+import { borderColors, tokens } from '../../lib/design-tokens.ts';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonVariant =
+	| 'primary'
+	| 'secondary'
+	| 'ghost'
+	| 'danger'
+	| 'warning'
+	| 'approve'
+	| 'interrupt';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ButtonProps
 	extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'size' | 'loading' | 'icon'> {
@@ -32,8 +39,11 @@ export function Button({
 	icon,
 	...rest
 }: ButtonProps) {
-	const baseStyles =
-		'inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-dark-950 disabled:opacity-50 disabled:cursor-not-allowed';
+	const baseStyles = cn(
+		'inline-flex items-center justify-center gap-2 rounded-lg font-medium',
+		tokens.transition.quick,
+		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-dark-950 disabled:opacity-50 disabled:cursor-not-allowed'
+	);
 
 	const variants = {
 		primary: 'bg-blue-600 hover:bg-blue-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
@@ -42,9 +52,14 @@ export function Button({
 		danger: 'bg-red-600 hover:bg-red-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
 		warning:
 			'bg-yellow-600 hover:bg-yellow-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
+		approve:
+			'bg-emerald-600 hover:bg-emerald-700 text-white shadow-sm hover:shadow active:scale-[0.98]',
+		interrupt:
+			'border border-amber-500 text-amber-500 bg-transparent hover:bg-amber-500/10 active:scale-[0.98]',
 	};
 
 	const sizes = {
+		xs: 'h-6 px-2 text-xs',
 		sm: 'text-sm px-3 py-1.5',
 		md: 'text-sm px-4 py-2',
 		lg: 'text-base px-6 py-3',

--- a/packages/web/src/components/ui/IconButton.tsx
+++ b/packages/web/src/components/ui/IconButton.tsx
@@ -6,7 +6,8 @@ export interface IconButtonProps {
 	onClick?: () => void;
 	disabled?: boolean;
 	size?: 'sm' | 'md' | 'lg';
-	variant?: 'ghost' | 'solid';
+	variant?: 'ghost' | 'solid' | 'default' | 'danger';
+	active?: boolean;
 	class?: string;
 	title?: string;
 	type?: 'button' | 'submit' | 'reset';
@@ -18,16 +19,19 @@ export function IconButton({
 	disabled = false,
 	size = 'md',
 	variant = 'ghost',
+	active = false,
 	class: className,
 	title,
 	type = 'button',
 }: IconButtonProps) {
 	const baseStyles =
-		'inline-flex items-center justify-center rounded-lg transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-dark-950 disabled:opacity-50 disabled:cursor-not-allowed';
+		'inline-flex items-center justify-center rounded-lg transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-dark-950 disabled:opacity-50 disabled:cursor-not-allowed';
 
 	const variants = {
 		ghost: 'hover:bg-dark-800 text-gray-400 hover:text-gray-100',
 		solid: 'bg-dark-800 hover:bg-dark-700 text-gray-300 hover:text-gray-100',
+		default: 'bg-dark-800 hover:bg-dark-700 text-gray-300 hover:text-gray-100',
+		danger: 'hover:bg-red-500/10 text-red-400 hover:text-red-300',
 	};
 
 	const sizes = {
@@ -36,6 +40,8 @@ export function IconButton({
 		lg: 'p-3',
 	};
 
+	const activeStyles = active ? 'bg-indigo-500/20 text-indigo-400' : '';
+
 	return (
 		<button
 			type={type}
@@ -43,7 +49,7 @@ export function IconButton({
 			disabled={disabled}
 			title={title}
 			aria-label={title}
-			class={cn(baseStyles, variants[variant], sizes[size], className)}
+			class={cn(baseStyles, variants[variant], sizes[size], activeStyles, className)}
 		>
 			{children}
 		</button>

--- a/packages/web/src/components/ui/NavIconButton.tsx
+++ b/packages/web/src/components/ui/NavIconButton.tsx
@@ -1,5 +1,6 @@
 import { ComponentChildren } from 'preact';
 import { cn } from '../../lib/utils.ts';
+import { tokens } from '../../lib/design-tokens.ts';
 
 export interface NavIconButtonProps {
 	children: ComponentChildren;
@@ -27,12 +28,13 @@ export function NavIconButton({
 			aria-label={label}
 			aria-pressed={active}
 			class={cn(
-				'w-12 h-12 flex items-center justify-center rounded-xl transition-all duration-150',
+				'w-10 h-10 flex items-center justify-center rounded-xl',
+				tokens.transition.quick,
 				'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
 				'disabled:opacity-40 disabled:cursor-not-allowed',
 				active
-					? 'bg-dark-800 text-gray-100'
-					: 'text-gray-400 hover:text-gray-200 hover:bg-dark-850',
+					? 'bg-indigo-500/20 text-indigo-400'
+					: 'text-gray-500 hover:text-gray-300 hover:bg-white/5',
 				className
 			)}
 		>

--- a/packages/web/src/components/ui/__tests__/Button.test.tsx
+++ b/packages/web/src/components/ui/__tests__/Button.test.tsx
@@ -54,6 +54,21 @@ describe('Button', () => {
 			const button = container.querySelector('button');
 			expect(button?.className).toContain('bg-red-600');
 		});
+
+		it('should render approve variant with emerald background', () => {
+			const { container } = render(<Button variant="approve">Approve</Button>);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('bg-emerald-600');
+			expect(button?.className).toContain('hover:bg-emerald-700');
+			expect(button?.className).toContain('text-white');
+		});
+
+		it('should render interrupt variant with amber outline', () => {
+			const { container } = render(<Button variant="interrupt">Interrupt</Button>);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('border-amber-500');
+			expect(button?.className).toContain('text-amber-500');
+		});
 	});
 
 	describe('Sizes', () => {
@@ -61,6 +76,14 @@ describe('Button', () => {
 			const { container } = render(<Button>Medium</Button>);
 			const button = container.querySelector('button');
 			expect(button?.className).toContain('px-4');
+		});
+
+		it('should render xs size', () => {
+			const { container } = render(<Button size="xs">XSmall</Button>);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('h-6');
+			expect(button?.className).toContain('px-2');
+			expect(button?.className).toContain('text-xs');
 		});
 
 		it('should render small size', () => {
@@ -206,6 +229,16 @@ describe('Button', () => {
 			const { container } = render(<Button disabled>Disabled</Button>);
 			const button = container.querySelector('button');
 			expect(button?.className).toContain('disabled:cursor-not-allowed');
+		});
+	});
+
+	describe('Transition', () => {
+		it('should use quick transition from design tokens', () => {
+			const { container } = render(<Button>Transition</Button>);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('transition-all');
+			expect(button?.className).toContain('duration-150');
+			expect(button?.className).toContain('ease-out');
 		});
 	});
 });

--- a/packages/web/src/components/ui/__tests__/IconButton.test.tsx
+++ b/packages/web/src/components/ui/__tests__/IconButton.test.tsx
@@ -60,6 +60,50 @@ describe('IconButton', () => {
 			const button = container.querySelector('button');
 			expect(button?.className).toContain('bg-dark-800');
 		});
+
+		it('should render default variant', () => {
+			const { container } = render(
+				<IconButton variant="default">
+					<span>Icon</span>
+				</IconButton>
+			);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('bg-dark-800');
+		});
+
+		it('should render danger variant', () => {
+			const { container } = render(
+				<IconButton variant="danger">
+					<span>Icon</span>
+				</IconButton>
+			);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('text-red-400');
+			expect(button?.className).toContain('hover:bg-red-500/10');
+		});
+	});
+
+	describe('Active State', () => {
+		it('should not be active by default', () => {
+			const { container } = render(
+				<IconButton>
+					<span>Icon</span>
+				</IconButton>
+			);
+			const button = container.querySelector('button');
+			expect(button?.className).not.toContain('bg-indigo-500/20');
+		});
+
+		it('should apply accent styles when active', () => {
+			const { container } = render(
+				<IconButton active>
+					<span>Icon</span>
+				</IconButton>
+			);
+			const button = container.querySelector('button');
+			expect(button?.className).toContain('bg-indigo-500/20');
+			expect(button?.className).toContain('text-indigo-400');
+		});
 	});
 
 	describe('Sizes', () => {

--- a/packages/web/src/components/ui/__tests__/NavIconButton.test.tsx
+++ b/packages/web/src/components/ui/__tests__/NavIconButton.test.tsx
@@ -78,8 +78,8 @@ describe('NavIconButton', () => {
 				</NavIconButton>
 			);
 			const button = container.querySelector('button');
-			expect(button?.className).toContain('bg-dark-800');
-			expect(button?.className).toContain('text-gray-100');
+			expect(button?.className).toContain('bg-indigo-500/20');
+			expect(button?.className).toContain('text-indigo-400');
 		});
 
 		it('should apply inactive CSS classes when not active', () => {
@@ -89,9 +89,9 @@ describe('NavIconButton', () => {
 				</NavIconButton>
 			);
 			const button = container.querySelector('button');
-			expect(button?.className).toContain('text-gray-400');
-			expect(button?.className).toContain('hover:text-gray-200');
-			expect(button?.className).toContain('hover:bg-dark-850');
+			expect(button?.className).toContain('text-gray-500');
+			expect(button?.className).toContain('hover:text-gray-300');
+			expect(button?.className).toContain('hover:bg-white/5');
 		});
 
 		it('should apply inactive CSS classes by default', () => {
@@ -101,7 +101,7 @@ describe('NavIconButton', () => {
 				</NavIconButton>
 			);
 			const button = container.querySelector('button');
-			expect(button?.className).toContain('text-gray-400');
+			expect(button?.className).toContain('text-gray-500');
 		});
 	});
 
@@ -224,8 +224,8 @@ describe('NavIconButton', () => {
 				</NavIconButton>
 			);
 			const button = container.querySelector('button');
-			expect(button?.className).toContain('w-12');
-			expect(button?.className).toContain('h-12');
+			expect(button?.className).toContain('w-10');
+			expect(button?.className).toContain('h-10');
 		});
 
 		it('should have rounded corners', () => {


### PR DESCRIPTION
- Button: add 'approve' (emerald-600) and 'interrupt' (amber-500 outline) variants, 'xs' size (h-6 px-2 text-xs), use tokens.transition.quick
- IconButton: add 'default' and 'danger' variants, add 'active' prop using accent token (bg-indigo-500/20 text-indigo-400)
- NavIconButton: resize to 40×40px, update active state to bg-indigo-500/20 text-indigo-400, inactive to text-gray-500 hover:text-gray-300 hover:bg-white/5, use tokens.transition.quick
- Tests: add coverage for new variants, sizes, and active states

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
