### PR TITLE
feat: add send_message_to_task tool to Space Agent

### DIFF
--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -27,6 +27,7 @@
  *       - retry_task
  *       - cancel_task
  *       - reassign_task
+ *       - send_message_to_task
  *
  * See: docs/plans/multi-agent-v2-customizable-agents-workflows/07-workflow-selection-intelligence.md
  */
@@ -277,6 +278,13 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 	sections.push(
 		`- **\`reassign_task\`** — Change the assigned agent for a task. Valid for tasks in \`pending\`, ` +
 			`\`needs_attention\`, or \`cancelled\` status. Use when a different agent would be better suited.`
+	);
+	sections.push('');
+	sections.push(
+		`- **\`send_message_to_task\`** — Send a message directly to the Task Agent session managing a ` +
+			`specific task. Use this to check on progress, provide feedback, or redirect work mid-execution. ` +
+			`The message is delivered to the Task Agent which may relay relevant parts to its active sub-session. ` +
+			`Only works for tasks that have an active Task Agent session (i.e., tasks in \`in_progress\` or \`review\` status).`
 	);
 
 	return sections.join('\n');

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -435,7 +435,9 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				});
 			}
 
-			const task = taskRepo.getTask(args.task_id);
+			// Use taskManager.getTask() (not taskRepo) to enforce space ownership — ensures
+			// Space Agent A cannot inject messages into Space B's Task Agent sessions.
+			const task = await taskManager.getTask(args.task_id);
 			if (!task) {
 				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
 			}
@@ -454,7 +456,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					success: true,
 					taskId: task.id,
 					taskStatus: task.status,
-					taskAgentSessionId: task.taskAgentSessionId,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -29,6 +29,7 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { jsonResult, SUGGEST_WORKFLOW_STOP_WORDS } from './tool-result';
 import type { ToolResult } from './tool-result';
 
