### PR TITLE
fix: clear stale sdkSessionId when SDK session file no longer exists

### DIFF
--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -164,8 +164,21 @@ export class QueryLifecycleManager {
 			// Validate and repair SDK session file before restarting.
 			// The interrupted query may have left the session file in an inconsistent state
 			// (e.g., orphaned tool_results from interrupted SDK context compaction).
+			// Also detects stale sdkSessionId when the session file no longer exists.
 			if (session.sdkSessionId) {
-				validateAndRepairSDKSession(session.workspacePath, session.sdkSessionId, session.id, db);
+				const isValid = validateAndRepairSDKSession(
+					session.workspacePath,
+					session.sdkSessionId,
+					session.id,
+					db
+				);
+				if (!isValid) {
+					this.logger.warn(
+						`SDK session file missing for ${session.sdkSessionId}, clearing sdkSessionId to start fresh`
+					);
+					session.sdkSessionId = undefined;
+					db.updateSession(session.id, { sdkSessionId: undefined });
+				}
 			}
 
 			await this.ctx.startStreamingQuery();
@@ -237,8 +250,21 @@ export class QueryLifecycleManager {
 				// Validate and repair SDK session file before restarting.
 				// The interrupted query may have left the session file in an inconsistent state
 				// (e.g., orphaned tool_results from interrupted SDK context compaction).
+				// Also detects stale sdkSessionId when the session file no longer exists.
 				if (session.sdkSessionId) {
-					validateAndRepairSDKSession(session.workspacePath, session.sdkSessionId, session.id, db);
+					const isValid = validateAndRepairSDKSession(
+						session.workspacePath,
+						session.sdkSessionId,
+						session.id,
+						db
+					);
+					if (!isValid) {
+						this.logger.warn(
+							`SDK session file missing for ${session.sdkSessionId}, clearing sdkSessionId to start fresh`
+						);
+						session.sdkSessionId = undefined;
+						db.updateSession(session.id, { sdkSessionId: undefined });
+					}
 				}
 
 				await this.ctx.startStreamingQuery();
@@ -284,7 +310,19 @@ export class QueryLifecycleManager {
 
 		// Validate SDK session file
 		if (session.sdkSessionId) {
-			validateAndRepairSDKSession(session.workspacePath, session.sdkSessionId, session.id, db);
+			const isValid = validateAndRepairSDKSession(
+				session.workspacePath,
+				session.sdkSessionId,
+				session.id,
+				db
+			);
+			if (!isValid) {
+				this.logger.warn(
+					`SDK session file missing for ${session.sdkSessionId}, clearing sdkSessionId to start fresh`
+				);
+				session.sdkSessionId = undefined;
+				db.updateSession(session.id, { sdkSessionId: undefined });
+			}
 		}
 
 		await this.ctx.startStreamingQuery();

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -320,18 +320,24 @@ export class QueryRunner {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			const isAbortError = error instanceof Error && error.name === 'AbortError';
 			const isStartupTimeout = errorMessage.includes('SDK startup timeout');
+			const isConversationNotFound = errorMessage.includes('No conversation found');
 
 			// Preserve queued messages for transparent retry when auto-recovery is
-			// registered (startup timeout + provider switch).  In all other cases,
-			// clear the queue so stale messages don't bleed into the next session.
-			if (!isStartupTimeout || isAbortError || !this.ctx.onStartupTimeoutAutoRecover) {
+			// registered (startup timeout / conversation not found + provider switch).
+			// In all other cases, clear the queue so stale messages don't bleed
+			// into the next session.
+			if (
+				!(isStartupTimeout || isConversationNotFound) ||
+				isAbortError ||
+				!this.ctx.onStartupTimeoutAutoRecover
+			) {
 				messageQueue.clear();
 			}
 
-			// If startup timed out while trying to resume a session, clear sdkSessionId
-			// so the next attempt (Reset Agent, or sending a message) starts a fresh SDK
-			// session instead of repeatedly failing on the same problematic session file.
-			if (isStartupTimeout && session.sdkSessionId) {
+			// If startup timed out or conversation not found while trying to resume a session,
+			// clear sdkSessionId so the next attempt starts a fresh SDK session instead of
+			// repeatedly failing on the same problematic session file.
+			if ((isStartupTimeout || isConversationNotFound) && session.sdkSessionId) {
 				logger.error(
 					`Clearing sdkSessionId (${session.sdkSessionId}) due to startup timeout. ` +
 						'Next query will start fresh without resume.'
@@ -341,15 +347,15 @@ export class QueryRunner {
 			}
 
 			if (!isAbortError) {
-				// On startup timeout, attempt transparent auto-recovery (up to 1 retry):
-				// restart the query without the old resume handle (sdkSessionId already
-				// cleared above).  Queued messages are preserved so the user's pending
-				// send is retried automatically without any visible error.
+				// On startup timeout or conversation not found, attempt transparent auto-recovery
+				// (up to 1 retry): restart the query without the old resume handle
+				// (sdkSessionId already cleared above). Queued messages are preserved so
+				// the user's pending send is retried automatically without any visible error.
 				// The retry limit (attempts <= 1) prevents infinite loops when the SDK is
 				// permanently broken: after 1 failed recovery, the error surfaces normally.
 				const startupRecoverAttempts = this.ctx.startupTimeoutAutoRecoverAttempts + 1;
 				const canAutoRecover =
-					isStartupTimeout &&
+					(isStartupTimeout || isConversationNotFound) &&
 					!this.ctx.isCleaningUp() &&
 					!!this.ctx.onStartupTimeoutAutoRecover &&
 					startupRecoverAttempts <= 1;
@@ -357,7 +363,7 @@ export class QueryRunner {
 				if (canAutoRecover) {
 					this.ctx.startupTimeoutAutoRecoverAttempts = startupRecoverAttempts;
 					logger.warn(
-						`SDK startup timeout — scheduling auto-recovery attempt ${startupRecoverAttempts} (fresh query without resume)`
+						`SDK ${isConversationNotFound ? 'conversation not found' : 'startup timeout'} — scheduling auto-recovery attempt ${startupRecoverAttempts} (fresh query without resume)`
 					);
 					// Defer until after finally{} completes so shared state is reset first.
 					setTimeout(() => {
@@ -368,7 +374,7 @@ export class QueryRunner {
 					// setIdle is handled by the finally block; skipping here avoids a double call.
 				} else {
 					// Reset counter so a future successfully-started session can recover again.
-					if (isStartupTimeout) {
+					if (isStartupTimeout || isConversationNotFound) {
 						this.ctx.startupTimeoutAutoRecoverAttempts = 0;
 					}
 					const apiErrorHandled = await this.handleApiValidationError(error);

--- a/packages/daemon/src/lib/sdk-session-file-manager.ts
+++ b/packages/daemon/src/lib/sdk-session-file-manager.ts
@@ -502,6 +502,15 @@ export function validateAndRepairSDKSession(
 	kaiSessionId: string,
 	db: Database
 ): boolean {
+	// If the SDK session file doesn't exist, the session can't be resumed.
+	// This happens when the file was deleted externally (cleanup, manual deletion,
+	// workspace path change). Return false so the caller clears sdkSessionId
+	// and starts a fresh query without resume.
+	const sessionFile = getSDKSessionFilePath(workspacePath, sdkSessionId);
+	if (!existsSync(sessionFile)) {
+		return false;
+	}
+
 	// First validate
 	const validation = validateSDKSessionFile(workspacePath, sdkSessionId);
 


### PR DESCRIPTION
## Summary

- Fix "No conversation found with session ID" error by detecting when the SDK session file has been deleted externally and clearing the stale `sdkSessionId` before it's passed to the SDK's `readMessages`
- Extend existing auto-recovery logic in QueryRunner to handle "No conversation found" errors the same way as startup timeouts — one transparent retry with a fresh session

## Test plan

- [ ] Verify that deleting an SDK session file while a session is active no longer causes cascading "No conversation found" errors
- [ ] Confirm auto-recovery kicks in: sending a message after the session file disappears starts a fresh SDK session transparently
- [ ] Verify slash commands fetch correctly after recovery instead of looping with "Query closed before response received"
- [ ] Run `make test-daemon` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)