### PR TITLE
fix: clean up stale spaces before creating in E2E tests

### DIFF
--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -20,6 +20,8 @@ import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-hel
 
 // ─── RPC helpers (infrastructure only) ───────────────────────────────────────
 
+const SPACE_NAME = 'E2E Export Import Space';
+
 async function createTestSpace(page: Page): Promise<{
 	spaceId: string;
 	agentId: string;
@@ -27,30 +29,44 @@ async function createTestSpace(page: Page): Promise<{
 }> {
 	await waitForWebSocketConnected(page);
 	const wsRoot = await getWorkspaceRoot(page);
-	const uniquePath = `${wsRoot}/e2e-export-import-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	return page.evaluate(async (workspacePath) => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
+	return page.evaluate(
+		async ({ workspacePath, name }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
 
-		// Create a space
-		const spaceRes = await hub.request('space.create', {
-			name: 'E2E Export Import Space',
-			description: 'Test space for export/import E2E tests',
-			workspacePath,
-		});
-		const spaceId = (spaceRes as { space: { id: string } }).space.id;
+			// Delete any leftover space from a previous failed run
+			try {
+				const spaces = await hub.request('space.list', {});
+				const list = (spaces as { spaces: Array<{ id: string; workspacePath: string }> }).spaces;
+				const existing = list.find((s) => s.workspacePath === workspacePath);
+				if (existing) {
+					await hub.request('space.delete', { id: existing.id });
+				}
+			} catch {
+				// Ignore cleanup errors
+			}
 
-		// Create an agent in the space
-		const agentRes = await hub.request('spaceAgent.create', {
-			spaceId,
-			name: 'Test Coder',
-			role: 'coder',
-			description: 'A test coder agent',
-		});
-		const agentId = (agentRes as { agent: { id: string } }).agent.id;
+			// Create a space
+			const spaceRes = await hub.request('space.create', {
+				name,
+				description: 'Test space for export/import E2E tests',
+				workspacePath,
+			});
+			const spaceId = (spaceRes as { space: { id: string } }).space.id;
 
-		return { spaceId, agentId, agentName: 'Test Coder' };
-	}, uniquePath);
+			// Create an agent in the space
+			const agentRes = await hub.request('spaceAgent.create', {
+				spaceId,
+				name: 'Test Coder',
+				role: 'coder',
+				description: 'A test coder agent',
+			});
+			const agentId = (agentRes as { agent: { id: string } }).agent.id;
+
+			return { spaceId, agentId, agentName: 'Test Coder' };
+		},
+		{ workspacePath: wsRoot, name: SPACE_NAME }
+	);
 }
 
 async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -26,16 +26,32 @@ const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 async function createTestSpace(page: Page): Promise<string> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
-	const uniquePath = `${workspaceRoot}/e2e-workflow-rules-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	return page.evaluate(async (wsPath) => {
-		const hub = window.__messageHub || window.appState?.messageHub;
-		if (!hub?.request) throw new Error('MessageHub not available');
-		const res = await hub.request('space.create', {
-			name: `E2E Rules Test Space ${Date.now()}`,
-			workspacePath: wsPath,
-		});
-		return (res as { space: { id: string } }).space.id;
-	}, uniquePath);
+	const spaceName = `E2E Rules Test Space ${Date.now()}`;
+	return page.evaluate(
+		async ({ wsPath, name }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Delete any leftover space from a previous failed run
+			try {
+				const spaces = await hub.request('space.list', {});
+				const list = (spaces as { spaces: Array<{ id: string; workspacePath: string }> }).spaces;
+				const existing = list.find((s) => s.workspacePath === wsPath);
+				if (existing) {
+					await hub.request('space.delete', { id: existing.id });
+				}
+			} catch {
+				// Ignore cleanup errors
+			}
+
+			const res = await hub.request('space.create', {
+				name,
+				workspacePath: wsPath,
+			});
+			return (res as { space: { id: string } }).space.id;
+		},
+		{ wsPath: workspaceRoot, name: spaceName }
+	);
 }
 
 async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Uses workspace root directly (guaranteed to exist on disk) instead of constructing non-existent paths
- Adds pre-creation cleanup: deletes any leftover space with the same workspace path before creating a new one, handling cleanup from previous failed CI runs
- Fixes `space.delete` parameter name (`{ spaceId: id }` → `{ id }`) in `space-export-import.e2e.ts`

## Test plan
- CI E2E runs for `features-space-export-import` and `features-space-workflow-rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)