### PR TITLE
fix: use worktree path for SDK session file lookups

### DIFF
--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -69,6 +69,19 @@ export class QueryLifecycleManager {
 	}
 
 	/**
+	 * Get the effective workspace path for SDK session file lookups.
+	 *
+	 * The SDK subprocess uses its CWD to determine the project directory
+	 * for session files. For worktree sessions, the CWD is the worktree path,
+	 * not session.workspacePath (which is the main repo path).
+	 * Must match QueryOptionsBuilder.getCwd() to find the correct files.
+	 */
+	private getSDKWorkspacePath(): string {
+		const { session } = this.ctx;
+		return session.worktree ? session.worktree.worktreePath : session.workspacePath;
+	}
+
+	/**
 	 * Stop the current query
 	 *
 	 * Shared logic for restart and reset operations:
@@ -167,7 +180,7 @@ export class QueryLifecycleManager {
 			// Also detects stale sdkSessionId when the session file no longer exists.
 			if (session.sdkSessionId) {
 				const isValid = validateAndRepairSDKSession(
-					session.workspacePath,
+					this.getSDKWorkspacePath(),
 					session.sdkSessionId,
 					session.id,
 					db
@@ -253,7 +266,7 @@ export class QueryLifecycleManager {
 				// Also detects stale sdkSessionId when the session file no longer exists.
 				if (session.sdkSessionId) {
 					const isValid = validateAndRepairSDKSession(
-						session.workspacePath,
+						this.getSDKWorkspacePath(),
 						session.sdkSessionId,
 						session.id,
 						db
@@ -311,7 +324,7 @@ export class QueryLifecycleManager {
 		// Validate SDK session file
 		if (session.sdkSessionId) {
 			const isValid = validateAndRepairSDKSession(
-				session.workspacePath,
+				this.getSDKWorkspacePath(),
 				session.sdkSessionId,
 				session.id,
 				db

--- a/packages/daemon/src/lib/agent/rewind-handler.ts
+++ b/packages/daemon/src/lib/agent/rewind-handler.ts
@@ -306,8 +306,13 @@ export class RewindHandler {
 		const messagesDeleted = db.deleteMessagesAtAndAfter(session.id, rewindPoint.timestamp);
 
 		// Step 2: Truncate the SDK JSONL file at this message
+		// Use worktree path when available — SDK creates session files based on CWD,
+		// which is the worktree path for worktree sessions, not session.workspacePath.
+		const sdkWorkspacePath = session.worktree
+			? session.worktree.worktreePath
+			: session.workspacePath;
 		const _jsonlResult = truncateSessionFileAtMessage(
-			session.workspacePath,
+			sdkWorkspacePath,
 			session.sdkSessionId,
 			session.id,
 			checkpointId
@@ -717,8 +722,11 @@ export class RewindHandler {
 				// Truncate JSONL at the earliest selected message
 				const jsonlUuid = (earliestMessage as { uuid?: string }).uuid;
 				if (jsonlUuid) {
+					const rewindSdkPath = session.worktree
+						? session.worktree.worktreePath
+						: session.workspacePath;
 					const _jsonlResult = truncateSessionFileAtMessage(
-						session.workspacePath,
+						rewindSdkPath,
 						session.sdkSessionId,
 						session.id,
 						jsonlUuid

--- a/packages/daemon/src/lib/rpc-handlers/message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/message-handlers.ts
@@ -49,8 +49,12 @@ export function setupMessageHandlers(
 
 		// Remove tool_result from the .jsonl file
 		// Pass both SDK session ID and NeoKai session ID for fallback search
+		// Use worktree path when available — SDK creates session files based on CWD
+		const sdkWorkspacePath = session.worktree
+			? session.worktree.worktreePath
+			: session.workspacePath;
 		const success = removeToolResultFromSessionFile(
-			session.workspacePath,
+			sdkWorkspacePath,
 			sdkSessionId,
 			messageUuid,
 			targetSessionId

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -444,8 +444,12 @@ export class SessionLifecycle {
 			// This removes the .jsonl files created by Claude Agent SDK
 			if (session) {
 				try {
+					// Use worktree path when available — SDK creates session files based on CWD
+					const sdkWorkspacePath = session.worktree
+						? session.worktree.worktreePath
+						: session.workspacePath;
 					const deleteResult = deleteSDKSessionFiles(
-						session.workspacePath,
+						sdkWorkspacePath,
 						session.sdkSessionId ?? null,
 						sessionId
 					);


### PR DESCRIPTION
## Summary
- SDK subprocess creates `.jsonl` session files based on its CWD, which is the worktree path for worktree sessions
- All SDK session file operations (validation, rewind truncation, output removal, deletion) were using `session.workspacePath` (main repo path), looking in the wrong directory
- This caused model switching to falsely report "SDK session file missing", clearing `sdkSessionId` and preventing session resume
- Fixed all 6 call sites to use worktree path when available, matching `QueryOptionsBuilder.getCwd()`

## Test plan
- [x] All 58 `query-lifecycle-manager.test.ts` tests pass
- [x] All 49 `sdk-session-file-manager.test.ts` tests pass
- [ ] Manual: switch models in a worktree session — no more "SDK session file missing" warnings
- [ ] Manual: rewind in a worktree session still correctly truncates the JSONL file
- [ ] Manual: delete a worktree session — SDK files are cleaned up from correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)