### PR TITLE
feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2)

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -467,6 +467,11 @@ export function createTaskAgentInit(config: TaskAgentSessionConfig): AgentSessio
 		space,
 		workflow: workflow ?? undefined,
 		workflowRun: workflowRun ?? undefined,
+		// availableAgents is required by TaskAgentContext but buildTaskAgentSystemPrompt()
+		// does not render an "Available Agents" section — that section only appears in
+		// buildTaskAgentInitialMessage(). The factory does not have agent data at init time,
+		// and passing an empty array here has no effect on the system prompt content.
+		// The caller must provide agent context via buildTaskAgentInitialMessage() instead.
 		availableAgents: [],
 	});
 

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -44,7 +44,10 @@ import type {
 	WorkflowStep,
 	WorkflowTransition,
 	WorkflowRule,
+	SessionFeatures,
 } from '@neokai/shared';
+import type { AgentSessionInit } from '../../agent/agent-session';
+import { inferProviderForModel } from '../../providers/registry';
 
 // ---------------------------------------------------------------------------
 // Context types
@@ -405,4 +408,77 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 	}
 
 	return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Session init factory
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TASK_AGENT_MODEL = 'claude-sonnet-4-5-20250929';
+
+const TASK_AGENT_FEATURES: SessionFeatures = {
+	rewind: false,
+	worktree: false,
+	coordinator: false,
+	archive: false,
+	sessionInfo: true,
+};
+
+/**
+ * Configuration for creating a Task Agent session.
+ *
+ * NOTE: MCP servers are intentionally NOT included here — they are attached at
+ * runtime by the TaskAgentManager after the session is created. This allows the
+ * manager to compose the MCP server with live runtime dependencies (session manager,
+ * task manager, workflow executor) that are unavailable at init time.
+ */
+export interface TaskAgentSessionConfig {
+	/** The task this agent will orchestrate */
+	task: SpaceTask;
+	/** The Space this task belongs to */
+	space: Space;
+	/** The workflow definition to execute (optional) */
+	workflow?: SpaceWorkflow | null;
+	/** The active workflow run for this task (optional) */
+	workflowRun?: SpaceWorkflowRun | null;
+	/** Session ID for the new session */
+	sessionId: string;
+	/** Workspace path (typically space.workspacePath) */
+	workspacePath: string;
+}
+
+/**
+ * Create an AgentSessionInit for a Task Agent session.
+ *
+ * The Task Agent is a built-in orchestrator session type (`space_task_agent`) that
+ * manages a single SpaceTask's workflow. It uses the task agent system prompt and
+ * does NOT include MCP servers — those are attached at runtime by the TaskAgentManager.
+ *
+ * Model resolution: Space.defaultModel → hardcoded default.
+ */
+export function createTaskAgentInit(config: TaskAgentSessionConfig): AgentSessionInit {
+	const { task, space, workflow, workflowRun, sessionId, workspacePath } = config;
+
+	const model = space.defaultModel ?? DEFAULT_TASK_AGENT_MODEL;
+	const provider = inferProviderForModel(model);
+
+	const systemPromptText = buildTaskAgentSystemPrompt({
+		task,
+		space,
+		workflow: workflow ?? undefined,
+		workflowRun: workflowRun ?? undefined,
+		availableAgents: [],
+	});
+
+	return {
+		sessionId,
+		workspacePath,
+		systemPrompt: systemPromptText,
+		features: TASK_AGENT_FEATURES,
+		context: { spaceId: space.id, taskId: task.id },
+		type: 'space_task_agent',
+		model,
+		provider,
+		contextAutoQueue: false,
+	};
 }

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -45,6 +45,17 @@ export {
 } from './agents/custom-agent';
 export type { CustomAgentConfig, ResolveAgentInitConfig } from './agents/custom-agent';
 
