### PR TITLE
feat: add needs_attention detection for standalone tasks in SpaceRuntime

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -654,6 +654,11 @@ export class SpaceRuntime {
 	 * is never notified twice in a row. Dedup keys are cleared when the task leaves the
 	 * flagged state, allowing re-notification if the task cycles back into it.
 	 *
+	 * Dedup cleanup includes archived tasks (fetched via includeArchived=true) to prevent
+	 * notifiedTaskSet from accumulating stale keys for tasks that were archived while in
+	 * a flagged state. Archived tasks can never re-enter needs_attention or in_progress,
+	 * so their dedup keys are always safe to remove.
+	 *
 	 * Restart contract: because `notifiedTaskSet` is in-memory only, tasks already in
 	 * `needs_attention` at daemon startup will re-notify once on the first tick. This is
 	 * intentional — the Space Agent session is new after restart and needs to be informed
@@ -663,26 +668,29 @@ export class SpaceRuntime {
 		const spaces = await this.config.spaceManager.listSpaces(false);
 
 		for (const space of spaces) {
-			// Fetch all non-archived standalone tasks for this space in a single query.
-			// Filtering by workflowRunId === undefined identifies tasks that are not
-			// associated with any workflow run (i.e., standalone tasks).
-			const standaloneTasks = this.config.taskRepo
-				.listBySpace(space.id)
-				.filter((t) => !t.workflowRunId);
+			// Fetch all standalone tasks including archived ones for the dedup cleanup pass.
+			// Using listStandaloneBySpace pushes workflow_run_id IS NULL into SQL so only
+			// standalone tasks are returned — no JS-side filtering needed.
+			// includeArchived=true ensures archived tasks have their dedup keys cleared and
+			// do not accumulate as stale entries in notifiedTaskSet indefinitely.
+			const allStandalone = this.config.taskRepo.listStandaloneBySpace(space.id, true);
+			const activeStandalone = allStandalone.filter((t) => !t.archivedAt);
 
 			// Dedup cleanup: clear keys for tasks that have left their flagged state.
-			// This mirrors the per-tick cleanup done in processRunTick() for workflow tasks.
-			for (const task of standaloneTasks) {
-				if (task.status !== 'needs_attention') {
+			// Archived tasks always get their keys cleared — they can never re-enter a
+			// flagged state, so keeping their keys would be a permanent memory leak.
+			for (const task of allStandalone) {
+				const archived = !!task.archivedAt;
+				if (archived || task.status !== 'needs_attention') {
 					this.notifiedTaskSet.delete(`${task.id}:needs_attention`);
 				}
-				if (task.status !== 'in_progress') {
+				if (archived || task.status !== 'in_progress') {
 					this.notifiedTaskSet.delete(`${task.id}:timeout`);
 				}
 			}
 
-			// Emit task_needs_attention for standalone tasks in needs_attention state.
-			for (const task of standaloneTasks) {
+			// Emit task_needs_attention for active standalone tasks in needs_attention state.
+			for (const task of activeStandalone) {
 				if (task.status !== 'needs_attention') continue;
 				const dedupKey = `${task.id}:needs_attention`;
 				if (!this.notifiedTaskSet.has(dedupKey)) {
@@ -697,11 +705,11 @@ export class SpaceRuntime {
 				}
 			}
 
-			// Timeout detection for standalone in_progress tasks.
+			// Timeout detection for active standalone in_progress tasks.
 			const taskTimeoutMs = space.config?.taskTimeoutMs;
 			if (taskTimeoutMs !== undefined) {
 				const now = Date.now();
-				for (const task of standaloneTasks) {
+				for (const task of activeStandalone) {
 					if (task.status !== 'in_progress' || !task.startedAt) continue;
 					const elapsedMs = now - task.startedAt;
 					if (elapsedMs > taskTimeoutMs) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -135,6 +135,11 @@ export class SpaceRuntime {
 	 * Deduplication set for notifications keyed by `taskId:status` (e.g. `task-1:needs_attention`
 	 * or `task-1:timeout`). Prevents re-notifying for the same task+status across ticks.
 	 * Entries are cleared when the task leaves the flagged state.
+	 *
+	 * Restart contract: this set is in-memory only and starts empty on every daemon restart.
+	 * Tasks already in `needs_attention` at restart time will be re-notified once on the first
+	 * tick. This is intentional: the Space Agent session is also new after restart and needs to
+	 * learn about outstanding issues. No DB persistence for dedup state is required.
 	 */
 	private notifiedTaskSet = new Set<string>();
 
@@ -203,6 +208,7 @@ export class SpaceRuntime {
 	 * On every call:
 	 * 1. Processes completed tasks and advances their workflows
 	 * 2. Cleans up executors for runs that have reached a terminal state
+	 * 3. Checks standalone tasks (no workflowRunId) for needs_attention and timeout
 	 */
 	async executeTick(): Promise<void> {
 		if (!this.rehydrated) {
@@ -212,6 +218,7 @@ export class SpaceRuntime {
 
 		await this.processCompletedTasks();
 		await this.cleanupTerminalExecutors();
+		await this.checkStandaloneTasks();
 	}
 
 	/**
@@ -636,6 +643,83 @@ export class SpaceRuntime {
 	 */
 	getTaskManagerForSpace(spaceId: string): SpaceTaskManager {
 		return this.getOrCreateTaskManager(spaceId);
+	}
+
+	/**
+	 * Checks standalone tasks (tasks without a workflowRunId) across all spaces for:
+	 *   - `needs_attention` status → emit `task_needs_attention` notification
+	 *   - `in_progress` timeout    → emit `task_timeout` notification
+	 *
+	 * Uses the shared `notifiedTaskSet` for deduplication so the same task+status pair
+	 * is never notified twice in a row. Dedup keys are cleared when the task leaves the
+	 * flagged state, allowing re-notification if the task cycles back into it.
+	 *
+	 * Restart contract: because `notifiedTaskSet` is in-memory only, tasks already in
+	 * `needs_attention` at daemon startup will re-notify once on the first tick. This is
+	 * intentional — the Space Agent session is new after restart and needs to be informed
+	 * of outstanding issues. See the `notifiedTaskSet` field comment for details.
+	 */
+	private async checkStandaloneTasks(): Promise<void> {
+		const spaces = await this.config.spaceManager.listSpaces(false);
+
+		for (const space of spaces) {
+			// Fetch all non-archived standalone tasks for this space in a single query.
+			// Filtering by workflowRunId === undefined identifies tasks that are not
+			// associated with any workflow run (i.e., standalone tasks).
+			const standaloneTasks = this.config.taskRepo
+				.listBySpace(space.id)
+				.filter((t) => !t.workflowRunId);
+
+			// Dedup cleanup: clear keys for tasks that have left their flagged state.
+			// This mirrors the per-tick cleanup done in processRunTick() for workflow tasks.
+			for (const task of standaloneTasks) {
+				if (task.status !== 'needs_attention') {
+					this.notifiedTaskSet.delete(`${task.id}:needs_attention`);
+				}
+				if (task.status !== 'in_progress') {
+					this.notifiedTaskSet.delete(`${task.id}:timeout`);
+				}
+			}
+
+			// Emit task_needs_attention for standalone tasks in needs_attention state.
+			for (const task of standaloneTasks) {
+				if (task.status !== 'needs_attention') continue;
+				const dedupKey = `${task.id}:needs_attention`;
+				if (!this.notifiedTaskSet.has(dedupKey)) {
+					this.notifiedTaskSet.add(dedupKey);
+					await this.notificationSink.notify({
+						kind: 'task_needs_attention',
+						spaceId: space.id,
+						taskId: task.id,
+						reason: task.error ?? 'Task requires attention',
+						timestamp: new Date().toISOString(),
+					});
+				}
+			}
+
+			// Timeout detection for standalone in_progress tasks.
+			const taskTimeoutMs = space.config?.taskTimeoutMs;
+			if (taskTimeoutMs !== undefined) {
+				const now = Date.now();
+				for (const task of standaloneTasks) {
+					if (task.status !== 'in_progress' || !task.startedAt) continue;
+					const elapsedMs = now - task.startedAt;
+					if (elapsedMs > taskTimeoutMs) {
+						const dedupKey = `${task.id}:timeout`;
+						if (!this.notifiedTaskSet.has(dedupKey)) {
+							this.notifiedTaskSet.add(dedupKey);
+							await this.notificationSink.notify({
+								kind: 'task_timeout',
+								spaceId: space.id,
+								taskId: task.id,
+								elapsedMs,
+								timestamp: new Date().toISOString(),
+							});
+						}
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -89,6 +89,22 @@ export class SpaceTaskRepository {
 	}
 
 	/**
+	 * List standalone tasks for a space (tasks with no workflowRunId).
+	 * The SQL-level filter avoids fetching workflow tasks that would be discarded by the caller.
+	 */
+	listStandaloneBySpace(spaceId: string, includeArchived = false): SpaceTask[] {
+		let query = `SELECT * FROM space_tasks WHERE space_id = ? AND workflow_run_id IS NULL`;
+		if (!includeArchived) {
+			query += ` AND archived_at IS NULL`;
+		}
+		query += ` ORDER BY updated_at DESC`;
+
+		const stmt = this.db.prepare(query);
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
 	 * List tasks by status within a space
 	 */
 	listByStatus(spaceId: string, status: SpaceTaskStatus): SpaceTask[] {

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -688,6 +688,320 @@ describe('SpaceRuntime — notification events', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Standalone task notifications
+	// -------------------------------------------------------------------------
+
+	describe('standalone task notifications', () => {
+		test('emits task_needs_attention for standalone task in needs_attention state', async () => {
+			// Create a standalone task (no workflowRunId) directly via repo
+			const created = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone Task',
+				description: 'No workflow',
+				status: 'needs_attention',
+			});
+			// createTask doesn't support error field — set it via update
+			const task = taskRepo.updateTask(created.id, { error: 'Disk full' })!;
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_needs_attention');
+			if (evt.kind === 'task_needs_attention') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.taskId).toBe(task.id);
+				expect(evt.reason).toBe('Disk full');
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('uses fallback reason when standalone task.error is null', async () => {
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone Task',
+				description: '',
+				status: 'needs_attention',
+			});
+
+			await runtime.executeTick();
+
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_needs_attention');
+			if (evt.kind === 'task_needs_attention') {
+				expect(evt.reason).toBe('Task requires attention');
+			}
+		});
+
+		test('deduplicates standalone needs_attention across ticks', async () => {
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone',
+				description: '',
+				status: 'needs_attention',
+			});
+
+			// First tick — emits
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Second tick — still needs_attention — deduped
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Third tick — still deduped
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+		});
+
+		test('re-notifies standalone task after it leaves and re-enters needs_attention', async () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone',
+				description: '',
+				status: 'needs_attention',
+			});
+
+			// First tick — emits
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Task gets retried: back to in_progress
+			taskRepo.updateTask(task.id, { status: 'in_progress' });
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Task fails again
+			taskRepo.updateTask(task.id, { status: 'needs_attention', error: 'Again' });
+			await runtime.executeTick();
+			// Should emit a second time since dedup key was cleared when task left needs_attention
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(2);
+		});
+
+		test('pending standalone tasks emit no notifications', async () => {
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone Pending',
+				description: '',
+				status: 'pending',
+			});
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+
+		test('in_progress standalone tasks without timeout emit no notifications', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 60_000); // 1 minute — won't fire in unit test
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Standalone In Progress',
+				description: '',
+				status: 'in_progress',
+			});
+			// Stamp started_at (normally done by repo on status transition, but we set in creation)
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(Date.now(), task.id);
+
+			await runtime.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(0);
+		});
+
+		test('emits task_timeout for standalone in_progress task that exceeds threshold', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000); // 1 second
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Slow Standalone',
+				description: '',
+				status: 'in_progress',
+			});
+			// Back-date started_at to 2 seconds ago to simulate timeout
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				task.id
+			);
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(1);
+			const evt = sink.events[0];
+			expect(evt.kind).toBe('task_timeout');
+			if (evt.kind === 'task_timeout') {
+				expect(evt.spaceId).toBe(SPACE_ID);
+				expect(evt.taskId).toBe(task.id);
+				expect(evt.elapsedMs).toBeGreaterThan(1000);
+				expect(typeof evt.timestamp).toBe('string');
+			}
+		});
+
+		test('does NOT emit timeout for standalone task when taskTimeoutMs is undefined', async () => {
+			// No config set — timeout disabled
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Slow Standalone No Config',
+				description: '',
+				status: 'in_progress',
+			});
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 100_000,
+				task.id
+			);
+
+			await runtime.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(0);
+		});
+
+		test('deduplicates standalone timeout notifications across ticks', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Timed Out Standalone',
+				description: '',
+				status: 'in_progress',
+			});
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				task.id
+			);
+
+			// First tick — emits
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Second tick — still in_progress and over threshold — deduped
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+		});
+
+		test('re-notifies standalone timeout after task leaves and re-enters in_progress', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Cycling Standalone',
+				description: '',
+				status: 'in_progress',
+			});
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				task.id
+			);
+
+			// First tick — emits timeout
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Task moves to needs_attention (leaves in_progress)
+			taskRepo.updateTask(task.id, { status: 'needs_attention' });
+			await runtime.executeTick();
+
+			// Task re-enters in_progress and times out again
+			taskRepo.updateTask(task.id, { status: 'in_progress' });
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 2000,
+				task.id
+			);
+			await runtime.executeTick();
+
+			// Should emit a second timeout since dedup key was cleared when task left in_progress
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(2);
+		});
+
+		test('workflow tasks are NOT processed by checkStandaloneTasks', async () => {
+			// Create a workflow task (has workflowRunId) with needs_attention status
+			// It should NOT generate a duplicate notification via the standalone path
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_CODER },
+			]);
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Workflow error' });
+
+			await runtime.executeTick();
+
+			// Should get exactly one notification (from processRunTick, not checkStandaloneTasks)
+			const naEvents = sink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(naEvents).toHaveLength(1);
+			if (naEvents[0].kind === 'task_needs_attention') {
+				expect(naEvents[0].taskId).toBe(tasks[0].id);
+			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Restart re-notification behavior (Task 2.3 restart contract)
+	// -------------------------------------------------------------------------
+
+	describe('restart re-notification (empty dedup set on restart)', () => {
+		test('standalone needs_attention task is re-notified after simulated restart', async () => {
+			const created = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Pre-existing Standalone',
+				description: '',
+				status: 'needs_attention',
+			});
+			// createTask doesn't support error field — set it via update
+			const task = taskRepo.updateTask(created.id, { error: 'Pre-restart error' })!;
+
+			// First runtime instance — first tick emits notification
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Simulate restart: create a fresh runtime with empty dedup set
+			// (In production the daemon process restarts and all in-memory state is lost)
+			const freshSink = new MockNotificationSink();
+			const freshRuntime = makeRuntime({ notificationSink: freshSink });
+
+			// First tick on fresh runtime — dedup set is empty → re-notifies once
+			await freshRuntime.executeTick();
+			const reNotified = freshSink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(reNotified).toHaveLength(1);
+			if (reNotified[0].kind === 'task_needs_attention') {
+				expect(reNotified[0].taskId).toBe(task.id);
+				expect(reNotified[0].reason).toBe('Pre-restart error');
+			}
+
+			// Second tick on fresh runtime — deduped, no new notification
+			await freshRuntime.executeTick();
+			expect(freshSink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+		});
+
+		test('standalone timed-out task is re-notified after simulated restart', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Pre-existing Timeout',
+				description: '',
+				status: 'in_progress',
+			});
+			db.prepare('UPDATE space_tasks SET started_at = ? WHERE id = ?').run(
+				Date.now() - 5000,
+				task.id
+			);
+
+			// First runtime instance — first tick emits timeout
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Simulate restart: fresh runtime with empty dedup set
+			const freshSink = new MockNotificationSink();
+			const freshRuntime = makeRuntime({ notificationSink: freshSink });
+
+			// First tick on fresh runtime — re-notifies once (dedup set was empty)
+			await freshRuntime.executeTick();
+			expect(freshSink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+
+			// Second tick — deduped
+			await freshRuntime.executeTick();
+			expect(freshSink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// setNotificationSink() — post-construction wiring
 	// -------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -911,6 +911,70 @@ describe('SpaceRuntime — notification events', () => {
 			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(2);
 		});
 
+		test('completed standalone task emits no notifications', async () => {
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Done',
+				description: '',
+				status: 'completed',
+			});
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+
+		test('cancelled standalone task emits no notifications', async () => {
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Cancelled',
+				description: '',
+				status: 'cancelled',
+			});
+
+			await runtime.executeTick();
+
+			expect(sink.events).toHaveLength(0);
+		});
+
+		test('archiving a standalone task clears its dedup key (no permanent leak)', async () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Soon Archived',
+				description: '',
+				status: 'needs_attention',
+			});
+
+			// First tick — emits notification, dedup key added
+			await runtime.executeTick();
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Archive the task while it is still in needs_attention
+			taskRepo.archiveTask(task.id);
+
+			// Second tick — task is now archived; dedup key should be cleared
+			await runtime.executeTick();
+			// No new notification (archived tasks never re-enter needs_attention)
+			expect(sink.events.filter((e) => e.kind === 'task_needs_attention')).toHaveLength(1);
+
+			// Create a fresh runtime to simulate a restart — the previously leaked key
+			// would have persisted in the old set. With the fix, the archived task was
+			// cleaned up on the previous tick so no re-notification occurs here.
+			// More importantly: verify the current runtime's set has been cleaned up by
+			// creating a NEW task in needs_attention and confirming dedup still works.
+			const task2 = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Another Task',
+				description: '',
+				status: 'needs_attention',
+			});
+			await runtime.executeTick();
+			const naEvents = sink.events.filter(
+				(e) => e.kind === 'task_needs_attention' && e.taskId === task2.id
+			);
+			expect(naEvents).toHaveLength(1);
+		});
+
 		test('workflow tasks are NOT processed by checkStandaloneTasks', async () => {
 			// Create a workflow task (has workflowRunId) with needs_attention status
 			// It should NOT generate a duplicate notification via the standalone path


### PR DESCRIPTION
Extends SpaceRuntime.executeTick() with checkStandaloneTasks() that
processes tasks without a workflowRunId after each workflow tick:
- Emits task_needs_attention for standalone tasks in needs_attention state
- Emits task_timeout for standalone in_progress tasks exceeding taskTimeoutMs
- Uses the shared notifiedTaskSet for deduplication (keyed by taskId:status)
- Documents the restart re-notification contract in notifiedTaskSet comment

Adds 14 new unit tests covering: needs_attention notification, fallback
reason, dedup across ticks, re-notification after state change, timeout
detection, timeout dedup, workflow task isolation, and restart contract.
