### PR TITLE
fix: always set provider in createCustomAgentInit for Space custom agents

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -17,6 +17,7 @@ import type {
 	AgentDefinition,
 } from '@neokai/shared';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import { inferProviderForModel } from '../../providers/registry';
 
 const DEFAULT_CUSTOM_AGENT_MODEL = 'claude-sonnet-4-5-20250929';
 
@@ -308,6 +309,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		customAgent.tools && customAgent.tools.length > 0 ? customAgent.tools : undefined;
 
 	const model = customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
+	const provider = inferProviderForModel(model);
 
 	const behavioralPrompt = buildCustomAgentSystemPrompt(customAgent);
 
@@ -335,6 +337,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			context: { spaceId: space.id },
 			type: 'worker',
 			model,
+			provider,
 			agent: agentKey,
 			agents: { [agentKey]: agentDef },
 			contextAutoQueue: false,
@@ -354,6 +357,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		context: { spaceId: space.id },
 		type: 'worker',
 		model,
+		provider,
 		contextAutoQueue: false,
 	};
 }

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -403,6 +403,51 @@ describe('createCustomAgentInit', () => {
 		expect(init.systemPrompt?.append).toContain('Planner Agent');
 		expect(init.systemPrompt?.append).not.toContain('Review Responsibilities');
 	});
+
+	// Provider inference tests — verifies the fix for the missing provider bug
+	it('always sets provider on simple-path init (Anthropic model)', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-sonnet-4-5-20250929' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('always sets provider on simple-path init (GLM model)', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'glm-4-flash' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.provider).toBe('glm');
+	});
+
+	it('always sets provider on agent/agents-path init', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: 'claude-opus-4-6', tools: ['Read', 'Bash'] }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.provider).toBe('anthropic');
+	});
+
+	it('inherits provider from space.defaultModel when agent model is unset', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: undefined }),
+			space: makeSpace({ defaultModel: 'glm-5-turbo' }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.provider).toBe('glm');
+	});
+
+	it('never produces undefined provider (always falls back to hardcoded default)', () => {
+		const config = makeConfig({
+			customAgent: makeAgent({ model: undefined }),
+			space: makeSpace({ defaultModel: undefined }),
+		});
+		const init = createCustomAgentInit(config);
+		expect(init.provider).toBeDefined();
+		expect(typeof init.provider).toBe('string');
+		expect(init.provider!.length).toBeGreaterThan(0);
+	});
 });
 
 // ============================================================================


### PR DESCRIPTION
Space custom agents (createCustomAgentInit) were returning AgentSessionInit
without a provider field, causing session.config.provider to be undefined.
query-runner.ts would then silently fall back to the Anthropic provider even
when a GLM or other non-Anthropic model was configured via SpaceAgent.model
or Space.defaultModel.

Fix: derive the provider from the resolved model ID using inferProviderForModel
and set it on both code paths (simple preset path and agent/agents pattern path).

Adds 5 new unit tests in custom-agent.test.ts covering provider inference for
Anthropic models, GLM models, agent/agents path, space.defaultModel inheritance,
and the guarantee that provider is never undefined.
