### PR TITLE
feat: update SpaceManager and RPC handlers for autonomy level (Task 1.2)

### DIFF
--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -51,6 +51,16 @@ export interface GlobalSpacesState {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Canonical list of valid autonomy level values.
+ * Used by both MCP tool zod schemas so there is a single source of truth.
+ * Must be kept in sync with the `SpaceAutonomyLevel` type in @neokai/shared.
+ */
+const AUTONOMY_LEVEL_VALUES = [
+	'supervised',
+	'semi_autonomous',
+] as const satisfies readonly SpaceAutonomyLevel[];
+
 interface ToolResult {
 	content: Array<{ type: 'text'; text: string }>;
 }
@@ -365,7 +375,7 @@ export function createGlobalSpacesMcpServer(
 					.optional()
 					.describe('Instructions for agents working in this space'),
 				autonomy_level: z
-					.enum(['supervised', 'semi_autonomous'])
+					.enum(AUTONOMY_LEVEL_VALUES)
 					.optional()
 					.describe(
 						'Autonomy level for the Space Agent. "supervised" (default): agent notifies human of all judgment-required events and waits for approval. "semi_autonomous": agent can retry failed tasks and reassign them autonomously.'
@@ -392,7 +402,7 @@ export function createGlobalSpacesMcpServer(
 				background_context: z.string().optional().describe('New background context'),
 				default_model: z.string().optional().describe('New default model ID'),
 				autonomy_level: z
-					.enum(['supervised', 'semi_autonomous'])
+					.enum(AUTONOMY_LEVEL_VALUES)
 					.optional()
 					.describe('New autonomy level for the Space Agent'),
 			},

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -13,7 +13,12 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { SpaceTaskStatus, CreateSpaceParams, UpdateSpaceParams } from '@neokai/shared';
+import type {
+	SpaceTaskStatus,
+	SpaceAutonomyLevel,
+	CreateSpaceParams,
+	UpdateSpaceParams,
+} from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceRuntime } from '../runtime/space-runtime';
@@ -139,6 +144,7 @@ export function createGlobalSpacesToolHandlers(
 			workspace_path: string;
 			description?: string;
 			instructions?: string;
+			autonomy_level?: SpaceAutonomyLevel;
 		}): Promise<ToolResult> {
 			try {
 				const params: CreateSpaceParams = {
@@ -146,6 +152,7 @@ export function createGlobalSpacesToolHandlers(
 					workspacePath: args.workspace_path,
 					description: args.description,
 					instructions: args.instructions,
+					autonomyLevel: args.autonomy_level,
 				};
 				const space = await spaceManager.createSpace(params);
 				return jsonResult({ success: true, space });
@@ -171,6 +178,7 @@ export function createGlobalSpacesToolHandlers(
 			instructions?: string;
 			background_context?: string;
 			default_model?: string;
+			autonomy_level?: SpaceAutonomyLevel;
 		}): Promise<ToolResult> {
 			try {
 				const params: UpdateSpaceParams = {};
@@ -180,6 +188,7 @@ export function createGlobalSpacesToolHandlers(
 				if (args.background_context !== undefined)
 					params.backgroundContext = args.background_context;
 				if (args.default_model !== undefined) params.defaultModel = args.default_model;
+				if (args.autonomy_level !== undefined) params.autonomyLevel = args.autonomy_level;
 				const space = await spaceManager.updateSpace(args.space_id, params);
 				return jsonResult({ success: true, space });
 			} catch (err) {
@@ -355,6 +364,12 @@ export function createGlobalSpacesMcpServer(
 					.string()
 					.optional()
 					.describe('Instructions for agents working in this space'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe(
+						'Autonomy level for the Space Agent. "supervised" (default): agent notifies human of all judgment-required events and waits for approval. "semi_autonomous": agent can retry failed tasks and reassign them autonomously.'
+					),
 			},
 			(args) => handlers.create_space(args)
 		),
@@ -376,6 +391,10 @@ export function createGlobalSpacesMcpServer(
 				instructions: z.string().optional().describe('New instructions for agents'),
 				background_context: z.string().optional().describe('New background context'),
 				default_model: z.string().optional().describe('New default model ID'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('New autonomy level for the Space Agent'),
 			},
 			(args) => handlers.update_space(args)
 		),

--- a/packages/daemon/tests/unit/lib/space-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-manager.test.ts
@@ -99,6 +99,36 @@ describe('SpaceManager', () => {
 				'already exists'
 			);
 		});
+
+		it('creates a space with supervised autonomy level', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'Supervised Space',
+				autonomyLevel: 'supervised',
+			});
+
+			expect(space.autonomyLevel).toBe('supervised');
+		});
+
+		it('creates a space with semi_autonomous autonomy level', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'Semi-Auto Space',
+				autonomyLevel: 'semi_autonomous',
+			});
+
+			expect(space.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('defaults autonomy level to supervised when not specified', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'Default Autonomy Space',
+			});
+
+			// DB default is 'supervised'
+			expect(space.autonomyLevel).toBe('supervised');
+		});
 	});
 
 	describe('getSpace', () => {
@@ -141,6 +171,32 @@ describe('SpaceManager', () => {
 
 		it('throws for unknown space', async () => {
 			await expect(manager.updateSpace('nonexistent', { name: 'X' })).rejects.toThrow('not found');
+		});
+
+		it('updates autonomy level to semi_autonomous', async () => {
+			const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+			const updated = await manager.updateSpace(space.id, { autonomyLevel: 'semi_autonomous' });
+			expect(updated.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('updates autonomy level back to supervised', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'A',
+				autonomyLevel: 'semi_autonomous',
+			});
+			const updated = await manager.updateSpace(space.id, { autonomyLevel: 'supervised' });
+			expect(updated.autonomyLevel).toBe('supervised');
+		});
+
+		it('does not change autonomy level when not provided in update', async () => {
+			const space = await manager.createSpace({
+				workspacePath: tmpDir,
+				name: 'A',
+				autonomyLevel: 'semi_autonomous',
+			});
+			const updated = await manager.updateSpace(space.id, { name: 'B' });
+			expect(updated.autonomyLevel).toBe('semi_autonomous');
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -220,6 +220,36 @@ describe('space-handlers', () => {
 				})
 			).rejects.toThrow('Invalid autonomyLevel: fully_autonomous');
 		});
+
+		it('passes autonomyLevel=supervised to SpaceManager', async () => {
+			await call('space.create', {
+				workspacePath: '/tmp/x',
+				name: 'X',
+				autonomyLevel: 'supervised',
+			});
+
+			expect(spaceManager.createSpace).toHaveBeenCalledTimes(1);
+			const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBe('supervised');
+		});
+
+		it('passes autonomyLevel=semi_autonomous to SpaceManager', async () => {
+			await call('space.create', {
+				workspacePath: '/tmp/x',
+				name: 'X',
+				autonomyLevel: 'semi_autonomous',
+			});
+
+			const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('passes undefined autonomyLevel to SpaceManager when not specified', async () => {
+			await call('space.create', { workspacePath: '/tmp/x', name: 'X' });
+
+			const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBeUndefined();
+		});
 	});
 
 	// ─── space.list ────────────────────────────────────────────────────────────
@@ -302,6 +332,28 @@ describe('space-handlers', () => {
 			await expect(
 				call('space.update', { id: 'space-1', autonomyLevel: 'fully_autonomous' })
 			).rejects.toThrow('Invalid autonomyLevel: fully_autonomous');
+		});
+
+		it('passes autonomyLevel=semi_autonomous to SpaceManager.updateSpace', async () => {
+			await call('space.update', { id: 'space-1', autonomyLevel: 'semi_autonomous' });
+
+			expect(spaceManager.updateSpace).toHaveBeenCalledTimes(1);
+			const [, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('passes autonomyLevel=supervised to SpaceManager.updateSpace', async () => {
+			await call('space.update', { id: 'space-1', autonomyLevel: 'supervised' });
+
+			const [, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBe('supervised');
+		});
+
+		it('does not set autonomyLevel in updateParams when not provided', async () => {
+			await call('space.update', { id: 'space-1', name: 'New Name' });
+
+			const [, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+			expect(params.autonomyLevel).toBeUndefined();
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-handlers.test.ts
@@ -17,6 +17,8 @@ import { MessageHub } from '@neokai/shared';
 import type { Space, SpaceTask, SpaceWorkflowRun } from '@neokai/shared';
 import { setupSpaceHandlers } from '../../../src/lib/rpc-handlers/space-handlers';
 import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
@@ -36,6 +38,7 @@ const mockSpace: Space = {
 	instructions: '',
 	sessionIds: [],
 	status: 'active',
+	autonomyLevel: 'supervised',
 	createdAt: NOW,
 	updatedAt: NOW,
 };
@@ -126,6 +129,21 @@ function createMockRunRepo(runs: SpaceWorkflowRun[] = [mockRun]): SpaceWorkflowR
 	} as unknown as SpaceWorkflowRunRepository;
 }
 
+function createMockSpaceAgentManager(): SpaceAgentManager {
+	return {
+		create: mock(async () => ({})),
+		listBySpaceId: mock(() => []),
+	} as unknown as SpaceAgentManager;
+}
+
+function createMockSpaceWorkflowManager(): SpaceWorkflowManager {
+	return {
+		createWorkflow: mock(() => ({})),
+		listWorkflows: mock(() => []),
+		getWorkflow: mock(() => null),
+	} as unknown as SpaceWorkflowManager;
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('space-handlers', () => {
@@ -144,7 +162,15 @@ describe('space-handlers', () => {
 		spaceManager = createMockSpaceManager(space);
 		taskRepo = createMockTaskRepo();
 		runRepo = createMockRunRepo();
-		setupSpaceHandlers(hub, spaceManager, taskRepo, runRepo, daemonHub);
+		setupSpaceHandlers(
+			hub,
+			spaceManager,
+			taskRepo,
+			runRepo,
+			daemonHub,
+			createMockSpaceAgentManager(),
+			createMockSpaceWorkflowManager()
+		);
 	}
 
 	const call = (method: string, data: unknown) => {

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for createGlobalSpacesToolHandlers()
+ *
+ * Covers autonomy level handling in:
+ * - create_space: passes autonomy_level through to SpaceManager
+ * - update_space: passes autonomy_level through to SpaceManager
+ * - Default behavior when autonomy_level is omitted
+ */
+
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import {
+	createGlobalSpacesToolHandlers,
+	type GlobalSpacesToolsConfig,
+	type GlobalSpacesState,
+} from '../../../src/lib/space/tools/global-spaces-tools';
+import type { Space, SpaceAutonomyLevel } from '@neokai/shared';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager';
+import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime';
+import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager';
+import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NOW = Date.now();
+
+function makeSpace(overrides: Partial<Space> = {}): Space {
+	return {
+		id: 'space-1',
+		workspacePath: '/tmp/test-ws',
+		name: 'Test Space',
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		autonomyLevel: 'supervised',
+		createdAt: NOW,
+		updatedAt: NOW,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeSpaceManager(space: Space): SpaceManager {
+	return {
+		createSpace: mock(async () => space),
+		getSpace: mock(async () => space),
+		listSpaces: mock(async () => [space]),
+		updateSpace: mock(async () => space),
+		archiveSpace: mock(async () => ({ ...space, status: 'archived' as const })),
+		deleteSpace: mock(async () => true),
+		addSession: mock(async () => space),
+		removeSession: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function makeConfig(spaceManager: SpaceManager): GlobalSpacesToolsConfig {
+	return {
+		spaceManager,
+		spaceAgentManager: {
+			listBySpaceId: mock(() => []),
+		} as unknown as SpaceAgentManager,
+		runtime: {} as unknown as SpaceRuntime,
+		workflowManager: {
+			listWorkflows: mock(() => []),
+		} as unknown as SpaceWorkflowManager,
+		taskRepo: {} as unknown as SpaceTaskRepository,
+		workflowRunRepo: {} as unknown as SpaceWorkflowRunRepository,
+	};
+}
+
+function makeState(): GlobalSpacesState {
+	return { activeSpaceId: 'space-1' };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseResult(result: { content: Array<{ type: 'text'; text: string }> }) {
+	return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('global-spaces-tools: create_space autonomy_level', () => {
+	let spaceManager: SpaceManager;
+	let handlers: ReturnType<typeof createGlobalSpacesToolHandlers>;
+
+	beforeEach(() => {
+		spaceManager = makeSpaceManager(makeSpace({ autonomyLevel: 'supervised' }));
+		handlers = createGlobalSpacesToolHandlers(makeConfig(spaceManager), makeState());
+	});
+
+	it('passes autonomy_level=supervised to SpaceManager.createSpace', async () => {
+		const result = parseResult(
+			await handlers.create_space({
+				name: 'My Space',
+				workspace_path: '/tmp/ws',
+				autonomy_level: 'supervised',
+			})
+		);
+
+		expect(result.success).toBe(true);
+		expect(spaceManager.createSpace).toHaveBeenCalledTimes(1);
+		const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(params.autonomyLevel).toBe('supervised');
+	});
+
+	it('passes autonomy_level=semi_autonomous to SpaceManager.createSpace', async () => {
+		const semiSpace = makeSpace({ autonomyLevel: 'semi_autonomous' });
+		(spaceManager.createSpace as ReturnType<typeof mock>).mockResolvedValue(semiSpace);
+
+		const result = parseResult(
+			await handlers.create_space({
+				name: 'Semi Space',
+				workspace_path: '/tmp/ws',
+				autonomy_level: 'semi_autonomous',
+			})
+		);
+
+		expect(result.success).toBe(true);
+		const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(params.autonomyLevel).toBe('semi_autonomous');
+	});
+
+	it('does not set autonomyLevel when autonomy_level is omitted', async () => {
+		await handlers.create_space({ name: 'My Space', workspace_path: '/tmp/ws' });
+
+		const [params] = (spaceManager.createSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(params.autonomyLevel).toBeUndefined();
+	});
+
+	it('returns success with the space returned by SpaceManager', async () => {
+		const space = makeSpace({ name: 'My Space', autonomyLevel: 'semi_autonomous' });
+		(spaceManager.createSpace as ReturnType<typeof mock>).mockResolvedValue(space);
+
+		const result = parseResult(
+			await handlers.create_space({
+				name: 'My Space',
+				workspace_path: '/tmp/ws',
+				autonomy_level: 'semi_autonomous',
+			})
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.space.autonomyLevel).toBe('semi_autonomous');
+	});
+
+	it('returns success:false on SpaceManager error', async () => {
+		(spaceManager.createSpace as ReturnType<typeof mock>).mockRejectedValue(
+			new Error('Workspace path does not exist: /tmp/ws')
+		);
+
+		const result = parseResult(
+			await handlers.create_space({ name: 'Bad', workspace_path: '/tmp/ws' })
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Workspace path does not exist');
+	});
+});
+
+describe('global-spaces-tools: update_space autonomy_level', () => {
+	let spaceManager: SpaceManager;
+	let handlers: ReturnType<typeof createGlobalSpacesToolHandlers>;
+
+	beforeEach(() => {
+		spaceManager = makeSpaceManager(makeSpace());
+		handlers = createGlobalSpacesToolHandlers(makeConfig(spaceManager), makeState());
+	});
+
+	it('passes autonomy_level=semi_autonomous to SpaceManager.updateSpace', async () => {
+		const updatedSpace = makeSpace({ autonomyLevel: 'semi_autonomous' });
+		(spaceManager.updateSpace as ReturnType<typeof mock>).mockResolvedValue(updatedSpace);
+
+		const result = parseResult(
+			await handlers.update_space({
+				space_id: 'space-1',
+				autonomy_level: 'semi_autonomous',
+			})
+		);
+
+		expect(result.success).toBe(true);
+		const [id, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(id).toBe('space-1');
+		expect(params.autonomyLevel).toBe('semi_autonomous');
+	});
+
+	it('passes autonomy_level=supervised to SpaceManager.updateSpace', async () => {
+		await handlers.update_space({ space_id: 'space-1', autonomy_level: 'supervised' });
+
+		const [, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(params.autonomyLevel).toBe('supervised');
+	});
+
+	it('does not set autonomyLevel in params when autonomy_level is omitted', async () => {
+		await handlers.update_space({ space_id: 'space-1', name: 'New Name' });
+
+		const [, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(params.autonomyLevel).toBeUndefined();
+		expect(params.name).toBe('New Name');
+	});
+
+	it('passes all fields including autonomy_level together', async () => {
+		await handlers.update_space({
+			space_id: 'space-1',
+			name: 'Updated',
+			description: 'New desc',
+			autonomy_level: 'semi_autonomous',
+		});
+
+		const [id, params] = (spaceManager.updateSpace as ReturnType<typeof mock>).mock.calls[0];
+		expect(id).toBe('space-1');
+		expect(params.name).toBe('Updated');
+		expect(params.description).toBe('New desc');
+		expect(params.autonomyLevel).toBe('semi_autonomous');
+	});
+
+	it('returns success with space from SpaceManager including updated autonomyLevel', async () => {
+		const updatedSpace = makeSpace({ autonomyLevel: 'semi_autonomous' as SpaceAutonomyLevel });
+		(spaceManager.updateSpace as ReturnType<typeof mock>).mockResolvedValue(updatedSpace);
+
+		const result = parseResult(
+			await handlers.update_space({
+				space_id: 'space-1',
+				autonomy_level: 'semi_autonomous',
+			})
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.space.autonomyLevel).toBe('semi_autonomous');
+	});
+
+	it('returns success:false on SpaceManager error', async () => {
+		(spaceManager.updateSpace as ReturnType<typeof mock>).mockRejectedValue(
+			new Error('Space not found: bad-id')
+		);
+
+		const result = parseResult(
+			await handlers.update_space({ space_id: 'bad-id', autonomy_level: 'supervised' })
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Space not found');
+	});
+});


### PR DESCRIPTION
- Add autonomy_level parameter to create_space and update_space in
  global-spaces-tools.ts (handler functions and MCP tool definitions)
- SpaceManager and space-handlers already correctly pass autonomyLevel
  through — confirmed and covered with new tests
- Add unit tests: SpaceManager autonomy level create/update/default behavior
- Add unit tests: global-spaces-tools create_space and update_space with
  autonomy_level parameter pass-through
- Add unit tests: space-handlers valid autonomyLevel pass-through for
  both space.create and space.update handlers
