### PR TITLE
feat: add coordination tools to global-spaces-tools.ts (Task 3.3)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -290,6 +290,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			spaceRuntimeService,
 			taskRepo: spaceTaskRepo,
 			workflowRunRepo: spaceWorkflowRunRepo,
+			db: deps.db.getDatabase(),
 			state: globalSpacesState,
 		}).catch((error) => {
 			log.error('Failed to provision global spaces agent:', error);

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -9,6 +9,7 @@
  */
 
 import type { McpServerConfig } from '@neokai/shared';
+import type { Database as BunDatabase } from 'bun:sqlite';
 import type { SessionManager } from '../session-manager';
 import type { SpaceManager } from './managers/space-manager';
 import type { SpaceAgentManager } from './managers/space-agent-manager';
@@ -31,6 +32,8 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	spaceRuntimeService: SpaceRuntimeService;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Database instance passed through to GlobalSpacesToolsConfig for SpaceTaskManager creation. */
+	db: BunDatabase;
 	/** Shared mutable state for the active space context. Created externally so RPC handlers can use the same reference. */
 	state: GlobalSpacesState;
 }
@@ -53,6 +56,7 @@ export async function provisionGlobalSpacesAgent(
 		spaceRuntimeService,
 		taskRepo,
 		workflowRunRepo,
+		db,
 		state,
 	} = deps;
 
@@ -92,6 +96,7 @@ export async function provisionGlobalSpacesAgent(
 			workflowManager: spaceWorkflowManager,
 			taskRepo,
 			workflowRunRepo,
+			db,
 		},
 		state
 	);

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -13,12 +13,14 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
+import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
 	SpaceTaskStatus,
-	SpaceTaskType,
 	SpaceAutonomyLevel,
 	CreateSpaceParams,
 	UpdateSpaceParams,
+	SpaceTaskPriority,
+	SpaceTaskType,
 } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
