### PR TITLE
feat: add coordination tools to space-agent-tools (Task 3.2)

### DIFF
--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -12,17 +12,21 @@
  * The prompt references the following tools by name. They must be registered in the
  * MCP server(s) composed with this agent's session at runtime:
  *
- *   Workflow tools (provided by createSpaceAgentMcpServer in space-agent-tools.ts):
- *     - list_workflows
- *     - start_workflow_run
- *     - suggest_workflow
- *     - get_workflow_detail
- *
- *   Task tools (to be provided by a separate space-task MCP server in a future task):
- *     - create_task
- *
- * When the space-task MCP server is wired up, the caller should compose both MCP
- * servers and pass the combined tool set to the chat agent session.
+ *   All tools are provided by createSpaceAgentMcpServer in space-agent-tools.ts:
+ *     Workflow tools:
+ *       - list_workflows
+ *       - start_workflow_run
+ *       - get_workflow_run
+ *       - change_plan
+ *       - get_workflow_detail
+ *       - suggest_workflow
+ *     Task tools:
+ *       - list_tasks
+ *       - create_standalone_task
+ *       - get_task_detail
+ *       - retry_task
+ *       - cancel_task
+ *       - reassign_task
  *
  * See: docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
  */

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -352,7 +352,7 @@ export class SpaceTaskManager {
 	 */
 	async reassignTask(
 		taskId: string,
-		customAgentId: string | null,
+		customAgentId: string | null | undefined,
 		assignedAgent?: 'coder' | 'general'
 	): Promise<SpaceTask> {
 		const task = await this.getTask(taskId);
@@ -367,7 +367,11 @@ export class SpaceTaskManager {
 			);
 		}
 
-		const updates: UpdateSpaceTaskParams = { customAgentId };
+		const updates: UpdateSpaceTaskParams = {};
+		// Only update customAgentId when explicitly provided (undefined = leave as-is)
+		if (customAgentId !== undefined) {
+			updates.customAgentId = customAgentId;
+		}
 		if (assignedAgent !== undefined) {
 			updates.assignedAgent = assignedAgent;
 		}

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -448,10 +448,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					}
 				}
 
-				const customAgentId = args.custom_agent_id !== undefined ? args.custom_agent_id : null;
+				// Pass args.custom_agent_id as-is (including undefined) so the manager
+				// only updates that field when it was explicitly provided.
 				const task = await taskManager.reassignTask(
 					args.task_id,
-					customAgentId,
+					args.custom_agent_id,
 					args.assigned_agent
 				);
 				return jsonResult({ success: true, task });

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -22,11 +22,13 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { SpaceTaskStatus } from '@neokai/shared';
+import type { SpaceTaskStatus, SpaceTaskPriority, SpaceTaskType } from '@neokai/shared';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceTaskManager } from '../managers/space-task-manager';
+import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 
@@ -45,6 +47,10 @@ export interface SpaceAgentToolsConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Workflow run repository for listing and updating runs. */
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Task manager for create/retry/cancel/reassign operations. */
+	taskManager: SpaceTaskManager;
+	/** Space agent manager for reassign validation. */
+	spaceAgentManager: SpaceAgentManager;
 }
 
 /**
@@ -102,7 +108,15 @@ const SUGGEST_WORKFLOW_STOP_WORDS = new Set([
  * Returns a map of tool name → handler function.
  */
 export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
