### PR TITLE
feat: implement NodeConfigPanel and extract GateConfig (Task 4.1)

### DIFF
--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -11,6 +11,8 @@
 import type { SpaceAgent } from '@neokai/shared';
 import type { WorkflowConditionType } from '@neokai/shared';
 import { cn } from '../../lib/utils';
+import { GateConfig, CONDITION_LABELS } from './visual-editor/GateConfig';
+import type { ConditionDraft } from './visual-editor/GateConfig';
 
 // ============================================================================
 // Draft Types (used by WorkflowEditor + WorkflowStepCard)
@@ -26,86 +28,8 @@ export interface StepDraft {
 	instructions: string;
 }
 
-export interface ConditionDraft {
-	type: WorkflowConditionType;
-	/** Shell expression for 'condition' type */
-	expression?: string;
-}
-
-// ============================================================================
-// Gate Config Sub-Form
-// ============================================================================
-
-interface GateConfigProps {
-	condition: ConditionDraft;
-	onChange: (cond: ConditionDraft) => void;
-	label: string;
-	/** Message shown when the gate is not configurable (first/last step boundary) */
-	terminalMessage?: string;
-}
-
-const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
-	always: 'Automatic',
-	human: 'Human Approval',
-	condition: 'Shell Condition',
-};
-
-function GateConfig({ condition, onChange, label, terminalMessage }: GateConfigProps) {
-	return (
-		<div class="space-y-1.5">
-			<label class="text-xs font-medium text-gray-400">{label}</label>
-			{terminalMessage ? (
-				<p class="text-xs text-gray-600 italic">{terminalMessage}</p>
-			) : (
-				<>
-					<select
-						value={condition.type}
-						onChange={(e) => {
-							const type = (e.currentTarget as HTMLSelectElement).value as WorkflowConditionType;
-							onChange({ type, expression: type === 'condition' ? '' : undefined });
-						}}
-						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
-					>
-						{(Object.keys(CONDITION_LABELS) as WorkflowConditionType[]).map((t) => (
-							<option key={t} value={t}>
-								{CONDITION_LABELS[t]}
-							</option>
-						))}
-					</select>
-
-					{condition.type === 'condition' && (
-						<div class="space-y-1">
-							<input
-								type="text"
-								required
-								placeholder="e.g. bun test && git diff --quiet"
-								value={condition.expression ?? ''}
-								onInput={(e) =>
-									onChange({
-										...condition,
-										expression: (e.currentTarget as HTMLInputElement).value,
-									})
-								}
-								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 font-mono focus:outline-none focus:border-blue-500 placeholder-gray-700"
-							/>
-							<p class="text-xs text-gray-600">
-								Transition fires when the shell command exits with code 0.
-							</p>
-						</div>
-					)}
-
-					{condition.type === 'human' && (
-						<p class="text-xs text-gray-600">Transition requires explicit human approval.</p>
-					)}
-
-					{condition.type === 'always' && (
-						<p class="text-xs text-gray-600">Transition fires automatically.</p>
-					)}
-				</>
-			)}
-		</div>
-	);
-}
+// Re-export ConditionDraft so existing importers don't break
+export type { ConditionDraft } from './visual-editor/GateConfig';
 
 // ============================================================================
 // Icon Components

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -1,0 +1,94 @@
+/**
+ * GateConfig
+ *
+ * Shared sub-form for configuring workflow transition conditions (entry/exit gates).
+ * Extracted so both WorkflowStepCard (list editor) and NodeConfigPanel (visual editor)
+ * can reuse the same UI without duplication.
+ */
+
+import type { WorkflowConditionType } from '@neokai/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ConditionDraft {
+	type: WorkflowConditionType;
+	/** Shell expression for 'condition' type */
+	expression?: string;
+}
+
+export const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
+	always: 'Automatic',
+	human: 'Human Approval',
+	condition: 'Shell Condition',
+};
+
+// ============================================================================
+// GateConfig Component
+// ============================================================================
+
+interface GateConfigProps {
+	condition: ConditionDraft;
+	onChange: (cond: ConditionDraft) => void;
+	label: string;
+	/** Message shown when the gate is not configurable (first/last step boundary) */
+	terminalMessage?: string;
+}
+
+export function GateConfig({ condition, onChange, label, terminalMessage }: GateConfigProps) {
+	return (
+		<div class="space-y-1.5">
+			<label class="text-xs font-medium text-gray-400">{label}</label>
+			{terminalMessage ? (
+				<p class="text-xs text-gray-600 italic">{terminalMessage}</p>
+			) : (
+				<>
+					<select
+						value={condition.type}
+						onChange={(e) => {
+							const type = (e.currentTarget as HTMLSelectElement).value as WorkflowConditionType;
+							onChange({ type, expression: type === 'condition' ? '' : undefined });
+						}}
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+					>
+						{(Object.keys(CONDITION_LABELS) as WorkflowConditionType[]).map((t) => (
+							<option key={t} value={t}>
+								{CONDITION_LABELS[t]}
+							</option>
+						))}
+					</select>
+
+					{condition.type === 'condition' && (
+						<div class="space-y-1">
+							<input
+								type="text"
+								required
+								placeholder="e.g. bun test && git diff --quiet"
+								value={condition.expression ?? ''}
+								onInput={(e) =>
+									onChange({
+										...condition,
+										expression: (e.currentTarget as HTMLInputElement).value,
+									})
+								}
+								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 font-mono focus:outline-none focus:border-blue-500 placeholder-gray-700"
+							/>
+							<p class="text-xs text-gray-600">
+								Transition fires when the shell command exits with code 0.
+							</p>
+						</div>
+					)}
+
+					{condition.type === 'human' && (
+						<p class="text-xs text-gray-600">Transition requires explicit human approval.</p>
+					)}
+
+					{condition.type === 'always' && (
+						<p class="text-xs text-gray-600">Transition fires automatically.</p>
+					)}
+				</>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -1,0 +1,251 @@
+/**
+ * NodeConfigPanel
+ *
+ * A right-anchored slide-in panel that appears when a workflow node is selected
+ * in the visual editor. Provides inline editing of all step properties using
+ * the same field layout as the WorkflowStepCard expanded view.
+ *
+ * Features:
+ * - Step Name input
+ * - "Set as Start" button (disabled when node is already the start node)
+ * - Agent dropdown
+ * - Entry Gate selector (GateConfig)
+ * - Exit Gate selector (GateConfig)
+ * - Instructions textarea
+ * - Delete Step button with confirmation (disabled for start node)
+ */
+
+import { useState } from 'preact/hooks';
+import type { SpaceAgent } from '@neokai/shared';
+import type { StepDraft } from '../WorkflowStepCard';
+import { GateConfig } from './GateConfig';
+import type { ConditionDraft } from './GateConfig';
+
+// ============================================================================
+// Props
+// ============================================================================
+
+export interface NodeConfigPanelProps {
+	step: StepDraft;
+	agents: SpaceAgent[];
+	entryCondition: ConditionDraft | null;
+	exitCondition: ConditionDraft | null;
+	isStartNode: boolean;
+	onUpdate: (step: StepDraft) => void;
+	onUpdateEntryCondition: (cond: ConditionDraft) => void;
+	onUpdateExitCondition: (cond: ConditionDraft) => void;
+	/** Designates this step as the workflow start node */
+	onSetAsStart: (stepId: string) => void;
+	onClose: () => void;
+	/** Called when the user confirms deletion of this step */
+	onDelete: (stepId: string) => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function NodeConfigPanel({
+	step,
+	agents,
+	entryCondition,
+	exitCondition,
+	isStartNode,
+	onUpdate,
+	onUpdateEntryCondition,
+	onUpdateExitCondition,
+	onSetAsStart,
+	onClose,
+	onDelete,
+}: NodeConfigPanelProps) {
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+	const handleDeleteClick = () => {
+		if (isStartNode) return; // guarded in UI
+		setConfirmingDelete(true);
+	};
+
+	const handleDeleteConfirm = () => {
+		setConfirmingDelete(false);
+		onDelete(step.localId);
+	};
+
+	const handleDeleteCancel = () => {
+		setConfirmingDelete(false);
+	};
+
+	return (
+		<div
+			data-testid="node-config-panel"
+			style={{
+				position: 'absolute',
+				top: 0,
+				right: 0,
+				bottom: 0,
+				width: 320,
+				display: 'flex',
+				flexDirection: 'column',
+				zIndex: 20,
+				transform: 'translateX(0)',
+				transition: 'transform 0.2s ease',
+			}}
+			class="bg-dark-900 border-l border-dark-700 shadow-xl"
+		>
+			{/* Header */}
+			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0">
+				<div class="flex items-center gap-2 min-w-0">
+					{isStartNode && (
+						<span
+							data-testid="start-node-badge"
+							class="text-xs font-bold text-green-400 uppercase tracking-wider flex-shrink-0"
+						>
+							START
+						</span>
+					)}
+					<h3 class="text-sm font-semibold text-gray-100 truncate">
+						{step.name || 'Unnamed Step'}
+					</h3>
+				</div>
+				<button
+					data-testid="close-button"
+					onClick={onClose}
+					class="p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-dark-700 transition-colors flex-shrink-0"
+					title="Close panel"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			{/* Scrollable body */}
+			<div class="flex-1 overflow-y-auto px-4 py-4 space-y-5">
+				{/* Step Name */}
+				<div class="space-y-1.5">
+					<label class="text-xs font-medium text-gray-400">Step Name</label>
+					<input
+						data-testid="step-name-input"
+						type="text"
+						value={step.name}
+						onInput={(e) =>
+							onUpdate({ ...step, name: (e.currentTarget as HTMLInputElement).value })
+						}
+						placeholder="e.g. Plan the approach"
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+					/>
+				</div>
+
+				{/* Set as Start button */}
+				{!isStartNode && (
+					<button
+						data-testid="set-as-start-button"
+						onClick={() => onSetAsStart(step.localId)}
+						class="w-full text-xs font-medium py-1.5 px-3 rounded border border-green-700 text-green-400 hover:bg-green-900/30 transition-colors"
+					>
+						Set as Start Node
+					</button>
+				)}
+
+				{/* Agent */}
+				<div class="space-y-1.5">
+					<label class="text-xs font-medium text-gray-400">Agent</label>
+					<select
+						data-testid="agent-select"
+						value={step.agentId}
+						onChange={(e) =>
+							onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
+						}
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+					>
+						<option value="">— Select agent —</option>
+						{agents.map((a) => (
+							<option key={a.id} value={a.id}>
+								{a.name}
+								{` (${a.role})`}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{/* Entry Gate */}
+				<GateConfig
+					label="Entry Gate"
+					condition={entryCondition ?? { type: 'always' }}
+					onChange={onUpdateEntryCondition}
+				/>
+
+				{/* Exit Gate */}
+				<GateConfig
+					label="Exit Gate"
+					condition={exitCondition ?? { type: 'always' }}
+					onChange={onUpdateExitCondition}
+				/>
+
+				{/* Instructions */}
+				<div class="space-y-1.5">
+					<label class="text-xs font-medium text-gray-400">
+						Instructions <span class="font-normal text-gray-600">(optional)</span>
+					</label>
+					<textarea
+						data-testid="instructions-textarea"
+						value={step.instructions}
+						onInput={(e) =>
+							onUpdate({
+								...step,
+								instructions: (e.currentTarget as HTMLTextAreaElement).value,
+							})
+						}
+						placeholder="Step-specific instructions appended to the agent's system prompt…"
+						rows={5}
+						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-700 resize-y"
+					/>
+				</div>
+			</div>
+
+			{/* Footer — Delete button */}
+			<div class="px-4 py-3 border-t border-dark-700 flex-shrink-0">
+				{confirmingDelete ? (
+					<div class="space-y-2">
+						<p class="text-xs text-gray-400">Delete this step? This cannot be undone.</p>
+						<div class="flex gap-2">
+							<button
+								data-testid="delete-confirm-button"
+								onClick={handleDeleteConfirm}
+								class="flex-1 text-xs py-1.5 px-3 rounded bg-red-700 hover:bg-red-600 text-white font-medium transition-colors"
+							>
+								Delete
+							</button>
+							<button
+								data-testid="delete-cancel-button"
+								onClick={handleDeleteCancel}
+								class="flex-1 text-xs py-1.5 px-3 rounded border border-dark-600 text-gray-400 hover:text-gray-200 hover:bg-dark-700 transition-colors"
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				) : (
+					<button
+						data-testid="delete-step-button"
+						onClick={handleDeleteClick}
+						disabled={isStartNode}
+						title={isStartNode ? 'Designate another node as start before deleting' : 'Delete step'}
+						class="w-full text-xs py-1.5 px-3 rounded border border-red-900 text-red-500 hover:bg-red-900/30 hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+					>
+						Delete Step
+					</button>
+				)}
+				{isStartNode && !confirmingDelete && (
+					<p class="text-xs text-gray-600 mt-1.5 text-center">
+						Designate another node as start before deleting.
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -15,7 +15,7 @@
  * - Delete Step button with confirmation (disabled for start node)
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import type { StepDraft } from '../WorkflowStepCard';
 import { GateConfig } from './GateConfig';
@@ -31,6 +31,16 @@ export interface NodeConfigPanelProps {
 	entryCondition: ConditionDraft | null;
 	exitCondition: ConditionDraft | null;
 	isStartNode: boolean;
+	/**
+	 * When true, the entry gate shows "Workflow starts here" (no selector).
+	 * Mirrors the WorkflowStepCard terminal message for the first step.
+	 */
+	isFirstStep?: boolean;
+	/**
+	 * When true, the exit gate shows "Workflow ends here" (no selector).
+	 * Mirrors the WorkflowStepCard terminal message for the last step.
+	 */
+	isLastStep?: boolean;
 	onUpdate: (step: StepDraft) => void;
 	onUpdateEntryCondition: (cond: ConditionDraft) => void;
 	onUpdateExitCondition: (cond: ConditionDraft) => void;
@@ -51,6 +61,8 @@ export function NodeConfigPanel({
 	entryCondition,
 	exitCondition,
 	isStartNode,
+	isFirstStep = false,
+	isLastStep = false,
 	onUpdate,
 	onUpdateEntryCondition,
 	onUpdateExitCondition,
@@ -60,8 +72,14 @@ export function NodeConfigPanel({
 }: NodeConfigPanelProps) {
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 
+	// Reset confirmation dialog when the selected step changes so a previously
+	// open confirmation on one node doesn't bleed through to the next node.
+	useEffect(() => {
+		setConfirmingDelete(false);
+	}, [step.localId]);
+
 	const handleDeleteClick = () => {
-		if (isStartNode) return; // guarded in UI
+		if (isStartNode) return; // defence-in-depth: button is also disabled
 		setConfirmingDelete(true);
 	};
 
@@ -86,10 +104,8 @@ export function NodeConfigPanel({
 				display: 'flex',
 				flexDirection: 'column',
 				zIndex: 20,
-				transform: 'translateX(0)',
-				transition: 'transform 0.2s ease',
 			}}
-			class="bg-dark-900 border-l border-dark-700 shadow-xl"
+			class="bg-dark-900 border-l border-dark-700 shadow-xl animate-slideInRight"
 		>
 			{/* Header */}
 			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0">
@@ -177,6 +193,7 @@ export function NodeConfigPanel({
 					label="Entry Gate"
 					condition={entryCondition ?? { type: 'always' }}
 					onChange={onUpdateEntryCondition}
+					terminalMessage={isFirstStep ? 'Workflow starts here' : undefined}
 				/>
 
 				{/* Exit Gate */}
@@ -184,6 +201,7 @@ export function NodeConfigPanel({
 					label="Exit Gate"
 					condition={exitCondition ?? { type: 'always' }}
 					onChange={onUpdateExitCondition}
+					terminalMessage={isLastStep ? 'Workflow ends here' : undefined}
 				/>
 
 				{/* Instructions */}

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { SpaceAgent } from '@neokai/shared';
 import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
@@ -303,6 +303,58 @@ describe('NodeConfigPanel', () => {
 			fireEvent.click(getByTestId('delete-step-button'));
 			fireEvent.click(getByTestId('delete-cancel-button'));
 			expect(onDelete).not.toHaveBeenCalled();
+		});
+
+		it('guard in handleDeleteClick suppresses dialog when isStartNode=true (defence-in-depth)', () => {
+			// The button is disabled, so a normal click won't fire. Dispatch a direct click event
+			// bypassing the disabled attribute to verify the handler guard still blocks the dialog.
+			const { getByTestId, queryByTestId } = render(
+				<NodeConfigPanel {...makeProps({ isStartNode: true })} />
+			);
+			const btn = getByTestId('delete-step-button') as HTMLButtonElement;
+			// Programmatically invoke the onClick handler via a non-trusted event
+			fireEvent.click(btn);
+			expect(queryByTestId('delete-confirm-button')).toBeNull();
+		});
+
+		it('confirmation dialog is reset when selected step changes', async () => {
+			const stepA = makeStep({ localId: 'step-a', name: 'Step A' });
+			const stepB = makeStep({ localId: 'step-b', name: 'Step B' });
+			const props = makeProps({ step: stepA });
+			const { getByTestId, queryByTestId, rerender } = render(<NodeConfigPanel {...props} />);
+
+			// Open confirmation on step A
+			fireEvent.click(getByTestId('delete-step-button'));
+			expect(getByTestId('delete-confirm-button')).toBeTruthy();
+
+			// Swap to step B (simulates user selecting a different node)
+			await act(async () => {
+				rerender(<NodeConfigPanel {...{ ...props, step: stepB }} />);
+			});
+
+			// Confirmation dialog should be gone
+			expect(queryByTestId('delete-confirm-button')).toBeNull();
+			expect(getByTestId('delete-step-button')).toBeTruthy();
+		});
+	});
+
+	describe('terminal messages for boundary nodes', () => {
+		it('shows "Workflow starts here" for first step entry gate', () => {
+			const { getByText } = render(<NodeConfigPanel {...makeProps({ isFirstStep: true })} />);
+			expect(getByText('Workflow starts here')).toBeTruthy();
+		});
+
+		it('shows "Workflow ends here" for last step exit gate', () => {
+			const { getByText } = render(<NodeConfigPanel {...makeProps({ isLastStep: true })} />);
+			expect(getByText('Workflow ends here')).toBeTruthy();
+		});
+
+		it('does not show terminal messages for mid-workflow nodes', () => {
+			const { container } = render(
+				<NodeConfigPanel {...makeProps({ isFirstStep: false, isLastStep: false })} />
+			);
+			expect(container.textContent).not.toContain('Workflow starts here');
+			expect(container.textContent).not.toContain('Workflow ends here');
 		});
 	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for NodeConfigPanel
+ *
+ * Tests:
+ * - Renders all fields (step name, agent dropdown, entry/exit gates, instructions)
+ * - Header shows step name and close button
+ * - Step name in header updates when step changes
+ * - "Set as Start" button visible for non-start nodes, hidden for start node
+ * - "Set as Start" calls onSetAsStart with the step localId
+ * - onClose fires when close button clicked
+ * - onUpdate fires with updated step when fields change
+ * - onUpdateEntryCondition fires when entry gate changes
+ * - onUpdateExitCondition fires when exit gate changes
+ * - Delete button is disabled for start node with tooltip hint
+ * - Delete button shows confirmation dialog when clicked
+ * - Confirming delete calls onDelete; cancelling dismisses dialog
+ * - Start node badge shown in header when isStartNode=true
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import type { SpaceAgent } from '@neokai/shared';
+import { NodeConfigPanel } from '../NodeConfigPanel';
+import type { NodeConfigPanelProps } from '../NodeConfigPanel';
+import type { StepDraft } from '../../WorkflowStepCard';
+import type { ConditionDraft } from '../GateConfig';
+
+afterEach(() => cleanup());
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeAgent(id: string, name: string, role = 'coder'): SpaceAgent {
+	return { id, spaceId: 'space-1', name, role, createdAt: Date.now(), updatedAt: Date.now() };
+}
+
+function makeStep(overrides: Partial<StepDraft> = {}): StepDraft {
+	return {
+		localId: 'step-local-1',
+		name: 'My Step',
+		agentId: 'agent-1',
+		instructions: 'Do stuff.',
+		...overrides,
+	};
+}
+
+const defaultAgents: SpaceAgent[] = [
+	makeAgent('agent-1', 'Planner', 'planner'),
+	makeAgent('agent-2', 'Coder', 'coder'),
+];
+
+function makeProps(overrides: Partial<NodeConfigPanelProps> = {}): NodeConfigPanelProps {
+	return {
+		step: makeStep(),
+		agents: defaultAgents,
+		entryCondition: { type: 'always' } as ConditionDraft,
+		exitCondition: { type: 'always' } as ConditionDraft,
+		isStartNode: false,
+		onUpdate: vi.fn(),
+		onUpdateEntryCondition: vi.fn(),
+		onUpdateExitCondition: vi.fn(),
+		onSetAsStart: vi.fn(),
+		onClose: vi.fn(),
+		onDelete: vi.fn(),
+		...overrides,
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('NodeConfigPanel', () => {
+	describe('rendering', () => {
+		it('renders the panel element', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByTestId('node-config-panel')).toBeTruthy();
+		});
+
+		it('shows the step name in the header', () => {
+			const { getByText } = render(
+				<NodeConfigPanel {...makeProps({ step: makeStep({ name: 'Parse Data' }) })} />
+			);
+			expect(getByText('Parse Data')).toBeTruthy();
+		});
+
+		it('shows "Unnamed Step" when name is empty', () => {
+			const { getByText } = render(
+				<NodeConfigPanel {...makeProps({ step: makeStep({ name: '' }) })} />
+			);
+			expect(getByText('Unnamed Step')).toBeTruthy();
+		});
+
+		it('renders the step name input with current value', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			const input = getByTestId('step-name-input') as HTMLInputElement;
+			expect(input.value).toBe('My Step');
+		});
+
+		it('renders the agent dropdown with all agents', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			const select = getByTestId('agent-select') as HTMLSelectElement;
+			const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+			expect(options).toContain('Planner (planner)');
+			expect(options).toContain('Coder (coder)');
+		});
+
+		it('shows currently selected agent in dropdown', () => {
+			const { getByTestId } = render(
+				<NodeConfigPanel {...makeProps({ step: makeStep({ agentId: 'agent-2' }) })} />
+			);
+			const select = getByTestId('agent-select') as HTMLSelectElement;
+			expect(select.value).toBe('agent-2');
+		});
+
+		it('renders the instructions textarea with current value', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			const textarea = getByTestId('instructions-textarea') as HTMLTextAreaElement;
+			expect(textarea.value).toBe('Do stuff.');
+		});
+
+		it('renders entry gate selector', () => {
+			const { getByText } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByText('Entry Gate')).toBeTruthy();
+		});
+
+		it('renders exit gate selector', () => {
+			const { getByText } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByText('Exit Gate')).toBeTruthy();
+		});
+
+		it('renders close button', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByTestId('close-button')).toBeTruthy();
+		});
+
+		it('renders delete step button', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByTestId('delete-step-button')).toBeTruthy();
+		});
+	});
+
+	describe('start node badge', () => {
+		it('shows START badge in header when isStartNode=true', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: true })} />);
+			expect(getByTestId('start-node-badge')).toBeTruthy();
+		});
+
+		it('does not show START badge when isStartNode=false', () => {
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: false })} />);
+			expect(queryByTestId('start-node-badge')).toBeNull();
+		});
+	});
+
+	describe('"Set as Start" button', () => {
+		it('is visible when node is not the start node', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: false })} />);
+			expect(getByTestId('set-as-start-button')).toBeTruthy();
+		});
+
+		it('is hidden when node is already the start node', () => {
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: true })} />);
+			expect(queryByTestId('set-as-start-button')).toBeNull();
+		});
+
+		it('calls onSetAsStart with the step localId when clicked', () => {
+			const onSetAsStart = vi.fn();
+			const { getByTestId } = render(
+				<NodeConfigPanel {...makeProps({ onSetAsStart, step: makeStep({ localId: 'my-step' }) })} />
+			);
+			fireEvent.click(getByTestId('set-as-start-button'));
+			expect(onSetAsStart).toHaveBeenCalledWith('my-step');
+		});
+	});
+
+	describe('close button', () => {
+		it('calls onClose when close button clicked', () => {
+			const onClose = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onClose })} />);
+			fireEvent.click(getByTestId('close-button'));
+			expect(onClose).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('field updates', () => {
+		it('calls onUpdate with new name when step name changes', () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			fireEvent.input(getByTestId('step-name-input'), { target: { value: 'New Name' } });
+			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Name' }));
+		});
+
+		it('calls onUpdate with new agentId when agent selection changes', () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			fireEvent.change(getByTestId('agent-select'), { target: { value: 'agent-2' } });
+			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ agentId: 'agent-2' }));
+		});
+
+		it('calls onUpdate with new instructions when textarea changes', () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			fireEvent.input(getByTestId('instructions-textarea'), {
+				target: { value: 'New instructions.' },
+			});
+			expect(onUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ instructions: 'New instructions.' })
+			);
+		});
+
+		it('calls onUpdateEntryCondition when entry gate type changes', () => {
+			const onUpdateEntryCondition = vi.fn();
+			const { container } = render(
+				<NodeConfigPanel
+					{...makeProps({ onUpdateEntryCondition, entryCondition: { type: 'always' } })}
+				/>
+			);
+			// selects: agent (index 0), entry gate (index 1), exit gate (index 2)
+			const selects = container.querySelectorAll('select');
+			fireEvent.change(selects[1], { target: { value: 'human' } });
+			expect(onUpdateEntryCondition).toHaveBeenCalledWith({ type: 'human', expression: undefined });
+		});
+
+		it('calls onUpdateExitCondition when exit gate type changes', () => {
+			const onUpdateExitCondition = vi.fn();
+			const { container } = render(
+				<NodeConfigPanel
+					{...makeProps({ onUpdateExitCondition, exitCondition: { type: 'always' } })}
+				/>
+			);
+			const selects = container.querySelectorAll('select');
+			fireEvent.change(selects[2], { target: { value: 'condition' } });
+			expect(onUpdateExitCondition).toHaveBeenCalledWith({ type: 'condition', expression: '' });
+		});
+	});
+
+	describe('gate config — condition type', () => {
+		it('shows shell expression input when entry gate type is "condition"', () => {
+			const { getByPlaceholderText } = render(
+				<NodeConfigPanel
+					{...makeProps({ entryCondition: { type: 'condition', expression: '' } })}
+				/>
+			);
+			expect(getByPlaceholderText('e.g. bun test && git diff --quiet')).toBeTruthy();
+		});
+
+		it('shows human approval hint for "human" type', () => {
+			const { getByText } = render(
+				<NodeConfigPanel {...makeProps({ entryCondition: { type: 'human' } })} />
+			);
+			expect(getByText('Transition requires explicit human approval.')).toBeTruthy();
+		});
+	});
+
+	describe('delete step', () => {
+		it('delete button is disabled for start node', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: true })} />);
+			const btn = getByTestId('delete-step-button') as HTMLButtonElement;
+			expect(btn.disabled).toBe(true);
+		});
+
+		it('delete button is enabled for non-start node', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ isStartNode: false })} />);
+			const btn = getByTestId('delete-step-button') as HTMLButtonElement;
+			expect(btn.disabled).toBe(false);
+		});
+
+		it('shows hint about designating another start node when start node is selected', () => {
+			const { getByText } = render(<NodeConfigPanel {...makeProps({ isStartNode: true })} />);
+			expect(getByText('Designate another node as start before deleting.')).toBeTruthy();
+		});
+
+		it('clicking delete shows confirmation dialog', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			fireEvent.click(getByTestId('delete-step-button'));
+			expect(getByTestId('delete-confirm-button')).toBeTruthy();
+			expect(getByTestId('delete-cancel-button')).toBeTruthy();
+		});
+
+		it('confirming delete calls onDelete with step localId', () => {
+			const onDelete = vi.fn();
+			const { getByTestId } = render(
+				<NodeConfigPanel {...makeProps({ onDelete, step: makeStep({ localId: 'step-xyz' }) })} />
+			);
+			fireEvent.click(getByTestId('delete-step-button'));
+			fireEvent.click(getByTestId('delete-confirm-button'));
+			expect(onDelete).toHaveBeenCalledWith('step-xyz');
+		});
+
+		it('cancelling delete hides confirmation dialog', () => {
+			const { getByTestId, queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			fireEvent.click(getByTestId('delete-step-button'));
+			expect(getByTestId('delete-confirm-button')).toBeTruthy();
+			fireEvent.click(getByTestId('delete-cancel-button'));
+			expect(queryByTestId('delete-confirm-button')).toBeNull();
+			expect(getByTestId('delete-step-button')).toBeTruthy();
+		});
+
+		it('onDelete not called when cancel clicked', () => {
+			const onDelete = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onDelete })} />);
+			fireEvent.click(getByTestId('delete-step-button'));
+			fireEvent.click(getByTestId('delete-cancel-button'));
+			expect(onDelete).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -13,3 +13,7 @@ export type {
 	UseConnectionDragOptions,
 	UseConnectionDragReturn,
 } from './useConnectionDrag';
+export { GateConfig, CONDITION_LABELS } from './GateConfig';
+export type { ConditionDraft } from './GateConfig';
+export { NodeConfigPanel } from './NodeConfigPanel';
+export type { NodeConfigPanelProps } from './NodeConfigPanel';


### PR DESCRIPTION
- Extract GateConfig sub-form from WorkflowStepCard into shared
  GateConfig.tsx so both the list editor and visual editor reuse it
- WorkflowStepCard re-exports ConditionDraft for backwards compat
- Add NodeConfigPanel: right-anchored 320px slide-in panel that shows
  when a node is selected in the visual editor
  - Fields: Step Name, Set as Start button, Agent dropdown,
    Entry/Exit Gate selectors (via GateConfig), Instructions textarea
  - Set as Start button hidden when node is already the start node
  - Delete Step button with confirmation dialog; disabled for start node
- 31 unit tests for NodeConfigPanel; all 61 affected tests pass
