### PR TITLE
fix: codex bridge 409 conflict on subprocess crash

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -272,6 +272,12 @@ export async function drainToSSE(
 			session.kill();
 			return;
 		}
+		// Ensure cleanup runs for any error that escapes the drain loop.
+		// This is critical when startTurn throws due to subprocess crash —
+		// without calling onError, turnInProgress stays true and the session
+		// is never deleted, causing subsequent requests to get 409 conflicts.
+		onError?.();
+		session.kill();
 		throw error;
 	}
 }


### PR DESCRIPTION
## Summary
- Fix 409 conflict errors when Codex subprocess crashes during `startTurn`
- When `startTurn` throws due to subprocess crash, `onError` was not being called
- This left `turnInProgress` true and the session never deleted
- Subsequent requests would get 409 conflicts from the stuck session

## Root Cause
In `drainToSSE`, errors escaping the drain loop (that weren't `isClosedControllerError`) did not call `onError?.()` before throwing. When the subprocess crashes, `startTurn` throws, and the error propagated without cleanup.

## Fix
Added `onError?.()` and `session.kill()` before re-throwing the error in the catch block.

## Test plan
- [ ] Verify codex bridge provider with gpt-5.3-codex model no longer gets 409 conflicts after subprocess crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)