### PR TITLE
fix: correct space.list response shape in E2E stale-space cleanup

### DIFF
--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -36,8 +36,10 @@ async function createTestSpace(page: Page): Promise<{
 
 			// Delete any leftover space from a previous failed run
 			try {
-				const spaces = await hub.request('space.list', {});
-				const list = (spaces as { spaces: Array<{ id: string; workspacePath: string }> }).spaces;
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
 				const existing = list.find((s) => s.workspacePath === workspacePath);
 				if (existing) {
 					await hub.request('space.delete', { id: existing.id });

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -34,8 +34,10 @@ async function createTestSpace(page: Page): Promise<string> {
 
 			// Delete any leftover space from a previous failed run
 			try {
-				const spaces = await hub.request('space.list', {});
-				const list = (spaces as { spaces: Array<{ id: string; workspacePath: string }> }).spaces;
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
 				const existing = list.find((s) => s.workspacePath === wsPath);
 				if (existing) {
 					await hub.request('space.delete', { id: existing.id });


### PR DESCRIPTION
## Summary
- `space.list` returns `Space[]` directly, not `{ spaces: Space[] }`. The cleanup code was accessing `.spaces` on an array which returned `undefined`, so stale spaces were never deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)