### PR TITLE
task/review pr 518

### DIFF
--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -69,6 +69,19 @@ export class QueryLifecycleManager {
 	}
 
 	/**
+	 * Get the effective workspace path for SDK session file lookups.
+	 *
+	 * The SDK subprocess uses its CWD to determine the project directory
+	 * for session files. For worktree sessions, the CWD is the worktree path,
+	 * not session.workspacePath (which is the main repo path).
+	 * Must match QueryOptionsBuilder.getCwd() to find the correct files.
+	 */
+	private getSDKWorkspacePath(): string {
+		const { session } = this.ctx;
+		return session.worktree ? session.worktree.worktreePath : session.workspacePath;
+	}
+
+	/**
 	 * Stop the current query
 	 *
 	 * Shared logic for restart and reset operations:
@@ -167,7 +180,7 @@ export class QueryLifecycleManager {
 			// Also detects stale sdkSessionId when the session file no longer exists.
 			if (session.sdkSessionId) {
 				const isValid = validateAndRepairSDKSession(
-					session.workspacePath,
+					this.getSDKWorkspacePath(),
 					session.sdkSessionId,
 					session.id,
 					db
@@ -253,7 +266,7 @@ export class QueryLifecycleManager {
 				// Also detects stale sdkSessionId when the session file no longer exists.
 				if (session.sdkSessionId) {
 					const isValid = validateAndRepairSDKSession(
-						session.workspacePath,
+						this.getSDKWorkspacePath(),
 						session.sdkSessionId,
 						session.id,
 						db
@@ -311,7 +324,7 @@ export class QueryLifecycleManager {
 		// Validate SDK session file
 		if (session.sdkSessionId) {
 			const isValid = validateAndRepairSDKSession(
-				session.workspacePath,
+				this.getSDKWorkspacePath(),
 				session.sdkSessionId,
 				session.id,
 				db

--- a/packages/daemon/src/lib/agent/rewind-handler.ts
+++ b/packages/daemon/src/lib/agent/rewind-handler.ts
@@ -306,8 +306,13 @@ export class RewindHandler {
 		const messagesDeleted = db.deleteMessagesAtAndAfter(session.id, rewindPoint.timestamp);
 
 		// Step 2: Truncate the SDK JSONL file at this message
+		// Use worktree path when available — SDK creates session files based on CWD,
+		// which is the worktree path for worktree sessions, not session.workspacePath.
+		const sdkWorkspacePath = session.worktree
+			? session.worktree.worktreePath
+			: session.workspacePath;
 		const _jsonlResult = truncateSessionFileAtMessage(
-			session.workspacePath,
+			sdkWorkspacePath,
 			session.sdkSessionId,
 			session.id,
 			checkpointId
@@ -717,8 +722,11 @@ export class RewindHandler {
 				// Truncate JSONL at the earliest selected message
 				const jsonlUuid = (earliestMessage as { uuid?: string }).uuid;
 				if (jsonlUuid) {
+					const rewindSdkPath = session.worktree
+						? session.worktree.worktreePath
+						: session.workspacePath;
 					const _jsonlResult = truncateSessionFileAtMessage(
-						session.workspacePath,
+						rewindSdkPath,
 						session.sdkSessionId,
 						session.id,
 						jsonlUuid

--- a/packages/daemon/src/lib/rpc-handlers/message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/message-handlers.ts
@@ -49,8 +49,12 @@ export function setupMessageHandlers(
 
 		// Remove tool_result from the .jsonl file
 		// Pass both SDK session ID and NeoKai session ID for fallback search
+		// Use worktree path when available — SDK creates session files based on CWD
+		const sdkWorkspacePath = session.worktree
+			? session.worktree.worktreePath
+			: session.workspacePath;
 		const success = removeToolResultFromSessionFile(
-			session.workspacePath,
+			sdkWorkspacePath,
 			sdkSessionId,
 			messageUuid,
 			targetSessionId

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -444,8 +444,12 @@ export class SessionLifecycle {
 			// This removes the .jsonl files created by Claude Agent SDK
 			if (session) {
 				try {
+					// Use worktree path when available — SDK creates session files based on CWD
+					const sdkWorkspacePath = session.worktree
+						? session.worktree.worktreePath
+						: session.workspacePath;
 					const deleteResult = deleteSDKSessionFiles(
-						session.workspacePath,
+						sdkWorkspacePath,
 						session.sdkSessionId ?? null,
 						sessionId
 					);

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -364,109 +364,6 @@ describe('QueryLifecycleManager', () => {
 			// Even with interrupt failure, should continue
 			await failingManager.restart();
 		});
-
-		describe('SDK session path selection', () => {
-			let tmpDir: string;
-
-			beforeEach(() => {
-				tmpDir = mkdtempSync(join(tmpdir(), 'kai-test-'));
-				process.env.TEST_SDK_SESSION_DIR = tmpDir;
-			});
-
-			afterEach(() => {
-				delete process.env.TEST_SDK_SESSION_DIR;
-				rmSync(tmpDir, { recursive: true, force: true });
-			});
-
-			test(
-				'uses worktree path when session has worktree — preserves sdkSessionId',
-				async () => {
-					const sdkSessionId = 'sdk-worktree-abc';
-					const worktreePath = '/worktree/path';
-					// SDK encodes path: replaces / and . with -
-					const projectKey = worktreePath.replace(/[/.]/g, '-');
-					const sessionDir = join(tmpDir, 'projects', projectKey);
-					mkdirSync(sessionDir, { recursive: true });
-					// Place the .jsonl file at the WORKTREE path (not workspace path)
-					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
-
-					mockContext.session.sdkSessionId = sdkSessionId;
-					mockContext.session.worktree = {
-						worktreePath,
-						branch: 'session/test',
-						mainRepoPath: '/test/workspace',
-					};
-					manager = new QueryLifecycleManager(mockContext);
-
-					await manager.restart();
-
-					// File found at worktree path → sdkSessionId preserved (not cleared)
-					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
-					expect(updateSessionSpy).not.toHaveBeenCalledWith(
-						'test-session',
-						expect.objectContaining({ sdkSessionId: undefined })
-					);
-				},
-				{ timeout: 5000 }
-			);
-
-			test(
-				'uses workspacePath when no worktree — preserves sdkSessionId',
-				async () => {
-					const sdkSessionId = 'sdk-workspace-abc';
-					const workspacePath = '/test/workspace';
-					const projectKey = workspacePath.replace(/[/.]/g, '-');
-					const sessionDir = join(tmpDir, 'projects', projectKey);
-					mkdirSync(sessionDir, { recursive: true });
-					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
-
-					mockContext.session.sdkSessionId = sdkSessionId;
-					// No worktree set
-					manager = new QueryLifecycleManager(mockContext);
-
-					await manager.restart();
-
-					// File found at workspace path → sdkSessionId preserved
-					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
-					expect(updateSessionSpy).not.toHaveBeenCalledWith(
-						'test-session',
-						expect.objectContaining({ sdkSessionId: undefined })
-					);
-				},
-				{ timeout: 5000 }
-			);
-
-			test(
-				'clears sdkSessionId when file is at workspace path but session has worktree',
-				async () => {
-					const sdkSessionId = 'sdk-wrong-path-abc';
-					const workspacePath = '/test/workspace';
-					// Put the file at the WORKSPACE path (not worktree path)
-					const projectKey = workspacePath.replace(/[/.]/g, '-');
-					const sessionDir = join(tmpDir, 'projects', projectKey);
-					mkdirSync(sessionDir, { recursive: true });
-					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
-
-					mockContext.session.sdkSessionId = sdkSessionId;
-					mockContext.session.worktree = {
-						worktreePath: '/worktree/path',
-						branch: 'session/test',
-						mainRepoPath: workspacePath,
-					};
-					manager = new QueryLifecycleManager(mockContext);
-
-					await manager.restart();
-
-					// File NOT found at worktree path → sdkSessionId cleared, fresh start
-					expect(mockContext.session.sdkSessionId).toBeUndefined();
-					expect(updateSessionSpy).toHaveBeenCalledWith(
-						'test-session',
-						expect.objectContaining({ sdkSessionId: undefined })
-					);
-				},
-				{ timeout: 5000 }
-			);
-		});
 	});
 
 	describe('reset', () => {
@@ -1041,6 +938,222 @@ describe('QueryLifecycleManager', () => {
 
 			// Should not throw
 			await manager.cleanup();
+		});
+	});
+
+	/**
+	 * Regression tests for the worktree path fix (PR #518).
+	 *
+	 * The SDK subprocess uses its CWD (worktree path for worktree sessions) to
+	 * determine where to write .jsonl session files. Before the fix, all 3 call
+	 * sites that validate/repair the SDK session file used session.workspacePath,
+	 * causing lookups to search the wrong directory and falsely clear sdkSessionId.
+	 *
+	 * Each method that calls validateAndRepairSDKSession gets its own sub-block.
+	 */
+	describe('SDK workspace path resolution', () => {
+		let tmpDir: string;
+
+		/**
+		 * Helper: create a valid (empty) JSONL fixture at the given path.
+		 * An empty file passes validateAndRepairSDKSession (no orphaned tool_results).
+		 */
+		function createSdkFile(basePath: string, sdkSessionId: string): void {
+			const projectKey = basePath.replace(/[/.]/g, '-');
+			const sessionDir = join(tmpDir, 'projects', projectKey);
+			mkdirSync(sessionDir, { recursive: true });
+			writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
+		}
+
+		beforeEach(() => {
+			tmpDir = mkdtempSync(join(tmpdir(), 'kai-test-'));
+			process.env.TEST_SDK_SESSION_DIR = tmpDir;
+		});
+
+		afterEach(() => {
+			delete process.env.TEST_SDK_SESSION_DIR;
+			rmSync(tmpDir, { recursive: true, force: true });
+		});
+
+		describe('restart()', () => {
+			test(
+				'uses worktreePath when session has worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-restart-worktree';
+					const worktreePath = '/worktree/path';
+					createSdkFile(worktreePath, sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath,
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					// File found at worktree path → sdkSessionId preserved
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'uses workspacePath when no worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-restart-workspace';
+					createSdkFile('/test/workspace', sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					// No worktree set
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'clears sdkSessionId when file is at workspacePath but session has worktree (pre-fix bug scenario)',
+				async () => {
+					const sdkSessionId = 'sdk-restart-wrong-dir';
+					// File is at workspacePath, NOT at worktreePath
+					createSdkFile('/test/workspace', sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath: '/worktree/path',
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					// File NOT found at worktree path → sdkSessionId cleared, fresh start
+					expect(mockContext.session.sdkSessionId).toBeUndefined();
+					expect(updateSessionSpy).toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
+		});
+
+		describe('reset()', () => {
+			test(
+				'uses worktreePath when session has worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-reset-worktree';
+					const worktreePath = '/worktree/path';
+					createSdkFile(worktreePath, sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath,
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					mockContext.queryObject = {
+						interrupt: mock(async () => {}),
+					} as unknown as QueryLifecycleManagerContext['queryObject'];
+					mockContext.queryPromise = Promise.resolve();
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.reset({ restartAfter: true });
+
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'clears sdkSessionId when file is at workspacePath but session has worktree (pre-fix bug scenario)',
+				async () => {
+					const sdkSessionId = 'sdk-reset-wrong-dir';
+					createSdkFile('/test/workspace', sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath: '/worktree/path',
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					mockContext.queryObject = {
+						interrupt: mock(async () => {}),
+					} as unknown as QueryLifecycleManagerContext['queryObject'];
+					mockContext.queryPromise = Promise.resolve();
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.reset({ restartAfter: true });
+
+					expect(mockContext.session.sdkSessionId).toBeUndefined();
+					expect(updateSessionSpy).toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
+		});
+
+		describe('ensureQueryStarted()', () => {
+			test(
+				'uses worktreePath when session has worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-ensure-worktree';
+					const worktreePath = '/worktree/path';
+					createSdkFile(worktreePath, sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath,
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.ensureQueryStarted();
+
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'clears sdkSessionId when file is at workspacePath but session has worktree (pre-fix bug scenario)',
+				async () => {
+					const sdkSessionId = 'sdk-ensure-wrong-dir';
+					createSdkFile('/test/workspace', sdkSessionId);
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						isWorktree: true,
+						worktreePath: '/worktree/path',
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.ensureQueryStarted();
+
+					expect(mockContext.session.sdkSessionId).toBeUndefined();
+					expect(updateSessionSpy).toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -9,7 +9,10 @@
  * - startQueryAndEnqueue: Starting query and enqueueing messages
  */
 
-import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, mock, spyOn, afterEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
 	QueryLifecycleManager,
 	type QueryLifecycleManagerContext,
@@ -360,6 +363,109 @@ describe('QueryLifecycleManager', () => {
 
 			// Even with interrupt failure, should continue
 			await failingManager.restart();
+		});
+
+		describe('SDK session path selection', () => {
+			let tmpDir: string;
+
+			beforeEach(() => {
+				tmpDir = mkdtempSync(join(tmpdir(), 'kai-test-'));
+				process.env.TEST_SDK_SESSION_DIR = tmpDir;
+			});
+
+			afterEach(() => {
+				delete process.env.TEST_SDK_SESSION_DIR;
+				rmSync(tmpDir, { recursive: true, force: true });
+			});
+
+			test(
+				'uses worktree path when session has worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-worktree-abc';
+					const worktreePath = '/worktree/path';
+					// SDK encodes path: replaces / and . with -
+					const projectKey = worktreePath.replace(/[/.]/g, '-');
+					const sessionDir = join(tmpDir, 'projects', projectKey);
+					mkdirSync(sessionDir, { recursive: true });
+					// Place the .jsonl file at the WORKTREE path (not workspace path)
+					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						worktreePath,
+						branch: 'session/test',
+						mainRepoPath: '/test/workspace',
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					// File found at worktree path → sdkSessionId preserved (not cleared)
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+					expect(updateSessionSpy).not.toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'uses workspacePath when no worktree — preserves sdkSessionId',
+				async () => {
+					const sdkSessionId = 'sdk-workspace-abc';
+					const workspacePath = '/test/workspace';
+					const projectKey = workspacePath.replace(/[/.]/g, '-');
+					const sessionDir = join(tmpDir, 'projects', projectKey);
+					mkdirSync(sessionDir, { recursive: true });
+					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					// No worktree set
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					// File found at workspace path → sdkSessionId preserved
+					expect(mockContext.session.sdkSessionId).toBe(sdkSessionId);
+					expect(updateSessionSpy).not.toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
+
+			test(
+				'clears sdkSessionId when file is at workspace path but session has worktree',
+				async () => {
+					const sdkSessionId = 'sdk-wrong-path-abc';
+					const workspacePath = '/test/workspace';
+					// Put the file at the WORKSPACE path (not worktree path)
+					const projectKey = workspacePath.replace(/[/.]/g, '-');
+					const sessionDir = join(tmpDir, 'projects', projectKey);
+					mkdirSync(sessionDir, { recursive: true });
+					writeFileSync(join(sessionDir, `${sdkSessionId}.jsonl`), '');
+
+					mockContext.session.sdkSessionId = sdkSessionId;
+					mockContext.session.worktree = {
+						worktreePath: '/worktree/path',
+						branch: 'session/test',
+						mainRepoPath: workspacePath,
+					};
+					manager = new QueryLifecycleManager(mockContext);
+
+					await manager.restart();
+
+					// File NOT found at worktree path → sdkSessionId cleared, fresh start
+					expect(mockContext.session.sdkSessionId).toBeUndefined();
+					expect(updateSessionSpy).toHaveBeenCalledWith(
+						'test-session',
+						expect.objectContaining({ sdkSessionId: undefined })
+					);
+				},
+				{ timeout: 5000 }
+			);
 		});
 	});
 


### PR DESCRIPTION
- **fix: use worktree path for SDK session file lookups**
- **Plan: Task Agent session orchestrator for Space tasks (#501)**
- **feat: add VisualWorkflowEditor orchestrator component (Task 6.1) (#500)**
- **feat: add space_task_agent session type and taskAgentSessionId to SpaceTask (#502)**
- **feat: define Task Agent MCP tool schemas (Task 1.3) (#503)**
- **feat: add List/Visual toggle in SpaceIsland workflow editor (Task 6.2) (#505)**
- **feat: add template support to visual workflow editor (Task 5.3) (#506)**
- **test: add performance validation for large workflows (Task 7.3) (#504)**
- **feat: build Task Agent system prompt and initial message builders (#507)**
- **feat: add task_agent_session_id to space_tasks schema and repository (#508)**
- **docs: plan for Space Agent Coordinator reactive event-driven task coordination (Layer 4a) (#512)**
- **feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2) (#510)**
- **feat: implement Task Agent MCP tool handlers (Task 3.1) (#513)**
- **test: add E2E tests for visual workflow editor (Task 7.1) (#509)**
- **feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1) (#515)**
- **feat: add retryTask and reassignTask methods to SpaceTaskManager (#514)**
- **feat: implement SessionNotificationSink for Space Agent event injection (#519)**
- **test: fix pre-existing test failures for compatibility (Task 7.2) (#511)**
- **feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column (#516)**
- **feat: add coordination tools to space-agent-tools (Task 3.2) (#520)**
- **test: add MCP server factory tests for createTaskAgentMcpServer (#517)**
- **test: add worktree path selection tests for QueryLifecycleManager**
