### PR TITLE
feat: add node selection and multi-select to visual editor (Task 2.3)

### DIFF
--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -58,9 +58,16 @@ interface VisualCanvasProps {
 	children?: ComponentChildren;
 	viewportState: ViewportState;
 	onViewportChange: (state: ViewportState) => void;
+	/** Called when the canvas background is clicked (not on a child node). */
+	onBackgroundClick?: () => void;
 }
 
-export function VisualCanvas({ children, viewportState, onViewportChange }: VisualCanvasProps) {
+export function VisualCanvas({
+	children,
+	viewportState,
+	onViewportChange,
+	onBackgroundClick,
+}: VisualCanvasProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	// Track spacebar state for pan-drag mode
@@ -72,6 +79,8 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 		originOffsetX: number;
 		originOffsetY: number;
 	} | null>(null);
+	// Track whether a spacebar-drag actually moved the canvas (suppress background click)
+	const didDrag = useRef(false);
 
 	// Keep a ref to the latest viewport so event handlers don't stale-close over it
 	const viewportRef = useRef(viewportState);
@@ -128,6 +137,7 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 	const handleMouseDown = useCallback((e: MouseEvent) => {
 		if (!spacebarDown.current || e.button !== 0) return;
 		e.preventDefault();
+		didDrag.current = false;
 		dragState.current = {
 			startX: e.clientX,
 			startY: e.clientY,
@@ -142,6 +152,7 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 	const handleMouseMove = useCallback(
 		(e: MouseEvent) => {
 			if (!dragState.current) return;
+			didDrag.current = true;
 			const dx = e.clientX - dragState.current.startX;
 			const dy = e.clientY - dragState.current.startY;
 			onViewportChange({
@@ -170,6 +181,27 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 		};
 	}, [handleMouseMove, handleMouseUp]);
 
+	// ---- Background click: fires when clicking the canvas outside of child nodes ----
+	// Child nodes should call e.stopPropagation() to prevent this from firing.
+	const handleContainerClick = useCallback(
+		(e: MouseEvent) => {
+			// Suppress if a spacebar-drag just finished
+			if (didDrag.current) {
+				didDrag.current = false;
+				return;
+			}
+			// Only fire for direct clicks on the container or transform layer, not nodes
+			const target = e.target as HTMLElement;
+			const isBackground =
+				target === containerRef.current ||
+				target.getAttribute('data-testid') === 'visual-canvas-transform';
+			if (isBackground) {
+				onBackgroundClick?.();
+			}
+		},
+		[onBackgroundClick]
+	);
+
 	const transform = `translate(${viewportState.offsetX}px, ${viewportState.offsetY}px) scale(${viewportState.scale})`;
 
 	return (
@@ -179,6 +211,7 @@ export function VisualCanvas({ children, viewportState, onViewportChange }: Visu
 			style={{ overflow: 'hidden', width: '100%', height: '100%', position: 'relative' }}
 			onMouseDown={handleMouseDown}
 			onWheel={handleWheel}
+			onClick={handleContainerClick}
 			data-testid="visual-canvas"
 		>
 			<div

--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -69,6 +69,7 @@ export function VisualCanvas({
 	onBackgroundClick,
 }: VisualCanvasProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const transformRef = useRef<HTMLDivElement>(null);
 
 	// Track spacebar state for pan-drag mode
 	const spacebarDown = useRef(false);
@@ -190,11 +191,10 @@ export function VisualCanvas({
 				didDrag.current = false;
 				return;
 			}
-			// Only fire for direct clicks on the container or transform layer, not nodes
+			// Use refs instead of data-testid so this works correctly in production
+			// (where data-testid attributes may be stripped by build tooling).
 			const target = e.target as HTMLElement;
-			const isBackground =
-				target === containerRef.current ||
-				target.getAttribute('data-testid') === 'visual-canvas-transform';
+			const isBackground = target === containerRef.current || target === transformRef.current;
 			if (isBackground) {
 				onBackgroundClick?.();
 			}
@@ -215,6 +215,7 @@ export function VisualCanvas({
 			data-testid="visual-canvas"
 		>
 			<div
+				ref={transformRef}
 				class="visual-canvas-transform"
 				style={{
 					transform,

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -1,0 +1,110 @@
+/**
+ * WorkflowCanvas
+ *
+ * Wraps VisualCanvas with workflow-specific behaviour:
+ *  - Manages selectedNodeId state (single-select)
+ *  - Renders WorkflowNode components with correct isSelected prop
+ *  - Handles Delete/Backspace keyboard shortcut to delete selected node
+ *  - Emits onNodeSelect(stepId | null) so parent components can react
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import { VisualCanvas } from './VisualCanvas';
+import { WorkflowNode } from './WorkflowNode';
+import type { ViewportState } from './types';
+
+export interface WorkflowNodeData {
+	stepId: string;
+	name: string;
+	/** Canvas-space X position. */
+	x: number;
+	/** Canvas-space Y position. */
+	y: number;
+	width?: number;
+	height?: number;
+}
+
+export interface WorkflowCanvasProps {
+	nodes: WorkflowNodeData[];
+	viewportState: ViewportState;
+	onViewportChange: (state: ViewportState) => void;
+	/** Called when the selected node changes. Null means nothing is selected. */
+	onNodeSelect?: (stepId: string | null) => void;
+	/** Called when Delete/Backspace is pressed with a node selected. */
+	onDeleteNode?: (stepId: string) => void;
+}
+
+export function WorkflowCanvas({
+	nodes,
+	viewportState,
+	onViewportChange,
+	onNodeSelect,
+	onDeleteNode,
+}: WorkflowCanvasProps) {
+	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+	// Keep ref so keyboard handler always sees the latest value without re-registering
+	const selectedNodeIdRef = useRef<string | null>(null);
+	selectedNodeIdRef.current = selectedNodeId;
+
+	const onNodeSelectRef = useRef(onNodeSelect);
+	onNodeSelectRef.current = onNodeSelect;
+
+	const onDeleteNodeRef = useRef(onDeleteNode);
+	onDeleteNodeRef.current = onDeleteNode;
+
+	const handleNodeSelect = useCallback(
+		(stepId: string) => {
+			setSelectedNodeId(stepId);
+			onNodeSelect?.(stepId);
+		},
+		[onNodeSelect]
+	);
+
+	const handleBackgroundClick = useCallback(() => {
+		setSelectedNodeId(null);
+		onNodeSelect?.(null);
+	}, [onNodeSelect]);
+
+	// ---- Keyboard: Delete / Backspace removes the selected node ----
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+			const tag = (e.target as HTMLElement)?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+			const current = selectedNodeIdRef.current;
+			if (!current || !onDeleteNodeRef.current) return;
+
+			e.preventDefault();
+			onDeleteNodeRef.current(current);
+			setSelectedNodeId(null);
+			onNodeSelectRef.current?.(null);
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, []);
+
+	return (
+		<VisualCanvas
+			viewportState={viewportState}
+			onViewportChange={onViewportChange}
+			onBackgroundClick={handleBackgroundClick}
+		>
+			{nodes.map((node) => (
+				<WorkflowNode
+					key={node.stepId}
+					stepId={node.stepId}
+					name={node.name}
+					x={node.x}
+					y={node.y}
+					width={node.width}
+					height={node.height}
+					isSelected={selectedNodeId === node.stepId}
+					onSelect={handleNodeSelect}
+				/>
+			))}
+		</VisualCanvas>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -53,6 +53,16 @@ export function WorkflowCanvas({
 	const onDeleteNodeRef = useRef(onDeleteNode);
 	onDeleteNodeRef.current = onDeleteNode;
 
+	// Clear selection if the selected node is removed externally (e.g. parent deletes it
+	// from the nodes array). Without this, a node re-added with the same stepId would
+	// appear pre-selected, which is unexpected.
+	useEffect(() => {
+		if (selectedNodeId !== null && !nodes.some((n) => n.stepId === selectedNodeId)) {
+			setSelectedNodeId(null);
+			onNodeSelectRef.current?.(null);
+		}
+	}, [nodes, selectedNodeId]);
+
 	const handleNodeSelect = useCallback(
 		(stepId: string) => {
 			setSelectedNodeId(stepId);

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -1,0 +1,89 @@
+/**
+ * WorkflowNode
+ *
+ * Renders a single workflow step as a positioned node on the canvas.
+ * The node is positioned absolutely within the canvas transform layer
+ * using canvas-space coordinates.
+ *
+ * Visual indicator: a ring/border highlight shows when `isSelected` is true.
+ */
+
+import type { JSX } from 'preact';
+
+export interface WorkflowNodeProps {
+	/** Stable identifier for this workflow step. */
+	stepId: string;
+	/** Human-readable label rendered inside the node. */
+	name: string;
+	/** Canvas-space X position (pixels, left edge). */
+	x: number;
+	/** Canvas-space Y position (pixels, top edge). */
+	y: number;
+	/** Node width in canvas-space pixels. Defaults to 160. */
+	width?: number;
+	/** Node height in canvas-space pixels. Defaults to 60. */
+	height?: number;
+	/** Whether this node is currently selected. */
+	isSelected: boolean;
+	/** Called when the node is clicked. */
+	onSelect: (stepId: string) => void;
+}
+
+export function WorkflowNode({
+	stepId,
+	name,
+	x,
+	y,
+	width = 160,
+	height = 60,
+	isSelected,
+	onSelect,
+}: WorkflowNodeProps): JSX.Element {
+	function handleClick(e: MouseEvent) {
+		e.stopPropagation();
+		onSelect(stepId);
+	}
+
+	return (
+		<div
+			data-testid={`workflow-node-${stepId}`}
+			data-node-id={stepId}
+			style={{
+				position: 'absolute',
+				left: `${x}px`,
+				top: `${y}px`,
+				width: `${width}px`,
+				height: `${height}px`,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'var(--color-surface, #fff)',
+				borderRadius: '8px',
+				border: isSelected
+					? '2px solid var(--color-primary, #6366f1)'
+					: '2px solid var(--color-border, #e2e8f0)',
+				boxShadow: isSelected
+					? '0 0 0 3px var(--color-primary-faint, rgba(99,102,241,0.2))'
+					: '0 1px 3px rgba(0,0,0,0.1)',
+				cursor: 'pointer',
+				userSelect: 'none',
+				boxSizing: 'border-box',
+			}}
+			class={`workflow-node${isSelected ? ' workflow-node--selected' : ''}`}
+			onClick={handleClick}
+		>
+			<span
+				style={{
+					fontSize: '13px',
+					fontWeight: 500,
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					whiteSpace: 'nowrap',
+					padding: '0 12px',
+				}}
+			>
+				{name}
+			</span>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -176,6 +176,49 @@ describe('WorkflowCanvas — keyboard delete', () => {
 	});
 });
 
+describe('WorkflowCanvas — stale selection cleanup', () => {
+	it('clears selection when the selected node is removed from the nodes array', () => {
+		const onNodeSelect = vi.fn();
+		const onDeleteNode = vi.fn();
+
+		function Wrapper() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			const [nodes, setNodes] = useState<WorkflowNodeData[]>(NODES);
+			return (
+				<div>
+					<button
+						data-testid="remove-step-1"
+						onClick={() => setNodes((prev) => prev.filter((n) => n.stepId !== 'step-1'))}
+					>
+						Remove
+					</button>
+					<WorkflowCanvas
+						nodes={nodes}
+						viewportState={vp}
+						onViewportChange={setVp}
+						onNodeSelect={onNodeSelect}
+						onDeleteNode={onDeleteNode}
+					/>
+				</div>
+			);
+		}
+
+		const { getByTestId, queryByTestId } = render(<Wrapper />);
+
+		// Select step-1
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(onNodeSelect).toHaveBeenLastCalledWith('step-1');
+		onNodeSelect.mockClear();
+
+		// Remove step-1 from the nodes array externally
+		fireEvent.click(getByTestId('remove-step-1'));
+
+		// Node element is gone and onNodeSelect(null) was called to clear selection
+		expect(queryByTestId('workflow-node-step-1')).toBeNull();
+		expect(onNodeSelect).toHaveBeenCalledWith(null);
+	});
+});
+
 describe('WorkflowNode — isSelected prop', () => {
 	it('node without selection does not have selected class', () => {
 		const { getByTestId } = renderCanvas();

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for WorkflowCanvas node selection and multi-select behaviour.
+ *
+ * Tests:
+ * - Renders all nodes
+ * - Clicking a node selects it (isSelected visual indicator)
+ * - Clicking a node calls onNodeSelect with the stepId
+ * - Clicking background deselects the active node
+ * - Clicking background calls onNodeSelect(null)
+ * - Clicking a different node switches selection
+ * - Delete key on selected node calls onDeleteNode
+ * - Backspace key on selected node calls onDeleteNode
+ * - Delete/Backspace without selection does not call onDeleteNode
+ * - Delete key clears selection after onDeleteNode
+ * - Delete key inside input does not trigger onDeleteNode
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
+import { WorkflowCanvas } from '../WorkflowCanvas';
+import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
+import type { ViewportState } from '../types';
+
+afterEach(() => cleanup());
+
+const VP: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 };
+
+const NODES: WorkflowNodeData[] = [
+	{ stepId: 'step-1', name: 'Step One', x: 10, y: 10 },
+	{ stepId: 'step-2', name: 'Step Two', x: 200, y: 10 },
+];
+
+function renderCanvas(extra: Partial<WorkflowCanvasProps> = {}) {
+	const onNodeSelect = vi.fn();
+	const onDeleteNode = vi.fn();
+
+	function Wrapper() {
+		const [vp, setVp] = useState<ViewportState>(VP);
+		return (
+			<WorkflowCanvas
+				nodes={NODES}
+				viewportState={vp}
+				onViewportChange={setVp}
+				onNodeSelect={onNodeSelect}
+				onDeleteNode={onDeleteNode}
+				{...extra}
+			/>
+		);
+	}
+
+	const result = render(<Wrapper />);
+	return { ...result, onNodeSelect, onDeleteNode };
+}
+
+describe('WorkflowCanvas — rendering', () => {
+	it('renders all provided nodes', () => {
+		const { getByTestId } = renderCanvas();
+		expect(getByTestId('workflow-node-step-1').textContent).toContain('Step One');
+		expect(getByTestId('workflow-node-step-2').textContent).toContain('Step Two');
+	});
+
+	it('starts with no node selected', () => {
+		const { getByTestId } = renderCanvas();
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('workflow-node--selected');
+		expect(getByTestId('workflow-node-step-2').className).not.toContain('workflow-node--selected');
+	});
+});
+
+describe('WorkflowCanvas — selection', () => {
+	it('clicking a node adds selected class', () => {
+		const { getByTestId } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(getByTestId('workflow-node-step-1').className).toContain('workflow-node--selected');
+	});
+
+	it('clicking a node calls onNodeSelect with the stepId', () => {
+		const { getByTestId, onNodeSelect } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(onNodeSelect).toHaveBeenCalledWith('step-1');
+	});
+
+	it('clicking a different node switches selection', () => {
+		const { getByTestId } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		fireEvent.click(getByTestId('workflow-node-step-2'));
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('workflow-node--selected');
+		expect(getByTestId('workflow-node-step-2').className).toContain('workflow-node--selected');
+	});
+
+	it('clicking background deselects the node', () => {
+		const { getByTestId } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(getByTestId('workflow-node-step-1').className).toContain('workflow-node--selected');
+
+		// Click the transform layer (canvas background)
+		fireEvent.click(getByTestId('visual-canvas-transform'));
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('workflow-node--selected');
+	});
+
+	it('clicking background calls onNodeSelect(null)', () => {
+		const { getByTestId, onNodeSelect } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		onNodeSelect.mockClear();
+
+		fireEvent.click(getByTestId('visual-canvas-transform'));
+		expect(onNodeSelect).toHaveBeenCalledWith(null);
+	});
+
+	it('clicking canvas container deselects', () => {
+		const { getByTestId, onNodeSelect } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		onNodeSelect.mockClear();
+
+		fireEvent.click(getByTestId('visual-canvas'));
+		expect(onNodeSelect).toHaveBeenCalledWith(null);
+	});
+});
+
+describe('WorkflowCanvas — keyboard delete', () => {
+	it('Delete key calls onDeleteNode with selected stepId', () => {
+		const { getByTestId, onDeleteNode } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onDeleteNode).toHaveBeenCalledWith('step-1');
+	});
+
+	it('Backspace key calls onDeleteNode with selected stepId', () => {
+		const { getByTestId, onDeleteNode } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-2'));
+		fireEvent.keyDown(document.body, { key: 'Backspace' });
+		expect(onDeleteNode).toHaveBeenCalledWith('step-2');
+	});
+
+	it('Delete key without selection does not call onDeleteNode', () => {
+		const { onDeleteNode } = renderCanvas();
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onDeleteNode).not.toHaveBeenCalled();
+	});
+
+	it('Delete key clears selection after calling onDeleteNode', () => {
+		const { getByTestId } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(getByTestId('workflow-node-step-1').className).toContain('workflow-node--selected');
+
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('workflow-node--selected');
+	});
+
+	it('Delete calls onNodeSelect(null) after deletion', () => {
+		const { getByTestId, onNodeSelect } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		onNodeSelect.mockClear();
+
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onNodeSelect).toHaveBeenCalledWith(null);
+	});
+
+	it('Delete inside an input does not trigger onDeleteNode', () => {
+		const { onDeleteNode, container } = renderCanvas();
+		// Simulate focused input by dispatching from an INPUT element
+		const input = document.createElement('input');
+		container.appendChild(input);
+		input.focus();
+		fireEvent.keyDown(input, { key: 'Delete', target: input });
+		expect(onDeleteNode).not.toHaveBeenCalled();
+	});
+
+	it('Delete inside a textarea does not trigger onDeleteNode', () => {
+		const { onDeleteNode, container } = renderCanvas();
+		const textarea = document.createElement('textarea');
+		container.appendChild(textarea);
+		textarea.focus();
+		fireEvent.keyDown(textarea, { key: 'Delete', target: textarea });
+		expect(onDeleteNode).not.toHaveBeenCalled();
+	});
+});
+
+describe('WorkflowNode — isSelected prop', () => {
+	it('node without selection does not have selected class', () => {
+		const { getByTestId } = renderCanvas();
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('workflow-node--selected');
+	});
+
+	it('selected node has workflow-node--selected class', () => {
+		const { getByTestId } = renderCanvas();
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(getByTestId('workflow-node-step-1').className).toContain('workflow-node--selected');
+		expect(getByTestId('workflow-node-step-2').className).not.toContain('workflow-node--selected');
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -1,3 +1,7 @@
 export { VisualCanvas, applyWheelEvent, MIN_SCALE, MAX_SCALE } from './VisualCanvas';
 export type { ViewportState, Point, Size, NodePosition } from './types';
 export { screenToCanvas, canvasToScreen } from './types';
+export { WorkflowNode } from './WorkflowNode';
+export type { WorkflowNodeProps } from './WorkflowNode';
+export { WorkflowCanvas } from './WorkflowCanvas';
+export type { WorkflowNodeData, WorkflowCanvasProps } from './WorkflowCanvas';


### PR DESCRIPTION
- Add WorkflowNode component with isSelected visual indicator and
  stopPropagation-based click handling
- Add WorkflowCanvas component managing selectedNodeId state, keyboard
  Delete/Backspace to remove selected node, and onNodeSelect callback
- Update VisualCanvas with onBackgroundClick prop; detect background
  clicks via target check and didDrag guard to suppress drag-end events
- Export all new types and components from visual-editor index
- 17 passing tests covering selection, deselection, and keyboard delete
