### PR TITLE
feat: define Task Agent MCP tool schemas (Task 1.3)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -59,6 +59,25 @@ export {
 export type { SpaceAgentToolsConfig, SpaceAgentMcpServer } from './tools/space-agent-tools';
 
 export {
+	TASK_AGENT_TOOL_SCHEMAS,
+	SpawnStepAgentSchema,
+	CheckStepStatusSchema,
+	AdvanceWorkflowSchema,
+	ReportResultSchema,
+	RequestHumanInputSchema,
+	TaskResultStatusSchema,
+} from './tools/task-agent-tool-schemas';
+export type {
+	SpawnStepAgentInput,
+	CheckStepStatusInput,
+	AdvanceWorkflowInput,
+	ReportResultInput,
+	RequestHumanInputInput,
+	TaskResultStatus,
+	TaskAgentToolName,
+} from './tools/task-agent-tool-schemas';
+
+export {
 	exportAgent,
 	exportWorkflow,
 	exportBundle,

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -12,9 +12,9 @@
  * This file is consumed by the MCP server factory (Milestone 3). It intentionally
  * contains only schema definitions — no runtime logic or side effects.
  *
- * Follow the same style as space-agent-tools.ts:
- *   - z.string().describe() on every field
- *   - optional fields use .optional()
+ * Style conventions (matching space-agent-tools.ts):
+ *   - z.string().describe() on every field — .describe() before .optional()
+ *   - optional fields use .optional() after .describe()
  *   - enum fields use z.enum([...])
  */
 
@@ -34,10 +34,8 @@ export const SpawnStepAgentSchema = z.object({
 	/** Optional override instructions to pass to the step agent. */
 	instructions: z
 		.string()
-		.optional()
-		.describe(
-			'Optional instructions to pass to the step agent, overriding the default step prompt'
-		),
+		.describe('Optional instructions to pass to the step agent, overriding the default step prompt')
+		.optional(),
 });
 
 export type SpawnStepAgentInput = z.infer<typeof SpawnStepAgentSchema>;
@@ -55,8 +53,8 @@ export const CheckStepStatusSchema = z.object({
 	/** Optional step ID to check. Omit to check the current active step. */
 	step_id: z
 		.string()
-		.optional()
-		.describe('ID of the workflow step to check. Omit to check the currently active step.'),
+		.describe('ID of the workflow step to check. Omit to check the currently active step.')
+		.optional(),
 });
 
 export type CheckStepStatusInput = z.infer<typeof CheckStepStatusSchema>;
@@ -73,10 +71,10 @@ export const AdvanceWorkflowSchema = z.object({
 	/** Optional result summary from the completed step, used for transition condition evaluation. */
 	step_result: z
 		.string()
-		.optional()
 		.describe(
 			'Optional result or output summary from the completed step, used when evaluating transition conditions'
-		),
+		)
+		.optional(),
 });
 
 export type AdvanceWorkflowInput = z.infer<typeof AdvanceWorkflowSchema>;
@@ -106,8 +104,8 @@ export const ReportResultSchema = z.object({
 	/** Optional error message when status is needs_attention or cancelled. */
 	error: z
 		.string()
-		.optional()
-		.describe('Error details when the task ended in needs_attention or was cancelled'),
+		.describe('Error details when the task ended in needs_attention or was cancelled')
+		.optional(),
 });
 
 export type ReportResultInput = z.infer<typeof ReportResultSchema>;
@@ -126,8 +124,8 @@ export const RequestHumanInputSchema = z.object({
 	/** Optional context to help the human understand why the question is being asked. */
 	context: z
 		.string()
-		.optional()
-		.describe('Optional context explaining why this question is being asked'),
+		.describe('Optional context explaining why this question is being asked')
+		.optional(),
 });
 
 export type RequestHumanInputInput = z.infer<typeof RequestHumanInputSchema>;

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -1,0 +1,151 @@
+/**
+ * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 5
+ * tools available to the Task Agent session.
+ *
+ * Tools:
+ *   spawn_step_agent      — spawn a sub-session for a specific workflow step
+ *   check_step_status     — check the status of the current or a specific step's sub-session
+ *   advance_workflow      — advance the workflow to the next step after the current step completes
+ *   report_result         — report the final task result (terminal tool)
+ *   request_human_input   — pause execution and surface a question to the human user
+ *
+ * This file is consumed by the MCP server factory (Milestone 3). It intentionally
+ * contains only schema definitions — no runtime logic or side effects.
+ *
+ * Follow the same style as space-agent-tools.ts:
+ *   - z.string().describe() on every field
+ *   - optional fields use .optional()
+ *   - enum fields use z.enum([...])
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// spawn_step_agent
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `spawn_step_agent` input.
+ * Spawns a sub-session for the given workflow step.
+ */
+export const SpawnStepAgentSchema = z.object({
+	/** ID of the workflow step to execute. */
+	step_id: z.string().describe('ID of the workflow step to spawn a sub-session for'),
+	/** Optional override instructions to pass to the step agent. */
+	instructions: z
+		.string()
+		.optional()
+		.describe(
+			'Optional instructions to pass to the step agent, overriding the default step prompt'
+		),
+});
+
+export type SpawnStepAgentInput = z.infer<typeof SpawnStepAgentSchema>;
+
+// ---------------------------------------------------------------------------
+// check_step_status
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `check_step_status` input.
+ * Checks the processing state, completion, and any errors for the current or
+ * a specific step's sub-session.
+ */
+export const CheckStepStatusSchema = z.object({
+	/** Optional step ID to check. Omit to check the current active step. */
+	step_id: z
+		.string()
+		.optional()
+		.describe('ID of the workflow step to check. Omit to check the currently active step.'),
+});
+
+export type CheckStepStatusInput = z.infer<typeof CheckStepStatusSchema>;
+
+// ---------------------------------------------------------------------------
+// advance_workflow
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `advance_workflow` input.
+ * Advances the workflow to the next step after the current step completes.
+ */
+export const AdvanceWorkflowSchema = z.object({
+	/** Optional result summary from the completed step, used for transition condition evaluation. */
+	step_result: z
+		.string()
+		.optional()
+		.describe(
+			'Optional result or output summary from the completed step, used when evaluating transition conditions'
+		),
+});
+
+export type AdvanceWorkflowInput = z.infer<typeof AdvanceWorkflowSchema>;
+
+// ---------------------------------------------------------------------------
+// report_result
+// ---------------------------------------------------------------------------
+
+/**
+ * Possible final statuses for a task result.
+ */
+export const TaskResultStatusSchema = z.enum(['completed', 'needs_attention', 'cancelled']);
+
+export type TaskResultStatus = z.infer<typeof TaskResultStatusSchema>;
+
+/**
+ * Schema for `report_result` input.
+ * Reports the final outcome of the task and closes the task lifecycle.
+ */
+export const ReportResultSchema = z.object({
+	/** Final task status. */
+	status: TaskResultStatusSchema.describe(
+		"Final task status: 'completed' (success), 'needs_attention' (human intervention required), or 'cancelled'"
+	),
+	/** Human-readable summary of what was accomplished or why it stopped. */
+	summary: z.string().describe('Human-readable summary of the task outcome'),
+	/** Optional error message when status is needs_attention or cancelled. */
+	error: z
+		.string()
+		.optional()
+		.describe('Error details when the task ended in needs_attention or was cancelled'),
+});
+
+export type ReportResultInput = z.infer<typeof ReportResultSchema>;
+
+// ---------------------------------------------------------------------------
+// request_human_input
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `request_human_input` input.
+ * Pauses workflow execution and surfaces a question to the human user.
+ */
+export const RequestHumanInputSchema = z.object({
+	/** The question to ask the human. */
+	question: z.string().describe('The question to surface to the human user'),
+	/** Optional context to help the human understand why the question is being asked. */
+	context: z
+		.string()
+		.optional()
+		.describe('Optional context explaining why this question is being asked'),
+});
+
+export type RequestHumanInputInput = z.infer<typeof RequestHumanInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Aggregate export for MCP server factory (Milestone 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * All Task Agent tool schemas keyed by tool name.
+ * The MCP server factory can iterate this map to register tools.
+ */
+export const TASK_AGENT_TOOL_SCHEMAS = {
+	spawn_step_agent: SpawnStepAgentSchema,
+	check_step_status: CheckStepStatusSchema,
+	advance_workflow: AdvanceWorkflowSchema,
+	report_result: ReportResultSchema,
+	request_human_input: RequestHumanInputSchema,
+} as const;
+
+export type TaskAgentToolName = keyof typeof TASK_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for task-agent-tool-schemas.ts
+ *
+ * Verifies that each Zod schema:
+ * - Accepts valid inputs (including optional fields present or absent)
+ * - Rejects invalid inputs with a ZodError
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	SpawnStepAgentSchema,
+	CheckStepStatusSchema,
+	AdvanceWorkflowSchema,
+	ReportResultSchema,
+	RequestHumanInputSchema,
+	TASK_AGENT_TOOL_SCHEMAS,
+} from '../../../src/lib/space/tools/task-agent-tool-schemas.ts';
+
+// ---------------------------------------------------------------------------
+// spawn_step_agent
+// ---------------------------------------------------------------------------
+
+describe('SpawnStepAgentSchema', () => {
+	test('accepts valid input with step_id only', () => {
+		const result = SpawnStepAgentSchema.safeParse({ step_id: 'step-abc' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.step_id).toBe('step-abc');
+			expect(result.data.instructions).toBeUndefined();
+		}
+	});
+
+	test('accepts valid input with step_id and instructions', () => {
+		const result = SpawnStepAgentSchema.safeParse({
+			step_id: 'step-abc',
+			instructions: 'Focus on unit tests only',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.instructions).toBe('Focus on unit tests only');
+		}
+	});
+
+	test('rejects missing step_id', () => {
+		const result = SpawnStepAgentSchema.safeParse({ instructions: 'some instructions' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string step_id', () => {
+		const result = SpawnStepAgentSchema.safeParse({ step_id: 42 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string instructions', () => {
+		const result = SpawnStepAgentSchema.safeParse({ step_id: 'step-1', instructions: 123 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty object', () => {
+		const result = SpawnStepAgentSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// check_step_status
+// ---------------------------------------------------------------------------
+
+describe('CheckStepStatusSchema', () => {
+	test('accepts empty object (check current active step)', () => {
+		const result = CheckStepStatusSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.step_id).toBeUndefined();
+		}
+	});
+
+	test('accepts valid input with step_id', () => {
+		const result = CheckStepStatusSchema.safeParse({ step_id: 'step-xyz' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.step_id).toBe('step-xyz');
+		}
+	});
+
+	test('rejects non-string step_id', () => {
+		const result = CheckStepStatusSchema.safeParse({ step_id: true });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects null step_id', () => {
+		const result = CheckStepStatusSchema.safeParse({ step_id: null });
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// advance_workflow
+// ---------------------------------------------------------------------------
+
+describe('AdvanceWorkflowSchema', () => {
+	test('accepts empty object (no step_result)', () => {
+		const result = AdvanceWorkflowSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.step_result).toBeUndefined();
+		}
+	});
+
+	test('accepts valid input with step_result', () => {
+		const result = AdvanceWorkflowSchema.safeParse({ step_result: 'All tests passed.' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.step_result).toBe('All tests passed.');
+		}
+	});
+
+	test('rejects non-string step_result', () => {
+		const result = AdvanceWorkflowSchema.safeParse({ step_result: 42 });
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// report_result
+// ---------------------------------------------------------------------------
+
+describe('ReportResultSchema', () => {
+	test('accepts completed status with summary', () => {
+		const result = ReportResultSchema.safeParse({ status: 'completed', summary: 'Task done.' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.status).toBe('completed');
+			expect(result.data.error).toBeUndefined();
+		}
+	});
+
+	test('accepts needs_attention status with summary and error', () => {
+		const result = ReportResultSchema.safeParse({
+			status: 'needs_attention',
+			summary: 'Blocked on auth issue.',
+			error: 'OAuth token expired',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.status).toBe('needs_attention');
+			expect(result.data.error).toBe('OAuth token expired');
+		}
+	});
+
+	test('accepts cancelled status', () => {
+		const result = ReportResultSchema.safeParse({
+			status: 'cancelled',
+			summary: 'User cancelled the task.',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects invalid status value', () => {
+		const result = ReportResultSchema.safeParse({ status: 'failed', summary: 'Bad.' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing status', () => {
+		const result = ReportResultSchema.safeParse({ summary: 'Done.' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing summary', () => {
+		const result = ReportResultSchema.safeParse({ status: 'completed' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty object', () => {
+		const result = ReportResultSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string summary', () => {
+		const result = ReportResultSchema.safeParse({ status: 'completed', summary: 99 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string error', () => {
+		const result = ReportResultSchema.safeParse({
+			status: 'cancelled',
+			summary: 'done',
+			error: { message: 'oops' },
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// request_human_input
+// ---------------------------------------------------------------------------
+
+describe('RequestHumanInputSchema', () => {
+	test('accepts valid input with question only', () => {
+		const result = RequestHumanInputSchema.safeParse({ question: 'Should I proceed?' });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.question).toBe('Should I proceed?');
+			expect(result.data.context).toBeUndefined();
+		}
+	});
+
+	test('accepts valid input with question and context', () => {
+		const result = RequestHumanInputSchema.safeParse({
+			question: 'Which environment should I deploy to?',
+			context: 'The staging build passed all tests.',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.context).toBe('The staging build passed all tests.');
+		}
+	});
+
+	test('rejects missing question', () => {
+		const result = RequestHumanInputSchema.safeParse({ context: 'some context' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string question', () => {
+		const result = RequestHumanInputSchema.safeParse({ question: 123 });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string context', () => {
+		const result = RequestHumanInputSchema.safeParse({ question: 'ok?', context: false });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty object', () => {
+		const result = RequestHumanInputSchema.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TASK_AGENT_TOOL_SCHEMAS aggregate
+// ---------------------------------------------------------------------------
+
+describe('TASK_AGENT_TOOL_SCHEMAS', () => {
+	test('contains all 5 tool schemas', () => {
+		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
+		expect(keys).toContain('spawn_step_agent');
+		expect(keys).toContain('check_step_status');
+		expect(keys).toContain('advance_workflow');
+		expect(keys).toContain('report_result');
+		expect(keys).toContain('request_human_input');
+		expect(keys).toHaveLength(5);
+	});
+
+	test('each schema value is a valid Zod schema with safeParse', () => {
+		for (const schema of Object.values(TASK_AGENT_TOOL_SCHEMAS)) {
+			expect(typeof schema.safeParse).toBe('function');
+		}
+	});
+});

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -13,6 +13,7 @@ import {
 	AdvanceWorkflowSchema,
 	ReportResultSchema,
 	RequestHumanInputSchema,
+	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
 } from '../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
@@ -117,6 +118,37 @@ describe('AdvanceWorkflowSchema', () => {
 
 	test('rejects non-string step_result', () => {
 		const result = AdvanceWorkflowSchema.safeParse({ step_result: 42 });
+		expect(result.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// TaskResultStatusSchema
+// ---------------------------------------------------------------------------
+
+describe('TaskResultStatusSchema', () => {
+	test('accepts completed', () => {
+		const result = TaskResultStatusSchema.safeParse('completed');
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts needs_attention', () => {
+		const result = TaskResultStatusSchema.safeParse('needs_attention');
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts cancelled', () => {
+		const result = TaskResultStatusSchema.safeParse('cancelled');
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects unknown status', () => {
+		const result = TaskResultStatusSchema.safeParse('failed');
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty string', () => {
+		const result = TaskResultStatusSchema.safeParse('');
 		expect(result.success).toBe(false);
 	});
 });


### PR DESCRIPTION
Add Zod schemas and TypeScript types for all 5 Task Agent MCP tools:
spawn_step_agent, check_step_status, advance_workflow, report_result,
and request_human_input. Includes 30 unit tests covering valid and
invalid inputs for each schema.
