### PR TITLE
feat: serialize visual state to SpaceWorkflow data model (Task 5.2)

### DIFF
--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -3,12 +3,12 @@
  *
  * Coverage:
  * - workflowToVisualState: position restoration from layout, auto-layout fallback,
- *   edge mapping, startStepId pass-through
+ *   edge mapping, startStepId pass-through, WorkflowCondition field preservation
  * - visualStateToCreateParams / visualStateToUpdateParams: round-trip, transition
- *   ordering, layout output, rules remapping
+ *   ordering, layout output, rules remapping, dangling edge handling
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	workflowToVisualState,
 	visualStateToCreateParams,
@@ -28,6 +28,10 @@ beforeEach(() => {
 		uuidCounter++;
 		return `test-uuid-${uuidCounter}` as ReturnType<typeof crypto.randomUUID>;
 	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -129,6 +133,20 @@ describe('workflowToVisualState', () => {
 		expect(state.nodes.find((n) => n.step.id === 's2')?.position).toEqual({ x: 350, y: 200 });
 	});
 
+	it('does not invoke autoLayout when all steps have stored positions', () => {
+		// This is validated by ensuring position values match the layout exactly.
+		// If autoLayout ran, it would produce different values (50, 50) not (999, 888).
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+			layout: { s1: { x: 999, y: 888 }, s2: { x: 777, y: 666 } },
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.nodes.find((n) => n.step.id === 's1')?.position).toEqual({ x: 999, y: 888 });
+		expect(state.nodes.find((n) => n.step.id === 's2')?.position).toEqual({ x: 777, y: 666 });
+	});
+
 	it('uses autoLayout when no layout is provided', () => {
 		const wf = makeWorkflow({
 			steps: [makeStep('s1'), makeStep('s2')],
@@ -136,13 +154,13 @@ describe('workflowToVisualState', () => {
 			startStepId: 's1',
 		});
 		const state = workflowToVisualState(wf);
-		// Positions should be non-zero values from autoLayout
+		// In a linear chain, s2 should be in a lower layer (higher y)
 		const s1 = state.nodes.find((n) => n.step.id === 's1')!;
 		const s2 = state.nodes.find((n) => n.step.id === 's2')!;
-		expect(s1.position.y).toBeLessThan(s2.position.y); // s2 is below s1 in a linear chain
+		expect(s1.position.y).toBeLessThan(s2.position.y);
 	});
 
-	it('uses autoLayout for steps missing from partial layout', () => {
+	it('uses autoLayout only for steps missing from partial layout', () => {
 		const wf = makeWorkflow({
 			steps: [makeStep('s1'), makeStep('s2')],
 			transitions: [makeTransition('s1', 's2')],
@@ -150,12 +168,35 @@ describe('workflowToVisualState', () => {
 			layout: { s1: { x: 999, y: 888 } }, // s2 not in layout
 		});
 		const state = workflowToVisualState(wf);
-		const s1 = state.nodes.find((n) => n.step.id === 's1')!;
-		const s2 = state.nodes.find((n) => n.step.id === 's2')!;
 		// s1 uses stored position
-		expect(s1.position).toEqual({ x: 999, y: 888 });
+		expect(state.nodes.find((n) => n.step.id === 's1')?.position).toEqual({ x: 999, y: 888 });
 		// s2 falls back to autoLayout (non-zero from algorithm)
-		expect(s2.position).toBeDefined();
+		const s2 = state.nodes.find((n) => n.step.id === 's2');
+		expect(s2?.position).toBeDefined();
+	});
+
+	it('preserves full WorkflowCondition fields (description, maxRetries, timeoutMs)', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [
+				makeTransition('s1', 's2', 't1', 0, {
+					type: 'condition',
+					expression: 'exit 0',
+					description: 'Check output file',
+					maxRetries: 3,
+					timeoutMs: 5000,
+				}),
+			],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.edges[0].condition).toEqual({
+			type: 'condition',
+			expression: 'exit 0',
+			description: 'Check output file',
+			maxRetries: 3,
+			timeoutMs: 5000,
+		});
 	});
 
 	it('maps condition types correctly', () => {
@@ -168,18 +209,18 @@ describe('workflowToVisualState', () => {
 			startStepId: 's1',
 		});
 		const state = workflowToVisualState(wf);
-		expect(state.edges[0].condition).toEqual({ type: 'human' });
-		expect(state.edges[1].condition).toEqual({ type: 'condition', expression: 'exit 0' });
+		expect(state.edges[0].condition).toMatchObject({ type: 'human' });
+		expect(state.edges[1].condition).toMatchObject({ type: 'condition', expression: 'exit 0' });
 	});
 
-	it('maps transitions without condition to always', () => {
+	it('maps transitions without condition to undefined (unconditional)', () => {
 		const wf = makeWorkflow({
 			steps: [makeStep('s1'), makeStep('s2')],
 			transitions: [makeTransition('s1', 's2')],
 			startStepId: 's1',
 		});
 		const state = workflowToVisualState(wf);
-		expect(state.edges[0].condition).toEqual({ type: 'always' });
+		expect(state.edges[0].condition).toBeUndefined();
 	});
 
 	it('converts rules to drafts', () => {
@@ -246,7 +287,7 @@ describe('visualStateToCreateParams', () => {
 				{
 					fromStepKey: 's1',
 					toStepKey: 's2',
-					condition: { type: 'always' },
+					condition: undefined,
 				},
 			],
 			startStepId: 's1',
@@ -279,7 +320,7 @@ describe('visualStateToCreateParams', () => {
 		expect(params.transitions![0]).toMatchObject({ from: 's1', to: 's2', order: 0 });
 	});
 
-	it('omits condition when type is always', () => {
+	it('omits condition when undefined (unconditional transition)', () => {
 		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
 		expect(params.transitions![0].condition).toBeUndefined();
 	});
@@ -292,8 +333,42 @@ describe('visualStateToCreateParams', () => {
 		expect(params.transitions![0].condition).toMatchObject({ type: 'human' });
 	});
 
+	it('preserves full condition fields (description, maxRetries, timeoutMs)', () => {
+		const state = makeState({
+			edges: [
+				{
+					fromStepKey: 's1',
+					toStepKey: 's2',
+					condition: {
+						type: 'condition',
+						expression: 'exit 0',
+						description: 'Check',
+						maxRetries: 2,
+						timeoutMs: 3000,
+					},
+				},
+			],
+		});
+		const params = visualStateToCreateParams(state, 'space-1', 'My Workflow');
+		expect(params.transitions![0].condition).toEqual({
+			type: 'condition',
+			expression: 'exit 0',
+			description: 'Check',
+			maxRetries: 2,
+			timeoutMs: 3000,
+		});
+	});
+
 	it('passes startStepId through', () => {
 		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.startStepId).toBe('s1');
+	});
+
+	it('resolves startStepId via localId when it references step.localId', () => {
+		// startStepId is set to the localId of an existing step (step.id='s1', localId='local-1')
+		const state = makeState({ startStepId: 'local-1' });
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		// Should resolve to the persisted step id 's1'
 		expect(params.startStepId).toBe('s1');
 	});
 
@@ -335,6 +410,18 @@ describe('visualStateToCreateParams', () => {
 		expect(params.rules![0].name).toBe('My Rule');
 	});
 
+	it('silently drops blank rules (both name and content empty)', () => {
+		const state = makeState({
+			rules: [
+				{ localId: 'lr1', name: '', content: '', appliesTo: [] },
+				{ localId: 'lr2', name: 'Real Rule', content: 'Content', appliesTo: [] },
+			],
+		});
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.rules).toHaveLength(1);
+		expect(params.rules![0].name).toBe('Real Rule');
+	});
+
 	it('generates a new UUID for steps without id', () => {
 		const state: VisualEditorState = {
 			nodes: [
@@ -351,6 +438,70 @@ describe('visualStateToCreateParams', () => {
 		const params = visualStateToCreateParams(state, 'space-1', 'WF');
 		expect(params.steps![0].id).toBeTruthy();
 		expect(params.startStepId).toBe(params.steps![0].id);
+	});
+
+	it('handles zero nodes gracefully', () => {
+		const state: VisualEditorState = {
+			nodes: [],
+			edges: [],
+			startStepId: '',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.steps).toHaveLength(0);
+		expect(params.transitions).toHaveLength(0);
+		expect(params.startStepId).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Dangling edge handling
+// ---------------------------------------------------------------------------
+
+describe('dangling edge handling', () => {
+	it('drops edges whose fromStepKey does not resolve to a known node', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+				{
+					step: { localId: 'l2', id: 's2', name: 'S2', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 150 },
+				},
+			],
+			edges: [
+				// Valid edge
+				{ fromStepKey: 's1', toStepKey: 's2', condition: undefined },
+				// Dangling: 'deleted-node' not in nodes
+				{ fromStepKey: 'deleted-node', toStepKey: 's2', condition: undefined },
+			],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.transitions).toHaveLength(1);
+		expect(params.transitions![0]).toMatchObject({ from: 's1', to: 's2' });
+	});
+
+	it('drops edges whose toStepKey does not resolve to a known node', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [{ fromStepKey: 's1', toStepKey: 'deleted-target', condition: undefined }],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.transitions).toHaveLength(0);
 	});
 });
 
@@ -378,8 +529,8 @@ describe('transition ordering', () => {
 				},
 			],
 			edges: [
-				{ fromStepKey: 's1', toStepKey: 's2', condition: { type: 'always' } },
-				{ fromStepKey: 's1', toStepKey: 's3', condition: { type: 'always' } },
+				{ fromStepKey: 's1', toStepKey: 's2', condition: undefined },
+				{ fromStepKey: 's1', toStepKey: 's3', condition: undefined },
 			],
 			startStepId: 's1',
 			rules: [],
@@ -411,7 +562,7 @@ describe('transition ordering', () => {
 					position: { x: 250, y: 150 },
 				},
 			],
-			edges: [{ fromStepKey: 's1', toStepKey: 's2', condition: { type: 'always' } }],
+			edges: [{ fromStepKey: 's1', toStepKey: 's2', condition: undefined }],
 			startStepId: 's1',
 			rules: [],
 			tags: [],
@@ -467,21 +618,27 @@ describe('round-trip serialization', () => {
 		});
 	});
 
-	it('preserves transition conditions after round-trip', () => {
+	it('preserves full WorkflowCondition fields after round-trip', () => {
 		const original = makeWorkflow({
 			steps: [makeStep('s1'), makeStep('s2')],
 			transitions: [
 				makeTransition('s1', 's2', 't1', 0, {
 					type: 'condition',
 					expression: 'test -f output.txt',
+					description: 'Verify output',
+					maxRetries: 2,
+					timeoutMs: 10000,
 				}),
 			],
 			startStepId: 's1',
 		});
 		const params = visualStateToUpdateParams(workflowToVisualState(original));
-		expect(params.transitions![0].condition).toMatchObject({
+		expect(params.transitions![0].condition).toEqual({
 			type: 'condition',
 			expression: 'test -f output.txt',
+			description: 'Verify output',
+			maxRetries: 2,
+			timeoutMs: 10000,
 		});
 	});
 
@@ -511,6 +668,16 @@ describe('round-trip serialization', () => {
 			content: 'No secrets in output',
 		});
 		expect(params.rules![0].appliesTo).toContain('s1');
+	});
+
+	it('unconditional transitions round-trip with undefined condition', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2', 't1', 0)], // no condition
+			startStepId: 's1',
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.transitions![0].condition).toBeUndefined();
 	});
 
 	it('is lossless for a 3-step workflow with all features', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Unit tests for visual editor serialization helpers.
+ *
+ * Coverage:
+ * - workflowToVisualState: position restoration from layout, auto-layout fallback,
+ *   edge mapping, startStepId pass-through
+ * - visualStateToCreateParams / visualStateToUpdateParams: round-trip, transition
+ *   ordering, layout output, rules remapping
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	workflowToVisualState,
+	visualStateToCreateParams,
+	visualStateToUpdateParams,
+} from '../serialization.ts';
+import type { VisualEditorState } from '../serialization.ts';
+import type { SpaceWorkflow, WorkflowStep, WorkflowTransition, WorkflowRule } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Stable UUID counter so tests are deterministic
+// ---------------------------------------------------------------------------
+
+let uuidCounter = 0;
+beforeEach(() => {
+	uuidCounter = 0;
+	vi.spyOn(crypto, 'randomUUID').mockImplementation(() => {
+		uuidCounter++;
+		return `test-uuid-${uuidCounter}` as ReturnType<typeof crypto.randomUUID>;
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeStep(id: string, name?: string, agentId?: string): WorkflowStep {
+	return { id, name: name ?? id, agentId: agentId ?? 'agent-1' };
+}
+
+function makeTransition(
+	from: string,
+	to: string,
+	id?: string,
+	order?: number,
+	condition?: WorkflowTransition['condition']
+): WorkflowTransition {
+	return { id: id ?? `${from}->${to}`, from, to, order, condition };
+}
+
+function makeRule(id: string, name: string, content: string, appliesTo?: string[]): WorkflowRule {
+	return { id, name, content, appliesTo };
+}
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'Test Workflow',
+		steps: [],
+		transitions: [],
+		startStepId: '',
+		rules: [],
+		tags: [],
+		createdAt: 0,
+		updatedAt: 0,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// workflowToVisualState
+// ---------------------------------------------------------------------------
+
+describe('workflowToVisualState', () => {
+	it('creates one node per step', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.nodes).toHaveLength(2);
+		expect(state.nodes[0].step.id).toBe('s1');
+		expect(state.nodes[1].step.id).toBe('s2');
+	});
+
+	it('creates one edge per transition', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2'), makeStep('s3')],
+			transitions: [makeTransition('s1', 's2'), makeTransition('s2', 's3')],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.edges).toHaveLength(2);
+		expect(state.edges[0]).toMatchObject({ fromStepKey: 's1', toStepKey: 's2' });
+		expect(state.edges[1]).toMatchObject({ fromStepKey: 's2', toStepKey: 's3' });
+	});
+
+	it('passes startStepId through unchanged', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's2',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.startStepId).toBe('s2');
+	});
+
+	it('falls back to first step when startStepId does not match any step', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1')],
+			transitions: [],
+			startStepId: 'nonexistent',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.startStepId).toBe('s1');
+	});
+
+	it('restores positions from workflow.layout', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+			layout: { s1: { x: 100, y: 200 }, s2: { x: 350, y: 200 } },
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.nodes.find((n) => n.step.id === 's1')?.position).toEqual({ x: 100, y: 200 });
+		expect(state.nodes.find((n) => n.step.id === 's2')?.position).toEqual({ x: 350, y: 200 });
+	});
+
+	it('uses autoLayout when no layout is provided', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		// Positions should be non-zero values from autoLayout
+		const s1 = state.nodes.find((n) => n.step.id === 's1')!;
+		const s2 = state.nodes.find((n) => n.step.id === 's2')!;
+		expect(s1.position.y).toBeLessThan(s2.position.y); // s2 is below s1 in a linear chain
+	});
+
+	it('uses autoLayout for steps missing from partial layout', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+			layout: { s1: { x: 999, y: 888 } }, // s2 not in layout
+		});
+		const state = workflowToVisualState(wf);
+		const s1 = state.nodes.find((n) => n.step.id === 's1')!;
+		const s2 = state.nodes.find((n) => n.step.id === 's2')!;
+		// s1 uses stored position
+		expect(s1.position).toEqual({ x: 999, y: 888 });
+		// s2 falls back to autoLayout (non-zero from algorithm)
+		expect(s2.position).toBeDefined();
+	});
+
+	it('maps condition types correctly', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2'), makeStep('s3')],
+			transitions: [
+				makeTransition('s1', 's2', 't1', 0, { type: 'human' }),
+				makeTransition('s2', 's3', 't2', 1, { type: 'condition', expression: 'exit 0' }),
+			],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.edges[0].condition).toEqual({ type: 'human' });
+		expect(state.edges[1].condition).toEqual({ type: 'condition', expression: 'exit 0' });
+	});
+
+	it('maps transitions without condition to always', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.edges[0].condition).toEqual({ type: 'always' });
+	});
+
+	it('converts rules to drafts', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1')],
+			transitions: [],
+			startStepId: 's1',
+			rules: [makeRule('r1', 'Rule 1', 'Content 1', ['s1'])],
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.rules).toHaveLength(1);
+		expect(state.rules[0].id).toBe('r1');
+		expect(state.rules[0].name).toBe('Rule 1');
+		expect(state.rules[0].appliesTo).toContain('s1');
+	});
+
+	it('passes tags through', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1')],
+			transitions: [],
+			startStepId: 's1',
+			tags: ['coding', 'review'],
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.tags).toEqual(['coding', 'review']);
+	});
+
+	it('assigns fresh localIds to each node', () => {
+		const wf = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [],
+			startStepId: 's1',
+		});
+		const state = workflowToVisualState(wf);
+		const localIds = state.nodes.map((n) => n.step.localId);
+		expect(new Set(localIds).size).toBe(2); // all unique
+	});
+});
+
+// ---------------------------------------------------------------------------
+// visualStateToCreateParams
+// ---------------------------------------------------------------------------
+
+describe('visualStateToCreateParams', () => {
+	function makeState(overrides: Partial<VisualEditorState> = {}): VisualEditorState {
+		return {
+			nodes: [
+				{
+					step: { localId: 'local-1', id: 's1', name: 'Step 1', agentId: 'a1', instructions: '' },
+					position: { x: 50, y: 50 },
+				},
+				{
+					step: {
+						localId: 'local-2',
+						id: 's2',
+						name: 'Step 2',
+						agentId: 'a2',
+						instructions: 'do work',
+					},
+					position: { x: 300, y: 50 },
+				},
+			],
+			edges: [
+				{
+					fromStepKey: 's1',
+					toStepKey: 's2',
+					condition: { type: 'always' },
+				},
+			],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+			...overrides,
+		};
+	}
+
+	it('produces correct steps array', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.steps).toHaveLength(2);
+		expect(params.steps![0]).toMatchObject({ id: 's1', name: 'Step 1', agentId: 'a1' });
+		expect(params.steps![1]).toMatchObject({
+			id: 's2',
+			name: 'Step 2',
+			agentId: 'a2',
+			instructions: 'do work',
+		});
+	});
+
+	it('omits empty instructions', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.steps![0].instructions).toBeUndefined();
+	});
+
+	it('produces correct transitions array', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.transitions).toHaveLength(1);
+		expect(params.transitions![0]).toMatchObject({ from: 's1', to: 's2', order: 0 });
+	});
+
+	it('omits condition when type is always', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.transitions![0].condition).toBeUndefined();
+	});
+
+	it('includes condition when type is not always', () => {
+		const state = makeState({
+			edges: [{ fromStepKey: 's1', toStepKey: 's2', condition: { type: 'human' } }],
+		});
+		const params = visualStateToCreateParams(state, 'space-1', 'My Workflow');
+		expect(params.transitions![0].condition).toMatchObject({ type: 'human' });
+	});
+
+	it('passes startStepId through', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.startStepId).toBe('s1');
+	});
+
+	it('builds layout from node positions', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-1', 'My Workflow');
+		expect(params.layout).toMatchObject({
+			s1: { x: 50, y: 50 },
+			s2: { x: 300, y: 50 },
+		});
+	});
+
+	it('passes spaceId, name, description', () => {
+		const params = visualStateToCreateParams(makeState(), 'space-42', 'Cool WF', 'A description');
+		expect(params.spaceId).toBe('space-42');
+		expect(params.name).toBe('Cool WF');
+		expect(params.description).toBe('A description');
+	});
+
+	it('includes tags', () => {
+		const params = visualStateToCreateParams(makeState({ tags: ['coding'] }), 'space-1', 'WF');
+		expect(params.tags).toEqual(['coding']);
+	});
+
+	it('includes rules without id field', () => {
+		const state = makeState({
+			rules: [
+				{
+					localId: 'lr1',
+					id: undefined,
+					name: 'My Rule',
+					content: 'Content',
+					appliesTo: ['s1'],
+				},
+			],
+		});
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.rules).toHaveLength(1);
+		expect(params.rules![0]).not.toHaveProperty('id');
+		expect(params.rules![0].name).toBe('My Rule');
+	});
+
+	it('generates a new UUID for steps without id', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'local-new', name: 'New Step', agentId: 'a1', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startStepId: 'local-new',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.steps![0].id).toBeTruthy();
+		expect(params.startStepId).toBe(params.steps![0].id);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Transition order: left-to-right by target x-position
+// ---------------------------------------------------------------------------
+
+describe('transition ordering', () => {
+	it('orders multiple outgoing transitions by target x-position', () => {
+		// Source node s1 has two outgoing edges: to s2 (x=400) and s3 (x=100)
+		// s3 is to the LEFT of s2 so should get order=0
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 200, y: 0 },
+				},
+				{
+					step: { localId: 'l2', id: 's2', name: 'S2', agentId: 'a', instructions: '' },
+					position: { x: 400, y: 150 },
+				},
+				{
+					step: { localId: 'l3', id: 's3', name: 'S3', agentId: 'a', instructions: '' },
+					position: { x: 100, y: 150 },
+				},
+			],
+			edges: [
+				{ fromStepKey: 's1', toStepKey: 's2', condition: { type: 'always' } },
+				{ fromStepKey: 's1', toStepKey: 's3', condition: { type: 'always' } },
+			],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		const t = params.transitions!;
+		// Find transitions from s1
+		const fromS1 = t
+			.filter((tr) => tr.from === 's1')
+			.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+		expect(fromS1).toHaveLength(2);
+		// order=0 should go to s3 (leftmost), order=1 to s2
+		expect(fromS1[0].to).toBe('s3');
+		expect(fromS1[0].order).toBe(0);
+		expect(fromS1[1].to).toBe('s2');
+		expect(fromS1[1].order).toBe(1);
+	});
+
+	it('preserves single outgoing edge with order=0', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+				{
+					step: { localId: 'l2', id: 's2', name: 'S2', agentId: 'a', instructions: '' },
+					position: { x: 250, y: 150 },
+				},
+			],
+			edges: [{ fromStepKey: 's1', toStepKey: 's2', condition: { type: 'always' } }],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.transitions![0].order).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: workflowToVisualState -> visualStateToUpdateParams
+// ---------------------------------------------------------------------------
+
+describe('round-trip serialization', () => {
+	it('produces equivalent steps after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1', 'Plan', 'agent-p'), makeStep('s2', 'Code', 'agent-c')],
+			transitions: [makeTransition('s1', 's2', 't1', 0)],
+			startStepId: 's1',
+			layout: { s1: { x: 50, y: 50 }, s2: { x: 50, y: 200 } },
+			tags: ['coding'],
+		});
+
+		const visualState = workflowToVisualState(original);
+		const params = visualStateToUpdateParams(visualState);
+
+		expect(params.steps).toHaveLength(2);
+		expect(params.steps![0]).toMatchObject({ id: 's1', name: 'Plan', agentId: 'agent-p' });
+		expect(params.steps![1]).toMatchObject({ id: 's2', name: 'Code', agentId: 'agent-c' });
+	});
+
+	it('preserves startStepId after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's2',
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.startStepId).toBe('s2');
+	});
+
+	it('preserves layout positions after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+			layout: { s1: { x: 111, y: 222 }, s2: { x: 333, y: 444 } },
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.layout).toMatchObject({
+			s1: { x: 111, y: 222 },
+			s2: { x: 333, y: 444 },
+		});
+	});
+
+	it('preserves transition conditions after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [
+				makeTransition('s1', 's2', 't1', 0, {
+					type: 'condition',
+					expression: 'test -f output.txt',
+				}),
+			],
+			startStepId: 's1',
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.transitions![0].condition).toMatchObject({
+			type: 'condition',
+			expression: 'test -f output.txt',
+		});
+	});
+
+	it('preserves tags after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1')],
+			transitions: [],
+			startStepId: 's1',
+			tags: ['research', 'review'],
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.tags).toEqual(['research', 'review']);
+	});
+
+	it('preserves rules after round-trip', () => {
+		const original = makeWorkflow({
+			steps: [makeStep('s1'), makeStep('s2')],
+			transitions: [makeTransition('s1', 's2')],
+			startStepId: 's1',
+			rules: [makeRule('r1', 'Security Rule', 'No secrets in output', ['s1'])],
+		});
+		const params = visualStateToUpdateParams(workflowToVisualState(original));
+		expect(params.rules).toHaveLength(1);
+		expect(params.rules![0]).toMatchObject({
+			id: 'r1',
+			name: 'Security Rule',
+			content: 'No secrets in output',
+		});
+		expect(params.rules![0].appliesTo).toContain('s1');
+	});
+
+	it('is lossless for a 3-step workflow with all features', () => {
+		const original = makeWorkflow({
+			steps: [
+				makeStep('s1', 'Plan', 'agent-p'),
+				makeStep('s2', 'Code', 'agent-c'),
+				makeStep('s3', 'Review', 'agent-r'),
+			],
+			transitions: [
+				makeTransition('s1', 's2', 't1', 0, { type: 'human' }),
+				makeTransition('s2', 's3', 't2', 0),
+			],
+			startStepId: 's1',
+			layout: { s1: { x: 50, y: 50 }, s2: { x: 50, y: 200 }, s3: { x: 50, y: 350 } },
+			tags: ['coding'],
+			rules: [makeRule('r1', 'R1', 'Content', ['s1', 's2'])],
+		});
+
+		const visualState = workflowToVisualState(original);
+		const params = visualStateToUpdateParams(visualState);
+
+		// Steps
+		expect(params.steps).toHaveLength(3);
+		const stepIds = params.steps!.map((s) => s.id);
+		expect(stepIds).toContain('s1');
+		expect(stepIds).toContain('s2');
+		expect(stepIds).toContain('s3');
+
+		// Transitions
+		expect(params.transitions).toHaveLength(2);
+		const t1 = params.transitions!.find((t) => t.from === 's1' && t.to === 's2')!;
+		expect(t1.condition).toMatchObject({ type: 'human' });
+		const t2 = params.transitions!.find((t) => t.from === 's2' && t.to === 's3')!;
+		expect(t2.condition).toBeUndefined();
+
+		// startStepId
+		expect(params.startStepId).toBe('s1');
+
+		// Layout
+		expect(params.layout).toMatchObject({
+			s1: { x: 50, y: 50 },
+			s2: { x: 50, y: 200 },
+			s3: { x: 50, y: 350 },
+		});
+
+		// Tags
+		expect(params.tags).toEqual(['coding']);
+
+		// Rules
+		expect(params.rules![0]).toMatchObject({ id: 'r1', name: 'R1', content: 'Content' });
+		expect(params.rules![0].appliesTo).toContain('s1');
+		expect(params.rules![0].appliesTo).toContain('s2');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// visualStateToUpdateParams specifics
+// ---------------------------------------------------------------------------
+
+describe('visualStateToUpdateParams', () => {
+	it('applies name/description overrides', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToUpdateParams(state, {
+			name: 'Updated Name',
+			description: 'New desc',
+		});
+		expect(params.name).toBe('Updated Name');
+		expect(params.description).toBe('New desc');
+	});
+
+	it('rules include generated IDs for new rules', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a', instructions: '' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startStepId: 's1',
+			rules: [
+				{ localId: 'lr1', id: undefined, name: 'New Rule', content: 'Content', appliesTo: [] },
+			],
+			tags: [],
+		};
+		const params = visualStateToUpdateParams(state);
+		expect(params.rules![0].id).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/index.ts
+++ b/packages/web/src/components/space/visual-editor/index.ts
@@ -1,4 +1,10 @@
 export { VisualCanvas, applyWheelEvent, MIN_SCALE, MAX_SCALE } from './VisualCanvas';
+export {
+	workflowToVisualState,
+	visualStateToCreateParams,
+	visualStateToUpdateParams,
+} from './serialization';
+export type { VisualNode, VisualEdge, VisualEditorState } from './serialization';
 export { CanvasToolbar, computeFitToView, ZOOM_STEP, FIT_PADDING } from './CanvasToolbar';
 export type { ViewportState, Point, Size, NodePosition } from './types';
 export { screenToCanvas, canvasToScreen } from './types';

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -9,16 +9,30 @@
  * - Transition `order` is computed from the left-to-right x-position of the
  *   target node among all outgoing edges of a given source node.
  * - When `workflow.layout` is present, stored positions are restored exactly.
- *   When absent, `autoLayout` is called to compute initial positions.
+ *   When absent (or only partially populated), `autoLayout` fills in missing positions.
+ * - `WorkflowCondition` is stored verbatim on `VisualEdge` (including `description`,
+ *   `maxRetries`, `timeoutMs`). Fields that the visual editor UI does not expose are
+ *   preserved through load/save so they are not silently stripped.
+ * - `WorkflowTransition.id` is intentionally not stored on `VisualEdge`. The update
+ *   API uses `WorkflowTransitionInput` (which omits `id`) and replaces the entire
+ *   transition list, so per-transition IDs are backend-assigned on every save.
+ *   If the backend API ever changes to patch individual transitions by ID, this
+ *   code will need to be revisited.
+ * - Blank rules (name and content both empty/whitespace) are silently filtered out
+ *   before submission, matching the behaviour of `WorkflowEditor.tsx`.
+ * - New steps (no `step.id`) receive a generated UUID inside `buildWorkflowFields`.
+ *   This UUID is stable within a single call but differs across calls — callers must
+ *   not invoke `visualStateToCreateParams` / `visualStateToUpdateParams` twice on the
+ *   same state and expect the generated IDs to match.
  */
 
 import type {
 	SpaceWorkflow,
 	CreateSpaceWorkflowParams,
 	UpdateSpaceWorkflowParams,
-	WorkflowConditionType,
+	WorkflowCondition,
 } from '@neokai/shared';
-import type { StepDraft, ConditionDraft } from '../WorkflowStepCard';
+import type { StepDraft } from '../WorkflowStepCard';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import { rulesToDrafts } from '../WorkflowRulesEditor';
 import type { Point } from './types';
@@ -40,14 +54,21 @@ export interface VisualNode {
 
 /**
  * A directed edge between two nodes in the visual editor.
+ *
  * `fromStepKey` and `toStepKey` are the stable step identifiers used
  * for serialization: `step.id` when the step already exists in the backend,
  * or `step.localId` for brand-new steps.
+ *
+ * `condition` stores the full `WorkflowCondition` from the backend (including
+ * `description`, `maxRetries`, `timeoutMs`), or undefined for unconditional
+ * (always-fire) transitions. This avoids silent data loss when the UI edits a
+ * transition that already has backend-only fields set.
  */
 export interface VisualEdge {
 	fromStepKey: string;
 	toStepKey: string;
-	condition: ConditionDraft;
+	/** Full backend condition — undefined means unconditional ("always"). */
+	condition: WorkflowCondition | undefined;
 }
 
 /**
@@ -72,17 +93,25 @@ export interface VisualEditorState {
 /**
  * Convert a SpaceWorkflow to a VisualEditorState.
  *
- * - If `workflow.layout` is present, node positions are restored from it.
- * - If `workflow.layout` is absent (or missing entries), `autoLayout` fills in positions.
+ * - If `workflow.layout` is present and covers all steps, positions are restored
+ *   exactly from the stored layout. Steps missing from a partial layout fall back
+ *   to `autoLayout` positions (autoLayout is only invoked when needed).
+ * - All `WorkflowCondition` fields are preserved verbatim on the edges.
  */
 export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorState {
-	// Compute auto-layout positions as fallback
-	const layoutFallback = autoLayout(workflow.steps, workflow.transitions, workflow.startStepId);
+	// Determine whether auto-layout is needed (any step missing from layout)
+	const layoutMap = workflow.layout;
+	const needsAutoLayout = !layoutMap || workflow.steps.some((s) => !layoutMap[s.id]);
+
+	// Lazily compute auto-layout only when at least one step lacks a stored position
+	const layoutFallback = needsAutoLayout
+		? autoLayout(workflow.steps, workflow.transitions, workflow.startStepId)
+		: new Map<string, Point>();
 
 	const nodes: VisualNode[] = workflow.steps.map((s) => {
 		let position: Point;
-		if (workflow.layout && workflow.layout[s.id]) {
-			position = { x: workflow.layout[s.id].x, y: workflow.layout[s.id].y };
+		if (layoutMap && layoutMap[s.id]) {
+			position = { x: layoutMap[s.id].x, y: layoutMap[s.id].y };
 		} else {
 			position = layoutFallback.get(s.id) ?? { x: 0, y: 0 };
 		}
@@ -96,17 +125,15 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		return { step, position };
 	});
 
+	// Preserve the full WorkflowCondition (all fields) to avoid silent data loss
 	const edges: VisualEdge[] = workflow.transitions.map((t) => ({
 		fromStepKey: t.from,
 		toStepKey: t.to,
-		condition: t.condition
-			? { type: t.condition.type, expression: t.condition.expression }
-			: { type: 'always' },
+		condition: t.condition ? { ...t.condition } : undefined,
 	}));
 
-	// startStepId: use the step.id directly (matches the edge keys)
-	// If the startStepId refers to a step that doesn't exist, fall back to the
-	// first step's key.
+	// startStepId: use the step.id directly (matches the edge keys).
+	// Fall back to the first step's id if the workflow's startStepId is missing.
 	const startKey =
 		workflow.steps.find((s) => s.id === workflow.startStepId)?.id ?? workflow.steps[0]?.id ?? '';
 
@@ -125,15 +152,13 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 
 /**
  * Shared structure returned by both create and update serialisation.
- * This is the same shape, just with different required/optional fields
- * depending on which API is being called.
  */
 interface BuiltWorkflowFields {
 	steps: Array<{ id: string; name: string; agentId: string; instructions?: string }>;
 	transitions: Array<{
 		from: string;
 		to: string;
-		condition?: { type: WorkflowConditionType; expression?: string };
+		condition?: WorkflowCondition;
 		order: number;
 	}>;
 	startStepId: string;
@@ -143,13 +168,13 @@ interface BuiltWorkflowFields {
 }
 
 /**
- * Resolve the stable persisted step ID for a given step key.
+ * Resolve the stable persisted step ID for a given node.
  * If the node has a persisted `step.id`, that is used directly.
- * Otherwise a new UUID is generated (for brand-new steps).
+ * Otherwise a new UUID is generated once and cached in `generatedIds`.
  */
 function resolveStepId(node: VisualNode, generatedIds: Map<string, string>): string {
-	const key = node.step.id ?? node.step.localId;
 	if (node.step.id) return node.step.id;
+	const key = node.step.localId;
 	if (!generatedIds.has(key)) {
 		generatedIds.set(key, crypto.randomUUID());
 	}
@@ -159,6 +184,10 @@ function resolveStepId(node: VisualNode, generatedIds: Map<string, string>): str
 /**
  * Build the serialized workflow fields from a VisualEditorState.
  * Shared between create and update serialisation.
+ *
+ * Blank rules (both name and content empty/whitespace) are silently filtered out
+ * before submission, matching the behaviour of `WorkflowEditor.tsx`. Callers
+ * should be aware that `fields.rules.length` may be less than `state.rules.length`.
  */
 function buildWorkflowFields(state: VisualEditorState): {
 	fields: BuiltWorkflowFields;
@@ -175,17 +204,18 @@ function buildWorkflowFields(state: VisualEditorState): {
 	}
 
 	// Also build a lookup by localId so startStepId can reference either key style
+	// (e.g. when startStepId was set to step.localId rather than step.id).
 	const localIdMap = new Map<string, { node: VisualNode; persistedId: string }>();
 	for (const [, entry] of nodeMap) {
 		localIdMap.set(entry.node.step.localId, entry);
 	}
 
-	// Build key -> persisted ID map for rules' appliesTo remapping
+	// Build key -> persisted ID map for transition and rule appliesTo remapping
 	const keyToPersistedId = new Map<string, string>();
 	for (const [key, { persistedId }] of nodeMap) {
 		keyToPersistedId.set(key, persistedId);
 	}
-	// Also map localId -> persistedId
+	// Also map localId -> persistedId (covers startStepId and appliesTo references)
 	for (const [, entry] of nodeMap) {
 		keyToPersistedId.set(entry.node.step.localId, entry.persistedId);
 	}
@@ -217,11 +247,14 @@ function buildWorkflowFields(state: VisualEditorState): {
 		outgoingBySource.set(edge.fromStepKey, list);
 	}
 
-	// Build transitions with computed order (left-to-right by target x-position)
+	// Build transitions with computed order (left-to-right by target x-position).
+	// Edges whose fromStepKey or toStepKey does not resolve to a known node are
+	// silently dropped — this is the correct behaviour when a node has been deleted
+	// while an edge still references it.
 	const transitions: BuiltWorkflowFields['transitions'] = [];
 	for (const [sourceKey, edgeGroup] of outgoingBySource) {
 		const fromId = keyToPersistedId.get(sourceKey);
-		if (!fromId) continue;
+		if (!fromId) continue; // dangling source — drop
 
 		// Sort by target node x-position (ascending = left-to-right)
 		const sorted = [...edgeGroup].sort((a, b) => {
@@ -233,15 +266,14 @@ function buildWorkflowFields(state: VisualEditorState): {
 		for (let i = 0; i < sorted.length; i++) {
 			const edge = sorted[i];
 			const toId = keyToPersistedId.get(edge.toStepKey);
-			if (!toId) continue;
+			if (!toId) continue; // dangling target — drop
 
 			transitions.push({
 				from: fromId,
 				to: toId,
-				condition:
-					edge.condition.type === 'always'
-						? undefined
-						: { type: edge.condition.type, expression: edge.condition.expression },
+				// Preserve full WorkflowCondition (including backend-only fields).
+				// undefined condition means unconditional ("always").
+				condition: edge.condition ? { ...edge.condition } : undefined,
 				order: i,
 			});
 		}
@@ -255,7 +287,7 @@ function buildWorkflowFields(state: VisualEditorState): {
 		layout[persistedId] = { x: node.position.x, y: node.position.y };
 	}
 
-	// Resolve startStepId
+	// Resolve startStepId — prefer exact key match, then localId match, then first node
 	const startEntry =
 		nodeMap.get(state.startStepId) ??
 		localIdMap.get(state.startStepId) ??
@@ -267,7 +299,7 @@ function buildWorkflowFields(state: VisualEditorState): {
 			: null);
 	const startStepId = startEntry?.persistedId ?? '';
 
-	// Build rules
+	// Build rules — blank rules (both name and content empty/whitespace) are filtered out
 	const rules = state.rules
 		.filter((r) => r.name.trim() || r.content.trim())
 		.map((r) => ({
@@ -306,6 +338,7 @@ export function visualStateToCreateParams(
 		steps: fields.steps,
 		transitions: fields.transitions,
 		startStepId: fields.startStepId || undefined,
+		// WorkflowRuleInput omits `id` — strip it from each rule
 		rules: fields.rules.map(({ id: _id, ...rest }) => rest),
 		layout: fields.layout,
 		tags: fields.tags,
@@ -329,6 +362,7 @@ export function visualStateToUpdateParams(
 		steps: fields.steps,
 		transitions: fields.transitions,
 		startStepId: fields.startStepId || null,
+		// WorkflowRule requires `id` — generate one for new rules that lack a persisted id
 		rules: fields.rules.map((r) => ({
 			id: r.id ?? crypto.randomUUID(),
 			name: r.name,

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -1,0 +1,341 @@
+/**
+ * Serialization helpers for converting between the visual editor's internal
+ * state and the SpaceWorkflow / CreateSpaceWorkflowParams / UpdateSpaceWorkflowParams
+ * data model used by the backend.
+ *
+ * Key design decisions:
+ * - `startStepId` is passed through from the editor state (explicitly set by the
+ *   user via "Set as Start"), never auto-detected from graph topology.
+ * - Transition `order` is computed from the left-to-right x-position of the
+ *   target node among all outgoing edges of a given source node.
+ * - When `workflow.layout` is present, stored positions are restored exactly.
+ *   When absent, `autoLayout` is called to compute initial positions.
+ */
+
+import type {
+	SpaceWorkflow,
+	CreateSpaceWorkflowParams,
+	UpdateSpaceWorkflowParams,
+	WorkflowConditionType,
+} from '@neokai/shared';
+import type { StepDraft, ConditionDraft } from '../WorkflowStepCard';
+import type { RuleDraft } from '../WorkflowRulesEditor';
+import { rulesToDrafts } from '../WorkflowRulesEditor';
+import type { Point } from './types';
+import { autoLayout } from './layout';
+
+// ============================================================================
+// Visual Editor State types
+// ============================================================================
+
+/**
+ * A single workflow node in the visual editor.
+ * `step.id` is the stable persisted step ID (present for existing steps).
+ * `step.localId` is used for React keying.
+ */
+export interface VisualNode {
+	step: StepDraft;
+	position: Point;
+}
+
+/**
+ * A directed edge between two nodes in the visual editor.
+ * `fromStepKey` and `toStepKey` are the stable step identifiers used
+ * for serialization: `step.id` when the step already exists in the backend,
+ * or `step.localId` for brand-new steps.
+ */
+export interface VisualEdge {
+	fromStepKey: string;
+	toStepKey: string;
+	condition: ConditionDraft;
+}
+
+/**
+ * Complete state of the visual workflow editor.
+ */
+export interface VisualEditorState {
+	nodes: VisualNode[];
+	edges: VisualEdge[];
+	/**
+	 * The step key (step.id for existing, step.localId for new) of the
+	 * start node. Managed explicitly by the user.
+	 */
+	startStepId: string;
+	rules: RuleDraft[];
+	tags: string[];
+}
+
+// ============================================================================
+// workflowToVisualState
+// ============================================================================
+
+/**
+ * Convert a SpaceWorkflow to a VisualEditorState.
+ *
+ * - If `workflow.layout` is present, node positions are restored from it.
+ * - If `workflow.layout` is absent (or missing entries), `autoLayout` fills in positions.
+ */
+export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorState {
+	// Compute auto-layout positions as fallback
+	const layoutFallback = autoLayout(workflow.steps, workflow.transitions, workflow.startStepId);
+
+	const nodes: VisualNode[] = workflow.steps.map((s) => {
+		let position: Point;
+		if (workflow.layout && workflow.layout[s.id]) {
+			position = { x: workflow.layout[s.id].x, y: workflow.layout[s.id].y };
+		} else {
+			position = layoutFallback.get(s.id) ?? { x: 0, y: 0 };
+		}
+		const step: StepDraft = {
+			localId: crypto.randomUUID(),
+			id: s.id,
+			name: s.name,
+			agentId: s.agentId,
+			instructions: s.instructions ?? '',
+		};
+		return { step, position };
+	});
+
+	const edges: VisualEdge[] = workflow.transitions.map((t) => ({
+		fromStepKey: t.from,
+		toStepKey: t.to,
+		condition: t.condition
+			? { type: t.condition.type, expression: t.condition.expression }
+			: { type: 'always' },
+	}));
+
+	// startStepId: use the step.id directly (matches the edge keys)
+	// If the startStepId refers to a step that doesn't exist, fall back to the
+	// first step's key.
+	const startKey =
+		workflow.steps.find((s) => s.id === workflow.startStepId)?.id ?? workflow.steps[0]?.id ?? '';
+
+	return {
+		nodes,
+		edges,
+		startStepId: startKey,
+		rules: rulesToDrafts(workflow.rules ?? []),
+		tags: workflow.tags ?? [],
+	};
+}
+
+// ============================================================================
+// visualStateToWorkflowParams
+// ============================================================================
+
+/**
+ * Shared structure returned by both create and update serialisation.
+ * This is the same shape, just with different required/optional fields
+ * depending on which API is being called.
+ */
+interface BuiltWorkflowFields {
+	steps: Array<{ id: string; name: string; agentId: string; instructions?: string }>;
+	transitions: Array<{
+		from: string;
+		to: string;
+		condition?: { type: WorkflowConditionType; expression?: string };
+		order: number;
+	}>;
+	startStepId: string;
+	rules: Array<{ id?: string; name: string; content: string; appliesTo?: string[] }>;
+	layout: Record<string, { x: number; y: number }>;
+	tags: string[];
+}
+
+/**
+ * Resolve the stable persisted step ID for a given step key.
+ * If the node has a persisted `step.id`, that is used directly.
+ * Otherwise a new UUID is generated (for brand-new steps).
+ */
+function resolveStepId(node: VisualNode, generatedIds: Map<string, string>): string {
+	const key = node.step.id ?? node.step.localId;
+	if (node.step.id) return node.step.id;
+	if (!generatedIds.has(key)) {
+		generatedIds.set(key, crypto.randomUUID());
+	}
+	return generatedIds.get(key)!;
+}
+
+/**
+ * Build the serialized workflow fields from a VisualEditorState.
+ * Shared between create and update serialisation.
+ */
+function buildWorkflowFields(state: VisualEditorState): {
+	fields: BuiltWorkflowFields;
+	keyToPersistedId: Map<string, string>;
+} {
+	const generatedIds = new Map<string, string>();
+
+	// Assign persisted IDs to all nodes
+	const nodeMap = new Map<string, { node: VisualNode; persistedId: string }>();
+	for (const node of state.nodes) {
+		const key = node.step.id ?? node.step.localId;
+		const persistedId = resolveStepId(node, generatedIds);
+		nodeMap.set(key, { node, persistedId });
+	}
+
+	// Also build a lookup by localId so startStepId can reference either key style
+	const localIdMap = new Map<string, { node: VisualNode; persistedId: string }>();
+	for (const [, entry] of nodeMap) {
+		localIdMap.set(entry.node.step.localId, entry);
+	}
+
+	// Build key -> persisted ID map for rules' appliesTo remapping
+	const keyToPersistedId = new Map<string, string>();
+	for (const [key, { persistedId }] of nodeMap) {
+		keyToPersistedId.set(key, persistedId);
+	}
+	// Also map localId -> persistedId
+	for (const [, entry] of nodeMap) {
+		keyToPersistedId.set(entry.node.step.localId, entry.persistedId);
+	}
+
+	// Build steps
+	const steps = state.nodes.map((node, i) => {
+		const key = node.step.id ?? node.step.localId;
+		const persistedId = nodeMap.get(key)!.persistedId;
+		return {
+			id: persistedId,
+			name: node.step.name || `Step ${i + 1}`,
+			agentId: node.step.agentId,
+			instructions: node.step.instructions || undefined,
+		};
+	});
+
+	// Build a position lookup for target nodes (used to compute transition order)
+	const positionByKey = new Map<string, Point>();
+	for (const node of state.nodes) {
+		const key = node.step.id ?? node.step.localId;
+		positionByKey.set(key, node.position);
+	}
+
+	// Group outgoing edges by source key to compute order
+	const outgoingBySource = new Map<string, VisualEdge[]>();
+	for (const edge of state.edges) {
+		const list = outgoingBySource.get(edge.fromStepKey) ?? [];
+		list.push(edge);
+		outgoingBySource.set(edge.fromStepKey, list);
+	}
+
+	// Build transitions with computed order (left-to-right by target x-position)
+	const transitions: BuiltWorkflowFields['transitions'] = [];
+	for (const [sourceKey, edgeGroup] of outgoingBySource) {
+		const fromId = keyToPersistedId.get(sourceKey);
+		if (!fromId) continue;
+
+		// Sort by target node x-position (ascending = left-to-right)
+		const sorted = [...edgeGroup].sort((a, b) => {
+			const xA = positionByKey.get(a.toStepKey)?.x ?? 0;
+			const xB = positionByKey.get(b.toStepKey)?.x ?? 0;
+			return xA - xB;
+		});
+
+		for (let i = 0; i < sorted.length; i++) {
+			const edge = sorted[i];
+			const toId = keyToPersistedId.get(edge.toStepKey);
+			if (!toId) continue;
+
+			transitions.push({
+				from: fromId,
+				to: toId,
+				condition:
+					edge.condition.type === 'always'
+						? undefined
+						: { type: edge.condition.type, expression: edge.condition.expression },
+				order: i,
+			});
+		}
+	}
+
+	// Build layout
+	const layout: Record<string, { x: number; y: number }> = {};
+	for (const node of state.nodes) {
+		const key = node.step.id ?? node.step.localId;
+		const persistedId = nodeMap.get(key)!.persistedId;
+		layout[persistedId] = { x: node.position.x, y: node.position.y };
+	}
+
+	// Resolve startStepId
+	const startEntry =
+		nodeMap.get(state.startStepId) ??
+		localIdMap.get(state.startStepId) ??
+		(state.nodes.length > 0
+			? {
+					persistedId: nodeMap.get(state.nodes[0].step.id ?? state.nodes[0].step.localId)!
+						.persistedId,
+				}
+			: null);
+	const startStepId = startEntry?.persistedId ?? '';
+
+	// Build rules
+	const rules = state.rules
+		.filter((r) => r.name.trim() || r.content.trim())
+		.map((r) => ({
+			id: r.id,
+			name: r.name.trim() || 'Untitled Rule',
+			content: r.content,
+			appliesTo: r.appliesTo.map((id) => keyToPersistedId.get(id) ?? id),
+		}));
+
+	return {
+		fields: { steps, transitions, startStepId, rules, layout, tags: state.tags },
+		keyToPersistedId,
+	};
+}
+
+/**
+ * Convert a VisualEditorState to CreateSpaceWorkflowParams.
+ *
+ * @param state - Current visual editor state
+ * @param spaceId - The space to create the workflow in
+ * @param name - Workflow name
+ * @param description - Optional workflow description
+ */
+export function visualStateToCreateParams(
+	state: VisualEditorState,
+	spaceId: string,
+	name: string,
+	description?: string
+): CreateSpaceWorkflowParams {
+	const { fields } = buildWorkflowFields(state);
+
+	return {
+		spaceId,
+		name,
+		description,
+		steps: fields.steps,
+		transitions: fields.transitions,
+		startStepId: fields.startStepId || undefined,
+		rules: fields.rules.map(({ id: _id, ...rest }) => rest),
+		layout: fields.layout,
+		tags: fields.tags,
+	};
+}
+
+/**
+ * Convert a VisualEditorState to UpdateSpaceWorkflowParams.
+ *
+ * @param state - Current visual editor state
+ * @param overrides - Optional field overrides (name, description)
+ */
+export function visualStateToUpdateParams(
+	state: VisualEditorState,
+	overrides?: { name?: string; description?: string | null }
+): UpdateSpaceWorkflowParams {
+	const { fields } = buildWorkflowFields(state);
+
+	return {
+		...overrides,
+		steps: fields.steps,
+		transitions: fields.transitions,
+		startStepId: fields.startStepId || null,
+		rules: fields.rules.map((r) => ({
+			id: r.id ?? crypto.randomUUID(),
+			name: r.name,
+			content: r.content,
+			appliesTo: r.appliesTo,
+		})),
+		layout: fields.layout,
+		tags: fields.tags,
+	};
+}


### PR DESCRIPTION
Add serialization.ts with workflowToVisualState, visualStateToCreateParams,
and visualStateToUpdateParams. Restores node positions from workflow.layout
when present, falls back to autoLayout. Transition order is computed from
left-to-right target x-position. startStepId is passed through explicitly
from editor state. 34 unit tests covering round-trip, position restoration,
transition ordering, and condition mapping.