@@ -51,6 +52,11 @@ export interface SpaceAgentToolsConfig {
 	taskManager: SpaceTaskManager;
 	/** Space agent manager for reassign validation. */
 	spaceAgentManager: SpaceAgentManager;
+	/**
+	 * Task Agent Manager for injecting messages into Task Agent sessions.
+	 * Optional — when not provided, send_message_to_task returns an error.
+	 */
+	taskAgentManager?: TaskAgentManager | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +76,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		workflowRunRepo,
 		taskManager,
 		spaceAgentManager,
+		taskAgentManager,
 	} = config;
 
 	return {
@@ -415,6 +422,45 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 		},
+
+		/**
+		 * Send a message to the Task Agent session managing a specific task.
+		 * Use this to check progress, provide feedback, or redirect work.
+		 */
+		async send_message_to_task(args: { task_id: string; message: string }): Promise<ToolResult> {
+			if (!taskAgentManager) {
+				return jsonResult({
+					success: false,
+					error: 'TaskAgentManager is not configured — cannot send messages to task agents.',
+				});
+			}
+
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+
+			if (!task.taskAgentSessionId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} has no active Task Agent session (status: ${task.status}).`,
+					taskStatus: task.status,
+				});
+			}
+
+			try {
+				await taskAgentManager.injectTaskAgentMessage(args.task_id, args.message);
+				return jsonResult({
+					success: true,
+					taskId: task.id,
+					taskStatus: task.status,
+					taskAgentSessionId: task.taskAgentSessionId,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -589,6 +635,17 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('Agent type to assign (coder or general)'),
 			},
 			(args) => handlers.reassign_task(args)
+		),
+		tool(
+			'send_message_to_task',
+			'Send a message to the Task Agent session managing a specific task. Use this to check on progress, provide feedback, or redirect work. The message will be delivered directly to the Task Agent which may relay relevant parts to its active sub-session.',
+			{
+				task_id: z
+					.string()
+					.describe('ID of the task whose Task Agent session should receive the message'),
+				message: z.string().describe('The message to send to the Task Agent'),
+			},
+			(args) => handlers.send_message_to_task(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1160,3 +1160,178 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
 		expect(parsed.task.customAgentId).toBe(ctx.agentId);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// send_message_to_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when taskAgentManager is not configured', async () => {
+		// makeHandlers() does not pass taskAgentManager — simulates unconfigured state
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'My task',
+			description: 'Some work',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).send_message_to_task({
+			task_id: taskId,
+			message: 'How is it going?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('TaskAgentManager is not configured');
+	});
+
+	test('returns error when task is not found', async () => {
+		const injected: Array<{ taskId: string; message: string }> = [];
+		const fakeTaskAgentManager = {
+			injectTaskAgentMessage: async (taskId: string, message: string) => {
+				injected.push({ taskId, message });
+			},
+		};
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			taskAgentManager: fakeTaskAgentManager as never,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: 'task-does-not-exist',
+			message: 'Hello?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-does-not-exist');
+		expect(injected).toHaveLength(0);
+	});
+
+	test('returns error when task has no taskAgentSessionId', async () => {
+		const injected: Array<{ taskId: string; message: string }> = [];
+		const fakeTaskAgentManager = {
+			injectTaskAgentMessage: async (taskId: string, message: string) => {
+				injected.push({ taskId, message });
+			},
+		};
+
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Pending task',
+			description: 'Not yet started',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		// Task is in 'pending' state — no taskAgentSessionId
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			taskAgentManager: fakeTaskAgentManager as never,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: taskId,
+			message: 'Any progress?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('no active Task Agent session');
+		expect(parsed.taskStatus).toBe('pending');
+		expect(injected).toHaveLength(0);
+	});
+
+	test('successfully injects message when task has a taskAgentSessionId', async () => {
+		const injected: Array<{ taskId: string; message: string }> = [];
+		const fakeTaskAgentManager = {
+			injectTaskAgentMessage: async (taskId: string, message: string) => {
+				injected.push({ taskId, message });
+			},
+		};
+
+		// Create a task and manually set taskAgentSessionId to simulate an active agent
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Active task',
+			description: 'In progress with agent',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		const sessionId = 'space:test:task:active-task:agent';
+		ctx.taskRepo.updateTask(taskId, { taskAgentSessionId: sessionId });
+		await ctx.taskManager.startTask(taskId);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			taskAgentManager: fakeTaskAgentManager as never,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: taskId,
+			message: 'Please prioritize the auth module.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBe(taskId);
+		expect(parsed.taskAgentSessionId).toBe(sessionId);
+		expect(injected).toHaveLength(1);
+		expect(injected[0].taskId).toBe(taskId);
+		expect(injected[0].message).toBe('Please prioritize the auth module.');
+	});
+
+	test('propagates error from injectTaskAgentMessage', async () => {
+		const fakeTaskAgentManager = {
+			injectTaskAgentMessage: async (_taskId: string, _message: string) => {
+				throw new Error('Session queue is full');
+			},
+		};
+
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Active task',
+			description: 'In progress',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, { taskAgentSessionId: 'space:test:task:active-task' });
+		await ctx.taskManager.startTask(taskId);
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			taskAgentManager: fakeTaskAgentManager as never,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: taskId,
+			message: 'Hello',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Session queue is full');
+	});
+});

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -1266,15 +1266,13 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			},
 		};
 
-		// Create a task and manually set taskAgentSessionId to simulate an active agent
+		// Create a task and set taskAgentSessionId to simulate an active agent
 		const createResult = await makeHandlers(ctx).create_standalone_task({
 			title: 'Active task',
 			description: 'In progress with agent',
 		});
 		const taskId = JSON.parse(createResult.content[0].text).task.id;
-		const sessionId = 'space:test:task:active-task:agent';
-		ctx.taskRepo.updateTask(taskId, { taskAgentSessionId: sessionId });
-		await ctx.taskManager.startTask(taskId);
+		ctx.taskRepo.updateTask(taskId, { taskAgentSessionId: 'space:test:task:active-task:agent' });
 
 		const handlers = createSpaceAgentToolHandlers({
 			spaceId: ctx.spaceId,
@@ -1294,10 +1292,53 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 		expect(parsed.taskId).toBe(taskId);
-		expect(parsed.taskAgentSessionId).toBe(sessionId);
+		// taskAgentSessionId is intentionally omitted from the response to avoid leaking internals
+		expect(parsed.taskAgentSessionId).toBeUndefined();
 		expect(injected).toHaveLength(1);
 		expect(injected[0].taskId).toBe(taskId);
 		expect(injected[0].message).toBe('Please prioritize the auth module.');
+	});
+
+	test('returns error when task belongs to a different space (cross-space ownership check)', async () => {
+		const injected: Array<{ taskId: string; message: string }> = [];
+		const fakeTaskAgentManager = {
+			injectTaskAgentMessage: async (taskId: string, message: string) => {
+				injected.push({ taskId, message });
+			},
+		};
+
+		// Seed a second space and create a task in it
+		const otherSpaceId = 'space-other';
+		seedSpaceRow(ctx.db, otherSpaceId);
+		const otherTaskManager = new SpaceTaskManager(ctx.db, otherSpaceId);
+		const otherTask = await otherTaskManager.createTask({
+			title: 'Other space task',
+			description: 'Belongs to another space',
+		});
+		ctx.taskRepo.updateTask(otherTask.id, {
+			taskAgentSessionId: 'space:other:task:other-task',
+		});
+
+		// Space Agent for ctx.spaceId tries to message a task in otherSpaceId
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			taskAgentManager: fakeTaskAgentManager as never,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: otherTask.id,
+			message: 'Infiltration attempt',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(otherTask.id);
+		expect(injected).toHaveLength(0);
 	});
 
 	test('propagates error from injectTaskAgentMessage', async () => {
@@ -1313,7 +1354,6 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		});
 		const taskId = JSON.parse(createResult.content[0].text).task.id;
 		ctx.taskRepo.updateTask(taskId, { taskAgentSessionId: 'space:test:task:active-task' });
-		await ctx.taskManager.startTask(taskId);
 
 		const handlers = createSpaceAgentToolHandlers({
 			spaceId: ctx.spaceId,

--- a/packages/daemon/tests/unit/space/space-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/space/space-chat-agent.test.ts
@@ -441,6 +441,11 @@ describe('buildSpaceChatSystemPrompt — coordination tools', () => {
 		expect(prompt).toContain('reassign_task');
 	});
 
+	test('documents send_message_to_task tool', () => {
+		const prompt = buildSpaceChatSystemPrompt();
+		expect(prompt).toContain('send_message_to_task');
+	});
+
 	test('coordination tools section present for all autonomy levels', () => {
 		const supervised = buildSpaceChatSystemPrompt({ autonomyLevel: 'supervised' });
 		const semi = buildSpaceChatSystemPrompt({ autonomyLevel: 'semi_autonomous' });


### PR DESCRIPTION
Add a new `send_message_to_task` MCP tool that allows the Space Agent
to inject messages into an active Task Agent session. The tool:
- Looks up the task by ID via SpaceTaskRepository
- Validates the task has a taskAgentSessionId
- Delegates to TaskAgentManager.injectTaskAgentMessage()
- Returns success/failure with the task's current status

TaskAgentManager is an optional field on SpaceAgentToolsConfig (null-safe)
so existing callers that don't have the Task Agent system set up continue
to work — the tool returns a descriptive error in that case.

Also documents the new tool in the Space Chat Agent system prompt and
adds 5 unit tests covering all edge cases.
