### PR TITLE
fix: use correct space.create response shape in E2E tests

### DIFF
--- a/packages/e2e/tests/features/space-export-import.e2e.ts
+++ b/packages/e2e/tests/features/space-export-import.e2e.ts
@@ -54,7 +54,7 @@ async function createTestSpace(page: Page): Promise<{
 				description: 'Test space for export/import E2E tests',
 				workspacePath,
 			});
-			const spaceId = (spaceRes as { space: { id: string } }).space.id;
+			const spaceId = (spaceRes as { id: string }).id;
 
 			// Create an agent in the space
 			const agentRes = await hub.request('spaceAgent.create', {

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -50,7 +50,7 @@ async function createTestSpace(page: Page): Promise<string> {
 				name,
 				workspacePath: wsPath,
 			});
-			return (res as { space: { id: string } }).space.id;
+			return (res as { id: string }).id;
 		},
 		{ wsPath: workspaceRoot, name: spaceName }
 	);


### PR DESCRIPTION
## Summary
- `space.create` returns a `Space` object directly, not `{ space: Space }`. The test was accessing `.space.id` on the space itself, getting `undefined`, so `spaceId` was never set and cleanup in `afterEach` silently did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)