### PR TITLE
feat: implement WorkflowNode with drag-and-drop support (Task 2.2)

### DIFF
--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -12,13 +12,16 @@ import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
 import type { WorkflowNodeProps } from './WorkflowNode';
-import type { ViewportState } from './types';
+import type { ViewportState, Point } from './types';
 
 /**
  * Per-node data passed to WorkflowCanvas.
- * All WorkflowNodeProps except `isSelected` and `onClick`, which WorkflowCanvas injects.
+ * WorkflowCanvas injects: isSelected, onClick, scale, onPositionChange.
  */
-export type WorkflowNodeData = Omit<WorkflowNodeProps, 'isSelected' | 'onClick'>;
+export type WorkflowNodeData = Omit<
+	WorkflowNodeProps,
+	'isSelected' | 'onClick' | 'scale' | 'onPositionChange'
+>;
 
 export interface WorkflowCanvasProps {
 	nodes: WorkflowNodeData[];
@@ -28,6 +31,8 @@ export interface WorkflowCanvasProps {
 	onNodeSelect?: (stepId: string | null) => void;
 	/** Called when Delete/Backspace is pressed with a node selected. */
 	onDeleteNode?: (stepId: string) => void;
+	/** Called when a node is dragged to a new position. */
+	onNodePositionChange?: (stepId: string, position: Point) => void;
 }
 
 export function WorkflowCanvas({
@@ -36,6 +41,7 @@ export function WorkflowCanvas({
 	onViewportChange,
 	onNodeSelect,
 	onDeleteNode,
+	onNodePositionChange,
 }: WorkflowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
@@ -102,6 +108,8 @@ export function WorkflowCanvas({
 				<WorkflowNode
 					key={node.step.localId}
 					{...node}
+					scale={viewportState.scale}
+					onPositionChange={onNodePositionChange ?? (() => {})}
 					isSelected={selectedNodeId === node.step.localId}
 					onClick={handleNodeSelect}
 				/>

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -1,108 +1,281 @@
 /**
- * WorkflowNode Component
+ * WorkflowNode
  *
- * Renders a single workflow step as an absolutely-positioned card on the canvas.
- * Shows step name, agent name, and step number badge.
- * Has input (top-center) and output (bottom-center) connection ports.
- * Start node gets a green border and hides its input port.
+ * Renders a single workflow step as a draggable card on the visual canvas.
+ *
+ * Features:
+ * - Card shows step number badge, step name, and assigned agent name
+ * - Start node gets a green border and "START" badge
+ * - Input port (top-center, hidden on start node) and output port (bottom-center)
+ *   for future connection creation
+ * - Draggable: mousedown on card body starts drag; delta is converted from
+ *   screen-space to canvas-space using the current viewport scale
+ * - Emits onPositionChange(stepId, newPosition) to parent on every move
+ * - stopPropagation on port mousedown prevents drag from starting on port clicks
  */
 
+import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
-import { cn } from '../../../lib/utils';
 import type { StepDraft } from '../WorkflowStepCard';
 import type { Point } from './types';
+
+// ============================================================================
+// Props
+// ============================================================================
 
 export type PortType = 'input' | 'output';
 
 export interface WorkflowNodeProps {
+	/** Zero-based index within the steps array; used for step number badge */
+	stepIndex: number;
 	step: StepDraft;
-	stepNumber: number;
+	/** Absolute position in canvas coordinates */
 	position: Point;
+	/** Full agents list — used to resolve the agent name from step.agentId */
 	agents: SpaceAgent[];
-	isSelected: boolean;
-	isStartNode: boolean;
-	onPortMouseDown: (stepId: string, port: PortType) => void;
+	isSelected?: boolean;
+	/** First step in the workflow — hides input port, adds green border + START badge */
+	isStartNode?: boolean;
+	/** Current viewport scale — used to convert screen-space drag deltas to canvas-space */
+	scale: number;
+	/** Called continuously while the node is being dragged */
+	onPositionChange: (stepId: string, newPosition: Point) => void;
+	/** Called when a connection port is pressed */
+	onPortMouseDown?: (stepId: string, portType: PortType, e: MouseEvent) => void;
+	/** Called when the card body is clicked (for selection) */
 	onClick?: (stepId: string) => void;
-	onMouseDown?: (stepId: string, e: MouseEvent) => void;
 }
 
-const NODE_WIDTH = 160;
+// ============================================================================
+// Component
+// ============================================================================
 
 export function WorkflowNode({
+	stepIndex,
 	step,
-	stepNumber,
 	position,
 	agents,
-	isSelected,
-	isStartNode,
+	isSelected = false,
+	isStartNode = false,
+	scale,
+	onPositionChange,
 	onPortMouseDown,
 	onClick,
-	onMouseDown,
 }: WorkflowNodeProps) {
+	const stepId = step.localId;
+
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
+
+	// ---- Drag state ----
+	const dragState = useRef<{
+		startX: number;
+		startY: number;
+		origX: number;
+		origY: number;
+	} | null>(null);
+
+	// Track whether a meaningful drag has occurred (to suppress post-drag click)
+	const hasDraggedRef = useRef(false);
+	const DRAG_THRESHOLD = 3; // px
+
+	// Keep refs to the latest values so window handlers don't close over stale data
+	const scaleRef = useRef(scale);
+	scaleRef.current = scale;
+
+	const onPositionChangeRef = useRef(onPositionChange);
+	onPositionChangeRef.current = onPositionChange;
+
+	const nodeRef = useRef<HTMLDivElement>(null);
+
+	// ---- Window-level listeners (always registered, guard on dragState) ----
+	// Mirrors the pattern used by VisualCanvas for its spacebar+drag pan.
+	useEffect(() => {
+		const onMouseMove = (e: MouseEvent) => {
+			if (!dragState.current) return;
+			const dx = e.clientX - dragState.current.startX;
+			const dy = e.clientY - dragState.current.startY;
+
+			// Only start tracking drag after threshold
+			if (Math.abs(dx) <= DRAG_THRESHOLD && Math.abs(dy) <= DRAG_THRESHOLD) return;
+
+			hasDraggedRef.current = true;
+
+			// Convert screen-space delta to canvas-space (guard against scale=0)
+			const safeScale = Math.max(scaleRef.current, 0.01);
+			const canvasDx = dx / safeScale;
+			const canvasDy = dy / safeScale;
+			onPositionChangeRef.current(stepId, {
+				x: dragState.current.origX + canvasDx,
+				y: dragState.current.origY + canvasDy,
+			});
+		};
+
+		const onMouseUp = () => {
+			if (!dragState.current) return;
+			dragState.current = null;
+			if (nodeRef.current) {
+				nodeRef.current.style.cursor = 'grab';
+				nodeRef.current.style.boxShadow = '';
+			}
+		};
+
+		window.addEventListener('mousemove', onMouseMove);
+		window.addEventListener('mouseup', onMouseUp);
+		return () => {
+			window.removeEventListener('mousemove', onMouseMove);
+			window.removeEventListener('mouseup', onMouseUp);
+		};
+	}, [stepId]);
+
+	// ---- Card body mousedown — starts drag ----
+	const handleMouseDown = useCallback(
+		(e: MouseEvent) => {
+			// Only primary button
+			if (e.button !== 0) return;
+			e.stopPropagation(); // prevent canvas pan from triggering
+			e.preventDefault();
+
+			hasDraggedRef.current = false; // reset for this interaction
+
+			dragState.current = {
+				startX: e.clientX,
+				startY: e.clientY,
+				origX: position.x,
+				origY: position.y,
+			};
+
+			if (nodeRef.current) {
+				nodeRef.current.style.cursor = 'grabbing';
+				nodeRef.current.style.boxShadow = '0 8px 24px rgba(0,0,0,0.4)';
+			}
+		},
+		[position.x, position.y]
+	);
+
+	// ---- Card click — for selection (suppressed after drag) ----
+	const handleClick = useCallback(
+		(e: MouseEvent) => {
+			e.stopPropagation();
+			if (hasDraggedRef.current) return; // don't fire selection after drag
+			onClick?.(stepId);
+		},
+		[onClick, stepId]
+	);
+
+	// ---- Port handlers ----
+	const handleInputPortMouseDown = useCallback(
+		(e: MouseEvent) => {
+			e.stopPropagation(); // prevent card drag from starting
+			onPortMouseDown?.(stepId, 'input', e);
+		},
+		[onPortMouseDown, stepId]
+	);
+
+	const handleOutputPortMouseDown = useCallback(
+		(e: MouseEvent) => {
+			e.stopPropagation(); // prevent card drag from starting
+			onPortMouseDown?.(stepId, 'output', e);
+		},
+		[onPortMouseDown, stepId]
+	);
+
+	// ---- Styles ----
+	const borderClass = isStartNode
+		? 'border-green-500'
+		: isSelected
+			? 'border-blue-500'
+			: 'border-gray-700';
+
+	const ringClass = isSelected ? 'ring-2 ring-blue-500' : '';
 
 	return (
 		<div
-			class={cn(
-				'absolute rounded-lg border bg-dark-850 shadow-lg select-none',
-				isSelected
-					? 'border-blue-500 ring-2 ring-blue-500'
-					: isStartNode
-						? 'border-green-500'
-						: 'border-dark-600',
-				'cursor-grab'
-			)}
+			ref={nodeRef}
+			data-testid={`workflow-node-${stepId}`}
+			data-step-id={stepId}
 			style={{
-				left: `${position.x}px`,
-				top: `${position.y}px`,
-				width: `${NODE_WIDTH}px`,
+				position: 'absolute',
+				left: position.x,
+				top: position.y,
+				minWidth: 160,
+				cursor: 'grab',
+				userSelect: 'none',
 			}}
-			data-testid={`workflow-node-${step.localId}`}
-			onClick={(e) => {
-				e.stopPropagation();
-				onClick?.(step.localId);
-			}}
-			onMouseDown={(e) => onMouseDown?.(step.localId, e as unknown as MouseEvent)}
+			class={`rounded-lg border-2 bg-gray-800 ${borderClass} ${ringClass}`}
+			onMouseDown={handleMouseDown}
+			onClick={handleClick}
 		>
-			{/* Input port — top-center, hidden for start node */}
+			{/* Top port */}
 			{!isStartNode && (
 				<div
-					class="absolute -top-2 left-1/2 -translate-x-1/2 w-3.5 h-3.5 rounded-full bg-dark-700 border-2 border-dark-400 hover:border-blue-400 hover:bg-blue-900 cursor-crosshair z-10"
-					title="Input port"
-					onMouseDown={(e) => {
-						e.stopPropagation();
-						onPortMouseDown(step.localId, 'input');
+					data-testid="port-input"
+					style={{
+						position: 'absolute',
+						top: -7,
+						left: '50%',
+						transform: 'translateX(-50%)',
+						width: 14,
+						height: 14,
+						borderRadius: '50%',
+						background: '#6b7280',
+						border: '2px solid #374151',
+						cursor: 'crosshair',
 					}}
+					onMouseDown={handleInputPortMouseDown}
 				/>
 			)}
 
-			{/* Card body */}
-			<div class="px-3 py-2.5">
-				{/* Header row: step badge + START badge */}
-				<div class="flex items-center justify-between mb-1.5">
-					<span class="w-5 h-5 flex items-center justify-center rounded-full bg-dark-700 text-xs font-semibold text-gray-400 flex-shrink-0">
-						{stepNumber}
+			{/* Card content */}
+			<div class="px-3 py-2">
+				{/* Header row: step badge + optional START badge */}
+				<div class="flex items-center justify-between mb-1">
+					<span
+						data-testid="step-badge"
+						class="text-xs font-mono bg-gray-700 text-gray-300 rounded px-1.5 py-0.5"
+					>
+						{stepIndex + 1}
 					</span>
-					{isStartNode && <span class="text-xs font-bold text-green-400 tracking-wide">START</span>}
+					{isStartNode && (
+						<span
+							data-testid="start-badge"
+							class="text-xs font-bold text-green-400 uppercase tracking-wider"
+						>
+							START
+						</span>
+					)}
 				</div>
 
 				{/* Step name */}
-				<p class="text-xs font-medium text-gray-200 truncate leading-tight">
-					{step.name || 'Unnamed Step'}
+				<p
+					data-testid="step-name"
+					class="text-sm font-medium text-white truncate"
+					style={{ maxWidth: 160 }}
+				>
+					{step.name || '(unnamed)'}
 				</p>
 
 				{/* Agent name */}
-				<p class="text-xs text-gray-500 truncate mt-0.5">{agentName || '—'}</p>
+				<p data-testid="agent-name" class="text-xs text-gray-400 truncate mt-0.5">
+					{agentName}
+				</p>
 			</div>
 
-			{/* Output port — bottom-center */}
+			{/* Bottom port */}
 			<div
-				class="absolute -bottom-2 left-1/2 -translate-x-1/2 w-3.5 h-3.5 rounded-full bg-dark-700 border-2 border-dark-400 hover:border-blue-400 hover:bg-blue-900 cursor-crosshair z-10"
-				title="Output port"
-				onMouseDown={(e) => {
-					e.stopPropagation();
-					onPortMouseDown(step.localId, 'output');
+				data-testid="port-output"
+				style={{
+					position: 'absolute',
+					bottom: -7,
+					left: '50%',
+					transform: 'translateX(-50%)',
+					width: 14,
+					height: 14,
+					borderRadius: '50%',
+					background: '#6b7280',
+					border: '2px solid #374151',
+					cursor: 'crosshair',
 				}}
+				onMouseDown={handleOutputPortMouseDown}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -48,7 +48,7 @@ const AGENTS: SpaceAgent[] = [makeAgent('agent-1', 'Coder')];
 const NODES: WorkflowNodeData[] = [
 	{
 		step: makeStep('step-1', 'Step One'),
-		stepNumber: 1,
+		stepIndex: 1,
 		position: { x: 10, y: 10 },
 		agents: AGENTS,
 		isStartNode: false,
@@ -56,7 +56,7 @@ const NODES: WorkflowNodeData[] = [
 	},
 	{
 		step: makeStep('step-2', 'Step Two'),
-		stepNumber: 2,
+		stepIndex: 2,
 		position: { x: 200, y: 10 },
 		agents: AGENTS,
 		isStartNode: false,

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -134,25 +134,25 @@ describe('WorkflowNode rendering', () => {
 
 	it('applies ring class when selected', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ isSelected: true })} />);
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 		expect(node.className).toContain('ring-2');
 		expect(node.className).toContain('ring-blue-500');
 	});
 
 	it('does not apply ring class when not selected', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ isSelected: false })} />);
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 		expect(node.className).not.toContain('ring-2');
 	});
 
 	it('applies green border class for start node', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
-		expect(getByTestId('workflow-node').className).toContain('border-green-500');
+		expect(getByTestId('workflow-node-step-local-1').className).toContain('border-green-500');
 	});
 
 	it('positions node using absolute style from position prop', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ position: { x: 42, y: 88 } })} />);
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 		expect(node.style.left).toBe('42px');
 		expect(node.style.top).toBe('88px');
 	});
@@ -208,14 +208,14 @@ describe('WorkflowNode click', () => {
 	it('calls onClick with stepId when card is clicked', () => {
 		const onClick = vi.fn();
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
-		fireEvent.click(getByTestId('workflow-node'));
+		fireEvent.click(getByTestId('workflow-node-step-local-1'));
 		expect(onClick).toHaveBeenCalledWith('step-local-1');
 	});
 
 	it('does NOT call onClick after a drag completes', () => {
 		const onClick = vi.fn();
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 
 		// Simulate drag: mousedown → move past threshold → mouseup → click
 		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
@@ -229,7 +229,7 @@ describe('WorkflowNode click', () => {
 	it('calls onClick normally after a sub-threshold mousedown (no real drag)', () => {
 		const onClick = vi.fn();
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 
 		// Mousedown then release without crossing threshold
 		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
@@ -252,7 +252,7 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 100, y: 200 }, scale: 1 })} />
 		);
 
-		const node = getByTestId('workflow-node');
+		const node = getByTestId('workflow-node-step-local-1');
 		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
 		windowMouseMove(30, 40);
 
@@ -267,7 +267,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 2 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(100, 60);
 
 		// canvas delta = screen delta / scale = 100/2=50, 60/2=30
@@ -282,7 +286,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 0.5 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(20, 10);
 
 		// canvas delta = screen delta / scale = 20/0.5=40, 10/0.5=20
@@ -297,7 +305,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(10, 10);
 		expect(onPositionChange).toHaveBeenCalledTimes(1);
 
@@ -312,7 +324,11 @@ describe('WorkflowNode drag-and-drop', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ onPositionChange, scale: 1 })} />);
 
 		// Right-click (button=2)
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 2, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 2,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(50, 50);
 
 		expect(onPositionChange).not.toHaveBeenCalled();
@@ -327,7 +343,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(10, 5);
 		windowMouseMove(20, 15);
 		windowMouseMove(30, 25);
@@ -347,7 +367,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(2, 1); // 2px — below the 3px threshold
 		expect(onPositionChange).not.toHaveBeenCalled();
 
@@ -360,7 +384,11 @@ describe('WorkflowNode drag-and-drop', () => {
 			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 0 })} />
 		);
 
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		windowMouseMove(10, 10);
 
 		expect(onPositionChange).toHaveBeenCalledOnce();
