### PR TITLE
feat: implement Task Agent MCP tool handlers (Task 3.1)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -59,6 +59,17 @@ export {
 export type { SpaceAgentToolsConfig, SpaceAgentMcpServer } from './tools/space-agent-tools';
 
 export {
+	createTaskAgentToolHandlers,
+	createTaskAgentMcpServer,
+} from './tools/task-agent-tools';
+export type {
+	TaskAgentToolsConfig,
+	TaskAgentMcpServer,
+	SubSessionFactory,
+	SubSessionState,
+} from './tools/task-agent-tools';
+
+export {
 	TASK_AGENT_TOOL_SCHEMAS,
 	SpawnStepAgentSchema,
 	CheckStepStatusSchema,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -27,6 +27,8 @@ import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import { jsonResult } from './tool-result';
+import type { ToolResult } from './tool-result';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -43,18 +45,6 @@ export interface SpaceAgentToolsConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Workflow run repository for listing and updating runs. */
 	workflowRunRepo: SpaceWorkflowRunRepository;
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-interface ToolResult {
-	content: Array<{ type: 'text'; text: string }>;
-}
-
-function jsonResult(data: unknown): ToolResult {
-	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
 
 /**

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,0 +1,719 @@
+/**
+ * Task Agent Tools — MCP tool handlers for the Task Agent session.
+ *
+ * These handlers implement the business logic for the 5 Task Agent tools:
+ *   spawn_step_agent      — Spawn a sub-session for a workflow step's assigned agent
+ *   check_step_status     — Poll the status of a running step agent sub-session
+ *   advance_workflow      — Advance the workflow to the next step after current step completes
+ *   report_result         — Mark the task as completed/failed and record the result
+ *   request_human_input   — Pause execution and surface a question to the human user
+ *
+ * Design:
+ * - Handlers are pure functions tested independently of any MCP server layer.
+ * - Dependencies are injected via `TaskAgentToolsConfig`.
+ * - The `SubSessionFactory` abstraction allows tests to mock session creation/state.
+ * - Session completion is signalled via two paths:
+ *     1. Completion callback registered in spawn_step_agent (fires automatically)
+ *     2. Polling via check_step_status (Task Agent polls this tool)
+ *
+ * Following the pattern established in space-agent-tools.ts.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { Space } from '@neokai/shared';
+import type { AgentSessionInit } from '../../agent/agent-session';
+import type { SpaceRuntime } from '../runtime/space-runtime';
+import { WorkflowGateError } from '../runtime/workflow-executor';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceTaskManager } from '../managers/space-task-manager';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import { resolveAgentInit, buildCustomAgentTaskMessage } from '../agents/custom-agent';
+import {
+	SpawnStepAgentSchema,
+	CheckStepStatusSchema,
+	AdvanceWorkflowSchema,
+	ReportResultSchema,
+	RequestHumanInputSchema,
+} from './task-agent-tool-schemas';
+import type {
+	SpawnStepAgentInput,
+	CheckStepStatusInput,
+	AdvanceWorkflowInput,
+	ReportResultInput,
+	RequestHumanInputInput,
+} from './task-agent-tool-schemas';
+
+// ---------------------------------------------------------------------------
+// Sub-session state
+// ---------------------------------------------------------------------------
+
+/**
+ * Processing state of a sub-session, as reported by SubSessionFactory.
+ */
+export interface SubSessionState {
+	/** Whether the session is actively processing a query */
+	isProcessing: boolean;
+	/** Whether the session has reached a terminal state (no more processing) */
+	isComplete: boolean;
+	/** Error details if the session ended in an error state */
+	error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// SubSessionFactory
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstraction for creating and querying sub-sessions.
+ * Injected into the config so tests can mock session behaviour without a real daemon.
+ */
+export interface SubSessionFactory {
+	/**
+	 * Creates and starts a new agent sub-session.
+	 * Returns the session ID of the created session.
+	 */
+	create(init: AgentSessionInit): Promise<string>;
+
+	/**
+	 * Returns the current processing state of a session, or null if the session
+	 * is not known / has been cleaned up.
+	 */
+	getProcessingState(sessionId: string): SubSessionState | null;
+
+	/**
+	 * Registers a callback that is invoked once when the given session completes
+	 * (transitions to a terminal state). The callback is called at most once.
+	 */
+	onComplete(sessionId: string, callback: () => Promise<void>): void;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies injected into createTaskAgentToolHandlers().
+ * All fields are required — the caller (TaskAgentManager) wires them up.
+ */
+export interface TaskAgentToolsConfig {
+	/** ID of the main SpaceTask this Task Agent is orchestrating. */
+	taskId: string;
+	/** ID of the Space this task belongs to. */
+	spaceId: string;
+	/** Full Space object — needed for agent init and task message building. */
+	space: Space;
+	/** ID of the active workflow run for this task. */
+	workflowRunId: string;
+	/** Absolute path to the workspace — forwarded to agent sessions. */
+	workspacePath: string;
+	/** SpaceRuntime for accessing WorkflowExecutors by run ID. */
+	runtime: SpaceRuntime;
+	/** Workflow manager for loading workflow definitions. */
+	workflowManager: SpaceWorkflowManager;
+	/** Task repository for direct DB reads. */
+	taskRepo: SpaceTaskRepository;
+	/** Workflow run repository for reading and updating runs. */
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Agent manager for resolving step agents. */
+	agentManager: SpaceAgentManager;
+	/** Task manager for validated status transitions. */
+	taskManager: SpaceTaskManager;
+	/** Sub-session factory for creating and querying agent sub-sessions. */
+	sessionFactory: SubSessionFactory;
+	/**
+	 * Injects a message into an existing sub-session as a user turn.
+	 * Called after spawn to deliver the step's task context message.
+	 */
+	messageInjector: (sessionId: string, message: string) => Promise<void>;
+	/**
+	 * Called by the completion mechanism when a sub-session finishes.
+	 * Provided by the TaskAgentManager; updates the step's SpaceTask to `completed`.
+	 * The Task Agent handler registers this as the session completion callback.
+	 */
+	onSubSessionComplete: (stepId: string, sessionId: string) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface ToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+function jsonResult(data: unknown): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers (separated for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create handler functions that can be tested directly without an MCP server.
+ * Returns a map of tool name → async handler function.
+ */
+export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
+	const {
+		taskId,
+		space,
+		workflowRunId,
+		workspacePath,
+		runtime,
+		workflowManager,
+		taskRepo,
+		workflowRunRepo,
+		agentManager,
+		taskManager,
+		sessionFactory,
+		messageInjector,
+		onSubSessionComplete,
+	} = config;
+
+	return {
+		/**
+		 * Spawn a sub-session for a workflow step's assigned agent.
+		 *
+		 * Flow:
+		 * 1. Validate the workflow run and workflow definition
+		 * 2. Find the step by step_id in the workflow
+		 * 3. Find the pending SpaceTask created by the WorkflowExecutor for this step
+		 * 4. Resolve the agent session init via resolveAgentInit()
+		 * 5. Create the sub-session via sessionFactory.create()
+		 * 6. Register completion callback (onSubSessionComplete) via sessionFactory.onComplete()
+		 * 7. Build and inject the task message via messageInjector
+		 * 8. Update the step task's active_session_id and the main task's currentStep
+		 * 9. Transition main task from pending → in_progress if not already in_progress
+		 */
+		async spawn_step_agent(args: SpawnStepAgentInput): Promise<ToolResult> {
+			const { step_id, instructions } = args;
+
+			// Load the workflow run
+			const run = workflowRunRepo.getRun(workflowRunId);
+			if (!run) {
+				return jsonResult({ success: false, error: `Workflow run not found: ${workflowRunId}` });
+			}
+
+			// Load the workflow definition
+			const workflow = workflowManager.getWorkflow(run.workflowId);
+			if (!workflow) {
+				return jsonResult({ success: false, error: `Workflow not found: ${run.workflowId}` });
+			}
+
+			// Find the step
+			const step = workflow.steps.find((s) => s.id === step_id);
+			if (!step) {
+				return jsonResult({
+					success: false,
+					error: `Step not found: ${step_id} in workflow ${run.workflowId}`,
+				});
+			}
+
+			// Find the pending task for this step (created by WorkflowExecutor.followTransition)
+			const allRunTasks = taskRepo.listByWorkflowRun(workflowRunId);
+			const stepTasks = allRunTasks.filter((t) => t.workflowStepId === step_id);
+			if (stepTasks.length === 0) {
+				return jsonResult({
+					success: false,
+					error:
+						`No task found for step "${step.name}" (id: ${step_id}). ` +
+						`Ensure advance_workflow was called first to create the step task.`,
+				});
+			}
+
+			// Use the most recently created task for this step
+			const stepTask = stepTasks[stepTasks.length - 1];
+
+			// Ensure customAgentId is set — fall back to step.agentId for preset agents
+			// (WorkflowExecutor sets customAgentId to undefined for coder/general preset roles)
+			const effectiveTask = {
+				...stepTask,
+				customAgentId: stepTask.customAgentId ?? step.agentId,
+			};
+
+			// Apply optional instruction override
+			if (instructions) {
+				effectiveTask.description = instructions;
+			}
+
+			// Generate a new session ID for the sub-session
+			const subSessionId = randomUUID();
+
+			// Resolve the agent session init
+			let init: AgentSessionInit;
+			try {
+				init = resolveAgentInit({
+					task: effectiveTask,
+					space,
+					agentManager,
+					sessionId: subSessionId,
+					workspacePath,
+					workflowRun: run,
+					workflow,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: `Failed to resolve agent init: ${message}` });
+			}
+
+			// Create and start the sub-session
+			let actualSessionId: string;
+			try {
+				actualSessionId = await sessionFactory.create(init);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: `Failed to create sub-session: ${message}` });
+			}
+
+			// Register the completion callback — fires when the sub-session finishes
+			sessionFactory.onComplete(actualSessionId, async () => {
+				await onSubSessionComplete(step_id, actualSessionId);
+			});
+
+			// Build the task context message and inject it into the sub-session
+			try {
+				const agent = agentManager.getById(effectiveTask.customAgentId!);
+				if (agent) {
+					const taskMessage = buildCustomAgentTaskMessage({
+						customAgent: agent,
+						task: effectiveTask,
+						workflowRun: run,
+						workflow,
+						space,
+						sessionId: actualSessionId,
+						workspacePath,
+					});
+					await messageInjector(actualSessionId, taskMessage);
+				}
+			} catch (err) {
+				// Message injection failure is non-fatal — the sub-session will still run,
+				// just without the task context message. Log the issue but don't abort.
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({
+					success: false,
+					error: `Sub-session created (${actualSessionId}) but message injection failed: ${message}`,
+				});
+			}
+
+			// Store the sub-session ID on the step task for later lookup by check_step_status.
+			// We use taskAgentSessionId as the field to record which sub-session is executing
+			// this step task (semantically: the session "orchestrating" this step's work).
+			taskRepo.updateTask(stepTask.id, {
+				taskAgentSessionId: actualSessionId,
+				currentStep: `Running agent for step: ${step.name}`,
+			});
+
+			// Transition main task from pending → in_progress (first step spawn)
+			const mainTask = taskRepo.getTask(taskId);
+			if (mainTask && mainTask.status === 'pending') {
+				try {
+					await taskManager.setTaskStatus(taskId, 'in_progress');
+				} catch {
+					// Non-fatal — task may have already been transitioned elsewhere
+				}
+			}
+
+			// Update main task's currentStep to reflect which step is being executed
+			taskRepo.updateTask(taskId, { currentStep: `Executing step: ${step.name}` });
+
+			return jsonResult({
+				success: true,
+				sessionId: actualSessionId,
+				stepId: step_id,
+				stepName: step.name,
+				taskId: stepTask.id,
+			});
+		},
+
+		/**
+		 * Check the processing state of a step's sub-session.
+		 *
+		 * This is the primary mechanism for the Task Agent to detect sub-session completion.
+		 * The Task Agent polls this tool after spawning a step agent.
+		 *
+		 * If step_id is omitted, checks the workflow run's current step.
+		 * Returns status = 'completed' when the step task has been marked completed in the DB
+		 * (which happens via the completion callback registered in spawn_step_agent).
+		 */
+		async check_step_status(args: CheckStepStatusInput): Promise<ToolResult> {
+			// Resolve step ID — use provided step_id or fall back to current step on run
+			let stepId = args.step_id;
+			if (!stepId) {
+				const run = workflowRunRepo.getRun(workflowRunId);
+				if (!run) {
+					return jsonResult({
+						success: false,
+						error: `Workflow run not found: ${workflowRunId}`,
+					});
+				}
+				if (!run.currentStepId) {
+					return jsonResult({
+						success: false,
+						error: 'No current step on the workflow run. Call spawn_step_agent first.',
+					});
+				}
+				stepId = run.currentStepId;
+			}
+
+			// Find task(s) for this step
+			const stepTasks = taskRepo
+				.listByWorkflowRun(workflowRunId)
+				.filter((t) => t.workflowStepId === stepId);
+
+			if (stepTasks.length === 0) {
+				return jsonResult({
+					success: true,
+					stepId,
+					taskStatus: 'not_found',
+					sessionStatus: 'not_started',
+					message: 'No task found for this step. Has spawn_step_agent been called?',
+				});
+			}
+
+			const stepTask = stepTasks[stepTasks.length - 1];
+
+			// Fast path: task already marked completed by the completion callback
+			if (stepTask.status === 'completed') {
+				return jsonResult({
+					success: true,
+					stepId,
+					taskId: stepTask.id,
+					taskStatus: 'completed',
+					sessionStatus: 'completed',
+					message: 'Step has completed successfully.',
+				});
+			}
+
+			// If no sub-session has been started yet, report not_started
+			if (!stepTask.taskAgentSessionId) {
+				return jsonResult({
+					success: true,
+					stepId,
+					taskId: stepTask.id,
+					taskStatus: stepTask.status,
+					sessionStatus: 'not_started',
+					message: 'Sub-session not yet started for this step. Call spawn_step_agent.',
+				});
+			}
+
+			// Query the sub-session processing state
+			const state = sessionFactory.getProcessingState(stepTask.taskAgentSessionId!);
+			if (!state) {
+				return jsonResult({
+					success: true,
+					stepId,
+					taskId: stepTask.id,
+					taskStatus: stepTask.status,
+					sessionStatus: 'unknown',
+					message:
+						'Sub-session state not available. ' +
+						'The session may have ended or been cleaned up before the completion callback fired.',
+				});
+			}
+
+			if (state.isComplete) {
+				return jsonResult({
+					success: true,
+					stepId,
+					taskId: stepTask.id,
+					taskStatus: stepTask.status,
+					sessionStatus: 'completed',
+					error: state.error,
+					message: state.error
+						? `Sub-session ended with an error: ${state.error}`
+						: 'Sub-session has completed. Waiting for completion callback to update task status.',
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				stepId,
+				taskId: stepTask.id,
+				taskStatus: stepTask.status,
+				sessionStatus: state.isProcessing ? 'running' : 'idle',
+				message: state.isProcessing
+					? 'Sub-session is actively processing. Check back soon.'
+					: 'Sub-session is idle (not currently processing). It may be waiting for input.',
+			});
+		},
+
+		/**
+		 * Advance the workflow to the next step after the current step completes.
+		 *
+		 * Pre-conditions:
+		 * - The current step's SpaceTask must have status = 'completed' in the DB
+		 *   (set by the completion callback registered in spawn_step_agent)
+		 *
+		 * Flow:
+		 * 1. Get the WorkflowExecutor for this run
+		 * 2. Verify the current step task is completed
+		 * 3. If the main task is needs_attention (waiting for human), reset to in_progress
+		 * 4. Call executor.advance() to evaluate transitions and move to next step
+		 * 5. Handle WorkflowGateError → return gate-blocked status (caller calls request_human_input)
+		 * 6. Return next step info (or terminal state)
+		 */
+		async advance_workflow(_args: AdvanceWorkflowInput): Promise<ToolResult> {
+			const executor = runtime.getExecutor(workflowRunId);
+			if (!executor) {
+				return jsonResult({
+					success: false,
+					error:
+						`No active executor found for workflow run: ${workflowRunId}. ` +
+						`The run may have completed or been cancelled.`,
+				});
+			}
+
+			if (executor.isComplete()) {
+				return jsonResult({
+					success: false,
+					error: 'Workflow run is already complete. Call report_result to close the task.',
+				});
+			}
+
+			const currentStep = executor.getCurrentStep();
+			if (!currentStep) {
+				return jsonResult({
+					success: false,
+					error: 'No current step on the workflow executor. The run may be in an invalid state.',
+				});
+			}
+
+			// Verify the current step's task is completed in the DB
+			const stepTasks = taskRepo
+				.listByWorkflowRun(workflowRunId)
+				.filter((t) => t.workflowStepId === currentStep.id);
+
+			const allCompleted = stepTasks.length > 0 && stepTasks.every((t) => t.status === 'completed');
+
+			if (!allCompleted) {
+				const taskStatus =
+					stepTasks.length > 0 ? stepTasks[stepTasks.length - 1].status : 'not_found';
+				return jsonResult({
+					success: false,
+					error:
+						`Current step "${currentStep.name}" has not completed yet. ` +
+						`Task status: ${taskStatus}. ` +
+						`Wait for the step agent to finish before calling advance_workflow.`,
+					currentStepId: currentStep.id,
+					currentStepName: currentStep.name,
+					taskStatus,
+				});
+			}
+
+			// If the main task is needs_attention (waiting after a human gate), reset to in_progress
+			const mainTask = taskRepo.getTask(taskId);
+			if (mainTask && mainTask.status === 'needs_attention') {
+				try {
+					await taskManager.setTaskStatus(taskId, 'in_progress');
+				} catch {
+					// Non-fatal — if transition fails, continue with advance attempt
+				}
+			}
+
+			try {
+				const { step: nextStep, tasks: newTasks } = await executor.advance();
+
+				if (newTasks.length === 0) {
+					// Terminal step reached — executor marked run as completed
+					return jsonResult({
+						success: true,
+						terminal: true,
+						completedStep: {
+							id: nextStep.id,
+							name: nextStep.name,
+						},
+						message:
+							'Workflow has reached a terminal step. ' +
+							`Call report_result with status "completed" to close the task.`,
+					});
+				}
+
+				// Workflow advanced to the next step
+				return jsonResult({
+					success: true,
+					terminal: false,
+					nextStep: {
+						id: nextStep.id,
+						name: nextStep.name,
+						instructions: nextStep.instructions,
+						agentId: nextStep.agentId,
+					},
+					newTasks: newTasks.map((t) => ({ id: t.id, title: t.title, status: t.status })),
+					message: `Workflow advanced to step "${nextStep.name}". Call spawn_step_agent to execute it.`,
+				});
+			} catch (err) {
+				if (err instanceof WorkflowGateError) {
+					return jsonResult({
+						success: true,
+						gateBlocked: true,
+						message: err.message,
+						instruction:
+							'A human gate is blocking workflow advancement. ' +
+							'Call request_human_input to surface this to the human user. ' +
+							'When the human responds, call advance_workflow again.',
+					});
+				}
+
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Report the final outcome of the task and close the task lifecycle.
+		 *
+		 * Updates the main SpaceTask status to one of:
+		 *   completed        — task succeeded; summary records the result
+		 *   needs_attention  — task requires human intervention; error describes the issue
+		 *   cancelled        — task was cancelled
+		 */
+		async report_result(args: ReportResultInput): Promise<ToolResult> {
+			const { status, summary, error: errorDetail } = args;
+
+			const mainTask = taskRepo.getTask(taskId);
+			if (!mainTask) {
+				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+			}
+
+			try {
+				await taskManager.setTaskStatus(taskId, status, {
+					result: summary,
+					error: errorDetail,
+				});
+
+				return jsonResult({
+					success: true,
+					taskId,
+					status,
+					summary,
+					message: `Task has been marked as "${status}". The task lifecycle is now closed.`,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Pause workflow execution and surface a question to the human user.
+		 *
+		 * Updates the main task status to `needs_attention` and stores the question
+		 * in the `currentStep` field so the human can see it in the UI.
+		 *
+		 * Gate re-engagement:
+		 * When the human responds (via space.task.sendMessage), the message is injected
+		 * into this Task Agent session as a normal conversation message. The Task Agent
+		 * receives it, sees the human's response, and calls advance_workflow to proceed.
+		 * The advance_workflow handler resets the task to in_progress before advancing.
+		 */
+		async request_human_input(args: RequestHumanInputInput): Promise<ToolResult> {
+			const { question, context: questionContext } = args;
+
+			const mainTask = taskRepo.getTask(taskId);
+			if (!mainTask) {
+				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+			}
+
+			// Only transition to needs_attention from valid states
+			// Valid transitions: in_progress → needs_attention, review → needs_attention
+			const canTransition = mainTask.status === 'in_progress' || mainTask.status === 'review';
+
+			if (!canTransition) {
+				return jsonResult({
+					success: false,
+					error:
+						`Cannot request human input when task status is "${mainTask.status}". ` +
+						`Task must be in_progress or review.`,
+				});
+			}
+
+			const questionWithContext = questionContext
+				? `${question}\n\nContext: ${questionContext}`
+				: question;
+
+			try {
+				await taskManager.setTaskStatus(taskId, 'needs_attention', {
+					error: questionWithContext,
+				});
+
+				// Update currentStep to surface the question visibly in the UI
+				taskRepo.updateTask(taskId, { currentStep: question });
+
+				return jsonResult({
+					success: true,
+					taskId,
+					question,
+					context: questionContext,
+					message:
+						'Human input has been requested. The question is now visible to the human in the UI. ' +
+						'Wait — do not call any other tools until the human responds. ' +
+						"When the human's response appears in the conversation, " +
+						'read it and then call advance_workflow to continue execution.',
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// MCP server factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an MCP server exposing all Task Agent tools.
+ * Pass the returned server to the SDK session init for the Task Agent session.
+ */
+export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
+	const handlers = createTaskAgentToolHandlers(config);
+
+	const tools = [
+		tool(
+			'spawn_step_agent',
+			"Start a sub-session for a workflow step's assigned agent. " +
+				'Call this to execute each workflow step. ' +
+				'Returns the session ID of the spawned sub-session.',
+			SpawnStepAgentSchema.shape,
+			(args) => handlers.spawn_step_agent(args)
+		),
+		tool(
+			'check_step_status',
+			'Poll the status of a running step agent sub-session. ' +
+				'Call this periodically after spawn_step_agent to detect when a step has completed.',
+			CheckStepStatusSchema.shape,
+			(args) => handlers.check_step_status(args)
+		),
+		tool(
+			'advance_workflow',
+			'Advance the workflow to the next step after the current step completes. ' +
+				'The current step must be completed before calling this. ' +
+				'Returns the next step info, a terminal state, or a gate-blocked status.',
+			AdvanceWorkflowSchema.shape,
+			(args) => handlers.advance_workflow(args)
+		),
+		tool(
+			'report_result',
+			'Mark the task as completed, failed, or cancelled and record the result summary. ' +
+				'Call this when the workflow reaches a terminal step or an unrecoverable error occurs.',
+			ReportResultSchema.shape,
+			(args) => handlers.report_result(args)
+		),
+		tool(
+			'request_human_input',
+			'Pause workflow execution and surface a question to the human user. ' +
+				'The task will be marked as needs_attention until the human responds. ' +
+				'When the human responds, their message will appear in this conversation.',
+			RequestHumanInputSchema.shape,
+			(args) => handlers.request_human_input(args)
+		),
+	];
+
+	return createSdkMcpServer({ name: 'task-agent', tools });
+}
+
+export type TaskAgentMcpServer = ReturnType<typeof createTaskAgentMcpServer>;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -31,6 +31,8 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { resolveAgentInit, buildCustomAgentTaskMessage } from '../agents/custom-agent';
+import { jsonResult } from './tool-result';
+import type { ToolResult } from './tool-result';
 import {
 	SpawnStepAgentSchema,
 	CheckStepStatusSchema,
@@ -45,6 +47,9 @@ import type {
 	ReportResultInput,
 	RequestHumanInputInput,
 } from './task-agent-tool-schemas';
+
+// Re-export for consumers that want the shared type
+export type { ToolResult };
 
 // ---------------------------------------------------------------------------
 // Sub-session state
@@ -101,9 +106,10 @@ export interface SubSessionFactory {
 export interface TaskAgentToolsConfig {
 	/** ID of the main SpaceTask this Task Agent is orchestrating. */
 	taskId: string;
-	/** ID of the Space this task belongs to. */
-	spaceId: string;
-	/** Full Space object — needed for agent init and task message building. */
+	/**
+	 * Full Space object — needed for agent init and task message building.
+	 * The space ID is available as `space.id`.
+	 */
 	space: Space;
 	/** ID of the active workflow run for this task. */
 	workflowRunId: string;
@@ -134,18 +140,6 @@ export interface TaskAgentToolsConfig {
 	 * The Task Agent handler registers this as the session completion callback.
 	 */
 	onSubSessionComplete: (stepId: string, sessionId: string) => Promise<void>;
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-interface ToolResult {
-	content: Array<{ type: 'text'; text: string }>;
-}
-
-function jsonResult(data: unknown): ToolResult {
-	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
 
 // ---------------------------------------------------------------------------
@@ -184,9 +178,11 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * 4. Resolve the agent session init via resolveAgentInit()
 		 * 5. Create the sub-session via sessionFactory.create()
 		 * 6. Register completion callback (onSubSessionComplete) via sessionFactory.onComplete()
-		 * 7. Build and inject the task message via messageInjector
-		 * 8. Update the step task's active_session_id and the main task's currentStep
-		 * 9. Transition main task from pending → in_progress if not already in_progress
+		 * 7. Record the sub-session ID on the step task (BEFORE message injection, so
+		 *    check_step_status can track the session even if injection later fails)
+		 * 8. Transition main task from pending → in_progress if not already in_progress
+		 * 9. Build and inject the task context message via messageInjector
+		 *    (non-fatal if injection fails — sub-session is already running and trackable)
 		 */
 		async spawn_step_agent(args: SpawnStepAgentInput): Promise<ToolResult> {
 			const { step_id, instructions } = args;
@@ -224,11 +220,26 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
-			// Use the most recently created task for this step
+			// Use the most recently created task for this step.
 			const stepTask = stepTasks[stepTasks.length - 1];
 
-			// Ensure customAgentId is set — fall back to step.agentId for preset agents
-			// (WorkflowExecutor sets customAgentId to undefined for coder/general preset roles)
+			// Idempotency guard: if this step already has a tracked sub-session, return it
+			// without creating a duplicate. Prevents double-spawning from orphaning the first
+			// session when the Task Agent retries a spawn_step_agent call.
+			if (stepTask.taskAgentSessionId) {
+				return jsonResult({
+					success: true,
+					sessionId: stepTask.taskAgentSessionId,
+					stepId: step_id,
+					stepName: step.name,
+					taskId: stepTask.id,
+					alreadySpawned: true,
+				});
+			}
+
+			// Ensure customAgentId is set — fall back to step.agentId for preset agents.
+			// WorkflowExecutor sets customAgentId to undefined for coder/general preset roles,
+			// but those agents are still SpaceAgent records indexed by step.agentId.
 			const effectiveTask = {
 				...stepTask,
 				customAgentId: stepTask.customAgentId ?? step.agentId,
@@ -239,7 +250,10 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				effectiveTask.description = instructions;
 			}
 
-			// Generate a new session ID for the sub-session
+			// Generate a new session ID for the sub-session.
+			// Note: the factory may assign a different ID internally. All subsequent code
+			// uses `actualSessionId` returned by sessionFactory.create(), not subSessionId.
+			// The subSessionId is embedded in the init only so the SDK can pre-wire it.
 			const subSessionId = randomUUID();
 
 			// Resolve the agent session init
@@ -268,39 +282,14 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Failed to create sub-session: ${message}` });
 			}
 
-			// Register the completion callback — fires when the sub-session finishes
+			// Register the completion callback — fires when the sub-session finishes.
 			sessionFactory.onComplete(actualSessionId, async () => {
 				await onSubSessionComplete(step_id, actualSessionId);
 			});
 
-			// Build the task context message and inject it into the sub-session
-			try {
-				const agent = agentManager.getById(effectiveTask.customAgentId!);
-				if (agent) {
-					const taskMessage = buildCustomAgentTaskMessage({
-						customAgent: agent,
-						task: effectiveTask,
-						workflowRun: run,
-						workflow,
-						space,
-						sessionId: actualSessionId,
-						workspacePath,
-					});
-					await messageInjector(actualSessionId, taskMessage);
-				}
-			} catch (err) {
-				// Message injection failure is non-fatal — the sub-session will still run,
-				// just without the task context message. Log the issue but don't abort.
-				const message = err instanceof Error ? err.message : String(err);
-				return jsonResult({
-					success: false,
-					error: `Sub-session created (${actualSessionId}) but message injection failed: ${message}`,
-				});
-			}
-
-			// Store the sub-session ID on the step task for later lookup by check_step_status.
-			// We use taskAgentSessionId as the field to record which sub-session is executing
-			// this step task (semantically: the session "orchestrating" this step's work).
+			// Record the sub-session ID on the step task BEFORE message injection.
+			// This ensures check_step_status can locate and track the session even if
+			// the subsequent message injection fails.
 			taskRepo.updateTask(stepTask.id, {
 				taskAgentSessionId: actualSessionId,
 				currentStep: `Running agent for step: ${step.name}`,
@@ -318,6 +307,54 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 
 			// Update main task's currentStep to reflect which step is being executed
 			taskRepo.updateTask(taskId, { currentStep: `Executing step: ${step.name}` });
+
+			// Build the task context message and inject it into the sub-session.
+			// This is non-fatal: if injection fails the sub-session still runs (and is
+			// already trackable via taskAgentSessionId recorded above), just without its
+			// initial task context. Return success with a warning field so the Task Agent
+			// can still poll check_step_status.
+			try {
+				// resolveAgentInit() already validated that the agent exists, so this
+				// getById() call should always succeed. If it somehow returns null after
+				// resolveAgentInit() passed, that is a data inconsistency worth surfacing.
+				const agent = agentManager.getById(effectiveTask.customAgentId!);
+				if (!agent) {
+					return jsonResult({
+						success: true,
+						sessionId: actualSessionId,
+						stepId: step_id,
+						stepName: step.name,
+						taskId: stepTask.id,
+						warning:
+							`Agent ${effectiveTask.customAgentId} not found when building task message — ` +
+							`sub-session is running without initial task context. This should not happen.`,
+					});
+				}
+				const taskMessage = buildCustomAgentTaskMessage({
+					customAgent: agent,
+					task: effectiveTask,
+					workflowRun: run,
+					workflow,
+					space,
+					sessionId: actualSessionId,
+					workspacePath,
+				});
+				await messageInjector(actualSessionId, taskMessage);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				// Return success:true because the sub-session was created, the completion
+				// callback is registered, and taskAgentSessionId is persisted. The Task Agent
+				// can still track completion via check_step_status. The warning informs it
+				// that the sub-session started without its initial task context message.
+				return jsonResult({
+					success: true,
+					sessionId: actualSessionId,
+					stepId: step_id,
+					stepName: step.name,
+					taskId: stepTask.id,
+					warning: `Message injection failed: ${message}. Sub-session is running without initial task context.`,
+				});
+			}
 
 			return jsonResult({
 				success: true,
@@ -399,8 +436,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
-			// Query the sub-session processing state
-			const state = sessionFactory.getProcessingState(stepTask.taskAgentSessionId!);
+			// Query the sub-session processing state.
+			// The guard above ensures taskAgentSessionId is non-null here.
+			const state = sessionFactory.getProcessingState(stepTask.taskAgentSessionId);
 			if (!state) {
 				return jsonResult({
 					success: true,
@@ -454,6 +492,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * 4. Call executor.advance() to evaluate transitions and move to next step
 		 * 5. Handle WorkflowGateError → return gate-blocked status (caller calls request_human_input)
 		 * 6. Return next step info (or terminal state)
+		 *
+		 * Note: AdvanceWorkflowInput includes a `step_result` field which is currently a
+		 * placeholder. WorkflowExecutor.advance() does not yet accept a result parameter;
+		 * transition conditions are evaluated against run.config (e.g. humanApproved).
+		 * The field is retained in the schema for forward compatibility but is not forwarded
+		 * to the executor in this implementation.
 		 */
 		async advance_workflow(_args: AdvanceWorkflowInput): Promise<ToolResult> {
 			const executor = runtime.getExecutor(workflowRunId);
@@ -517,11 +561,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				const { step: nextStep, tasks: newTasks } = await executor.advance();
 
 				if (newTasks.length === 0) {
-					// Terminal step reached — executor marked run as completed
+					// Terminal step reached — executor marked run as completed.
+					// `nextStep` is the step that was just completed (the terminal one).
 					return jsonResult({
 						success: true,
 						terminal: true,
-						completedStep: {
+						terminalStep: {
 							id: nextStep.id,
 							name: nextStep.name,
 						},
@@ -602,6 +647,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 *
 		 * Updates the main task status to `needs_attention` and stores the question
 		 * in the `currentStep` field so the human can see it in the UI.
+		 * The full question + context is stored in the `error` field for complete context.
 		 *
 		 * Gate re-engagement:
 		 * When the human responds (via space.task.sendMessage), the message is injected
@@ -617,8 +663,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 			}
 
-			// Only transition to needs_attention from valid states
-			// Valid transitions: in_progress → needs_attention, review → needs_attention
+			// Only transition to needs_attention from valid states.
+			// Valid transitions: in_progress → needs_attention, review → needs_attention.
 			const canTransition = mainTask.status === 'in_progress' || mainTask.status === 'review';
 
 			if (!canTransition) {
@@ -630,6 +676,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
+			// The `error` field stores the full question + context for complete diagnostic context.
+			// The `currentStep` field stores just the bare question for UI display — it is
+			// intentionally shorter than `error` to fit the summary display in the task list.
 			const questionWithContext = questionContext
 				? `${question}\n\nContext: ${questionContext}`
 				: question;
@@ -639,7 +688,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					error: questionWithContext,
 				});
 
-				// Update currentStep to surface the question visibly in the UI
+				// Update currentStep to the bare question for visible UI display
 				taskRepo.updateTask(taskId, { currentStep: question });
 
 				return jsonResult({

--- a/packages/daemon/src/lib/space/tools/tool-result.ts
+++ b/packages/daemon/src/lib/space/tools/tool-result.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared ToolResult type and jsonResult helper for Space MCP tool handlers.
+ *
+ * Extracted from space-agent-tools.ts and task-agent-tools.ts to eliminate
+ * duplication. Both files previously defined identical types inline.
+ */
+
+export interface ToolResult {
+	content: Array<{ type: 'text'; text: string }>;
+}
+
+export function jsonResult(data: unknown): ToolResult {
+	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -540,6 +540,29 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		const after = ctx.taskRepo.getTask(mainTask.id);
 		expect(after?.status).toBe('in_progress');
 	});
+
+	test('double-spawn for same step_id returns success on second call (idempotent session reuse)', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// First spawn
+		const first = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const firstParsed = JSON.parse(first.content[0].text);
+		expect(firstParsed.success).toBe(true);
+		const firstSessionId = firstParsed.sessionId;
+
+		// Second spawn for same step — the step task already has taskAgentSessionId set
+		// Handler should detect the existing session and return it without creating a new one
+		const second = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const secondParsed = JSON.parse(second.content[0].text);
+
+		// Must not error out — should succeed or return existing session info
+		expect(secondParsed.success).toBe(true);
+		// The returned sessionId should be the same as the first (no duplicate sessions)
+		expect(secondParsed.sessionId).toBe(firstSessionId);
+	});
 });
 
 // ===========================================================================
@@ -693,10 +716,7 @@ describe('createTaskAgentToolHandlers — check_step_status', () => {
 		const { sessionId } = JSON.parse(spawnResult.content[0].text);
 
 		// Simulate session completing without the completion callback updating DB
-		const extFactory = factory as ReturnType<typeof makeMockSessionFactory> & {
-			_setState: (id: string, state: SubSessionState) => void;
-		};
-		// Access private map via cast to trigger isComplete=true
+		// Override getProcessingState to report the session as complete
 		(
 			factory as unknown as { getProcessingState: (id: string) => SubSessionState }
 		).getProcessingState = (_id: string) => ({ isProcessing: false, isComplete: true });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1,0 +1,1262 @@
+/**
+ * Unit tests for createTaskAgentToolHandlers()
+ *
+ * Covers all 5 Task Agent tools:
+ *   spawn_step_agent    — creates sub-session, registers callback, injects message
+ *   check_step_status   — polling detection of sub-session completion
+ *   advance_workflow    — delegates to WorkflowExecutor.advance(), handles gate errors
+ *   report_result       — transitions main task to final status
+ *   request_human_input — pauses execution, marks task needs_attention
+ *
+ * Tests use a real SQLite database (via runMigrations) and mock SubSessionFactory
+ * so no real agent sessions are created.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import {
+	createTaskAgentToolHandlers,
+	type SubSessionFactory,
+	type SubSessionState,
+	type TaskAgentToolsConfig,
+} from '../../../src/lib/space/tools/task-agent-tools.ts';
+import type { Space, SpaceWorkflow, SpaceTask } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-task-agent-tools',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgentRow(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	name: string,
+	role: string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, name, role, Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
+	return {
+		id: spaceId,
+		workspacePath,
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Workflow helpers
+// ---------------------------------------------------------------------------
+
+function buildTwoStepWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string,
+	name = 'Two-Step WF'
+): SpaceWorkflow {
+	const step1Id = `step-1-${Math.random().toString(36).slice(2)}`;
+	const step2Id = `step-2-${Math.random().toString(36).slice(2)}`;
+
+	return workflowManager.createWorkflow({
+		spaceId,
+		name,
+		description: 'Two-step test workflow',
+		steps: [
+			{ id: step1Id, name: 'Step One', agentId, instructions: 'Do the first thing' },
+			{ id: step2Id, name: 'Step Two', agentId, instructions: 'Do the second thing' },
+		],
+		transitions: [{ from: step1Id, to: step2Id, condition: { type: 'always' } }],
+		startStepId: step1Id,
+		rules: [],
+	});
+}
+
+function buildSingleStepWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string,
+	name = 'Single-Step WF'
+): SpaceWorkflow {
+	const stepId = `step-${Math.random().toString(36).slice(2)}`;
+	return workflowManager.createWorkflow({
+		spaceId,
+		name,
+		steps: [{ id: stepId, name: 'Only Step', agentId }],
+		transitions: [],
+		startStepId: stepId,
+		rules: [],
+	});
+}
+
+function buildHumanGateWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string
+): SpaceWorkflow {
+	const step1Id = `step-1-${Math.random().toString(36).slice(2)}`;
+	const step2Id = `step-2-${Math.random().toString(36).slice(2)}`;
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: 'Human Gate WF',
+		steps: [
+			{ id: step1Id, name: 'Work Step', agentId },
+			{ id: step2Id, name: 'After Gate', agentId },
+		],
+		transitions: [{ from: step1Id, to: step2Id, condition: { type: 'human' } }],
+		startStepId: step1Id,
+		rules: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mock SubSessionFactory
+// ---------------------------------------------------------------------------
+
+function makeMockSessionFactory(overrides?: {
+	create?: (init: unknown) => Promise<string>;
+	getProcessingState?: (sessionId: string) => SubSessionState | null;
+	onComplete?: (sessionId: string, callback: () => Promise<void>) => void;
+}): SubSessionFactory & { _completionCallbacks: Map<string, () => Promise<void>> } {
+	const completionCallbacks = new Map<string, () => Promise<void>>();
+	const sessionStates = new Map<string, SubSessionState>();
+
+	return {
+		_completionCallbacks: completionCallbacks,
+
+		async create(init: unknown): Promise<string> {
+			if (overrides?.create) return overrides.create(init);
+			const id = `sub-session-${Math.random().toString(36).slice(2)}`;
+			sessionStates.set(id, { isProcessing: true, isComplete: false });
+			return id;
+		},
+
+		getProcessingState(sessionId: string): SubSessionState | null {
+			if (overrides?.getProcessingState) return overrides.getProcessingState(sessionId);
+			return sessionStates.get(sessionId) ?? null;
+		},
+
+		onComplete(sessionId: string, callback: () => Promise<void>): void {
+			if (overrides?.onComplete) {
+				overrides.onComplete(sessionId, callback);
+				return;
+			}
+			completionCallbacks.set(sessionId, callback);
+		},
+
+		// Test helper: simulate a session completing
+		async _triggerComplete(sessionId: string): Promise<void> {
+			sessionStates.set(sessionId, { isProcessing: false, isComplete: true });
+			const cb = completionCallbacks.get(sessionId);
+			if (cb) await cb();
+		},
+	} as SubSessionFactory & {
+		_completionCallbacks: Map<string, () => Promise<void>>;
+		_triggerComplete: (sessionId: string) => Promise<void>;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test context
+// ---------------------------------------------------------------------------
+
+interface TestCtx {
+	db: BunDatabase;
+	dir: string;
+	spaceId: string;
+	agentId: string;
+	space: Space;
+	workflowManager: SpaceWorkflowManager;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
+	agentManager: SpaceAgentManager;
+	runtime: SpaceRuntime;
+}
+
+function makeCtx(): TestCtx {
+	const { db, dir } = makeDb();
+	const spaceId = 'space-tat-test';
+	const workspacePath = '/tmp/test-workspace';
+
+	seedSpaceRow(db, spaceId, workspacePath);
+
+	const agentId = 'agent-coder-1';
+	seedAgentRow(db, agentId, spaceId, 'Coder', 'coder');
+
+	const agentRepo = new SpaceAgentRepository(db);
+	const agentManager = new SpaceAgentManager(agentRepo);
+
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const spaceManager = new SpaceManager(db);
+	const taskManager = new SpaceTaskManager(db, spaceId);
+
+	const runtime = new SpaceRuntime({
+		db,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+	});
+
+	const space = makeSpace(spaceId, workspacePath);
+
+	return {
+		db,
+		dir,
+		spaceId,
+		agentId,
+		space,
+		workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		taskManager,
+		agentManager,
+		runtime,
+	};
+}
+
+function makeConfig(
+	ctx: TestCtx,
+	taskId: string,
+	workflowRunId: string,
+	sessionFactory: SubSessionFactory,
+	options?: {
+		messageInjector?: (sessionId: string, message: string) => Promise<void>;
+		onSubSessionComplete?: (stepId: string, sessionId: string) => Promise<void>;
+	}
+): TaskAgentToolsConfig {
+	return {
+		taskId,
+		spaceId: ctx.spaceId,
+		space: ctx.space,
+		workflowRunId,
+		workspacePath: ctx.space.workspacePath,
+		runtime: ctx.runtime,
+		workflowManager: ctx.workflowManager,
+		taskRepo: ctx.taskRepo,
+		workflowRunRepo: ctx.workflowRunRepo,
+		agentManager: ctx.agentManager,
+		taskManager: ctx.taskManager,
+		sessionFactory,
+		messageInjector: options?.messageInjector ?? (async () => {}),
+		onSubSessionComplete: options?.onSubSessionComplete ?? (async () => {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helper: start workflow run and get the main task + step task
+// ---------------------------------------------------------------------------
+
+async function startRun(
+	ctx: TestCtx,
+	workflow: SpaceWorkflow
+): Promise<{ run: { id: string }; mainTask: SpaceTask; stepTask: SpaceTask }> {
+	const { run, tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, workflow.id, 'Test run');
+	const stepTask = tasks[0];
+
+	// Create the main "task agent task" (the task that has a Task Agent session)
+	const mainTask = ctx.taskRepo.createTask({
+		spaceId: ctx.spaceId,
+		title: 'Main orchestration task',
+		description: 'The task being orchestrated',
+		status: 'pending',
+		workflowRunId: run.id,
+	});
+
+	return { run, mainTask, stepTask };
+}
+
+// ===========================================================================
+// spawn_step_agent tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('successfully spawns a sub-session for a valid step', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.sessionId).toBeString();
+		expect(parsed.stepId).toBe(wf.startStepId);
+		expect(parsed.taskId).toBe(stepTask.id);
+	});
+
+	test('transitions main task from pending to in_progress', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Main task starts as pending
+		const before = ctx.taskRepo.getTask(mainTask.id);
+		expect(before?.status).toBe('pending');
+
+		await handlers.spawn_step_agent({ step_id: wf.startStepId });
+
+		const after = ctx.taskRepo.getTask(mainTask.id);
+		expect(after?.status).toBe('in_progress');
+	});
+
+	test('stores sub-session ID on step task via taskAgentSessionId', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		const updatedStepTask = ctx.taskRepo.getTask(stepTask.id);
+		expect(updatedStepTask?.taskAgentSessionId).toBe(parsed.sessionId);
+	});
+
+	test('registers completion callback on the sub-session', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+
+		const completedSteps: string[] = [];
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				onSubSessionComplete: async (stepId) => {
+					completedSteps.push(stepId);
+					// Actually mark the step task as completed (as TaskAgentManager would do)
+					ctx.taskRepo.updateTask(stepTask.id, {
+						status: 'completed',
+						completedAt: Date.now(),
+					});
+				},
+			})
+		);
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Trigger sub-session completion
+		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(parsed.sessionId);
+
+		expect(completedSteps).toContain(wf.startStepId);
+		const updatedStepTask = ctx.taskRepo.getTask(stepTask.id);
+		expect(updatedStepTask?.status).toBe('completed');
+	});
+
+	test('injects the task context message into the sub-session', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const injections: Array<{ sessionId: string; message: string }> = [];
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				messageInjector: async (sessionId, message) => {
+					injections.push({ sessionId, message });
+				},
+			})
+		);
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(injections).toHaveLength(1);
+		expect(injections[0].sessionId).toBe(parsed.sessionId);
+		expect(injections[0].message).toBeString();
+		expect(injections[0].message.length).toBeGreaterThan(0);
+	});
+
+	test('applies instruction override when provided', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const injections: Array<{ sessionId: string; message: string }> = [];
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				messageInjector: async (sessionId, message) => {
+					injections.push({ sessionId, message });
+				},
+			})
+		);
+
+		await handlers.spawn_step_agent({
+			step_id: wf.startStepId,
+			instructions: 'Custom override instructions here',
+		});
+
+		expect(injections).toHaveLength(1);
+		// The injected message should contain the override instructions
+		expect(injections[0].message).toContain('Custom override instructions here');
+	});
+
+	test('returns error when step_id not found in workflow', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: 'step-does-not-exist' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('step-does-not-exist');
+	});
+
+	test('returns error when no task found for step (advance_workflow not yet called)', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// The second step has no task yet because advance_workflow hasn't been called
+		const step2Id = wf.steps[1].id;
+		const result = await handlers.spawn_step_agent({ step_id: step2Id });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(step2Id);
+	});
+
+	test('returns error when workflow run not found', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'pending',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, 'run-does-not-exist', factory)
+		);
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('run-does-not-exist');
+	});
+
+	test('returns error when sessionFactory.create throws', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const factory = makeMockSessionFactory({
+			create: async () => {
+				throw new Error('Session creation failed: quota exceeded');
+			},
+		});
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('quota exceeded');
+	});
+
+	test('does not re-transition main task if already in_progress', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		// Manually transition to in_progress
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		const after = ctx.taskRepo.getTask(mainTask.id);
+		expect(after?.status).toBe('in_progress');
+	});
+});
+
+// ===========================================================================
+// check_step_status tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — check_step_status', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns not_started when spawn has not been called yet', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.check_step_status({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.sessionStatus).toBe('not_started');
+	});
+
+	test('returns running when sub-session is actively processing', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Spawn the step agent first
+		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const { sessionId } = JSON.parse(spawnResult.content[0].text);
+
+		// Factory returns isProcessing: true by default
+		const result = await handlers.check_step_status({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.sessionStatus).toBe('running');
+		expect(sessionId).toBeString();
+	});
+
+	test('returns completed when task status is completed in DB', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the step task as completed directly (simulating completion callback)
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		const result = await handlers.check_step_status({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskStatus).toBe('completed');
+		expect(parsed.sessionStatus).toBe('completed');
+	});
+
+	test('returns unknown when session state is not available', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+
+		const factory = makeMockSessionFactory({
+			getProcessingState: () => null, // State not available
+		});
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Manually set taskAgentSessionId without spawning (simulate orphaned session)
+		ctx.taskRepo.updateTask(stepTask.id, { taskAgentSessionId: 'orphaned-session-id' });
+
+		const result = await handlers.check_step_status({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.sessionStatus).toBe('unknown');
+	});
+
+	test('uses current step from workflow run when step_id is omitted', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Call without step_id — should use run.currentStepId
+		const result = await handlers.check_step_status({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.stepId).toBe(wf.startStepId);
+	});
+
+	test('returns not_found when step has no task yet', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Check step 2 which has no task (advance_workflow not yet called)
+		const step2Id = wf.steps[1].id;
+		const result = await handlers.check_step_status({ step_id: step2Id });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskStatus).toBe('not_found');
+		expect(parsed.sessionStatus).toBe('not_started');
+	});
+
+	test('returns error when workflow run not found', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'pending',
+		});
+		const factory = makeMockSessionFactory();
+
+		// No step_id, so it tries to look up the run
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, 'run-missing', factory)
+		);
+
+		const result = await handlers.check_step_status({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('run-missing');
+	});
+
+	test('session state shows completed status when session isComplete=true', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Spawn and then trigger complete (but don't update DB task status yet)
+		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const { sessionId } = JSON.parse(spawnResult.content[0].text);
+
+		// Simulate session completing without the completion callback updating DB
+		const extFactory = factory as ReturnType<typeof makeMockSessionFactory> & {
+			_setState: (id: string, state: SubSessionState) => void;
+		};
+		// Access private map via cast to trigger isComplete=true
+		(
+			factory as unknown as { getProcessingState: (id: string) => SubSessionState }
+		).getProcessingState = (_id: string) => ({ isProcessing: false, isComplete: true });
+
+		const result = await handlers.check_step_status({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.sessionStatus).toBe('completed');
+		expect(sessionId).toBeString();
+	});
+});
+
+// ===========================================================================
+// advance_workflow tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — advance_workflow', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when executor not found for run', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, 'run-missing', factory)
+		);
+
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('run-missing');
+	});
+
+	test('returns error when current step tasks are not completed', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick(); // Rehydrate executor
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Step task is still pending — advance should fail
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not completed yet');
+		expect(parsed.taskStatus).toBe('pending');
+	});
+
+	test('successfully advances to next step when current step is completed', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick(); // Rehydrate executor
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the first step task as completed
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.terminal).toBe(false);
+		expect(parsed.nextStep).toBeDefined();
+		expect(parsed.nextStep.name).toBe('Step Two');
+		expect(parsed.newTasks).toHaveLength(1);
+	});
+
+	test('returns terminal status when reaching a terminal step', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the single step task as completed
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.terminal).toBe(true);
+		expect(parsed.message).toContain('report_result');
+	});
+
+	test('returns gateBlocked status for human gate condition', async () => {
+		const wf = buildHumanGateWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the first step task as completed
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Human gate → gateBlocked, not an error
+		expect(parsed.success).toBe(true);
+		expect(parsed.gateBlocked).toBe(true);
+		expect(parsed.instruction).toContain('request_human_input');
+	});
+
+	test('resets main task from needs_attention to in_progress when advancing', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+		const factory = makeMockSessionFactory();
+
+		// Set main task to in_progress first (required for needs_attention transition)
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'in_progress');
+		// Set main task to needs_attention (simulating request_human_input was called)
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'needs_attention');
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the step task as completed
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// Main task should be back to in_progress
+		const mainTaskAfter = ctx.taskRepo.getTask(mainTask.id);
+		expect(mainTaskAfter?.status).toBe('in_progress');
+	});
+
+	test('returns error when workflow run is already complete', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark step completed and advance once to terminal
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+		await handlers.advance_workflow({}); // First advance → terminal
+
+		// Try to advance again — should fail
+		const result = await handlers.advance_workflow({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('complete');
+	});
+});
+
+// ===========================================================================
+// report_result tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — report_result', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('marks task as completed with summary', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.report_result({
+			status: 'completed',
+			summary: 'All steps completed successfully.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('completed');
+		expect(parsed.summary).toBe('All steps completed successfully.');
+
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		expect(updated?.status).toBe('completed');
+	});
+
+	test('marks task as needs_attention with error', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.report_result({
+			status: 'needs_attention',
+			summary: 'An error occurred.',
+			error: 'Tests failed in CI.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('needs_attention');
+
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		expect(updated?.status).toBe('needs_attention');
+	});
+
+	test('marks task as cancelled', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.report_result({
+			status: 'cancelled',
+			summary: 'User cancelled the task.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.status).toBe('cancelled');
+	});
+
+	test('returns error when task not found', async () => {
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, 'task-does-not-exist', 'run-id', factory)
+		);
+
+		const result = await handlers.report_result({
+			status: 'completed',
+			summary: 'Done.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-does-not-exist');
+	});
+
+	test('returns error when status transition is invalid', async () => {
+		// completed → completed is not a valid transition
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Already done',
+			description: '',
+			status: 'completed',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.report_result({
+			status: 'completed',
+			summary: 'Done again?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('transition');
+	});
+});
+
+// ===========================================================================
+// request_human_input tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — request_human_input', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('marks task as needs_attention with question in currentStep', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.request_human_input({
+			question: 'Should we proceed with the current approach?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.question).toBe('Should we proceed with the current approach?');
+
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		expect(updated?.status).toBe('needs_attention');
+		expect(updated?.currentStep).toBe('Should we proceed with the current approach?');
+	});
+
+	test('includes context in the error field when provided', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		await handlers.request_human_input({
+			question: 'Approve the PR?',
+			context: 'The PR includes breaking changes to the auth module.',
+		});
+
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		// error field should contain both question and context
+		expect(updated?.error).toContain('Approve the PR?');
+		expect(updated?.error).toContain('breaking changes');
+	});
+
+	test('returns message instructing Task Agent to wait', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.request_human_input({
+			question: 'Which approach should we take?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.message).toContain('Wait');
+		expect(parsed.message).toContain('advance_workflow');
+	});
+
+	test('returns error when task not found', async () => {
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, 'task-missing', 'run-id', factory)
+		);
+
+		const result = await handlers.request_human_input({
+			question: 'What to do?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+
+	test('returns error when task is not in valid state for human input request', async () => {
+		// pending → needs_attention is not valid
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'pending',
+		});
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.request_human_input({
+			question: 'Approve?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('pending');
+	});
+
+	test('works from review status too', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Main task',
+			description: '',
+			status: 'in_progress',
+		});
+		// Transition to review first
+		await ctx.taskManager.setTaskStatus(mainTask.id, 'review');
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.request_human_input({
+			question: 'Review passed?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		expect(updated?.status).toBe('needs_attention');
+	});
+});
+
+// ===========================================================================
+// Integration: spawn → check → advance → report lifecycle
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — end-to-end lifecycle', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('full single-step workflow lifecycle: spawn → check(running) → check(done) → advance(terminal) → report', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				onSubSessionComplete: async (stepId) => {
+					// TaskAgentManager marks the step task completed
+					const tasks = ctx.taskRepo
+						.listByWorkflowRun(run.id)
+						.filter((t) => t.workflowStepId === stepId);
+					if (tasks.length > 0) {
+						ctx.taskRepo.updateTask(tasks[0].id, {
+							status: 'completed',
+							completedAt: Date.now(),
+						});
+					}
+				},
+			})
+		);
+
+		// 1. Spawn step agent
+		const spawnResult = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const { sessionId } = JSON.parse(spawnResult.content[0].text);
+		expect(sessionId).toBeString();
+
+		// 2. Check status — running
+		const checkRunning = await handlers.check_step_status({ step_id: wf.startStepId });
+		expect(JSON.parse(checkRunning.content[0].text).sessionStatus).toBe('running');
+
+		// 3. Trigger sub-session completion (fires onSubSessionComplete callback)
+		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(sessionId);
+
+		// 4. Check status — completed
+		const checkDone = await handlers.check_step_status({ step_id: wf.startStepId });
+		expect(JSON.parse(checkDone.content[0].text).taskStatus).toBe('completed');
+
+		// 5. Advance workflow — terminal step
+		const advanceResult = await handlers.advance_workflow({});
+		const advanceParsed = JSON.parse(advanceResult.content[0].text);
+		expect(advanceParsed.success).toBe(true);
+		expect(advanceParsed.terminal).toBe(true);
+
+		// 6. Report result
+		const reportResult = await handlers.report_result({
+			status: 'completed',
+			summary: 'Workflow completed successfully.',
+		});
+		const reportParsed = JSON.parse(reportResult.content[0].text);
+		expect(reportParsed.success).toBe(true);
+		expect(reportParsed.status).toBe('completed');
+
+		const finalTask = ctx.taskRepo.getTask(mainTask.id);
+		expect(finalTask?.status).toBe('completed');
+	});
+
+	test('two-step workflow: spawn → advance → spawn step 2 → advance(terminal) → report', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick();
+
+		const completedStepTasks: Set<string> = new Set();
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				onSubSessionComplete: async (stepId) => {
+					const tasks = ctx.taskRepo
+						.listByWorkflowRun(run.id)
+						.filter((t) => t.workflowStepId === stepId);
+					if (tasks.length > 0) {
+						ctx.taskRepo.updateTask(tasks[0].id, {
+							status: 'completed',
+							completedAt: Date.now(),
+						});
+						completedStepTasks.add(tasks[0].id);
+					}
+				},
+			})
+		);
+
+		// Step 1: Spawn, complete, advance
+		const spawn1 = await handlers.spawn_step_agent({ step_id: wf.steps[0].id });
+		const { sessionId: sid1 } = JSON.parse(spawn1.content[0].text);
+		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(sid1);
+
+		const advance1 = await handlers.advance_workflow({});
+		const adv1Parsed = JSON.parse(advance1.content[0].text);
+		expect(adv1Parsed.success).toBe(true);
+		expect(adv1Parsed.terminal).toBe(false);
+
+		const step2Id = wf.steps[1].id;
+
+		// Step 2: Spawn, complete, advance to terminal
+		const spawn2 = await handlers.spawn_step_agent({ step_id: step2Id });
+		const { sessionId: sid2 } = JSON.parse(spawn2.content[0].text);
+		await (factory as ReturnType<typeof makeMockSessionFactory>)._triggerComplete(sid2);
+
+		const advance2 = await handlers.advance_workflow({});
+		const adv2Parsed = JSON.parse(advance2.content[0].text);
+		expect(adv2Parsed.success).toBe(true);
+		expect(adv2Parsed.terminal).toBe(true);
+
+		// Report final result
+		const report = await handlers.report_result({
+			status: 'completed',
+			summary: 'Both steps done.',
+		});
+		expect(JSON.parse(report.content[0].text).success).toBe(true);
+	});
+});


### PR DESCRIPTION
Create createTaskAgentToolHandlers() with 5 handlers: spawn_step_agent,
check_step_status, advance_workflow, report_result, and request_human_input.

- spawn_step_agent: resolves agent via resolveAgentInit(), creates sub-session
  via SubSessionFactory, registers completion callback via onSubSessionComplete,
  injects task message, transitions main task pending→in_progress
- check_step_status: polls sub-session state via SubSessionFactory, detects
  completion via taskAgentSessionId stored on step task
- advance_workflow: validates step task is completed in DB, calls executor.advance(),
  handles WorkflowGateError as gateBlocked (not error), resets needs_attention→in_progress
- report_result: delegates to SpaceTaskManager.setTaskStatus with result/error
- request_human_input: transitions task to needs_attention, stores question in
  currentStep, instructs Task Agent to wait for human response

Also add createTaskAgentMcpServer() factory and barrel exports in index.ts.
39 unit tests covering success paths, error paths, and edge cases.
