### PR TITLE
feat: integrate NotificationSink into SpaceRuntime tick loop (Task 2.2)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -15,6 +15,7 @@ import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { NotificationSink } from './notification-sink';
 import { SpaceRuntime } from './space-runtime';
 import { Logger } from '../../logger';
 
@@ -83,6 +84,17 @@ export class SpaceRuntimeService {
 			this.start();
 		}
 		return this.runtime;
+	}
+
+	/**
+	 * Wire a notification sink into the underlying SpaceRuntime.
+	 *
+	 * Called after construction once the Space Agent session has been provisioned,
+	 * since SpaceRuntimeService is instantiated before the global agent session exists.
+	 * Delegates directly to the shared SpaceRuntime instance.
+	 */
+	setNotificationSink(sink: NotificationSink): void {
+		this.runtime.setNotificationSink(sink);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -36,6 +36,7 @@ import { SpaceTaskManager } from '../managers/space-task-manager';
 import { WorkflowExecutor, WorkflowTransitionError } from './workflow-executor';
 import { selectWorkflow } from './workflow-selector';
 import { Logger } from '../../logger';
+import { type NotificationSink, NullNotificationSink } from './notification-sink';
 
 const log = new Logger('space-runtime');
 
@@ -61,6 +62,12 @@ export interface SpaceRuntimeConfig {
 	 * Used by start(). Default: 5000 (5 seconds).
 	 */
 	tickIntervalMs?: number;
+	/**
+	 * Sink for structured notification events emitted after mechanical processing.
+	 * Defaults to NullNotificationSink (no-op). Use setNotificationSink() to wire
+	 * in a real sink after construction (e.g. once the Space Agent session exists).
+	 */
+	notificationSink?: NotificationSink;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +128,29 @@ export class SpaceRuntime {
 	/** Handle returned by setInterval when the tick loop is running */
 	private tickTimer: ReturnType<typeof setInterval> | null = null;
 
-	constructor(private config: SpaceRuntimeConfig) {}
+	/** Active notification sink — replaced at runtime via setNotificationSink() */
+	private notificationSink: NotificationSink;
+
+	/**
+	 * Deduplication set for notifications keyed by `taskId:status` (e.g. `task-1:needs_attention`
+	 * or `task-1:timeout`). Prevents re-notifying for the same task+status across ticks.
+	 * Entries are cleared when the task leaves the flagged state.
+	 */
+	private notifiedTaskSet = new Set<string>();
+
+	constructor(private config: SpaceRuntimeConfig) {
+		this.notificationSink = config.notificationSink ?? new NullNotificationSink();
+	}
+
+	/**
+	 * Replace the notification sink at runtime.
+	 *
+	 * Called after construction once the Space Agent session has been provisioned,
+	 * since SpaceRuntimeService is instantiated before the global agent session exists.
+	 */
+	setNotificationSink(sink: NotificationSink): void {
+		this.notificationSink = sink;
+	}
 
 	// -------------------------------------------------------------------------
 	// Lifecycle — start / stop
@@ -182,7 +211,7 @@ export class SpaceRuntime {
 		}
 
 		await this.processCompletedTasks();
-		this.cleanupTerminalExecutors();
+		await this.cleanupTerminalExecutors();
 	}
 
 	/**
@@ -473,6 +502,61 @@ export class SpaceRuntime {
 		// step has not been spawned yet (session group creation is async and handled
 		// by a separate layer). Silently returning here is intentional.
 		if (stepTasks.length === 0) return;
+
+		// Refresh dedup entries: clear keys for tasks that have left their flagged state.
+		for (const task of stepTasks) {
+			if (task.status !== 'needs_attention') {
+				this.notifiedTaskSet.delete(`${task.id}:needs_attention`);
+			}
+			if (task.status !== 'in_progress') {
+				this.notifiedTaskSet.delete(`${task.id}:timeout`);
+			}
+		}
+
+		// Detect task-level needs_attention BEFORE the all-completed guard.
+		// This is an explicit check — not inferred from WorkflowTransitionError.
+		if (stepTasks.some((t) => t.status === 'needs_attention')) {
+			for (const task of stepTasks) {
+				if (task.status !== 'needs_attention') continue;
+				const dedupKey = `${task.id}:needs_attention`;
+				if (!this.notifiedTaskSet.has(dedupKey)) {
+					this.notifiedTaskSet.add(dedupKey);
+					await this.notificationSink.notify({
+						kind: 'task_needs_attention',
+						spaceId: meta.spaceId,
+						taskId: task.id,
+						reason: task.error ?? 'Task requires attention',
+						timestamp: new Date().toISOString(),
+					});
+				}
+			}
+			return;
+		}
+
+		// Timeout detection: check in_progress tasks against Space.config.taskTimeoutMs.
+		const space = await this.config.spaceManager.getSpace(meta.spaceId);
+		const taskTimeoutMs = space?.config?.taskTimeoutMs;
+		if (taskTimeoutMs !== undefined) {
+			const now = Date.now();
+			for (const task of stepTasks) {
+				if (task.status !== 'in_progress' || !task.startedAt) continue;
+				const elapsedMs = now - task.startedAt;
+				if (elapsedMs > taskTimeoutMs) {
+					const dedupKey = `${task.id}:timeout`;
+					if (!this.notifiedTaskSet.has(dedupKey)) {
+						this.notifiedTaskSet.add(dedupKey);
+						await this.notificationSink.notify({
+							kind: 'task_timeout',
+							spaceId: meta.spaceId,
+							taskId: task.id,
+							elapsedMs,
+							timestamp: new Date().toISOString(),
+						});
+					}
+				}
+			}
+		}
+
 		if (!stepTasks.every((t) => t.status === 'completed')) return;
 
 		try {
@@ -482,9 +566,10 @@ export class SpaceRuntime {
 			// injected into the executor via buildExecutor(). No second update needed.
 
 			if (newTasks.length === 0) {
-				// Terminal step reached — run marked completed by advance(); clean up executor.
-				this.executors.delete(runId);
-				this.executorMeta.delete(runId);
+				// Terminal step reached — run marked completed by advance().
+				// cleanupTerminalExecutors() will emit workflow_run_completed and remove executor.
+				// No cleanup here: executors map is iterated by for..of which captures the
+				// initial key set, so the entry stays until cleanupTerminalExecutors() runs.
 			}
 		} catch (err) {
 			if (!(err instanceof WorkflowTransitionError)) {
@@ -492,6 +577,14 @@ export class SpaceRuntime {
 				throw err;
 			}
 			// Gate blocked: run status already set to 'needs_attention' by the executor.
+			// Emit notification so the Space Agent session is informed.
+			await this.notificationSink.notify({
+				kind: 'workflow_run_needs_attention',
+				spaceId: meta.spaceId,
+				runId,
+				reason: err.message,
+				timestamp: new Date().toISOString(),
+			});
 			// Keep executor and meta in map — will be retried after gate is resolved.
 		}
 	}
@@ -503,11 +596,26 @@ export class SpaceRuntime {
 	 * Reads run status from DB rather than relying on the executor's cached
 	 * this.run, so external status changes (e.g. cancellation via API) are
 	 * picked up without requiring executor recreation.
+	 *
+	 * Emits a `workflow_run_completed` notification for runs that reached the
+	 * `completed` state (either naturally via advance() or externally).
 	 */
-	private cleanupTerminalExecutors(): void {
+	private async cleanupTerminalExecutors(): Promise<void> {
 		for (const [runId] of this.executors) {
 			const run = this.config.workflowRunRepo.getRun(runId);
 			if (!run || run.status === 'completed' || run.status === 'cancelled') {
+				if (run?.status === 'completed') {
+					const meta = this.executorMeta.get(runId);
+					if (meta) {
+						await this.notificationSink.notify({
+							kind: 'workflow_run_completed',
+							spaceId: meta.spaceId,
+							runId,
+							status: 'completed',
+							timestamp: new Date().toISOString(),
+						});
+					}
+				}
 				this.executors.delete(runId);
 				this.executorMeta.delete(runId);
 			}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -616,6 +616,14 @@ export class SpaceRuntime {
 						});
 					}
 				}
+				// Prune dedup entries for all tasks in this run so the set doesn't
+				// grow unboundedly. Once a run is terminal its tasks will never
+				// reappear in stepTasks, so the normal per-tick pruning loop
+				// (processRunTick) would never clear them otherwise.
+				for (const task of this.config.taskRepo.listByWorkflowRun(runId)) {
+					this.notifiedTaskSet.delete(`${task.id}:needs_attention`);
+					this.notifiedTaskSet.delete(`${task.id}:timeout`);
+				}
 				this.executors.delete(runId);
 				this.executorMeta.delete(runId);
 			}

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1,0 +1,734 @@
+/**
+ * SpaceRuntime Notification Tests
+ *
+ * Verifies that SpaceRuntime emits structured notifications via NotificationSink
+ * for all four event types:
+ *   - workflow_run_needs_attention  (gate blocked)
+ *   - task_needs_attention          (task entered needs_attention)
+ *   - workflow_run_completed        (run reached terminal step)
+ *   - task_timeout                  (in_progress task exceeded threshold)
+ *
+ * Also verifies:
+ *   - Deduplication: same task in needs_attention across two ticks → one notification
+ *   - Normal advancement emits NO notifications
+ *   - setNotificationSink() replaces the sink at runtime
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../src/lib/space/runtime/space-runtime.ts';
+import type {
+	NotificationSink,
+	SpaceNotificationEvent,
+} from '../../../src/lib/space/runtime/notification-sink.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// MockNotificationSink
+// ---------------------------------------------------------------------------
+
+class MockNotificationSink implements NotificationSink {
+	readonly events: SpaceNotificationEvent[] = [];
+
+	notify(event: SpaceNotificationEvent): Promise<void> {
+		this.events.push(event);
+		return Promise.resolve();
+	}
+
+	get byKind(): Record<string, SpaceNotificationEvent[]> {
+		const map: Record<string, SpaceNotificationEvent[]> = {};
+		for (const e of this.events) {
+			if (!map[e.kind]) map[e.kind] = [];
+			map[e.kind].push(e);
+		}
+		return map;
+	}
+
+	clear(): void {
+		this.events.length = 0;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-runtime-notif',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+function setSpaceTaskTimeoutMs(db: BunDatabase, spaceId: string, timeoutMs: number): void {
+	db.prepare(`UPDATE spaces SET config = ? WHERE id = ?`).run(
+		JSON.stringify({ taskTimeoutMs: timeoutMs }),
+		spaceId
+	);
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, role: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+     config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, role, Date.now(), Date.now());
+}
+
+function buildLinearWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	steps: Array<{ id: string; name: string; agentId: string }>,
+	conditions: Array<{ type: 'always' | 'human' }> = []
+): SpaceWorkflow {
+	const transitions = steps.slice(0, -1).map((step, i) => ({
+		from: step.id,
+		to: steps[i + 1].id,
+		condition: conditions[i] ?? { type: 'always' as const },
+		order: 0,
+	}));
+
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: `Workflow ${Date.now()}-${Math.random()}`,
+		description: '',
+		steps,
+		transitions,
+		startStepId: steps[0].id,
+		rules: [],
+		tags: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Test suite setup
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — notification events', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let sink: MockNotificationSink;
+	let runtime: SpaceRuntime;
+
+	const SPACE_ID = 'space-notif-1';
+	const WORKSPACE = '/tmp/notif-ws';
+	const AGENT_CODER = 'agent-coder-notif';
+	const STEP_A = 'step-na';
+	const STEP_B = 'step-nb';
+
+	function makeRuntime(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+		const config: SpaceRuntimeConfig = {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			notificationSink: sink,
+			...extraConfig,
+		};
+		return new SpaceRuntime(config);
+	}
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+
+		seedSpaceRow(db, SPACE_ID, WORKSPACE);
+		seedAgentRow(db, AGENT_CODER, SPACE_ID, 'coder');
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+		spaceManager = new SpaceManager(db);
+		sink = new MockNotificationSink();
+		runtime = makeRuntime();
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// workflow_run_needs_attention
+	// -------------------------------------------------------------------------
+
+	describe('workflow_run_needs_attention', () => {
+		test('emits event when human gate blocks advancement', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('workflow_run_needs_attention');
+			if (evt.kind === 'workflow_run_needs_attention') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.runId).toBe(run.id);
+				expect(typeof evt.reason).toBe('string');
+				expect(evt.reason.length).toBeGreaterThan(0);
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('emits event with the WorkflowTransitionError message as reason', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			const evt = sink.events[0];
+			// WorkflowGateError message should contain human-gate context
+			expect(evt.kind).toBe('workflow_run_needs_attention');
+			if (evt.kind === 'workflow_run_needs_attention') {
+				expect(evt.reason).toMatch(/human/i);
+			}
+		});
+
+		test('does NOT re-emit on subsequent ticks (run already in needs_attention status)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'human' }]
+			);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// First tick — gate fires
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1);
+
+			// Second tick — run is needs_attention, processRunTick returns early
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1); // still just one
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// task_needs_attention
+	// -------------------------------------------------------------------------
+
+	describe('task_needs_attention', () => {
+		test('emits event when a step task enters needs_attention', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Build failed' });
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_needs_attention');
+			if (evt.kind === 'task_needs_attention') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.taskId).toBe(tasks[0].id);
+				expect(evt.reason).toBe('Build failed');
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('uses fallback reason when task.error is null', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Set to needs_attention without error message
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention' });
+
+			await runtime.executeTick();
+
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_needs_attention');
+			if (evt.kind === 'task_needs_attention') {
+				expect(evt.reason).toBe('Task requires attention');
+			}
+		});
+
+		test('does NOT advance when task is needs_attention (returns early)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention' });
+
+			await runtime.executeTick();
+
+			// No step B task should be created
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Deduplication — task_needs_attention
+	// -------------------------------------------------------------------------
+
+	describe('deduplication', () => {
+		test('same task in needs_attention across two ticks emits only ONE notification', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention' });
+
+			// First tick — should emit
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1);
+
+			// Second tick — same task still in needs_attention — should NOT emit again
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1);
+
+			// Third tick — still deduped
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1);
+		});
+
+		test('re-notifies after task leaves and re-enters needs_attention', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention' });
+
+			// First tick — emits
+			await runtime.executeTick();
+			expect(sink.events).toHaveLength(1);
+
+			// Task gets retried: back to in_progress
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			await runtime.executeTick();
+			// No new event for in_progress
+			expect(sink.events).toHaveLength(1);
+
+			// Task fails again
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Again' });
+			await runtime.executeTick();
+			// Should emit a second time since the dedup key was cleared
+			expect(sink.events).toHaveLength(2);
+			expect(sink.events[1].kind).toBe('task_needs_attention');
+		});
+
+		test('multiple tasks in needs_attention each emit their own notification', async () => {
+			// Two-step workflow where both tasks (for different steps) end up needing attention
+			// In practice, each step has one task; we test with a single-step workflow and
+			// verify only one event per step.
+			// For multiple tasks we'd need a parallel step model; instead verify per-task dedup
+			// with two separate single-step workflows.
+			const wf1 = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-multi-a', name: 'Step A', agentId: AGENT_CODER },
+			]);
+			const wf2 = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-multi-b', name: 'Step B', agentId: AGENT_CODER },
+			]);
+
+			const { tasks: tasks1 } = await runtime.startWorkflowRun(SPACE_ID, wf1.id, 'Run 1');
+			const { tasks: tasks2 } = await runtime.startWorkflowRun(SPACE_ID, wf2.id, 'Run 2');
+
+			taskRepo.updateTask(tasks1[0].id, { status: 'needs_attention' });
+			taskRepo.updateTask(tasks2[0].id, { status: 'needs_attention' });
+
+			await runtime.executeTick();
+
+			// Both should emit
+			const naEvents = sink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(naEvents).toHaveLength(2);
+			const taskIds = naEvents.map((e) => (e.kind === 'task_needs_attention' ? e.taskId : ''));
+			expect(taskIds).toContain(tasks1[0].id);
+			expect(taskIds).toContain(tasks2[0].id);
+
+			// Second tick — still deduped (no new events)
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// workflow_run_completed
+	// -------------------------------------------------------------------------
+
+	describe('workflow_run_completed', () => {
+		test('emits event when terminal step is completed', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Only Step', agentId: AGENT_CODER },
+			]);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('workflow_run_completed');
+			if (evt.kind === 'workflow_run_completed') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.runId).toBe(run.id);
+				expect(evt.status).toBe('completed');
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('emits event after multi-step workflow completes', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Complete step A → advance to step B
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			// No completed event yet (still running)
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
+
+			// Complete step B → run completes
+			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+			taskRepo.updateTask(stepBTask!.id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
+			expect(completedEvents).toHaveLength(1);
+			if (completedEvents[0].kind === 'workflow_run_completed') {
+				expect(completedEvents[0].runId).toBe(run.id);
+				expect(completedEvents[0].status).toBe('completed');
+			}
+		});
+
+		test('does NOT emit completed event for normal step advancement (mid-workflow)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			// Should have no events — just a normal advance
+			expect(sink.events).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// task_timeout
+	// -------------------------------------------------------------------------
+
+	describe('task_timeout', () => {
+		test('emits event when in_progress task exceeds taskTimeoutMs', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000); // 1 second timeout
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Set task to in_progress — this stamps started_at = Date.now()
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+
+			// Back-date started_at to simulate timeout (2 seconds ago)
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				tasks[0].id
+			);
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_timeout');
+			if (evt.kind === 'task_timeout') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.taskId).toBe(tasks[0].id);
+				expect(evt.elapsedMs).toBeGreaterThan(1000);
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('does NOT emit timeout when task has not exceeded the threshold', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 60_000); // 1 minute — won't fire in a unit test
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+
+			await runtime.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(0);
+		});
+
+		test('does NOT emit timeout when taskTimeoutMs is undefined (disabled)', async () => {
+			// No config set on space → timeout disabled
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			// Back-date started_at as if a long time has passed
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 100_000,
+				tasks[0].id
+			);
+
+			await runtime.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(0);
+		});
+
+		test('deduplicates timeout notifications across ticks', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				tasks[0].id
+			);
+
+			// First tick — emits timeout
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Second tick — same task still in_progress and over threshold — deduped
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+		});
+
+		test('re-notifies timeout after task leaves in_progress and re-enters', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				tasks[0].id
+			);
+
+			// First tick — emits
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Task leaves in_progress (e.g. paused to needs_attention)
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention' });
+			await runtime.executeTick();
+
+			// Task re-enters in_progress, back-dated again
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				tasks[0].id
+			);
+			await runtime.executeTick();
+
+			// Should emit again since the dedup key was cleared when task left in_progress
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// No notifications for normal advancement
+	// -------------------------------------------------------------------------
+
+	describe('no notifications for mechanical advancement', () => {
+		test('normal step completion and advancement emits no notifications', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+
+		test('task in pending state emits no notifications', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Task stays pending (no update)
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+
+		test('task in in_progress state (no timeout) emits no notifications', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// setNotificationSink() — post-construction wiring
+	// -------------------------------------------------------------------------
+
+	describe('setNotificationSink()', () => {
+		test('replaces the sink at runtime before first tick', async () => {
+			const newSink = new MockNotificationSink();
+			// Create runtime WITHOUT a sink (uses NullNotificationSink)
+			const rt = makeRuntime({ notificationSink: undefined });
+
+			// Wire in the new sink before the first tick
+			rt.setNotificationSink(newSink);
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-wire', name: 'Only Step', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await rt.executeTick();
+
+			// Original sink should NOT have received events
+			expect(sink.events).toHaveLength(0);
+			// New sink SHOULD have received workflow_run_completed
+			expect(newSink.events).toHaveLength(1);
+			expect(newSink.events[0].kind).toBe('workflow_run_completed');
+		});
+
+		test('NullNotificationSink (default) silently drops all events', async () => {
+			// Create runtime without any sink — no error should be thrown
+			const rt = makeRuntime({ notificationSink: undefined });
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-null', name: 'Only Step', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			// Should not throw
+			await expect(rt.executeTick()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -9,7 +9,10 @@
  * - start() / stop() lifecycle: idempotent, starts/stops underlying runtime
  */
 
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntimeServiceConfig } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
@@ -17,8 +20,19 @@ import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-ag
 import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import type {
+	NotificationSink,
+	SpaceNotificationEvent,
+} from '../../../src/lib/space/runtime/notification-sink.ts';
 import type { Space } from '@neokai/shared';
