### PR TITLE
feat: P0 — replace hidden ⋮ Dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2)

### DIFF
--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -42,9 +42,7 @@ export function RoomDashboard() {
 	const [actionLoading, setActionLoading] = useState(false);
 	const [showPauseConfirm, setShowPauseConfirm] = useState(false);
 	const [showStopConfirm, setShowStopConfirm] = useState(false);
-	const [showApproveConfirm, setShowApproveConfirm] = useState<string | null>(null);
 	const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
-	const [approvalLoading, setApprovalLoading] = useState(false);
 
 	// Get the resolved models (leader and worker)
 	const { leaderModel, workerModel } = runtimeModels;
@@ -81,20 +79,6 @@ export function RoomDashboard() {
 		} finally {
 			setActionLoading(false);
 			setShowStopConfirm(false);
-		}
-	};
-
-	const handleApprove = async () => {
-		const taskId = showApproveConfirm;
-		if (!taskId) return;
-		setApprovalLoading(true);
-		try {
-			await roomStore.approveTask(taskId);
-		} catch {
-			// Error handled by store
-		} finally {
-			setApprovalLoading(false);
-			setShowApproveConfirm(null);
 		}
 	};
 
@@ -219,7 +203,6 @@ export function RoomDashboard() {
 				<RoomTasks
 					tasks={tasks}
 					onTaskClick={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
-					onApprove={roomId ? (taskId) => setShowApproveConfirm(taskId) : undefined}
 					onView={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
 				/>
 			</div>
@@ -251,18 +234,6 @@ export function RoomDashboard() {
 				message="Stopping will completely shut down the room runtime. All active sessions will be terminated and no new tasks will be processed. You can start the room again later."
 				confirmText="Stop Room"
 				isLoading={actionLoading}
-			/>
-
-			{/* Approve Task Confirmation */}
-			<ConfirmModal
-				isOpen={showApproveConfirm !== null}
-				onClose={() => setShowApproveConfirm(null)}
-				onConfirm={handleApprove}
-				title="Approve Task"
-				message="Are you sure you want to approve this task? It will proceed to the next phase."
-				confirmText="Approve"
-				confirmButtonVariant="primary"
-				isLoading={approvalLoading}
 			/>
 
 			{/* Archive Confirmation */}

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -152,100 +152,56 @@ describe('RoomTasks', () => {
 			expect(header?.textContent).toContain('Review');
 		});
 
-		it('should show Approve button for review tasks when onApprove is provided', () => {
-			const onApprove = vi.fn();
-			const tasks = [createTask('t1', 'review', { title: 'Review me' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
-
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('Approve')
-			);
-			expect(approveBtn).toBeTruthy();
-		});
-
-		it('should show View button for review tasks when onView is provided', () => {
+		it('should show 审阅 button for review tasks when onView is provided', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('t1', 'review', { title: 'Review me' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			);
 			expect(viewBtn).toBeTruthy();
 		});
 
-		it('should NOT show View button when onView is not provided', () => {
+		it('should NOT show 审阅 button when onView is not provided', () => {
 			const tasks = [createTask('t1', 'review')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			);
 			expect(viewBtn).toBeFalsy();
 		});
 
-		it('should call onView with task id when View button is clicked', () => {
+		it('should call onView with task id when 审阅 button is clicked', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('task-42', 'review', { title: 'Review me' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			) as HTMLButtonElement;
 			fireEvent.click(viewBtn);
 
 			expect(onView).toHaveBeenCalledWith('task-42');
 		});
 
-		it('should show both Approve and View buttons when both callbacks are provided', () => {
-			const onApprove = vi.fn();
-			const onView = vi.fn();
-			const tasks = [createTask('t1', 'review', { title: 'Review me' })];
-
-			const { container } = render(
-				<RoomTasks tasks={tasks} onApprove={onApprove} onView={onView} />
-			);
-
-			const btns = Array.from(container.querySelectorAll('button')).map((b) => b.textContent);
-			expect(btns.some((t) => t?.includes('Approve'))).toBe(true);
-			expect(btns.some((t) => t?.includes('View'))).toBe(true);
-		});
-
-		it('should NOT show View button for non-review tasks', () => {
+		it('should NOT show 审阅 button for non-review tasks', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('t1', 'in_progress')];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			);
 			expect(viewBtn).toBeFalsy();
 		});
 
-		it('should NOT call onTaskClick when Approve button is clicked (stopPropagation)', () => {
-			const onApprove = vi.fn();
-			const onTaskClick = vi.fn();
-			const tasks = [createTask('task-42', 'review', { title: 'Review me' })];
-
-			const { container } = render(
-				<RoomTasks tasks={tasks} onApprove={onApprove} onTaskClick={onTaskClick} />
-			);
-
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('Approve')
-			) as HTMLButtonElement;
-			fireEvent.click(approveBtn);
-
-			expect(onApprove).toHaveBeenCalledWith('task-42');
-			expect(onTaskClick).not.toHaveBeenCalled();
-		});
-
-		it('should NOT call onTaskClick when View button is clicked (stopPropagation)', () => {
+		it('should NOT call onTaskClick when 审阅 button is clicked (stopPropagation)', () => {
 			const onView = vi.fn();
 			const onTaskClick = vi.fn();
 			const tasks = [createTask('task-42', 'review', { title: 'Review me' })];
@@ -255,7 +211,7 @@ describe('RoomTasks', () => {
 			);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			) as HTMLButtonElement;
 			fireEvent.click(viewBtn);
 
@@ -393,16 +349,16 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Stopped task');
 		});
 
-		it('should not show Approve button for cancelled tasks', () => {
-			const onApprove = vi.fn();
+		it('should not show 审阅 button for cancelled tasks', () => {
+			const onView = vi.fn();
 			const tasks = [createTask('t1', 'cancelled')];
 
-			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('Approve')
+			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('审阅')
 			);
-			expect(approveBtn).toBeFalsy();
+			expect(viewBtn).toBeFalsy();
 		});
 
 		it('should render cancelled separately from needs attention tasks', () => {

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -45,7 +45,6 @@ if (typeof window !== 'undefined') {
 interface RoomTasksProps {
 	tasks: TaskSummary[];
 	onTaskClick?: (taskId: string) => void;
-	onApprove?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 }
 
@@ -74,7 +73,7 @@ function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary
 	}
 }
 
-export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksProps) {
+export function RoomTasks({ tasks, onTaskClick, onView }: RoomTasksProps) {
 	const selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 	const filteredTasks = getFilteredTasks(tasks, selectedTab);
@@ -134,7 +133,6 @@ export function RoomTasks({ tasks, onTaskClick, onApprove, onView }: RoomTasksPr
 					allTasks={tasks}
 					tab={selectedTab}
 					onTaskClick={onTaskClick}
-					onApprove={onApprove}
 					onView={onView}
 				/>
 			)}
@@ -233,14 +231,12 @@ function TaskList({
 	allTasks,
 	tab,
 	onTaskClick,
-	onApprove,
 	onView,
 }: {
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
 	tab: TaskFilterTab;
 	onTaskClick?: (taskId: string) => void;
-	onApprove?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 }) {
 	// For Active tab, group by in_progress and pending
@@ -288,7 +284,6 @@ function TaskList({
 					tasks={tasks}
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
-					onApprove={onApprove}
 					onView={onView}
 				/>
 			</div>
@@ -349,7 +344,6 @@ function TaskGroup({
 	tasks,
 	allTasks,
 	onTaskClick,
-	onApprove,
 	onView,
 	showAlert = false,
 }: {
@@ -359,7 +353,6 @@ function TaskGroup({
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
 	onTaskClick?: (taskId: string) => void;
-	onApprove?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 	showAlert?: boolean;
 }) {
@@ -421,7 +414,6 @@ function TaskGroup({
 						task={task}
 						allTasks={allTasks}
 						onClick={onTaskClick}
-						onApprove={onApprove}
 						onView={onView}
 					/>
 				))}
@@ -442,17 +434,14 @@ function TaskItem({
 	task,
 	allTasks,
 	onClick,
-	onApprove,
 	onView,
 }: {
 	task: TaskSummary;
 	allTasks: TaskSummary[];
 	onClick?: (taskId: string) => void;
-	onApprove?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 }) {
 	const isClickable = !!onClick;
-	const showApprove = task.status === 'review' && !!onApprove;
 	const showView = task.status === 'review' && !!onView;
 	const blocked = task.status === 'pending' && isBlocked(task, allTasks);
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
@@ -500,26 +489,15 @@ function TaskItem({
 							<span>PR #{task.prNumber ?? '?'}</span>
 						</a>
 					)}
-					{showApprove && (
-						<button
-							onClick={(e) => {
-								e.stopPropagation();
-								onApprove(task.id);
-							}}
-							class="px-2 py-1 text-xs font-medium text-green-400 bg-green-900/20 hover:bg-green-900/40 border border-green-700/50 rounded transition-colors"
-						>
-							Approve
-						</button>
-					)}
 					{showView && (
 						<button
 							onClick={(e) => {
 								e.stopPropagation();
 								onView(task.id);
 							}}
-							class="px-2 py-1 text-xs font-medium text-blue-400 bg-blue-900/20 hover:bg-blue-900/40 border border-blue-700/50 rounded transition-colors"
+							class="px-2 py-1 text-xs font-medium text-amber-400 bg-amber-900/20 hover:bg-amber-900/40 border border-amber-700/50 rounded transition-colors"
 						>
-							View
+							审阅
 						</button>
 					)}
 					{isClickable && <span class="text-xs text-gray-600">&rarr;</span>}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -22,8 +22,8 @@ import { useMessageHub } from '../../hooks/useMessageHub';
 import { useModal } from '../../hooks/useModal';
 import { useTaskInputDraft } from '../../hooks/useTaskInputDraft';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { toast } from '../../lib/toast.ts';
 import { copyToClipboard } from '../../lib/utils';
-import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
 import { Modal } from '../ui/Modal';
 import { RejectModal } from '../ui/RejectModal';
 import { InputTextarea } from '../InputTextarea';
@@ -656,6 +656,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	// UI state for info panel and autoscroll toggle
 	const [showInfoPanel, setShowInfoPanel] = useState(false);
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+	const [interrupting, setInterrupting] = useState(false);
 
 	// Task action modals
 	const completeModal = useModal();
@@ -825,6 +826,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			result: summary || 'Marked complete by user',
 		});
 		completeModal.close();
+		toast.success('Task completed');
 		navigateToRoom(roomId);
 	};
 
@@ -832,51 +834,12 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const cancelTask = async () => {
 		await request('task.cancel', { roomId, taskId });
 		cancelModal.close();
+		toast.info('Task cancelled');
 		navigateToRoom(roomId);
 	};
 
-	// Build dropdown menu items for task actions
-	const dropdownItems: DropdownMenuItem[] = [];
-	if (canComplete) {
-		dropdownItems.push({
-			label: 'Mark as Complete',
-			icon: (
-				<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M5 13l4 4L19 7"
-					/>
-				</svg>
-			),
-			onClick: () => completeModal.open(),
-		});
-	}
-	if (canCancel) {
-		if (canComplete) {
-			dropdownItems.push({ type: 'divider' });
-		}
-		dropdownItems.push({
-			label: 'Cancel Task',
-			icon: (
-				<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width="2"
-						d="M6 18L18 6M6 6l12 12"
-					/>
-				</svg>
-			),
-			danger: true,
-			onClick: () => cancelModal.open(),
-		});
-	}
-
 	// Interrupt button shown only when task has active agent sessions
 	const canInterrupt = task.status === 'in_progress' || task.status === 'review';
-	const [interrupting, setInterrupting] = useState(false);
 
 	// Interrupt handler - stops LLM generation without changing task status
 	const interruptSession = async () => {
@@ -972,25 +935,36 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						</svg>
 					</button>
 				)}
-				{/* Task options dropdown — shown when at least one action is available */}
-				{dropdownItems.length > 0 && (
-					<Dropdown
-						position="right"
-						trigger={
-							<button
-								class="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-dark-700 transition-colors"
-								title="Task options"
-								data-testid="task-options-menu"
-							>
-								<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-									<circle cx="12" cy="5" r="2" />
-									<circle cx="12" cy="12" r="2" />
-									<circle cx="12" cy="19" r="2" />
-								</svg>
-							</button>
-						}
-						items={dropdownItems}
-					/>
+				{/* Inline action buttons — always visible based on task status */}
+				{canCancel && (
+					<button
+						class="py-1 px-2.5 rounded-lg text-xs border border-dark-600 text-gray-400 hover:text-red-400 hover:border-red-700/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						onClick={cancelModal.open}
+						disabled={interrupting}
+						data-testid="task-cancel-button"
+						title="Cancel task"
+					>
+						Cancel
+					</button>
+				)}
+				{canComplete && task.status !== 'review' && (
+					<button
+						class="py-1 px-2.5 rounded-lg text-xs bg-green-700 hover:bg-green-600 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1"
+						onClick={completeModal.open}
+						disabled={interrupting}
+						data-testid="task-complete-button"
+						title="Mark task as complete"
+					>
+						<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M5 13l4 4L19 7"
+							/>
+						</svg>
+						Complete
+					</button>
 				)}
 				{/* Info toggle button */}
 				<button


### PR DESCRIPTION
## Summary

- **TaskView**: Remove the `⋮` Dropdown that hid Cancel/Complete behind a menu. Replace with always-visible inline buttons next to the Interrupt button:
  - **Cancel** button (shown when `canCancel`): gray border, hover→red
  - **Complete** button (shown when `canComplete && status !== 'review'`): green solid with checkmark; review status is handled by `HeaderReviewBar`
- **TaskView**: Move `interrupting` useState to component top-level (fixes React hook ordering violation after early returns)
- **TaskView**: Add `toast.success('Task completed')` and `toast.info('Task cancelled')` feedback
- **RoomDashboard**: Remove `showApproveConfirm`, `approvalLoading`, `handleApprove`, and the Approve `ConfirmModal`; drop `onApprove` prop from `<RoomTasks>`
- **RoomTasks**: Remove `onApprove` prop entirely from all interfaces/components; change the Review tab action button from "Approve" (green) → "审阅" (amber, calls `onView` → navigates to TaskView)
- **RoomTasks.test**: Update tests to reflect the new `审阅` button API

## Test plan

- [ ] `bun run typecheck` — zero errors in modified files ✅
- [ ] `bun run lint` — 0 warnings, 0 errors ✅
- [ ] `bunx vitest run src/components/room/RoomTasks.test.tsx` — 49/49 pass ✅
- [ ] Manually verify: TaskView header shows Cancel/Complete buttons inline
- [ ] Manually verify: No ⋮ dropdown visible anywhere in TaskView
- [ ] Manually verify: RoomTasks Review tab shows "审阅" amber button that navigates to TaskView

🤖 Generated with [Claude Code](https://claude.com/claude-code)