@@ -26,6 +28,7 @@ import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import { SpaceTaskManager } from '../managers/space-task-manager';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -38,6 +41,8 @@ export interface GlobalSpacesToolsConfig {
 	workflowManager: SpaceWorkflowManager;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	/** Database instance used to create SpaceTaskManager instances on demand. */
+	db: BunDatabase;
 }
 
 /**
@@ -126,8 +131,27 @@ export function createGlobalSpacesToolHandlers(
 	config: GlobalSpacesToolsConfig,
 	state: GlobalSpacesState
 ) {
-	const { spaceManager, spaceAgentManager, runtime, workflowManager, taskRepo, workflowRunRepo } =
-		config;
+	const {
+		spaceManager,
+		spaceAgentManager,
+		runtime,
+		workflowManager,
+		taskRepo,
+		workflowRunRepo,
+		db,
+	} = config;
+
+	/** Cache of SpaceTaskManager instances keyed by spaceId (same getOrCreate pattern as SpaceRuntime). */
+	const taskManagers = new Map<string, SpaceTaskManager>();
+
+	function getOrCreateTaskManager(spaceId: string): SpaceTaskManager {
+		let mgr = taskManagers.get(spaceId);
+		if (!mgr) {
+			mgr = new SpaceTaskManager(db, spaceId);
+			taskManagers.set(spaceId, mgr);
+		}
+		return mgr;
+	}
 
 	/**
 	 * Resolve the spaceId for per-space tools.
@@ -338,24 +362,30 @@ export function createGlobalSpacesToolHandlers(
 			});
 		},
 
-		// ---- Task coordination tools ----
+		// ---- Coordination tools ----
 
 		async create_standalone_task(args: {
 			space_id?: string;
 			title: string;
-			description?: string;
+			description: string;
+			priority?: SpaceTaskPriority;
 			task_type?: SpaceTaskType;
+			assigned_agent?: 'coder' | 'general';
 			custom_agent_id?: string;
+			depends_on?: string[];
 		}): Promise<ToolResult> {
 			const resolved = resolveSpaceId(args.space_id);
 			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });
 			try {
-				const taskManager = runtime.getTaskManagerForSpace(resolved.spaceId);
-				const task = await taskManager.createTask({
+				const mgr = getOrCreateTaskManager(resolved.spaceId);
+				const task = await mgr.createTask({
 					title: args.title,
-					description: args.description ?? '',
-					taskType: args.task_type ?? 'coding',
+					description: args.description,
+					priority: args.priority,
+					taskType: args.task_type,
+					assignedAgent: args.assigned_agent,
 					customAgentId: args.custom_agent_id,
+					dependsOn: args.depends_on,
 				});
 				return jsonResult({ success: true, space_id: resolved.spaceId, task });
 			} catch (err) {
@@ -364,24 +394,42 @@ export function createGlobalSpacesToolHandlers(
 			}
 		},
 
-		async get_task_detail(args: { task_id: string }): Promise<ToolResult> {
+		async get_task_detail(args: { task_id: string; space_id?: string }): Promise<ToolResult> {
 			const task = taskRepo.getTask(args.task_id);
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			// Validate the task belongs to the resolved space when a space context is available.
+			const resolved = resolveSpaceId(args.space_id);
+			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to space ${resolved.spaceId}`,
+				});
 			}
 			return jsonResult({ success: true, task });
 		},
 
-		async retry_task(args: { task_id: string; description?: string }): Promise<ToolResult> {
+		async retry_task(args: {
+			task_id: string;
+			space_id?: string;
+			description?: string;
+		}): Promise<ToolResult> {
 			const task = taskRepo.getTask(args.task_id);
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
-			try {
-				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
-				const retried = await taskManager.retryTask(args.task_id, {
-					description: args.description,
+			// Validate space ownership when space context is available.
+			const resolved = resolveSpaceId(args.space_id);
+			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to space ${resolved.spaceId}`,
 				});
+			}
+			try {
+				const mgr = getOrCreateTaskManager(task.spaceId);
+				const retried = await mgr.retryTask(args.task_id, { description: args.description });
 				return jsonResult({ success: true, task: retried });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -391,24 +439,30 @@ export function createGlobalSpacesToolHandlers(
 
 		async cancel_task(args: {
 			task_id: string;
+			space_id?: string;
 			cancel_workflow_run?: boolean;
 		}): Promise<ToolResult> {
 			const task = taskRepo.getTask(args.task_id);
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
+			// Validate space ownership when space context is available.
+			const resolved = resolveSpaceId(args.space_id);
+			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to space ${resolved.spaceId}`,
+				});
+			}
 			try {
-				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
-				const cancelled = await taskManager.cancelTask(args.task_id);
-				const result: { success: boolean; task: unknown; workflow_run_cancelled?: boolean } = {
-					success: true,
-					task: cancelled,
-				};
+				const mgr = getOrCreateTaskManager(task.spaceId);
+				const cancelled = await mgr.cancelTask(args.task_id);
+				let cancelledRun = null;
 				if (args.cancel_workflow_run && task.workflowRunId) {
-					await workflowRunRepo.updateRun(task.workflowRunId, { status: 'cancelled' });
-					result.workflow_run_cancelled = true;
+					workflowRunRepo.updateStatus(task.workflowRunId, 'cancelled');
+					cancelledRun = task.workflowRunId;
 				}
-				return jsonResult(result);
+				return jsonResult({ success: true, task: cancelled, cancelledWorkflowRunId: cancelledRun });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
@@ -417,6 +471,7 @@ export function createGlobalSpacesToolHandlers(
 
 		async reassign_task(args: {
 			task_id: string;
+			space_id?: string;
 			custom_agent_id: string | null;
 			assigned_agent?: 'coder' | 'general';
 		}): Promise<ToolResult> {
@@ -424,9 +479,17 @@ export function createGlobalSpacesToolHandlers(
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
+			// Validate space ownership when space context is available.
+			const resolved = resolveSpaceId(args.space_id);
+			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to space ${resolved.spaceId}`,
+				});
+			}
 			try {
-				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
-				const reassigned = await taskManager.reassignTask(
+				const mgr = getOrCreateTaskManager(task.spaceId);
+				const reassigned = await mgr.reassignTask(
 					args.task_id,
 					args.custom_agent_id,
 					args.assigned_agent
@@ -609,70 +672,102 @@ export function createGlobalSpacesMcpServer(
 			(args) => handlers.suggest_workflow(args)
 		),
 
-		// Task coordination tools
+		// Coordination tools
 		tool(
 			'create_standalone_task',
-			'Create a task outside any workflow. Use for ad-hoc work that does not fit an existing workflow.',
+			'Create a task outside any workflow. Use this to spin up ad-hoc work that does not belong to an existing workflow run.',
 			{
 				space_id: z
 					.string()
 					.optional()
 					.describe('Target space ID (defaults to the active space context)'),
 				title: z.string().describe('Short title for the task'),
-				description: z.string().optional().describe('Detailed description of the work'),
-				task_type: z
-					.enum(['planning', 'coding', 'review'])
+				description: z.string().describe('Detailed description of the work to be done'),
+				priority: z
+					.enum(['low', 'normal', 'high', 'urgent'])
 					.optional()
-					.describe('Task type (defaults to coding)'),
-				custom_agent_id: z.string().optional().describe('ID of a custom agent to assign'),
+					.describe('Task priority (default: normal)'),
+				task_type: z
+					.enum(['planning', 'coding', 'research', 'design', 'review'])
+					.optional()
+					.describe('Task type for routing and display'),
+				assigned_agent: z
+					.enum(['coder', 'general'])
+					.optional()
+					.describe('Built-in agent type to assign (default: coder)'),
+				custom_agent_id: z
+					.string()
+					.optional()
+					.describe('Custom Space agent ID to assign instead of the built-in agent'),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe('IDs of tasks that must complete before this task can start'),
 			},
 			(args) => handlers.create_standalone_task(args)
 		),
 		tool(
 			'get_task_detail',
-			'Get full task details including agent output, PR status, and error information. Call this before deciding how to handle a failed task.',
+			'Get the full detail of a task including agent output, PR status, and error info. Task IDs are globally unique.',
 			{
 				task_id: z.string().describe('ID of the task to retrieve'),
+				space_id: z
+					.string()
+					.optional()
+					.describe(
+						'Space ID to validate ownership against (defaults to the active space context; omit to skip validation)'
+					),
 			},
 			(args) => handlers.get_task_detail(args)
 		),
 		tool(
 			'retry_task',
-			'Reset a needs_attention or cancelled task back to pending so it can be picked up again. Optionally update the description.',
+			'Reset a failed (needs_attention) or cancelled task back to pending so it can be picked up again. Optionally update the description before retry.',
 			{
 				task_id: z.string().describe('ID of the task to retry'),
-				description: z
+				space_id: z
 					.string()
 					.optional()
-					.describe('Updated task description (clarified instructions for the retry)'),
+					.describe('Space ID to validate ownership (defaults to active space context)'),
+				description: z.string().optional().describe('Updated task description to use on retry'),
 			},
 			(args) => handlers.retry_task(args)
 		),
 		tool(
 			'cancel_task',
-			'Cancel a task. Optionally cancel its entire workflow run.',
+			'Cancel a task. Pending tasks that depend on this task are also cancelled (cascade). Optionally cancel the associated workflow run.',
 			{
 				task_id: z.string().describe('ID of the task to cancel'),
+				space_id: z
+					.string()
+					.optional()
+					.describe('Space ID to validate ownership (defaults to active space context)'),
 				cancel_workflow_run: z
 					.boolean()
 					.optional()
-					.describe('Also cancel the workflow run this task belongs to'),
+					.describe(
+						'If true and the task belongs to a workflow run, cancel that run as well (default: false)'
+					),
 			},
 			(args) => handlers.cancel_task(args)
 		),
 		tool(
 			'reassign_task',
-			'Change the assigned agent for a task. Only works for tasks in pending, needs_attention, or cancelled status.',
+			'Change the agent assigned to a task. Only allowed for tasks in pending, needs_attention, or cancelled status.',
 			{
 				task_id: z.string().describe('ID of the task to reassign'),
+				space_id: z
+					.string()
+					.optional()
+					.describe('Space ID to validate ownership (defaults to active space context)'),
 				custom_agent_id: z
 					.string()
 					.nullable()
-					.describe('ID of the custom agent to assign, or null to clear the custom assignment'),
+					.describe('Custom Space agent ID to assign, or null to revert to the built-in agent'),
 				assigned_agent: z
 					.enum(['coder', 'general'])
 					.optional()
-					.describe('Preset agent role to assign'),
+					.describe('Built-in agent type (used when custom_agent_id is null)'),
 			},
 			(args) => handlers.reassign_task(args)
 		),

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -29,6 +29,8 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import { SpaceTaskManager } from '../managers/space-task-manager';
+import { jsonResult, SUGGEST_WORKFLOW_STOP_WORDS } from './tool-result';
+import type { ToolResult } from './tool-result';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -66,61 +68,6 @@ const AUTONOMY_LEVEL_VALUES = [
 	'supervised',
 	'semi_autonomous',
 ] as const satisfies readonly SpaceAutonomyLevel[];
-
-interface ToolResult {
-	content: Array<{ type: 'text'; text: string }>;
-}
-
-function jsonResult(data: unknown): ToolResult {
-	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
-}
-
-/**
- * Common English stop words filtered out by suggest_workflow before keyword matching.
- */
-const SUGGEST_WORKFLOW_STOP_WORDS = new Set([
-	'the',
-	'and',
-	'for',
-	'are',
-	'but',
-	'not',
-	'you',
-	'all',
-	'can',
-	'her',
-	'was',
-	'one',
-	'our',
-	'out',
-	'day',
-	'get',
-	'has',
-	'him',
-	'his',
-	'how',
-	'its',
-	'may',
-	'new',
-	'now',
-	'old',
-	'see',
-	'two',
-	'use',
-	'way',
-	'who',
-	'did',
-	'let',
-	'put',
-	'say',
-	'she',
-	'too',
-	'had',
-	'any',
-	'via',
-]);
-
-// ---------------------------------------------------------------------------
 // Tool handlers (separated for testability)
 // ---------------------------------------------------------------------------
 
