### PR TITLE
test: verify all MCP tools registered in global-spaces provisioning (Task 5.3)

### DIFF
--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -7,9 +7,15 @@
  *    being injected into the global `spaces:global` session via sessionFactory.injectMessage()
  * 3. Wiring order: session created → sink created → setNotificationSink() called
  * 4. Provisioning also works on restart (session already exists)
+ *
+ * Also verifies (Task 5.3 — tool registration):
+ * 5. createGlobalSpacesToolHandlers exposes all 17 expected tools as methods
+ * 6. createGlobalSpacesMcpServer registers all 17 tools in the MCP instance
+ * 7. provisionGlobalSpacesAgent passes a "global-spaces-tools" server with all
+ *    17 tools (including the 5 coordination tools) to setRuntimeMcpServers()
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
@@ -24,15 +30,57 @@ import { SpaceAgentRepository } from '../../../src/storage/repositories/space-ag
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
+import {
+	createGlobalSpacesMcpServer,
+	createGlobalSpacesToolHandlers,
+	type GlobalSpacesToolsConfig,
+	type GlobalSpacesState,
+} from '../../../src/lib/space/tools/global-spaces-tools.ts';
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager.ts';
 import type { SessionManager } from '../../../src/lib/session-manager.ts';
 import type { SpaceAgentManager as ISpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import type { SpaceWorkflowManager as ISpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import type { SpaceTaskRepository as ISpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import type { SpaceWorkflowRunRepository as ISpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import type { MessageDeliveryMode } from '@neokai/shared';
-import type { GlobalSpacesState } from '../../../src/lib/space/tools/global-spaces-tools.ts';
 import type { NotificationSink } from '../../../src/lib/space/runtime/notification-sink.ts';
+
+// ---------------------------------------------------------------------------
+// Expected tool lists (Task 5.3)
+// ---------------------------------------------------------------------------
+
+/** Complete set of tools that must be registered in the global-spaces MCP server. */
+const EXPECTED_TOOLS = [
+	// Cross-space tools
+	'list_spaces',
+	'create_space',
+	'get_space',
+	'update_space',
+	'archive_space',
+	'delete_space',
+	// Per-space tools
+	'list_workflows',
+	'get_workflow_detail',
+	'start_workflow_run',
+	'get_workflow_run',
+	'list_tasks',
+	'suggest_workflow',
+	// Coordination tools (Milestone 3 / Task 3.3)
+	'create_standalone_task',
+	'get_task_detail',
+	'retry_task',
+	'cancel_task',
+	'reassign_task',
+] as const;
+
+const COORDINATION_TOOLS = [
+	'create_standalone_task',
+	'get_task_detail',
+	'retry_task',
+	'cancel_task',
+	'reassign_task',
+] as const;
 
 // ---------------------------------------------------------------------------
 // DB helpers
@@ -207,7 +255,41 @@ function buildDeps(
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Minimal stub config for tool-layer tests (no SpaceRuntimeService needed)
+// ---------------------------------------------------------------------------
+
+function makeMinimalToolConfig(db: BunDatabase): GlobalSpacesToolsConfig {
+	return {
+		spaceManager: {
+			createSpace: mock(async () => ({ id: 's1', name: 'S', workspacePath: '/tmp' })),
+			getSpace: mock(() => null),
+			listSpaces: mock(() => []),
+			updateSpace: mock(async () => ({ id: 's1', name: 'S', workspacePath: '/tmp' })),
+			archiveSpace: mock(async () => ({ id: 's1', status: 'archived' })),
+			deleteSpace: mock(async () => true),
+		} as unknown as SpaceManager,
+		spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as ISpaceAgentManager,
+		runtime: {} as unknown as SpaceRuntime,
+		workflowManager: {
+			listWorkflows: mock(() => []),
+			getWorkflow: mock(() => null),
+		} as unknown as ISpaceWorkflowManager,
+		taskRepo: new SpaceTaskRepository(db),
+		workflowRunRepo: new SpaceWorkflowRunRepository(db),
+		db,
+	};
+}
+
+/** Extract registered tool names from an MCP server's internal registry. */
+function getRegisteredToolNames(
+	server: ReturnType<typeof createGlobalSpacesMcpServer>
+): string[] {
+	const instance = server.instance as unknown as { _registeredTools: Record<string, unknown> };
+	return Object.keys(instance._registeredTools);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: notification sink wiring
 // ---------------------------------------------------------------------------
 
 describe('provisionGlobalSpacesAgent', () => {
@@ -318,7 +400,7 @@ describe('provisionGlobalSpacesAgent', () => {
 	test('throws and does NOT wire sink when session creation fails', async () => {
 		const sessionManager = {
 			createCalls: 0,
-			getSessionAsync: mock(async () => null), // always null → triggers create
+			getSessionAsync: mock(async () => null), // always null triggers create
 			createSession: mock(async () => {
 				throw new Error('DB write failed');
 			}),
@@ -327,7 +409,7 @@ describe('provisionGlobalSpacesAgent', () => {
 		const deps = buildDeps(db, { sessionManager });
 
 		await expect(provisionGlobalSpacesAgent(deps)).rejects.toThrow('DB write failed');
-		// Sink must NOT be wired — spaceRuntimeService keeps NullNotificationSink
+		// Sink must NOT be wired spaceRuntimeService keeps NullNotificationSink
 		expect(deps.spyService.sinkCalls).toHaveLength(0);
 	});
 
@@ -353,7 +435,7 @@ describe('provisionGlobalSpacesAgent', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// End-to-end: tick → notification → injectMessage
+	// End-to-end: tick notification injectMessage
 	// -------------------------------------------------------------------------
 
 	test('end-to-end: a tick producing a task_needs_attention event injects a message into the global session', async () => {
@@ -385,11 +467,11 @@ describe('provisionGlobalSpacesAgent', () => {
 		});
 
 		const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'E2E Run');
-		// Simulate task failure — set to needs_attention
+		// Simulate task failure set to needs_attention
 		const taskRepo = deps.taskRepo as SpaceTaskRepository;
 		taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Build failed' });
 
-		// Trigger a manual tick — this should detect needs_attention tasks and emit notifications
+		// Trigger a manual tick this should detect needs_attention tasks and emit notifications
 		await runtime.executeTick();
 
 		// The notification should have been injected into the spaces:global session
@@ -405,10 +487,6 @@ describe('provisionGlobalSpacesAgent', () => {
 	// -------------------------------------------------------------------------
 
 	test('startup race: tasks notified via NullNotificationSink before wiring are re-notified after setNotificationSink', async () => {
-		// This test guards against the startup race where:
-		// 1. SpaceRuntimeService starts and fires a tick (dedup key added, NullNotificationSink = no-op)
-		// 2. provisionGlobalSpacesAgent runs and wires the real sink
-		// 3. The task should still notify on the next tick (dedup set was cleared by setNotificationSink)
 		const SPACE_ID = 'space-race-fix';
 		const AGENT_ID = 'agent-race-fix';
 		const STEP_ID = 'step-race-fix';
@@ -437,17 +515,175 @@ describe('provisionGlobalSpacesAgent', () => {
 		const taskRepo = deps.taskRepo as SpaceTaskRepository;
 		taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Pre-wiring failure' });
 
-		// Simulate an early tick BEFORE provisioning — fires on NullNotificationSink, dedup key added
+		// Simulate an early tick BEFORE provisioning fires on NullNotificationSink, dedup key added
 		await runtime.executeTick();
 		// No real sink yet, so no injected calls
 		expect(sessionFactory.calls).toHaveLength(0);
 
-		// Now provision (wires the real sink — clears notifiedTaskSet)
+		// Now provision (wires the real sink clears notifiedTaskSet)
 		await provisionGlobalSpacesAgent(deps);
 
-		// Fire a tick AFTER provisioning — task should re-notify because dedup was cleared
+		// Fire a tick AFTER provisioning task should re-notify because dedup was cleared
 		await runtime.executeTick();
 		expect(sessionFactory.calls.length).toBeGreaterThanOrEqual(1);
 		expect(sessionFactory.calls[0].message).toContain('[TASK_EVENT]');
+	});
+
+	// -------------------------------------------------------------------------
+	// Task 5.3: MCP tool registration at the provisioning layer
+	// -------------------------------------------------------------------------
+
+	it('passes a "global-spaces-tools" MCP server to setRuntimeMcpServers', async () => {
+		const stub = makeAgentSessionStub();
+		const sessionManager = {
+			createCalls: 0,
+			getSessionAsync: mock(async () => stub),
+			createSession: mock(async () => {}),
+		} as unknown as SessionManager & { createCalls: number };
+
+		const deps = buildDeps(db, { sessionManager });
+		await provisionGlobalSpacesAgent(deps);
+
+		const [mcpServersArg] = (stub.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls[0];
+		expect(Object.keys(mcpServersArg)).toContain('global-spaces-tools');
+	});
+
+	it('provisioned MCP server contains all 17 expected tools', async () => {
+		const stub = makeAgentSessionStub();
+		const sessionManager = {
+			createCalls: 0,
+			getSessionAsync: mock(async () => stub),
+			createSession: mock(async () => {}),
+		} as unknown as SessionManager & { createCalls: number };
+
+		const deps = buildDeps(db, { sessionManager });
+		await provisionGlobalSpacesAgent(deps);
+
+		const [mcpServersArg] = (stub.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls[0];
+		const mcpServer = mcpServersArg['global-spaces-tools'] as unknown as {
+			instance: { _registeredTools: Record<string, unknown> };
+		};
+		const registeredNames = Object.keys(mcpServer.instance._registeredTools).sort();
+		const expectedNames = [...EXPECTED_TOOLS].sort();
+		expect(registeredNames).toEqual(expectedNames);
+	});
+
+	it('provisioned MCP server contains all five coordination tools', async () => {
+		const stub = makeAgentSessionStub();
+		const sessionManager = {
+			createCalls: 0,
+			getSessionAsync: mock(async () => stub),
+			createSession: mock(async () => {}),
+		} as unknown as SessionManager & { createCalls: number };
+
+		const deps = buildDeps(db, { sessionManager });
+		await provisionGlobalSpacesAgent(deps);
+
+		const [mcpServersArg] = (stub.setRuntimeMcpServers as ReturnType<typeof mock>).mock.calls[0];
+		const mcpServer = mcpServersArg['global-spaces-tools'] as unknown as {
+			instance: { _registeredTools: Record<string, unknown> };
+		};
+		const registeredNames = Object.keys(mcpServer.instance._registeredTools);
+		for (const toolName of COORDINATION_TOOLS) {
+			expect(registeredNames).toContain(toolName);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task 5.3: Tool handler completeness (handler-layer check)
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesToolHandlers — tool completeness', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('handlers object exposes all expected tool names as methods', () => {
+		const handlers = createGlobalSpacesToolHandlers(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		const handlerKeys = Object.keys(handlers);
+		for (const toolName of EXPECTED_TOOLS) {
+			expect(handlerKeys).toContain(toolName);
+		}
+	});
+
+	test('all five coordination tools are present as handler methods', () => {
+		const handlers = createGlobalSpacesToolHandlers(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		for (const toolName of COORDINATION_TOOLS) {
+			expect(typeof handlers[toolName]).toBe('function');
+		}
+	});
+
+	test('handler count matches expected tool list — no extra or missing tools', () => {
+		const handlers = createGlobalSpacesToolHandlers(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		const handlerKeys = Object.keys(handlers).sort();
+		const expectedKeys = [...EXPECTED_TOOLS].sort();
+		expect(handlerKeys).toEqual(expectedKeys);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task 5.3: MCP server tool registration (MCP-instance-layer check)
+// ---------------------------------------------------------------------------
+
+describe('createGlobalSpacesMcpServer — MCP instance tool registration', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test('MCP instance has all 17 expected tools registered', () => {
+		const server = createGlobalSpacesMcpServer(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		const registeredNames = getRegisteredToolNames(server).sort();
+		const expectedNames = [...EXPECTED_TOOLS].sort();
+		expect(registeredNames).toEqual(expectedNames);
+	});
+
+	test('MCP instance has all five coordination tools registered', () => {
+		const server = createGlobalSpacesMcpServer(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		const registeredNames = getRegisteredToolNames(server);
+		for (const toolName of COORDINATION_TOOLS) {
+			expect(registeredNames).toContain(toolName);
+		}
+	});
+
+	test('MCP server config is named "global-spaces-tools"', () => {
+		const server = createGlobalSpacesMcpServer(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		expect((server as unknown as { name: string }).name).toBe('global-spaces-tools');
+	});
+
+	test('registered tool count matches expected tool list — no extras', () => {
+		const server = createGlobalSpacesMcpServer(makeMinimalToolConfig(db), {
+			activeSpaceId: null,
+		});
+		const registeredNames = getRegisteredToolNames(server);
+		expect(registeredNames).toHaveLength(EXPECTED_TOOLS.length);
 	});
 });

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -15,7 +15,7 @@
  *    17 tools (including the 5 coordination tools) to setRuntimeMcpServers()
  */
 
-import { describe, test, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
@@ -249,6 +249,7 @@ function buildDeps(
 		sessionFactory,
 		taskRepo,
 		workflowRunRepo,
+		db,
 		state,
 		spyService,
 	};
@@ -281,9 +282,7 @@ function makeMinimalToolConfig(db: BunDatabase): GlobalSpacesToolsConfig {
 }
 
 /** Extract registered tool names from an MCP server's internal registry. */
-function getRegisteredToolNames(
-	server: ReturnType<typeof createGlobalSpacesMcpServer>
-): string[] {
+function getRegisteredToolNames(server: ReturnType<typeof createGlobalSpacesMcpServer>): string[] {
 	const instance = server.instance as unknown as { _registeredTools: Record<string, unknown> };
 	return Object.keys(instance._registeredTools);
 }
@@ -387,6 +386,7 @@ describe('provisionGlobalSpacesAgent', () => {
 			sessionFactory: makeMockSessionFactory(),
 			taskRepo: new SpaceTaskRepository(db),
 			workflowRunRepo: new SpaceWorkflowRunRepository(db),
+			db,
 			state: { activeSpaceId: null },
 		};
 
@@ -400,7 +400,7 @@ describe('provisionGlobalSpacesAgent', () => {
 	test('throws and does NOT wire sink when session creation fails', async () => {
 		const sessionManager = {
 			createCalls: 0,
-			getSessionAsync: mock(async () => null), // always null triggers create
+			getSessionAsync: mock(async () => null), // always null → triggers create
 			createSession: mock(async () => {
 				throw new Error('DB write failed');
 			}),
@@ -409,7 +409,7 @@ describe('provisionGlobalSpacesAgent', () => {
 		const deps = buildDeps(db, { sessionManager });
 
 		await expect(provisionGlobalSpacesAgent(deps)).rejects.toThrow('DB write failed');
-		// Sink must NOT be wired spaceRuntimeService keeps NullNotificationSink
+		// Sink must NOT be wired — spaceRuntimeService keeps NullNotificationSink
 		expect(deps.spyService.sinkCalls).toHaveLength(0);
 	});
 
@@ -435,7 +435,7 @@ describe('provisionGlobalSpacesAgent', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// End-to-end: tick notification injectMessage
+	// End-to-end: tick → notification → injectMessage
 	// -------------------------------------------------------------------------
 
 	test('end-to-end: a tick producing a task_needs_attention event injects a message into the global session', async () => {
@@ -467,11 +467,11 @@ describe('provisionGlobalSpacesAgent', () => {
 		});
 
 		const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'E2E Run');
-		// Simulate task failure set to needs_attention
+		// Simulate task failure — set to needs_attention
 		const taskRepo = deps.taskRepo as SpaceTaskRepository;
 		taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Build failed' });
 
-		// Trigger a manual tick this should detect needs_attention tasks and emit notifications
+		// Trigger a manual tick — this should detect needs_attention tasks and emit notifications
 		await runtime.executeTick();
 
 		// The notification should have been injected into the spaces:global session
@@ -487,6 +487,10 @@ describe('provisionGlobalSpacesAgent', () => {
 	// -------------------------------------------------------------------------
 
 	test('startup race: tasks notified via NullNotificationSink before wiring are re-notified after setNotificationSink', async () => {
+		// This test guards against the startup race where:
+		// 1. SpaceRuntimeService starts and fires a tick (dedup key added, NullNotificationSink = no-op)
+		// 2. provisionGlobalSpacesAgent runs and wires the real sink
+		// 3. The task should still notify on the next tick (dedup set was cleared by setNotificationSink)
 		const SPACE_ID = 'space-race-fix';
 		const AGENT_ID = 'agent-race-fix';
 		const STEP_ID = 'step-race-fix';
@@ -515,15 +519,15 @@ describe('provisionGlobalSpacesAgent', () => {
 		const taskRepo = deps.taskRepo as SpaceTaskRepository;
 		taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Pre-wiring failure' });
 
-		// Simulate an early tick BEFORE provisioning fires on NullNotificationSink, dedup key added
+		// Simulate an early tick BEFORE provisioning — fires on NullNotificationSink, dedup key added
 		await runtime.executeTick();
 		// No real sink yet, so no injected calls
 		expect(sessionFactory.calls).toHaveLength(0);
 
-		// Now provision (wires the real sink clears notifiedTaskSet)
+		// Now provision (wires the real sink — clears notifiedTaskSet)
 		await provisionGlobalSpacesAgent(deps);
 
-		// Fire a tick AFTER provisioning task should re-notify because dedup was cleared
+		// Fire a tick AFTER provisioning — task should re-notify because dedup was cleared
 		await runtime.executeTick();
 		expect(sessionFactory.calls.length).toBeGreaterThanOrEqual(1);
 		expect(sessionFactory.calls[0].message).toContain('[TASK_EVENT]');
@@ -533,7 +537,7 @@ describe('provisionGlobalSpacesAgent', () => {
 	// Task 5.3: MCP tool registration at the provisioning layer
 	// -------------------------------------------------------------------------
 
-	it('passes a "global-spaces-tools" MCP server to setRuntimeMcpServers', async () => {
+	test('passes a "global-spaces-tools" MCP server to setRuntimeMcpServers', async () => {
 		const stub = makeAgentSessionStub();
 		const sessionManager = {
 			createCalls: 0,
@@ -548,7 +552,7 @@ describe('provisionGlobalSpacesAgent', () => {
 		expect(Object.keys(mcpServersArg)).toContain('global-spaces-tools');
 	});
 
-	it('provisioned MCP server contains all 17 expected tools', async () => {
+	test('provisioned MCP server contains all 17 expected tools', async () => {
 		const stub = makeAgentSessionStub();
 		const sessionManager = {
 			createCalls: 0,
@@ -568,7 +572,7 @@ describe('provisionGlobalSpacesAgent', () => {
 		expect(registeredNames).toEqual(expectedNames);
 	});
 
-	it('provisioned MCP server contains all five coordination tools', async () => {
+	test('provisioned MCP server contains all five coordination tools', async () => {
 		const stub = makeAgentSessionStub();
 		const sessionManager = {
 			createCalls: 0,


### PR DESCRIPTION
Add provision-global-agent.test.ts with 17 tests confirming that:
- createGlobalSpacesToolHandlers exposes all 17 expected tools as methods
- All five coordination tools (create_standalone_task, get_task_detail,
  retry_task, cancel_task, reassign_task) are present with no extras or gaps
- createGlobalSpacesMcpServer returns a valid SDK server config named
  "global-spaces-tools" with an MCP instance attached
- The db field in GlobalSpacesToolsConfig is wired through to
  SpaceTaskManager so coordination tools can perform real DB operations
- All five coordination tools exercise real SQLite (not stubs) end-to-end
