### PR TITLE
feat: add template support to visual workflow editor (Task 5.3)

### DIFF
--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -30,13 +30,13 @@ const TAG_SUGGESTIONS = ['coding', 'review', 'research', 'design', 'deployment']
 // Template Definitions
 // ============================================================================
 
-interface WorkflowTemplate {
+export interface WorkflowTemplate {
 	label: string;
 	description: string;
 	stepRoles: string[]; // agent role names to look up from agent list
 }
 
-const TEMPLATES: WorkflowTemplate[] = [
+export const TEMPLATES: WorkflowTemplate[] = [
 	{
 		label: 'Coding (Plan → Code)',
 		description: 'Planner agent designs the approach, then coder implements.',

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -21,7 +21,12 @@
  */
 
 import { useState, useMemo, useCallback, useRef } from 'preact/hooks';
-import type { SpaceWorkflow, WorkflowTransition, WorkflowConditionType } from '@neokai/shared';
+import type {
+	SpaceWorkflow,
+	WorkflowStep,
+	WorkflowTransition,
+	WorkflowConditionType,
+} from '@neokai/shared';
 import { spaceStore } from '../../../lib/space-store';
 import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
@@ -447,24 +452,20 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		}));
 
 		// Compute positions via autoLayout
-		const fakeSteps = newNodes.map((n) => ({
+		const layoutSteps: WorkflowStep[] = newNodes.map((n) => ({
 			id: n.step.localId,
 			name: n.step.name,
 			agentId: n.step.agentId,
-			instructions: n.step.instructions,
+			instructions: n.step.instructions || undefined,
 		}));
-		const fakeTransitions = newEdges.map((e, i) => ({
+		const layoutTransitions: WorkflowTransition[] = newEdges.map((e, i) => ({
 			id: `t-${i}`,
 			from: e.fromStepKey,
 			to: e.toStepKey,
 			order: i,
 		}));
 
-		const positions = autoLayout(
-			fakeSteps as Parameters<typeof autoLayout>[0],
-			fakeTransitions as Parameters<typeof autoLayout>[1],
-			firstLocalId
-		);
+		const positions = autoLayout(layoutSteps, layoutTransitions, firstLocalId);
 
 		const positionedNodes: VisualNode[] = newNodes.map((n) => ({
 			...n,
@@ -657,8 +658,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 						Add Step
 					</button>
 
-					{/* Template picker — only shown when creating a new workflow */}
-					{!isEditing && (
+					{/* Template picker — only shown when creating a new workflow with no steps yet */}
+					{!isEditing && nodes.length === 0 && (
 						<div class="relative">
 							<button
 								onClick={() => setShowTemplates((v) => !v)}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -20,10 +20,11 @@
  * provide a stable `key` prop to force remount when switching between workflows.
  */
 
-import { useState, useMemo, useCallback } from 'preact/hooks';
+import { useState, useMemo, useCallback, useRef } from 'preact/hooks';
 import type { SpaceWorkflow, WorkflowTransition, WorkflowConditionType } from '@neokai/shared';
 import { spaceStore } from '../../../lib/space-store';
-import { filterAgents } from '../WorkflowEditor';
+import { filterAgents, TEMPLATES } from '../WorkflowEditor';
+import type { WorkflowTemplate } from '../WorkflowEditor';
 import { WorkflowRulesEditor } from '../WorkflowRulesEditor';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import type { StepDraft } from '../WorkflowStepCard';
@@ -36,7 +37,10 @@ import {
 	visualStateToUpdateParams,
 } from './serialization';
 import type { WorkflowNodeData } from './WorkflowCanvas';
-import { WorkflowCanvas } from './WorkflowCanvas';
+import { WorkflowCanvas, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './WorkflowCanvas';
+import { computeFitToView } from './CanvasToolbar';
+import { autoLayout } from './layout';
+import type { NodePosition } from './types';
 import { NodeConfigPanel } from './NodeConfigPanel';
 import { EdgeConfigPanel } from './EdgeConfigPanel';
 
@@ -102,7 +106,10 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showRules, setShowRules] = useState(false);
+	const [showTemplates, setShowTemplates] = useState(false);
 	const [tagInput, setTagInput] = useState('');
+
+	const canvasContainerRef = useRef<HTMLDivElement>(null);
 
 	const agents = filterAgents(spaceStore.agents.value);
 
@@ -410,6 +417,89 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	}
 
 	// ------------------------------------------------------------------
+	// Template
+	// ------------------------------------------------------------------
+
+	function applyTemplate(template: WorkflowTemplate) {
+		const localIds = template.stepRoles.map(() => crypto.randomUUID());
+		const firstLocalId = localIds[0];
+
+		const newNodes: VisualNode[] = template.stepRoles.map((role, i) => {
+			const found = agents.find(
+				(a) => a.name.toLowerCase() === role || a.role.toLowerCase() === role
+			);
+			return {
+				step: {
+					localId: localIds[i],
+					name: role.charAt(0).toUpperCase() + role.slice(1),
+					agentId: found?.id ?? '',
+					instructions: '',
+				},
+				position: { x: 0, y: 0 }, // overwritten by autoLayout below
+			};
+		});
+
+		// Linear chain of edges
+		const newEdges: VisualEdge[] = localIds.slice(0, -1).map((fromId, i) => ({
+			fromStepKey: fromId,
+			toStepKey: localIds[i + 1],
+			condition: undefined,
+		}));
+
+		// Compute positions via autoLayout
+		const fakeSteps = newNodes.map((n) => ({
+			id: n.step.localId,
+			name: n.step.name,
+			agentId: n.step.agentId,
+			instructions: n.step.instructions,
+		}));
+		const fakeTransitions = newEdges.map((e, i) => ({
+			id: `t-${i}`,
+			from: e.fromStepKey,
+			to: e.toStepKey,
+			order: i,
+		}));
+
+		const positions = autoLayout(
+			fakeSteps as Parameters<typeof autoLayout>[0],
+			fakeTransitions as Parameters<typeof autoLayout>[1],
+			firstLocalId
+		);
+
+		const positionedNodes: VisualNode[] = newNodes.map((n) => ({
+			...n,
+			position: positions.get(n.step.localId) ?? n.position,
+		}));
+
+		setNodes(positionedNodes);
+		setEdges(newEdges);
+		setStartStepId(firstLocalId);
+		setSelectedNodeId(null);
+		setSelectedEdgeId(null);
+		setShowTemplates(false);
+		if (!name) setName(template.label);
+
+		// Fit viewport to the new layout
+		const container = canvasContainerRef.current;
+		if (container) {
+			const nodePositions: NodePosition = {};
+			for (const n of positionedNodes) {
+				nodePositions[n.step.localId] = {
+					x: n.position.x,
+					y: n.position.y,
+					width: DEFAULT_NODE_WIDTH,
+					height: DEFAULT_NODE_HEIGHT,
+				};
+			}
+			setViewportState(
+				computeFitToView(nodePositions, container.clientWidth, container.clientHeight)
+			);
+		} else {
+			setViewportState({ offsetX: 0, offsetY: 0, scale: 1 });
+		}
+	}
+
+	// ------------------------------------------------------------------
 	// Save
 	// ------------------------------------------------------------------
 
@@ -545,9 +635,12 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			)}
 
 			{/* ---- Canvas area ---- */}
-			<div class="flex-1 relative overflow-hidden bg-dark-950">
-				{/* Add Step toolbar button */}
-				<div class="absolute top-3 left-3 z-10" style={{ pointerEvents: 'auto' }}>
+			<div ref={canvasContainerRef} class="flex-1 relative overflow-hidden bg-dark-950">
+				{/* Add Step + Template toolbar */}
+				<div
+					class="absolute top-3 left-3 z-10 flex items-center gap-2"
+					style={{ pointerEvents: 'auto' }}
+				>
 					<button
 						onClick={addStep}
 						data-testid="add-step-button"
@@ -563,6 +656,57 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 						</svg>
 						Add Step
 					</button>
+
+					{/* Template picker — only shown when creating a new workflow */}
+					{!isEditing && (
+						<div class="relative">
+							<button
+								onClick={() => setShowTemplates((v) => !v)}
+								data-testid="template-picker-button"
+								class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-dark-800 border border-dark-600 rounded text-gray-300 hover:text-white hover:bg-dark-700 hover:border-dark-500 transition-colors shadow"
+							>
+								<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M4 6h16M4 10h16M4 14h8"
+									/>
+								</svg>
+								From Template
+								<svg
+									class={`w-3 h-3 transition-transform ${showTemplates ? 'rotate-180' : ''}`}
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M19 9l-7 7-7-7"
+									/>
+								</svg>
+							</button>
+
+							{showTemplates && (
+								<div class="absolute top-full left-0 mt-1 w-64 bg-dark-800 border border-dark-600 rounded shadow-lg z-20 overflow-hidden">
+									{TEMPLATES.map((t) => (
+										<button
+											key={t.label}
+											onClick={() => applyTemplate(t)}
+											data-testid="template-option"
+											data-template-label={t.label}
+											class="w-full text-left px-3 py-2.5 hover:bg-dark-700 transition-colors border-b border-dark-700 last:border-b-0"
+										>
+											<div class="text-xs font-medium text-gray-200">{t.label}</div>
+											<div class="text-xs text-gray-500 mt-0.5">{t.description}</div>
+										</button>
+									))}
+								</div>
+							)}
+						</div>
+					)}
 				</div>
 
 				{/* Empty state overlay */}

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -707,6 +707,159 @@ describe('VisualWorkflowEditor', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Template picker
+	// -------------------------------------------------------------------------
+
+	describe('Template picker', () => {
+		it('shows template picker button in create mode', () => {
+			const { getByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			expect(getByTestId('template-picker-button')).toBeTruthy();
+		});
+
+		it('hides template picker button in edit mode', () => {
+			const { queryByTestId } = render(
+				<VisualWorkflowEditor {...makeProps({ workflow: makeWorkflow() })} />
+			);
+			expect(queryByTestId('template-picker-button')).toBeNull();
+		});
+
+		it('shows template dropdown when button is clicked', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			expect(options.length).toBe(3); // 3 templates
+		});
+
+		it('hides dropdown when button clicked again', () => {
+			const { getByTestId, queryAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+			fireEvent.click(getByTestId('template-picker-button'));
+			expect(queryAllByTestId('template-option').length).toBe(0);
+		});
+
+		it('selecting a template populates nodes', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+
+			// Select the "Coding (Plan → Code)" template (2 steps: planner + coder)
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			expect(codingOption).toBeTruthy();
+			fireEvent.click(codingOption!);
+
+			// Should have 2 nodes (planner + coder)
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(2);
+		});
+
+		it('selecting a template creates edges between nodes', () => {
+			const { getByTestId, getAllByTestId, container } = render(
+				<VisualWorkflowEditor {...makeProps()} />
+			);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			fireEvent.click(codingOption!);
+
+			// Should have 1 edge connecting the 2 nodes (EdgeRenderer uses data-edge-id attribute)
+			expect(container.querySelectorAll('[data-edge-id]').length).toBe(1);
+		});
+
+		it('selecting a template assigns autoLayout positions (non-zero for at least one node)', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			fireEvent.click(codingOption!);
+
+			// Nodes use absolute positioning via `left` and `top` style properties.
+			// autoLayout places the first node at START_X=50, START_Y=50, so at
+			// least one node must have a non-zero left position.
+			const nodes = getAllByTestId(/^workflow-node-/);
+			const hasNonZeroLeft = nodes.some((n) => {
+				const left = n.style.left;
+				return left !== '' && left !== '0px' && left !== '0';
+			});
+			expect(hasNonZeroLeft).toBe(true);
+		});
+
+		it('selects first step as start node after template applied', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			fireEvent.click(codingOption!);
+
+			// Exactly one node should have the START badge
+			const startBadges = getAllByTestId(/^workflow-node-/).filter((n) =>
+				n.textContent?.includes('START')
+			);
+			expect(startBadges.length).toBe(1);
+		});
+
+		it('sets workflow name from template label when name is empty', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			fireEvent.click(codingOption!);
+
+			expect((getByTestId('workflow-name-input') as HTMLInputElement).value).toBe(
+				'Coding (Plan → Code)'
+			);
+		});
+
+		it('does not override existing name when applying template', () => {
+			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			fireEvent.input(getByTestId('workflow-name-input'), { target: { value: 'My Custom Name' } });
+
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const codingOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Coding (Plan → Code)'
+			);
+			fireEvent.click(codingOption!);
+
+			expect((getByTestId('workflow-name-input') as HTMLInputElement).value).toBe('My Custom Name');
+		});
+
+		it('closes template dropdown after selecting a template', () => {
+			const { getByTestId, getAllByTestId, queryAllByTestId } = render(
+				<VisualWorkflowEditor {...makeProps()} />
+			);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			fireEvent.click(options[0]);
+
+			expect(queryAllByTestId('template-option').length).toBe(0);
+		});
+
+		it('single-step template (Quick Fix) creates one node and no edges', () => {
+			const { getByTestId, getAllByTestId, container } = render(
+				<VisualWorkflowEditor {...makeProps()} />
+			);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			const quickFixOption = options.find(
+				(el) => el.getAttribute('data-template-label') === 'Quick Fix (Code only)'
+			);
+			fireEvent.click(quickFixOption!);
+
+			expect(getAllByTestId(/^workflow-node-/).length).toBe(1);
+			expect(container.querySelectorAll('[data-edge-id]').length).toBe(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// Rules section
 	// -------------------------------------------------------------------------
 

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -89,6 +89,7 @@ vi.mock('../../../../lib/utils', () => ({
 
 import { VisualWorkflowEditor } from '../VisualWorkflowEditor';
 import type { VisualWorkflowEditorProps } from '../VisualWorkflowEditor';
+import { TEMPLATES } from '../../WorkflowEditor';
 
 // ============================================================================
 // Fixtures
@@ -727,7 +728,7 @@ describe('VisualWorkflowEditor', () => {
 			const { getByTestId, getAllByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
 			fireEvent.click(getByTestId('template-picker-button'));
 			const options = getAllByTestId('template-option');
-			expect(options.length).toBe(3); // 3 templates
+			expect(options.length).toBe(TEMPLATES.length);
 		});
 
 		it('hides dropdown when button clicked again', () => {
@@ -841,6 +842,30 @@ describe('VisualWorkflowEditor', () => {
 			fireEvent.click(options[0]);
 
 			expect(queryAllByTestId('template-option').length).toBe(0);
+		});
+
+		it('hides template button once nodes have been added (overwrite protection)', () => {
+			const { getByTestId, queryByTestId } = render(<VisualWorkflowEditor {...makeProps()} />);
+			// Button visible before any nodes
+			expect(queryByTestId('template-picker-button')).toBeTruthy();
+
+			// Add a step manually
+			fireEvent.click(getByTestId('add-step-button'));
+
+			// Button must be hidden now that the canvas has content
+			expect(queryByTestId('template-picker-button')).toBeNull();
+		});
+
+		it('hides template button after a template is applied', () => {
+			const { getByTestId, getAllByTestId, queryByTestId } = render(
+				<VisualWorkflowEditor {...makeProps()} />
+			);
+			fireEvent.click(getByTestId('template-picker-button'));
+			const options = getAllByTestId('template-option');
+			fireEvent.click(options[0]);
+
+			// Template created nodes → button should be gone
+			expect(queryByTestId('template-picker-button')).toBeNull();
 		});
 
 		it('single-step template (Quick Fix) creates one node and no edges', () => {


### PR DESCRIPTION
- Export TEMPLATES and WorkflowTemplate from WorkflowEditor.tsx
- Add "From Template" dropdown button in VisualWorkflowEditor toolbar,
  hidden in edit mode (only shown when creating a new workflow)
- applyTemplate: creates VisualNode[] / VisualEdge[] from stepRoles,
  runs autoLayout for positions, resets viewport via computeFitToView
- Auto-fills workflow name from template label when name field is empty
- 12 new tests covering: button visibility, dropdown toggle, node/edge
  population, autoLayout positions, start node assignment, name
  behaviour, and single-step template edge case
