### PR TITLE
feat: implement EdgeConfigPanel component for transition editing (Task 4.2)

### DIFF
--- a/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
@@ -6,24 +6,25 @@
  */
 
 import { useCallback } from 'preact/hooks';
-import type { WorkflowConditionType } from '@neokai/shared';
+import type { WorkflowCondition, WorkflowConditionType } from '@neokai/shared';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 export interface EdgeTransition {
-	/** Unique identifier for the transition */
+	/**
+	 * Unique identifier for the transition — used as a stable key forwarded to
+	 * onUpdateCondition and onDelete callbacks so the parent can locate the edge.
+	 */
 	id: string;
 	/** Source step name (human-readable, read-only) */
 	fromStepName: string;
 	/** Target step name (human-readable, read-only) */
 	toStepName: string;
-	/** Condition guarding this transition */
-	condition: {
-		type: WorkflowConditionType;
-		expression?: string;
-	};
+	/** Condition guarding this transition. Extra fields (description, maxRetries, etc.)
+	 *  are passed through unchanged; the panel only edits `type` and `expression`. */
+	condition: WorkflowCondition;
 }
 
 export interface EdgeConfigPanelProps {
@@ -47,6 +48,9 @@ const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
 	condition: 'Expression',
 };
 
+/** Explicit ordering for the condition type <select> options. */
+const CONDITION_TYPE_ORDER: WorkflowConditionType[] = ['always', 'human', 'condition'];
+
 export function EdgeConfigPanel({
 	transition,
 	onUpdateCondition,
@@ -58,7 +62,10 @@ export function EdgeConfigPanel({
 	const handleTypeChange = useCallback(
 		(e: Event) => {
 			const type = (e.target as HTMLSelectElement).value as WorkflowConditionType;
-			// When switching away from 'condition', clear the expression
+			// When switching away from 'condition', clear the expression so callers
+			// don't persist a stale expression string under a non-expression condition.
+			// Note: the parent is responsible for preserving the expression across
+			// two-way type switches if that behaviour is desired.
 			onUpdateCondition(id, type, type === 'condition' ? condition.expression : undefined);
 		},
 		[id, condition.expression, onUpdateCondition]
@@ -90,7 +97,7 @@ export function EdgeConfigPanel({
 					onClick={onClose}
 					aria-label="Close"
 				>
-					✕
+					×
 				</button>
 			</div>
 
@@ -128,7 +135,7 @@ export function EdgeConfigPanel({
 					value={condition.type}
 					onChange={handleTypeChange}
 				>
-					{(Object.keys(CONDITION_LABELS) as WorkflowConditionType[]).map((type) => (
+					{CONDITION_TYPE_ORDER.map((type) => (
 						<option key={type} value={type}>
 							{CONDITION_LABELS[type]}
 						</option>

--- a/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
@@ -1,0 +1,167 @@
+/**
+ * EdgeConfigPanel
+ *
+ * Shown when a workflow transition (edge) is selected in the visual editor.
+ * Allows editing the condition type and expression, and deleting the transition.
+ */
+
+import { useCallback } from 'preact/hooks';
+import type { WorkflowConditionType } from '@neokai/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface EdgeTransition {
+	/** Unique identifier for the transition */
+	id: string;
+	/** Source step name (human-readable, read-only) */
+	fromStepName: string;
+	/** Target step name (human-readable, read-only) */
+	toStepName: string;
+	/** Condition guarding this transition */
+	condition: {
+		type: WorkflowConditionType;
+		expression?: string;
+	};
+}
+
+export interface EdgeConfigPanelProps {
+	transition: EdgeTransition;
+	onUpdateCondition: (
+		transitionId: string,
+		conditionType: WorkflowConditionType,
+		expression?: string
+	) => void;
+	onDelete: (transitionId: string) => void;
+	onClose: () => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
+	always: 'Always',
+	human: 'Human approval',
+	condition: 'Expression',
+};
+
+export function EdgeConfigPanel({
+	transition,
+	onUpdateCondition,
+	onDelete,
+	onClose,
+}: EdgeConfigPanelProps) {
+	const { id, fromStepName, toStepName, condition } = transition;
+
+	const handleTypeChange = useCallback(
+		(e: Event) => {
+			const type = (e.target as HTMLSelectElement).value as WorkflowConditionType;
+			// When switching away from 'condition', clear the expression
+			onUpdateCondition(id, type, type === 'condition' ? condition.expression : undefined);
+		},
+		[id, condition.expression, onUpdateCondition]
+	);
+
+	const handleExpressionChange = useCallback(
+		(e: Event) => {
+			const expression = (e.target as HTMLInputElement).value;
+			onUpdateCondition(id, 'condition', expression);
+		},
+		[id, onUpdateCondition]
+	);
+
+	const handleDelete = useCallback(() => {
+		onDelete(id);
+	}, [id, onDelete]);
+
+	return (
+		<div
+			data-testid="edge-config-panel"
+			class="flex flex-col gap-3 p-4 bg-dark-850 border border-dark-700 rounded-lg text-sm text-white"
+		>
+			{/* Header */}
+			<div class="flex items-center justify-between">
+				<span class="font-semibold text-white text-sm">Transition</span>
+				<button
+					data-testid="close-button"
+					class="text-gray-400 hover:text-white transition-colors"
+					onClick={onClose}
+					aria-label="Close"
+				>
+					✕
+				</button>
+			</div>
+
+			{/* From / To (read-only) */}
+			<div class="flex flex-col gap-1">
+				<div class="flex items-center gap-2 text-xs">
+					<span class="text-gray-400 w-10 shrink-0">From</span>
+					<span
+						data-testid="from-step-name"
+						class="font-mono bg-dark-700 rounded px-2 py-0.5 text-gray-200 truncate"
+					>
+						{fromStepName}
+					</span>
+				</div>
+				<div class="flex items-center gap-2 text-xs">
+					<span class="text-gray-400 w-10 shrink-0">To</span>
+					<span
+						data-testid="to-step-name"
+						class="font-mono bg-dark-700 rounded px-2 py-0.5 text-gray-200 truncate"
+					>
+						{toStepName}
+					</span>
+				</div>
+			</div>
+
+			{/* Condition type */}
+			<div class="flex flex-col gap-1">
+				<label class="text-xs text-gray-400 font-medium" for="condition-type-select">
+					Condition
+				</label>
+				<select
+					id="condition-type-select"
+					data-testid="condition-type-select"
+					class="bg-dark-700 border border-dark-600 rounded px-2 py-1 text-sm text-white focus:outline-none focus:border-blue-500"
+					value={condition.type}
+					onChange={handleTypeChange}
+				>
+					{(Object.keys(CONDITION_LABELS) as WorkflowConditionType[]).map((type) => (
+						<option key={type} value={type}>
+							{CONDITION_LABELS[type]}
+						</option>
+					))}
+				</select>
+			</div>
+
+			{/* Expression input — only shown for 'condition' type */}
+			{condition.type === 'condition' && (
+				<div class="flex flex-col gap-1">
+					<label class="text-xs text-gray-400 font-medium" for="condition-expression">
+						Expression
+					</label>
+					<input
+						id="condition-expression"
+						data-testid="condition-expression"
+						type="text"
+						class="bg-dark-700 border border-dark-600 rounded px-2 py-1 text-sm text-white font-mono focus:outline-none focus:border-blue-500"
+						placeholder="e.g. test -f output.txt"
+						value={condition.expression ?? ''}
+						onInput={handleExpressionChange}
+					/>
+				</div>
+			)}
+
+			{/* Delete transition */}
+			<button
+				data-testid="delete-transition-button"
+				class="mt-1 w-full rounded px-2 py-1.5 text-xs font-medium text-red-400 border border-red-800 hover:bg-red-900/30 transition-colors"
+				onClick={handleDelete}
+			>
+				Delete transition
+			</button>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for EdgeConfigPanel component.
+ *
+ * Tests:
+ * - Renders from/to step names (read-only)
+ * - Renders condition type selector with current value
+ * - Does not show expression input for 'always' condition type
+ * - Does not show expression input for 'human' condition type
+ * - Shows expression input for 'condition' type
+ * - Expression input reflects current expression value
+ * - Changing condition type calls onUpdateCondition with new type
+ * - Switching away from 'condition' type clears expression
+ * - Switching to 'condition' type preserves existing expression
+ * - Editing expression calls onUpdateCondition with updated expression
+ * - Clicking delete button calls onDelete with transition id
+ * - Clicking close button calls onClose
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { EdgeConfigPanel } from '../EdgeConfigPanel';
+import type { EdgeConfigPanelProps, EdgeTransition } from '../EdgeConfigPanel';
+
+afterEach(() => cleanup());
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeTransition(overrides?: Partial<EdgeTransition>): EdgeTransition {
+	return {
+		id: 'trans-1',
+		fromStepName: 'Step A',
+		toStepName: 'Step B',
+		condition: { type: 'always' },
+		...overrides,
+	};
+}
+
+function makeProps(
+	transition: EdgeTransition,
+	overrides?: Partial<EdgeConfigPanelProps>
+): EdgeConfigPanelProps {
+	return {
+		transition,
+		onUpdateCondition: vi.fn(),
+		onDelete: vi.fn(),
+		onClose: vi.fn(),
+		...overrides,
+	};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('EdgeConfigPanel', () => {
+	it('renders from step name', () => {
+		const { getByTestId } = render(<EdgeConfigPanel {...makeProps(makeTransition())} />);
+		expect(getByTestId('from-step-name').textContent).toBe('Step A');
+	});
+
+	it('renders to step name', () => {
+		const { getByTestId } = render(<EdgeConfigPanel {...makeProps(makeTransition())} />);
+		expect(getByTestId('to-step-name').textContent).toBe('Step B');
+	});
+
+	it('shows condition type selector with current value "always"', () => {
+		const { getByTestId } = render(<EdgeConfigPanel {...makeProps(makeTransition())} />);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		expect(select.value).toBe('always');
+	});
+
+	it('shows condition type selector with current value "human"', () => {
+		const { getByTestId } = render(
+			<EdgeConfigPanel {...makeProps(makeTransition({ condition: { type: 'human' } }))} />
+		);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		expect(select.value).toBe('human');
+	});
+
+	it('shows condition type selector with current value "condition"', () => {
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(makeTransition({ condition: { type: 'condition', expression: 'true' } }))}
+			/>
+		);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		expect(select.value).toBe('condition');
+	});
+
+	it('does not show expression input for "always" type', () => {
+		const { queryByTestId } = render(<EdgeConfigPanel {...makeProps(makeTransition())} />);
+		expect(queryByTestId('condition-expression')).toBeNull();
+	});
+
+	it('does not show expression input for "human" type', () => {
+		const { queryByTestId } = render(
+			<EdgeConfigPanel {...makeProps(makeTransition({ condition: { type: 'human' } }))} />
+		);
+		expect(queryByTestId('condition-expression')).toBeNull();
+	});
+
+	it('shows expression input for "condition" type', () => {
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(makeTransition({ condition: { type: 'condition', expression: '' } }))}
+			/>
+		);
+		expect(getByTestId('condition-expression')).toBeTruthy();
+	});
+
+	it('expression input reflects current expression value', () => {
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(
+					makeTransition({ condition: { type: 'condition', expression: 'test -f out.txt' } })
+				)}
+			/>
+		);
+		const input = getByTestId('condition-expression') as HTMLInputElement;
+		expect(input.value).toBe('test -f out.txt');
+	});
+
+	it('changing condition type from always to human calls onUpdateCondition', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel {...makeProps(makeTransition(), { onUpdateCondition })} />
+		);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: 'human' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'human', undefined);
+	});
+
+	it('changing condition type to condition preserves existing expression', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(makeTransition({ condition: { type: 'always', expression: 'my-expr' } }), {
+					onUpdateCondition,
+				})}
+			/>
+		);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: 'condition' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'condition', 'my-expr');
+	});
+
+	it('changing condition type away from condition clears expression', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(
+					makeTransition({ condition: { type: 'condition', expression: 'test -f out.txt' } }),
+					{ onUpdateCondition }
+				)}
+			/>
+		);
+
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: 'always' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'always', undefined);
+	});
+
+	it('editing expression calls onUpdateCondition with updated expression', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(makeTransition({ condition: { type: 'condition', expression: 'old' } }), {
+					onUpdateCondition,
+				})}
+			/>
+		);
+		const input = getByTestId('condition-expression') as HTMLInputElement;
+		fireEvent.input(input, { target: { value: 'new-expr' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'condition', 'new-expr');
+	});
+
+	it('clicking delete button calls onDelete with transition id', () => {
+		const onDelete = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel {...makeProps(makeTransition(), { onDelete })} />
+		);
+		fireEvent.click(getByTestId('delete-transition-button'));
+		expect(onDelete).toHaveBeenCalledWith('trans-1');
+	});
+
+	it('clicking close button calls onClose', () => {
+		const onClose = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel {...makeProps(makeTransition(), { onClose })} />
+		);
+		fireEvent.click(getByTestId('close-button'));
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 /**
  * Unit tests for EdgeConfigPanel component.
  *

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -27,3 +27,5 @@ export {
 	SELECTED_STROKE_WIDTH,
 } from './EdgeRenderer';
 export type { EdgeRendererProps, EdgePoints } from './EdgeRenderer';
+export { EdgeConfigPanel } from './EdgeConfigPanel';
+export type { EdgeConfigPanelProps, EdgeTransition } from './EdgeConfigPanel';


### PR DESCRIPTION
Adds EdgeConfigPanel to the visual editor for configuring workflow transition
(edge) properties when selected. Panel shows read-only from/to step names,
a condition type selector (always/human/condition), an expression input that
appears only for the 'condition' type, and a delete transition button.

15 unit tests cover all acceptance criteria: from/to name display, condition
type selector, expression input visibility per type, onUpdateCondition/onDelete/
onClose callback behaviour, and expression preservation on type switch.
