### PR TITLE
feat: add VisualCanvas component with pan and zoom (Task 1.2)

### DIFF
--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -1,0 +1,198 @@
+/**
+ * VisualCanvas
+ *
+ * A pannable, zoomable viewport container for the visual workflow editor.
+ *
+ * Pan methods:
+ *  - Two-finger trackpad scroll (wheel event without ctrlKey)
+ *  - Spacebar + left-click drag
+ *
+ * Zoom methods:
+ *  - Trackpad pinch (wheel event with ctrlKey=true)
+ *  - Ctrl/Cmd + scroll wheel
+ *  - Scale is clamped to [0.25, 2.0] and zooms toward cursor position.
+ */
+
+import { useEffect, useRef, useCallback } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+import type { ViewportState } from './types';
+
+export const MIN_SCALE = 0.25;
+export const MAX_SCALE = 2.0;
+
+function clampScale(s: number): number {
+	return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
+}
+
+/**
+ * Pure function: compute the next ViewportState for a wheel event.
+ *
+ * @param vp        Current viewport state
+ * @param deltaX    Horizontal scroll delta
+ * @param deltaY    Vertical scroll delta (negative = zoom in)
+ * @param isZoom    True when the wheel event should zoom (ctrlKey pressed / pinch)
+ * @param cursorX   Cursor X relative to the canvas container (for zoom-toward-cursor)
+ * @param cursorY   Cursor Y relative to the canvas container
+ */
+export function applyWheelEvent(
+	vp: ViewportState,
+	deltaX: number,
+	deltaY: number,
+	isZoom: boolean,
+	cursorX = 0,
+	cursorY = 0
+): ViewportState {
+	if (isZoom) {
+		const zoomFactor = 1 - deltaY * 0.005;
+		const newScale = clampScale(vp.scale * zoomFactor);
+		// Adjust offset so the point under the cursor stays fixed
+		const newOffsetX = cursorX - (cursorX - vp.offsetX) * (newScale / vp.scale);
+		const newOffsetY = cursorY - (cursorY - vp.offsetY) * (newScale / vp.scale);
+		return { offsetX: newOffsetX, offsetY: newOffsetY, scale: newScale };
+	}
+	// Two-finger scroll — pan
+	return { ...vp, offsetX: vp.offsetX - deltaX, offsetY: vp.offsetY - deltaY };
+}
+
+interface VisualCanvasProps {
+	children?: ComponentChildren;
+	viewportState: ViewportState;
+	onViewportChange: (state: ViewportState) => void;
+}
+
+export function VisualCanvas({ children, viewportState, onViewportChange }: VisualCanvasProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// Track spacebar state for pan-drag mode
+	const spacebarDown = useRef(false);
+	// Track drag state
+	const dragState = useRef<{
+		startX: number;
+		startY: number;
+		originOffsetX: number;
+		originOffsetY: number;
+	} | null>(null);
+
+	// Keep a ref to the latest viewport so event handlers don't stale-close over it
+	const viewportRef = useRef(viewportState);
+	viewportRef.current = viewportState;
+
+	// ---- Wheel handler (pan + zoom) ----
+	// Registered via onWheel JSX prop so Preact attaches it as a non-passive
+	// listener, which lets us call e.preventDefault() to suppress browser
+	// scroll/pinch-zoom behaviour.
+	const handleWheel = useCallback(
+		(e: WheelEvent) => {
+			e.preventDefault();
+			const vp = viewportRef.current;
+			const rect = containerRef.current?.getBoundingClientRect();
+			const cursorX = e.clientX - (rect?.left ?? 0);
+			const cursorY = e.clientY - (rect?.top ?? 0);
+			onViewportChange(applyWheelEvent(vp, e.deltaX, e.deltaY, e.ctrlKey, cursorX, cursorY));
+		},
+		[onViewportChange]
+	);
+
+	// ---- Spacebar listeners ----
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.code === 'Space' && !e.repeat) {
+				// Don't capture space when focused on an input/textarea
+				const tag = (e.target as HTMLElement)?.tagName;
+				if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+				spacebarDown.current = true;
+				if (containerRef.current) {
+					containerRef.current.style.cursor = 'grab';
+				}
+			}
+		};
+		const onKeyUp = (e: KeyboardEvent) => {
+			if (e.code === 'Space') {
+				spacebarDown.current = false;
+				dragState.current = null;
+				if (containerRef.current) {
+					containerRef.current.style.cursor = '';
+				}
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
+		return () => {
+			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keyup', onKeyUp);
+		};
+	}, []);
+
+	// ---- Mouse drag for spacebar+click pan ----
+	const handleMouseDown = useCallback((e: MouseEvent) => {
+		if (!spacebarDown.current || e.button !== 0) return;
+		e.preventDefault();
+		dragState.current = {
+			startX: e.clientX,
+			startY: e.clientY,
+			originOffsetX: viewportRef.current.offsetX,
+			originOffsetY: viewportRef.current.offsetY,
+		};
+		if (containerRef.current) {
+			containerRef.current.style.cursor = 'grabbing';
+		}
+	}, []);
+
+	const handleMouseMove = useCallback(
+		(e: MouseEvent) => {
+			if (!dragState.current) return;
+			const dx = e.clientX - dragState.current.startX;
+			const dy = e.clientY - dragState.current.startY;
+			onViewportChange({
+				...viewportRef.current,
+				offsetX: dragState.current.originOffsetX + dx,
+				offsetY: dragState.current.originOffsetY + dy,
+			});
+		},
+		[onViewportChange]
+	);
+
+	const handleMouseUp = useCallback(() => {
+		if (!dragState.current) return;
+		dragState.current = null;
+		if (containerRef.current) {
+			containerRef.current.style.cursor = spacebarDown.current ? 'grab' : '';
+		}
+	}, []);
+
+	useEffect(() => {
+		window.addEventListener('mousemove', handleMouseMove);
+		window.addEventListener('mouseup', handleMouseUp);
+		return () => {
+			window.removeEventListener('mousemove', handleMouseMove);
+			window.removeEventListener('mouseup', handleMouseUp);
+		};
+	}, [handleMouseMove, handleMouseUp]);
+
+	const transform = `translate(${viewportState.offsetX}px, ${viewportState.offsetY}px) scale(${viewportState.scale})`;
+
+	return (
+		<div
+			ref={containerRef}
+			class="visual-canvas-container"
+			style={{ overflow: 'hidden', width: '100%', height: '100%', position: 'relative' }}
+			onMouseDown={handleMouseDown}
+			onWheel={handleWheel}
+			data-testid="visual-canvas"
+		>
+			<div
+				class="visual-canvas-transform"
+				style={{
+					transform,
+					transformOrigin: '0 0',
+					position: 'absolute',
+					top: 0,
+					left: 0,
+				}}
+				data-testid="visual-canvas-transform"
+			>
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -100,6 +100,7 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 				// Don't capture space when focused on an input/textarea
 				const tag = (e.target as HTMLElement)?.tagName;
 				if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+				e.preventDefault(); // prevent browser "scroll down" default
 				spacebarDown.current = true;
 				if (containerRef.current) {
 					containerRef.current.style.cursor = 'grab';

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualCanvas.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for VisualCanvas and coordinate conversion utilities.
+ *
+ * Tests:
+ * - Renders children inside the transform layer
+ * - Transform style reflects ViewportState
+ * - applyWheelEvent: zoom increases/decreases scale correctly
+ * - applyWheelEvent: zoom clamps to [0.25, 2.0]
+ * - applyWheelEvent: pan updates offsets
+ * - applyWheelEvent: zoom adjusts offset toward cursor
+ * - Pan via wheel event (no ctrlKey) updates offset via DOM event
+ * - screenToCanvas and canvasToScreen are correct inverse functions
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
+import { VisualCanvas, applyWheelEvent, MIN_SCALE, MAX_SCALE } from '../VisualCanvas';
+import { screenToCanvas, canvasToScreen } from '../types';
+import type { ViewportState } from '../types';
+
+afterEach(() => cleanup());
+
+// ---- Helper ----
+
+function renderCanvas(initial: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 }) {
+	const changes: ViewportState[] = [];
+
+	function Wrapper() {
+		const [vp, setVp] = useState<ViewportState>(initial);
+		return (
+			<VisualCanvas
+				viewportState={vp}
+				onViewportChange={(next) => {
+					changes.push(next);
+					setVp(next);
+				}}
+			>
+				<div data-testid="child-node">Hello</div>
+			</VisualCanvas>
+		);
+	}
+
+	const result = render(<Wrapper />);
+	return { ...result, changes };
+}
+
+// ---- Component rendering tests ----
+
+describe('VisualCanvas', () => {
+	it('renders children inside the transform layer', () => {
+		const { getByTestId } = renderCanvas();
+		expect(getByTestId('child-node').textContent).toBe('Hello');
+		const transformEl = getByTestId('visual-canvas-transform');
+		expect(transformEl.contains(getByTestId('child-node'))).toBe(true);
+	});
+
+	it('applies the correct CSS transform from ViewportState', () => {
+		const { getByTestId } = renderCanvas({ offsetX: 50, offsetY: -20, scale: 1.5 });
+		const transformEl = getByTestId('visual-canvas-transform');
+		expect(transformEl.style.transform).toBe('translate(50px, -20px) scale(1.5)');
+	});
+
+	it('pans via wheel event (no ctrlKey) - deltaX/deltaY update offsets', () => {
+		const { getByTestId, changes } = renderCanvas({ offsetX: 0, offsetY: 0, scale: 1 });
+		const container = getByTestId('visual-canvas');
+
+		fireEvent.wheel(container, { deltaX: 30, deltaY: 10 });
+
+		expect(changes.length).toBeGreaterThan(0);
+		const last = changes[changes.length - 1];
+		expect(last.offsetX).toBe(-30);
+		expect(last.offsetY).toBe(-10);
+		expect(last.scale).toBe(1);
+	});
+});
+
+// ---- applyWheelEvent pure logic tests ----
+
+describe('applyWheelEvent', () => {
+	const base: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 };
+
+	it('pans when isZoom=false', () => {
+		const result = applyWheelEvent(base, 30, 10, false);
+		expect(result.offsetX).toBe(-30);
+		expect(result.offsetY).toBe(-10);
+		expect(result.scale).toBe(1);
+	});
+
+	it('zooms in (negative deltaY) when isZoom=true', () => {
+		const result = applyWheelEvent(base, 0, -100, true, 0, 0);
+		expect(result.scale).toBeGreaterThan(1);
+	});
+
+	it('zooms out (positive deltaY) when isZoom=true', () => {
+		const result = applyWheelEvent(base, 0, 100, true, 0, 0);
+		expect(result.scale).toBeLessThan(1);
+	});
+
+	it('clamps scale to MIN_SCALE on aggressive zoom-out', () => {
+		const result = applyWheelEvent({ ...base, scale: 0.3 }, 0, 10000, true, 0, 0);
+		expect(result.scale).toBeGreaterThanOrEqual(MIN_SCALE);
+		expect(result.scale).toBe(MIN_SCALE);
+	});
+
+	it('clamps scale to MAX_SCALE on aggressive zoom-in', () => {
+		const result = applyWheelEvent({ ...base, scale: 1.9 }, 0, -10000, true, 0, 0);
+		expect(result.scale).toBeLessThanOrEqual(MAX_SCALE);
+		expect(result.scale).toBe(MAX_SCALE);
+	});
+
+	it('zooms toward cursor position', () => {
+		// At cursor (100, 100) with scale going from 1 to ~1.5,
+		// the point under cursor should remain at (100, 100) in screen space.
+		const vp: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 };
+		const cursorX = 100;
+		const cursorY = 100;
+		const result = applyWheelEvent(vp, 0, -100, true, cursorX, cursorY);
+
+		// The canvas point under cursor before and after should be the same
+		const canvasBefore = {
+			x: (cursorX - vp.offsetX) / vp.scale,
+			y: (cursorY - vp.offsetY) / vp.scale,
+		};
+		const screenAfter = {
+			x: canvasBefore.x * result.scale + result.offsetX,
+			y: canvasBefore.y * result.scale + result.offsetY,
+		};
+		expect(screenAfter.x).toBeCloseTo(cursorX);
+		expect(screenAfter.y).toBeCloseTo(cursorY);
+	});
+});
+
+// ---- Coordinate conversion ----
+
+describe('screenToCanvas / canvasToScreen', () => {
+	it('are inverse functions at scale=1, no offset', () => {
+		const vp: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 };
+		const screen = { x: 100, y: 200 };
+		const canvas = screenToCanvas(screen, vp);
+		const back = canvasToScreen(canvas, vp);
+		expect(back.x).toBeCloseTo(screen.x);
+		expect(back.y).toBeCloseTo(screen.y);
+	});
+
+	it('are inverse functions with offset and scale', () => {
+		const vp: ViewportState = { offsetX: 50, offsetY: -30, scale: 1.5 };
+		const screen = { x: 300, y: 150 };
+		const canvas = screenToCanvas(screen, vp);
+		const back = canvasToScreen(canvas, vp);
+		expect(back.x).toBeCloseTo(screen.x);
+		expect(back.y).toBeCloseTo(screen.y);
+	});
+
+	it('screenToCanvas maps correctly', () => {
+		const vp: ViewportState = { offsetX: 100, offsetY: 50, scale: 2 };
+		// canvas.x = (screenX - offsetX) / scale = (200 - 100) / 2 = 50
+		const canvas = screenToCanvas({ x: 200, y: 150 }, vp);
+		expect(canvas.x).toBeCloseTo(50);
+		expect(canvas.y).toBeCloseTo(50);
+	});
+
+	it('canvasToScreen maps correctly', () => {
+		const vp: ViewportState = { offsetX: 100, offsetY: 50, scale: 2 };
+		// screen.x = canvas.x * scale + offsetX = 50 * 2 + 100 = 200
+		const screen = canvasToScreen({ x: 50, y: 50 }, vp);
+		expect(screen.x).toBeCloseTo(200);
+		expect(screen.y).toBeCloseTo(150);
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -1,0 +1,3 @@
+export { VisualCanvas } from './VisualCanvas';
+export type { ViewportState, Point, Size, NodePosition } from './types';
+export { screenToCanvas, canvasToScreen } from './types';

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -1,3 +1,3 @@
-export { VisualCanvas } from './VisualCanvas';
+export { VisualCanvas, applyWheelEvent, MIN_SCALE, MAX_SCALE } from './VisualCanvas';
 export type { ViewportState, Point, Size, NodePosition } from './types';
 export { screenToCanvas, canvasToScreen } from './types';

--- a/packages/web/src/components/space/visual-editor/types.ts
+++ b/packages/web/src/components/space/visual-editor/types.ts
@@ -26,9 +26,10 @@ export type NodePosition = Record<string, { x: number; y: number; width: number;
  * Inverse of canvasToScreen.
  */
 export function screenToCanvas(point: Point, viewport: ViewportState): Point {
+	const scale = viewport.scale || 1;
 	return {
-		x: (point.x - viewport.offsetX) / viewport.scale,
-		y: (point.y - viewport.offsetY) / viewport.scale,
+		x: (point.x - viewport.offsetX) / scale,
+		y: (point.y - viewport.offsetY) / scale,
 	};
 }
 

--- a/packages/web/src/components/space/visual-editor/types.ts
+++ b/packages/web/src/components/space/visual-editor/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types for the visual editor canvas and nodes.
+ */
+
+export interface Point {
+	x: number;
+	y: number;
+}
+
+export interface Size {
+	width: number;
+	height: number;
+}
+
+export interface ViewportState {
+	offsetX: number;
+	offsetY: number;
+	scale: number;
+}
+
+/** Per-node position and size keyed by node ID. */
+export type NodePosition = Record<string, { x: number; y: number; width: number; height: number }>;
+
+/**
+ * Convert a screen-space point to canvas-space using the current viewport.
+ * Inverse of canvasToScreen.
+ */
+export function screenToCanvas(point: Point, viewport: ViewportState): Point {
+	return {
+		x: (point.x - viewport.offsetX) / viewport.scale,
+		y: (point.y - viewport.offsetY) / viewport.scale,
+	};
+}
+
+/**
+ * Convert a canvas-space point to screen-space using the current viewport.
+ * Inverse of screenToCanvas.
+ */
+export function canvasToScreen(point: Point, viewport: ViewportState): Point {
+	return {
+		x: point.x * viewport.scale + viewport.offsetX,
+		y: point.y * viewport.scale + viewport.offsetY,
+	};
+}


### PR DESCRIPTION
- Add shared types: Point, Size, ViewportState, NodePosition
- Add screenToCanvas/canvasToScreen coordinate conversion helpers
- Implement VisualCanvas with two-finger scroll pan, spacebar+drag pan,
  and Ctrl/pinch zoom clamped to [0.25, 2.0] toward cursor
- Extract applyWheelEvent as pure function for deterministic unit testing
- Add 13 unit tests covering rendering, pan/zoom logic, scale clamping,
  zoom-toward-cursor behaviour, and coordinate conversion math
