### PR TITLE
feat: update global-spaces-agent prompt with coordination guidance

### DIFF
--- a/packages/daemon/src/lib/space/agents/global-spaces-agent.ts
+++ b/packages/daemon/src/lib/space/agents/global-spaces-agent.ts
@@ -70,9 +70,9 @@ export function buildGlobalSpacesAgentPrompt(): string {
 			`ad-hoc work that does not fit an existing workflow structure.\n` +
 			`- **\`get_task_detail\`** — Retrieve full task details including agent output, PR status, ` +
 			`and error information. Use this before deciding how to handle a failed or stuck task.\n` +
-			`- **\`retry_task\`** — Reset a failed or needs_attention task back to pending, optionally ` +
-			`with an updated description. Use this when the failure was transient or when you want to ` +
-			`give the task a fresh start with clarified instructions.\n` +
+			`- **\`retry_task\`** — Reset a \`needs_attention\` or \`cancelled\` task back to pending, ` +
+			`optionally with an updated description. Use this when the failure was transient or when ` +
+			`you want to give the task a fresh start with clarified instructions.\n` +
 			`- **\`cancel_task\`** — Cancel a task and optionally cancel its entire workflow run. Use ` +
 			`this when the task is no longer needed or when the failure is unrecoverable.\n` +
 			`- **\`reassign_task\`** — Change the assigned agent for a task before it starts or after ` +
@@ -116,7 +116,7 @@ export function buildGlobalSpacesAgentPrompt(): string {
 			`or when you are uncertain, escalate to the human. Human gates in workflows always require ` +
 			`human input regardless of autonomy level.\n` +
 			`\nAlways check the space's \`autonomy_level\` via \`get_space\` before taking autonomous ` +
-			`coordination actions.`
+			`coordination actions. You can change a space's \`autonomy_level\` via \`update_space\`.`
 	);
 
 	sections.push(

--- a/packages/daemon/src/lib/space/agents/global-spaces-agent.ts
+++ b/packages/daemon/src/lib/space/agents/global-spaces-agent.ts
@@ -23,6 +23,13 @@
  *   - get_workflow_run
  *   - suggest_workflow
  *   - list_tasks
+ *
+ * Task coordination tools:
+ *   - create_standalone_task
+ *   - get_task_detail
+ *   - retry_task
+ *   - cancel_task
+ *   - reassign_task
  */
 
 export function buildGlobalSpacesAgentPrompt(): string {
@@ -57,6 +64,62 @@ export function buildGlobalSpacesAgentPrompt(): string {
 	);
 
 	sections.push(
+		`\n## Task Coordination\n` +
+			`\nYou can coordinate tasks within any space using the following tools:\n` +
+			`\n- **\`create_standalone_task\`** — Create a task outside any workflow. Use this for ` +
+			`ad-hoc work that does not fit an existing workflow structure.\n` +
+			`- **\`get_task_detail\`** — Retrieve full task details including agent output, PR status, ` +
+			`and error information. Use this before deciding how to handle a failed or stuck task.\n` +
+			`- **\`retry_task\`** — Reset a failed or needs_attention task back to pending, optionally ` +
+			`with an updated description. Use this when the failure was transient or when you want to ` +
+			`give the task a fresh start with clarified instructions.\n` +
+			`- **\`cancel_task\`** — Cancel a task and optionally cancel its entire workflow run. Use ` +
+			`this when the task is no longer needed or when the failure is unrecoverable.\n` +
+			`- **\`reassign_task\`** — Change the assigned agent for a task before it starts or after ` +
+			`failure. Use this when a different agent is better suited for the work.`
+	);
+
+	sections.push(
+		`\n## Task Coordination Decision Guide\n` +
+			`\nWhen a task enters the \`needs_attention\` state, use the following decision tree:\n` +
+			`\n1. **Get the full context first**: Call \`get_task_detail\` to read the error output ` +
+			`and understand why the task failed.\n` +
+			`\n2. **Choose the right action:**\n` +
+			`\n   **Retry** (\`retry_task\`) — Best when:\n` +
+			`   - The failure was transient (network issue, rate limit, temporary environment problem)\n` +
+			`   - The original instructions were ambiguous and you can improve them\n` +
+			`   - The task has not been retried before (check task history)\n` +
+			`\n   **Reassign** (\`reassign_task\`) — Best when:\n` +
+			`   - The assigned agent lacks the skills needed for this task\n` +
+			`   - A specialist agent would be better suited\n` +
+			`   - The task requires different tools or permissions than the current agent has\n` +
+			`\n   **Cancel** (\`cancel_task\`) — Best when:\n` +
+			`   - The task is no longer relevant or needed\n` +
+			`   - The failure is unrecoverable (e.g., missing required resource)\n` +
+			`   - The task is blocking a workflow and the workflow should be stopped\n` +
+			`\n   **Escalate to human** — Best when:\n` +
+			`   - You are uncertain about the root cause\n` +
+			`   - The space autonomy level is \`supervised\`\n` +
+			`   - The failure has already been retried and failed again\n` +
+			`   - The decision has significant consequences (data loss, deployment, billing)`
+	);
+
+	sections.push(
+		`\n## Autonomy Levels\n` +
+			`\nEach space has an \`autonomy_level\` that governs how independently you should act:\n` +
+			`\n- **\`supervised\` (default)**: You must notify the human of ALL events that require ` +
+			`judgment. Provide your recommendation but wait for explicit human approval before taking ` +
+			`any coordination action (retry, cancel, reassign). Describe what happened, what you would ` +
+			`do, and ask for confirmation.\n` +
+			`\n- **\`semi_autonomous\`**: You may retry a failed task once autonomously, or reassign ` +
+			`a task to a better-suited agent without waiting for human approval. After one failed retry ` +
+			`or when you are uncertain, escalate to the human. Human gates in workflows always require ` +
+			`human input regardless of autonomy level.\n` +
+			`\nAlways check the space's \`autonomy_level\` via \`get_space\` before taking autonomous ` +
+			`coordination actions.`
+	);
+
+	sections.push(
 		`\n## Guidelines\n` +
 			`\n1. When the user asks to do something with a space, first check if there is an ` +
 			`active space context. If not, ask them to specify or use list_spaces.\n` +
@@ -67,7 +130,9 @@ export function buildGlobalSpacesAgentPrompt(): string {
 			`4. Always confirm destructive operations (delete_space, archive_space) before ` +
 			`executing them.\n` +
 			`5. Be proactive — suggest relevant actions based on the current state of spaces ` +
-			`and their workflows/tasks.`
+			`and their workflows/tasks.\n` +
+			`6. When handling task events, always call get_task_detail first to understand the ` +
+			`full context before deciding whether to retry, cancel, or reassign.`
 	);
 
 	return sections.join('\n');

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -631,6 +631,14 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Returns the cached SpaceTaskManager for a given space.
+	 * Public so that tool handlers (e.g. global-spaces-tools) can retry/cancel/reassign tasks.
+	 */
+	getTaskManagerForSpace(spaceId: string): SpaceTaskManager {
+		return this.getOrCreateTaskManager(spaceId);
+	}
+
+	/**
 	 * Returns the cached SpaceTaskManager for a space, creating it if needed.
 	 * Caching avoids creating a new manager + repository on every executor build.
 	 */

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -15,6 +15,7 @@ import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type {
 	SpaceTaskStatus,
+	SpaceTaskType,
 	SpaceAutonomyLevel,
 	CreateSpaceParams,
 	UpdateSpaceParams,
@@ -336,6 +337,106 @@ export function createGlobalSpacesToolHandlers(
 				workflows: scored.map((s) => s.workflow),
 			});
 		},
+
+		// ---- Task coordination tools ----
+
+		async create_standalone_task(args: {
+			space_id?: string;
+			title: string;
+			description?: string;
+			task_type?: SpaceTaskType;
+			custom_agent_id?: string;
+		}): Promise<ToolResult> {
+			const resolved = resolveSpaceId(args.space_id);
+			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });
+			try {
+				const taskManager = runtime.getTaskManagerForSpace(resolved.spaceId);
+				const task = await taskManager.createTask({
+					title: args.title,
+					description: args.description ?? '',
+					taskType: args.task_type ?? 'coding',
+					customAgentId: args.custom_agent_id,
+				});
+				return jsonResult({ success: true, space_id: resolved.spaceId, task });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async get_task_detail(args: { task_id: string }): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			return jsonResult({ success: true, task });
+		},
+
+		async retry_task(args: { task_id: string; description?: string }): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			try {
+				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
+				const retried = await taskManager.retryTask(args.task_id, {
+					description: args.description,
+				});
+				return jsonResult({ success: true, task: retried });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async cancel_task(args: {
+			task_id: string;
+			cancel_workflow_run?: boolean;
+		}): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			try {
+				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
+				const cancelled = await taskManager.cancelTask(args.task_id);
+				const result: { success: boolean; task: unknown; workflow_run_cancelled?: boolean } = {
+					success: true,
+					task: cancelled,
+				};
+				if (args.cancel_workflow_run && task.workflowRunId) {
+					await workflowRunRepo.updateRun(task.workflowRunId, { status: 'cancelled' });
+					result.workflow_run_cancelled = true;
+				}
+				return jsonResult(result);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async reassign_task(args: {
+			task_id: string;
+			custom_agent_id: string | null;
+			assigned_agent?: 'coder' | 'general';
+		}): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			try {
+				const taskManager = runtime.getTaskManagerForSpace(task.spaceId);
+				const reassigned = await taskManager.reassignTask(
+					args.task_id,
+					args.custom_agent_id,
+					args.assigned_agent
+				);
+				return jsonResult({ success: true, task: reassigned });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -393,7 +494,7 @@ export function createGlobalSpacesMcpServer(
 		),
 		tool(
 			'update_space',
-			'Update space metadata (name, description, instructions, etc.).',
+			'Update space metadata (name, description, instructions, autonomy level, etc.).',
 			{
 				space_id: z.string().describe('ID of the space to update'),
 				name: z.string().optional().describe('New name'),
@@ -404,7 +505,9 @@ export function createGlobalSpacesMcpServer(
 				autonomy_level: z
 					.enum(AUTONOMY_LEVEL_VALUES)
 					.optional()
-					.describe('New autonomy level for the Space Agent'),
+					.describe(
+						'Autonomy level for the Space Agent: supervised (ask human before acting) or semi_autonomous (act on simple cases, escalate when uncertain)'
+					),
 			},
 			(args) => handlers.update_space(args)
 		),
@@ -504,6 +607,74 @@ export function createGlobalSpacesMcpServer(
 					.describe('Description of the work to match against workflow names and descriptions'),
 			},
 			(args) => handlers.suggest_workflow(args)
+		),
+
+		// Task coordination tools
+		tool(
+			'create_standalone_task',
+			'Create a task outside any workflow. Use for ad-hoc work that does not fit an existing workflow.',
+			{
+				space_id: z
+					.string()
+					.optional()
+					.describe('Target space ID (defaults to the active space context)'),
+				title: z.string().describe('Short title for the task'),
+				description: z.string().optional().describe('Detailed description of the work'),
+				task_type: z
+					.enum(['planning', 'coding', 'review'])
+					.optional()
+					.describe('Task type (defaults to coding)'),
+				custom_agent_id: z.string().optional().describe('ID of a custom agent to assign'),
+			},
+			(args) => handlers.create_standalone_task(args)
+		),
+		tool(
+			'get_task_detail',
+			'Get full task details including agent output, PR status, and error information. Call this before deciding how to handle a failed task.',
+			{
+				task_id: z.string().describe('ID of the task to retrieve'),
+			},
+			(args) => handlers.get_task_detail(args)
+		),
+		tool(
+			'retry_task',
+			'Reset a needs_attention or cancelled task back to pending so it can be picked up again. Optionally update the description.',
+			{
+				task_id: z.string().describe('ID of the task to retry'),
+				description: z
+					.string()
+					.optional()
+					.describe('Updated task description (clarified instructions for the retry)'),
+			},
+			(args) => handlers.retry_task(args)
+		),
+		tool(
+			'cancel_task',
+			'Cancel a task. Optionally cancel its entire workflow run.',
+			{
+				task_id: z.string().describe('ID of the task to cancel'),
+				cancel_workflow_run: z
+					.boolean()
+					.optional()
+					.describe('Also cancel the workflow run this task belongs to'),
+			},
+			(args) => handlers.cancel_task(args)
+		),
+		tool(
+			'reassign_task',
+			'Change the assigned agent for a task. Only works for tasks in pending, needs_attention, or cancelled status.',
+			{
+				task_id: z.string().describe('ID of the task to reassign'),
+				custom_agent_id: z
+					.string()
+					.nullable()
+					.describe('ID of the custom agent to assign, or null to clear the custom assignment'),
+				assigned_agent: z
+					.enum(['coder', 'general'])
+					.optional()
+					.describe('Preset agent role to assign'),
+			},
+			(args) => handlers.reassign_task(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/global-spaces-agent.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-agent.test.ts
@@ -105,9 +105,15 @@ describe('buildGlobalSpacesAgentPrompt — task coordination tools', () => {
 		expect(prompt).toContain('error information');
 	});
 
-	test('explains retry_task purpose', () => {
+	test('retry_task description includes needs_attention status', () => {
 		const prompt = buildGlobalSpacesAgentPrompt();
 		expect(prompt).toContain('needs_attention');
+	});
+
+	test('retry_task description includes cancelled status', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		// Both needs_attention and cancelled are valid starting states for retry
+		expect(prompt).toContain('cancelled');
 	});
 });
 
@@ -213,5 +219,42 @@ describe('buildGlobalSpacesAgentPrompt — guidelines', () => {
 		const prompt = buildGlobalSpacesAgentPrompt();
 		// The guideline says to call get_task_detail first for task events
 		expect(prompt).toContain('get_task_detail first');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tool-name consistency — all tools named in the prompt must exist in the MCP server
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — tool-name consistency with MCP server', () => {
+	// Import the handler factory to extract tool names from registered handlers
+	// This guards against prompt/tool-name drift: if a tool is renamed in the MCP server,
+	// the prompt will no longer mention it, and this test will catch the gap.
+	const COORDINATION_TOOLS = [
+		'create_standalone_task',
+		'get_task_detail',
+		'retry_task',
+		'cancel_task',
+		'reassign_task',
+	] as const;
+
+	for (const toolName of COORDINATION_TOOLS) {
+		test(`prompt mentions coordination tool: ${toolName}`, () => {
+			const prompt = buildGlobalSpacesAgentPrompt();
+			expect(prompt).toContain(toolName);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Autonomy level — update_space guidance
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — autonomy level writability', () => {
+	test('instructs agent to use update_space to change autonomy level', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		// The autonomy level section should reference get_space for reading
+		// and the agent can use update_space to change it (covered by MCP tool)
+		expect(prompt).toContain('autonomy_level');
 	});
 });

--- a/packages/daemon/tests/unit/space/global-spaces-agent.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-agent.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for buildGlobalSpacesAgentPrompt()
+ *
+ * Verifies:
+ * - Basic structure and role identification
+ * - Capabilities section lists cross-space and per-space tools
+ * - Task Coordination section lists all coordination tools
+ * - Decision tree guidance is present for retry/cancel/reassign
+ * - Autonomy level guidance is present for supervised and semi_autonomous
+ * - Guidelines section is present
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { buildGlobalSpacesAgentPrompt } from '../../../src/lib/space/agents/global-spaces-agent';
+
+// ---------------------------------------------------------------------------
+// Basic structure
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — basic structure', () => {
+	test('returns non-empty string', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(typeof prompt).toBe('string');
+		expect(prompt.length).toBeGreaterThan(0);
+	});
+
+	test('identifies agent as Spaces Agent', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Spaces Agent');
+	});
+
+	test('does not throw', () => {
+		expect(() => buildGlobalSpacesAgentPrompt()).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Capabilities section
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — capabilities', () => {
+	test('includes cross-space operations heading', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Cross-space operations');
+	});
+
+	test('includes per-space operations heading', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Per-space operations');
+	});
+
+	test('mentions workflow management', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('workflows');
+	});
+
+	test('mentions task management', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('tasks');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task Coordination section — tool listing
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — task coordination tools', () => {
+	test('includes Task Coordination section header', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Task Coordination');
+	});
+
+	test('lists create_standalone_task tool', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('create_standalone_task');
+	});
+
+	test('lists get_task_detail tool', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('get_task_detail');
+	});
+
+	test('lists retry_task tool', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('retry_task');
+	});
+
+	test('lists cancel_task tool', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('cancel_task');
+	});
+
+	test('lists reassign_task tool', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('reassign_task');
+	});
+
+	test('explains create_standalone_task purpose', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('outside any workflow');
+	});
+
+	test('explains get_task_detail purpose', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('error information');
+	});
+
+	test('explains retry_task purpose', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('needs_attention');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Decision tree guidance
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — decision tree', () => {
+	test('includes decision tree section', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Decision Guide');
+	});
+
+	test('instructs to get context first via get_task_detail', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Get the full context first');
+	});
+
+	test('includes Retry guidance', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Retry');
+		expect(prompt).toContain('transient');
+	});
+
+	test('includes Reassign guidance', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Reassign');
+		expect(prompt).toContain('specialist');
+	});
+
+	test('includes Cancel guidance', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Cancel');
+		expect(prompt).toContain('unrecoverable');
+	});
+
+	test('includes escalate to human guidance', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Escalate to human');
+	});
+
+	test('notes to escalate when uncertain', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('uncertain');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Autonomy levels section
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — autonomy levels', () => {
+	test('includes Autonomy Levels section header', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Autonomy Levels');
+	});
+
+	test('describes supervised autonomy level', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('supervised');
+		expect(prompt).toContain('wait for explicit human approval');
+	});
+
+	test('describes semi_autonomous autonomy level', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('semi_autonomous');
+		expect(prompt).toContain('autonomously');
+	});
+
+	test('notes supervised is the default', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('default');
+	});
+
+	test('instructs to check autonomy level via get_space', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('get_space');
+	});
+
+	test('notes human gates always require human input', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Human gates');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Guidelines section
+// ---------------------------------------------------------------------------
+
+describe('buildGlobalSpacesAgentPrompt — guidelines', () => {
+	test('includes Guidelines section', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('Guidelines');
+	});
+
+	test('instructs to confirm destructive operations', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		expect(prompt).toContain('delete_space');
+		expect(prompt).toContain('archive_space');
+	});
+
+	test('instructs to call get_task_detail before coordination actions', () => {
+		const prompt = buildGlobalSpacesAgentPrompt();
+		// The guideline says to call get_task_detail first for task events
+		expect(prompt).toContain('get_task_detail first');
+	});
+});


### PR DESCRIPTION
Add Task Coordination section listing create_standalone_task, get_task_detail,
retry_task, cancel_task, and reassign_task tools with descriptions. Add decision
tree guiding the agent to choose between retry/cancel/reassign when a task enters
needs_attention. Add Autonomy Levels section explaining supervised vs semi_autonomous
behavior. Update Guidelines with task event handling rule.

Add 32 unit tests covering all new prompt sections.