@@ -395,7 +423,11 @@ describe('WorkflowNode drag-and-drop', () => {
 		const { getByTestId } = render(<Wrapper />);
 
 		// Start drag at (50,50) with mouse at screen (0,0)
-		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		fireEvent.mouseDown(getByTestId('workflow-node-step-local-1'), {
+			button: 0,
+			clientX: 0,
+			clientY: 0,
+		});
 		// Move 20px in screen space — canvas delta = 20
 		windowMouseMove(20, 10);
 		expect(onPositionChange).toHaveBeenLastCalledWith('step-local-1', { x: 70, y: 60 });

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -1,189 +1,351 @@
 /**
- * Unit tests for WorkflowNode
+ * Unit tests for WorkflowNode component.
  *
  * Tests:
  * - Renders step name and agent name
  * - Shows step number badge
- * - Applies selected styles (ring-2, ring-blue-500)
- * - Renders input and output ports
- * - Start node hides input port and shows START badge + green border
- * - Port mousedown emits onPortMouseDown with correct args
+ * - Start node shows START badge and green border, hides input port
+ * - Non-start node shows input port
+ * - Selected state applies ring
+ * - Port mousedown events do not trigger drag (stopPropagation check)
+ * - Port mousedown calls onPortMouseDown with correct args
+ * - Dragging updates position accounting for viewport scale
+ * - Drag with scale=2 halves the canvas-space delta
+ * - Drag with scale=0.5 doubles the canvas-space delta
+ * - Click calls onClick with stepId
+ *
+ * Note: window.dispatchEvent(new MouseEvent(...)) is used for window-level
+ * mouse events because fireEvent(window, ...) does not work in happy-dom.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
-import type { SpaceAgent } from '@neokai/shared';
+import { useState } from 'preact/hooks';
 import { WorkflowNode } from '../WorkflowNode';
 import type { WorkflowNodeProps } from '../WorkflowNode';
-import type { StepDraft } from '../../WorkflowStepCard';
+import type { SpaceAgent } from '@neokai/shared';
+import type { Point } from '../types';
 
-vi.mock('../../../../lib/utils', () => ({
-	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
-}));
+afterEach(() => cleanup());
 
-function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
-	return {
-		id,
-		spaceId: 'space-1',
-		name,
-		role,
-		createdAt: Date.now(),
-		updatedAt: Date.now(),
-	};
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function windowMouseMove(clientX: number, clientY: number) {
+	window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX, clientY }));
 }
 
-function makeStep(overrides: Partial<StepDraft> = {}): StepDraft {
-	return {
-		localId: 'step-1',
-		name: 'My Step',
-		agentId: 'agent-1',
-		instructions: '',
-		...overrides,
-	};
+function windowMouseUp() {
+	window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
 }
 
-const defaultAgents: SpaceAgent[] = [
-	makeAgent('agent-1', 'planner', 'planner'),
-	makeAgent('agent-2', 'coder', 'coder'),
-];
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+const AGENT_A: SpaceAgent = {
+	id: 'agent-1',
+	spaceId: 'space-1',
+	name: 'Alpha Agent',
+	role: 'coder',
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+const AGENT_B: SpaceAgent = {
+	id: 'agent-2',
+	spaceId: 'space-1',
+	name: 'Beta Agent',
+	role: 'reviewer',
+	createdAt: 0,
+	updatedAt: 0,
+};
+
+const STEP_DRAFT = {
+	localId: 'step-local-1',
+	id: 'step-id-1',
+	name: 'Build App',
+	agentId: 'agent-1',
+	instructions: 'build it',
+};
+
+const DEFAULT_POSITION: Point = { x: 100, y: 200 };
 
 function makeProps(overrides: Partial<WorkflowNodeProps> = {}): WorkflowNodeProps {
 	return {
-		step: makeStep(),
-		stepNumber: 1,
-		position: { x: 100, y: 200 },
-		agents: defaultAgents,
+		stepIndex: 0,
+		step: STEP_DRAFT,
+		position: DEFAULT_POSITION,
+		agents: [AGENT_A, AGENT_B],
 		isSelected: false,
 		isStartNode: false,
+		scale: 1,
+		onPositionChange: vi.fn(),
 		onPortMouseDown: vi.fn(),
+		onClick: vi.fn(),
 		...overrides,
 	};
 }
 
-describe('WorkflowNode', () => {
-	afterEach(() => {
-		cleanup();
-	});
+// ============================================================================
+// Rendering tests
+// ============================================================================
 
+describe('WorkflowNode rendering', () => {
 	it('renders step name', () => {
-		const { getByText } = render(<WorkflowNode {...makeProps()} />);
-		expect(getByText('My Step')).toBeTruthy();
+		const { getByTestId } = render(<WorkflowNode {...makeProps()} />);
+		expect(getByTestId('step-name').textContent).toBe('Build App');
 	});
 
 	it('renders agent name resolved from agents list', () => {
-		const { getByText } = render(<WorkflowNode {...makeProps()} />);
-		expect(getByText('planner')).toBeTruthy();
+		const { getByTestId } = render(<WorkflowNode {...makeProps()} />);
+		expect(getByTestId('agent-name').textContent).toBe('Alpha Agent');
 	});
 
 	it('falls back to agentId when agent not found', () => {
-		const step = makeStep({ agentId: 'unknown-agent' });
-		const { getByText } = render(<WorkflowNode {...makeProps({ step })} />);
-		expect(getByText('unknown-agent')).toBeTruthy();
+		const props = makeProps({ step: { ...STEP_DRAFT, agentId: 'unknown-agent' } });
+		const { getByTestId } = render(<WorkflowNode {...props} />);
+		expect(getByTestId('agent-name').textContent).toBe('unknown-agent');
 	});
 
-	it('renders step number badge', () => {
-		const { getByText } = render(<WorkflowNode {...makeProps({ stepNumber: 3 })} />);
-		expect(getByText('3')).toBeTruthy();
+	it('shows correct step number badge (1-indexed)', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ stepIndex: 2 })} />);
+		expect(getByTestId('step-badge').textContent).toBe('3');
 	});
 
-	it('shows "Unnamed Step" when name is empty', () => {
-		const step = makeStep({ name: '' });
-		const { getByText } = render(<WorkflowNode {...makeProps({ step })} />);
-		expect(getByText('Unnamed Step')).toBeTruthy();
+	it('shows START badge and input port is hidden when isStartNode=true', () => {
+		const { getByTestId, queryByTestId } = render(
+			<WorkflowNode {...makeProps({ isStartNode: true })} />
+		);
+		expect(getByTestId('start-badge').textContent).toBe('START');
+		expect(queryByTestId('port-input')).toBeNull();
 	});
 
-	it('positions card via inline styles', () => {
-		const { container } = render(<WorkflowNode {...makeProps({ position: { x: 150, y: 300 } })} />);
-		const card = container.firstChild as HTMLElement;
-		expect(card.style.left).toBe('150px');
-		expect(card.style.top).toBe('300px');
+	it('shows input port when not start node', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ isStartNode: false })} />);
+		expect(getByTestId('port-input')).toBeTruthy();
 	});
 
-	describe('selection state', () => {
-		it('applies selection ring classes when isSelected is true', () => {
-			const { container } = render(<WorkflowNode {...makeProps({ isSelected: true })} />);
-			const card = container.firstChild as HTMLElement;
-			expect(card.className).toContain('ring-2');
-			expect(card.className).toContain('ring-blue-500');
-			expect(card.className).toContain('border-blue-500');
-		});
-
-		it('does not apply selection ring when isSelected is false', () => {
-			const { container } = render(<WorkflowNode {...makeProps({ isSelected: false })} />);
-			const card = container.firstChild as HTMLElement;
-			expect(card.className).not.toContain('ring-2');
-		});
+	it('always renders output port', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
+		expect(getByTestId('port-output')).toBeTruthy();
 	});
 
-	describe('start node', () => {
-		it('shows START badge when isStartNode is true', () => {
-			const { getByText } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
-			expect(getByText('START')).toBeTruthy();
-		});
-
-		it('does not show START badge for non-start nodes', () => {
-			const { container } = render(<WorkflowNode {...makeProps({ isStartNode: false })} />);
-			const text = container.textContent ?? '';
-			expect(text).not.toContain('START');
-		});
-
-		it('applies green border when isStartNode is true', () => {
-			const { container } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
-			const card = container.firstChild as HTMLElement;
-			expect(card.className).toContain('border-green-500');
-		});
-
-		it('hides input port when isStartNode is true', () => {
-			const { queryByTitle } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
-			expect(queryByTitle('Input port')).toBeNull();
-		});
-
-		it('shows input port when isStartNode is false', () => {
-			const { getByTitle } = render(<WorkflowNode {...makeProps({ isStartNode: false })} />);
-			expect(getByTitle('Input port')).toBeTruthy();
-		});
+	it('applies ring class when selected', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ isSelected: true })} />);
+		const node = getByTestId('workflow-node');
+		expect(node.className).toContain('ring-2');
+		expect(node.className).toContain('ring-blue-500');
 	});
 
-	describe('ports', () => {
-		it('renders output port', () => {
-			const { getByTitle } = render(<WorkflowNode {...makeProps()} />);
-			expect(getByTitle('Output port')).toBeTruthy();
-		});
+	it('does not apply ring class when not selected', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ isSelected: false })} />);
+		const node = getByTestId('workflow-node');
+		expect(node.className).not.toContain('ring-2');
+	});
 
-		it('calls onPortMouseDown with stepId and "input" when input port is clicked', () => {
-			const onPortMouseDown = vi.fn();
-			const step = makeStep({ localId: 'step-abc' });
-			const { getByTitle } = render(
-				<WorkflowNode {...makeProps({ step, onPortMouseDown, isStartNode: false })} />
+	it('applies green border class for start node', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ isStartNode: true })} />);
+		expect(getByTestId('workflow-node').className).toContain('border-green-500');
+	});
+
+	it('positions node using absolute style from position prop', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ position: { x: 42, y: 88 } })} />);
+		const node = getByTestId('workflow-node');
+		expect(node.style.left).toBe('42px');
+		expect(node.style.top).toBe('88px');
+	});
+
+	it('shows (unnamed) when step name is empty', () => {
+		const props = makeProps({ step: { ...STEP_DRAFT, name: '' } });
+		const { getByTestId } = render(<WorkflowNode {...props} />);
+		expect(getByTestId('step-name').textContent).toBe('(unnamed)');
+	});
+});
+
+// ============================================================================
+// Port events
+// ============================================================================
+
+describe('WorkflowNode port events', () => {
+	it('calls onPortMouseDown with input type when input port is pressed', () => {
+		const onPortMouseDown = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPortMouseDown, isStartNode: false })} />
+		);
+		fireEvent.mouseDown(getByTestId('port-input'), { button: 0 });
+		expect(onPortMouseDown).toHaveBeenCalledWith('step-local-1', 'input', expect.any(Object));
+	});
+
+	it('calls onPortMouseDown with output type when output port is pressed', () => {
+		const onPortMouseDown = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onPortMouseDown })} />);
+		fireEvent.mouseDown(getByTestId('port-output'), { button: 0 });
+		expect(onPortMouseDown).toHaveBeenCalledWith('step-local-1', 'output', expect.any(Object));
+	});
+
+	it('port mousedown does not trigger drag (stopPropagation)', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onPositionChange })} />);
+
+		// Press the output port then move mouse on window
+		fireEvent.mouseDown(getByTestId('port-output'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(50, 50);
+
+		// Position should not change because the port stopPropagation prevented drag start
+		expect(onPositionChange).not.toHaveBeenCalled();
+
+		windowMouseUp();
+	});
+});
+
+// ============================================================================
+// Click events
+// ============================================================================
+
+describe('WorkflowNode click', () => {
+	it('calls onClick with stepId when card is clicked', () => {
+		const onClick = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
+		fireEvent.click(getByTestId('workflow-node'));
+		expect(onClick).toHaveBeenCalledWith('step-local-1');
+	});
+});
+
+// ============================================================================
+// Drag-and-drop tests
+// ============================================================================
+
+describe('WorkflowNode drag-and-drop', () => {
+	it('updates position on drag at scale=1', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 100, y: 200 }, scale: 1 })} />
+		);
+
+		const node = getByTestId('workflow-node');
+		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(30, 40);
+
+		expect(onPositionChange).toHaveBeenCalledWith('step-local-1', { x: 130, y: 240 });
+
+		windowMouseUp();
+	});
+
+	it('halves canvas-space delta when scale=2', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 2 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(100, 60);
+
+		// canvas delta = screen delta / scale = 100/2=50, 60/2=30
+		expect(onPositionChange).toHaveBeenCalledWith('step-local-1', { x: 50, y: 30 });
+
+		windowMouseUp();
+	});
+
+	it('doubles canvas-space delta when scale=0.5', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 0.5 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(20, 10);
+
+		// canvas delta = screen delta / scale = 20/0.5=40, 10/0.5=20
+		expect(onPositionChange).toHaveBeenCalledWith('step-local-1', { x: 40, y: 20 });
+
+		windowMouseUp();
+	});
+
+	it('stops dragging after mouseup', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(10, 10);
+		expect(onPositionChange).toHaveBeenCalledTimes(1);
+
+		windowMouseUp();
+		windowMouseMove(50, 50);
+		// No additional calls after mouseup
+		expect(onPositionChange).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores non-primary mouse button', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onPositionChange, scale: 1 })} />);
+
+		// Right-click (button=2)
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 2, clientX: 0, clientY: 0 });
+		windowMouseMove(50, 50);
+
+		expect(onPositionChange).not.toHaveBeenCalled();
+		windowMouseUp();
+	});
+
+	it('continuously updates position on multiple mousemove events', () => {
+		const positions: Point[] = [];
+		const onPositionChange = vi.fn((_, pos: Point) => positions.push(pos));
+
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(10, 5);
+		windowMouseMove(20, 15);
+		windowMouseMove(30, 25);
+
+		expect(positions).toEqual([
+			{ x: 10, y: 5 },
+			{ x: 20, y: 15 },
+			{ x: 30, y: 25 },
+		]);
+
+		windowMouseUp();
+	});
+
+	it('drag uses position prop at drag-start time (not stale closure)', () => {
+		// Simulate dynamic position updates: wrapper re-renders with new position
+		// between the mousedown and mousemove.
+		const onPositionChange = vi.fn();
+
+		function Wrapper() {
+			const [pos, setPos] = useState<Point>({ x: 50, y: 50 });
+			return (
+				<WorkflowNode
+					{...makeProps({
+						position: pos,
+						scale: 1,
+						onPositionChange: (id, newPos) => {
+							onPositionChange(id, newPos);
+							setPos(newPos);
+						},
+					})}
+				/>
 			);
-			fireEvent.mouseDown(getByTitle('Input port'));
-			expect(onPortMouseDown).toHaveBeenCalledWith('step-abc', 'input');
-		});
+		}
 
-		it('calls onPortMouseDown with stepId and "output" when output port is clicked', () => {
-			const onPortMouseDown = vi.fn();
-			const step = makeStep({ localId: 'step-xyz' });
-			const { getByTitle } = render(<WorkflowNode {...makeProps({ step, onPortMouseDown })} />);
-			fireEvent.mouseDown(getByTitle('Output port'));
-			expect(onPortMouseDown).toHaveBeenCalledWith('step-xyz', 'output');
-		});
-	});
+		const { getByTestId } = render(<Wrapper />);
 
-	describe('event handlers', () => {
-		it('calls onClick with stepId when card is clicked', () => {
-			const onClick = vi.fn();
-			const step = makeStep({ localId: 'step-click' });
-			const { container } = render(<WorkflowNode {...makeProps({ step, onClick })} />);
-			fireEvent.click(container.firstChild as HTMLElement);
-			expect(onClick).toHaveBeenCalledWith('step-click');
-		});
+		// Start drag at (50,50) with mouse at screen (0,0)
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		// Move 20px in screen space — canvas delta = 20
+		windowMouseMove(20, 10);
+		expect(onPositionChange).toHaveBeenLastCalledWith('step-local-1', { x: 70, y: 60 });
 
-		it('calls onMouseDown with stepId when card mousedown fires', () => {
-			const onMouseDown = vi.fn();
-			const step = makeStep({ localId: 'step-md' });
-			const { container } = render(<WorkflowNode {...makeProps({ step, onMouseDown })} />);
-			fireEvent.mouseDown(container.firstChild as HTMLElement);
-			expect(onMouseDown).toHaveBeenCalledWith('step-md', expect.anything());
-		});
+		// Move another 10px — still relative to drag start (0,0), so total delta = 30
+		windowMouseMove(30, 20);
+		expect(onPositionChange).toHaveBeenLastCalledWith('step-local-1', { x: 80, y: 70 });
+
+		windowMouseUp();
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -211,6 +211,34 @@ describe('WorkflowNode click', () => {
 		fireEvent.click(getByTestId('workflow-node'));
 		expect(onClick).toHaveBeenCalledWith('step-local-1');
 	});
+
+	it('does NOT call onClick after a drag completes', () => {
+		const onClick = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
+		const node = getByTestId('workflow-node');
+
+		// Simulate drag: mousedown → move past threshold → mouseup → click
+		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(20, 20); // well past 3px threshold
+		windowMouseUp();
+		fireEvent.click(node);
+
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it('calls onClick normally after a sub-threshold mousedown (no real drag)', () => {
+		const onClick = vi.fn();
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ onClick })} />);
+		const node = getByTestId('workflow-node');
+
+		// Mousedown then release without crossing threshold
+		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(1, 1); // below 3px threshold — not a drag
+		windowMouseUp();
+		fireEvent.click(node);
+
+		expect(onClick).toHaveBeenCalledWith('step-local-1');
+	});
 });
 
 // ============================================================================
@@ -309,6 +337,36 @@ describe('WorkflowNode drag-and-drop', () => {
 			{ x: 20, y: 15 },
 			{ x: 30, y: 25 },
 		]);
+
+		windowMouseUp();
+	});
+
+	it('does not fire onPositionChange for moves below 3px threshold', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 1 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(2, 1); // 2px — below the 3px threshold
+		expect(onPositionChange).not.toHaveBeenCalled();
+
+		windowMouseUp();
+	});
+
+	it('guards against scale=0 (no Infinity positions)', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ onPositionChange, position: { x: 0, y: 0 }, scale: 0 })} />
+		);
+
+		fireEvent.mouseDown(getByTestId('workflow-node'), { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(10, 10);
+
+		expect(onPositionChange).toHaveBeenCalledOnce();
+		const [, pos] = onPositionChange.mock.calls[0];
+		expect(isFinite(pos.x)).toBe(true);
+		expect(isFinite(pos.y)).toBe(true);
 
 		windowMouseUp();
 	});


### PR DESCRIPTION
Add WorkflowNode component to the visual canvas with full drag-and-drop
functionality. Node position updates are converted from screen-space to
canvas-space using the current viewport scale (deltaCanvas = deltaScreen / scale).

- WorkflowNode renders step name, agent name, step badge, optional START badge
- Input port (top-center, hidden on start nodes) and output port (bottom-center)
  for future connection creation
- Drag: mousedown on card body sets dragState; window mousemove/mouseup handlers
  (registered via useEffect, same pattern as VisualCanvas) compute and emit
  onPositionChange(stepId, newPosition) on every frame
- stopPropagation on port mousedown prevents drag from initiating on port clicks
- stopPropagation on card mousedown prevents VisualCanvas spacebar-pan conflict
- Visual feedback: cursor changes to grabbing and box-shadow elevates during drag
- 23 unit tests covering rendering, port events, click, and all drag scenarios
  including scale=0.5/1/2 coordinate conversion and multi-move sequences
