### PR TITLE
feat: display API retry errors in UI during SDK retry attempts

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -468,15 +468,24 @@ export class SDKMessageHandler {
 			return;
 		}
 
-		// Suppress API retry messages: log at daemon level but do not save to DB or broadcast.
+		// Handle API retry messages: emit event for UI to display retry progress, but do not save to DB.
 		// These carry operational metadata (attempt count, delay, error) that is useful for
-		// debugging but should not appear in the transcript or accumulate in the database.
+		// debugging and user feedback but should not appear in the transcript.
 		if (isSDKAPIRetryMessage(message)) {
 			this.logger.warn(
 				`API retry: attempt ${message.attempt}/${message.max_retries}, ` +
 					`delay ${message.retry_delay_ms}ms, status ${message.error_status ?? 'n/a'}, ` +
 					`error ${message.error}`
 			);
+			// Emit event for UI to show retry progress
+			await this.ctx.daemonHub.emit('session.retryAttempt', {
+				sessionId: session.id,
+				attempt: message.attempt,
+				max_retries: message.max_retries,
+				delay_ms: message.retry_delay_ms,
+				error_status: message.error_status,
+				error: message.error,
+			});
 			return;
 		}
 

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -86,6 +86,16 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	'session.error': { sessionId: string; error: string; details?: unknown };
 	'session.errorClear': { sessionId: string };
 
+	// API retry events
+	'session.retryAttempt': {
+		sessionId: string;
+		attempt: number;
+		max_retries: number;
+		delay_ms: number;
+		error_status: number | null;
+		error: string;
+	};
+
 	// Message events
 	'message.sent': { sessionId: string };
 

--- a/packages/shared/src/event-bus.ts
+++ b/packages/shared/src/event-bus.ts
@@ -90,6 +90,16 @@ export interface EventMap {
 	'session:error': { sessionId: string; error: string; details?: unknown };
 	'session:error:clear': { sessionId: string };
 
+	// API retry events - emitted when SDK retries on server_error
+	'session:retry:attempt': {
+		sessionId: string;
+		attempt: number;
+		max_retries: number;
+		delay_ms: number;
+		error_status: number | null;
+		error: string;
+	};
+
 	// Message events - emitted when user sends a message
 	'message:sent': { sessionId: string };
 

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -774,8 +774,20 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 		return { currentAction: undefined, streamingPhase: null };
 	}, [agentState, messages]);
 
-	// Combined error (local + store)
-	const error = localError || storeError?.message || null;
+	// Get retry attempts from session store
+	const retryAttempts = sessionStore.retryAttempts.value;
+
+	// Build retry status message if there are retry attempts
+	const retryStatusMessage = useMemo(() => {
+		if (retryAttempts.length === 0) return null;
+		const lastRetry = retryAttempts[retryAttempts.length - 1];
+		const progress = `${lastRetry.attempt}/${lastRetry.max_retries}`;
+		const errorInfo = lastRetry.error_status ? ` (${lastRetry.error_status})` : '';
+		return `API retry: attempt ${progress}${errorInfo} - ${lastRetry.error}`;
+	}, [retryAttempts]);
+
+	// Combined error (local + store + retry status)
+	const error = localError || retryStatusMessage || storeError?.message || null;
 
 	// Build provider-specific action buttons for structured errors
 	const errorDetails = storeError?.details as StructuredError | undefined;

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -44,6 +44,18 @@ class SessionStore {
 	/** SDK messages from state.sdkMessages channel */
 	readonly sdkMessages = signal<SDKMessage[]>([]);
 
+	/** API retry attempts (populated from session.retryAttempt events) */
+	readonly retryAttempts = signal<
+		Array<{
+			attempt: number;
+			max_retries: number;
+			delay_ms: number;
+			error_status: number | null;
+			error: string;
+			occurredAt: number;
+		}>
+	>([]);
+
 	// ========================================
 	// Computed Accessors
 	// ========================================
@@ -164,6 +176,7 @@ class SessionStore {
 		// 2. Clear state
 		this.sessionState.value = null;
 		this.sdkMessages.value = [];
+		this.retryAttempts.value = []; // Clear retry attempts on session switch
 		this._initialMessageCount.value = 0;
 		this._hasMoreMessages.value = false;
 		this._contextInfo.value = null; // Clear context info on session switch
@@ -270,7 +283,33 @@ class SessionStore {
 			});
 			this.cleanupFunctions.push(unsubSDKMessagesDelta);
 
-			// 3. Fetch initial state via RPC (pure WebSocket - no REST API)
+			// 3. API retry attempt events (from SDK retry handling)
+			const unsubRetryAttempt = hub.onEvent<{
+				sessionId: string;
+				attempt: number;
+				max_retries: number;
+				delay_ms: number;
+				error_status: number | null;
+				error: string;
+			}>('session.retryAttempt', (retryInfo) => {
+				// Only handle events for the current session
+				if (retryInfo.sessionId !== sessionId) return;
+				// Append retry attempt to the list
+				this.retryAttempts.value = [
+					...this.retryAttempts.value,
+					{
+						attempt: retryInfo.attempt,
+						max_retries: retryInfo.max_retries,
+						delay_ms: retryInfo.delay_ms,
+						error_status: retryInfo.error_status,
+						error: retryInfo.error,
+						occurredAt: Date.now(),
+					},
+				];
+			});
+			this.cleanupFunctions.push(unsubRetryAttempt);
+
+			// 4. Fetch initial state via RPC (pure WebSocket - no REST API)
 			// This replaces the old REST API calls and state.sdkMessages subscription
 			await this.fetchInitialState(hub, sessionId);
 		} catch (err) {
@@ -494,6 +533,8 @@ class SessionStore {
 				error: null,
 			};
 		}
+		// Also clear retry attempts when error is dismissed
+		this.retryAttempts.value = [];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Emit `session.retryAttempt` events when SDK retries on `server_error` instead of only logging
- Surface retry progress in ChatContainer as an error block, giving users visibility into ongoing retries
- Multiple retry attempts accumulate in `sessionStore.retryAttempts` signal

## Changes

- **packages/shared/src/event-bus.ts**: Added `session:retry:attempt` event type
- **packages/daemon/src/lib/daemon-hub.ts**: Added `session.retryAttempt` event
- **packages/daemon/src/lib/agent/sdk-message-handler.ts**: Emit `session.retryAttempt` event on API retry
- **packages/web/src/lib/session-store.ts**: Track retry attempts in `retryAttempts` signal
- **packages/web/src/islands/ChatContainer.tsx**: Display retry status in error area

## Test plan

- [ ] Trigger an API retry scenario and verify retry attempts appear in UI error block
- [ ] Verify retry attempts clear when session switches or error is dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)