-	const { spaceId, runtime, workflowManager, taskRepo, workflowRunRepo } = config;
+	const {
+		spaceId,
+		runtime,
+		workflowManager,
+		taskRepo,
+		workflowRunRepo,
+		taskManager,
+		spaceAgentManager,
+	} = config;
 
 	return {
 		/**
@@ -321,6 +335,131 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 			return jsonResult({ success: true, tasks });
 		},
+
+		/**
+		 * Create a standalone task not associated with any workflow run.
+		 */
+		async create_standalone_task(args: {
+			title: string;
+			description: string;
+			priority?: SpaceTaskPriority;
+			task_type?: SpaceTaskType;
+			assigned_agent?: 'coder' | 'general';
+			custom_agent_id?: string;
+		}): Promise<ToolResult> {
+			try {
+				// Validate custom_agent_id if provided
+				if (args.custom_agent_id) {
+					const agent = spaceAgentManager.getById(args.custom_agent_id);
+					if (!agent) {
+						return jsonResult({
+							success: false,
+							error: `Custom agent not found: ${args.custom_agent_id}`,
+						});
+					}
+				}
+
+				const task = await taskManager.createTask({
+					title: args.title,
+					description: args.description,
+					priority: args.priority,
+					taskType: args.task_type,
+					assignedAgent: args.assigned_agent,
+					customAgentId: args.custom_agent_id,
+				});
+				return jsonResult({ success: true, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Get the full detail of a task by ID.
+		 */
+		async get_task_detail(args: { task_id: string }): Promise<ToolResult> {
+			const task = await taskManager.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			return jsonResult({ success: true, task });
+		},
+
+		/**
+		 * Retry a failed or cancelled task by resetting it to pending.
+		 */
+		async retry_task(args: { task_id: string; description?: string }): Promise<ToolResult> {
+			try {
+				const task = await taskManager.retryTask(args.task_id, {
+					description: args.description,
+				});
+				return jsonResult({ success: true, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Cancel a task and optionally cancel its workflow run.
+		 * Cascades cancellation to pending dependent tasks automatically.
+		 */
+		async cancel_task(args: {
+			task_id: string;
+			cancel_workflow_run?: boolean;
+		}): Promise<ToolResult> {
+			try {
+				const task = await taskManager.cancelTask(args.task_id);
+
+				if (args.cancel_workflow_run && task.workflowRunId) {
+					workflowRunRepo.updateStatus(task.workflowRunId, 'cancelled');
+					return jsonResult({
+						success: true,
+						task,
+						workflowRunCancelled: true,
+						workflowRunId: task.workflowRunId,
+					});
+				}
+
+				return jsonResult({ success: true, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Reassign a task to a different agent.
+		 */
+		async reassign_task(args: {
+			task_id: string;
+			custom_agent_id?: string | null;
+			assigned_agent?: 'coder' | 'general';
+		}): Promise<ToolResult> {
+			try {
+				// Validate custom_agent_id if being set to a non-null value
+				if (args.custom_agent_id != null) {
+					const agent = spaceAgentManager.getById(args.custom_agent_id);
+					if (!agent) {
+						return jsonResult({
+							success: false,
+							error: `Custom agent not found: ${args.custom_agent_id}`,
+						});
+					}
+				}
+
+				const customAgentId = args.custom_agent_id !== undefined ? args.custom_agent_id : null;
+				const task = await taskManager.reassignTask(
+					args.task_id,
+					customAgentId,
+					args.assigned_agent
+				);
+				return jsonResult({ success: true, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -417,6 +556,84 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('Filter to only tasks belonging to a specific workflow run'),
 			},
 			(args) => handlers.list_tasks(args)
+		),
+		tool(
+			'create_standalone_task',
+			'Create a standalone task not associated with any workflow run. Use this to assign ad-hoc work directly to an agent.',
+			{
+				title: z.string().describe('Short title for the task'),
+				description: z.string().describe('Detailed description of the work to be done'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
+					.optional()
+					.describe('Task priority (default: normal)'),
+				task_type: z
+					.enum(['planning', 'coding', 'research', 'design', 'review'])
+					.optional()
+					.describe('Task type — determines default execution approach'),
+				assigned_agent: z
+					.enum(['coder', 'general'])
+					.optional()
+					.describe('Agent type to execute this task (default: coder)'),
+				custom_agent_id: z
+					.string()
+					.optional()
+					.describe('ID of a custom Space agent to assign this task to'),
+			},
+			(args) => handlers.create_standalone_task(args)
+		),
+		tool(
+			'get_task_detail',
+			'Get the full detail of a task by ID, including error, result, PR URL, PR number, progress, and current step.',
+			{
+				task_id: z.string().describe('ID of the task to retrieve'),
+			},
+			(args) => handlers.get_task_detail(args)
+		),
+		tool(
+			'retry_task',
+			'Retry a failed (needs_attention) or cancelled task by resetting it to pending. Optionally provide an updated description.',
+			{
+				task_id: z.string().describe('ID of the task to retry'),
+				description: z
+					.string()
+					.optional()
+					.describe('Updated task description for the retry attempt'),
+			},
+			(args) => handlers.retry_task(args)
+		),
+		tool(
+			'cancel_task',
+			'Cancel a task. Automatically cascades cancellation to pending dependent tasks. Optionally also cancel the associated workflow run.',
+			{
+				task_id: z.string().describe('ID of the task to cancel'),
+				cancel_workflow_run: z
+					.boolean()
+					.optional()
+					.describe(
+						'If true and the task belongs to a workflow run, also cancel that workflow run'
+					),
+			},
+			(args) => handlers.cancel_task(args)
+		),
+		tool(
+			'reassign_task',
+			'Change the agent assignment for a task. Only allowed for tasks in pending, needs_attention, or cancelled status.',
+			{
+				task_id: z.string().describe('ID of the task to reassign'),
+				custom_agent_id: z
+					.string()
+					.nullable()
+					.optional()
+					.describe(
+						'ID of the custom Space agent to assign to. Pass null to clear the custom agent assignment.'
+					),
+				assigned_agent: z
+					.enum(['coder', 'general'])
+					.optional()
+					.describe('Agent type to assign (coder or general)'),
+			},
+			(args) => handlers.reassign_task(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -20,6 +20,7 @@ import { SpaceTaskRepository } from '../../../src/storage/repositories/space-tas
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import { createSpaceAgentToolHandlers } from '../../../src/lib/space/tools/space-agent-tools.ts';
@@ -102,6 +103,8 @@ interface TestCtx {
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
+	agentManager: SpaceAgentManager;
 	runtime: SpaceRuntime;
 }
 
@@ -134,7 +137,20 @@ function makeCtx(): TestCtx {
 		taskRepo,
 	});
 
-	return { db, dir, spaceId, agentId, workflowManager, workflowRunRepo, taskRepo, runtime };
+	const taskManager = new SpaceTaskManager(db, spaceId);
+
+	return {
+		db,
+		dir,
+		spaceId,
+		agentId,
+		workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		taskManager,
+		agentManager,
+		runtime,
+	};
 }
 
 function makeHandlers(ctx: TestCtx) {
@@ -144,6 +160,8 @@ function makeHandlers(ctx: TestCtx) {
 		workflowManager: ctx.workflowManager,
 		taskRepo: ctx.taskRepo,
 		workflowRunRepo: ctx.workflowRunRepo,
+		taskManager: ctx.taskManager,
+		spaceAgentManager: ctx.agentManager,
 	});
 }
 
@@ -675,5 +693,449 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// create_standalone_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('creates a task with required fields only', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'My task',
+			description: 'Do something',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.title).toBe('My task');
+		expect(parsed.task.description).toBe('Do something');
+		expect(parsed.task.workflowRunId ?? null).toBeNull();
+		expect(parsed.task.workflowStepId ?? null).toBeNull();
+		expect(parsed.task.spaceId).toBe(ctx.spaceId);
+	});
+
+	test('creates a task with all optional fields', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Full task',
+			description: 'Detailed description',
+			priority: 'high',
+			task_type: 'coding',
+			assigned_agent: 'coder',
+			custom_agent_id: ctx.agentId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.priority).toBe('high');
+		expect(parsed.task.taskType).toBe('coding');
+		expect(parsed.task.assignedAgent).toBe('coder');
+		expect(parsed.task.customAgentId).toBe(ctx.agentId);
+	});
+
+	test('returns error when custom_agent_id does not exist', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Task',
+			description: 'Desc',
+			custom_agent_id: 'agent-does-not-exist',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('agent-does-not-exist');
+	});
+
+	test('task is retrievable from repo after creation', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Stored task',
+			description: 'Check storage',
+		});
+		const taskId = JSON.parse(result.content[0].text).task.id;
+		const stored = ctx.taskRepo.getTask(taskId);
+		expect(stored).not.toBeNull();
+		expect(stored?.title).toBe('Stored task');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_task_detail
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — get_task_detail', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns full task record by ID', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Detail task',
+			description: 'Some work',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).get_task_detail({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.id).toBe(taskId);
+		expect(parsed.task.title).toBe('Detail task');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).get_task_detail({ task_id: 'task-missing' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+
+	test('returns task with error and result fields', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Failed task',
+			description: 'Will fail',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Start and then fail the task
+		await ctx.taskManager.startTask(taskId);
+		await ctx.taskManager.failTask(taskId, 'Something went wrong');
+
+		const result = await makeHandlers(ctx).get_task_detail({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('needs_attention');
+		expect(parsed.task.error).toBe('Something went wrong');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// retry_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — retry_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('resets a needs_attention task to pending', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Retry task',
+			description: 'Will be retried',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.startTask(taskId);
+		await ctx.taskManager.failTask(taskId, 'Error');
+
+		const result = await makeHandlers(ctx).retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+		expect(parsed.task.error ?? null).toBeNull();
+	});
+
+	test('resets a cancelled task to pending', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Cancelled task',
+			description: 'Will be retried',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.cancelTask(taskId);
+
+		const result = await makeHandlers(ctx).retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+	});
+
+	test('updates description on retry when provided', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Task with desc update',
+			description: 'Original description',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.startTask(taskId);
+		await ctx.taskManager.failTask(taskId, 'Error');
+
+		const result = await makeHandlers(ctx).retry_task({
+			task_id: taskId,
+			description: 'Updated description',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.description).toBe('Updated description');
+	});
+
+	test('returns error for in_progress task', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Active task',
+			description: 'Currently running',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.startTask(taskId);
+
+		const result = await makeHandlers(ctx).retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('in_progress');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).retry_task({ task_id: 'task-missing' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancel_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — cancel_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('cancels a pending task', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Cancel me',
+			description: 'Will be cancelled',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).cancel_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('cancelled');
+	});
+
+	test('cancels dependent tasks in cascade', async () => {
+		// Create two tasks where second depends on first
+		const t1 = await ctx.taskManager.createTask({ title: 'T1', description: 'First' });
+		const t2 = await ctx.taskManager.createTask({
+			title: 'T2',
+			description: 'Depends on T1',
+			dependsOn: [t1.id],
+		});
+
+		const result = await makeHandlers(ctx).cancel_task({ task_id: t1.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.id).toBe(t1.id);
+		expect(parsed.task.status).toBe('cancelled');
+
+		// Dependent task should also be cancelled
+		const t2Updated = ctx.taskRepo.getTask(t2.id);
+		expect(t2Updated?.status).toBe('cancelled');
+	});
+
+	test('cancels the workflow run when cancel_workflow_run is true', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Cancel WF');
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'Run to cancel',
+		});
+		const { run, tasks } = JSON.parse(startResult.content[0].text);
+		const taskId = tasks[0].id;
+		const runId = run.id;
+
+		const result = await makeHandlers(ctx).cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: true,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.workflowRunCancelled).toBe(true);
+		expect(parsed.workflowRunId).toBe(runId);
+
+		const updatedRun = ctx.workflowRunRepo.getRun(runId);
+		expect(updatedRun?.status).toBe('cancelled');
+	});
+
+	test('does not cancel workflow run when cancel_workflow_run is false', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Keep Run WF'
+		);
+		const startResult = await makeHandlers(ctx).start_workflow_run({
+			workflow_id: wf.id,
+			title: 'Run to keep',
+		});
+		const { run, tasks } = JSON.parse(startResult.content[0].text);
+		const taskId = tasks[0].id;
+		const runId = run.id;
+
+		await makeHandlers(ctx).cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: false,
+		});
+
+		const updatedRun = ctx.workflowRunRepo.getRun(runId);
+		expect(updatedRun?.status).toBe('in_progress');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).cancel_task({ task_id: 'task-missing' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+
+	test('returns error when cancelling a completed task', async () => {
+		const t = await ctx.taskManager.createTask({ title: 'T', description: 'Done' });
+		await ctx.taskManager.startTask(t.id);
+		await ctx.taskManager.completeTask(t.id, 'done');
+
+		const result = await makeHandlers(ctx).cancel_task({ task_id: t.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reassign_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — reassign_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('reassigns a pending task to a custom agent', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Reassign me',
+			description: 'Will be reassigned',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			custom_agent_id: ctx.agentId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe(ctx.agentId);
+	});
+
+	test('reassigns by changing assigned_agent type', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Agent type change',
+			description: 'Change agent type',
+			assigned_agent: 'coder',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			assigned_agent: 'general',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.assignedAgent).toBe('general');
+	});
+
+	test('clears custom agent when custom_agent_id is null', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Clear agent',
+			description: 'Remove custom agent',
+			custom_agent_id: ctx.agentId,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			custom_agent_id: null,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId ?? null).toBeNull();
+	});
+
+	test('returns error when custom_agent_id does not exist', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Task',
+			description: 'Desc',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			custom_agent_id: 'agent-does-not-exist',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('agent-does-not-exist');
+	});
+
+	test('returns error when task is in_progress', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Active task',
+			description: 'Currently running',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.startTask(taskId);
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			assigned_agent: 'general',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('in_progress');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: 'task-missing',
+			assigned_agent: 'general',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+
+	test('reassigns a needs_attention task successfully', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Failed task',
+			description: 'Failed and reassign',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		await ctx.taskManager.startTask(taskId);
+		await ctx.taskManager.failTask(taskId, 'Error');
+
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			custom_agent_id: ctx.agentId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe(ctx.agentId);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1061,6 +1061,27 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
 		expect(parsed.task.assignedAgent).toBe('general');
 	});
 
+	test('does not clear existing customAgentId when only assigned_agent is changed', async () => {
+		// Create task with a custom agent assigned
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Has custom agent',
+			description: 'Custom agent must be preserved',
+			custom_agent_id: ctx.agentId,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Reassign only the agent type — custom_agent_id not provided
+		const result = await makeHandlers(ctx).reassign_task({
+			task_id: taskId,
+			assigned_agent: 'general',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.assignedAgent).toBe('general');
+		// customAgentId must NOT have been cleared
+		expect(parsed.task.customAgentId).toBe(ctx.agentId);
+	});
+
 	test('clears custom agent when custom_agent_id is null', async () => {
 		const createResult = await makeHandlers(ctx).create_standalone_task({
 			title: 'Clear agent',


### PR DESCRIPTION
Add create_standalone_task, get_task_detail, retry_task, cancel_task,
and reassign_task tool handlers and MCP tool definitions to the
per-space Space Agent tools.

- Extend SpaceAgentToolsConfig with taskManager and spaceAgentManager
- create_standalone_task: creates tasks without workflow association
- get_task_detail: returns full task record including error/result/PR fields
- retry_task: wraps SpaceTaskManager.retryTask() with optional description
- cancel_task: wraps SpaceTaskManager.cancelTask() (cascade built-in) with
  optional cancel_workflow_run flag to also update the workflow run status
- reassign_task: wraps SpaceTaskManager.reassignTask() with agent validation
- 53 unit tests covering success and error paths for all five tools