@@ -141,7 +88,13 @@ export function createGlobalSpacesToolHandlers(
 		db,
 	} = config;
 
-	/** Cache of SpaceTaskManager instances keyed by spaceId (same getOrCreate pattern as SpaceRuntime). */
+	/**
+	 * Cache of SpaceTaskManager instances keyed by spaceId.
+	 * Follows the same getOrCreate pattern as SpaceRuntime.getOrCreateTaskManager().
+	 * Lifecycle: the cache is created once per createGlobalSpacesToolHandlers() call.
+	 * In practice createGlobalSpacesMcpServer() calls this exactly once per provisioning,
+	 * so there is no cross-call state sharing to worry about.
+	 */
 	const taskManagers = new Map<string, SpaceTaskManager>();
 
 	function getOrCreateTaskManager(spaceId: string): SpaceTaskManager {
@@ -399,7 +352,10 @@ export function createGlobalSpacesToolHandlers(
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
-			// Validate the task belongs to the resolved space when a space context is available.
+			// Space ownership validation: when a space context is available (explicit space_id or
+			// activeSpaceId), reject cross-space access. When no context is available the Global
+			// Agent is operating cross-space and the check is intentionally skipped — task IDs are
+			// globally unique UUIDs and the Global Agent is trusted to use them responsibly.
 			const resolved = resolveSpaceId(args.space_id);
 			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
 				return jsonResult({
@@ -419,7 +375,8 @@ export function createGlobalSpacesToolHandlers(
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
-			// Validate space ownership when space context is available.
+			// Space ownership validation: when a context is available, enforce it. When absent,
+			// the Global Agent is operating cross-space and the check is intentionally skipped.
 			const resolved = resolveSpaceId(args.space_id);
 			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
 				return jsonResult({
@@ -446,7 +403,8 @@ export function createGlobalSpacesToolHandlers(
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
-			// Validate space ownership when space context is available.
+			// Space ownership validation: when a context is available, enforce it. When absent,
+			// the Global Agent is operating cross-space and the check is intentionally skipped.
 			const resolved = resolveSpaceId(args.space_id);
 			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
 				return jsonResult({
@@ -459,8 +417,12 @@ export function createGlobalSpacesToolHandlers(
 				const cancelled = await mgr.cancelTask(args.task_id);
 				let cancelledRun = null;
 				if (args.cancel_workflow_run && task.workflowRunId) {
-					workflowRunRepo.updateStatus(task.workflowRunId, 'cancelled');
-					cancelledRun = task.workflowRunId;
+					// Guard against stale run IDs: updateStatus returns null when the run is
+					// not found, which would leave the task cancelled but the run untouched.
+					const updatedRun = workflowRunRepo.updateStatus(task.workflowRunId, 'cancelled');
+					if (updatedRun) {
+						cancelledRun = task.workflowRunId;
+					}
 				}
 				return jsonResult({ success: true, task: cancelled, cancelledWorkflowRunId: cancelledRun });
 			} catch (err) {
@@ -479,7 +441,8 @@ export function createGlobalSpacesToolHandlers(
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
-			// Validate space ownership when space context is available.
+			// Space ownership validation: when a context is available, enforce it. When absent,
+			// the Global Agent is operating cross-space and the check is intentionally skipped.
 			const resolved = resolveSpaceId(args.space_id);
 			if ('spaceId' in resolved && task.spaceId !== resolved.spaceId) {
 				return jsonResult({

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -29,7 +29,7 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
-import { jsonResult } from './tool-result';
+import { jsonResult, SUGGEST_WORKFLOW_STOP_WORDS } from './tool-result';
 import type { ToolResult } from './tool-result';
 
 // ---------------------------------------------------------------------------
@@ -52,52 +52,6 @@ export interface SpaceAgentToolsConfig {
 	/** Space agent manager for reassign validation. */
 	spaceAgentManager: SpaceAgentManager;
 }
-
-/**
- * Common English stop words filtered out by suggest_workflow before keyword matching.
- * Hoisted to module scope so the Set is constructed once, not on every tool call.
- */
-const SUGGEST_WORKFLOW_STOP_WORDS = new Set([
-	'the',
-	'and',
-	'for',
-	'are',
-	'but',
-	'not',
-	'you',
-	'all',
-	'can',
-	'her',
-	'was',
-	'one',
-	'our',
-	'out',
-	'day',
-	'get',
-	'has',
-	'him',
-	'his',
-	'how',
-	'its',
-	'may',
-	'new',
-	'now',
-	'old',
-	'see',
-	'two',
-	'use',
-	'way',
-	'who',
-	'did',
-	'let',
-	'put',
-	'say',
-	'she',
-	'too',
-	'had',
-	'any',
-	'via',
-]);
 
 // ---------------------------------------------------------------------------
 // Tool handlers (separated for testability)

--- a/packages/daemon/src/lib/space/tools/tool-result.ts
+++ b/packages/daemon/src/lib/space/tools/tool-result.ts
@@ -1,5 +1,5 @@
 /**
- * Shared ToolResult type and jsonResult helper for Space MCP tool handlers.
+ * Shared ToolResult type, jsonResult helper, and common constants for Space MCP tool handlers.
  *
  * Extracted from space-agent-tools.ts and task-agent-tools.ts to eliminate
  * duplication. Both files previously defined identical types inline.
@@ -12,3 +12,49 @@ export interface ToolResult {
 export function jsonResult(data: unknown): ToolResult {
 	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
+
+/**
+ * Common English stop words filtered out by suggest_workflow before keyword matching.
+ * Hoisted to module scope so the Set is constructed once across all importers.
+ */
+export const SUGGEST_WORKFLOW_STOP_WORDS = new Set([
+	'the',
+	'and',
+	'for',
+	'are',
+	'but',
+	'not',
+	'you',
+	'all',
+	'can',
+	'her',
+	'was',
+	'one',
+	'our',
+	'out',
+	'day',
+	'get',
+	'has',
+	'him',
+	'his',
+	'how',
+	'its',
+	'may',
+	'new',
+	'now',
+	'old',
+	'see',
+	'two',
+	'use',
+	'way',
+	'who',
+	'did',
+	'let',
+	'put',
+	'say',
+	'she',
+	'too',
+	'had',
+	'any',
+	'via',
+]);

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -1,28 +1,42 @@
 /**
  * Unit tests for createGlobalSpacesToolHandlers()
  *
- * Covers autonomy level handling in:
- * - create_space: passes autonomy_level through to SpaceManager
- * - update_space: passes autonomy_level through to SpaceManager
- * - Default behavior when autonomy_level is omitted
+ * Section 1 — Autonomy level handling (mock-based):
+ *   create_space: passes autonomy_level through to SpaceManager
+ *   update_space: passes autonomy_level through to SpaceManager
+ *
+ * Section 2 — Coordination tools (real DB integration):
+ *   create_standalone_task — create task outside a workflow with space_id resolution
+ *   get_task_detail        — fetch full task detail; validate space ownership
+ *   retry_task             — reset failed/cancelled task to pending
+ *   cancel_task            — cancel task (with optional workflow run cancellation)
+ *   reassign_task          — change agent assignment for a task
+ *
+ * Also covers the resolveSpaceId / activeSpaceId fallback mechanism for each tool.
  */
 
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import {
 	createGlobalSpacesToolHandlers,
 	type GlobalSpacesToolsConfig,
 	type GlobalSpacesState,
-} from '../../../src/lib/space/tools/global-spaces-tools';
-import type { Space, SpaceAutonomyLevel } from '@neokai/shared';
-import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
-import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
-import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime';
-import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
-import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
-import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+} from '../../../src/lib/space/tools/global-spaces-tools.ts';
+import type { Space, SpaceAutonomyLevel, SpaceWorkflow } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
-// Fixtures
+// Section 1: Mock-based fixtures for autonomy level tests
 // ---------------------------------------------------------------------------
 
 const NOW = Date.now();
@@ -44,11 +58,7 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Mock factories
-// ---------------------------------------------------------------------------
-
-function makeSpaceManager(space: Space): SpaceManager {
+function makeSpaceManager(space: Space) {
 	return {
 		createSpace: mock(async () => space),
 		getSpace: mock(async () => space),
@@ -58,12 +68,12 @@ function makeSpaceManager(space: Space): SpaceManager {
 		deleteSpace: mock(async () => true),
 		addSession: mock(async () => space),
 		removeSession: mock(async () => space),
-	} as unknown as SpaceManager;
+	};
 }
 
-function makeConfig(spaceManager: SpaceManager): GlobalSpacesToolsConfig {
+function makeMockConfig(spaceManager: ReturnType<typeof makeSpaceManager>): GlobalSpacesToolsConfig {
 	return {
-		spaceManager,
+		spaceManager: spaceManager as unknown as SpaceManager,
 		spaceAgentManager: {
 			listBySpaceId: mock(() => []),
 		} as unknown as SpaceAgentManager,
@@ -73,32 +83,30 @@ function makeConfig(spaceManager: SpaceManager): GlobalSpacesToolsConfig {
 		} as unknown as SpaceWorkflowManager,
 		taskRepo: {} as unknown as SpaceTaskRepository,
 		workflowRunRepo: {} as unknown as SpaceWorkflowRunRepository,
+		// db not exercised by autonomy-level tests; cast to satisfy type
+		db: null as unknown as BunDatabase,
 	};
 }
 
-function makeState(): GlobalSpacesState {
+function makeMockState(): GlobalSpacesState {
 	return { activeSpaceId: 'space-1' };
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function parseResult(result: { content: Array<{ type: 'text'; text: string }> }) {
 	return JSON.parse(result.content[0].text);
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Section 1a: create_space autonomy_level
 // ---------------------------------------------------------------------------
 
 describe('global-spaces-tools: create_space autonomy_level', () => {
-	let spaceManager: SpaceManager;
+	let spaceManager: ReturnType<typeof makeSpaceManager>;
 	let handlers: ReturnType<typeof createGlobalSpacesToolHandlers>;
 
 	beforeEach(() => {
 		spaceManager = makeSpaceManager(makeSpace({ autonomyLevel: 'supervised' }));
-		handlers = createGlobalSpacesToolHandlers(makeConfig(spaceManager), makeState());
+		handlers = createGlobalSpacesToolHandlers(makeMockConfig(spaceManager), makeMockState());
 	});
 
 	it('passes autonomy_level=supervised to SpaceManager.createSpace', async () => {
@@ -170,13 +178,17 @@ describe('global-spaces-tools: create_space autonomy_level', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Section 1b: update_space autonomy_level
+// ---------------------------------------------------------------------------
+
 describe('global-spaces-tools: update_space autonomy_level', () => {
-	let spaceManager: SpaceManager;
+	let spaceManager: ReturnType<typeof makeSpaceManager>;
 	let handlers: ReturnType<typeof createGlobalSpacesToolHandlers>;
 
 	beforeEach(() => {
 		spaceManager = makeSpaceManager(makeSpace());
-		handlers = createGlobalSpacesToolHandlers(makeConfig(spaceManager), makeState());
+		handlers = createGlobalSpacesToolHandlers(makeMockConfig(spaceManager), makeMockState());
 	});
 
 	it('passes autonomy_level=semi_autonomous to SpaceManager.updateSpace', async () => {
@@ -252,5 +264,796 @@ describe('global-spaces-tools: update_space autonomy_level', () => {
 
 		expect(result.success).toBe(false);
 		expect(result.error).toContain('Space not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Section 2: Real-DB helpers for coordination tool tests
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-global-spaces-tools',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function seedAgentRow(
+	db: BunDatabase,
+	agentId: string,
+	spaceId: string,
+	name: string,
+	role: string
+): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, name, role, Date.now(), Date.now());
+}
+
+function buildSingleStepWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string,
+	name: string
+): SpaceWorkflow {
+	const stepId = `step-${Math.random().toString(36).slice(2)}`;
+	return workflowManager.createWorkflow({
+		spaceId,
+		name,
+		steps: [{ id: stepId, name: 'Work', agentId }],
+		transitions: [],
+		startStepId: stepId,
+		rules: [],
+		tags: [],
+	});
+}
+
+interface TestCtx {
+	db: BunDatabase;
+	dir: string;
+	spaceId: string;
+	otherSpaceId: string;
+	agentId: string;
+	workflowManager: SpaceWorkflowManager;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	taskRepo: SpaceTaskRepository;
+	runtime: SpaceRuntime;
+	spaceManager: SpaceManager;
+	spaceAgentManager: SpaceAgentManager;
+}
+
+function makeCtx(): TestCtx {
+	const { db, dir } = makeDb();
+	const spaceId = 'space-global-tools-test';
+	const otherSpaceId = 'space-other-test';
+	const workspacePath = '/tmp/test-workspace';
+
+	seedSpaceRow(db, spaceId, workspacePath);
+	seedSpaceRow(db, otherSpaceId, '/tmp/other-workspace');
+
+	const agentId = 'agent-coder-1';
+	seedAgentRow(db, agentId, spaceId, 'Coder', 'coder');
+
+	const agentRepo = new SpaceAgentRepository(db);
+	const spaceAgentManager = new SpaceAgentManager(agentRepo);
+
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const spaceManager = new SpaceManager(db);
+
+	const runtime = new SpaceRuntime({
+		db,
+		spaceManager,
+		spaceAgentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+	});
+
+	return {
+		db,
+		dir,
+		spaceId,
+		otherSpaceId,
+		agentId,
+		workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		runtime,
+		spaceManager,
+		spaceAgentManager,
+	};
+}
+
+function makeHandlers(ctx: TestCtx, state: GlobalSpacesState) {
+	return createGlobalSpacesToolHandlers(
+		{
+			spaceManager: ctx.spaceManager,
+			spaceAgentManager: ctx.spaceAgentManager,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			db: ctx.db,
+		},
+		state
+	);
+}
+
+// ---------------------------------------------------------------------------
+// create_standalone_task
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — create_standalone_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('creates task with explicit space_id', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'My task',
+			description: 'Do something',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.title).toBe('My task');
+		expect(parsed.task.description).toBe('Do something');
+		expect(parsed.task.spaceId).toBe(ctx.spaceId);
+		expect(parsed.task.status).toBe('pending');
+		expect(parsed.space_id).toBe(ctx.spaceId);
+	});
+
+	test('creates task using active space context when no space_id provided', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+
+		const result = await handlers.create_standalone_task({
+			title: 'Active space task',
+			description: 'Via active context',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.spaceId).toBe(ctx.spaceId);
+	});
+
+	test('returns error when no space context is available', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.create_standalone_task({
+			title: 'Orphan task',
+			description: 'No space',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('No space specified');
+	});
+
+	test('creates task with all optional fields', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Full task',
+			description: 'Full description',
+			priority: 'high',
+			task_type: 'coding',
+			assigned_agent: 'general',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.priority).toBe('high');
+		expect(parsed.task.taskType).toBe('coding');
+		expect(parsed.task.assignedAgent).toBe('general');
+	});
+
+	test('returns error when dependency task does not exist', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Dependent task',
+			description: 'Depends on ghost',
+			depends_on: ['non-existent-task-id'],
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBeDefined();
+	});
+
+	test('creates task with depends_on pointing to an existing task', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const r1 = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'First task',
+			description: 'Do first',
+		});
+		const firstTaskId = JSON.parse(r1.content[0].text).task.id;
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Second task',
+			description: 'Do second',
+			depends_on: [firstTaskId],
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.dependsOn).toContain(firstTaskId);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// get_task_detail
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — get_task_detail', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns full task detail when task exists', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Detail task',
+			description: 'For detail test',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.get_task_detail({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.id).toBe(taskId);
+		expect(parsed.task.title).toBe('Detail task');
+	});
+
+	test('returns error when task does not exist', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.get_task_detail({ task_id: 'no-such-task' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('no-such-task');
+	});
+
+	test('validates task belongs to explicit space_id', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Space A task',
+			description: 'Belongs to space A',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.get_task_detail({
+			task_id: taskId,
+			space_id: ctx.otherSpaceId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(ctx.otherSpaceId);
+	});
+
+	test('validates task belongs to active space context', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.otherSpaceId });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Wrong space task',
+			description: 'Should fail validation',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.get_task_detail({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(ctx.otherSpaceId);
+	});
+
+	test('returns task without space validation when no space context available', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'No context task',
+			description: 'Should succeed without context',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.get_task_detail({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.id).toBe(taskId);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// retry_task
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — retry_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	async function createAndFailTask(handlers: ReturnType<typeof makeHandlers>): Promise<string> {
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Fail task',
+			description: 'Will fail',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+		ctx.taskRepo.updateTask(taskId, { status: 'needs_attention', error: 'Something went wrong' });
+		return taskId;
+	}
+
+	test('resets a needs_attention task to pending', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+		const taskId = await createAndFailTask(handlers);
+
+		const result = await handlers.retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+		// null DB values become undefined in SpaceTask and are omitted in JSON
+		expect(parsed.task.error).toBeUndefined();
+	});
+
+	test('retries with updated description', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+		const taskId = await createAndFailTask(handlers);
+
+		const result = await handlers.retry_task({
+			task_id: taskId,
+			description: 'Updated description on retry',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+		expect(parsed.task.description).toBe('Updated description on retry');
+	});
+
+	test('returns error when task does not exist', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.retry_task({ task_id: 'ghost-task' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('ghost-task');
+	});
+
+	test('returns error when task is in completed status', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Completed task',
+			description: 'Already done',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+		ctx.taskRepo.updateTask(taskId, { status: 'completed' });
+
+		const result = await handlers.retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('completed');
+	});
+
+	test('returns error when task belongs to different space', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+		const taskId = await createAndFailTask(handlers);
+
+		const result = await handlers.retry_task({
+			task_id: taskId,
+			space_id: ctx.otherSpaceId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(ctx.otherSpaceId);
+	});
+
+	test('uses active space context for ownership validation', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		const taskId = await createAndFailTask(handlers);
+
+		const result = await handlers.retry_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('pending');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancel_task
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — cancel_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('cancels a pending task', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Cancel me',
+			description: 'Will be cancelled',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.cancel_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('cancelled');
+		expect(parsed.cancelledWorkflowRunId).toBeNull();
+	});
+
+	test('returns error when task does not exist', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.cancel_task({ task_id: 'ghost-id' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('ghost-id');
+	});
+
+	test('returns error when cancelling a completed task (invalid transition)', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Completed task',
+			description: 'Already done',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+		ctx.taskRepo.updateTask(taskId, { status: 'completed' });
+
+		const result = await handlers.cancel_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBeDefined();
+	});
+
+	test('cancels associated workflow run when cancel_workflow_run is true', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Test WF');
+
+		const startResult = await handlers.start_workflow_run({
+			space_id: ctx.spaceId,
+			workflow_id: wf.id,
+			title: 'run to cancel',
+		});
+		const { run, tasks } = JSON.parse(startResult.content[0].text);
+		const taskId = tasks[0].id;
+
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+
+		const result = await handlers.cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: true,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('cancelled');
+		expect(parsed.cancelledWorkflowRunId).toBe(run.id);
+
+		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
+		expect(updatedRun?.status).toBe('cancelled');
+	});
+
+	test('does not cancel workflow run when cancel_workflow_run is false', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Keep WF');
+
+		const startResult = await handlers.start_workflow_run({
+			space_id: ctx.spaceId,
+			workflow_id: wf.id,
+			title: 'run to keep',
+		});
+		const { run, tasks } = JSON.parse(startResult.content[0].text);
+		const taskId = tasks[0].id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+
+		const result = await handlers.cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: false,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.cancelledWorkflowRunId).toBeNull();
+
+		const updatedRun = ctx.workflowRunRepo.getRun(run.id);
+		expect(updatedRun?.status).toBe('in_progress');
+	});
+
+	test('cancel_workflow_run: true on standalone task (no workflowRunId) is a no-op', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Standalone task',
+			description: 'No workflow run',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: true,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('cancelled');
+		expect(parsed.cancelledWorkflowRunId).toBeNull();
+	});
+
+	test('returns error when task belongs to different space', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Task in space A',
+			description: 'Cancel from wrong space',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.cancel_task({
+			task_id: taskId,
+			space_id: ctx.otherSpaceId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(ctx.otherSpaceId);
+	});
+
+	test('cascades cancellation to dependent pending tasks', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const r1 = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Parent task',
+			description: 'Parent',
+		});
+		const parentId = JSON.parse(r1.content[0].text).task.id;
+
+		const r2 = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Child task',
+			description: 'Child',
+			depends_on: [parentId],
+		});
+		const childId = JSON.parse(r2.content[0].text).task.id;
+
+		await handlers.cancel_task({ task_id: parentId });
+
+		const childTask = ctx.taskRepo.getTask(childId);
+		expect(childTask?.status).toBe('cancelled');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reassign_task
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — reassign_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('reassigns a pending task to a custom agent', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Reassign me',
+			description: 'Will be reassigned',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			custom_agent_id: 'custom-agent-x',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe('custom-agent-x');
+	});
+
+	test('clears custom agent by setting custom_agent_id to null', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Clear agent task',
+			description: 'Will clear custom agent',
+			custom_agent_id: 'custom-agent-to-clear',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			custom_agent_id: null,
+			assigned_agent: 'general',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// null DB value becomes undefined in SpaceTask and is omitted in JSON
+		expect(parsed.task.customAgentId).toBeUndefined();
+		expect(parsed.task.assignedAgent).toBe('general');
+	});
+
+	test('returns error when task does not exist', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.reassign_task({
+			task_id: 'ghost-task',
+			custom_agent_id: 'some-agent',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('ghost-task');
+	});
+
+	test('returns error when trying to reassign an in_progress task', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'In progress task',
+			description: 'Cannot reassign',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			custom_agent_id: 'new-agent',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('in_progress');
+	});
+
+	test('returns error when task belongs to different space', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Space A task',
+			description: 'Reassign from wrong space',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			space_id: ctx.otherSpaceId,
+			custom_agent_id: 'new-agent',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(ctx.otherSpaceId);
+	});
+
+	test('reassigns a needs_attention task', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Failed task',
+			description: 'Needs reassignment',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+		ctx.taskRepo.updateTask(taskId, { status: 'needs_attention', error: 'failed' });
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			custom_agent_id: 'backup-agent',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe('backup-agent');
+	});
+
+	test('uses active space context for ownership validation', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: ctx.spaceId });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Active context task',
+			description: 'Reassign via active context',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.reassign_task({
+			task_id: taskId,
+			custom_agent_id: 'agent-via-context',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.customAgentId).toBe('agent-via-context');
 	});
 });

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -71,7 +71,9 @@ function makeSpaceManager(space: Space) {
 	};
 }
 
-function makeMockConfig(spaceManager: ReturnType<typeof makeSpaceManager>): GlobalSpacesToolsConfig {
+function makeMockConfig(
+	spaceManager: ReturnType<typeof makeSpaceManager>
+): GlobalSpacesToolsConfig {
 	return {
 		spaceManager: spaceManager as unknown as SpaceManager,
 		spaceAgentManager: {

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -877,6 +877,47 @@ describe('createGlobalSpacesToolHandlers — cancel_task', () => {
 		expect(parsed.error).toContain(ctx.otherSpaceId);
 	});
 
+	test('returns error when cancelling a completed task (invalid transition)', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Completed task',
+			description: 'Already done',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { status: 'in_progress' });
+		ctx.taskRepo.updateTask(taskId, { status: 'completed' });
+
+		const result = await handlers.cancel_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBeDefined();
+	});
+
+	test('cancel_workflow_run: true on standalone task (no workflowRunId) is a no-op', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const createResult = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Standalone task',
+			description: 'No workflow run',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await handlers.cancel_task({
+			task_id: taskId,
+			cancel_workflow_run: true,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('cancelled');
+		// No workflow run to cancel — should be null
+		expect(parsed.cancelledWorkflowRunId).toBeNull();
+	});
+
 	test('cascades cancellation to dependent pending tasks', async () => {
 		const handlers = makeHandlers(ctx, { activeSpaceId: null });
 


### PR DESCRIPTION
Mirror the five new Space Agent coordination tools in the global layer
with space_id resolution via the active space context pattern.

New handlers in createGlobalSpacesToolHandlers():
- create_standalone_task: creates tasks outside any workflow with resolveSpaceId
- get_task_detail: fetches full task detail; validates space ownership
- retry_task: resets needs_attention/cancelled tasks to pending
- cancel_task: cancels a task with optional workflow run cascade
- reassign_task: changes agent assignment for pending/needs_attention tasks

GlobalSpacesToolsConfig gains a `db` field used to instantiate
SpaceTaskManager instances via a getOrCreate cache (same pattern as
SpaceRuntime). ProvisionGlobalSpacesAgentDeps passes db through from
the Database facade via getDatabase().

MCP tool definitions with zod schemas added for all five tools.

30 unit tests cover space resolution, all tool operations, error paths,
and ownership validation (explicit space_id vs activeSpaceId fallback).