+export {
+	buildTaskAgentSystemPrompt,
+	buildTaskAgentInitialMessage,
+	createTaskAgentInit,
+} from './agents/task-agent';
+export type {
+	TaskAgentContext,
+	PreviousTaskSummary,
+	TaskAgentSessionConfig,
+} from './agents/task-agent';
+
 export { buildSpaceChatSystemPrompt } from './agents/space-chat-agent';
 export type {
 	SpaceChatAgentContext,

--- a/packages/daemon/tests/unit/space/task-agent-init.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-init.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for createTaskAgentInit()
+ *
+ * Verifies:
+ * - Returns AgentSessionInit with correct session type, features, context, model
+ * - System prompt is built from buildTaskAgentSystemPrompt()
+ * - MCP servers are NOT included in the init
+ * - Model resolution: space.defaultModel → hardcoded default
+ * - context includes both spaceId and taskId
+ * - contextAutoQueue is false
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	createTaskAgentInit,
+	type TaskAgentSessionConfig,
+} from '../../../src/lib/space/agents/task-agent';
+import type { SpaceTask, Space, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSpace(overrides?: Partial<Space>): Space {
+	return {
+		id: 'space-1',
+		workspacePath: '/workspace',
+		name: 'Test Space',
+		description: 'A test space',
+		backgroundContext: null,
+		instructions: null,
+		sessionIds: [],
+		status: 'active',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'Implement feature X',
+		description: 'Add the X feature to the codebase with tests.',
+		status: 'in_progress',
+		priority: 'high',
+		dependsOn: [],
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeWorkflow(overrides?: Partial<SpaceWorkflow>): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'Feature Workflow',
+		description: 'Plan, code, and review.',
+		steps: [{ id: 'step-code', name: 'Code', agentId: 'agent-1' }],
+		transitions: [],
+		rules: [],
+		startStepId: 'step-code',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeWorkflowRun(overrides?: Partial<SpaceWorkflowRun>): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title: 'Feature X run',
+		currentStepId: 'step-code',
+		status: 'in_progress',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+function makeConfig(overrides?: Partial<TaskAgentSessionConfig>): TaskAgentSessionConfig {
+	return {
+		task: makeTask(),
+		space: makeSpace(),
+		sessionId: 'session-abc',
+		workspacePath: '/workspace',
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createTaskAgentInit', () => {
+	describe('session type', () => {
+		test('sets type to space_task_agent', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.type).toBe('space_task_agent');
+		});
+	});
+
+	describe('features', () => {
+		test('disables rewind', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.features?.rewind).toBe(false);
+		});
+
+		test('disables worktree', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.features?.worktree).toBe(false);
+		});
+
+		test('disables coordinator', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.features?.coordinator).toBe(false);
+		});
+
+		test('enables sessionInfo', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.features?.sessionInfo).toBe(true);
+		});
+	});
+
+	describe('context', () => {
+		test('includes spaceId', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.context?.spaceId).toBe('space-1');
+		});
+
+		test('includes taskId', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.context?.taskId).toBe('task-1');
+		});
+
+		test('uses correct space and task IDs', () => {
+			const config = makeConfig({
+				task: makeTask({ id: 'task-xyz', spaceId: 'space-abc' }),
+				space: makeSpace({ id: 'space-abc' }),
+			});
+			const init = createTaskAgentInit(config);
+			expect(init.context?.spaceId).toBe('space-abc');
+			expect(init.context?.taskId).toBe('task-xyz');
+		});
+	});
+
+	describe('session IDs', () => {
+		test('uses provided sessionId', () => {
+			const init = createTaskAgentInit(makeConfig({ sessionId: 'my-session-id' }));
+			expect(init.sessionId).toBe('my-session-id');
+		});
+
+		test('uses provided workspacePath', () => {
+			const init = createTaskAgentInit(makeConfig({ workspacePath: '/my/workspace' }));
+			expect(init.workspacePath).toBe('/my/workspace');
+		});
+	});
+
+	describe('model resolution', () => {
+		test('uses space.defaultModel when set', () => {
+			const config = makeConfig({
+				space: makeSpace({ defaultModel: 'claude-opus-4-6' }),
+			});
+			const init = createTaskAgentInit(config);
+			expect(init.model).toBe('claude-opus-4-6');
+		});
+
+		test('falls back to hardcoded default when space.defaultModel is unset', () => {
+			const config = makeConfig({
+				space: makeSpace({ defaultModel: undefined }),
+			});
+			const init = createTaskAgentInit(config);
+			expect(init.model).toBe('claude-sonnet-4-5-20250929');
+		});
+
+		test('falls back to hardcoded default when space.defaultModel is null', () => {
+			const config = makeConfig({
+				space: makeSpace({ defaultModel: null }),
+			});
+			const init = createTaskAgentInit(config);
+			expect(init.model).toBe('claude-sonnet-4-5-20250929');
+		});
+	});
+
+	describe('system prompt', () => {
+		test('systemPrompt is a string', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(typeof init.systemPrompt).toBe('string');
+		});
+
+		test('systemPrompt contains task title', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.systemPrompt as string).toContain('Implement feature X');
+		});
+
+		test('systemPrompt contains Task Agent role declaration', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.systemPrompt as string).toContain('Task Agent');
+		});
+
+		test('systemPrompt includes workflow info when workflow is provided', () => {
+			const config = makeConfig({
+				workflow: makeWorkflow({ name: 'My Workflow' }),
+			});
+			const init = createTaskAgentInit(config);
+			// The system prompt itself doesn't embed workflow steps, but task details are present
+			expect(init.systemPrompt as string).toContain('Implement feature X');
+		});
+	});
+
+	describe('MCP servers', () => {
+		test('does not include mcpServers', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.mcpServers).toBeUndefined();
+		});
+
+		test('does not include mcpServers even with workflow', () => {
+			const config = makeConfig({ workflow: makeWorkflow() });
+			const init = createTaskAgentInit(config);
+			expect(init.mcpServers).toBeUndefined();
+		});
+	});
+
+	describe('contextAutoQueue', () => {
+		test('sets contextAutoQueue to false', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.contextAutoQueue).toBe(false);
+		});
+	});
+
+	describe('optional workflow and workflowRun', () => {
+		test('works without workflow', () => {
+			const config = makeConfig({ workflow: undefined });
+			const init = createTaskAgentInit(config);
+			expect(init.type).toBe('space_task_agent');
+		});
+
+		test('works with null workflow', () => {
+			const config = makeConfig({ workflow: null });
+			const init = createTaskAgentInit(config);
+			expect(init.type).toBe('space_task_agent');
+		});
+
+		test('works with workflow and workflowRun', () => {
+			const config = makeConfig({
+				workflow: makeWorkflow(),
+				workflowRun: makeWorkflowRun(),
+			});
+			const init = createTaskAgentInit(config);
+			expect(init.type).toBe('space_task_agent');
+			expect(init.context?.taskId).toBe('task-1');
+		});
+	});
+
+	describe('provider', () => {
+		test('sets provider for default model', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.provider).toBeDefined();
+			expect(typeof init.provider).toBe('string');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/task-agent-init.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-init.test.ts
@@ -27,8 +27,8 @@ function makeSpace(overrides?: Partial<Space>): Space {
 		workspacePath: '/workspace',
 		name: 'Test Space',
 		description: 'A test space',
-		backgroundContext: null,
-		instructions: null,
+		backgroundContext: '',
+		instructions: '',
 		sessionIds: [],
 		status: 'active',
 		createdAt: 1000,
@@ -120,6 +120,11 @@ describe('createTaskAgentInit', () => {
 			expect(init.features?.coordinator).toBe(false);
 		});
 
+		test('disables archive', () => {
+			const init = createTaskAgentInit(makeConfig());
+			expect(init.features?.archive).toBe(false);
+		});
+
 		test('enables sessionInfo', () => {
 			const init = createTaskAgentInit(makeConfig());
 			expect(init.features?.sessionInfo).toBe(true);
@@ -202,12 +207,12 @@ describe('createTaskAgentInit', () => {
 			expect(init.systemPrompt as string).toContain('Task Agent');
 		});
 
-		test('systemPrompt includes workflow info when workflow is provided', () => {
+		test('systemPrompt contains task details even when workflow is provided', () => {
 			const config = makeConfig({
 				workflow: makeWorkflow({ name: 'My Workflow' }),
 			});
 			const init = createTaskAgentInit(config);
-			// The system prompt itself doesn't embed workflow steps, but task details are present
+			// Workflow steps appear only in buildTaskAgentInitialMessage(), not the system prompt
 			expect(init.systemPrompt as string).toContain('Implement feature X');
 		});
 	});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -77,6 +77,8 @@ export interface SessionContext {
 	lobbyId?: string;
 	/** Space ID for Space system sessions */
 	spaceId?: string;
+	/** Task ID for Space Task Agent sessions */
+	taskId?: string;
 }
 
 /**


### PR DESCRIPTION
- Add `taskId` field to `SessionContext` in shared types for Task Agent context
- Define `TaskAgentSessionConfig` interface in task-agent.ts
- Implement `createTaskAgentInit()` factory producing `AgentSessionInit` with:
  - type: 'space_task_agent'
  - system prompt from buildTaskAgentSystemPrompt()
  - features: rewind/worktree/coordinator disabled, sessionInfo enabled
  - context: { spaceId, taskId }
  - model: space.defaultModel ?? hardcoded default
  - contextAutoQueue: false
  - no mcpServers (attached at runtime by TaskAgentManager)
- Export factory, types, and prompt builders from space module index
- Add 24 unit tests covering type, features, context, model resolution, MCP absence
