### PR TITLE
feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1)

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -31,6 +31,15 @@ export type {
 } from './runtime/workflow-executor';
 export { SpaceRuntime } from './runtime/space-runtime';
 export type { SpaceRuntimeConfig, ResolvedTaskType } from './runtime/space-runtime';
+export { NullNotificationSink } from './runtime/notification-sink';
+export type {
+	NotificationSink,
+	SpaceNotificationEvent,
+	TaskNeedsAttentionEvent,
+	WorkflowRunNeedsAttentionEvent,
+	TaskTimeoutEvent,
+	WorkflowRunCompletedEvent,
+} from './runtime/notification-sink';
 export { SpaceRuntimeService } from './runtime/space-runtime-service';
 export type { SpaceRuntimeServiceConfig } from './runtime/space-runtime-service';
 

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -1,0 +1,136 @@
+/**
+ * NotificationSink — interface for Space Runtime to push structured events
+ * to consumers such as the Space Agent session or test harnesses.
+ *
+ * SpaceRuntime calls `notify()` after mechanical processing whenever a state
+ * change requires judgment or awareness (e.g. a task hits `needs_attention`,
+ * a workflow run completes, or a task times out).
+ *
+ * Consumers that don't need notifications can use `NullNotificationSink`.
+ */
+
+// ---------------------------------------------------------------------------
+// Event payload types
+// ---------------------------------------------------------------------------
+
+/** A task has transitioned to `needs_attention` and requires judgment. */
+export interface TaskNeedsAttentionEvent {
+	kind: 'task_needs_attention';
+	/** Space the task belongs to. */
+	spaceId: string;
+	/** Task that needs attention. */
+	taskId: string;
+	/** Human-readable reason the task needs attention. */
+	reason: string;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
+/** A workflow run has transitioned to `needs_attention` (e.g. a transition condition failed). */
+export interface WorkflowRunNeedsAttentionEvent {
+	kind: 'workflow_run_needs_attention';
+	/** Space the workflow run belongs to. */
+	spaceId: string;
+	/** Workflow run that needs attention. */
+	runId: string;
+	/** Human-readable reason the run needs attention. */
+	reason: string;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
+/** A task has been running longer than the configured timeout threshold. */
+export interface TaskTimeoutEvent {
+	kind: 'task_timeout';
+	/** Space the task belongs to. */
+	spaceId: string;
+	/** Task that has exceeded its time threshold. */
+	taskId: string;
+	/** Elapsed milliseconds since the task started. */
+	elapsedMs: number;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
+/** A workflow run has reached a terminal state (completed or failed). */
+export interface WorkflowRunCompletedEvent {
+	kind: 'workflow_run_completed';
+	/** Space the workflow run belongs to. */
+	spaceId: string;
+	/** Workflow run that completed. */
+	runId: string;
+	/** Final status of the run. */
+	status: 'completed' | 'failed' | 'cancelled';
+	/** Optional summary of what the run accomplished. */
+	summary?: string;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
+/**
+ * Discriminated union of all structured notification events emitted by
+ * `SpaceRuntime`. Use the `kind` field to narrow to a specific event type.
+ *
+ * @example
+ * ```ts
+ * function handleEvent(event: SpaceNotificationEvent) {
+ *   switch (event.kind) {
+ *     case 'task_needs_attention':
+ *       // event is TaskNeedsAttentionEvent
+ *       break;
+ *     case 'workflow_run_needs_attention':
+ *       // event is WorkflowRunNeedsAttentionEvent
+ *       break;
+ *     case 'task_timeout':
+ *       // event is TaskTimeoutEvent
+ *       break;
+ *     case 'workflow_run_completed':
+ *       // event is WorkflowRunCompletedEvent
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+export type SpaceNotificationEvent =
+	| TaskNeedsAttentionEvent
+	| WorkflowRunNeedsAttentionEvent
+	| TaskTimeoutEvent
+	| WorkflowRunCompletedEvent;
+
+// ---------------------------------------------------------------------------
+// NotificationSink interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Receives structured notification events from `SpaceRuntime`.
+ *
+ * Implementations must be non-blocking from the runtime's perspective —
+ * the runtime awaits the returned promise but does not retry on failure.
+ * Implementations should handle their own errors internally.
+ */
+export interface NotificationSink {
+	/**
+	 * Called by `SpaceRuntime` when an event occurs that may require
+	 * judgment or awareness from a consumer.
+	 *
+	 * @param event - The structured notification event.
+	 */
+	notify(event: SpaceNotificationEvent): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// NullNotificationSink — no-op implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * No-op `NotificationSink` implementation.
+ *
+ * Use this as the default when no real consumer is connected (e.g. in unit
+ * tests that don't care about notifications, or before the Space Agent session
+ * has been provisioned).
+ */
+export class NullNotificationSink implements NotificationSink {
+	async notify(_event: SpaceNotificationEvent): Promise<void> {
+		// intentional no-op
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -52,15 +52,19 @@ export interface TaskTimeoutEvent {
 	timestamp: string;
 }
 
-/** A workflow run has reached a terminal state (completed or failed). */
+/** A workflow run has reached a terminal state (completed, cancelled, or needs_attention). */
 export interface WorkflowRunCompletedEvent {
 	kind: 'workflow_run_completed';
 	/** Space the workflow run belongs to. */
 	spaceId: string;
 	/** Workflow run that completed. */
 	runId: string;
-	/** Final status of the run. */
-	status: 'completed' | 'failed' | 'cancelled';
+	/**
+	 * Final status of the run — a terminal subset of `WorkflowRunStatus`.
+	 * `'needs_attention'` represents a run that ended due to an unrecoverable
+	 * error or condition gate failure.
+	 */
+	status: 'completed' | 'cancelled' | 'needs_attention';
 	/** Optional summary of what the run accomplished. */
 	summary?: string;
 	/** ISO-8601 timestamp when the event was emitted. */
@@ -130,7 +134,7 @@ export interface NotificationSink {
  * has been provisioned).
  */
 export class NullNotificationSink implements NotificationSink {
-	async notify(_event: SpaceNotificationEvent): Promise<void> {
-		// intentional no-op
+	notify(_event: SpaceNotificationEvent): Promise<void> {
+		return Promise.resolve();
 	}
 }

--- a/packages/daemon/tests/unit/space/notification-sink.test.ts
+++ b/packages/daemon/tests/unit/space/notification-sink.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'bun:test';
+import {
+	NullNotificationSink,
+	type SpaceNotificationEvent,
+	type TaskNeedsAttentionEvent,
+	type WorkflowRunNeedsAttentionEvent,
+	type TaskTimeoutEvent,
+	type WorkflowRunCompletedEvent,
+} from '../../../src/lib/space/runtime/notification-sink';
+
+describe('SpaceNotificationEvent types', () => {
+	it('constructs a task_needs_attention event', () => {
+		const event: TaskNeedsAttentionEvent = {
+			kind: 'task_needs_attention',
+			spaceId: 'space-1',
+			taskId: 'task-42',
+			reason: 'Agent reported an unrecoverable error',
+			timestamp: '2026-03-20T10:00:00.000Z',
+		};
+
+		expect(event.kind).toBe('task_needs_attention');
+		expect(event.spaceId).toBe('space-1');
+		expect(event.taskId).toBe('task-42');
+		expect(event.reason).toBe('Agent reported an unrecoverable error');
+		expect(event.timestamp).toBe('2026-03-20T10:00:00.000Z');
+	});
+
+	it('constructs a workflow_run_needs_attention event', () => {
+		const event: WorkflowRunNeedsAttentionEvent = {
+			kind: 'workflow_run_needs_attention',
+			spaceId: 'space-2',
+			runId: 'run-99',
+			reason: 'Transition condition failed: tests did not pass',
+			timestamp: '2026-03-20T11:00:00.000Z',
+		};
+
+		expect(event.kind).toBe('workflow_run_needs_attention');
+		expect(event.spaceId).toBe('space-2');
+		expect(event.runId).toBe('run-99');
+		expect(event.reason).toBe('Transition condition failed: tests did not pass');
+	});
+
+	it('constructs a task_timeout event', () => {
+		const event: TaskTimeoutEvent = {
+			kind: 'task_timeout',
+			spaceId: 'space-3',
+			taskId: 'task-7',
+			elapsedMs: 3600000,
+			timestamp: '2026-03-20T12:00:00.000Z',
+		};
+
+		expect(event.kind).toBe('task_timeout');
+		expect(event.elapsedMs).toBe(3600000);
+	});
+
+	it('constructs a workflow_run_completed event with summary', () => {
+		const event: WorkflowRunCompletedEvent = {
+			kind: 'workflow_run_completed',
+			spaceId: 'space-4',
+			runId: 'run-1',
+			status: 'completed',
+			summary: 'All three steps finished successfully. PR #42 merged.',
+			timestamp: '2026-03-20T13:00:00.000Z',
+		};
+
+		expect(event.kind).toBe('workflow_run_completed');
+		expect(event.status).toBe('completed');
+		expect(event.summary).toBe('All three steps finished successfully. PR #42 merged.');
+	});
+
+	it('constructs a workflow_run_completed event without summary', () => {
+		const event: WorkflowRunCompletedEvent = {
+			kind: 'workflow_run_completed',
+			spaceId: 'space-4',
+			runId: 'run-2',
+			status: 'failed',
+			timestamp: '2026-03-20T13:00:00.000Z',
+		};
+
+		expect(event.kind).toBe('workflow_run_completed');
+		expect(event.status).toBe('failed');
+		expect(event.summary).toBeUndefined();
+	});
+
+	it('SpaceNotificationEvent union narrows correctly via kind', () => {
+		const events: SpaceNotificationEvent[] = [
+			{
+				kind: 'task_needs_attention',
+				spaceId: 's',
+				taskId: 't',
+				reason: 'r',
+				timestamp: 'ts',
+			},
+			{
+				kind: 'workflow_run_needs_attention',
+				spaceId: 's',
+				runId: 'r',
+				reason: 'r',
+				timestamp: 'ts',
+			},
+			{ kind: 'task_timeout', spaceId: 's', taskId: 't', elapsedMs: 0, timestamp: 'ts' },
+			{
+				kind: 'workflow_run_completed',
+				spaceId: 's',
+				runId: 'r',
+				status: 'completed',
+				timestamp: 'ts',
+			},
+		];
+
+		const kinds = events.map((e) => e.kind);
+		expect(kinds).toEqual([
+			'task_needs_attention',
+			'workflow_run_needs_attention',
+			'task_timeout',
+			'workflow_run_completed',
+		]);
+	});
+});
+
+describe('NullNotificationSink', () => {
+	it('implements NotificationSink and resolves without error', async () => {
+		const sink = new NullNotificationSink();
+		const event: SpaceNotificationEvent = {
+			kind: 'task_needs_attention',
+			spaceId: 'space-1',
+			taskId: 'task-1',
+			reason: 'test',
+			timestamp: new Date().toISOString(),
+		};
+
+		await expect(sink.notify(event)).resolves.toBeUndefined();
+	});
+
+	it('handles all event kinds without throwing', async () => {
+		const sink = new NullNotificationSink();
+
+		const events: SpaceNotificationEvent[] = [
+			{
+				kind: 'task_needs_attention',
+				spaceId: 's',
+				taskId: 't',
+				reason: 'r',
+				timestamp: 'ts',
+			},
+			{
+				kind: 'workflow_run_needs_attention',
+				spaceId: 's',
+				runId: 'r',
+				reason: 'r',
+				timestamp: 'ts',
+			},
+			{ kind: 'task_timeout', spaceId: 's', taskId: 't', elapsedMs: 5000, timestamp: 'ts' },
+			{
+				kind: 'workflow_run_completed',
+				spaceId: 's',
+				runId: 'r',
+				status: 'cancelled',
+				timestamp: 'ts',
+			},
+		];
+
+		for (const event of events) {
+			await expect(sink.notify(event)).resolves.toBeUndefined();
+		}
+	});
+
+	it('can be called multiple times concurrently', async () => {
+		const sink = new NullNotificationSink();
+		const event: SpaceNotificationEvent = {
+			kind: 'workflow_run_completed',
+			spaceId: 's',
+			runId: 'r',
+			status: 'completed',
+			timestamp: 'ts',
+		};
+
+		await expect(
+			Promise.all([sink.notify(event), sink.notify(event), sink.notify(event)])
+		).resolves.toBeDefined();
+	});
+});

--- a/packages/daemon/tests/unit/space/notification-sink.test.ts
+++ b/packages/daemon/tests/unit/space/notification-sink.test.ts
@@ -38,6 +38,7 @@ describe('SpaceNotificationEvent types', () => {
 		expect(event.spaceId).toBe('space-2');
 		expect(event.runId).toBe('run-99');
 		expect(event.reason).toBe('Transition condition failed: tests did not pass');
+		expect(event.timestamp).toBe('2026-03-20T11:00:00.000Z');
 	});
 
 	it('constructs a task_timeout event', () => {
@@ -73,12 +74,12 @@ describe('SpaceNotificationEvent types', () => {
 			kind: 'workflow_run_completed',
 			spaceId: 'space-4',
 			runId: 'run-2',
-			status: 'failed',
+			status: 'needs_attention',
 			timestamp: '2026-03-20T13:00:00.000Z',
 		};
 
 		expect(event.kind).toBe('workflow_run_completed');
-		expect(event.status).toBe('failed');
+		expect(event.status).toBe('needs_attention');
 		expect(event.summary).toBeUndefined();
 	});
 


### PR DESCRIPTION
- Add SpaceNotificationEvent discriminated union with four event kinds:
  task_needs_attention, workflow_run_needs_attention, task_timeout,
  workflow_run_completed — each with typed payloads
- Add NotificationSink interface (single notify() method) for SpaceRuntime
  to push events to consumers without coupling to a real session
- Add NullNotificationSink no-op implementation for tests and default wiring
- Export all types from the space module index
- Add unit tests covering event construction, union narrowing, and
  NullNotificationSink behaviour
