### PR TITLE
feat: add task_agent_session_id to space_tasks schema and repository

### DIFF
--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,8 +25,8 @@ export class SpaceTaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, depends_on, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, depends_on, task_agent_session_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -43,6 +43,7 @@ export class SpaceTaskRepository {
 			params.workflowStepId ?? null,
 			params.createdByTaskId ?? null,
 			JSON.stringify(params.dependsOn ?? []),
+			params.taskAgentSessionId ?? null,
 			now,
 			now
 		);
@@ -206,6 +207,10 @@ export class SpaceTaskRepository {
 			fields.push('input_draft = ?');
 			values.push(params.inputDraft ?? null);
 		}
+		if (params.taskAgentSessionId !== undefined) {
+			fields.push('task_agent_session_id = ?');
+			values.push(params.taskAgentSessionId ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -259,6 +264,18 @@ export class SpaceTaskRepository {
 	}
 
 	/**
+	 * Get a task by its Task Agent session ID
+	 */
+	getTaskBySessionId(sessionId: string): SpaceTask | null {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_tasks WHERE task_agent_session_id = ? LIMIT 1`
+		);
+		const row = stmt.get(sessionId) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return this.rowToSpaceTask(row);
+	}
+
+	/**
 	 * Get draft tasks created by a specific planning task
 	 */
 	getDraftTasksByCreator(createdByTaskId: string): SpaceTask[] {
@@ -294,6 +311,7 @@ export class SpaceTaskRepository {
 			dependsOn: JSON.parse(row.depends_on as string) as string[],
 			inputDraft: (row.input_draft as string | null) ?? undefined,
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,
+			taskAgentSessionId: (row.task_agent_session_id as string | null) ?? undefined,
 			prUrl: (row.pr_url as string | null) ?? undefined,
 			prNumber: (row.pr_number as number | null) ?? undefined,
 			prCreatedAt: (row.pr_created_at as number | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1671,6 +1671,9 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
 	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+	);
 
 	// -------------------------------------------------------------------------
 	// space_session_groups
@@ -1977,4 +1980,7 @@ function runMigration32(db: BunDatabase): void {
 	} catch {
 		db.exec(`ALTER TABLE space_tasks ADD COLUMN task_agent_session_id TEXT`);
 	}
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -123,6 +123,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 31: Add 'space_task_agent' to sessions type CHECK constraint.
 	runMigration31(db);
+
+	// Migration 32: Add task_agent_session_id column to space_tasks.
+	runMigration32(db);
 }
 
 /**
@@ -1643,6 +1646,7 @@ function runMigration29(db: BunDatabase): void {
 			input_draft TEXT,
 			active_session TEXT
 				CHECK(active_session IN ('worker', 'leader')),
+			task_agent_session_id TEXT,
 			pr_url TEXT,
 			pr_number INTEGER,
 			pr_created_at INTEGER,
@@ -1957,5 +1961,20 @@ function runMigration31(db: BunDatabase): void {
 		} finally {
 			db.exec('PRAGMA foreign_keys = ON');
 		}
+	}
+}
+
+/**
+ * Migration 32: Add `task_agent_session_id` column to `space_tasks`.
+ *
+ * Stores the ID of the Task Agent session associated with this task. Nullable —
+ * tasks without a Task Agent return NULL (mapped to undefined in code).
+ */
+function runMigration32(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+	try {
+		db.prepare(`SELECT task_agent_session_id FROM space_tasks LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN task_agent_session_id TEXT`);
 	}
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -143,6 +143,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			input_draft TEXT,
 			active_session TEXT
 				CHECK(active_session IN ('worker', 'leader')),
+			task_agent_session_id TEXT,
 			pr_url TEXT,
 			pr_number INTEGER,
 			pr_created_at INTEGER,

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -73,6 +73,7 @@ describe('SpaceTaskRepository', () => {
 			expect(task.customAgentId).toBeUndefined();
 			expect(task.workflowRunId).toBeUndefined();
 			expect(task.workflowStepId).toBeUndefined();
+			expect(task.taskAgentSessionId).toBeUndefined();
 		});
 
 		it('creates a task with workflow routing fields', () => {
@@ -98,6 +99,21 @@ describe('SpaceTaskRepository', () => {
 				status: 'draft',
 			});
 			expect(task.status).toBe('draft');
+		});
+
+		it('persists taskAgentSessionId when provided', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Agent task',
+				description: '',
+				taskAgentSessionId: 'session-abc',
+			});
+			expect(task.taskAgentSessionId).toBe('session-abc');
+		});
+
+		it('leaves taskAgentSessionId undefined when not provided', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			expect(task.taskAgentSessionId).toBeUndefined();
 		});
 	});
 
@@ -197,6 +213,54 @@ describe('SpaceTaskRepository', () => {
 			});
 			const updated = repo.updateTask(task.id, { customAgentId: null });
 			expect(updated!.customAgentId).toBeUndefined();
+		});
+
+		it('sets taskAgentSessionId', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, { taskAgentSessionId: 'session-xyz' });
+			expect(updated!.taskAgentSessionId).toBe('session-xyz');
+		});
+
+		it('clears taskAgentSessionId', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'T',
+				description: '',
+				taskAgentSessionId: 'session-xyz',
+			});
+			const updated = repo.updateTask(task.id, { taskAgentSessionId: null });
+			expect(updated!.taskAgentSessionId).toBeUndefined();
+		});
+	});
+
+	describe('getTaskBySessionId', () => {
+		it('returns the task matching the session ID', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Agent task',
+				description: '',
+				taskAgentSessionId: 'session-lookup',
+			});
+			const found = repo.getTaskBySessionId('session-lookup');
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(task.id);
+			expect(found!.taskAgentSessionId).toBe('session-lookup');
+		});
+
+		it('returns null when no task matches the session ID', () => {
+			expect(repo.getTaskBySessionId('nonexistent-session')).toBeNull();
+		});
+
+		it('returns the correct task when multiple tasks exist', () => {
+			repo.createTask({ spaceId, title: 'Other', description: '' });
+			const task = repo.createTask({
+				spaceId,
+				title: 'Agent task',
+				description: '',
+				taskAgentSessionId: 'session-specific',
+			});
+			const found = repo.getTaskBySessionId('session-specific');
+			expect(found!.id).toBe(task.id);
 		});
 	});
 


### PR DESCRIPTION
- Migration 32: ALTER TABLE space_tasks ADD COLUMN task_agent_session_id TEXT
- Updated CREATE TABLE schema for fresh databases
- createTask() persists taskAgentSessionId when provided
- updateTask() can set/clear taskAgentSessionId
- rowToSpaceTask() maps task_agent_session_id to taskAgentSessionId
- getTaskBySessionId() looks up a task by its Task Agent session ID
- Updated space-test-db helper to include the new column
- Added unit tests covering create, update, get, and getTaskBySessionId
