### PR TITLE
fix: display Copilot quota errors as UI error blocks and stop retrying

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -420,7 +420,14 @@ export class QueryRunner {
 							errorMessage.includes('ENOTFOUND')
 						) {
 							category = ErrorCategory.CONNECTION;
-						} else if (errorMessage.includes('429') || errorMessage.includes('rate limit')) {
+						} else if (
+							errorMessage.includes('429') ||
+							errorMessage.includes('rate limit') ||
+							errorMessage.includes('402') ||
+							errorMessage.toLowerCase().includes('no quota') ||
+							errorMessage.toLowerCase().includes('quota exceeded') ||
+							errorMessage.toLowerCase().includes('insufficient_quota')
+						) {
 							category = ErrorCategory.RATE_LIMIT;
 						} else if (errorMessage.includes('timeout')) {
 							category = ErrorCategory.TIMEOUT;
@@ -614,29 +621,63 @@ export class QueryRunner {
 		try {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 
+			// JSON-body 4xx (standard Anthropic API errors: "402 {...}")
 			const apiErrorMatch = errorMessage.match(/^(4\d{2})\s+(\{.+\})$/s);
-			if (!apiErrorMatch) {
-				return false;
+			if (apiErrorMatch) {
+				const [, statusCode, jsonBody] = apiErrorMatch;
+
+				let errorBody: { type?: string; error?: { type?: string; message?: string } };
+				try {
+					errorBody = JSON.parse(jsonBody);
+				} catch {
+					return false;
+				}
+
+				const apiErrorMessage = errorBody.error?.message || errorMessage;
+				const apiErrorType = errorBody.error?.type || 'api_error';
+
+				await this.displayErrorAsAssistantMessage(
+					`**API Error (${statusCode})**: ${apiErrorType}\n\n${apiErrorMessage}\n\nThis error occurred while processing your request. Please review the error message above and adjust your request accordingly.`,
+					{ markAsError: true }
+				);
+
+				return true;
 			}
 
-			const [, statusCode, jsonBody] = apiErrorMatch;
+			// Plain-text 4xx (e.g. Copilot returns "402 You have no quota (Request ID: ...)")
+			const plainErrorMatch = errorMessage.match(/^(4\d{2})\s+(.+)$/s);
+			if (plainErrorMatch) {
+				const [, statusCode, plainMessage] = plainErrorMatch;
+				await this.displayErrorAsAssistantMessage(
+					`**API Error (${statusCode})**: ${plainMessage.trim()}\n\nThis error occurred while processing your request.`,
+					{ markAsError: true }
+				);
+				return true;
+			}
 
-			let errorBody: { type?: string; error?: { type?: string; message?: string } };
+			// JSON SSE error event (e.g. from Copilot bridge: {"type":"error","error":{"type":"api_error","message":"402 You have no quota ..."}})
 			try {
-				errorBody = JSON.parse(jsonBody);
+				const parsed = JSON.parse(errorMessage) as {
+					type?: string;
+					error?: { type?: string; message?: string };
+				};
+				const innerMessage = parsed?.error?.message;
+				if (typeof innerMessage === 'string') {
+					const innerMatch = innerMessage.match(/^(4\d{2})\s+(.+)$/s);
+					if (innerMatch) {
+						const [, statusCode, plainMessage] = innerMatch;
+						await this.displayErrorAsAssistantMessage(
+							`**API Error (${statusCode})**: ${plainMessage.trim()}\n\nThis error occurred while processing your request.`,
+							{ markAsError: true }
+						);
+						return true;
+					}
+				}
 			} catch {
-				return false;
+				// not JSON
 			}
 
-			const apiErrorMessage = errorBody.error?.message || errorMessage;
-			const apiErrorType = errorBody.error?.type || 'api_error';
-
-			await this.displayErrorAsAssistantMessage(
-				`**API Error (${statusCode})**: ${apiErrorType}\n\n${apiErrorMessage}\n\nThis error occurred while processing your request. Please review the error message above and adjust your request accordingly.`,
-				{ markAsError: true }
-			);
-
-			return true;
+			return false;
 		} catch (err) {
 			logger.warn('Failed to handle API validation error:', err);
 			return false;

--- a/packages/daemon/src/lib/error-manager.ts
+++ b/packages/daemon/src/lib/error-manager.ts
@@ -151,7 +151,12 @@ export class ErrorManager {
 		if (message.includes('ENOTFOUND') || message.includes('EHOSTUNREACH')) {
 			return 'HOST_UNREACHABLE';
 		}
-		if (message.includes('insufficient_quota') || message.includes('quota exceeded')) {
+		if (
+			message.includes('insufficient_quota') ||
+			message.includes('quota exceeded') ||
+			message.includes('no quota') ||
+			message.includes('402')
+		) {
 			return 'QUOTA_EXCEEDED';
 		}
 		if (message.includes('invalid_api_key')) {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
@@ -175,10 +175,18 @@ export class ConversationManager {
 				onPreToolUse: () => Promise.resolve({ permissionDecision: 'allow' as const }),
 				onPostToolUse: () => {},
 				onErrorOccurred: (input) => {
+					const errorMsg = typeof input.error === 'string' ? input.error : String(input.error);
 					logger.warn(
-						`SDK error (${input.errorContext}, recoverable=${String(input.recoverable)}): ${String(input.error)}`
+						`SDK error (${input.errorContext}, recoverable=${String(input.recoverable)}): ${errorMsg}`
 					);
+					// Do not retry quota/payment errors — they will not resolve with retries.
+					const isQuotaError =
+						errorMsg.includes('402') ||
+						errorMsg.toLowerCase().includes('no quota') ||
+						errorMsg.toLowerCase().includes('quota exceeded') ||
+						errorMsg.toLowerCase().includes('insufficient_quota');
 					if (
+						!isQuotaError &&
 						input.recoverable &&
 						(input.errorContext === 'model_call' || input.errorContext === 'tool_execution')
 					) {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -139,10 +139,18 @@ function buildPlainSessionConfig(
 			onPreToolUse: () => Promise.resolve({ permissionDecision: 'allow' as const }),
 			onPostToolUse: () => {},
 			onErrorOccurred: (input) => {
+				const errorMsg = typeof input.error === 'string' ? input.error : String(input.error);
 				logger.warn(
-					`SDK error (${input.errorContext}, recoverable=${String(input.recoverable)}): ${String(input.error)}`
+					`SDK error (${input.errorContext}, recoverable=${String(input.recoverable)}): ${errorMsg}`
 				);
+				// Do not retry quota/payment errors — they will not resolve with retries.
+				const isQuotaError =
+					errorMsg.includes('402') ||
+					errorMsg.toLowerCase().includes('no quota') ||
+					errorMsg.toLowerCase().includes('quota exceeded') ||
+					errorMsg.toLowerCase().includes('insufficient_quota');
 				if (
+					!isQuotaError &&
 					input.recoverable &&
 					(input.errorContext === 'model_call' || input.errorContext === 'tool_execution')
 				) {


### PR DESCRIPTION
## Summary

- Handle plain-text 4xx errors from Copilot (e.g. `402 You have no quota`) in `query-runner`, not just JSON-body API errors
- Parse JSON SSE error events that wrap a 4xx plain message (e.g. `{"type":"error","error":{"message":"402 You have no quota..."}}`)
- Mark quota/payment errors as non-recoverable in `onErrorOccurred` so the SDK stops retrying endlessly
- Extend `error-manager` and `query-runner` error categorization to recognize `"no quota"` and `"402"` patterns as `RATE_LIMIT`/`QUOTA_EXCEEDED`

## Test plan

- [ ] Trigger a Copilot session with an exhausted quota — should display an error block in the UI and stop immediately, not retry in a loop
- [ ] JSON-body API errors (standard Anthropic format) still surface correctly
- [ ] Non-quota recoverable errors still retry as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)