### PR TITLE
feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -20,8 +20,6 @@ import type {
 	SpaceTask,
 	SpaceWorkflowRun,
 } from '@neokai/shared';
-
-const VALID_AUTONOMY_LEVELS: SpaceAutonomyLevel[] = ['supervised', 'semi_autonomous'];
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
@@ -33,6 +31,7 @@ import { seedBuiltInWorkflows } from '../space/workflows/built-in-workflows';
 import { Logger } from '../logger';
 
 const log = new Logger('space-handlers');
+const VALID_AUTONOMY_LEVELS: SpaceAutonomyLevel[] = ['supervised', 'semi_autonomous'];
 
 export interface SpaceOverviewResult {
 	space: Space;

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -14,11 +14,14 @@
 import type { MessageHub } from '@neokai/shared';
 import type {
 	Space,
+	SpaceAutonomyLevel,
 	CreateSpaceParams,
 	UpdateSpaceParams,
 	SpaceTask,
 	SpaceWorkflowRun,
 } from '@neokai/shared';
+
+const VALID_AUTONOMY_LEVELS: SpaceAutonomyLevel[] = ['supervised', 'semi_autonomous'];
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
@@ -56,6 +59,14 @@ export function setupSpaceHandlers(
 		}
 		if (!params.name || params.name.trim() === '') {
 			throw new Error('name is required');
+		}
+		if (
+			params.autonomyLevel !== undefined &&
+			!VALID_AUTONOMY_LEVELS.includes(params.autonomyLevel)
+		) {
+			throw new Error(
+				`Invalid autonomyLevel: ${params.autonomyLevel}. Must be one of: ${VALID_AUTONOMY_LEVELS.join(', ')}`
+			);
 		}
 
 		const space = await spaceManager.createSpace(params);
@@ -118,6 +129,14 @@ export function setupSpaceHandlers(
 
 		if (!params.id) {
 			throw new Error('id is required');
+		}
+		if (
+			params.autonomyLevel !== undefined &&
+			!VALID_AUTONOMY_LEVELS.includes(params.autonomyLevel)
+		) {
+			throw new Error(
+				`Invalid autonomyLevel: ${params.autonomyLevel}. Must be one of: ${VALID_AUTONOMY_LEVELS.join(', ')}`
+			);
 		}
 
 		const { id, ...updateParams } = params;

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -6,7 +6,13 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
-import type { Space, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
+import type {
+	Space,
+	SpaceAutonomyLevel,
+	SpaceConfig,
+	CreateSpaceParams,
+	UpdateSpaceParams,
+} from '@neokai/shared';
 import type { SQLiteValue } from '../types';
 
 export class SpaceRepository {
@@ -20,8 +26,8 @@ export class SpaceRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, config, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -35,6 +41,7 @@ export class SpaceRepository {
 			JSON.stringify(params.allowedModels ?? []),
 			'[]',
 			'active',
+			params.autonomyLevel ?? 'supervised',
 			params.config ? JSON.stringify(params.config) : null,
 			now,
 			now
@@ -115,6 +122,10 @@ export class SpaceRepository {
 		if (params.allowedModels !== undefined) {
 			fields.push('allowed_models = ?');
 			values.push(JSON.stringify(params.allowedModels));
+		}
+		if (params.autonomyLevel !== undefined) {
+			fields.push('autonomy_level = ?');
+			values.push(params.autonomyLevel);
 		}
 		if (params.config !== undefined) {
 			fields.push('config = ?');
@@ -204,7 +215,8 @@ export class SpaceRepository {
 	private rowToSpace(row: Record<string, unknown>): Space {
 		const rawModels = JSON.parse((row.allowed_models as string) ?? '[]') as string[];
 		const rawConfig = row.config as string | null;
-		const config = rawConfig ? (JSON.parse(rawConfig) as Record<string, unknown>) : undefined;
+		const config = rawConfig ? (JSON.parse(rawConfig) as SpaceConfig) : undefined;
+		const rawAutonomyLevel = (row.autonomy_level as string | null) ?? 'supervised';
 
 		return {
 			id: row.id as string,
@@ -217,6 +229,7 @@ export class SpaceRepository {
 			allowedModels: rawModels.length > 0 ? rawModels : undefined,
 			sessionIds: JSON.parse(row.session_ids as string) as string[],
 			status: row.status as 'active' | 'archived',
+			autonomyLevel: rawAutonomyLevel as SpaceAutonomyLevel,
 			config,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -126,6 +126,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 32: Add task_agent_session_id column to space_tasks.
 	runMigration32(db);
+
+	// Migration 33: Add autonomy_level column to spaces table.
+	runMigration33(db);
 }
 
 /**
@@ -1983,4 +1986,22 @@ function runMigration32(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
 	);
+}
+
+/**
+ * Migration 33: Add `autonomy_level` column to `spaces`.
+ *
+ * Controls how much the Space Agent can act autonomously:
+ * - 'supervised' (default): notifies human of all judgment calls, waits for approval.
+ * - 'semi_autonomous': retries/reassigns tasks autonomously; escalates after one failed retry.
+ *
+ * Default is 'supervised' so all existing spaces remain supervised after migration.
+ */
+function runMigration33(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+	try {
+		db.prepare(`SELECT autonomy_level FROM spaces LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE spaces ADD COLUMN autonomy_level TEXT NOT NULL DEFAULT 'supervised'`);
+	}
 }

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -21,13 +21,14 @@ export function createSpaceAgentSchema(db: Database): void {
 			allowed_models TEXT NOT NULL DEFAULT '[]',
 			session_ids TEXT NOT NULL DEFAULT '[]',
 			status TEXT NOT NULL DEFAULT 'active',
+			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
 			config TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
 	`);
 
-	// Keep in sync with runMigration29 in migrations.ts and space-test-db.ts.
+	// Keep in sync with runMigration33 in migrations.ts and space-test-db.ts.
 	db.exec(`
 		CREATE TABLE space_agents (
 			id TEXT PRIMARY KEY,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration30 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration33 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
  */
 
@@ -26,6 +26,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			session_ids TEXT NOT NULL DEFAULT '[]',
 			status TEXT NOT NULL DEFAULT 'active'
 				CHECK(status IN ('active', 'archived')),
+			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
 			config TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -210,6 +210,16 @@ describe('space-handlers', () => {
 				call('space.create', { workspacePath: '/tmp/test', name: 'Dup' })
 			).rejects.toThrow('A space already exists');
 		});
+
+		it('throws when autonomyLevel is invalid', async () => {
+			await expect(
+				call('space.create', {
+					workspacePath: '/tmp/x',
+					name: 'X',
+					autonomyLevel: 'fully_autonomous',
+				})
+			).rejects.toThrow('Invalid autonomyLevel: fully_autonomous');
+		});
 	});
 
 	// ─── space.list ────────────────────────────────────────────────────────────
@@ -286,6 +296,12 @@ describe('space-handlers', () => {
 			await expect(call('space.update', { id: 'bad-id', name: 'X' })).rejects.toThrow(
 				'Space not found'
 			);
+		});
+
+		it('throws when autonomyLevel is invalid', async () => {
+			await expect(
+				call('space.update', { id: 'space-1', autonomyLevel: 'fully_autonomous' })
+			).rejects.toThrow('Invalid autonomyLevel: fully_autonomous');
 		});
 	});
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-spaces-autonomy-level_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-spaces-autonomy-level_test.ts
@@ -1,0 +1,202 @@
+/**
+ * Migration 33 Tests — autonomy_level column on spaces
+ *
+ * Tests for Migration 33: Add autonomy_level column to the spaces table.
+ *
+ * Covers:
+ * - Fresh DB (full migration chain): column exists with correct default
+ * - Legacy DB path: column is added to an existing table that lacks it
+ * - Idempotency: running migration twice on a table that already has the column is a no-op
+ * - Default value: existing rows get 'supervised' as autonomy_level after column add
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return rows.some((r) => r.name === column);
+}
+
+function getColumnDefault(db: BunDatabase, table: string, column: string): string | null {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+		name: string;
+		dflt_value: string | null;
+	}>;
+	return rows.find((r) => r.name === column)?.dflt_value ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 33: Add autonomy_level to spaces', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-spaces-autonomy', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Fresh DB — full migration chain
+	// -------------------------------------------------------------------------
+
+	test('fresh DB: autonomy_level column exists after full migration', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'spaces', 'autonomy_level')).toBe(true);
+	});
+
+	test("fresh DB: autonomy_level has default value of 'supervised'", () => {
+		runMigrations(db, () => {});
+		expect(getColumnDefault(db, 'spaces', 'autonomy_level')).toBe("'supervised'");
+	});
+
+	test("fresh DB: new spaces default to autonomy_level = 'supervised'", () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+
+		const row = db.prepare(`SELECT autonomy_level FROM spaces WHERE id = 'space-1'`).get() as {
+			autonomy_level: string;
+		};
+		expect(row.autonomy_level).toBe('supervised');
+	});
+
+	test("fresh DB: autonomy_level can be set to 'semi_autonomous'", () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, autonomy_level, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', 'semi_autonomous', now, now);
+
+		const row = db.prepare(`SELECT autonomy_level FROM spaces WHERE id = 'space-1'`).get() as {
+			autonomy_level: string;
+		};
+		expect(row.autonomy_level).toBe('semi_autonomous');
+	});
+
+	// -------------------------------------------------------------------------
+	// Legacy DB path — simulate pre-migration-33 state without the column
+	// -------------------------------------------------------------------------
+
+	test('legacy DB: column is added to existing spaces table that lacks it', () => {
+		// Create the spaces table as it existed before migration 33
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		// Confirm column is absent before migration
+		expect(columnExists(db, 'spaces', 'autonomy_level')).toBe(false);
+
+		// Run migrations
+		runMigrations(db, () => {});
+
+		// Column should now exist
+		expect(columnExists(db, 'spaces', 'autonomy_level')).toBe(true);
+	});
+
+	test("legacy DB: existing space rows get 'supervised' as autonomy_level after column add", () => {
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/a', 'Space A', now, now);
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-2', '/workspace/b', 'Space B', now, now);
+
+		runMigrations(db, () => {});
+
+		const rows = db
+			.prepare(`SELECT id, name, autonomy_level FROM spaces ORDER BY id`)
+			.all() as Array<{ id: string; name: string; autonomy_level: string }>;
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toMatchObject({ id: 'space-1', name: 'Space A', autonomy_level: 'supervised' });
+		expect(rows[1]).toMatchObject({ id: 'space-2', name: 'Space B', autonomy_level: 'supervised' });
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency — column already exists
+	// -------------------------------------------------------------------------
+
+	test('idempotency: running migration twice does not error', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+		expect(columnExists(db, 'spaces', 'autonomy_level')).toBe(true);
+	});
+
+	test('idempotency: data is not duplicated on second migration run', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test', now, now);
+
+		runMigrations(db, () => {});
+
+		const rows = db.prepare(`SELECT id FROM spaces`).all();
+		expect(rows).toHaveLength(1);
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-repository.test.ts
@@ -35,6 +35,7 @@ describe('SpaceRepository', () => {
 			expect(space.backgroundContext).toBe('');
 			expect(space.instructions).toBe('');
 			expect(space.status).toBe('active');
+			expect(space.autonomyLevel).toBe('supervised');
 			expect(space.sessionIds).toEqual([]);
 			expect(space.config).toBeUndefined();
 			expect(space.createdAt).toBeGreaterThan(0);
@@ -50,7 +51,8 @@ describe('SpaceRepository', () => {
 				instructions: 'Do this',
 				defaultModel: 'claude-opus',
 				allowedModels: ['claude-opus', 'claude-sonnet'],
-				config: { maxConcurrentTasks: 3 },
+				autonomyLevel: 'semi_autonomous',
+				config: { maxConcurrentTasks: 3, taskTimeoutMs: 60000 },
 			});
 
 			expect(space.description).toBe('A description');
@@ -58,7 +60,13 @@ describe('SpaceRepository', () => {
 			expect(space.instructions).toBe('Do this');
 			expect(space.defaultModel).toBe('claude-opus');
 			expect(space.allowedModels).toEqual(['claude-opus', 'claude-sonnet']);
-			expect(space.config).toEqual({ maxConcurrentTasks: 3 });
+			expect(space.autonomyLevel).toBe('semi_autonomous');
+			expect(space.config).toEqual({ maxConcurrentTasks: 3, taskTimeoutMs: 60000 });
+		});
+
+		it("defaults autonomyLevel to 'supervised' when not specified", () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/project', name: 'P' });
+			expect(space.autonomyLevel).toBe('supervised');
 		});
 
 		it('enforces unique workspace_path', () => {
@@ -134,6 +142,32 @@ describe('SpaceRepository', () => {
 			});
 			const updated = repo.updateSpace(space.id, { defaultModel: null });
 			expect(updated!.defaultModel).toBeUndefined();
+		});
+
+		it("updates autonomyLevel to 'semi_autonomous'", () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			expect(space.autonomyLevel).toBe('supervised');
+
+			const updated = repo.updateSpace(space.id, { autonomyLevel: 'semi_autonomous' });
+			expect(updated!.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it("updates autonomyLevel back to 'supervised'", () => {
+			const space = repo.createSpace({
+				workspacePath: '/workspace/a',
+				name: 'A',
+				autonomyLevel: 'semi_autonomous',
+			});
+			const updated = repo.updateSpace(space.id, { autonomyLevel: 'supervised' });
+			expect(updated!.autonomyLevel).toBe('supervised');
+		});
+
+		it('updates typed config fields', () => {
+			const space = repo.createSpace({ workspacePath: '/workspace/a', name: 'A' });
+			const updated = repo.updateSpace(space.id, {
+				config: { maxConcurrentTasks: 5, taskTimeoutMs: 30000 },
+			});
+			expect(updated!.config).toEqual({ maxConcurrentTasks: 5, taskTimeoutMs: 30000 });
 		});
 
 		it('returns null for unknown ID', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -16,6 +16,26 @@
 export type SpaceStatus = 'active' | 'archived';
 
 /**
+ * Space autonomy level — controls how much the Space Agent can act without human approval.
+ *
+ * - `supervised` (default): Space Agent notifies human of all judgment-required events
+ *   and waits for approval before acting.
+ * - `semi_autonomous`: Space Agent can retry failed tasks and reassign them autonomously;
+ *   escalates to human after one failed retry or when uncertain.
+ */
+export type SpaceAutonomyLevel = 'supervised' | 'semi_autonomous';
+
+/**
+ * Typed runtime configuration for a Space.
+ */
+export interface SpaceConfig {
+	/** Maximum number of tasks that may run concurrently in this Space */
+	maxConcurrentTasks?: number;
+	/** Timeout for a single task in milliseconds */
+	taskTimeoutMs?: number;
+}
+
+/**
  * A Space — a workspace-first context for multi-agent workflows.
  * Unlike Rooms, a Space has a single required workspace path and is
  * designed around workflow execution with customizable agents.
@@ -41,8 +61,10 @@ export interface Space {
 	sessionIds: string[];
 	/** Current status of the Space */
 	status: SpaceStatus;
-	/** Runtime configuration (maxConcurrentTasks, taskTimeout, etc.) */
-	config?: Record<string, unknown>;
+	/** Autonomy level — controls how much the Space Agent can act without human approval */
+	autonomyLevel?: SpaceAutonomyLevel;
+	/** Runtime configuration (maxConcurrentTasks, taskTimeoutMs, etc.) */
+	config?: SpaceConfig;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -67,8 +89,10 @@ export interface CreateSpaceParams {
 	defaultModel?: string;
 	/** Allowed models for this Space */
 	allowedModels?: string[];
+	/** Autonomy level for the Space Agent */
+	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration */
-	config?: Record<string, unknown>;
+	config?: SpaceConfig;
 }
 
 /**
@@ -81,7 +105,8 @@ export interface UpdateSpaceParams {
 	instructions?: string;
 	defaultModel?: string | null;
 	allowedModels?: string[];
-	config?: Record<string, unknown>;
+	autonomyLevel?: SpaceAutonomyLevel;
+	config?: SpaceConfig;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `SpaceAutonomyLevel = 'supervised' | 'semi_autonomous'` type to shared package — controls how much the Space Agent can act without human approval
- Adds typed `SpaceConfig` interface with `maxConcurrentTasks?: number` and `taskTimeoutMs?: number` fields; replaces the previous `config?: Record<string, unknown>` on `Space`, `CreateSpaceParams`, and `UpdateSpaceParams`
- Adds optional `autonomyLevel?: SpaceAutonomyLevel` field to `Space`, `CreateSpaceParams`, and `UpdateSpaceParams` (defaults to `'supervised'`)
- Migration 33: `ALTER TABLE spaces ADD COLUMN autonomy_level TEXT NOT NULL DEFAULT 'supervised'` — backward-compatible (all existing spaces become supervised)
- `SpaceRepository` updated to read/write `autonomy_level` in `createSpace`, `updateSpace`, and `rowToSpace`

## Test plan

- [ ] Migration tests: column exists after full migration chain, default is `'supervised'`, legacy DB path (table without column gets column added), idempotency (second run is a no-op)
- [ ] Repository tests: default autonomyLevel on create, explicit `'semi_autonomous'` on create, update autonomyLevel, typed config fields round-trip
- [ ] All existing space repository and migration tests continue to pass
- [ ] `bun run typecheck` passes with no errors