-import type { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository as SpaceWorkflowRunRepo } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository as SpaceTaskRepo } from '../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager as AgentMgr } from '../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager as WorkflowMgr } from '../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager as SpaceMgr } from '../../../src/lib/space/managers/space-manager.ts';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -141,6 +155,15 @@ describe('SpaceRuntimeService', () => {
 		});
 	});
 
+	// ─── setNotificationSink ─────────────────────────────────────────────────
+
+	describe('setNotificationSink()', () => {
+		test('method exists and is callable', () => {
+			// Verify the delegation method is present on SpaceRuntimeService
+			expect(typeof service.setNotificationSink).toBe('function');
+		});
+	});
+
 	// ─── start / stop lifecycle ───────────────────────────────────────────────
 
 	describe('start() / stop()', () => {
@@ -183,5 +206,154 @@ describe('SpaceRuntimeService', () => {
 			const runtime = await service.createOrGetRuntime('space-1');
 			expect(runtime).toBeDefined();
 		});
+	});
+});
+
+// ─── setNotificationSink() integration tests ─────────────────────────────────
+//
+// Requires a real DB to trigger actual events via executeTick().
+
+class MockSink implements NotificationSink {
+	readonly events: SpaceNotificationEvent[] = [];
+	notify(event: SpaceNotificationEvent): Promise<void> {
+		this.events.push(event);
+		return Promise.resolve();
+	}
+}
+
+function makeTestDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-srs-notif',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+describe('SpaceRuntimeService.setNotificationSink() — delegation integration', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let svc: SpaceRuntimeService;
+	let taskRepo: SpaceTaskRepo;
+	let workflowRunRepo: SpaceWorkflowRunRepo;
+	let workflowManager: WorkflowMgr;
+
+	const SPACE_ID = 'srs-notif-space';
+	const AGENT_ID = 'srs-notif-agent';
+	const STEP_A = 'srs-step-a';
+
+	beforeEach(() => {
+		({ db, dir } = makeTestDb());
+
+		// Seed space row
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+       allowed_models, session_ids, status, created_at, updated_at)
+       VALUES (?, ?, ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+		).run(SPACE_ID, '/tmp/srs-ws', `Space ${SPACE_ID}`, Date.now(), Date.now());
+
+		// Seed agent row
+		db.prepare(
+			`INSERT INTO space_agents (id, space_id, name, role, description, model, tools, system_prompt,
+       config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, '', null, '[]', '', null, ?, ?)`
+		).run(AGENT_ID, SPACE_ID, 'Coder', 'coder', Date.now(), Date.now());
+
+		workflowRunRepo = new SpaceWorkflowRunRepo(db);
+		taskRepo = new SpaceTaskRepo(db);
+
+		const agentManager = new AgentMgr(new SpaceAgentRepository(db));
+		workflowManager = new WorkflowMgr(new SpaceWorkflowRepository(db));
+		const spaceManager = new SpaceMgr(db);
+
+		svc = new SpaceRuntimeService({
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+		});
+	});
+
+	afterEach(() => {
+		svc.stop();
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('setNotificationSink() delegates to SpaceRuntime — sink receives workflow_run_completed', async () => {
+		const sink = new MockSink();
+
+		// Wire sink via the service (post-construction wiring)
+		svc.setNotificationSink(sink);
+
+		const workflow = workflowManager.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'Single-step',
+			description: '',
+			steps: [{ id: STEP_A, name: 'Only Step', agentId: AGENT_ID }],
+			transitions: [],
+			startStepId: STEP_A,
+			rules: [],
+			tags: [],
+		});
+
+		const runtime = await svc.createOrGetRuntime(SPACE_ID);
+		const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Test Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+		await runtime.executeTick();
+
+		// The sink was wired through the service — it must have received the event
+		expect(sink.events).toHaveLength(1);
+		expect(sink.events[0].kind).toBe('workflow_run_completed');
+		if (sink.events[0].kind === 'workflow_run_completed') {
+			expect(sink.events[0].spaceId).toBe(SPACE_ID);
+			expect(sink.events[0].status).toBe('completed');
+		}
+	});
+
+	test('setNotificationSink() replaces any previously set sink', async () => {
+		const sink1 = new MockSink();
+		const sink2 = new MockSink();
+
+		svc.setNotificationSink(sink1);
+		svc.setNotificationSink(sink2); // replaces sink1
+
+		const workflow = workflowManager.createWorkflow({
+			spaceId: SPACE_ID,
+			name: 'Replace Sink',
+			description: '',
+			steps: [{ id: STEP_A, name: 'Only Step', agentId: AGENT_ID }],
+			transitions: [],
+			startStepId: STEP_A,
+			rules: [],
+			tags: [],
+		});
+
+		const runtime = await svc.createOrGetRuntime(SPACE_ID);
+		const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+		await runtime.executeTick();
+
+		// Only sink2 should have received events
+		expect(sink1.events).toHaveLength(0);
+		expect(sink2.events).toHaveLength(1);
+		expect(sink2.events[0].kind).toBe('workflow_run_completed');
 	});
 });


### PR DESCRIPTION
- Add `notificationSink?: NotificationSink` to `SpaceRuntimeConfig` and
  `setNotificationSink()` setter on `SpaceRuntime` for post-construction wiring
- Emit `workflow_run_needs_attention` after catching `WorkflowTransitionError`
  (gate blocked) in `processRunTick()`
- Add explicit `task_needs_attention` detection before the all-completed guard:
  checks `stepTasks.some(t => t.status === 'needs_attention')` and notifies per
  affected task, returning early to prevent advancement
- Add `notifiedTaskSet: Set<string>` deduplication (keyed by `taskId:status`)
  to emit only once per task+status across ticks; clears when task leaves state
- Add timeout detection for `in_progress` tasks using `Space.config.taskTimeoutMs`
  (defaults to disabled when undefined); also deduplicated via `notifiedTaskSet`
- Make `cleanupTerminalExecutors()` async; emit `workflow_run_completed` for runs
  that reach `completed` status before removing their executor from the map
- Add `setNotificationSink()` to `SpaceRuntimeService` delegating to the runtime
- 22 new unit tests covering all 4 event types, deduplication, and no-notification
  cases; all 638 existing space tests continue to pass
