### PR TITLE
feat: wire TaskAgentManager into DaemonApp (Task 4.3)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -19,6 +19,7 @@ import { SpaceAgentRepository } from './storage/repositories/space-agent-reposit
 import { SpaceAgentManager } from './lib/space/managers/space-agent-manager';
 import { SpaceManager } from './lib/space/managers/space-manager';
 import type { SpaceRuntimeService } from './lib/space/runtime/space-runtime-service';
+import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -60,6 +61,8 @@ export interface DaemonAppContext {
 	spaceManager: SpaceManager;
 	/** Space runtime service for workflow run lifecycle management */
 	spaceRuntimeService: SpaceRuntimeService;
+	/** Task Agent Manager — manages Task Agent session lifecycle for space tasks */
+	taskAgentManager: TaskAgentManager;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -210,7 +213,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	}
 
 	// Setup RPC handlers (returns cleanup function + exposed services)
-	const { cleanup: rpcHandlerCleanup, spaceRuntimeService } = setupRPCHandlers({
+	const {
+		cleanup: rpcHandlerCleanup,
+		spaceRuntimeService,
+		taskAgentManager,
+	} = setupRPCHandlers({
 		messageHub,
 		sessionManager,
 		authManager,
@@ -399,6 +406,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				logInfo('[Daemon] GitHub service stopped');
 			}
 
+			// Stop all Task Agent sessions before sessionManager.cleanup() so that
+			// Task Agent sessions are interrupted cleanly before the session pool drains.
+			await taskAgentManager.cleanupAll();
+
 			// Stop all agent sessions first — this closes any open SSE connections
 			// that are held by providers (e.g. AnthropicToCopilotBridgeProvider's embedded
 			// HTTP server). Provider shutdown must follow so server.close() is not
@@ -439,6 +450,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		spaceAgentManager,
 		spaceManager,
 		spaceRuntimeService,
+		taskAgentManager,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -63,6 +63,8 @@ import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
+import { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import { setupSpaceTaskSendMessageHandler } from './space-task-message-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -92,6 +94,7 @@ export type RPCHandlerCleanup = () => void;
 export interface RPCHandlerSetupResult {
 	cleanup: RPCHandlerCleanup;
 	spaceRuntimeService: SpaceRuntimeService;
+	taskAgentManager: TaskAgentManager;
 }
 
 /**
@@ -249,6 +252,25 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	});
 	spaceRuntimeService.start();
 
+	// Task Agent Manager — manages Task Agent session lifecycle for space tasks
+	const taskAgentManager = new TaskAgentManager({
+		db: deps.db,
+		sessionManager: deps.sessionManager,
+		spaceManager: deps.spaceManager,
+		spaceAgentManager: deps.spaceAgentManager,
+		spaceWorkflowManager,
+		spaceRuntimeService,
+		taskRepo: spaceTaskRepo,
+		workflowRunRepo: spaceWorkflowRunRepo,
+		daemonHub: deps.daemonHub,
+		messageHub: deps.messageHub,
+		getApiKey: () => deps.authManager.getCurrentApiKey(),
+		defaultModel: deps.config.defaultModel,
+	});
+
+	// space.task.sendMessage — inject a message into a Task Agent session
+	setupSpaceTaskSendMessageHandler(deps.messageHub, taskAgentManager);
+
 	// Space export/import handlers
 	setupSpaceExportImportHandlers(
 		deps.messageHub,
@@ -304,5 +326,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			spaceRuntimeService.stop();
 		},
 		spaceRuntimeService,
+		taskAgentManager,
 	};
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -26,10 +26,11 @@ export function setupSpaceTaskSendMessageHandler(
 			throw new Error('message is required');
 		}
 
-		if (!taskAgentManager.isTaskAgentAlive(params.taskId)) {
-			throw new Error(`No active Task Agent session for task: ${params.taskId}`);
-		}
-
+		// Delegate directly to injectTaskAgentMessage — it is the single authoritative
+		// gate that throws "Task Agent session not found" if the session no longer exists.
+		// A separate isTaskAgentAlive pre-check would introduce a TOCTOU race: a
+		// concurrent cleanupAll() (e.g., triggered by daemon shutdown) could remove the
+		// session between the check and the injection call.
 		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message);
 		log.info(`space.task.sendMessage: injected message into task ${params.taskId}`);
 

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -1,0 +1,38 @@
+/**
+ * Space Task Message RPC Handlers
+ *
+ * RPC handler for sending messages to Task Agent sessions:
+ * - space.task.sendMessage — inject a human or agent message into a Task Agent session
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('space-task-message-handlers');
+
+export function setupSpaceTaskSendMessageHandler(
+	messageHub: MessageHub,
+	taskAgentManager: TaskAgentManager
+): void {
+	// ─── space.task.sendMessage ──────────────────────────────────────────────────
+	messageHub.onRequest('space.task.sendMessage', async (data) => {
+		const params = data as { taskId: string; message: string };
+
+		if (!params.taskId) {
+			throw new Error('taskId is required');
+		}
+		if (!params.message || params.message.trim() === '') {
+			throw new Error('message is required');
+		}
+
+		if (!taskAgentManager.isTaskAgentAlive(params.taskId)) {
+			throw new Error(`No active Task Agent session for task: ${params.taskId}`);
+		}
+
+		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message);
+		log.info(`space.task.sendMessage: injected message into task ${params.taskId}`);
+
+		return { ok: true };
+	});
+}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -427,6 +427,16 @@ export class TaskAgentManager {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * Stop and clean up all active Task Agent sessions and their sub-sessions.
+	 * Called on daemon shutdown to release all resources.
+	 */
+	async cleanupAll(): Promise<void> {
+		const taskIds = Array.from(this.taskAgentSessions.keys());
+		await Promise.allSettled(taskIds.map((taskId) => this.cleanup(taskId)));
+		log.info(`TaskAgentManager: cleanupAll complete (${taskIds.length} tasks cleaned up)`);
+	}
+
+	/**
 	 * Stop and clean up all sessions for a task.
 	 *
 	 * Stops the Task Agent session and all sub-sessions, removes DB records

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -694,13 +694,20 @@ export class TaskAgentManager {
 	): Promise<void> {
 		const sessionId = session.session.id;
 		const state = session.getProcessingState();
-		// 'processing'/'queued' = actively running; 'waiting_for_input' = human gate open.
-		// All three states mean the session cannot safely receive a next_turn message
-		// right now — defer it for replay after the current interaction completes.
+		// 'processing'/'queued' = actively running; 'waiting_for_input' = human gate open;
+		// 'interrupted' = the current turn was interrupted but the session is still alive.
+		// All four states mean a next_turn message cannot be safely delivered right now —
+		// defer it for replay after the current interaction resolves.
+		//
+		// Note on 'interrupted': an interrupted session CAN accept a new current_turn
+		// message (ensureQueryStarted restarts the query), so only next_turn delivery is
+		// deferred. This matches the pattern for 'processing'/'queued': the message is
+		// saved and replayed once the session becomes idle.
 		const isBusy =
 			state.status === 'processing' ||
 			state.status === 'queued' ||
-			state.status === 'waiting_for_input';
+			state.status === 'waiting_for_input' ||
+			state.status === 'interrupted';
 
 		const messageId = generateUUID();
 		const sdkUserMessage: SDKUserMessage = {

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for space.task.sendMessage RPC handler
+ *
+ * Covers:
+ * - Happy path: message injected when Task Agent is alive
+ * - Error: missing taskId
+ * - Error: empty message
+ * - Error: no active Task Agent session
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { setupSpaceTaskSendMessageHandler } from '../../../src/lib/rpc-handlers/space-task-message-handlers';
+import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: (name: string, handler: RequestHandler) => {
+			handlers.set(name, handler);
+		},
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockTaskAgentManager(overrides?: Partial<TaskAgentManager>): TaskAgentManager {
+	return {
+		isTaskAgentAlive: mock(() => true),
+		injectTaskAgentMessage: mock(() => Promise.resolve()),
+		...overrides,
+	} as unknown as TaskAgentManager;
+}
+
+describe('setupSpaceTaskSendMessageHandler', () => {
+	let hub: MessageHub;
+	let handlers: Map<string, RequestHandler>;
+	let taskAgentManager: TaskAgentManager;
+
+	beforeEach(() => {
+		({ hub, handlers } = createMockMessageHub());
+		taskAgentManager = createMockTaskAgentManager();
+		setupSpaceTaskSendMessageHandler(hub, taskAgentManager);
+	});
+
+	it('registers space.task.sendMessage handler', () => {
+		expect(handlers.has('space.task.sendMessage')).toBe(true);
+	});
+
+	it('injects message when Task Agent is alive', async () => {
+		const handler = handlers.get('space.task.sendMessage')!;
+		const result = await handler({ taskId: 'task-1', message: 'hello' });
+
+		expect(result).toEqual({ ok: true });
+		expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith('task-1', 'hello');
+	});
+
+	it('throws when taskId is missing', async () => {
+		const handler = handlers.get('space.task.sendMessage')!;
+		await expect(handler({ message: 'hello' })).rejects.toThrow('taskId is required');
+	});
+
+	it('throws when message is empty', async () => {
+		const handler = handlers.get('space.task.sendMessage')!;
+		await expect(handler({ taskId: 'task-1', message: '' })).rejects.toThrow('message is required');
+	});
+
+	it('throws when message is whitespace only', async () => {
+		const handler = handlers.get('space.task.sendMessage')!;
+		await expect(handler({ taskId: 'task-1', message: '   ' })).rejects.toThrow(
+			'message is required'
+		);
+	});
+
+	it('throws when no active Task Agent session exists', async () => {
+		taskAgentManager = createMockTaskAgentManager({
+			isTaskAgentAlive: mock(() => false),
+		});
+		const { hub: hub2, handlers: handlers2 } = createMockMessageHub();
+		setupSpaceTaskSendMessageHandler(hub2, taskAgentManager);
+
+		const handler = handlers2.get('space.task.sendMessage')!;
+		await expect(handler({ taskId: 'task-missing', message: 'hello' })).rejects.toThrow(
+			'No active Task Agent session for task: task-missing'
+		);
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -2,10 +2,11 @@
  * Tests for space.task.sendMessage RPC handler
  *
  * Covers:
- * - Happy path: message injected when Task Agent is alive
+ * - Happy path: message injected into active Task Agent session
  * - Error: missing taskId
- * - Error: empty message
- * - Error: no active Task Agent session
+ * - Error: empty / whitespace-only message
+ * - Error: no active Task Agent session (injectTaskAgentMessage throws)
+ * - No TOCTOU pre-check: handler delegates entirely to injectTaskAgentMessage
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
@@ -30,7 +31,6 @@ function createMockMessageHub(): {
 
 function createMockTaskAgentManager(overrides?: Partial<TaskAgentManager>): TaskAgentManager {
 	return {
-		isTaskAgentAlive: mock(() => true),
 		injectTaskAgentMessage: mock(() => Promise.resolve()),
 		...overrides,
 	} as unknown as TaskAgentManager;
@@ -51,12 +51,26 @@ describe('setupSpaceTaskSendMessageHandler', () => {
 		expect(handlers.has('space.task.sendMessage')).toBe(true);
 	});
 
-	it('injects message when Task Agent is alive', async () => {
+	it('injects message and returns { ok: true }', async () => {
 		const handler = handlers.get('space.task.sendMessage')!;
 		const result = await handler({ taskId: 'task-1', message: 'hello' });
 
 		expect(result).toEqual({ ok: true });
 		expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith('task-1', 'hello');
+	});
+
+	it('does not call isTaskAgentAlive (no TOCTOU pre-check)', async () => {
+		// The handler must not call isTaskAgentAlive — the single authoritative gate
+		// is injectTaskAgentMessage itself, which avoids a TOCTOU race with cleanupAll().
+		const isAliveMock = mock(() => true);
+		taskAgentManager = createMockTaskAgentManager({
+			isTaskAgentAlive: isAliveMock,
+		});
+		const { hub: hub2, handlers: handlers2 } = createMockMessageHub();
+		setupSpaceTaskSendMessageHandler(hub2, taskAgentManager);
+
+		await handlers2.get('space.task.sendMessage')!({ taskId: 'task-1', message: 'hi' });
+		expect(isAliveMock).not.toHaveBeenCalled();
 	});
 
 	it('throws when taskId is missing', async () => {
@@ -76,16 +90,19 @@ describe('setupSpaceTaskSendMessageHandler', () => {
 		);
 	});
 
-	it('throws when no active Task Agent session exists', async () => {
+	it('propagates error from injectTaskAgentMessage when session does not exist', async () => {
+		// The authoritative error comes from injectTaskAgentMessage, not a pre-check.
 		taskAgentManager = createMockTaskAgentManager({
-			isTaskAgentAlive: mock(() => false),
+			injectTaskAgentMessage: mock(() =>
+				Promise.reject(new Error('Task Agent session not found for task task-missing'))
+			),
 		});
 		const { hub: hub2, handlers: handlers2 } = createMockMessageHub();
 		setupSpaceTaskSendMessageHandler(hub2, taskAgentManager);
 
 		const handler = handlers2.get('space.task.sendMessage')!;
 		await expect(handler({ taskId: 'task-missing', message: 'hello' })).rejects.toThrow(
-			'No active Task Agent session for task: task-missing'
+			'Task Agent session not found for task task-missing'
 		);
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1144,6 +1144,26 @@ describe('TaskAgentManager', () => {
 			expect(ctx.manager.isSpawning(task.id)).toBe(false);
 		});
 
+		test('cleanupAll stops all active task agent sessions', async () => {
+			const task1 = await makeTask(ctx.taskManager);
+			const task2 = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task1, ctx.space, null, null);
+			await ctx.manager.spawnTaskAgent(task2, ctx.space, null, null);
+
+			expect(ctx.manager.isTaskAgentAlive(task1.id)).toBe(true);
+			expect(ctx.manager.isTaskAgentAlive(task2.id)).toBe(true);
+
+			await ctx.manager.cleanupAll();
+
+			expect(ctx.manager.isTaskAgentAlive(task1.id)).toBe(false);
+			expect(ctx.manager.isTaskAgentAlive(task2.id)).toBe(false);
+		});
+
+		test('cleanupAll is a no-op when no sessions are active', async () => {
+			// Should not throw
+			await expect(ctx.manager.cleanupAll()).resolves.toBeUndefined();
+		});
+
 		test('can retry spawn after error', async () => {
 			// First call throws
 			const fromInitSpy = spyOn(AgentSession, 'fromInit')

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1026,6 +1026,51 @@ describe('TaskAgentManager', () => {
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 
+		test('saves with "saved" status when session is interrupted (next_turn deferred)', async () => {
+			// 'interrupted' is included in isBusy for next_turn delivery.
+			// A next_turn message to an interrupted session should be deferred, not sent
+			// blindly — the session may restart on its own or receive a current_turn message.
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			const session = ctx.createdSessions.get(sessionId)!;
+
+			session._processingState = { status: 'interrupted' } as AgentProcessingState;
+
+			const savedStatuses: string[] = [];
+			const enqueuedBefore = session._enqueuedMessages.length;
+			const originalSave = ctx.mockDb.saveUserMessage;
+			ctx.mockDb.saveUserMessage = (
+				_sid: string,
+				_msg: unknown,
+				status: string
+			): ReturnType<typeof ctx.mockDb.saveUserMessage> => {
+				savedStatuses.push(status);
+				return 'msg-id';
+			};
+
+			await callInjectMessage(ctx.manager, session, 'check in', 'next_turn');
+
+			ctx.mockDb.saveUserMessage = originalSave;
+
+			expect(savedStatuses).toEqual(['saved']);
+			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
+		});
+
+		test('enqueues immediately for current_turn when session is interrupted (restartable)', async () => {
+			// An interrupted session can accept a current_turn message: ensureQueryStarted
+			// restarts the query and the message is enqueued normally.
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			const session = ctx.createdSessions.get(sessionId)!;
+
+			session._processingState = { status: 'interrupted' } as AgentProcessingState;
+			const msgsBefore = session._enqueuedMessages.length;
+
+			await callInjectMessage(ctx.manager, session, 'restart signal', 'current_turn');
+
+			expect(session._enqueuedMessages.length).toBeGreaterThan(msgsBefore);
+		});
+
 		test('enqueues immediately for next_turn when session is idle', async () => {
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);


### PR DESCRIPTION
- Add `cleanupAll()` to TaskAgentManager for graceful daemon shutdown
- Instantiate TaskAgentManager inside setupRPCHandlers (after SpaceRuntimeService) with all required dependencies
- Expose TaskAgentManager via RPCHandlerSetupResult
- Add `taskAgentManager: TaskAgentManager` to DaemonAppContext interface
- Wire TaskAgentManager into createDaemonApp and call cleanupAll() on shutdown
- Add `space.task.sendMessage` RPC handler (space-task-message-handlers.ts) that injects messages into Task Agent sessions via TaskAgentManager.injectTaskAgentMessage()
- Add 6 unit tests for space.task.sendMessage handler (happy path, validation errors, no-session error)
- Add 2 unit tests for cleanupAll() (multi-task cleanup, no-op when empty)
