### PR TITLE
feat: implement SessionNotificationSink for Space Agent event injection

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -40,6 +40,8 @@ export type {
 	TaskTimeoutEvent,
 	WorkflowRunCompletedEvent,
 } from './runtime/notification-sink';
+export { SessionNotificationSink, formatEventMessage } from './runtime/session-notification-sink';
+export type { SessionNotificationSinkConfig } from './runtime/session-notification-sink';
 export { SpaceRuntimeService } from './runtime/space-runtime-service';
 export type { SpaceRuntimeServiceConfig } from './runtime/space-runtime-service';
 

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -1,0 +1,230 @@
+/**
+ * SessionNotificationSink — production NotificationSink implementation.
+ *
+ * Formats SpaceNotificationEvents into structured messages and injects them
+ * into the Space Agent session via `sessionFactory.injectMessage()`.
+ *
+ * ## Delivery mode: `'next_turn'`
+ *
+ * Notifications use `deliveryMode: 'next_turn'` for non-blocking injection:
+ * - If the Space Agent session is **idle**: the message is enqueued immediately
+ *   and the agent processes it on the next turn.
+ * - If the Space Agent session is **busy** (actively streaming a response or
+ *   has a message queued): the message is persisted to the DB with status
+ *   `'saved'` and automatically replayed once the current turn completes.
+ *
+ * This ensures notifications are never dropped and never interrupt the agent
+ * mid-response. The trade-off is a possible short delay if the agent is busy,
+ * which is acceptable for event-driven coordination messages.
+ *
+ * ## Message format
+ *
+ * Messages use a `[TASK_EVENT]` prefix followed by structured JSON for reliable
+ * prompt parsing, plus a human-readable summary for context. The space's
+ * autonomy level is always included so the agent knows how much it can act
+ * autonomously without human approval.
+ */
+
+import type { NotificationSink, SpaceNotificationEvent } from './notification-sink';
+import type { SessionFactory } from '../../room/runtime/task-group-manager';
+import type { AutonomyLevel } from '@neokai/shared';
+import { Logger } from '../../logger';
+
+const log = new Logger('session-notification-sink');
+
+export interface SessionNotificationSinkConfig {
+	/** The SessionFactory used to inject messages into sessions. */
+	sessionFactory: SessionFactory;
+	/**
+	 * The session ID of the Space Agent's global session (e.g. the `spaces:global`
+	 * session that receives coordination notifications).
+	 */
+	sessionId: string;
+	/**
+	 * The autonomy level for this space. Included in every notification message
+	 * so the agent has context for how much it can act without human approval.
+	 *
+	 * Defaults to `'supervised'` if not provided.
+	 */
+	autonomyLevel?: AutonomyLevel;
+}
+
+/**
+ * Production `NotificationSink` that formats events into human+LLM-readable
+ * messages and injects them into the Space Agent session.
+ *
+ * Use `NullNotificationSink` instead when no Space Agent session is active.
+ */
+export class SessionNotificationSink implements NotificationSink {
+	private readonly sessionFactory: SessionFactory;
+	private readonly sessionId: string;
+	private readonly autonomyLevel: AutonomyLevel;
+
+	constructor(config: SessionNotificationSinkConfig) {
+		this.sessionFactory = config.sessionFactory;
+		this.sessionId = config.sessionId;
+		this.autonomyLevel = config.autonomyLevel ?? 'supervised';
+	}
+
+	async notify(event: SpaceNotificationEvent): Promise<void> {
+		const message = formatEventMessage(event, this.autonomyLevel);
+		try {
+			await this.sessionFactory.injectMessage(this.sessionId, message, {
+				deliveryMode: 'next_turn',
+			});
+		} catch (err) {
+			// Session not found or unavailable — log warning, do not propagate.
+			// SpaceRuntime must not fail its tick loop due to notification errors.
+			log.warn(
+				`[SessionNotificationSink] Failed to inject notification into session ${this.sessionId} (event: ${event.kind}): ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Message formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a `SpaceNotificationEvent` into a structured message string suitable
+ * for injection into the Space Agent session.
+ *
+ * The message has three sections:
+ * 1. `[TASK_EVENT] <kind>` — machine-parseable prefix + event kind
+ * 2. Human-readable summary with context
+ * 3. JSON payload for structured processing + autonomy level
+ */
+export function formatEventMessage(
+	event: SpaceNotificationEvent,
+	autonomyLevel: AutonomyLevel
+): string {
+	switch (event.kind) {
+		case 'task_needs_attention':
+			return formatTaskNeedsAttention(event, autonomyLevel);
+		case 'workflow_run_needs_attention':
+			return formatWorkflowRunNeedsAttention(event, autonomyLevel);
+		case 'task_timeout':
+			return formatTaskTimeout(event, autonomyLevel);
+		case 'workflow_run_completed':
+			return formatWorkflowRunCompleted(event, autonomyLevel);
+	}
+}
+
+function formatTaskNeedsAttention(
+	event: {
+		kind: 'task_needs_attention';
+		spaceId: string;
+		taskId: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: AutonomyLevel
+): string {
+	const humanReadable = `Task ${event.taskId} in space ${event.spaceId} needs attention: ${event.reason}`;
+	const payload = {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage(event.kind, humanReadable, payload);
+}
+
+function formatWorkflowRunNeedsAttention(
+	event: {
+		kind: 'workflow_run_needs_attention';
+		spaceId: string;
+		runId: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: AutonomyLevel
+): string {
+	const humanReadable = `Workflow run ${event.runId} in space ${event.spaceId} needs attention: ${event.reason}`;
+	const payload = {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		runId: event.runId,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage(event.kind, humanReadable, payload);
+}
+
+function formatTaskTimeout(
+	event: {
+		kind: 'task_timeout';
+		spaceId: string;
+		taskId: string;
+		elapsedMs: number;
+		timestamp: string;
+	},
+	autonomyLevel: AutonomyLevel
+): string {
+	const elapsedMin = Math.round(event.elapsedMs / 60000);
+	const humanReadable = `Task ${event.taskId} in space ${event.spaceId} has been running for ${elapsedMin} minute(s) and may be stuck.`;
+	const payload = {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		elapsedMs: event.elapsedMs,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage(event.kind, humanReadable, payload);
+}
+
+function formatWorkflowRunCompleted(
+	event: {
+		kind: 'workflow_run_completed';
+		spaceId: string;
+		runId: string;
+		status: 'completed' | 'cancelled' | 'needs_attention';
+		summary?: string;
+		timestamp: string;
+	},
+	autonomyLevel: AutonomyLevel
+): string {
+	const statusLabel =
+		event.status === 'completed'
+			? 'completed successfully'
+			: event.status === 'cancelled'
+				? 'was cancelled'
+				: 'ended and needs attention';
+	const summaryPart = event.summary ? ` Summary: ${event.summary}` : '';
+	const humanReadable = `Workflow run ${event.runId} in space ${event.spaceId} ${statusLabel}.${summaryPart}`;
+	const payload: Record<string, unknown> = {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		runId: event.runId,
+		status: event.status,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	if (event.summary !== undefined) {
+		payload['summary'] = event.summary;
+	}
+	return buildMessage(event.kind, humanReadable, payload);
+}
+
+function buildMessage(
+	kind: string,
+	humanReadable: string,
+	payload: Record<string, unknown>
+): string {
+	return [
+		`[TASK_EVENT] ${kind}`,
+		'',
+		humanReadable,
+		'',
+		`Autonomy level: ${payload['autonomyLevel']}`,
+		'',
+		'```json',
+		JSON.stringify(payload, null, 2),
+		'```',
+	].join('\n');
+}

--- a/packages/daemon/tests/unit/space/session-notification-sink.test.ts
+++ b/packages/daemon/tests/unit/space/session-notification-sink.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import {
+	SessionNotificationSink,
+	formatEventMessage,
+} from '../../../src/lib/space/runtime/session-notification-sink';
+import type { SessionNotificationSinkConfig } from '../../../src/lib/space/runtime/session-notification-sink';
+import type { SpaceNotificationEvent } from '../../../src/lib/space/runtime/notification-sink';
+import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
+import type { MessageDeliveryMode } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mock SessionFactory
+// ---------------------------------------------------------------------------
+
+interface InjectedCall {
+	sessionId: string;
+	message: string;
+	opts?: { deliveryMode?: MessageDeliveryMode };
+}
+
+function makeMockSessionFactory(opts?: {
+	sessionExists?: boolean;
+	injectError?: Error;
+}): SessionFactory & { calls: InjectedCall[] } {
+	const calls: InjectedCall[] = [];
+	const sessionExists = opts?.sessionExists ?? true;
+	const injectError = opts?.injectError;
+
+	const factory: SessionFactory & { calls: InjectedCall[] } = {
+		calls,
+		createAndStartSession: async () => {},
+		injectMessage: async (sessionId, message, injectOpts) => {
+			if (injectError) throw injectError;
+			calls.push({ sessionId, message, opts: injectOpts });
+		},
+		hasSession: () => sessionExists,
+		answerQuestion: async () => false,
+		createWorktree: async () => null,
+		restoreSession: async () => false,
+		startSession: async () => false,
+		setSessionMcpServers: () => false,
+		removeWorktree: async () => false,
+	};
+
+	return factory;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'spaces:global:session-1';
+const SPACE_ID = 'space-abc';
+const TIMESTAMP = '2026-03-20T10:00:00.000Z';
+
+function makeSink(
+	factoryOrOpts?:
+		| (SessionFactory & { calls: InjectedCall[] })
+		| Parameters<typeof makeMockSessionFactory>[0],
+	extra?: Partial<SessionNotificationSinkConfig>
+): { sink: SessionNotificationSink; factory: SessionFactory & { calls: InjectedCall[] } } {
+	let factory: SessionFactory & { calls: InjectedCall[] };
+	if (factoryOrOpts && 'calls' in factoryOrOpts) {
+		factory = factoryOrOpts as SessionFactory & { calls: InjectedCall[] };
+	} else {
+		factory = makeMockSessionFactory(factoryOrOpts as Parameters<typeof makeMockSessionFactory>[0]);
+	}
+	const sink = new SessionNotificationSink({
+		sessionFactory: factory,
+		sessionId: SESSION_ID,
+		...extra,
+	});
+	return { sink, factory };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionNotificationSink', () => {
+	describe('task_needs_attention event', () => {
+		it('injects a message with [TASK_EVENT] prefix', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Agent reported an error',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls).toHaveLength(1);
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_needs_attention');
+		});
+
+		it('injects into the correct session ID', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls[0].sessionId).toBe(SESSION_ID);
+		});
+
+		it('uses next_turn delivery mode', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+		});
+
+		it('message includes human-readable text with taskId, spaceId, and reason', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-99',
+				reason: 'Unrecoverable build failure',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('task-99');
+			expect(message).toContain(SPACE_ID);
+			expect(message).toContain('Unrecoverable build failure');
+		});
+
+		it('message includes JSON payload with all event fields', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-42',
+				reason: 'Timed out',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_needs_attention');
+			expect(json.spaceId).toBe(SPACE_ID);
+			expect(json.taskId).toBe('task-42');
+			expect(json.reason).toBe('Timed out');
+			expect(json.timestamp).toBe(TIMESTAMP);
+		});
+
+		it('message includes autonomy level (default supervised)', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('supervised');
+			const json = extractJson(message);
+			expect(json.autonomyLevel).toBe('supervised');
+		});
+
+		it('message includes semi_autonomous level when configured', async () => {
+			const { sink, factory } = makeSink(undefined, { autonomyLevel: 'semi_autonomous' });
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('semi_autonomous');
+			const json = extractJson(message);
+			expect(json.autonomyLevel).toBe('semi_autonomous');
+		});
+	});
+
+	describe('workflow_run_needs_attention event', () => {
+		it('formats message correctly', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_needs_attention',
+				spaceId: SPACE_ID,
+				runId: 'run-55',
+				reason: 'Transition condition failed: tests did not pass',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_needs_attention');
+			expect(message).toContain('run-55');
+			expect(message).toContain('Transition condition failed: tests did not pass');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('workflow_run_needs_attention');
+			expect(json.runId).toBe('run-55');
+			expect(json.autonomyLevel).toBe('supervised');
+		});
+
+		it('uses next_turn delivery mode', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_needs_attention',
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				reason: 'Failure',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+		});
+	});
+
+	describe('task_timeout event', () => {
+		it('formats elapsed time in minutes', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_timeout',
+				spaceId: SPACE_ID,
+				taskId: 'task-slow',
+				elapsedMs: 3600000, // 60 minutes
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_timeout');
+			expect(message).toContain('60 minute');
+			expect(message).toContain('task-slow');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_timeout');
+			expect(json.elapsedMs).toBe(3600000);
+			expect(json.autonomyLevel).toBe('supervised');
+		});
+
+		it('uses next_turn delivery mode', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'task_timeout',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				elapsedMs: 60000,
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+		});
+	});
+
+	describe('workflow_run_completed event', () => {
+		it('formats a completed run', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_completed',
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				status: 'completed',
+				summary: 'All steps finished. PR #42 merged.',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_completed');
+			expect(message).toContain('completed successfully');
+			expect(message).toContain('PR #42 merged.');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('completed');
+			expect(json.summary).toBe('All steps finished. PR #42 merged.');
+			expect(json.autonomyLevel).toBe('supervised');
+		});
+
+		it('formats a cancelled run', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_completed',
+				spaceId: SPACE_ID,
+				runId: 'run-2',
+				status: 'cancelled',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('was cancelled');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('cancelled');
+			expect(json.summary).toBeUndefined();
+		});
+
+		it('formats a needs_attention run', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_completed',
+				spaceId: SPACE_ID,
+				runId: 'run-3',
+				status: 'needs_attention',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('needs attention');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('needs_attention');
+		});
+
+		it('uses next_turn delivery mode', async () => {
+			const { sink, factory } = makeSink();
+			const event: SpaceNotificationEvent = {
+				kind: 'workflow_run_completed',
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				status: 'completed',
+				timestamp: TIMESTAMP,
+			};
+
+			await sink.notify(event);
+
+			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+		});
+	});
+
+	describe('error handling', () => {
+		it('logs warning and does not throw when session not found', async () => {
+			const { sink, factory } = makeSink({
+				injectError: new Error('Session not in service cache: spaces:global:session-1'),
+			});
+
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			};
+
+			// Should not throw despite injectMessage failing
+			await expect(sink.notify(event)).resolves.toBeUndefined();
+			// Message was attempted
+			expect(factory.calls).toHaveLength(0); // error was thrown before push
+		});
+
+		it('does not throw on any error from injectMessage', async () => {
+			const { sink } = makeSink({ injectError: new Error('Unexpected failure') });
+			const events: SpaceNotificationEvent[] = [
+				{
+					kind: 'task_needs_attention',
+					spaceId: SPACE_ID,
+					taskId: 't',
+					reason: 'r',
+					timestamp: TIMESTAMP,
+				},
+				{
+					kind: 'workflow_run_needs_attention',
+					spaceId: SPACE_ID,
+					runId: 'r',
+					reason: 'r',
+					timestamp: TIMESTAMP,
+				},
+				{
+					kind: 'task_timeout',
+					spaceId: SPACE_ID,
+					taskId: 't',
+					elapsedMs: 1000,
+					timestamp: TIMESTAMP,
+				},
+				{
+					kind: 'workflow_run_completed',
+					spaceId: SPACE_ID,
+					runId: 'r',
+					status: 'completed',
+					timestamp: TIMESTAMP,
+				},
+			];
+
+			for (const event of events) {
+				await expect(sink.notify(event)).resolves.toBeUndefined();
+			}
+		});
+	});
+
+	describe('formatEventMessage (exported helper)', () => {
+		it('produces consistent output for the same input', () => {
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: 'space-x',
+				taskId: 'task-x',
+				reason: 'test reason',
+				timestamp: TIMESTAMP,
+			};
+
+			const msg1 = formatEventMessage(event, 'supervised');
+			const msg2 = formatEventMessage(event, 'supervised');
+			expect(msg1).toBe(msg2);
+		});
+
+		it('differs by autonomy level', () => {
+			const event: SpaceNotificationEvent = {
+				kind: 'task_needs_attention',
+				spaceId: 'space-x',
+				taskId: 'task-x',
+				reason: 'test',
+				timestamp: TIMESTAMP,
+			};
+
+			const supervised = formatEventMessage(event, 'supervised');
+			const semiAuto = formatEventMessage(event, 'semi_autonomous');
+			expect(supervised).not.toBe(semiAuto);
+			expect(supervised).toContain('supervised');
+			expect(semiAuto).toContain('semi_autonomous');
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test utility: extract the first JSON block from a message
+// ---------------------------------------------------------------------------
+
+function extractJson(message: string): Record<string, unknown> {
+	const match = message.match(/```json\n([\s\S]*?)```/);
+	if (!match) throw new Error(`No JSON block found in message:\n${message}`);
+	return JSON.parse(match[1]) as Record<string, unknown>;
+}


### PR DESCRIPTION
Formats SpaceNotificationEvents into structured [TASK_EVENT] messages
and injects them into the Space Agent session via sessionFactory.injectMessage()
with 'next_turn' delivery mode to avoid interrupting active responses.

- SessionNotificationSink class in space/runtime/session-notification-sink.ts
- Accepts SessionFactory + sessionId; uses 'next_turn' for non-blocking delivery
- Formats all 4 event kinds with [TASK_EVENT] prefix, human-readable text,
  autonomy level, and JSON payload for reliable prompt parsing
- Gracefully handles missing/unavailable sessions (logs warning, no throw)
- 19 unit tests covering all event kinds, delivery mode, autonomy level, error cases
