### PR TITLE
task/task 31 render edges as svg bezier curves

### DIFF
--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -16,11 +16,19 @@
  * visible edge to make clicking easier. An arrowhead marker indicates direction.
  *
  * Delete/Backspace while an edge is selected calls onEdgeDelete.
+ *
+ * Marker IDs are prefixed with a stable per-instance ID (via useId) to prevent
+ * collisions when multiple EdgeRenderer instances are mounted simultaneously.
  */
 
 import { useEffect, useRef } from 'preact/hooks';
 import type { WorkflowTransition, WorkflowConditionType } from '@neokai/shared';
 import type { NodePosition } from './types';
+
+// Module-level counter — increments on each EdgeRenderer mount, giving every
+// instance a unique marker ID prefix even when multiple instances are on the
+// same page (e.g. split-view or comparison mode).
+let _instanceCounter = 0;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -36,8 +44,8 @@ export const EDGE_COLORS: Record<WorkflowConditionType, string> = {
 	condition: '#c084fc', // purple-400
 };
 
-const NORMAL_STROKE_WIDTH = 1.5;
-const SELECTED_STROKE_WIDTH = 3;
+export const NORMAL_STROKE_WIDTH = 1.5;
+export const SELECTED_STROKE_WIDTH = 3;
 const HITBOX_STROKE_WIDTH = 12;
 
 // ---------------------------------------------------------------------------
