### PR TITLE
ci: skip unstable space E2E tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -690,8 +690,10 @@ jobs:
             settings/auto-title
           )
 
-          # Tests to exclude entirely (disabled, pending refactor)
+          # Tests to exclude entirely (disabled, pending stabilization)
           EXCLUDED_TESTS=(
+            features/space-export-import
+            features/space-workflow-rules
           )
 
           # Build lookup sets


### PR DESCRIPTION
## Summary
- Skip `features/space-export-import` and `features/space-workflow-rules` E2E tests in CI until they can be stabilized

🤖 Generated with [Claude Code](https://claude.com/claude-code)