### PR TITLE
feat: create connections by dragging from output to input ports (Task 3.2)

### DIFF
--- a/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualCanvas.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useEffect, useRef, useCallback, useState } from 'preact/hooks';
-import type { ComponentChildren } from 'preact';
+import type { ComponentChildren, RefObject } from 'preact';
 import type { NodePosition, ViewportState } from './types';
 import { CanvasToolbar } from './CanvasToolbar';
 
@@ -67,6 +67,13 @@ interface VisualCanvasProps {
 	nodes?: NodePosition;
 	/** Whether to show the zoom/fit toolbar overlay. Defaults to true. */
 	showToolbar?: boolean;
+	/**
+	 * Optional external ref to the canvas container element.
+	 * When provided, coordinate calculations (e.g. for ghost edges) use the same
+	 * element that VisualCanvas uses internally, avoiding any bounding-rect drift
+	 * if an outer wrapper gains padding/borders in future.
+	 */
+	containerRef?: RefObject<HTMLDivElement>;
 }
 
 export function VisualCanvas({
@@ -77,8 +84,12 @@ export function VisualCanvas({
 	edgeLayer,
 	nodes = {},
 	showToolbar = true,
+	containerRef: externalContainerRef,
 }: VisualCanvasProps) {
-	const containerRef = useRef<HTMLDivElement>(null);
+	const internalContainerRef = useRef<HTMLDivElement>(null);
+	// Use externally-provided ref when available so callers can do their own
+	// coordinate math against the exact same element VisualCanvas uses.
+	const containerRef = externalContainerRef ?? internalContainerRef;
 	const transformRef = useRef<HTMLDivElement>(null);
 	const [containerSize, setContainerSize] = useState({ width: 800, height: 600 });
 

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
-import type { ComponentChildren, RefObject } from 'preact';
+import type { ComponentChildren, JSX, RefObject } from 'preact';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
 import type { WorkflowNodeProps, PortType } from './WorkflowNode';
@@ -57,11 +57,22 @@ export interface WorkflowCanvasProps {
 // ---- Ghost edge rendering ----
 
 /** Render a dashed bezier ghost edge from `from` to `to` in canvas-space SVG coordinates. */
-function GhostEdge({ from, to }: { from: Point; to: Point }): ComponentChildren {
-	// Control points: vertical bezier (source goes down, target comes from above)
-	const dy = Math.abs(to.y - from.y);
-	const cpOffset = Math.max(50, dy * 0.5);
-	const d = `M ${from.x} ${from.y} C ${from.x} ${from.y + cpOffset}, ${to.x} ${to.y - cpOffset}, ${to.x} ${to.y}`;
+function GhostEdge({ from, to }: { from: Point; to: Point }): JSX.Element | null {
+	// Directional bezier: for forward (downward) drags use a vertical S-curve.
+	// For backward (upward) drags, route horizontally to avoid the path looping.
+	const dx = to.x - from.x;
+	const dy = to.y - from.y;
+	let d: string;
+	if (dy >= -40) {
+		// Forward or slightly backward: standard vertical bezier
+		const cpOffset = Math.max(50, dy * 0.5);
+		d = `M ${from.x} ${from.y} C ${from.x} ${from.y + cpOffset}, ${to.x} ${to.y - cpOffset}, ${to.x} ${to.y}`;
+	} else {
+		// Backward drag: route around horizontally to avoid S-curve loops
+		const sideOffset = Math.max(60, Math.abs(dx) * 0.4 + 40);
+		const midY = (from.y + to.y) / 2;
+		d = `M ${from.x} ${from.y} C ${from.x} ${from.y + 40}, ${from.x + sideOffset} ${from.y + 40}, ${from.x + sideOffset} ${midY} S ${from.x + sideOffset} ${to.y - 40}, ${to.x} ${to.y}`;
+	}
 
 	return (
 		<>
@@ -161,11 +172,13 @@ export function WorkflowCanvas({
 
 	const handlePortMouseEnter = useCallback(
 		(stepId: string, portType: PortType) => {
-			if (portType === 'input' && dragState.active) {
+			// setHoverTarget guards on dragRef.current.active internally —
+			// no need to read dragState here, which would cause re-renders on every toggle
+			if (portType === 'input') {
 				setHoverTarget(stepId);
 			}
 		},
-		[dragState.active, setHoverTarget]
+		[setHoverTarget]
 	);
 
 	const handlePortMouseLeave = useCallback(

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -6,21 +6,36 @@
  *  - Renders WorkflowNode components with correct isSelected prop
  *  - Handles Delete/Backspace keyboard shortcut to delete selected node
  *  - Emits onNodeSelect(stepId | null) so parent components can react
+ *  - Manages connection drag via useConnectionDrag hook
+ *    - Shows ghost edge (dashed SVG path) during drag
+ *    - Highlights valid input ports as drop targets
+ *    - Creates transitions on valid drop
  */
 
 import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
+import type { ComponentChildren, RefObject } from 'preact';
 import { VisualCanvas } from './VisualCanvas';
 import { WorkflowNode } from './WorkflowNode';
-import type { WorkflowNodeProps } from './WorkflowNode';
+import type { WorkflowNodeProps, PortType } from './WorkflowNode';
 import type { ViewportState, Point } from './types';
+import { useConnectionDrag } from './useConnectionDrag';
+import type { TransitionLike } from './useConnectionDrag';
 
 /**
  * Per-node data passed to WorkflowCanvas.
- * WorkflowCanvas injects: isSelected, onClick, scale, onPositionChange.
+ * WorkflowCanvas injects: isSelected, isDropTarget, onClick, scale, onPositionChange,
+ * onPortMouseDown, onPortMouseEnter, onPortMouseLeave.
  */
 export type WorkflowNodeData = Omit<
 	WorkflowNodeProps,
-	'isSelected' | 'onClick' | 'scale' | 'onPositionChange'
+	| 'isSelected'
+	| 'isDropTarget'
+	| 'onClick'
+	| 'scale'
+	| 'onPositionChange'
+	| 'onPortMouseDown'
+	| 'onPortMouseEnter'
+	| 'onPortMouseLeave'
 >;
 
 export interface WorkflowCanvasProps {
@@ -33,7 +48,50 @@ export interface WorkflowCanvasProps {
 	onDeleteNode?: (stepId: string) => void;
 	/** Called when a node is dragged to a new position. */
 	onNodePositionChange?: (stepId: string, position: Point) => void;
+	/** Existing transitions — used for duplicate detection during connection drag. */
+	transitions?: TransitionLike[];
+	/** Called when a new connection is created by dragging from an output to an input port. */
+	onCreateTransition?: (fromStepId: string, toStepId: string) => void;
 }
+
+// ---- Ghost edge rendering ----
+
+/** Render a dashed bezier ghost edge from `from` to `to` in canvas-space SVG coordinates. */
+function GhostEdge({ from, to }: { from: Point; to: Point }): ComponentChildren {
+	// Control points: vertical bezier (source goes down, target comes from above)
+	const dy = Math.abs(to.y - from.y);
+	const cpOffset = Math.max(50, dy * 0.5);
+	const d = `M ${from.x} ${from.y} C ${from.x} ${from.y + cpOffset}, ${to.x} ${to.y - cpOffset}, ${to.x} ${to.y}`;
+
+	return (
+		<>
+			{/* Shadow for contrast */}
+			<path
+				d={d}
+				fill="none"
+				stroke="rgba(0,0,0,0.3)"
+				strokeWidth={5}
+				strokeDasharray="8 4"
+				strokeLinecap="round"
+			/>
+			{/* Visible ghost stroke */}
+			<path
+				data-testid="ghost-edge"
+				d={d}
+				fill="none"
+				stroke="#60a5fa"
+				strokeWidth={2.5}
+				strokeDasharray="8 4"
+				strokeLinecap="round"
+				opacity={0.9}
+			/>
+		</>
+	);
+}
+
+// ============================================================================
+// WorkflowCanvas
+// ============================================================================
 
 export function WorkflowCanvas({
 	nodes,
@@ -42,6 +100,8 @@ export function WorkflowCanvas({
 	onNodeSelect,
 	onDeleteNode,
 	onNodePositionChange,
+	transitions = [],
+	onCreateTransition,
 }: WorkflowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
@@ -54,6 +114,17 @@ export function WorkflowCanvas({
 
 	const onDeleteNodeRef = useRef(onDeleteNode);
 	onDeleteNodeRef.current = onDeleteNode;
+
+	// Ref to the VisualCanvas container (for coordinate conversion in connection drag)
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// ---- Connection drag ----
+	const { dragState, startDrag, setHoverTarget } = useConnectionDrag({
+		viewportState,
+		containerRef: containerRef as RefObject<HTMLElement>,
+		transitions,
+		onCreateTransition: onCreateTransition ?? (() => {}),
+	});
 
 	// Clear selection if the selected node is removed externally (e.g. parent deletes it
 	// from the nodes array). Without this, a node re-added with the same stepId would
@@ -78,6 +149,34 @@ export function WorkflowCanvas({
 		onNodeSelect?.(null);
 	}, [onNodeSelect]);
 
+	// ---- Port event handlers ----
+	const handlePortMouseDown = useCallback(
+		(stepId: string, portType: PortType, e: MouseEvent, portEl: Element) => {
+			if (portType === 'output') {
+				startDrag(stepId, portEl, e);
+			}
+		},
+		[startDrag]
+	);
+
+	const handlePortMouseEnter = useCallback(
+		(stepId: string, portType: PortType) => {
+			if (portType === 'input' && dragState.active) {
+				setHoverTarget(stepId);
+			}
+		},
+		[dragState.active, setHoverTarget]
+	);
+
+	const handlePortMouseLeave = useCallback(
+		(_stepId: string, portType: PortType) => {
+			if (portType === 'input') {
+				setHoverTarget(null);
+			}
+		},
+		[setHoverTarget]
+	);
+
 	// ---- Keyboard: Delete / Backspace removes the selected node ----
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -98,22 +197,45 @@ export function WorkflowCanvas({
 		return () => window.removeEventListener('keydown', handleKeyDown);
 	}, []);
 
+	// ---- Ghost edge (rendered in SVG edge layer) ----
+	const edgeLayer = useCallback(
+		(_vp: ViewportState): ComponentChildren => {
+			if (!dragState.active || !dragState.fromPos || !dragState.currentPos) return null;
+			return <GhostEdge from={dragState.fromPos} to={dragState.currentPos} />;
+		},
+		[dragState]
+	);
+
 	return (
-		<VisualCanvas
-			viewportState={viewportState}
-			onViewportChange={onViewportChange}
-			onBackgroundClick={handleBackgroundClick}
-		>
-			{nodes.map((node) => (
-				<WorkflowNode
-					key={node.step.localId}
-					{...node}
-					scale={viewportState.scale}
-					onPositionChange={onNodePositionChange ?? (() => {})}
-					isSelected={selectedNodeId === node.step.localId}
-					onClick={handleNodeSelect}
-				/>
-			))}
-		</VisualCanvas>
+		<div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
+			<VisualCanvas
+				viewportState={viewportState}
+				onViewportChange={onViewportChange}
+				onBackgroundClick={handleBackgroundClick}
+				edgeLayer={edgeLayer}
+			>
+				{nodes.map((node) => {
+					const stepId = node.step.localId;
+					// A node is a valid drop target if: drag is active, not the source, not start node
+					const isDropTarget =
+						dragState.active && dragState.fromStepId !== stepId && !node.isStartNode;
+
+					return (
+						<WorkflowNode
+							key={stepId}
+							{...node}
+							scale={viewportState.scale}
+							onPositionChange={onNodePositionChange ?? (() => {})}
+							isSelected={selectedNodeId === stepId}
+							isDropTarget={isDropTarget}
+							onClick={handleNodeSelect}
+							onPortMouseDown={handlePortMouseDown}
+							onPortMouseEnter={handlePortMouseEnter}
+							onPortMouseLeave={handlePortMouseLeave}
+						/>
+					);
+				})}
+			</VisualCanvas>
+		</div>
 	);
 }

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -220,35 +220,34 @@ export function WorkflowCanvas({
 	);
 
 	return (
-		<div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
-			<VisualCanvas
-				viewportState={viewportState}
-				onViewportChange={onViewportChange}
-				onBackgroundClick={handleBackgroundClick}
-				edgeLayer={edgeLayer}
-			>
-				{nodes.map((node) => {
-					const stepId = node.step.localId;
-					// A node is a valid drop target if: drag is active, not the source, not start node
-					const isDropTarget =
-						dragState.active && dragState.fromStepId !== stepId && !node.isStartNode;
+		<VisualCanvas
+			containerRef={containerRef}
+			viewportState={viewportState}
+			onViewportChange={onViewportChange}
+			onBackgroundClick={handleBackgroundClick}
+			edgeLayer={edgeLayer}
+		>
+			{nodes.map((node) => {
+				const stepId = node.step.localId;
+				// A node is a valid drop target if: drag is active, not the source, not start node
+				const isDropTarget =
+					dragState.active && dragState.fromStepId !== stepId && !node.isStartNode;
 
-					return (
-						<WorkflowNode
-							key={stepId}
-							{...node}
-							scale={viewportState.scale}
-							onPositionChange={onNodePositionChange ?? (() => {})}
-							isSelected={selectedNodeId === stepId}
-							isDropTarget={isDropTarget}
-							onClick={handleNodeSelect}
-							onPortMouseDown={handlePortMouseDown}
-							onPortMouseEnter={handlePortMouseEnter}
-							onPortMouseLeave={handlePortMouseLeave}
-						/>
-					);
-				})}
-			</VisualCanvas>
-		</div>
+				return (
+					<WorkflowNode
+						key={stepId}
+						{...node}
+						scale={viewportState.scale}
+						onPositionChange={onNodePositionChange ?? (() => {})}
+						isSelected={selectedNodeId === stepId}
+						isDropTarget={isDropTarget}
+						onClick={handleNodeSelect}
+						onPortMouseDown={handlePortMouseDown}
+						onPortMouseEnter={handlePortMouseEnter}
+						onPortMouseLeave={handlePortMouseLeave}
+					/>
+				);
+			})}
+		</VisualCanvas>
 	);
 }

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -188,6 +188,11 @@ export function WorkflowNode({
 		[onPortMouseDown, stepId]
 	);
 
+	// Prevent clicks on ports from bubbling to the card and triggering node selection
+	const stopClickPropagation = useCallback((e: MouseEvent) => {
+		e.stopPropagation();
+	}, []);
+
 	const handleInputPortMouseEnter = useCallback(() => {
 		onPortMouseEnter?.(stepId, 'input');
 	}, [onPortMouseEnter, stepId]);
@@ -247,6 +252,7 @@ export function WorkflowNode({
 					onMouseDown={handleInputPortMouseDown}
 					onMouseEnter={handleInputPortMouseEnter}
 					onMouseLeave={handleInputPortMouseLeave}
+					onClick={stopClickPropagation}
 				/>
 			)}
 
@@ -301,6 +307,7 @@ export function WorkflowNode({
 					cursor: 'crosshair',
 				}}
 				onMouseDown={handleOutputPortMouseDown}
+				onClick={stopClickPropagation}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -41,7 +41,13 @@ export interface WorkflowNodeProps {
 	/** Called continuously while the node is being dragged */
 	onPositionChange: (stepId: string, newPosition: Point) => void;
 	/** Called when a connection port is pressed */
-	onPortMouseDown?: (stepId: string, portType: PortType, e: MouseEvent) => void;
+	onPortMouseDown?: (stepId: string, portType: PortType, e: MouseEvent, portEl: Element) => void;
+	/** Called when the mouse enters a port during a connection drag */
+	onPortMouseEnter?: (stepId: string, portType: PortType) => void;
+	/** Called when the mouse leaves a port during a connection drag */
+	onPortMouseLeave?: (stepId: string, portType: PortType) => void;
+	/** Highlight the input port as a valid drop target (during connection drag) */
+	isDropTarget?: boolean;
 	/** Called when the card body is clicked (for selection) */
 	onClick?: (stepId: string) => void;
 }
@@ -57,9 +63,12 @@ export function WorkflowNode({
 	agents,
 	isSelected = false,
 	isStartNode = false,
+	isDropTarget = false,
 	scale,
 	onPositionChange,
 	onPortMouseDown,
+	onPortMouseEnter,
+	onPortMouseLeave,
 	onClick,
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
@@ -166,7 +175,7 @@ export function WorkflowNode({
 	const handleInputPortMouseDown = useCallback(
 		(e: MouseEvent) => {
 			e.stopPropagation(); // prevent card drag from starting
-			onPortMouseDown?.(stepId, 'input', e);
+			onPortMouseDown?.(stepId, 'input', e, e.currentTarget as Element);
 		},
 		[onPortMouseDown, stepId]
 	);
@@ -174,10 +183,18 @@ export function WorkflowNode({
 	const handleOutputPortMouseDown = useCallback(
 		(e: MouseEvent) => {
 			e.stopPropagation(); // prevent card drag from starting
-			onPortMouseDown?.(stepId, 'output', e);
+			onPortMouseDown?.(stepId, 'output', e, e.currentTarget as Element);
 		},
 		[onPortMouseDown, stepId]
 	);
+
+	const handleInputPortMouseEnter = useCallback(() => {
+		onPortMouseEnter?.(stepId, 'input');
+	}, [onPortMouseEnter, stepId]);
+
+	const handleInputPortMouseLeave = useCallback(() => {
+		onPortMouseLeave?.(stepId, 'input');
+	}, [onPortMouseLeave, stepId]);
 
 	// ---- Styles ----
 	const borderClass = isStartNode
@@ -185,6 +202,10 @@ export function WorkflowNode({
 		: isSelected
 			? 'border-blue-500'
 			: 'border-gray-700';
+
+	const inputPortBg = isDropTarget ? '#22c55e' : '#6b7280';
+	const inputPortBorder = isDropTarget ? '#16a34a' : '#374151';
+	const inputPortScale = isDropTarget ? 'scale(1.4)' : '';
 
 	const ringClass = isSelected ? 'ring-2 ring-blue-500' : '';
 
@@ -213,15 +234,19 @@ export function WorkflowNode({
 						position: 'absolute',
 						top: -7,
 						left: '50%',
-						transform: 'translateX(-50%)',
+						transform: `translateX(-50%) ${inputPortScale}`,
 						width: 14,
 						height: 14,
 						borderRadius: '50%',
-						background: '#6b7280',
-						border: '2px solid #374151',
+						background: inputPortBg,
+						border: `2px solid ${inputPortBorder}`,
 						cursor: 'crosshair',
+						transition: 'transform 0.1s, background 0.1s',
+						zIndex: isDropTarget ? 10 : undefined,
 					}}
 					onMouseDown={handleInputPortMouseDown}
+					onMouseEnter={handleInputPortMouseEnter}
+					onMouseLeave={handleInputPortMouseLeave}
 				/>
 			)}
 

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowCanvas.test.tsx
@@ -52,7 +52,6 @@ const NODES: WorkflowNodeData[] = [
 		position: { x: 10, y: 10 },
 		agents: AGENTS,
 		isStartNode: false,
-		onPortMouseDown: vi.fn(),
 	},
 	{
 		step: makeStep('step-2', 'Step Two'),
@@ -60,7 +59,6 @@ const NODES: WorkflowNodeData[] = [
 		position: { x: 200, y: 10 },
 		agents: AGENTS,
 		isStartNode: false,
-		onPortMouseDown: vi.fn(),
 	},
 ];
 

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -175,14 +175,24 @@ describe('WorkflowNode port events', () => {
 			<WorkflowNode {...makeProps({ onPortMouseDown, isStartNode: false })} />
 		);
 		fireEvent.mouseDown(getByTestId('port-input'), { button: 0 });
-		expect(onPortMouseDown).toHaveBeenCalledWith('step-local-1', 'input', expect.any(Object));
+		expect(onPortMouseDown).toHaveBeenCalledWith(
+			'step-local-1',
+			'input',
+			expect.any(Object),
+			expect.any(Object)
+		);
 	});
 
 	it('calls onPortMouseDown with output type when output port is pressed', () => {
 		const onPortMouseDown = vi.fn();
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ onPortMouseDown })} />);
 		fireEvent.mouseDown(getByTestId('port-output'), { button: 0 });
-		expect(onPortMouseDown).toHaveBeenCalledWith('step-local-1', 'output', expect.any(Object));
+		expect(onPortMouseDown).toHaveBeenCalledWith(
+			'step-local-1',
+			'output',
+			expect.any(Object),
+			expect.any(Object)
+		);
 	});
 
 	it('port mousedown does not trigger drag (stopPropagation)', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
@@ -485,3 +485,68 @@ describe('WorkflowCanvas — start node not a drop target', () => {
 		expect(startNode.querySelector('[data-testid="port-input"]')).toBeNull();
 	});
 });
+
+describe('WorkflowCanvas — end-to-end connection creation', () => {
+	it('calls onCreateTransition when dropping on a valid input port', () => {
+		const { getByTestId, onCreateTransition } = renderCanvas();
+
+		// 1. Start drag from step-1 output port
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+
+		// 2. Simulate hovering over step-2 input port
+		const inputPort2 = getByTestId('workflow-node-step-2').querySelector(
+			'[data-testid="port-input"]'
+		)!;
+		fireEvent.mouseEnter(inputPort2);
+
+		// 3. Release mouse — should create transition
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(onCreateTransition).toHaveBeenCalledWith('step-1', 'step-2');
+	});
+
+	it('does not call onCreateTransition when releasing over empty space', () => {
+		const { getByTestId, onCreateTransition } = renderCanvas();
+
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+
+		// No mouseEnter on any input port
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(onCreateTransition).not.toHaveBeenCalled();
+	});
+
+	it('cancels drag when Escape is pressed', () => {
+		const { getByTestId, queryByTestId, onCreateTransition } = renderCanvas();
+
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+		// Ghost edge should be visible
+		expect(queryByTestId('ghost-edge')).toBeTruthy();
+
+		// Press Escape — should cancel the drag
+		act(() => {
+			window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		});
+
+		expect(queryByTestId('ghost-edge')).toBeNull();
+		expect(onCreateTransition).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/useConnectionDrag.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * Tests for useConnectionDrag hook.
+ *
+ * Tests:
+ * - Ghost edge renders during drag (dragState.active = true, fromPos/currentPos set)
+ * - dragState starts idle
+ * - startDrag activates drag and sets fromStepId
+ * - mousemove during drag updates currentPos
+ * - mouseup without hover target cancels drag (no transition created)
+ * - mouseup with valid hover target creates transition
+ * - self-connection is blocked (fromStepId === hoverTargetStepId)
+ * - duplicate transition is blocked
+ * - setHoverTarget ignored when drag is inactive
+ * - drag resets to idle after mouseup
+ *
+ * WorkflowCanvas integration tests:
+ * - ghost edge element renders during drag
+ * - ghost edge disappears after mouseup
+ * - isDropTarget applied to non-source nodes during drag
+ * - output port mousedown starts drag
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
+import { useRef, useState } from 'preact/hooks';
+import type { RefObject } from 'preact';
+import { useConnectionDrag } from '../useConnectionDrag';
+import type { TransitionLike } from '../useConnectionDrag';
+import type { ViewportState } from '../types';
+import { WorkflowCanvas } from '../WorkflowCanvas';
+import type { WorkflowNodeData, WorkflowCanvasProps } from '../WorkflowCanvas';
+import type { SpaceAgent } from '@neokai/shared';
+import type { StepDraft } from '../../WorkflowStepCard';
+
+vi.mock('../../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+afterEach(() => cleanup());
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const VP: ViewportState = { offsetX: 0, offsetY: 0, scale: 1 };
+
+function makeAgent(id: string, name = 'Agent'): SpaceAgent {
+	return { id, spaceId: 'space-1', name, role: 'coder', createdAt: 0, updatedAt: 0 };
+}
+
+function makeStep(localId: string, name = 'Step'): StepDraft {
+	return { localId, name, agentId: 'agent-1', instructions: '' };
+}
+
+const AGENTS = [makeAgent('agent-1')];
+
+function makeNode(
+	localId: string,
+	name = 'Step',
+	opts: Partial<WorkflowNodeData> = {}
+): WorkflowNodeData {
+	return {
+		step: makeStep(localId, name),
+		stepIndex: 0,
+		position: { x: 0, y: 0 },
+		agents: AGENTS,
+		isStartNode: false,
+		...opts,
+	};
+}
+
+/** Fake port element with a specific getBoundingClientRect */
+function makePortEl(x = 100, y = 200, w = 14, h = 14): Element {
+	const el = document.createElement('div');
+	el.getBoundingClientRect = () => ({
+		left: x,
+		top: y,
+		right: x + w,
+		bottom: y + h,
+		width: w,
+		height: h,
+		x,
+		y,
+		toJSON: () => ({}),
+	});
+	return el;
+}
+
+/** Fake container element */
+function makeContainerEl(left = 0, top = 0): HTMLElement {
+	const el = document.createElement('div');
+	el.getBoundingClientRect = () => ({
+		left,
+		top,
+		right: left + 800,
+		bottom: top + 600,
+		width: 800,
+		height: 600,
+		x: left,
+		y: top,
+		toJSON: () => ({}),
+	});
+	return el;
+}
+
+// ============================================================================
+// Hook test harness
+// ============================================================================
+
+interface HarnessProps {
+	viewportState: ViewportState;
+	transitions?: TransitionLike[];
+	onCreateTransition?: (from: string, to: string) => void;
+}
+
+function HookHarness({
+	viewportState,
+	transitions = [],
+	onCreateTransition = vi.fn(),
+}: HarnessProps) {
+	const containerRef = useRef<HTMLElement>(makeContainerEl() as HTMLElement);
+
+	const { dragState, startDrag, setHoverTarget } = useConnectionDrag({
+		viewportState,
+		containerRef: containerRef as RefObject<HTMLElement>,
+		transitions,
+		onCreateTransition,
+	});
+
+	return (
+		<div>
+			<div data-testid="active">{String(dragState.active)}</div>
+			<div data-testid="from-step-id">{dragState.fromStepId ?? ''}</div>
+			<div data-testid="hover-target">{dragState.hoverTargetStepId ?? ''}</div>
+			<div data-testid="from-x">{dragState.fromPos?.x ?? ''}</div>
+			<div data-testid="from-y">{dragState.fromPos?.y ?? ''}</div>
+			<div data-testid="current-x">{dragState.currentPos?.x ?? ''}</div>
+			<div data-testid="current-y">{dragState.currentPos?.y ?? ''}</div>
+			<button
+				data-testid="start-drag"
+				onClick={(e) => startDrag('step-a', makePortEl(100, 200), e as unknown as MouseEvent)}
+			/>
+			<button data-testid="set-hover" onClick={() => setHoverTarget('step-b')} />
+			<button data-testid="clear-hover" onClick={() => setHoverTarget(null)} />
+		</div>
+	);
+}
+
+// ============================================================================
+// useConnectionDrag unit tests
+// ============================================================================
+
+describe('useConnectionDrag — idle state', () => {
+	it('starts idle', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		expect(getByTestId('active').textContent).toBe('false');
+		expect(getByTestId('from-step-id').textContent).toBe('');
+	});
+});
+
+describe('useConnectionDrag — startDrag', () => {
+	it('activates drag and sets fromStepId', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+		expect(getByTestId('active').textContent).toBe('true');
+		expect(getByTestId('from-step-id').textContent).toBe('step-a');
+	});
+
+	it('sets fromPos to port center in canvas coords (scale 1, no offset)', () => {
+		// Port at screen (100, 200) with size 14x14 → center at (107, 207)
+		// Container at (0, 0)
+		// Viewport offset (0,0), scale 1 → canvas same as screen
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+		// Port center relative to container: (107 - 0) / 1 = 107, (207 - 0) / 1 = 207
+		expect(Number(getByTestId('from-x').textContent)).toBeCloseTo(107, 0);
+		expect(Number(getByTestId('from-y').textContent)).toBeCloseTo(207, 0);
+	});
+});
+
+describe('useConnectionDrag — mousemove', () => {
+	it('updates currentPos during drag', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 400 })
+			);
+		});
+
+		expect(getByTestId('current-x').textContent).toBe('300');
+		expect(getByTestId('current-y').textContent).toBe('400');
+	});
+
+	it('does not update currentPos when drag is inactive', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 400 })
+			);
+		});
+
+		expect(getByTestId('current-x').textContent).toBe('');
+	});
+});
+
+describe('useConnectionDrag — setHoverTarget', () => {
+	it('sets hoverTargetStepId during drag', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+		fireEvent.click(getByTestId('set-hover'));
+		expect(getByTestId('hover-target').textContent).toBe('step-b');
+	});
+
+	it('clears hoverTargetStepId', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+		fireEvent.click(getByTestId('set-hover'));
+		fireEvent.click(getByTestId('clear-hover'));
+		expect(getByTestId('hover-target').textContent).toBe('');
+	});
+
+	it('is ignored when drag is not active', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('set-hover')); // no drag active
+		expect(getByTestId('hover-target').textContent).toBe('');
+	});
+});
+
+describe('useConnectionDrag — mouseup (cancel)', () => {
+	it('cancels drag when no hover target', () => {
+		const onCreateTransition = vi.fn();
+		const { getByTestId } = render(
+			<HookHarness viewportState={VP} onCreateTransition={onCreateTransition} />
+		);
+
+		fireEvent.click(getByTestId('start-drag'));
+		expect(getByTestId('active').textContent).toBe('true');
+
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(getByTestId('active').textContent).toBe('false');
+		expect(onCreateTransition).not.toHaveBeenCalled();
+	});
+
+	it('resets to idle after mouseup', () => {
+		const { getByTestId } = render(<HookHarness viewportState={VP} />);
+		fireEvent.click(getByTestId('start-drag'));
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+		expect(getByTestId('from-step-id').textContent).toBe('');
+		expect(getByTestId('hover-target').textContent).toBe('');
+	});
+});
+
+describe('useConnectionDrag — mouseup (connect)', () => {
+	it('calls onCreateTransition on valid drop', () => {
+		const onCreateTransition = vi.fn();
+		const { getByTestId } = render(
+			<HookHarness viewportState={VP} onCreateTransition={onCreateTransition} />
+		);
+
+		fireEvent.click(getByTestId('start-drag')); // fromStepId = 'step-a'
+		fireEvent.click(getByTestId('set-hover')); // hoverTarget = 'step-b'
+
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(onCreateTransition).toHaveBeenCalledWith('step-a', 'step-b');
+		expect(getByTestId('active').textContent).toBe('false');
+	});
+
+	it('blocks self-connections', () => {
+		// We need to make fromStepId === hoverTargetStepId
+		// Override setHoverTarget: use a different harness that sets hover to 'step-a'
+		const onCreateTransition = vi.fn();
+
+		function SelfConnectionHarness() {
+			const containerRef = useRef<HTMLElement>(makeContainerEl() as HTMLElement);
+			const { dragState, startDrag, setHoverTarget } = useConnectionDrag({
+				viewportState: VP,
+				containerRef: containerRef as RefObject<HTMLElement>,
+				transitions: [],
+				onCreateTransition,
+			});
+			return (
+				<div>
+					<div data-testid="active">{String(dragState.active)}</div>
+					<button
+						data-testid="start"
+						onClick={(e) => startDrag('node-x', makePortEl(), e as unknown as MouseEvent)}
+					/>
+					<button data-testid="hover-self" onClick={() => setHoverTarget('node-x')} />
+				</div>
+			);
+		}
+
+		const { getByTestId } = render(<SelfConnectionHarness />);
+		fireEvent.click(getByTestId('start'));
+		fireEvent.click(getByTestId('hover-self'));
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(onCreateTransition).not.toHaveBeenCalled();
+		expect(getByTestId('active').textContent).toBe('false');
+	});
+
+	it('blocks duplicate transitions', () => {
+		const onCreateTransition = vi.fn();
+		const existing: TransitionLike[] = [{ from: 'step-a', to: 'step-b' }];
+		const { getByTestId } = render(
+			<HookHarness
+				viewportState={VP}
+				transitions={existing}
+				onCreateTransition={onCreateTransition}
+			/>
+		);
+
+		fireEvent.click(getByTestId('start-drag'));
+		fireEvent.click(getByTestId('set-hover'));
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		expect(onCreateTransition).not.toHaveBeenCalled();
+	});
+});
+
+// ============================================================================
+// WorkflowCanvas integration tests
+// ============================================================================
+
+function renderCanvas(extra: Partial<WorkflowCanvasProps> = {}) {
+	const nodes: WorkflowNodeData[] = [
+		makeNode('step-1', 'Step One', { isStartNode: true }),
+		makeNode('step-2', 'Step Two'),
+		makeNode('step-3', 'Step Three'),
+	];
+	const onCreateTransition = vi.fn();
+
+	function Wrapper() {
+		const [vp, setVp] = useState<ViewportState>(VP);
+		return (
+			<WorkflowCanvas
+				nodes={nodes}
+				viewportState={vp}
+				onViewportChange={setVp}
+				transitions={[]}
+				onCreateTransition={onCreateTransition}
+				{...extra}
+			/>
+		);
+	}
+
+	const result = render(<Wrapper />);
+	return { ...result, onCreateTransition };
+}
+
+describe('WorkflowCanvas — connection drag ghost edge', () => {
+	it('ghost edge is not present when drag is inactive', () => {
+		const { queryByTestId } = renderCanvas();
+		expect(queryByTestId('ghost-edge')).toBeNull();
+	});
+
+	it('ghost edge appears when output port is pressed and mouse moves', () => {
+		const { getByTestId } = renderCanvas();
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+
+		expect(getByTestId('ghost-edge')).toBeTruthy();
+	});
+
+	it('ghost edge disappears after mouseup (cancel)', () => {
+		const { getByTestId, queryByTestId } = renderCanvas();
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+		expect(getByTestId('ghost-edge')).toBeTruthy();
+
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+		expect(queryByTestId('ghost-edge')).toBeNull();
+	});
+});
+
+describe('WorkflowCanvas — drop target highlighting', () => {
+	it('non-source nodes get drop target highlight during drag', () => {
+		const { getByTestId } = renderCanvas();
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+
+		// step-2 and step-3 input ports should be green (drop target)
+		const inputPort2 = getByTestId('workflow-node-step-2').querySelector(
+			'[data-testid="port-input"]'
+		) as HTMLElement;
+		const inputPort3 = getByTestId('workflow-node-step-3').querySelector(
+			'[data-testid="port-input"]'
+		) as HTMLElement;
+		// JSDOM retains hex value as-is rather than normalizing to rgb()
+		expect(inputPort2?.style.background).toBe('#22c55e'); // green-500
+		expect(inputPort3?.style.background).toBe('#22c55e');
+	});
+
+	it('source node does NOT get drop target highlight', () => {
+		const { getByTestId } = renderCanvas();
+		const outputPort = getByTestId('workflow-node-step-2').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+
+		// step-2 is source — its input port should not be green
+		const inputPort2 = getByTestId('workflow-node-step-2').querySelector(
+			'[data-testid="port-input"]'
+		) as HTMLElement;
+		expect(inputPort2?.style.background).not.toBe('#22c55e');
+	});
+
+	it('highlights disappear after drag ends', () => {
+		const { getByTestId } = renderCanvas();
+		const outputPort = getByTestId('workflow-node-step-1').querySelector(
+			'[data-testid="port-output"]'
+		)!;
+
+		fireEvent.mouseDown(outputPort, { button: 0, clientX: 50, clientY: 50 });
+		act(() => {
+			window.dispatchEvent(
+				new MouseEvent('mousemove', { bubbles: true, clientX: 150, clientY: 200 })
+			);
+		});
+
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+		});
+
+		const inputPort2 = getByTestId('workflow-node-step-2').querySelector(
+			'[data-testid="port-input"]'
+		) as HTMLElement;
+		// After drag ends, should revert to default gray
+		expect(inputPort2?.style.background).not.toBe('#22c55e');
+	});
+});
+
+describe('WorkflowCanvas — start node not a drop target', () => {
+	it('start node input port is hidden, so it cannot be a drop target', () => {
+		const { getByTestId } = renderCanvas();
+		// step-1 is isStartNode=true → no port-input element
+		const startNode = getByTestId('workflow-node-step-1');
+		expect(startNode.querySelector('[data-testid="port-input"]')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -6,3 +6,10 @@ export { WorkflowNode } from './WorkflowNode';
 export type { WorkflowNodeProps, PortType } from './WorkflowNode';
 export { WorkflowCanvas } from './WorkflowCanvas';
 export type { WorkflowNodeData, WorkflowCanvasProps } from './WorkflowCanvas';
+export { useConnectionDrag } from './useConnectionDrag';
+export type {
+	ConnectionDragState,
+	TransitionLike,
+	UseConnectionDragOptions,
+	UseConnectionDragReturn,
+} from './useConnectionDrag';

--- a/packages/web/src/components/space/visual-editor/useConnectionDrag.ts
+++ b/packages/web/src/components/space/visual-editor/useConnectionDrag.ts
@@ -1,0 +1,204 @@
+/**
+ * useConnectionDrag
+ *
+ * Hook that manages the "drag from output port → input port to create a transition" workflow.
+ *
+ * Usage:
+ *  1. Call `startDrag(fromStepId, portScreenCenter, e)` from a node's output port mousedown.
+ *  2. Call `setHoverTarget(stepId | null)` from input port mouseenter/mouseleave.
+ *  3. The hook tracks the ghost-edge endpoint via window mousemove.
+ *  4. On window mouseup it either commits or cancels the connection.
+ *
+ * The hook converts screen coordinates → canvas coordinates using the current viewport so
+ * the ghost edge can be drawn in SVG canvas-space without extra transforms.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'preact/hooks';
+import type { RefObject } from 'preact';
+import type { Point, ViewportState } from './types';
+import { screenToCanvas } from './types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TransitionLike {
+	from: string;
+	to: string;
+}
+
+export interface ConnectionDragState {
+	/** Whether a connection drag is currently in progress */
+	active: boolean;
+	/** Step ID of the source node */
+	fromStepId: string | null;
+	/** Canvas-space center of the source output port */
+	fromPos: Point | null;
+	/** Canvas-space position of the current mouse cursor */
+	currentPos: Point | null;
+	/** Step ID of the input port currently being hovered, or null */
+	hoverTargetStepId: string | null;
+}
+
+const IDLE: ConnectionDragState = {
+	active: false,
+	fromStepId: null,
+	fromPos: null,
+	currentPos: null,
+	hoverTargetStepId: null,
+};
+
+export interface UseConnectionDragOptions {
+	/** Used to convert screen coordinates to canvas coordinates */
+	viewportState: ViewportState;
+	/** Container element used to compute relative coordinates */
+	containerRef: RefObject<HTMLElement>;
+	/** Existing transitions — used to block duplicate edges */
+	transitions: TransitionLike[];
+	/** Called when the user successfully drops onto a valid input port */
+	onCreateTransition: (fromStepId: string, toStepId: string) => void;
+}
+
+export interface UseConnectionDragReturn {
+	/** Current drag state — read by the canvas to render the ghost edge and highlights */
+	dragState: ConnectionDragState;
+	/**
+	 * Call this from a node's **output** port onMouseDown handler.
+	 * @param fromStepId  The step the connection originates from
+	 * @param portEl      The port DOM element (used to compute screen-space center)
+	 * @param e           The originating mouse event (used for initial cursor position)
+	 */
+	startDrag: (fromStepId: string, portEl: Element, e: MouseEvent) => void;
+	/**
+	 * Call this from a node's **input** port onMouseEnter/onMouseLeave handler.
+	 * Pass null on mouseleave.
+	 */
+	setHoverTarget: (stepId: string | null) => void;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useConnectionDrag({
+	viewportState,
+	containerRef,
+	transitions,
+	onCreateTransition,
+}: UseConnectionDragOptions): UseConnectionDragReturn {
+	const [dragState, setDragState] = useState<ConnectionDragState>(IDLE);
+
+	// Keep refs to avoid stale closures inside window listeners
+	const viewportRef = useRef(viewportState);
+	viewportRef.current = viewportState;
+
+	const transitionsRef = useRef(transitions);
+	transitionsRef.current = transitions;
+
+	const onCreateTransitionRef = useRef(onCreateTransition);
+	onCreateTransitionRef.current = onCreateTransition;
+
+	// Mutable ref holding drag state for use inside window listeners
+	// (setState is async; we need synchronous access to fromStepId and hoverTarget)
+	const dragRef = useRef<ConnectionDragState>(IDLE);
+
+	// ---- startDrag ----
+	const startDrag = useCallback(
+		(fromStepId: string, portEl: Element, e: MouseEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			const container = containerRef.current;
+			const portRect = portEl.getBoundingClientRect();
+			const containerRect = container?.getBoundingClientRect() ?? { left: 0, top: 0 };
+
+			// Port center in screen coordinates (relative to container)
+			const portScreenCenter: Point = {
+				x: portRect.left + portRect.width / 2 - containerRect.left,
+				y: portRect.top + portRect.height / 2 - containerRect.top,
+			};
+
+			const fromPos = screenToCanvas(portScreenCenter, viewportRef.current);
+
+			// Cursor position at start of drag
+			const cursorScreen: Point = {
+				x: e.clientX - containerRect.left,
+				y: e.clientY - containerRect.top,
+			};
+			const currentPos = screenToCanvas(cursorScreen, viewportRef.current);
+
+			const next: ConnectionDragState = {
+				active: true,
+				fromStepId,
+				fromPos,
+				currentPos,
+				hoverTargetStepId: null,
+			};
+
+			dragRef.current = next;
+			setDragState(next);
+		},
+		[containerRef]
+	);
+
+	// ---- setHoverTarget ----
+	const setHoverTarget = useCallback((stepId: string | null) => {
+		if (!dragRef.current.active) return;
+		const next = { ...dragRef.current, hoverTargetStepId: stepId };
+		dragRef.current = next;
+		setDragState(next);
+	}, []);
+
+	// ---- Window listeners (registered once; guard on dragRef.current.active) ----
+	useEffect(() => {
+		const onMouseMove = (e: MouseEvent) => {
+			if (!dragRef.current.active) return;
+
+			const containerRect = containerRef.current?.getBoundingClientRect() ?? { left: 0, top: 0 };
+			const cursorScreen: Point = {
+				x: e.clientX - containerRect.left,
+				y: e.clientY - containerRect.top,
+			};
+			const currentPos = screenToCanvas(cursorScreen, viewportRef.current);
+
+			const next = { ...dragRef.current, currentPos };
+			dragRef.current = next;
+			setDragState(next);
+		};
+
+		const onMouseUp = () => {
+			if (!dragRef.current.active) return;
+
+			const { fromStepId, hoverTargetStepId } = dragRef.current;
+
+			if (fromStepId && hoverTargetStepId) {
+				// Validate: no self-connections
+				if (fromStepId === hoverTargetStepId) {
+					dragRef.current = IDLE;
+					setDragState(IDLE);
+					return;
+				}
+
+				// Validate: no duplicate transitions
+				const isDuplicate = transitionsRef.current.some(
+					(t) => t.from === fromStepId && t.to === hoverTargetStepId
+				);
+				if (!isDuplicate) {
+					onCreateTransitionRef.current(fromStepId, hoverTargetStepId);
+				}
+			}
+
+			dragRef.current = IDLE;
+			setDragState(IDLE);
+		};
+
+		window.addEventListener('mousemove', onMouseMove);
+		window.addEventListener('mouseup', onMouseUp);
+		return () => {
+			window.removeEventListener('mousemove', onMouseMove);
+			window.removeEventListener('mouseup', onMouseUp);
+		};
+	}, [containerRef]);
+
+	return { dragState, startDrag, setHoverTarget };
+}

--- a/packages/web/src/components/space/visual-editor/useConnectionDrag.ts
+++ b/packages/web/src/components/space/visual-editor/useConnectionDrag.ts
@@ -192,11 +192,20 @@ export function useConnectionDrag({
 			setDragState(IDLE);
 		};
 
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' && dragRef.current.active) {
+				dragRef.current = IDLE;
+				setDragState(IDLE);
+			}
+		};
+
 		window.addEventListener('mousemove', onMouseMove);
 		window.addEventListener('mouseup', onMouseUp);
+		window.addEventListener('keydown', onKeyDown);
 		return () => {
 			window.removeEventListener('mousemove', onMouseMove);
 			window.removeEventListener('mouseup', onMouseUp);
+			window.removeEventListener('keydown', onKeyDown);
 		};
 	}, [containerRef]);
 


### PR DESCRIPTION
- Add useConnectionDrag hook tracking drag state (fromStepId, fromPos, currentPos, hoverTarget)
- Render dashed bezier ghost edge via VisualCanvas edgeLayer during drag
- Highlight valid input ports (green) as drop targets during drag
- Validate: block self-connections and duplicate transitions
- WorkflowNode gains isDropTarget prop + port mouseenter/leave callbacks
- WorkflowCanvas manages connection drag internally (onCreateTransition prop)
- 20 new tests covering ghost edge rendering, valid/invalid drops, highlights