@@ -112,6 +120,13 @@ export function EdgeRenderer({
 	onEdgeSelect,
 	onEdgeDelete,
 }: EdgeRendererProps) {
+	// Stable per-instance prefix to prevent marker ID collisions across instances
+	const markerPrefixRef = useRef<string | null>(null);
+	if (markerPrefixRef.current === null) {
+		markerPrefixRef.current = `edge-arrow-${_instanceCounter++}`;
+	}
+	const markerPrefix = markerPrefixRef.current;
+
 	// Keep refs so the keyboard handler always sees the latest values
 	const selectedEdgeIdRef = useRef(selectedEdgeId);
 	selectedEdgeIdRef.current = selectedEdgeId;
@@ -123,8 +138,9 @@ export function EdgeRenderer({
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Delete' && e.key !== 'Backspace') return;
-			const tag = (e.target as HTMLElement)?.tagName;
-			if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+			const target = e.target as HTMLElement;
+			const tag = target?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
 
 			const current = selectedEdgeIdRef.current;
 			if (!current || !onEdgeDeleteRef.current) return;
@@ -139,12 +155,13 @@ export function EdgeRenderer({
 
 	return (
 		<>
-			{/* Arrowhead marker definitions — one per condition type + one for selected state */}
+			{/* Arrowhead marker definitions — one per condition type + one for selected state.
+			    IDs are prefixed with instanceId to prevent collisions between multiple instances. */}
 			<defs>
 				{(Object.entries(EDGE_COLORS) as [WorkflowConditionType, string][]).map(([type, color]) => (
 					<marker
-						key={`arrow-${type}`}
-						id={`edge-arrow-${type}`}
+						key={`${markerPrefix}-${type}`}
+						id={`${markerPrefix}-${type}`}
 						viewBox="0 0 10 10"
 						refX="10"
 						refY="5"
@@ -156,7 +173,7 @@ export function EdgeRenderer({
 					</marker>
 				))}
 				<marker
-					id="edge-arrow-selected"
+					id={`${markerPrefix}-selected`}
 					viewBox="0 0 10 10"
 					refX="10"
 					refY="5"
@@ -178,7 +195,9 @@ export function EdgeRenderer({
 				const isSelected = transition.id === selectedEdgeId;
 				const strokeColor = isSelected ? 'white' : color;
 				const strokeWidth = isSelected ? SELECTED_STROKE_WIDTH : NORMAL_STROKE_WIDTH;
-				const markerId = isSelected ? 'edge-arrow-selected' : `edge-arrow-${conditionType}`;
+				const markerId = isSelected
+					? `${markerPrefix}-selected`
+					: `${markerPrefix}-${conditionType}`;
 
 				return (
 					<g
@@ -209,6 +228,8 @@ export function EdgeRenderer({
 							strokeOpacity={isSelected ? 1 : 0.85}
 							fill="none"
 							markerEnd={`url(#${markerId})`}
+							data-stroke-color={strokeColor}
+							data-stroke-width={String(strokeWidth)}
 							style={{ pointerEvents: 'none' }}
 						/>
 					</g>

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -1,0 +1,219 @@
+/**
+ * EdgeRenderer
+ *
+ * Renders WorkflowTransition entries as SVG cubic bezier paths.
+ *
+ * Each edge connects the output port (bottom-center) of the source node to the
+ * input port (top-center) of the target node. Control points are offset vertically
+ * by CONTROL_OFFSET px for a smooth curve.
+ *
+ * Edge color reflects the condition type:
+ *   always   → blue  (#3b82f6)
+ *   human    → yellow (#facc15)
+ *   condition → purple (#c084fc)
+ *
+ * A wider invisible hitbox path (stroke-width 12px) is rendered behind each
+ * visible edge to make clicking easier. An arrowhead marker indicates direction.
+ *
+ * Delete/Backspace while an edge is selected calls onEdgeDelete.
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+import type { WorkflowTransition, WorkflowConditionType } from '@neokai/shared';
+import type { NodePosition } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Control point vertical offset for bezier curves (px, canvas space). */
+export const CONTROL_OFFSET = 60;
+
+/** Stroke colors matching GATE_COLORS from WorkflowList.tsx */
+export const EDGE_COLORS: Record<WorkflowConditionType, string> = {
+	always: '#3b82f6', // blue-500
+	human: '#facc15', // yellow-400
+	condition: '#c084fc', // purple-400
+};
+
+const NORMAL_STROKE_WIDTH = 1.5;
+const SELECTED_STROKE_WIDTH = 3;
+const HITBOX_STROKE_WIDTH = 12;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EdgeRendererProps {
+	transitions: WorkflowTransition[];
+	nodePositions: NodePosition;
+	selectedEdgeId?: string | null;
+	onEdgeSelect?: (transitionId: string) => void;
+	onEdgeDelete?: (transitionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: compute bezier path string
+// ---------------------------------------------------------------------------
+
+export interface EdgePoints {
+	sx: number;
+	sy: number;
+	tx: number;
+	ty: number;
+	cp1x: number;
+	cp1y: number;
+	cp2x: number;
+	cp2y: number;
+}
+
+/**
+ * Compute the bezier path data and control points for a transition.
+ * Returns null when either node position is missing.
+ */
+export function computeEdgePoints(
+	transition: WorkflowTransition,
+	nodePositions: NodePosition
+): EdgePoints | null {
+	const fromPos = nodePositions[transition.from];
+	const toPos = nodePositions[transition.to];
+	if (!fromPos || !toPos) return null;
+
+	// Source: bottom-center of from-node (output port center)
+	const sx = fromPos.x + fromPos.width / 2;
+	const sy = fromPos.y + fromPos.height;
+
+	// Target: top-center of to-node (input port center)
+	const tx = toPos.x + toPos.width / 2;
+	const ty = toPos.y;
+
+	// Bezier control points offset vertically
+	const cp1x = sx;
+	const cp1y = sy + CONTROL_OFFSET;
+	const cp2x = tx;
+	const cp2y = ty - CONTROL_OFFSET;
+
+	return { sx, sy, tx, ty, cp1x, cp1y, cp2x, cp2y };
+}
+
+/** Build the SVG path `d` attribute string from computed edge points. */
+export function buildPathD(pts: EdgePoints): string {
+	return `M ${pts.sx} ${pts.sy} C ${pts.cp1x} ${pts.cp1y}, ${pts.cp2x} ${pts.cp2y}, ${pts.tx} ${pts.ty}`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function EdgeRenderer({
+	transitions,
+	nodePositions,
+	selectedEdgeId,
+	onEdgeSelect,
+	onEdgeDelete,
+}: EdgeRendererProps) {
+	// Keep refs so the keyboard handler always sees the latest values
+	const selectedEdgeIdRef = useRef(selectedEdgeId);
+	selectedEdgeIdRef.current = selectedEdgeId;
+
+	const onEdgeDeleteRef = useRef(onEdgeDelete);
+	onEdgeDeleteRef.current = onEdgeDelete;
+
+	// ---- Keyboard: Delete / Backspace deletes the selected edge ----
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Delete' && e.key !== 'Backspace') return;
+			const tag = (e.target as HTMLElement)?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+			const current = selectedEdgeIdRef.current;
+			if (!current || !onEdgeDeleteRef.current) return;
+
+			e.preventDefault();
+			onEdgeDeleteRef.current(current);
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, []);
+
+	return (
+		<>
+			{/* Arrowhead marker definitions — one per condition type + one for selected state */}
+			<defs>
+				{(Object.entries(EDGE_COLORS) as [WorkflowConditionType, string][]).map(([type, color]) => (
+					<marker
+						key={`arrow-${type}`}
+						id={`edge-arrow-${type}`}
+						viewBox="0 0 10 10"
+						refX="10"
+						refY="5"
+						markerWidth="6"
+						markerHeight="6"
+						orient="auto-start-reverse"
+					>
+						<path d="M 0 0 L 10 5 L 0 10 z" fill={color} />
+					</marker>
+				))}
+				<marker
+					id="edge-arrow-selected"
+					viewBox="0 0 10 10"
+					refX="10"
+					refY="5"
+					markerWidth="6"
+					markerHeight="6"
+					orient="auto-start-reverse"
+				>
+					<path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
+				</marker>
+			</defs>
+
+			{transitions.map((transition) => {
+				const pts = computeEdgePoints(transition, nodePositions);
+				if (!pts) return null;
+
+				const d = buildPathD(pts);
+				const conditionType: WorkflowConditionType = transition.condition?.type ?? 'always';
+				const color = EDGE_COLORS[conditionType];
+				const isSelected = transition.id === selectedEdgeId;
+				const strokeColor = isSelected ? 'white' : color;
+				const strokeWidth = isSelected ? SELECTED_STROKE_WIDTH : NORMAL_STROKE_WIDTH;
+				const markerId = isSelected ? 'edge-arrow-selected' : `edge-arrow-${conditionType}`;
+
+				return (
+					<g
+						key={transition.id}
+						data-testid={`edge-${transition.id}`}
+						data-edge-id={transition.id}
+						data-selected={isSelected ? 'true' : 'false'}
+						data-condition-type={conditionType}
+						style={{ pointerEvents: 'auto' }}
+					>
+						{/* Invisible wider hitbox for easier click selection */}
+						<path
+							d={d}
+							stroke="transparent"
+							strokeWidth={HITBOX_STROKE_WIDTH}
+							fill="none"
+							style={{ cursor: 'pointer', pointerEvents: 'stroke' }}
+							onClick={(e: MouseEvent) => {
+								e.stopPropagation();
+								onEdgeSelect?.(transition.id);
+							}}
+						/>
+						{/* Visible edge path */}
+						<path
+							d={d}
+							stroke={strokeColor}
+							strokeWidth={strokeWidth}
+							strokeOpacity={isSelected ? 1 : 0.85}
+							fill="none"
+							markerEnd={`url(#${markerId})`}
+							style={{ pointerEvents: 'none' }}
+						/>
+					</g>
+				);
+			})}
+		</>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -225,14 +225,11 @@ export function WorkflowCanvas({
 		[onEdgeSelect]
 	);
 
-	const handleEdgeDelete = useCallback(
-		(transitionId: string) => {
-			setSelectedEdgeId(null);
-			onEdgeSelectRef.current?.(null);
-			onDeleteEdgeRef.current?.(transitionId);
-		},
-		[]
-	);
+	const handleEdgeDelete = useCallback((transitionId: string) => {
+		setSelectedEdgeId(null);
+		onEdgeSelectRef.current?.(null);
+		onDeleteEdgeRef.current?.(transitionId);
+	}, []);
 
 	const handleBackgroundClick = useCallback(() => {
 		setSelectedNodeId(null);

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -3,23 +3,35 @@
  *
  * Wraps VisualCanvas with workflow-specific behaviour:
  *  - Manages selectedNodeId state (single-select)
+ *  - Manages selectedEdgeId state (mutually exclusive with selectedNodeId)
  *  - Renders WorkflowNode components with correct isSelected prop
- *  - Handles Delete/Backspace keyboard shortcut to delete selected node
- *  - Emits onNodeSelect(stepId | null) so parent components can react
+ *  - Renders EdgeRenderer via the edgeLayer render prop of VisualCanvas
+ *  - Handles Delete/Backspace keyboard shortcut to delete selected node or edge
+ *  - Emits onNodeSelect(stepId | null) and onEdgeSelect(transitionId | null)
  *  - Manages connection drag via useConnectionDrag hook
  *    - Shows ghost edge (dashed SVG path) during drag
  *    - Highlights valid input ports as drop targets
  *    - Creates transitions on valid drop
+ *
+ * Node and edge selection are mutually exclusive: selecting a node clears the
+ * selected edge and vice versa. This prevents the two independent Delete/Backspace
+ * listeners (WorkflowCanvas for nodes, EdgeRenderer for edges) from both firing on
+ * the same keystroke.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'preact/hooks';
 import type { ComponentChildren, JSX, RefObject } from 'preact';
+import type { WorkflowTransition } from '@neokai/shared';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
 import type { WorkflowNodeProps, PortType } from './WorkflowNode';
-import type { ViewportState, Point } from './types';
+import { EdgeRenderer } from './EdgeRenderer';
+import type { ViewportState, Point, NodePosition } from './types';
 import { useConnectionDrag } from './useConnectionDrag';
-import type { TransitionLike } from './useConnectionDrag';
+
+/** Default node dimensions used when deriving NodePosition from WorkflowNodeData. */
+export const DEFAULT_NODE_WIDTH = 160;
+export const DEFAULT_NODE_HEIGHT = 80;
 
 /**
  * Per-node data passed to WorkflowCanvas.
@@ -42,16 +54,25 @@ export interface WorkflowCanvasProps {
 	nodes: WorkflowNodeData[];
 	viewportState: ViewportState;
 	onViewportChange: (state: ViewportState) => void;
+	/** Edges to render between nodes. Also used for duplicate detection during connection drag. */
+	transitions?: WorkflowTransition[];
+	/**
+	 * Explicit node positions including width/height for edge port computation.
+	 * When omitted, positions are derived from nodes with DEFAULT_NODE_WIDTH/HEIGHT.
+	 */
+	nodePositions?: NodePosition;
 	/** Called when the selected node changes. Null means nothing is selected. */
 	onNodeSelect?: (stepId: string | null) => void;
 	/** Called when Delete/Backspace is pressed with a node selected. */
 	onDeleteNode?: (stepId: string) => void;
 	/** Called when a node is dragged to a new position. */
 	onNodePositionChange?: (stepId: string, position: Point) => void;
-	/** Existing transitions — used for duplicate detection during connection drag. */
-	transitions?: TransitionLike[];
 	/** Called when a new connection is created by dragging from an output to an input port. */
 	onCreateTransition?: (fromStepId: string, toStepId: string) => void;
+	/** Called when the selected edge changes. Null means nothing is selected. */
+	onEdgeSelect?: (transitionId: string | null) => void;
+	/** Called when Delete/Backspace is pressed with an edge selected. */
+	onDeleteEdge?: (transitionId: string) => void;
 }
 
 // ---- Ghost edge rendering ----
@@ -108,23 +129,36 @@ export function WorkflowCanvas({
 	nodes,
 	viewportState,
 	onViewportChange,
+	transitions = [],
+	nodePositions,
 	onNodeSelect,
 	onDeleteNode,
 	onNodePositionChange,
-	transitions = [],
 	onCreateTransition,
+	onEdgeSelect,
+	onDeleteEdge,
 }: WorkflowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+	const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
 	// Keep refs so keyboard handler always sees the latest value without re-registering
 	const selectedNodeIdRef = useRef<string | null>(null);
 	selectedNodeIdRef.current = selectedNodeId;
 
+	const selectedEdgeIdRef = useRef<string | null>(null);
+	selectedEdgeIdRef.current = selectedEdgeId;
+
 	const onNodeSelectRef = useRef(onNodeSelect);
 	onNodeSelectRef.current = onNodeSelect;
 
+	const onEdgeSelectRef = useRef(onEdgeSelect);
+	onEdgeSelectRef.current = onEdgeSelect;
+
 	const onDeleteNodeRef = useRef(onDeleteNode);
 	onDeleteNodeRef.current = onDeleteNode;
+
+	const onDeleteEdgeRef = useRef(onDeleteEdge);
+	onDeleteEdgeRef.current = onDeleteEdge;
 
 	// Ref to the VisualCanvas container (for coordinate conversion in connection drag)
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -137,6 +171,22 @@ export function WorkflowCanvas({
 		onCreateTransition: onCreateTransition ?? (() => {}),
 	});
 
+	// Derive NodePosition map from nodes when not explicitly provided.
+	// Edges update positions automatically because nodes update when dragged.
+	const effectiveNodePositions = useMemo((): NodePosition => {
+		if (nodePositions) return nodePositions;
+		const result: NodePosition = {};
+		for (const node of nodes) {
+			result[node.step.localId] = {
+				x: node.position.x,
+				y: node.position.y,
+				width: DEFAULT_NODE_WIDTH,
+				height: DEFAULT_NODE_HEIGHT,
+			};
+		}
+		return result;
+	}, [nodes, nodePositions]);
+
 	// Clear selection if the selected node is removed externally (e.g. parent deletes it
 	// from the nodes array). Without this, a node re-added with the same stepId would
 	// appear pre-selected, which is unexpected.
@@ -147,18 +197,49 @@ export function WorkflowCanvas({
 		}
 	}, [nodes, selectedNodeId]);
 
+	// Selecting a node clears the edge selection (mutually exclusive).
 	const handleNodeSelect = useCallback(
 		(stepId: string) => {
 			setSelectedNodeId(stepId);
 			onNodeSelect?.(stepId);
+			// Clear edge selection to prevent dual Delete handlers from both firing
+			if (selectedEdgeIdRef.current !== null) {
+				setSelectedEdgeId(null);
+				onEdgeSelectRef.current?.(null);
+			}
 		},
 		[onNodeSelect]
+	);
+
+	// Selecting an edge clears the node selection (mutually exclusive).
+	const handleEdgeSelect = useCallback(
+		(transitionId: string) => {
+			setSelectedEdgeId(transitionId);
+			onEdgeSelect?.(transitionId);
+			// Clear node selection to prevent dual Delete handlers from both firing
+			if (selectedNodeIdRef.current !== null) {
+				setSelectedNodeId(null);
+				onNodeSelectRef.current?.(null);
+			}
+		},
+		[onEdgeSelect]
+	);
+
+	const handleEdgeDelete = useCallback(
+		(transitionId: string) => {
+			setSelectedEdgeId(null);
+			onEdgeSelectRef.current?.(null);
+			onDeleteEdgeRef.current?.(transitionId);
+		},
+		[]
 	);
 
 	const handleBackgroundClick = useCallback(() => {
 		setSelectedNodeId(null);
 		onNodeSelect?.(null);
-	}, [onNodeSelect]);
+		setSelectedEdgeId(null);
+		onEdgeSelect?.(null);
+	}, [onNodeSelect, onEdgeSelect]);
 
 	// ---- Port event handlers ----
 	const handlePortMouseDown = useCallback(
@@ -191,11 +272,14 @@ export function WorkflowCanvas({
 	);
 
 	// ---- Keyboard: Delete / Backspace removes the selected node ----
+	// (Edge deletion is handled by EdgeRenderer's own listener. Selections are mutually
+	// exclusive so at most one handler fires per keystroke.)
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Delete' && e.key !== 'Backspace') return;
-			const tag = (e.target as HTMLElement)?.tagName;
-			if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+			const target = e.target as HTMLElement;
+			const tag = target?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
 
 			const current = selectedNodeIdRef.current;
 			if (!current || !onDeleteNodeRef.current) return;
@@ -210,13 +294,30 @@ export function WorkflowCanvas({
 		return () => window.removeEventListener('keydown', handleKeyDown);
 	}, []);
 
-	// ---- Ghost edge (rendered in SVG edge layer) ----
+	// ---- Edge layer: committed edges (EdgeRenderer) + ghost edge during drag ----
 	const edgeLayer = useCallback(
-		(_vp: ViewportState): ComponentChildren => {
-			if (!dragState.active || !dragState.fromPos || !dragState.currentPos) return null;
-			return <GhostEdge from={dragState.fromPos} to={dragState.currentPos} />;
-		},
-		[dragState]
+		(_vp: ViewportState): ComponentChildren => (
+			<>
+				<EdgeRenderer
+					transitions={transitions}
+					nodePositions={effectiveNodePositions}
+					selectedEdgeId={selectedEdgeId}
+					onEdgeSelect={handleEdgeSelect}
+					onEdgeDelete={handleEdgeDelete}
+				/>
+				{dragState.active && dragState.fromPos && dragState.currentPos && (
+					<GhostEdge from={dragState.fromPos} to={dragState.currentPos} />
+				)}
+			</>
+		),
+		[
+			transitions,
+			effectiveNodePositions,
+			selectedEdgeId,
+			handleEdgeSelect,
+			handleEdgeDelete,
+			dragState,
+		]
 	);
 
 	return (
@@ -225,6 +326,7 @@ export function WorkflowCanvas({
 			viewportState={viewportState}
 			onViewportChange={onViewportChange}
 			onBackgroundClick={handleBackgroundClick}
+			nodes={effectiveNodePositions}
 			edgeLayer={edgeLayer}
 		>
 			{nodes.map((node) => {

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for EdgeRenderer
+ *
+ * Tests:
+ * - Correct number of paths rendered per transition
+ * - Missing node position skips that edge
+ * - computeEdgePoints bezier control point math
+ * - buildPathD produces correct SVG path string
+ * - Edge color matches condition type (always/human/condition)
+ * - Selected edge gets thicker stroke and white color
+ * - Clicking an edge calls onEdgeSelect with transitionId
+ * - Delete key on selected edge calls onEdgeDelete
+ * - Backspace key on selected edge calls onEdgeDelete
+ * - Delete key without selection does not call onEdgeDelete
+ * - Delete inside input does not trigger onEdgeDelete
+ * - Arrowhead markers are rendered in defs
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import type { WorkflowTransition } from '@neokai/shared';
+import {
+	EdgeRenderer,
+	computeEdgePoints,
+	buildPathD,
+	CONTROL_OFFSET,
+	EDGE_COLORS,
+} from '../EdgeRenderer';
+import type { EdgeRendererProps } from '../EdgeRenderer';
+import type { NodePosition } from '../types';
+
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NODE_POSITIONS: NodePosition = {
+	'step-1': { x: 50, y: 50, width: 160, height: 80 },
+	'step-2': { x: 300, y: 250, width: 160, height: 80 },
+	'step-3': { x: 50, y: 450, width: 160, height: 80 },
+};
+
+function makeTransition(
+	id: string,
+	from: string,
+	to: string,
+	conditionType?: 'always' | 'human' | 'condition'
+): WorkflowTransition {
+	return {
+		id,
+		from,
+		to,
+		condition: conditionType ? { type: conditionType } : undefined,
+	};
+}
+
+const T1 = makeTransition('t1', 'step-1', 'step-2'); // always (no condition)
+const T2 = makeTransition('t2', 'step-2', 'step-3', 'human');
+const T3 = makeTransition('t3', 'step-1', 'step-3', 'condition');
+
+function renderEdges(props: Partial<EdgeRendererProps> = {}) {
+	const onEdgeSelect = vi.fn();
+	const onEdgeDelete = vi.fn();
+	const result = render(
+		<svg>
+			<EdgeRenderer
+				transitions={[T1, T2, T3]}
+				nodePositions={NODE_POSITIONS}
+				onEdgeSelect={onEdgeSelect}
+				onEdgeDelete={onEdgeDelete}
+				{...props}
+			/>
+		</svg>
+	);
+	return { ...result, onEdgeSelect, onEdgeDelete };
+}
+
+// ---------------------------------------------------------------------------
+// computeEdgePoints
+// ---------------------------------------------------------------------------
+
+describe('computeEdgePoints', () => {
+	it('returns null when from-node is missing', () => {
+		const t = makeTransition('t', 'missing', 'step-2');
+		expect(computeEdgePoints(t, NODE_POSITIONS)).toBeNull();
+	});
+
+	it('returns null when to-node is missing', () => {
+		const t = makeTransition('t', 'step-1', 'missing');
+		expect(computeEdgePoints(t, NODE_POSITIONS)).toBeNull();
+	});
+
+	it('source x is horizontal center of from-node', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		expect(pts).not.toBeNull();
+		// step-1: x=50, width=160 → center x = 50 + 80 = 130
+		expect(pts!.sx).toBe(50 + 160 / 2);
+	});
+
+	it('source y is bottom edge of from-node', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		// step-1: y=50, height=80 → bottom = 130
+		expect(pts!.sy).toBe(50 + 80);
+	});
+
+	it('target x is horizontal center of to-node', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		// step-2: x=300, width=160 → center x = 380
+		expect(pts!.tx).toBe(300 + 160 / 2);
+	});
+
+	it('target y is top edge of to-node', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		// step-2: y=250
+		expect(pts!.ty).toBe(250);
+	});
+
+	it('control point 1 is directly below source by CONTROL_OFFSET', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		expect(pts!.cp1x).toBe(pts!.sx);
+		expect(pts!.cp1y).toBe(pts!.sy + CONTROL_OFFSET);
+	});
+
+	it('control point 2 is directly above target by CONTROL_OFFSET', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS);
+		expect(pts!.cp2x).toBe(pts!.tx);
+		expect(pts!.cp2y).toBe(pts!.ty - CONTROL_OFFSET);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildPathD
+// ---------------------------------------------------------------------------
+
+describe('buildPathD', () => {
+	it('produces a valid SVG cubic bezier path string', () => {
+		const pts = computeEdgePoints(T1, NODE_POSITIONS)!;
+		const d = buildPathD(pts);
+		// Format: M sx sy C cp1x cp1y, cp2x cp2y, tx ty
+		expect(d).toBe(
+			`M ${pts.sx} ${pts.sy} C ${pts.cp1x} ${pts.cp1y}, ${pts.cp2x} ${pts.cp2y}, ${pts.tx} ${pts.ty}`
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — rendering', () => {
+	it('renders a <g> element for each transition', () => {
+		const { container } = renderEdges();
+		const groups = container.querySelectorAll('g[data-edge-id]');
+		expect(groups).toHaveLength(3);
+	});
+
+	it('renders two paths per edge (hitbox + visible)', () => {
+		const { container } = renderEdges();
+		// Each <g> should have 2 paths
+		const groups = container.querySelectorAll('g[data-edge-id]');
+		for (const g of groups) {
+			expect(g.querySelectorAll('path')).toHaveLength(2);
+		}
+	});
+
+	it('skips edges where node positions are missing', () => {
+		const missingEdge = makeTransition('tmissing', 'step-1', 'missing-node');
+		const { container } = renderEdges({ transitions: [T1, missingEdge] });
+		// Only t1 should render (missingEdge skipped)
+		const groups = container.querySelectorAll('g[data-edge-id]');
+		expect(groups).toHaveLength(1);
+		expect(groups[0].getAttribute('data-edge-id')).toBe('t1');
+	});
+
+	it('renders arrowhead marker definitions', () => {
+		const { container } = renderEdges();
+		// Should have markers for always, human, condition, and selected
+		expect(container.querySelector('#edge-arrow-always')).not.toBeNull();
+		expect(container.querySelector('#edge-arrow-human')).not.toBeNull();
+		expect(container.querySelector('#edge-arrow-condition')).not.toBeNull();
+		expect(container.querySelector('#edge-arrow-selected')).not.toBeNull();
+	});
+
+	it('uses testid data-testid="edge-{id}" on each group', () => {
+		const { getByTestId } = renderEdges();
+		expect(getByTestId('edge-t1')).toBeTruthy();
+		expect(getByTestId('edge-t2')).toBeTruthy();
+		expect(getByTestId('edge-t3')).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge colors
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — edge colors', () => {
+	it('always transition (no condition) has data-condition-type="always"', () => {
+		const { getByTestId } = renderEdges();
+		expect(getByTestId('edge-t1').getAttribute('data-condition-type')).toBe('always');
+	});
+
+	it('human transition has data-condition-type="human"', () => {
+		const { getByTestId } = renderEdges();
+		expect(getByTestId('edge-t2').getAttribute('data-condition-type')).toBe('human');
+	});
+
+	it('condition transition has data-condition-type="condition"', () => {
+		const { getByTestId } = renderEdges();
+		expect(getByTestId('edge-t3').getAttribute('data-condition-type')).toBe('condition');
+	});
+
+	it('EDGE_COLORS has entries for all condition types', () => {
+		expect(EDGE_COLORS.always).toBe('#3b82f6');
+		expect(EDGE_COLORS.human).toBe('#facc15');
+		expect(EDGE_COLORS.condition).toBe('#c084fc');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Selected edge
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — selected state', () => {
+	it('selected edge uses white stroke color', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		const group = getByTestId('edge-t1');
+		const visiblePath = group.querySelectorAll('path')[1];
+		expect(visiblePath.getAttribute('stroke')).toBe('white');
+	});
+
+	it('selected edge has data-selected="true"', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		expect(getByTestId('edge-t1').getAttribute('data-selected')).toBe('true');
+		expect(getByTestId('edge-t2').getAttribute('data-selected')).toBe('false');
+	});
+
+	it('non-selected edges retain their condition type attribute', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		expect(getByTestId('edge-t2').getAttribute('data-condition-type')).toBe('human');
+	});
+
+	it('non-selected edges have data-selected="false"', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		expect(getByTestId('edge-t2').getAttribute('data-selected')).toBe('false');
+		expect(getByTestId('edge-t3').getAttribute('data-selected')).toBe('false');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Click selection
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — click selection', () => {
+	it('clicking an edge calls onEdgeSelect with the transitionId', () => {
+		const { getByTestId, onEdgeSelect } = renderEdges();
+		const group = getByTestId('edge-t1');
+		const hitboxPath = group.querySelectorAll('path')[0];
+		fireEvent.click(hitboxPath);
+		expect(onEdgeSelect).toHaveBeenCalledWith('t1');
+	});
+
+	it('clicking a different edge calls onEdgeSelect with its id', () => {
+		const { getByTestId, onEdgeSelect } = renderEdges();
+		const group = getByTestId('edge-t2');
+		const hitboxPath = group.querySelectorAll('path')[0];
+		fireEvent.click(hitboxPath);
+		expect(onEdgeSelect).toHaveBeenCalledWith('t2');
+	});
+
+	it('hitbox path uses transparent stroke', () => {
+		const { getByTestId } = renderEdges();
+		const group = getByTestId('edge-t1');
+		const hitboxPath = group.querySelectorAll('path')[0];
+		expect(hitboxPath.getAttribute('stroke')).toBe('transparent');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard delete
+// ---------------------------------------------------------------------------
+
+describe('EdgeRenderer — keyboard delete', () => {
+	it('Delete key calls onEdgeDelete with selected edgeId', () => {
+		const { onEdgeDelete } = renderEdges({ selectedEdgeId: 't1' });
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onEdgeDelete).toHaveBeenCalledWith('t1');
+	});
+
+	it('Backspace key calls onEdgeDelete with selected edgeId', () => {
+		const { onEdgeDelete } = renderEdges({ selectedEdgeId: 't2' });
+		fireEvent.keyDown(document.body, { key: 'Backspace' });
+		expect(onEdgeDelete).toHaveBeenCalledWith('t2');
+	});
+
+	it('Delete without selection does not call onEdgeDelete', () => {
+		const { onEdgeDelete } = renderEdges({ selectedEdgeId: null });
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onEdgeDelete).not.toHaveBeenCalled();
+	});
+
+	it('Delete inside an input does not trigger onEdgeDelete', () => {
+		const { onEdgeDelete, container } = renderEdges({ selectedEdgeId: 't1' });
+		const input = document.createElement('input');
+		container.appendChild(input);
+		input.focus();
+		fireEvent.keyDown(input, { key: 'Delete', target: input });
+		expect(onEdgeDelete).not.toHaveBeenCalled();
+	});
+
+	it('Delete inside a textarea does not trigger onEdgeDelete', () => {
+		const { onEdgeDelete, container } = renderEdges({ selectedEdgeId: 't1' });
+		const textarea = document.createElement('textarea');
+		container.appendChild(textarea);
+		textarea.focus();
+		fireEvent.keyDown(textarea, { key: 'Delete', target: textarea });
+		expect(onEdgeDelete).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -6,14 +6,15 @@
  * - Missing node position skips that edge
  * - computeEdgePoints bezier control point math
  * - buildPathD produces correct SVG path string
- * - Edge color matches condition type (always/human/condition)
- * - Selected edge gets thicker stroke and white color
+ * - Edge color matches condition type (always/human/condition) via data-stroke-color
+ * - Selected edge gets thicker stroke (data-stroke-width) and white color
  * - Clicking an edge calls onEdgeSelect with transitionId
  * - Delete key on selected edge calls onEdgeDelete
  * - Backspace key on selected edge calls onEdgeDelete
  * - Delete key without selection does not call onEdgeDelete
- * - Delete inside input does not trigger onEdgeDelete
+ * - Delete inside input/textarea/contenteditable does not trigger onEdgeDelete
  * - Arrowhead markers are rendered in defs
+ * - Multiple instances have non-colliding marker IDs
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -25,6 +26,8 @@ import {
 	buildPathD,
 	CONTROL_OFFSET,
 	EDGE_COLORS,
+	NORMAL_STROKE_WIDTH,
+	SELECTED_STROKE_WIDTH,
 } from '../EdgeRenderer';
 import type { EdgeRendererProps } from '../EdgeRenderer';
 import type { NodePosition } from '../types';
@@ -74,6 +77,11 @@ function renderEdges(props: Partial<EdgeRendererProps> = {}) {
 		</svg>
 	);
 	return { ...result, onEdgeSelect, onEdgeDelete };
+}
+
+// Helper to get the visible path (second <path> in the group)
+function getVisiblePath(group: Element): Element {
+	return group.querySelectorAll('path')[1];
 }
 
 // ---------------------------------------------------------------------------
@@ -173,13 +181,12 @@ describe('EdgeRenderer — rendering', () => {
 		expect(groups[0].getAttribute('data-edge-id')).toBe('t1');
 	});
 
-	it('renders arrowhead marker definitions', () => {
+	it('renders arrowhead marker <defs>', () => {
 		const { container } = renderEdges();
-		// Should have markers for always, human, condition, and selected
-		expect(container.querySelector('#edge-arrow-always')).not.toBeNull();
-		expect(container.querySelector('#edge-arrow-human')).not.toBeNull();
-		expect(container.querySelector('#edge-arrow-condition')).not.toBeNull();
-		expect(container.querySelector('#edge-arrow-selected')).not.toBeNull();
+		const defs = container.querySelector('defs');
+		expect(defs).not.toBeNull();
+		// Should have 4 markers: always, human, condition, selected
+		expect(defs!.querySelectorAll('marker')).toHaveLength(4);
 	});
 
 	it('uses testid data-testid="edge-{id}" on each group', () => {
@@ -188,6 +195,26 @@ describe('EdgeRenderer — rendering', () => {
 		expect(getByTestId('edge-t2')).toBeTruthy();
 		expect(getByTestId('edge-t3')).toBeTruthy();
 	});
+
+	it('multiple instances have non-colliding marker IDs', () => {
+		// Render two EdgeRenderer instances and check their marker IDs differ
+		const { container: c1 } = render(
+			<svg>
+				<EdgeRenderer transitions={[T1]} nodePositions={NODE_POSITIONS} />
+			</svg>
+		);
+		const { container: c2 } = render(
+			<svg>
+				<EdgeRenderer transitions={[T1]} nodePositions={NODE_POSITIONS} />
+			</svg>
+		);
+		const markers1 = Array.from(c1.querySelectorAll('marker')).map((m) => m.id);
+		const markers2 = Array.from(c2.querySelectorAll('marker')).map((m) => m.id);
+		// No overlap between the two instances' marker IDs
+		const overlap = markers1.filter((id) => markers2.includes(id));
+		expect(overlap).toHaveLength(0);
+		cleanup();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -195,6 +222,12 @@ describe('EdgeRenderer — rendering', () => {
 // ---------------------------------------------------------------------------
 
 describe('EdgeRenderer — edge colors', () => {
+	it('EDGE_COLORS has correct hex values for all condition types', () => {
+		expect(EDGE_COLORS.always).toBe('#3b82f6');
+		expect(EDGE_COLORS.human).toBe('#facc15');
+		expect(EDGE_COLORS.condition).toBe('#c084fc');
+	});
+
 	it('always transition (no condition) has data-condition-type="always"', () => {
 		const { getByTestId } = renderEdges();
 		expect(getByTestId('edge-t1').getAttribute('data-condition-type')).toBe('always');
@@ -210,10 +243,22 @@ describe('EdgeRenderer — edge colors', () => {
 		expect(getByTestId('edge-t3').getAttribute('data-condition-type')).toBe('condition');
 	});
 
-	it('EDGE_COLORS has entries for all condition types', () => {
-		expect(EDGE_COLORS.always).toBe('#3b82f6');
-		expect(EDGE_COLORS.human).toBe('#facc15');
-		expect(EDGE_COLORS.condition).toBe('#c084fc');
+	it('always transition visible path has correct stroke color', () => {
+		const { getByTestId } = renderEdges();
+		const visible = getVisiblePath(getByTestId('edge-t1'));
+		expect(visible.getAttribute('data-stroke-color')).toBe(EDGE_COLORS.always);
+	});
+
+	it('human transition visible path has correct stroke color', () => {
+		const { getByTestId } = renderEdges();
+		const visible = getVisiblePath(getByTestId('edge-t2'));
+		expect(visible.getAttribute('data-stroke-color')).toBe(EDGE_COLORS.human);
+	});
+
+	it('condition transition visible path has correct stroke color', () => {
+		const { getByTestId } = renderEdges();
+		const visible = getVisiblePath(getByTestId('edge-t3'));
+		expect(visible.getAttribute('data-stroke-color')).toBe(EDGE_COLORS.condition);
 	});
 });
 
@@ -222,28 +267,39 @@ describe('EdgeRenderer — edge colors', () => {
 // ---------------------------------------------------------------------------
 
 describe('EdgeRenderer — selected state', () => {
-	it('selected edge uses white stroke color', () => {
-		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
-		const group = getByTestId('edge-t1');
-		const visiblePath = group.querySelectorAll('path')[1];
-		expect(visiblePath.getAttribute('stroke')).toBe('white');
-	});
-
 	it('selected edge has data-selected="true"', () => {
 		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
 		expect(getByTestId('edge-t1').getAttribute('data-selected')).toBe('true');
-		expect(getByTestId('edge-t2').getAttribute('data-selected')).toBe('false');
-	});
-
-	it('non-selected edges retain their condition type attribute', () => {
-		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
-		expect(getByTestId('edge-t2').getAttribute('data-condition-type')).toBe('human');
 	});
 
 	it('non-selected edges have data-selected="false"', () => {
 		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
 		expect(getByTestId('edge-t2').getAttribute('data-selected')).toBe('false');
 		expect(getByTestId('edge-t3').getAttribute('data-selected')).toBe('false');
+	});
+
+	it('selected edge visible path has white stroke color', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		const visible = getVisiblePath(getByTestId('edge-t1'));
+		expect(visible.getAttribute('data-stroke-color')).toBe('white');
+	});
+
+	it('selected edge visible path has thicker stroke-width than normal', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		const selectedVisible = getVisiblePath(getByTestId('edge-t1'));
+		const normalVisible = getVisiblePath(getByTestId('edge-t2'));
+		const selectedWidth = parseFloat(selectedVisible.getAttribute('data-stroke-width') ?? '0');
+		const normalWidth = parseFloat(normalVisible.getAttribute('data-stroke-width') ?? '0');
+		expect(selectedWidth).toBe(SELECTED_STROKE_WIDTH);
+		expect(normalWidth).toBe(NORMAL_STROKE_WIDTH);
+		expect(selectedWidth).toBeGreaterThan(normalWidth);
+	});
+
+	it('non-selected edges retain their condition color when one is selected', () => {
+		const { getByTestId } = renderEdges({ selectedEdgeId: 't1' });
+		expect(getVisiblePath(getByTestId('edge-t2')).getAttribute('data-stroke-color')).toBe(
+			EDGE_COLORS.human
+		);
 	});
 });
 
@@ -314,6 +370,16 @@ describe('EdgeRenderer — keyboard delete', () => {
 		container.appendChild(textarea);
 		textarea.focus();
 		fireEvent.keyDown(textarea, { key: 'Delete', target: textarea });
+		expect(onEdgeDelete).not.toHaveBeenCalled();
+	});
+
+	it('Delete inside a contenteditable element does not trigger onEdgeDelete', () => {
+		const { onEdgeDelete, container } = renderEdges({ selectedEdgeId: 't1' });
+		const div = document.createElement('div');
+		div.contentEditable = 'true';
+		container.appendChild(div);
+		div.focus();
+		fireEvent.keyDown(div, { key: 'Delete', target: div });
 		expect(onEdgeDelete).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -19,7 +19,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { useState } from 'preact/hooks';
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, WorkflowTransition } from '@neokai/shared';
 import { WorkflowCanvas } from '../WorkflowCanvas';
 import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
 import type { StepDraft } from '../../WorkflowStepCard';
@@ -268,5 +268,196 @@ describe('WorkflowNode — isSelected prop via WorkflowCanvas', () => {
 		expect(getByTestId('workflow-node-step-1').className).toContain('ring-2');
 		expect(getByTestId('workflow-node-step-1').className).toContain('ring-blue-500');
 		expect(getByTestId('workflow-node-step-2').className).not.toContain('ring-2');
+	});
+});
+
+// ---- Transitions / edge integration ----
+
+const TRANSITIONS: WorkflowTransition[] = [
+	{ id: 'tr1', from: 'step-1', to: 'step-2' },
+	{ id: 'tr2', from: 'step-2', to: 'step-1', condition: { type: 'human' } },
+];
+
+function renderCanvasWithEdges(extra: Partial<WorkflowCanvasProps> = {}) {
+	const onEdgeSelect = vi.fn();
+	const onDeleteEdge = vi.fn();
+
+	function Wrapper() {
+		const [vp, setVp] = useState<ViewportState>(VP);
+		return (
+			<WorkflowCanvas
+				nodes={NODES}
+				viewportState={vp}
+				onViewportChange={setVp}
+				transitions={TRANSITIONS}
+				onEdgeSelect={onEdgeSelect}
+				onDeleteEdge={onDeleteEdge}
+				{...extra}
+			/>
+		);
+	}
+
+	const result = render(<Wrapper />);
+	return { ...result, onEdgeSelect, onDeleteEdge };
+}
+
+describe('WorkflowCanvas — edge rendering', () => {
+	it('renders SVG edges for each transition', () => {
+		const { getByTestId } = renderCanvasWithEdges();
+		expect(getByTestId('edge-tr1')).toBeTruthy();
+		expect(getByTestId('edge-tr2')).toBeTruthy();
+	});
+
+	it('renders SVG overlay layer', () => {
+		const { getByTestId } = renderCanvasWithEdges();
+		expect(getByTestId('visual-canvas-svg')).toBeTruthy();
+	});
+});
+
+describe('WorkflowCanvas — edge selection mutual exclusivity', () => {
+	it('clicking an edge calls onEdgeSelect', () => {
+		const { getByTestId, onEdgeSelect } = renderCanvasWithEdges();
+		const group = getByTestId('edge-tr1');
+		const hitbox = group.querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		expect(onEdgeSelect).toHaveBeenCalledWith('tr1');
+	});
+
+	it('selecting a node clears edge selection and calls onEdgeSelect(null)', () => {
+		const onEdgeSelect = vi.fn();
+		const onNodeSelect = vi.fn();
+
+		function Wrapper() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			return (
+				<WorkflowCanvas
+					nodes={NODES}
+					viewportState={vp}
+					onViewportChange={setVp}
+					transitions={TRANSITIONS}
+					onEdgeSelect={onEdgeSelect}
+					onNodeSelect={onNodeSelect}
+				/>
+			);
+		}
+		const { getByTestId } = render(<Wrapper />);
+
+		// Select an edge first
+		const hitbox = getByTestId('edge-tr1').querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		expect(onEdgeSelect).toHaveBeenCalledWith('tr1');
+		expect(getByTestId('edge-tr1').getAttribute('data-selected')).toBe('true');
+		onEdgeSelect.mockClear();
+
+		// Now select a node — edge should be cleared
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(onEdgeSelect).toHaveBeenCalledWith(null);
+		expect(getByTestId('edge-tr1').getAttribute('data-selected')).toBe('false');
+		cleanup();
+	});
+
+	it('selecting an edge clears node selection and calls onNodeSelect(null)', () => {
+		const onEdgeSelect = vi.fn();
+		const onNodeSelect = vi.fn();
+
+		function Wrapper() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			return (
+				<WorkflowCanvas
+					nodes={NODES}
+					viewportState={vp}
+					onViewportChange={setVp}
+					transitions={TRANSITIONS}
+					onEdgeSelect={onEdgeSelect}
+					onNodeSelect={onNodeSelect}
+				/>
+			);
+		}
+		const { getByTestId } = render(<Wrapper />);
+
+		// Select a node first
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		expect(getByTestId('workflow-node-step-1').className).toContain('ring-2');
+		onNodeSelect.mockClear();
+
+		// Now select an edge — node should be cleared
+		const hitbox = getByTestId('edge-tr1').querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		expect(onNodeSelect).toHaveBeenCalledWith(null);
+		expect(getByTestId('workflow-node-step-1').className).not.toContain('ring-2');
+		cleanup();
+	});
+
+	it('background click clears both node and edge selection', () => {
+		const onEdgeSelect = vi.fn();
+		const onNodeSelect = vi.fn();
+
+		function Wrapper() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			return (
+				<WorkflowCanvas
+					nodes={NODES}
+					viewportState={vp}
+					onViewportChange={setVp}
+					transitions={TRANSITIONS}
+					onEdgeSelect={onEdgeSelect}
+					onNodeSelect={onNodeSelect}
+				/>
+			);
+		}
+		const { getByTestId } = render(<Wrapper />);
+
+		const hitbox = getByTestId('edge-tr1').querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		expect(getByTestId('edge-tr1').getAttribute('data-selected')).toBe('true');
+		onEdgeSelect.mockClear();
+
+		fireEvent.click(getByTestId('visual-canvas-transform'));
+		expect(onEdgeSelect).toHaveBeenCalledWith(null);
+		expect(getByTestId('edge-tr1').getAttribute('data-selected')).toBe('false');
+		cleanup();
+	});
+});
+
+describe('WorkflowCanvas — edge delete', () => {
+	it('Delete key on selected edge calls onDeleteEdge', () => {
+		const { getByTestId, onDeleteEdge } = renderCanvasWithEdges();
+		const hitbox = getByTestId('edge-tr1').querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onDeleteEdge).toHaveBeenCalledWith('tr1');
+	});
+
+	it('Delete on selected edge does not call onDeleteNode', () => {
+		const onDeleteNode = vi.fn();
+
+		function Wrapper() {
+			const [vp, setVp] = useState<ViewportState>(VP);
+			return (
+				<WorkflowCanvas
+					nodes={NODES}
+					viewportState={vp}
+					onViewportChange={setVp}
+					transitions={TRANSITIONS}
+					onDeleteNode={onDeleteNode}
+				/>
+			);
+		}
+		const { getByTestId } = render(<Wrapper />);
+
+		// Select edge (clears node selection)
+		const hitbox = getByTestId('edge-tr1').querySelectorAll('path')[0];
+		fireEvent.click(hitbox);
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onDeleteNode).not.toHaveBeenCalled();
+		cleanup();
+	});
+
+	it('Delete on selected node does not call onDeleteEdge when edge not selected', () => {
+		const { getByTestId, onDeleteEdge } = renderCanvasWithEdges();
+		// Select a node (mutually exclusive — no edge selected)
+		fireEvent.click(getByTestId('workflow-node-step-1'));
+		fireEvent.keyDown(document.body, { key: 'Delete' });
+		expect(onDeleteEdge).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -4,7 +4,7 @@ export type { ViewportState, Point, Size, NodePosition } from './types';
 export { screenToCanvas, canvasToScreen } from './types';
 export { WorkflowNode } from './WorkflowNode';
 export type { WorkflowNodeProps, PortType } from './WorkflowNode';
-export { WorkflowCanvas } from './WorkflowCanvas';
+export { WorkflowCanvas, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './WorkflowCanvas';
 export type { WorkflowNodeData, WorkflowCanvasProps } from './WorkflowCanvas';
 export { useConnectionDrag } from './useConnectionDrag';
 export type {
@@ -23,5 +23,7 @@ export {
 	buildPathD,
 	CONTROL_OFFSET,
 	EDGE_COLORS,
+	NORMAL_STROKE_WIDTH,
+	SELECTED_STROKE_WIDTH,
 } from './EdgeRenderer';
 export type { EdgeRendererProps, EdgePoints } from './EdgeRenderer';

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -17,3 +17,11 @@ export { GateConfig, CONDITION_LABELS } from './GateConfig';
 export type { ConditionDraft } from './GateConfig';
 export { NodeConfigPanel } from './NodeConfigPanel';
 export type { NodeConfigPanelProps } from './NodeConfigPanel';
+export {
+	EdgeRenderer,
+	computeEdgePoints,
+	buildPathD,
+	CONTROL_OFFSET,
+	EDGE_COLORS,
+} from './EdgeRenderer';
+export type { EdgeRendererProps, EdgePoints } from './EdgeRenderer';


### PR DESCRIPTION
- **feat(tasks): make failed state non-terminal (allow messages + retry)**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: align needs_attention handling between RPC and agent-tool paths**
- **ci: add setup-devproxy composite action with caching to fix CI install failures**
- **fix(ci): use jq + GITHUB_TOKEN auth to resolve devproxy version in setup action**
- **fix(ci): inject github.token into composite action step env for API auth**
- **fix: resolve leftover conflict markers in human-message-routing tests**
- **ci: simplify CI pipeline by removing intermediate gate jobs and extracting Dev Proxy action**
- **fix: restore runner.os guard on setup-devproxy, add startup timeout failure**
- **fix: always set archivedAt when archiving task without active runtime**
- **fix: correct comment about orphaned worktree cleanup, add review state test**
- **fix(ci): use nc -z TCP check for devproxy readiness instead of curl**
- **feat: add draft message auto-save to task view input**
- **fix: address review feedback on task draft auto-save**
- **feat: persist task input draft to server-side storage**
- **fix: address review feedback on task draft RPC handler**
- **ci: add rpc-task-draft-handlers.test.ts to rpc-1 CI matrix shard**
- **ci: register rpc-task-draft-handlers.test.ts in validate-online-test-matrix script**
- **fix: address review feedback on task draft hook (round 2)**
- **fix: add cancelled flag to loadDraft to prevent cross-task data corruption**
- **fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker**
- **test(dialog-handlers): fix platform-agnostic test and cover error-handling path**
- **fix: address round-7 review feedback on task draft hook**
- **ci: retrigger CI after base branch corrected to dev**
- **ci: retrigger CI (rpc-remove-output flaky timeout)**
- **feat: raise draft/message char limit from 100k to 200k**
- **fix: correct too-long test repeat count and JSDoc after 200k limit raise**
- **chore: bump version to 0.7.1 (#357)**
- **fix: skip max feedback iterations limit when task is in review state (#358)**
- **docs: Goal V2 (Mission System) plan for autonomous agent workflows (#322)**
- **fix: preserve PR data on runtime escalation and show PR in task view header (#360)**
- **chore: update deps to latest minor versions (except claude agent SDK) (#362)**
- **chore: upgrade @anthropic-ai/claude-agent-sdk from 0.2.55 to 0.2.76 (#363)**
- **feat: order tasks by most recently updated within each status (#365)**
- **feat: add GLM-5-Turbo model support (#367)**
- **fix: prevent API error bounce loops for all agents in runtime (#366)**
- **feat: Anthropic-compatible HTTP bridge backed by codex app-server (#339)**
- **feat: GitHub Copilot as transparent AgentSession backend via embedded Anthropic-compatible server (#340)**
- **feat: add mission metadata schema and types for Goal V2 (#369)**
- **docs: Goal V2 Mission System -- Autonomous Agent Workflows plan (#368)**
- **fix: show PR link for all task statuses once created (#372)**
- **Plan: Full first-class anthropic-copilot and anthropic-codex provider support (#370)**
- **feat: tighten leader agent tool permissions to read-only context subset (#371)**
- **feat: define V2 mission types and extend RoomGoal (Task 1.1) (#374)**
- **chore: remove pi-mono approach dead code (#364)**
- **feat: widen Provider type union to include anthropic-copilot and anthropic-codex (#373)**
- **fix: remove unsafe provider casts in daemon, use widened Provider type (#377)**
- **fix: Enter to send in task HumanInputArea, default target to leader (#387)**
- **fix: inject room chat system prompt to prevent premature task creation (#379)**
- **feat: add anthropic-codex Codex entry to PROVIDER_LABELS (#375)**
- **feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs (#376)**
- **fix: parse /context response from assistant messages (new SDK format) (#381)**
- **fix: prevent agent from creating duplicate PRs on re-dispatch (#392)**
- **fix: remove merge method flag from human approval message (#393)**
- **feat: iterate all tool results in codex bridge continuation (#378)**
- **feat: replace copy toast with inline green check mark (#394)**
- **feat: require explicit provider ID for all model resolution (#388)**
- **test: add provider routing tests for copilot/cross-provider model switches (#395)**
- **feat: provider-grouped model picker with availability dots (#398)**
- **feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge (#380)**
- **feat: improve error mapping in copilot bridge (Task 5.1) (#384)**
- **fix: render leader questions as interactive forms in task conversation (#400)**
- **feat: wire thread/tokenUsage/updated into SSE message_delta token counts (#383)**
- **feat: recurring missions — scheduling with execution identity and recovery (Task 3) (#390)**
- **feat: UI terminology — rename Goal to Mission (Task 5) (#397)**
- **feat: implement semi-autonomous mode for coder/general tasks (Task 4) (#396)**
- **feat: measurable missions — structured metrics and adaptive replanning (Task 2) (#382)**
- **fix: call queryObject.close() before clearing transport reference (#403)**
- **fix: scope message locator in persistence e2e test to avoid strict mode violation (#402)**
- **feat: provider-aware session creation (#399) (#401)**
- **feat: add provider badge in session status bar next to model icon (#391)**
- **feat: heuristic token accounting for copilot bridge (#385)**
- **test: unit tests for provider routing and type safety (Task 7.1) (#399)**
- **feat: log warning when tool_choice is provided but not honored in both bridges (#386)**
- **task/task 72 update online provider test shards (#409)**
- **feat: graceful degradation on provider unavailability (#408)**
- **test: add E2E tests for provider model switching UI (#406)**
- **feat: eager leader initialization and fix observer race in TaskGroupManager (#411)**
- **feat: filter unauthenticated providers from model picker (#410)**
- **Fix SQLITE_BUSY retries and closed SSE controller handling (#415)**
- **fix: resolve leader questions routing to dead session instances (#404)**
- **feat: add OpenAI token refresh/login in settings for Codex (#416)**
- **fix: use correct /room/:id route in mission-terminology e2e tests (#419)**
- **fix: restore dead worker sessions before routing leader feedback (#418)**
- **feat: UI — type-specific mission creation and detail views (Task 6) (#405)**
- **fix: capture assistant.message.content when Copilot SDK skips streaming deltas (#421)**
- **fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback (#412)**
- **fix: support Agent tool name for subagent blocks (SDK 0.2.76+ renamed Task to Agent) (#424)**
- **fix(codex-bridge): persist Codex sessions across turns (#420)**
- **docs: add final provider parity report (#413)**
- **docs: plan for Multi-Agent V2 customizable agents and workflows (#359)**
- **task/fix logout button not working for openai and copil (#423)**
- **feat: define Space shared types in @neokai/shared (#425)**
- **feat: add Migration 29 — create all Space system tables (#427)**
- **feat: add SpaceAgent and workflow types to space.ts (Task 3.1) (#426)**
- **feat: custom agent types, repository, and manager (Task 2.1) (#428)**
- **feat: add Space repositories and managers (Task 1.3) (#429)**
- **feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2) (#430)**
- **feat: Space RPC handlers and DaemonEventMap registration (Task 1.4) (#433)**
- **docs: add provider setup documentation for anthropic-copilot and anthropic-codex (#414)**
- **test: integration testing and documentation for Mission System V2 (Task 7) (#422)**
- **feat: add task management tools to leader role (#435)**
- **feat: add spaceAgent RPC handlers and DaemonEventMap entries (Task 2.2) (#431)**
- **feat: simplify multi-agent space — explicit workflowId or AI auto-select only (#434)**
- **feat: add leader progress summary at end of each turn (#436)**
- **feat: custom agent session init factory and SpaceAgent tools (Task 2.3) (#432)**
- **docs: update multi-agent space task docs with simplified workflow selection design (#439)**
- **docs: NeoKai UI/UX 1.0.0 upgrade plan (#442)**
- **docs: add NeoKai UI/UX 1.0.0 upgrade specification (#444)**
- **feat: extend CSS custom properties vocabulary in styles.css (#445)**
- **feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3) (#437)**
- **feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4) (#440)**
- **feat: Space navigation, routing, and signals (Task 5.1) (#438)**
- **feat: add WorkflowExecutor core for Space workflow run progression (Task 4.1) (#443)**
- **feat: define Space export/import JSON format (Task 8.1) (#441)**
- **docs: align Milestone 4 planning docs with transition/condition implementation (#447)**
- **feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2) (#450)**
- **fix: make CreateWorkflowRunParams.currentStepId optional (#449)**
- **feat: add SpaceStore reactive state management (Task 5.2) (#446)**
- **fix: fix failing E2E tests for mission creation routes and persistence (#451)**
- **feat: add Space export/import RPC handlers (Task 8.2) (#452)**
- **feat: workflow selection logic and Space agent tools (Task 7.1) (#453)**
- **fix: sync space_agents columns in space-test-db.ts with migration schema (#448)**
- **feat: Space creation UX and 3-column layout (Task 5.3) (#455)**
- **task/make turn summary card use bigger font and render  (#460)**
- **feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3) (#454)**
- **feat: Task 8.3 — Frontend Export/Import UI for Space agents and workflows**
- **fix: fetch real Copilot model IDs dynamically via client.listModels() (#464)**
- **task/fix agent session crash when switching modelprovid (#459)**
- **task/add support for minimax m27 highspeed model (#458)**
- **feat: Task 6.1 - Custom Agent List and Editor**
- **task/task 72 space agent prompt enhancement (#457)**
- **feat: workflow step builder (Task 6.2) (#463)**
- **fix: handle thinking blocks in SDK title generation (#461)**
- **refactor: remove detectProvider heuristic entirely (#467)**
- **feat: Task 6.3 - Workflow Rules Editor and Space integration (#468)**
- **feat: add structured tokens object to design-tokens module (#469)**
- **test: add tokens unified namespace tests for Task 1.2 (#470)**
- **feat: typography and global prose refinements (Task 1.3) (#471)**
- **fix: ensure onError cleanup runs on subprocess crash in codex bridge (#473)**
- **fix: clear stale sdkSessionId when SDK session file no longer exists (#474)**
- **fix: display Copilot quota errors as UI error blocks and stop retrying (#476)**
- **feat: display API retry errors in UI during SDK retry attempts (#475)**
- **fix: use unique workspace paths and correct delete params in space E2E tests (#477)**
- **feat: Button/IconButton/NavIconButton unification (Task 2.1) (#472)**
- **fix: clean up stale spaces before creating in E2E tests (#478)**
- **fix: correct space.list response shape in E2E stale-space cleanup (#481)**
- **fix: use correct space.create response shape in E2E tests (#482)**
- **ci: skip unstable space E2E tests (export-import, workflow-rules) (#483)**
- **docs: plan for workflow visual editor implementation (#479)**
- **feat: add VisualCanvas component with pan and zoom (Task 1.2) (#484)**
- **feat: add layout column to space_workflows for visual editor (Task 1.1) (#485)**
- **feat: replace hidden dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2) (#480)**
- **feat: add SVG overlay layer for edges in VisualCanvas (Task 1.3) (#488)**
- **feat: add WorkflowNode canvas component (Task 2.1) (#490)**
- **fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors (#486)**
- **feat: DAG auto-layout algorithm for workflow visual editor (Task 5.1) (#487)**
- **feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4) (#489)**
- **feat: add node selection and multi-select to visual editor (Task 2.3) (#491)**
- **feat: implement WorkflowNode with drag-and-drop support (Task 2.2) (#492)**
- **feat: add EdgeRenderer SVG bezier edge component (Task 3.1)**
