### PR TITLE
fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -83,6 +83,7 @@ import type {
 	SelectiveRewindResult,
 	SystemPromptConfig,
 	McpServerConfig,
+	Provider,
 } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import type { DaemonHub } from '../daemon-hub';
@@ -122,6 +123,9 @@ export interface AgentSessionInit {
 
 	/** Model ID - defaults to default model */
 	model?: string;
+
+	/** Provider ID for this session — if omitted, auto-detected from model or falls back to Anthropic */
+	provider?: string;
 
 	/** Enable coordinator mode — main agent orchestrates specialist sub-agents */
 	coordinatorMode?: boolean;
@@ -470,6 +474,7 @@ export class AgentSession
 
 		const config: SessionConfig = {
 			model: init.model ?? defaultModel,
+			provider: init.provider as Provider | undefined,
 			maxTokens: 4096,
 			temperature: 1.0,
 			// Pass through system prompt from init

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -76,6 +76,20 @@ export class ProviderRegistry {
 	}
 
 	/**
+	 * Find the first registered provider that owns this model ID.
+	 * Uses each provider's ownsModel() heuristic for auto-detection.
+	 * Returns undefined if no provider claims the model.
+	 */
+	findProviderForModel(modelId: string): Provider | undefined {
+		for (const provider of this.providers.values()) {
+			if (provider.ownsModel(modelId)) {
+				return provider;
+			}
+		}
+		return undefined;
+	}
+
+	/**
 	 * Resolve provider by explicit (modelId, providerId) pair — fully deterministic.
 	 *
 	 * Both the model ID and provider ID must be known at the call site. This is the

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -83,7 +83,7 @@ export class ProviderRegistry {
 	 */
 	findProviderForModel(modelId: string): Provider | undefined {
 		for (const provider of this.providers.values()) {
-			if (provider.ownsModel(modelId)) {
+			if (typeof provider.ownsModel === 'function' && provider.ownsModel(modelId)) {
 				return provider;
 			}
 		}
@@ -239,20 +239,28 @@ export function resetProviderRegistry(): void {
 }
 
 /**
- * Infer the provider for a given model ID based on known naming conventions.
+ * Infer the provider for a given model ID.
  *
- * This is a static heuristic that avoids loading the full provider registry
- * (which may require optional SDK dependencies). It covers all known provider
- * model naming conventions:
- * - `glm-*` → 'glm'
- * - `minimax-*` → 'minimax'
- * - `gpt-*` → 'anthropic-codex' (Codex bridge models like gpt-5.3-codex)
- * - Everything else → 'anthropic' (standard Claude models, and Copilot models
- *   which share Claude model IDs and are routed via explicit providerId)
+ * Strategy (two-pass):
+ * 1. Try the live registry via `findProviderForModel()` — covers all registered providers
+ *    including `anthropic-copilot` and `anthropic-codex`, which have dynamic model lists.
+ *    Returns the correct provider whenever the daemon has finished initializing.
+ * 2. Fall back to a static naming heuristic when the registry is empty (e.g., unit tests
+ *    or early-startup callers where providers are not yet registered):
+ *    - `glm-*` → 'glm'
+ *    - `minimax-*` → 'minimax'
+ *    - `gpt-*` → 'anthropic-codex'
+ *    - everything else → 'anthropic'
  *
- * @public Exported so callers that cannot use the full registry can still infer providers.
+ * Callers should NOT call `initializeProviders()` just for this function — the registry
+ * is populated at daemon startup; calling it lazily at spawn-time is safe and avoids
+ * test-interference from re-registering providers.
  */
 export function inferProviderForModel(modelId: string): ProviderIdStr {
+	// Live registry lookup (populated at daemon startup, empty in unit tests)
+	const fromRegistry = getProviderRegistry().findProviderForModel(modelId)?.id;
+	if (fromRegistry) return fromRegistry as ProviderIdStr;
+	// Static fallback when registry is empty
 	if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
 	if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
 	if (modelId.startsWith('gpt-')) return 'anthropic-codex';

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -11,6 +11,7 @@
 
 import { createLogger } from '@neokai/shared/logger';
 import type { Provider, ProviderId, ProviderInfo } from '@neokai/shared/provider';
+import type { Provider as ProviderIdStr } from '@neokai/shared';
 
 const log = createLogger('kai:providers:registry');
 
@@ -235,4 +236,25 @@ export function getProviderRegistry(): ProviderRegistry {
  */
 export function resetProviderRegistry(): void {
 	registryInstance = null;
+}
+
+/**
+ * Infer the provider for a given model ID based on known naming conventions.
+ *
+ * This is a static heuristic that avoids loading the full provider registry
+ * (which may require optional SDK dependencies). It covers all known provider
+ * model naming conventions:
+ * - `glm-*` → 'glm'
+ * - `minimax-*` → 'minimax'
+ * - `gpt-*` → 'anthropic-codex' (Codex bridge models like gpt-5.3-codex)
+ * - Everything else → 'anthropic' (standard Claude models, and Copilot models
+ *   which share Claude model IDs and are routed via explicit providerId)
+ *
+ * @public Exported so callers that cannot use the full registry can still infer providers.
+ */
+export function inferProviderForModel(modelId: string): ProviderIdStr {
+	if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
+	if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
+	if (modelId.startsWith('gpt-')) return 'anthropic-codex';
+	return 'anthropic';
 }

--- a/packages/daemon/src/lib/room/agents/coder-agent.ts
+++ b/packages/daemon/src/lib/room/agents/coder-agent.ts
@@ -37,6 +37,8 @@ export interface CoderAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID for this session — auto-detected from model if omitted */
+	provider?: string;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }
@@ -455,6 +457,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 			context: { roomId: config.room.id },
 			type: 'coder',
 			model: config.model ?? DEFAULT_CODER_MODEL,
+			provider: config.provider,
 			agent: 'Coder',
 			agents: {
 				Coder: coderAgentDef,
@@ -478,6 +481,7 @@ export function createCoderAgentInit(config: CoderAgentConfig): AgentSessionInit
 		context: { roomId: config.room.id },
 		type: 'coder',
 		model: config.model ?? DEFAULT_CODER_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/general-agent.ts
+++ b/packages/daemon/src/lib/room/agents/general-agent.ts
@@ -28,6 +28,8 @@ export interface GeneralAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID for this session — auto-detected from model if omitted */
+	provider?: string;
 	/** Summaries of previously completed tasks in the same goal */
 	previousTaskSummaries?: string[];
 }
@@ -199,6 +201,7 @@ export function createGeneralAgentInit(config: GeneralAgentConfig): AgentSession
 		context: { roomId: config.room.id },
 		type: 'general',
 		model: config.model ?? DEFAULT_GENERAL_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -80,6 +80,8 @@ export interface LeaderAgentConfig {
 	workspacePath: string;
 	groupId: string;
 	model?: string;
+	/** Provider ID for this session — auto-detected from model if omitted */
+	provider?: string;
 	/** What type of work is being reviewed */
 	reviewContext?: ReviewContext;
 	/** Dependencies for the leader context MCP server (optional - only needed when creating MCP server) */
@@ -1150,6 +1152,7 @@ export function createLeaderAgentInit(
 			context: { roomId: config.room.id },
 			type: 'leader' as const,
 			model: config.model ?? DEFAULT_LEADER_MODEL,
+			provider: config.provider,
 			agent: 'Leader',
 			agents: allAgents,
 			contextAutoQueue: false,
@@ -1173,6 +1176,7 @@ export function createLeaderAgentInit(
 		context: { roomId: config.room.id },
 		type: 'leader',
 		model: config.model ?? DEFAULT_LEADER_MODEL,
+		provider: config.provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/src/lib/room/agents/planner-agent.ts
+++ b/packages/daemon/src/lib/room/agents/planner-agent.ts
@@ -82,6 +82,8 @@ export interface PlannerAgentConfig {
 	sessionId: string;
 	workspacePath: string;
 	model?: string;
+	/** Provider ID for this session — auto-detected from model if omitted */
+	provider?: string;
 	/** Callback to create a draft task linked to this planning task */
 	createDraftTask: (params: PlannerCreateTaskParams) => Promise<{ id: string; title: string }>;
 	/** Callback to update an existing draft task */
@@ -607,6 +609,7 @@ export function createPlannerAgentInit(config: PlannerAgentConfig): AgentSession
 		context: { roomId: config.room.id },
 		type: 'planner',
 		model: config.model ?? DEFAULT_PLANNER_MODEL,
+		provider: config.provider,
 		agent: 'Planner',
 		agents: {
 			Planner: plannerAgentDef,

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -8,7 +8,7 @@
  * Follows the LobbyAgentService pattern.
  */
 
-import type { Room, McpServerConfig, RuntimeState } from '@neokai/shared';
+import type { Room, McpServerConfig, RuntimeState, Provider } from '@neokai/shared';
 import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
@@ -432,6 +432,16 @@ export class RoomRuntimeService {
 		return runtime;
 	}
 
+	/**
+	 * Infer the provider for a given model ID based on known naming conventions.
+	 * This avoids loading the full provider registry (which requires optional SDK deps).
+	 */
+	private resolveProviderForModel(modelId: string): Provider {
+		if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
+		if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
+		return 'anthropic';
+	}
+
 	private setupRoomAgentSession(
 		room: Room,
 		groupRepo: SessionGroupRepository,
@@ -452,11 +462,32 @@ export class RoomRuntimeService {
 		// DaemonHub subscriptions and duplicate query execution.
 		void this.ctx.sessionManager
 			.getSessionAsync(roomChatSessionId)
-			.then((roomChatSession) => {
+			.then(async (roomChatSession) => {
 				if (!roomChatSession) {
 					log.warn(`Room chat session not found for room ${room.id}`);
 					return;
 				}
+
+				// Sync room chat session model with the room's current defaultModel.
+				// This fixes stale sessions created when the room had a different model
+				// (e.g., glm-5-turbo) that is no longer configured or accessible.
+				const currentModel = room.defaultModel ?? this.ctx.defaultModel;
+				const sessionData = roomChatSession.getSessionData();
+				const sessionModel = sessionData.config.model;
+				if (currentModel && sessionModel !== currentModel) {
+					try {
+						const newProvider = this.resolveProviderForModel(currentModel);
+						await this.ctx.sessionManager.updateSession(roomChatSessionId, {
+							config: { ...sessionData.config, model: currentModel, provider: newProvider },
+						});
+						log.info(
+							`Synced room chat session ${roomChatSessionId}: model ${sessionModel} → ${currentModel} (${newProvider})`
+						);
+					} catch (err) {
+						log.warn(`Failed to sync room chat session model for room ${room.id}:`, err);
+					}
+				}
+
 				roomChatSession.setRuntimeMcpServers({
 					'room-agent-tools': roomAgentMcpServer,
 				});

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -8,7 +8,7 @@
  * Follows the LobbyAgentService pattern.
  */
 
-import type { Room, McpServerConfig, RuntimeState, Provider } from '@neokai/shared';
+import type { Room, McpServerConfig, RuntimeState } from '@neokai/shared';
 import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
@@ -29,6 +29,7 @@ import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-
 import { recoverRuntime, type SessionStateChecker } from './runtime-recovery';
 import type { RoomManager } from '../managers/room-manager';
 import { WorktreeManager } from '../../worktree-manager';
+import { inferProviderForModel } from '../../providers/registry';
 import { Logger } from '../../logger';
 
 const log = new Logger('room-runtime-service');
@@ -432,16 +433,6 @@ export class RoomRuntimeService {
 		return runtime;
 	}
 
-	/**
-	 * Infer the provider for a given model ID based on known naming conventions.
-	 * This avoids loading the full provider registry (which requires optional SDK deps).
-	 */
-	private resolveProviderForModel(modelId: string): Provider {
-		if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
-		if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
-		return 'anthropic';
-	}
-
 	private setupRoomAgentSession(
 		room: Room,
 		groupRepo: SessionGroupRepository,
@@ -476,7 +467,7 @@ export class RoomRuntimeService {
 				const sessionModel = sessionData.config.model;
 				if (currentModel && sessionModel !== currentModel) {
 					try {
-						const newProvider = this.resolveProviderForModel(currentModel);
+						const newProvider = inferProviderForModel(currentModel);
 						await this.ctx.sessionManager.updateSession(roomChatSessionId, {
 							config: { ...sessionData.config, model: currentModel, provider: newProvider },
 						});

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -276,7 +276,11 @@ export class RoomRuntime {
 			sessionFactory: config.sessionFactory,
 			workspacePath: config.workspacePath,
 			model: config.model,
+			provider: config.model ? this.resolveProviderForModel(config.model) : undefined,
 			workerModel: config.workerModel,
+			workerProvider: config.workerModel
+				? this.resolveProviderForModel(config.workerModel)
+				: undefined,
 			getRoom: config.getRoom,
 			getTask: config.getTask,
 			getGoal: config.getGoal,
@@ -286,7 +290,8 @@ export class RoomRuntime {
 		// Keep test and direct-runtime usage predictable: when no explicit leader model
 		// is provided, derive it from the initial room config.
 		if (!config.model || config.model.trim() === '') {
-			this.taskGroupManager.updateModel(this.resolveAgentModel(config.room, 'leader'));
+			const leaderModel = this.resolveAgentModel(config.room, 'leader');
+			this.taskGroupManager.updateModel(leaderModel, this.resolveProviderForModel(leaderModel));
 		}
 	}
 
@@ -345,6 +350,16 @@ export class RoomRuntime {
 	}
 
 	/**
+	 * Infer the provider for a given model ID using a simple naming heuristic.
+	 * Returns 'anthropic' by default if no other provider prefix is matched.
+	 */
+	private resolveProviderForModel(modelId: string): string {
+		if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
+		if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
+		return 'anthropic';
+	}
+
+	/**
 	 * Return the freshest room snapshot available to the runtime.
 	 * Prefer newer snapshots by updatedAt so updateRoom() calls can take effect
 	 * immediately even if an external room provider still returns stale data.
@@ -376,7 +391,11 @@ export class RoomRuntime {
 		const config = (currentRoom.config ?? {}) as Record<string, unknown>;
 
 		// Keep TaskGroupManager model aligned to the current Leader model.
-		this.taskGroupManager.updateModel(this.resolveAgentModel(currentRoom, 'leader'));
+		const updatedLeaderModel = this.resolveAgentModel(currentRoom, 'leader');
+		this.taskGroupManager.updateModel(
+			updatedLeaderModel,
+			this.resolveProviderForModel(updatedLeaderModel)
+		);
 
 		const rawGroups = config.maxConcurrentGroups;
 		this.maxConcurrentGroups =
@@ -2780,6 +2799,8 @@ export class RoomRuntime {
 		}
 		const plannerModel = this.resolveAgentModel(currentRoom, 'planner');
 		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
+		const plannerProvider = this.resolveProviderForModel(plannerModel);
+		const leaderProvider = this.resolveProviderForModel(leaderModel);
 
 		// Build WorkerConfig for the Planner agent
 		// isPlanApproved uses a mutable ref — groupId is set after spawn() returns
@@ -2795,6 +2816,7 @@ export class RoomRuntime {
 			sessionId: '', // placeholder — overwritten by initFactory
 			workspacePath: this.taskGroupManager.workspacePath,
 			model: plannerModel,
+			provider: plannerProvider,
 			createDraftTask,
 			updateDraftTask,
 			removeDraftTask,
@@ -2814,6 +2836,7 @@ export class RoomRuntime {
 				workspacePath: this.taskGroupManager.workspacePath,
 				groupId: '', // not used by buildLeaderTaskContext
 				model: leaderModel,
+				provider: leaderProvider,
 				reviewContext: 'plan_review',
 			}),
 		};
@@ -2906,6 +2929,8 @@ export class RoomRuntime {
 		const workerRole = agentType === 'general' ? 'general' : 'coder';
 		const workerModel = this.resolveAgentModel(currentRoom, workerRole);
 		const leaderModel = this.resolveAgentModel(currentRoom, 'leader');
+		const workerProvider = this.resolveProviderForModel(workerModel);
+		const leaderProvider = this.resolveProviderForModel(leaderModel);
 		let workerConfig: WorkerConfig;
 
 		// Shared leader context config (groupId not used by buildLeaderTaskContext)
@@ -2917,6 +2942,7 @@ export class RoomRuntime {
 			workspacePath: this.taskGroupManager.workspacePath,
 			groupId: '',
 			model: leaderModel,
+			provider: leaderProvider,
 			reviewContext: 'code_review' as const,
 		};
 
@@ -2928,6 +2954,7 @@ export class RoomRuntime {
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
 				model: workerModel,
+				provider: workerProvider,
 				previousTaskSummaries,
 			};
 			workerConfig = {
@@ -2946,6 +2973,7 @@ export class RoomRuntime {
 				sessionId: '', // placeholder — overwritten by initFactory
 				workspacePath: this.taskGroupManager.workspacePath,
 				model: workerModel,
+				provider: workerProvider,
 				previousTaskSummaries,
 			};
 			workerConfig = {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -73,6 +73,7 @@ import {
 } from './lifecycle-hooks';
 import { checkDeadLoop, DEFAULT_DEAD_LOOP_CONFIG, type DeadLoopConfig } from './dead-loop-detector';
 import { getNextRunAt } from './cron-utils';
+import { inferProviderForModel } from '../../providers/registry';
 
 const log = new Logger('room-runtime');
 
@@ -350,13 +351,11 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Infer the provider for a given model ID using a simple naming heuristic.
-	 * Returns 'anthropic' by default if no other provider prefix is matched.
+	 * Infer the provider for a given model ID using naming conventions.
+	 * Delegates to the shared inferProviderForModel utility.
 	 */
 	private resolveProviderForModel(modelId: string): string {
-		if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
-		if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
-		return 'anthropic';
+		return inferProviderForModel(modelId);
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -154,8 +154,12 @@ export interface TaskGroupManagerConfig {
 	workspacePath: string;
 	/** Leader model */
 	model?: string;
+	/** Leader provider (auto-detected from model if omitted) */
+	provider?: string;
 	/** Worker model (defaults to model if not set) */
 	workerModel?: string;
+	/** Worker provider (auto-detected from workerModel if omitted) */
+	workerProvider?: string;
 	/** Fetch room from DB by ID. Used to get CURRENT room config at route time. */
 	getRoom: (roomId: string) => Room | null;
 	/** Fetch task from DB by ID. Used to get CURRENT task data at route time. */
@@ -178,7 +182,9 @@ export class TaskGroupManager {
 	private readonly daemonHub?: DaemonHub;
 	readonly workspacePath: string;
 	private _model?: string;
+	private _provider?: string;
 	readonly workerModel?: string;
+	readonly workerProvider?: string;
 
 	constructor(config: TaskGroupManagerConfig) {
 		this.groupRepo = config.groupRepo;
@@ -191,7 +197,9 @@ export class TaskGroupManager {
 		this.getGoalById = config.getGoal;
 		this.workspacePath = config.workspacePath;
 		this._model = config.model;
+		this._provider = config.provider;
 		this.workerModel = config.workerModel;
+		this.workerProvider = config.workerProvider;
 		this.daemonHub = config.daemonHub;
 	}
 
@@ -200,9 +208,15 @@ export class TaskGroupManager {
 		return this._model;
 	}
 
-	/** Update the model for new leader sessions (e.g., when room settings change) */
-	updateModel(model: string | undefined): void {
+	/** Get the current provider for leader sessions */
+	get provider(): string | undefined {
+		return this._provider;
+	}
+
+	/** Update the model and provider for new leader sessions (e.g., when room settings change) */
+	updateModel(model: string | undefined, provider?: string): void {
 		this._model = model;
+		this._provider = provider;
 	}
 
 	/**
@@ -308,6 +322,7 @@ export class TaskGroupManager {
 			workspacePath: groupWorkspacePath,
 			groupId: group.id,
 			model: this._model,
+			provider: this._provider,
 			reviewContext,
 			goalManager: this.goalManager,
 			taskManager: this.taskManager,
@@ -429,6 +444,7 @@ export class TaskGroupManager {
 				workspacePath: group.workspacePath ?? this.workspacePath,
 				groupId: group.id,
 				model: this.model,
+				provider: this._provider,
 				reviewContext: deferredLeader.reviewContext,
 				goalManager: this.goalManager,
 				taskManager: this.taskManager,

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -13,22 +13,13 @@
  * - agents.cli.list - List detected CLI agents
  */
 
-import type { MessageHub, WorkspacePath, Provider } from '@neokai/shared';
-
-/**
- * Infer the provider for a given model ID based on known naming conventions.
- * This avoids loading the full provider registry (which requires optional SDK deps).
- */
-function inferProviderForModel(modelId: string): Provider {
-	if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
-	if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
-	return 'anthropic';
-}
+import type { MessageHub, WorkspacePath } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import type { SessionManager } from '../session-manager';
 import { getCliAgents, refresh as refreshCliAgents } from '../room/agents/cli-agent-registry';
+import { inferProviderForModel } from '../providers/registry';
 import { Logger } from '../logger';
 
 const log = new Logger('room-handlers');
@@ -75,6 +66,7 @@ export function setupRoomHandlers(
 					workspacePath: defaultPath ?? allowedPaths[0]?.path,
 					config: {
 						model: room.defaultModel,
+						provider: room.defaultModel ? inferProviderForModel(room.defaultModel) : undefined,
 					},
 					sessionType: 'room_chat',
 					roomId: room.id,

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -13,7 +13,17 @@
  * - agents.cli.list - List detected CLI agents
  */
 
-import type { MessageHub, WorkspacePath } from '@neokai/shared';
+import type { MessageHub, WorkspacePath, Provider } from '@neokai/shared';
+
+/**
+ * Infer the provider for a given model ID based on known naming conventions.
+ * This avoids loading the full provider registry (which requires optional SDK deps).
+ */
+function inferProviderForModel(modelId: string): Provider {
+	if (modelId.startsWith('glm-') || modelId === 'glm') return 'glm';
+	if (modelId.startsWith('minimax-') || modelId === 'minimax') return 'minimax';
+	return 'anthropic';
+}
 import type { DaemonHub } from '../daemon-hub';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
@@ -145,6 +155,28 @@ export function setupRoomHandlers(
 
 		if (!room) {
 			throw new Error(`Room not found: ${params.roomId}`);
+		}
+
+		// When defaultModel changes, sync the room chat session's model so it uses
+		// the new model on the next query. This prevents stale sessions from running
+		// with a model that is no longer configured (e.g., after switching from GLM to Anthropic).
+		if (params.defaultModel && sessionManager) {
+			const roomChatSessionId = `room:chat:${room.id}`;
+			try {
+				const existingSession = sessionManager.getSessionFromDB(roomChatSessionId);
+				if (existingSession) {
+					const newProvider = inferProviderForModel(params.defaultModel);
+					await sessionManager.updateSession(roomChatSessionId, {
+						config: {
+							...existingSession.config,
+							model: params.defaultModel,
+							provider: newProvider,
+						},
+					});
+				}
+			} catch (err) {
+				log.warn(`Could not sync room chat session model for room ${room.id}:`, err);
+			}
 		}
 
 		// Broadcast room update event

--- a/packages/daemon/tests/unit/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/providers/provider-registry.test.ts
@@ -10,6 +10,7 @@ import { initializeProviders, resetProviderFactory } from '../../../src/lib/prov
 import {
 	ProviderRegistry,
 	getProviderRegistry,
+	inferProviderForModel,
 	resetProviderRegistry,
 } from '../../../src/lib/providers/registry';
 
@@ -454,5 +455,39 @@ describe('ProviderRegistry', () => {
 		it('should throw when no providers registered', async () => {
 			await expect(registry.getDefaultProvider()).rejects.toThrow('No providers registered');
 		});
+	});
+});
+
+describe('inferProviderForModel', () => {
+	it('maps glm- prefix to glm', () => {
+		expect(inferProviderForModel('glm-5-turbo')).toBe('glm');
+		expect(inferProviderForModel('glm-4')).toBe('glm');
+	});
+
+	it('maps bare glm to glm', () => {
+		expect(inferProviderForModel('glm')).toBe('glm');
+	});
+
+	it('maps minimax- prefix to minimax', () => {
+		expect(inferProviderForModel('minimax-m2.5')).toBe('minimax');
+	});
+
+	it('maps bare minimax to minimax', () => {
+		expect(inferProviderForModel('minimax')).toBe('minimax');
+	});
+
+	it('maps gpt- prefix to anthropic-codex', () => {
+		expect(inferProviderForModel('gpt-5.3-codex')).toBe('anthropic-codex');
+		expect(inferProviderForModel('gpt-5.4')).toBe('anthropic-codex');
+	});
+
+	it('defaults claude- models to anthropic', () => {
+		expect(inferProviderForModel('claude-sonnet-4-5-20250929')).toBe('anthropic');
+		expect(inferProviderForModel('claude-opus-4-6')).toBe('anthropic');
+	});
+
+	it('defaults unknown models to anthropic', () => {
+		expect(inferProviderForModel('sonnet')).toBe('anthropic');
+		expect(inferProviderForModel('unknown-model')).toBe('anthropic');
 	});
 });

--- a/packages/daemon/tests/unit/rpc/room-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/room-handlers.test.ts
@@ -20,7 +20,8 @@ import { MessageHub } from '@neokai/shared';
 import { setupRoomHandlers } from '../../../src/lib/rpc-handlers/room-handlers';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
-import type { Room, RoomOverview, NeoStatus } from '@neokai/shared';
+import type { SessionManager } from '../../../src/lib/session-manager';
+import type { Room, RoomOverview, NeoStatus, Session } from '@neokai/shared';
 
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
@@ -326,6 +327,47 @@ describe('Room RPC Handlers', () => {
 				expect.objectContaining({
 					sessionId: 'global',
 					roomId: 'room-123',
+				})
+			);
+		});
+
+		it('syncs room chat session model when defaultModel changes', async () => {
+			const updateSessionMock = mock(async () => {});
+			const existingSession: Partial<Session> = {
+				id: 'room:chat:room-123',
+				config: {
+					model: 'glm-5-turbo',
+					provider: 'glm',
+					maxTokens: 4096,
+					temperature: 1.0,
+				},
+			};
+			const sessionManager = {
+				getSessionFromDB: mock(() => existingSession as Session),
+				updateSession: updateSessionMock,
+			} as unknown as SessionManager;
+
+			const { hub, handlers } = createMockMessageHub();
+			setupRoomHandlers(
+				hub,
+				roomManagerData.roomManager,
+				daemonHubData.daemonHub,
+				undefined,
+				sessionManager
+			);
+
+			const handler = handlers.get('room.update');
+			expect(handler).toBeDefined();
+
+			await handler!({ roomId: 'room-123', defaultModel: 'sonnet' }, {});
+
+			expect(updateSessionMock).toHaveBeenCalledWith(
+				'room:chat:room-123',
+				expect.objectContaining({
+					config: expect.objectContaining({
+						model: 'sonnet',
+						provider: 'anthropic',
+					}),
 				})
 			);
 		});


### PR DESCRIPTION
Room chat sessions (`room:chat:<roomId>`) were being created with whatever
model was configured at room-creation time. If the room's defaultModel was
later changed (or was already using `glm-5-turbo`), the session kept the
stale model/provider, causing "There's an issue with the selected model
(glm-5-turbo)" errors.

Changes:
- room-handlers: when `room.update` changes `defaultModel`, immediately
  update the corresponding room chat session's config (model + provider).
  Uses a lightweight `inferProviderForModel` utility to avoid loading the
  full provider registry (which requires optional `@github/copilot-sdk`).
- room-runtime-service: same lightweight heuristic replaces the previous
  async `resolveProviderForModel` that used dynamic factory import; also
  fixes a missing `await` bug on that call site.
- test: add unit test asserting that `room.update` syncs the session
  model from glm-5-turbo/glm to sonnet/anthropic.
