### PR TITLE
feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4)

### DIFF
--- a/packages/web/src/components/space/visual-editor/CanvasToolbar.tsx
+++ b/packages/web/src/components/space/visual-editor/CanvasToolbar.tsx
@@ -1,0 +1,163 @@
+/**
+ * CanvasToolbar
+ *
+ * A small floating toolbar positioned at the bottom-right of the canvas
+ * that provides zoom controls and a fit-to-view button.
+ */
+
+import type { NodePosition, ViewportState } from './types';
+import { MIN_SCALE, MAX_SCALE } from './VisualCanvas';
+
+export const ZOOM_STEP = 0.25;
+export const FIT_PADDING = 40;
+
+/**
+ * Compute a ViewportState that centers and fits all nodes inside the viewport
+ * with the given padding on each side.
+ *
+ * Returns the current viewport unchanged when there are no nodes.
+ */
+export function computeFitToView(
+	nodes: NodePosition,
+	viewportWidth: number,
+	viewportHeight: number,
+	padding = FIT_PADDING
+): ViewportState {
+	const entries = Object.values(nodes);
+	if (entries.length === 0) {
+		return { offsetX: 0, offsetY: 0, scale: 1 };
+	}
+
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const { x, y, width, height } of entries) {
+		if (x < minX) minX = x;
+		if (y < minY) minY = y;
+		if (x + width > maxX) maxX = x + width;
+		if (y + height > maxY) maxY = y + height;
+	}
+
+	const nodesW = maxX - minX;
+	const nodesH = maxY - minY;
+
+	const availableW = viewportWidth - 2 * padding;
+	const availableH = viewportHeight - 2 * padding;
+
+	const scaleX = availableW > 0 ? availableW / nodesW : 1;
+	const scaleY = availableH > 0 ? availableH / nodesH : 1;
+	const scale = Math.min(scaleX, scaleY, MAX_SCALE);
+	const clampedScale = Math.max(MIN_SCALE, scale);
+
+	// Center the nodes in the viewport
+	const scaledW = nodesW * clampedScale;
+	const scaledH = nodesH * clampedScale;
+	const offsetX = (viewportWidth - scaledW) / 2 - minX * clampedScale;
+	const offsetY = (viewportHeight - scaledH) / 2 - minY * clampedScale;
+
+	return { offsetX, offsetY, scale: clampedScale };
+}
+
+interface CanvasToolbarProps {
+	viewport: ViewportState;
+	nodes: NodePosition;
+	viewportWidth: number;
+	viewportHeight: number;
+	onViewportChange: (state: ViewportState) => void;
+}
+
+export function CanvasToolbar({
+	viewport,
+	nodes,
+	viewportWidth,
+	viewportHeight,
+	onViewportChange,
+}: CanvasToolbarProps) {
+	const handleZoomIn = () => {
+		const newScale = Math.min(MAX_SCALE, viewport.scale + ZOOM_STEP);
+		// Zoom toward center of viewport
+		const cx = viewportWidth / 2;
+		const cy = viewportHeight / 2;
+		const ratio = newScale / viewport.scale;
+		onViewportChange({
+			scale: newScale,
+			offsetX: cx - (cx - viewport.offsetX) * ratio,
+			offsetY: cy - (cy - viewport.offsetY) * ratio,
+		});
+	};
+
+	const handleZoomOut = () => {
+		const newScale = Math.max(MIN_SCALE, viewport.scale - ZOOM_STEP);
+		const cx = viewportWidth / 2;
+		const cy = viewportHeight / 2;
+		const ratio = newScale / viewport.scale;
+		onViewportChange({
+			scale: newScale,
+			offsetX: cx - (cx - viewport.offsetX) * ratio,
+			offsetY: cy - (cy - viewport.offsetY) * ratio,
+		});
+	};
+
+	const handleReset = () => {
+		onViewportChange({ offsetX: 0, offsetY: 0, scale: 1 });
+	};
+
+	const handleFitToView = () => {
+		onViewportChange(computeFitToView(nodes, viewportWidth, viewportHeight));
+	};
+
+	const zoomPercent = Math.round(viewport.scale * 100);
+
+	return (
+		<div
+			class="absolute bottom-4 right-4 flex items-center gap-1 px-2 py-1.5 bg-dark-850 border border-dark-700 rounded-lg shadow-lg select-none pointer-events-auto"
+			data-testid="canvas-toolbar"
+		>
+			<button
+				type="button"
+				class="w-7 h-7 flex items-center justify-center rounded text-gray-400 hover:text-gray-100 hover:bg-dark-700 transition-colors text-base font-medium"
+				onClick={handleZoomOut}
+				title="Zoom out"
+				data-testid="canvas-toolbar-zoom-out"
+				disabled={viewport.scale <= MIN_SCALE}
+			>
+				−
+			</button>
+
+			<button
+				type="button"
+				class="min-w-[3rem] h-7 px-1 flex items-center justify-center rounded text-xs text-gray-400 hover:text-gray-100 hover:bg-dark-700 transition-colors tabular-nums"
+				onClick={handleReset}
+				title="Reset zoom (100%)"
+				data-testid="canvas-toolbar-reset"
+			>
+				{zoomPercent}%
+			</button>
+
+			<button
+				type="button"
+				class="w-7 h-7 flex items-center justify-center rounded text-gray-400 hover:text-gray-100 hover:bg-dark-700 transition-colors text-base font-medium"
+				onClick={handleZoomIn}
+				title="Zoom in"
+				data-testid="canvas-toolbar-zoom-in"
+				disabled={viewport.scale >= MAX_SCALE}
+			>
+				+
+			</button>
+
+			<div class="w-px h-4 bg-dark-700 mx-0.5" />
+
+			<button
+				type="button"
+				class="h-7 px-2 flex items-center justify-center rounded text-xs text-gray-400 hover:text-gray-100 hover:bg-dark-700 transition-colors"
+				onClick={handleFitToView}
+				title="Fit all nodes to view"
+				data-testid="canvas-toolbar-fit"
+			>
+				Fit
+			</button>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -13,9 +13,10 @@
  *  - Scale is clamped to [0.25, 2.0] and zooms toward cursor position.
  */
 
-import { useEffect, useRef, useCallback } from 'preact/hooks';
+import { useEffect, useRef, useCallback, useState } from 'preact/hooks';
 import type { ComponentChildren } from 'preact';
-import type { ViewportState } from './types';
+import type { NodePosition, ViewportState } from './types';
+import { CanvasToolbar } from './CanvasToolbar';
 
 export const MIN_SCALE = 0.25;
 export const MAX_SCALE = 2.0;
@@ -60,6 +61,10 @@ interface VisualCanvasProps {
 	onViewportChange: (state: ViewportState) => void;
 	/** Render prop for injecting SVG edge content. Receives current viewport state. */
 	edgeLayer?: (viewport: ViewportState) => ComponentChildren;
+	/** Node positions used by the fit-to-view toolbar button. */
+	nodes?: NodePosition;
+	/** Whether to show the zoom/fit toolbar overlay. Defaults to true. */
+	showToolbar?: boolean;
 }
 
 export function VisualCanvas({
@@ -67,8 +72,11 @@ export function VisualCanvas({
 	viewportState,
 	onViewportChange,
 	edgeLayer,
+	nodes = {},
+	showToolbar = true,
 }: VisualCanvasProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const [containerSize, setContainerSize] = useState({ width: 800, height: 600 });
 
 	// Track spacebar state for pan-drag mode
 	const spacebarDown = useRef(false);
@@ -83,6 +91,25 @@ export function VisualCanvas({
 	// Keep a ref to the latest viewport so event handlers don't stale-close over it
 	const viewportRef = useRef(viewportState);
 	viewportRef.current = viewportState;
+
+	// ---- Track container size for toolbar fit-to-view ----
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const obs = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (entry) {
+				setContainerSize({
+					width: entry.contentRect.width,
+					height: entry.contentRect.height,
+				});
+			}
+		});
+		obs.observe(el);
+		// Set initial size
+		setContainerSize({ width: el.clientWidth, height: el.clientHeight });
+		return () => obs.disconnect();
+	}, []);
 
 	// ---- Wheel handler (pan + zoom) ----
 	// Registered via onWheel JSX prop so Preact attaches it as a non-passive
@@ -216,6 +243,15 @@ export function VisualCanvas({
 				</svg>
 				{children}
 			</div>
+			{showToolbar && (
+				<CanvasToolbar
+					viewport={viewportState}
+					nodes={nodes}
+					viewportWidth={containerSize.width}
+					viewportHeight={containerSize.height}
+					onViewportChange={onViewportChange}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/visual-editor/__tests__/CanvasToolbar.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/CanvasToolbar.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for CanvasToolbar and computeFitToView.
+ *
+ * Tests:
+ * - computeFitToView: returns default viewport when no nodes
+ * - computeFitToView: centers a single node
+ * - computeFitToView: fits multiple nodes with padding
+ * - computeFitToView: clamps scale to MIN_SCALE
+ * - computeFitToView: clamps scale to MAX_SCALE
+ * - computeFitToView: asymmetric nodes (wider vs taller)
+ * - CanvasToolbar: renders all buttons
+ * - CanvasToolbar: zoom-in increases scale
+ * - CanvasToolbar: zoom-out decreases scale
+ * - CanvasToolbar: reset returns to scale=1 and offset=0
+ * - CanvasToolbar: fit-to-view calls onViewportChange with centered viewport
+ * - CanvasToolbar: zoom-in disabled at MAX_SCALE
+ * - CanvasToolbar: zoom-out disabled at MIN_SCALE
+ * - CanvasToolbar: displays current zoom percentage
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { computeFitToView, CanvasToolbar, ZOOM_STEP, FIT_PADDING } from '../CanvasToolbar';
+import { MIN_SCALE, MAX_SCALE } from '../VisualCanvas';
+import type { NodePosition, ViewportState } from '../types';
+
+afterEach(() => cleanup());
+
+// ---- computeFitToView pure logic ----
+
+describe('computeFitToView', () => {
+	it('returns default viewport when nodes is empty', () => {
+		const result = computeFitToView({}, 800, 600);
+		expect(result).toEqual({ offsetX: 0, offsetY: 0, scale: 1 });
+	});
+
+	it('centers a single node in the viewport', () => {
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 100, height: 100 } };
+		const vw = 800;
+		const vh = 600;
+		const result = computeFitToView(nodes, vw, vh, 0);
+
+		// With no padding: scale = min(800/100, 600/100) = 6 → clamped to MAX_SCALE=2
+		expect(result.scale).toBe(MAX_SCALE);
+
+		// Node should be centered
+		const scaledW = 100 * result.scale;
+		const scaledH = 100 * result.scale;
+		const expectedOffsetX = (vw - scaledW) / 2;
+		const expectedOffsetY = (vh - scaledH) / 2;
+		expect(result.offsetX).toBeCloseTo(expectedOffsetX);
+		expect(result.offsetY).toBeCloseTo(expectedOffsetY);
+	});
+
+	it('fits multiple nodes with default padding', () => {
+		const nodes: NodePosition = {
+			a: { x: 0, y: 0, width: 100, height: 80 },
+			b: { x: 200, y: 100, width: 100, height: 80 },
+		};
+		// Bounding box: [0,0] to [300, 180] → size 300x180
+		const vw = 800;
+		const vh = 600;
+		const result = computeFitToView(nodes, vw, vh, FIT_PADDING);
+
+		const availW = vw - 2 * FIT_PADDING;
+		const availH = vh - 2 * FIT_PADDING;
+		const expectedScale = Math.min(availW / 300, availH / 180, MAX_SCALE);
+		expect(result.scale).toBeCloseTo(expectedScale);
+
+		// Check centering: scaled nodes midpoint should be at viewport center
+		const nodesW = 300;
+		const nodesH = 180;
+		const scaledW = nodesW * result.scale;
+		const scaledH = nodesH * result.scale;
+		const expectedOffsetX = (vw - scaledW) / 2 - 0 * result.scale; // minX=0
+		const expectedOffsetY = (vh - scaledH) / 2 - 0 * result.scale; // minY=0
+		expect(result.offsetX).toBeCloseTo(expectedOffsetX);
+		expect(result.offsetY).toBeCloseTo(expectedOffsetY);
+	});
+
+	it('clamps scale to MIN_SCALE for tiny viewport', () => {
+		// Very small viewport relative to nodes
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 10000, height: 10000 } };
+		const result = computeFitToView(nodes, 100, 100, 0);
+		expect(result.scale).toBe(MIN_SCALE);
+	});
+
+	it('clamps scale to MAX_SCALE for tiny nodes in large viewport', () => {
+		// Very small nodes in large viewport
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 1, height: 1 } };
+		const result = computeFitToView(nodes, 1000, 1000, 0);
+		expect(result.scale).toBe(MAX_SCALE);
+	});
+
+	it('fits wide content (limited by width)', () => {
+		// 400x50 nodes in 800x600 viewport with no padding
+		// scaleX = 800/400 = 2, scaleY = 600/50 = 12 → min is 2 → clamped to MAX_SCALE=2
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 400, height: 50 } };
+		const result = computeFitToView(nodes, 800, 600, 0);
+		expect(result.scale).toBe(MAX_SCALE);
+	});
+
+	it('fits tall content (limited by height)', () => {
+		// 50x400 nodes in 800x600 viewport with no padding
+		// scaleX = 800/50 = 16, scaleY = 600/400 = 1.5 → min is 1.5
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 50, height: 400 } };
+		const result = computeFitToView(nodes, 800, 600, 0);
+		expect(result.scale).toBeCloseTo(1.5);
+	});
+
+	it('handles nodes not starting at origin', () => {
+		// Nodes offset from origin
+		const nodes: NodePosition = { a: { x: 500, y: 500, width: 100, height: 100 } };
+		const vw = 800;
+		const vh = 600;
+		const result = computeFitToView(nodes, vw, vh, 0);
+
+		expect(result.scale).toBe(MAX_SCALE);
+		// offsetX: (800 - 100*2)/2 - 500*2 = 300 - 1000 = -700
+		expect(result.offsetX).toBeCloseTo((vw - 100 * result.scale) / 2 - 500 * result.scale);
+		expect(result.offsetY).toBeCloseTo((vh - 100 * result.scale) / 2 - 500 * result.scale);
+	});
+});
+
+// ---- CanvasToolbar component ----
+
+function makeViewport(scale = 1, offsetX = 0, offsetY = 0): ViewportState {
+	return { scale, offsetX, offsetY };
+}
+
+describe('CanvasToolbar', () => {
+	it('renders zoom-in, zoom-out, reset, and fit buttons', () => {
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport()}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={() => {}}
+			/>
+		);
+		expect(getByTestId('canvas-toolbar-zoom-in')).toBeTruthy();
+		expect(getByTestId('canvas-toolbar-zoom-out')).toBeTruthy();
+		expect(getByTestId('canvas-toolbar-reset')).toBeTruthy();
+		expect(getByTestId('canvas-toolbar-fit')).toBeTruthy();
+	});
+
+	it('displays the current zoom percentage', () => {
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(1.5)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={() => {}}
+			/>
+		);
+		expect(getByTestId('canvas-toolbar-reset').textContent).toBe('150%');
+	});
+
+	it('zoom-in increases scale by ZOOM_STEP', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(1)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={onChange}
+			/>
+		);
+		fireEvent.click(getByTestId('canvas-toolbar-zoom-in'));
+		expect(onChange).toHaveBeenCalledOnce();
+		const next = onChange.mock.calls[0][0] as ViewportState;
+		expect(next.scale).toBeCloseTo(1 + ZOOM_STEP);
+	});
+
+	it('zoom-out decreases scale by ZOOM_STEP', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(1)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={onChange}
+			/>
+		);
+		fireEvent.click(getByTestId('canvas-toolbar-zoom-out'));
+		expect(onChange).toHaveBeenCalledOnce();
+		const next = onChange.mock.calls[0][0] as ViewportState;
+		expect(next.scale).toBeCloseTo(1 - ZOOM_STEP);
+	});
+
+	it('reset returns to scale=1 and offset=0,0', () => {
+		const onChange = vi.fn();
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(1.5, 100, 200)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={onChange}
+			/>
+		);
+		fireEvent.click(getByTestId('canvas-toolbar-reset'));
+		expect(onChange).toHaveBeenCalledWith({ offsetX: 0, offsetY: 0, scale: 1 });
+	});
+
+	it('fit-to-view calls onViewportChange with computed fit viewport', () => {
+		const onChange = vi.fn();
+		const nodes: NodePosition = { a: { x: 0, y: 0, width: 200, height: 150 } };
+		const vw = 800;
+		const vh = 600;
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(1)}
+				nodes={nodes}
+				viewportWidth={vw}
+				viewportHeight={vh}
+				onViewportChange={onChange}
+			/>
+		);
+		fireEvent.click(getByTestId('canvas-toolbar-fit'));
+		expect(onChange).toHaveBeenCalledOnce();
+		const next = onChange.mock.calls[0][0] as ViewportState;
+		const expected = computeFitToView(nodes, vw, vh);
+		expect(next.scale).toBeCloseTo(expected.scale);
+		expect(next.offsetX).toBeCloseTo(expected.offsetX);
+		expect(next.offsetY).toBeCloseTo(expected.offsetY);
+	});
+
+	it('zoom-in button is disabled at MAX_SCALE', () => {
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(MAX_SCALE)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={() => {}}
+			/>
+		);
+		expect((getByTestId('canvas-toolbar-zoom-in') as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('zoom-out button is disabled at MIN_SCALE', () => {
+		const { getByTestId } = render(
+			<CanvasToolbar
+				viewport={makeViewport(MIN_SCALE)}
+				nodes={{}}
+				viewportWidth={800}
+				viewportHeight={600}
+				onViewportChange={() => {}}
+			/>
+		);
+		expect((getByTestId('canvas-toolbar-zoom-out') as HTMLButtonElement).disabled).toBe(true);
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -1,3 +1,4 @@
 export { VisualCanvas, applyWheelEvent, MIN_SCALE, MAX_SCALE } from './VisualCanvas';
+export { CanvasToolbar, computeFitToView, ZOOM_STEP, FIT_PADDING } from './CanvasToolbar';
 export type { ViewportState, Point, Size, NodePosition } from './types';
 export { screenToCanvas, canvasToScreen } from './types';


### PR DESCRIPTION
- CanvasToolbar component with zoom-in (+0.25), zoom-out (-0.25), reset
  (scale=1, offset=0,0), and fit-to-view buttons
- computeFitToView pure function: computes scale/offset to center all
  nodes with configurable padding, clamps to [MIN_SCALE, MAX_SCALE]
- VisualCanvas now accepts optional `nodes` and `showToolbar` props and
  renders CanvasToolbar as an absolute bottom-right overlay; tracks
  container size via ResizeObserver for accurate fit-to-view
- 16 new tests covering computeFitToView edge cases and toolbar interactions
