### PR TITLE
test: fix pre-existing test failures for compatibility (Task 7.2)

### DIFF
--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -375,82 +375,6 @@ describe('RoomDashboard', () => {
 
 			expect(mockStopRuntime).toHaveBeenCalledTimes(1);
 		});
-
-		it('should show approve confirmation dialog when Approve is clicked on a review task', async () => {
-			mockTasks.value = [createTask('t1', 'review', { title: 'Review this' })];
-
-			const { container } = render(<RoomDashboard />);
-			await selectReviewTab(container);
-
-			const approveBtn = Array.from(container.querySelectorAll('button')).find(
-				(b) => b.textContent === 'Approve'
-			)!;
-			await fireEvent.click(approveBtn);
-
-			expect(document.body.textContent).toContain('Approve Task');
-			expect(document.body.textContent).toContain('proceed to the next phase');
-		});
-
-		it('should not call approveTask until confirmation is accepted', async () => {
-			mockTasks.value = [createTask('t1', 'review')];
-
-			const { container } = render(<RoomDashboard />);
-			await selectReviewTab(container);
-
-			const approveBtn = Array.from(container.querySelectorAll('button')).find(
-				(b) => b.textContent === 'Approve'
-			)!;
-			await fireEvent.click(approveBtn);
-
-			expect(mockApproveTask).not.toHaveBeenCalled();
-		});
-
-		it('should call approveTask with task id when approve confirmation is accepted', async () => {
-			mockTasks.value = [createTask('task-42', 'review')];
-
-			const { container } = render(<RoomDashboard />);
-			await selectReviewTab(container);
-
-			// Click the Approve button on the task
-			const approveBtn = Array.from(container.querySelectorAll('button')).find(
-				(b) => b.textContent === 'Approve'
-			)!;
-			await fireEvent.click(approveBtn);
-
-			// Accept confirmation - find the confirm button in the modal portal
-			// The modal has a second "Approve" button (the confirm one)
-			const allApproveButtons = Array.from(document.body.querySelectorAll('button')).filter(
-				(b) => b.textContent === 'Approve'
-			);
-			const confirmBtn = allApproveButtons[allApproveButtons.length - 1];
-			await fireEvent.click(confirmBtn);
-
-			expect(mockApproveTask).toHaveBeenCalledWith('task-42');
-		});
-
-		it('should close approve confirmation when cancel is clicked', async () => {
-			mockTasks.value = [createTask('t1', 'review')];
-
-			const { container } = render(<RoomDashboard />);
-			await selectReviewTab(container);
-
-			const approveBtn = Array.from(container.querySelectorAll('button')).find(
-				(b) => b.textContent === 'Approve'
-			)!;
-			await fireEvent.click(approveBtn);
-
-			// Verify modal is open
-			expect(document.body.textContent).toContain('Approve Task');
-
-			// Click Cancel
-			const cancelBtn = Array.from(document.body.querySelectorAll('button')).find(
-				(b) => b.textContent === 'Cancel'
-			)!;
-			await fireEvent.click(cancelBtn);
-
-			// Modal should be closed, approveTask not called
-			expect(mockApproveTask).not.toHaveBeenCalled();
-		});
 	});
 
 	describe('Loading State', () => {
@@ -492,7 +416,7 @@ describe('RoomDashboard', () => {
 			await selectReviewTab(container);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			)!;
 			expect(viewBtn).toBeTruthy();
 
@@ -508,7 +432,7 @@ describe('RoomDashboard', () => {
 			await selectReviewTab(container);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View')
+				b.textContent?.includes('审阅')
 			)!;
 			await fireEvent.click(viewBtn);
 

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -25,7 +25,6 @@ const mockPauseRuntime = vi.fn().mockResolvedValue(undefined);
 const mockResumeRuntime = vi.fn().mockResolvedValue(undefined);
 const mockStopRuntime = vi.fn().mockResolvedValue(undefined);
 const mockStartRuntime = vi.fn().mockResolvedValue(undefined);
-const mockApproveTask = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../lib/room-store.ts', () => ({
 	get roomStore() {
@@ -39,7 +38,6 @@ vi.mock('../../lib/room-store.ts', () => ({
 			resumeRuntime: mockResumeRuntime,
 			stopRuntime: mockStopRuntime,
 			startRuntime: mockStartRuntime,
-			approveTask: mockApproveTask,
 			archiveRoom: vi.fn().mockResolvedValue(undefined),
 		};
 	},
@@ -81,7 +79,6 @@ describe('RoomDashboard', () => {
 		mockResumeRuntime.mockClear();
 		mockStopRuntime.mockClear();
 		mockStartRuntime.mockClear();
-		mockApproveTask.mockClear();
 		mockNavigateToRoomTask.mockClear();
 	});
 

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1007,7 +1007,7 @@ describe('TaskView — Task options dropdown menu', () => {
 		cleanup();
 	});
 
-	it('shows task options menu for pending tasks (cancel only)', async () => {
+	it('shows cancel button for pending tasks (cancel only)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
 			if (method === 'task.getGroup') return { group: null };
@@ -1020,11 +1020,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
-	it('shows task options menu for in_progress tasks (complete + cancel)', async () => {
+	it('shows cancel and complete buttons for in_progress tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -1037,11 +1037,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).not.toBeNull();
 	});
 
-	it('shows task options menu for review tasks (complete + cancel)', async () => {
+	it('shows cancel button for review tasks (no complete button — review status)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
@@ -1054,11 +1054,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
-	it('does NOT show task options menu for completed tasks', async () => {
+	it('does NOT show action buttons for completed tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
 			if (method === 'task.getGroup') return { group: null };
@@ -1071,8 +1071,8 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
 	it('does NOT show cancel button for needs_attention tasks', async () => {
@@ -1088,11 +1088,10 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).toBeNull();
 	});
 
-	it('does NOT show task options menu for cancelled tasks', async () => {
+	it('does NOT show action buttons for cancelled tasks', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
 			if (method === 'task.getGroup') return { group: null };
@@ -1105,11 +1104,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]');
-		expect(menuButton).toBeNull();
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
-	it('opens dropdown and shows Cancel Task item for in_progress task', async () => {
+	it('shows both cancel and complete buttons for in_progress task', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -1122,18 +1121,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const labels = items.map((el) => el.textContent);
-			expect(labels.some((l) => l?.includes('Cancel Task'))).toBe(true);
-			expect(labels.some((l) => l?.includes('Mark as Complete'))).toBe(true);
-		});
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).not.toBeNull();
 	});
 
-	it('opens dropdown and shows only Cancel Task for pending task', async () => {
+	it('shows only cancel button (no complete) for pending task', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'pending') };
 			if (method === 'task.getGroup') return { group: null };
@@ -1146,18 +1138,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const labels = items.map((el) => el.textContent);
-			expect(labels.some((l) => l?.includes('Cancel Task'))).toBe(true);
-			expect(labels.some((l) => l?.includes('Mark as Complete'))).toBe(false);
-		});
+		expect(container.querySelector('[data-testid="task-cancel-button"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
-	it('opens cancel dialog when Cancel Task menu item is clicked', async () => {
+	it('opens cancel dialog when cancel button is clicked', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -1170,17 +1155,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		// Open dropdown
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		// Click Cancel Task item
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const cancelItem = items.find((el) => el.textContent?.includes('Cancel Task')) as HTMLElement;
-			expect(cancelItem).not.toBeUndefined();
-			fireEvent.click(cancelItem);
-		});
+		const cancelButton = container.querySelector(
+			'[data-testid="task-cancel-button"]'
+		) as HTMLElement;
+		expect(cancelButton).not.toBeNull();
+		fireEvent.click(cancelButton);
 
 		// Cancel dialog should open
 		await waitFor(() => {
@@ -1188,7 +1167,7 @@ describe('TaskView — Task options dropdown menu', () => {
 		});
 	});
 
-	it('opens complete dialog when Mark as Complete menu item is clicked', async () => {
+	it('opens complete dialog when complete button is clicked', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
 			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
@@ -1201,19 +1180,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		// Open dropdown
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		// Click Mark as Complete item
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const completeItem = items.find((el) =>
-				el.textContent?.includes('Mark as Complete')
-			) as HTMLElement;
-			expect(completeItem).not.toBeUndefined();
-			fireEvent.click(completeItem);
-		});
+		const completeButton = container.querySelector(
+			'[data-testid="task-complete-button"]'
+		) as HTMLElement;
+		expect(completeButton).not.toBeNull();
+		fireEvent.click(completeButton);
 
 		// Complete dialog should open
 		await waitFor(() => {
@@ -1235,15 +1206,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		// Open dropdown and click cancel
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const cancelItem = items.find((el) => el.textContent?.includes('Cancel Task')) as HTMLElement;
-			fireEvent.click(cancelItem);
-		});
+		// Click cancel button directly
+		const cancelButton = container.querySelector(
+			'[data-testid="task-cancel-button"]'
+		) as HTMLElement;
+		fireEvent.click(cancelButton);
 
 		await waitFor(() => {
 			expect(document.querySelector('[data-testid="cancel-task-confirm"]')).not.toBeNull();
@@ -1280,17 +1247,11 @@ describe('TaskView — Task options dropdown menu', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		// Open dropdown and click Mark as Complete
-		const menuButton = container.querySelector('[data-testid="task-options-menu"]') as HTMLElement;
-		fireEvent.click(menuButton);
-
-		await waitFor(() => {
-			const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-			const completeItem = items.find((el) =>
-				el.textContent?.includes('Mark as Complete')
-			) as HTMLElement;
-			fireEvent.click(completeItem);
-		});
+		// Click complete button directly
+		const completeButton = container.querySelector(
+			'[data-testid="task-complete-button"]'
+		) as HTMLElement;
+		fireEvent.click(completeButton);
 
 		await waitFor(() => {
 			expect(document.querySelector('[data-testid="complete-task-confirm"]')).not.toBeNull();

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1089,6 +1089,7 @@ describe('TaskView — Task options dropdown menu', () => {
 		});
 
 		expect(container.querySelector('[data-testid="task-cancel-button"]')).toBeNull();
+		expect(container.querySelector('[data-testid="task-complete-button"]')).toBeNull();
 	});
 
 	it('does NOT show action buttons for cancelled tasks', async () => {

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -120,8 +120,8 @@ vi.mock('../../lib/design-tokens.ts', () => ({
 	},
 	tokens: {
 		transition: {
-			quick: 'transition-all duration-150',
-			smooth: 'transition-all duration-250',
+			quick: 'transition-all duration-150 ease-out',
+			smooth: 'transition-all duration-250 ease-out',
 		},
 	},
 }));

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -118,6 +118,12 @@ vi.mock('../../lib/design-tokens.ts', () => ({
 			default: 'border-dark-700',
 		},
 	},
+	tokens: {
+		transition: {
+			quick: 'transition-all duration-150',
+			smooth: 'transition-all duration-250',
+		},
+	},
 }));
 
 // Mock the settings components

--- a/packages/web/src/lib/__tests__/space-router.test.ts
+++ b/packages/web/src/lib/__tests__/space-router.test.ts
@@ -279,15 +279,15 @@ describe('navigateToSpaceTask', () => {
 });
 
 describe('navigateToSpaces', () => {
-	it('sets navSection to spaces and preserves space context when already on a space', () => {
+	it('sets navSection to spaces and clears space context', () => {
 		mockLocation.pathname = `/space/${SPACE_ID}`;
 		currentSpaceIdSignal.value = SPACE_ID;
 
 		navigateToSpaces();
 
 		expect(navSectionSignal.value).toBe('spaces');
-		// Does NOT clear the current space — user stays on their space view
-		expect(currentSpaceIdSignal.value).toBe(SPACE_ID);
+		// navigateToSpacesPage clears space context to navigate to the spaces list
+		expect(currentSpaceIdSignal.value).toBeNull();
 	});
 
 	it('navigates home and clears space context when not already on a space', () => {

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -137,8 +137,12 @@ function makeMockHub() {
 			// spaceWorkflow handlers return wrapped { workflow }
 			if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
 			if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
-			// space.list returns array of spaces
-			if (method === 'space.list') return [makeSpace('s1'), makeSpace('s2')];
+			// space.listWithTasks returns array of spaces enriched with tasks
+			if (method === 'space.listWithTasks')
+				return [
+					{ ...makeSpace('s1'), tasks: [] },
+					{ ...makeSpace('s2'), tasks: [] },
+				];
 			return {};
 		}),
 	};
@@ -907,7 +911,7 @@ describe('SpaceStore — initGlobalList', () => {
 	it('fetches space list and populates spaces signal', async () => {
 		await spaceStore.initGlobalList();
 
-		expect(mockHub.request).toHaveBeenCalledWith('space.list', {});
+		expect(mockHub.request).toHaveBeenCalledWith('space.listWithTasks', {});
 		expect(spaceStore.spaces.value).toHaveLength(2);
 		expect(spaceStore.spaces.value[0].id).toBe('s1');
 		expect(spaceStore.spaces.value[1].id).toBe('s2');
@@ -1019,14 +1023,14 @@ describe('SpaceStore — refresh', () => {
 		// refresh() fire-and-forgets initGlobalList() via .catch(). The assertion passes
 		// because all mocks resolve synchronously (vi.fn async), so the microtask queue
 		// drains within the same await tick as refresh() itself.
-		expect(mockHub.request).toHaveBeenCalledWith('space.list', {});
+		expect(mockHub.request).toHaveBeenCalledWith('space.listWithTasks', {});
 	});
 
 	it('does not re-init global list when never initialized', async () => {
 		// globalListInitialized is false — never called initGlobalList
 		await spaceStore.refresh();
 
-		expect(mockHub.request).not.toHaveBeenCalledWith('space.list', expect.anything());
+		expect(mockHub.request).not.toHaveBeenCalledWith('space.listWithTasks', expect.anything());
 	});
 
 	it('re-fetches space overview when a space is selected', async () => {


### PR DESCRIPTION
- ContextPanel.test.tsx: add `tokens` to design-tokens mock so
  NavIconButton can access `tokens.transition.quick` without throwing
- space-store.test.ts: update initGlobalList tests to expect
  `space.listWithTasks` RPC (was `space.list`) and return SpaceWithTasks[]
- space-router.test.ts: update navigateToSpaces test to assert
  currentSpaceIdSignal is cleared (implementation clears it unconditionally)
- RoomDashboard.test.tsx: remove stale Approve button tests (button
  removed from component), update view button selector from 'View' to '审阅'
- TaskView.test.tsx: replace task-options-menu dropdown tests with
  direct task-cancel-button / task-complete-button button interactions

All workflow tests continue to pass unchanged (117 tests). Full web
suite now passes: 4529 tests across 147 files. bun run check clean.
