### PR TITLE
feat: add human message routing to Task Agent via space.task.sendMessage/getMessages

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -44,7 +44,12 @@ import { TaskManager } from '../room/managers/task-manager';
 import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
-import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
+import {
+	setupSpaceTaskHandlers,
+	setupSpaceTaskMessageHandlers,
+	type SpaceTaskManagerFactory,
+} from './space-task-handlers';
+import { TaskAgentManager } from '../space/runtime/task-agent-manager';
 import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
@@ -63,8 +68,7 @@ import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
-import { TaskAgentManager } from '../space/runtime/task-agent-manager';
-import { setupSpaceTaskSendMessageHandler } from './space-task-message-handlers';
+import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -252,7 +256,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	});
 	spaceRuntimeService.start();
 
-	// Task Agent Manager — manages Task Agent session lifecycle for space tasks
+	// Task Agent Manager — manages Task Agent session lifecycle and message injection.
+	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
+	// spaceRuntimeService.createOrGetRuntime(spaceId).
 	const taskAgentManager = new TaskAgentManager({
 		db: deps.db,
 		sessionManager: deps.sessionManager,
@@ -268,8 +274,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultModel: deps.config.defaultModel,
 	});
 
-	// space.task.sendMessage — inject a message into a Task Agent session
-	setupSpaceTaskSendMessageHandler(deps.messageHub, taskAgentManager);
+	// Human ↔ Task Agent message routing handlers (require taskAgentManager)
+	setupSpaceTaskMessageHandlers(deps.messageHub, taskAgentManager, deps.db);
 
 	// Space export/import handlers
 	setupSpaceExportImportHandlers(

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -65,7 +65,6 @@ import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
-import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -44,11 +44,8 @@ import { TaskManager } from '../room/managers/task-manager';
 import { setupDialogHandlers } from './dialog-handlers';
 // Space handlers
 import { setupSpaceHandlers } from './space-handlers';
-import {
-	setupSpaceTaskHandlers,
-	setupSpaceTaskMessageHandlers,
-	type SpaceTaskManagerFactory,
-} from './space-task-handlers';
+import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-task-handlers';
+import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
 import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -1,39 +1,129 @@
 /**
  * Space Task Message RPC Handlers
  *
- * RPC handler for sending messages to Task Agent sessions:
- * - space.task.sendMessage — inject a human or agent message into a Task Agent session
+ * RPC handlers for human ↔ Task Agent message routing:
+ * - space.task.sendMessage — inject a human message into a Task Agent session
+ * - space.task.getMessages — paginated snapshot of messages from a Task Agent session
  */
 
 import type { MessageHub } from '@neokai/shared';
-import type { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import type { Database } from '../../storage/database';
+import type { AgentSession } from '../agent/agent-session';
+import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { Logger } from '../logger';
 
 const log = new Logger('space-task-message-handlers');
 
-export function setupSpaceTaskSendMessageHandler(
-	messageHub: MessageHub,
-	taskAgentManager: TaskAgentManager
-): void {
-	// ─── space.task.sendMessage ──────────────────────────────────────────────────
-	messageHub.onRequest('space.task.sendMessage', async (data) => {
-		const params = data as { taskId: string; message: string };
+/**
+ * Minimal interface for interacting with the Task Agent manager.
+ * Decouples RPC handlers from the concrete TaskAgentManager class.
+ */
+export interface TaskAgentManagerInterface {
+	/** Inject a message into the Task Agent session for the given task. */
+	injectTaskAgentMessage(taskId: string, message: string): Promise<void>;
+	/** Returns the live AgentSession for the given task, or undefined if not spawned. */
+	getTaskAgent(taskId: string): AgentSession | undefined;
+}
 
+/**
+ * Register RPC handlers for human ↔ Task Agent message routing.
+ *
+ * Separate from `setupSpaceTaskHandlers` because it requires a live
+ * `TaskAgentManager` instance, which is created after `SpaceRuntimeService`.
+ *
+ * Handlers:
+ *   space.task.sendMessage  — inject a human message into a Task Agent session
+ *   space.task.getMessages  — paginated snapshot of messages from a Task Agent session
+ */
+export function setupSpaceTaskMessageHandlers(
+	messageHub: MessageHub,
+	taskAgentManager: TaskAgentManagerInterface,
+	db: Database
+): void {
+	const taskRepo = new SpaceTaskRepository(db.getDatabase());
+
+	// ─── space.task.sendMessage ─────────────────────────────────────────────────
+	messageHub.onRequest('space.task.sendMessage', async (data) => {
+		const params = data as { spaceId: string; taskId: string; message: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
 		if (!params.taskId) {
 			throw new Error('taskId is required');
 		}
 		if (!params.message || params.message.trim() === '') {
 			throw new Error('message is required');
 		}
+		if (params.message.length > 10_000) {
+			throw new Error('Message is too long (max 10,000 characters)');
+		}
 
-		// Delegate directly to injectTaskAgentMessage — it is the single authoritative
-		// gate that throws "Task Agent session not found" if the session no longer exists.
-		// A separate isTaskAgentAlive pre-check would introduce a TOCTOU race: a
-		// concurrent cleanupAll() (e.g., triggered by daemon shutdown) could remove the
-		// session between the check and the injection call.
+		// Validate task exists and belongs to the given space
+		const task = taskRepo.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (task.spaceId !== params.spaceId) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (!task.taskAgentSessionId) {
+			throw new Error(`Task Agent session not started for task: ${params.taskId}`);
+		}
+
 		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message);
 		log.info(`space.task.sendMessage: injected message into task ${params.taskId}`);
 
 		return { ok: true };
+	});
+
+	// ─── space.task.getMessages ─────────────────────────────────────────────────
+	messageHub.onRequest('space.task.getMessages', async (data) => {
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			cursor?: string;
+			limit?: number;
+		};
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.taskId) {
+			throw new Error('taskId is required');
+		}
+
+		// Validate task exists and belongs to the given space
+		const task = taskRepo.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (task.spaceId !== params.spaceId) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (!task.taskAgentSessionId) {
+			throw new Error(`Task Agent session not started for task: ${params.taskId}`);
+		}
+
+		const sessionId = task.taskAgentSessionId;
+		const limit = Math.max(1, Math.min(params.limit ?? 50, 200));
+
+		// Parse cursor as a numeric timestamp for the `before` DB filter
+		let before: number | undefined;
+		if (params.cursor) {
+			const parsed = Number(params.cursor);
+			if (!Number.isNaN(parsed)) {
+				before = parsed;
+			}
+		}
+
+		// Prefer reading from the live in-memory session (if the Task Agent is active),
+		// falling back to the DB for completed or restarted sessions.
+		const liveSession = taskAgentManager.getTaskAgent(params.taskId);
+		const { messages, hasMore } = liveSession
+			? liveSession.getSDKMessages(limit, before)
+			: db.getSDKMessages(sessionId, limit, before);
+
+		return { messages, hasMore, sessionId };
 	});
 }

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -415,9 +415,9 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 		it('throws when taskId is missing', async () => {
 			setup(mockTaskWithSession);
-			await expect(
-				call('space.task.getMessages', { spaceId: 'space-1' })
-			).rejects.toThrow('taskId is required');
+			await expect(call('space.task.getMessages', { spaceId: 'space-1' })).rejects.toThrow(
+				'taskId is required'
+			);
 		});
 
 		it('throws when task is not found', async () => {

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -1,20 +1,69 @@
 /**
- * Tests for space.task.sendMessage RPC handler
+ * Tests for Space Task Message RPC Handlers
  *
  * Covers:
- * - Happy path: message injected into active Task Agent session
- * - Error: missing taskId
- * - Error: empty / whitespace-only message
- * - Error: no active Task Agent session (injectTaskAgentMessage throws)
- * - No TOCTOU pre-check: handler delegates entirely to injectTaskAgentMessage
+ * - space.task.sendMessage: happy path, missing params, task not found,
+ *   no Task Agent session, TaskAgentManager error propagation,
+ *   cross-space isolation, message length validation
+ * - space.task.getMessages: happy path (live session), fallback to DB,
+ *   cursor parsing, limit capping, missing params, task not found,
+ *   no Task Agent session, cross-space isolation
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
 import { MessageHub } from '@neokai/shared';
-import { setupSpaceTaskSendMessageHandler } from '../../../src/lib/rpc-handlers/space-task-message-handlers';
-import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager';
+import type { SpaceTask } from '@neokai/shared';
+import type { SDKMessage } from '@neokai/shared/sdk';
+import {
+	setupSpaceTaskMessageHandlers,
+	type TaskAgentManagerInterface,
+} from '../../../src/lib/rpc-handlers/space-task-message-handlers';
+import type { Database } from '../../../src/storage/database';
+import type { AgentSession } from '../../../src/lib/agent/agent-session';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockTaskWithSession: SpaceTask = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	title: 'Test Task',
+	description: 'A task description',
+	status: 'in_progress',
+	priority: 'normal',
+	dependsOn: [],
+	taskAgentSessionId: 'space:space-1:task:task-1',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockTaskWithoutSession: SpaceTask = {
+	id: 'task-2',
+	spaceId: 'space-1',
+	title: 'Pending Task',
+	description: 'Not yet spawned',
+	status: 'pending',
+	priority: 'normal',
+	dependsOn: [],
+	taskAgentSessionId: undefined,
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockSDKMessages: SDKMessage[] = [
+	{
+		type: 'user',
+		uuid: 'msg-1' as import('crypto').UUID,
+		session_id: 'space:space-1:task:task-1',
+		parent_tool_use_id: null,
+		message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+	},
+] as unknown as SDKMessage[];
+
+// ─── Mock helpers ────────────────────────────────────────────────────────────
 
 function createMockMessageHub(): {
 	hub: MessageHub;
@@ -22,87 +71,373 @@ function createMockMessageHub(): {
 } {
 	const handlers = new Map<string, RequestHandler>();
 	const hub = {
-		onRequest: (name: string, handler: RequestHandler) => {
-			handlers.set(name, handler);
-		},
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
 	} as unknown as MessageHub;
 	return { hub, handlers };
 }
 
-function createMockTaskAgentManager(overrides?: Partial<TaskAgentManager>): TaskAgentManager {
+function createMockAgentSession(messages = mockSDKMessages): Partial<AgentSession> {
 	return {
-		injectTaskAgentMessage: mock(() => Promise.resolve()),
-		...overrides,
-	} as unknown as TaskAgentManager;
+		getSDKMessages: mock((_limit?: number, _before?: number) => ({
+			messages,
+			hasMore: false,
+		})),
+	};
 }
 
-describe('setupSpaceTaskSendMessageHandler', () => {
+function createMockTaskAgentManager(
+	liveSession: Partial<AgentSession> | null = null
+): TaskAgentManagerInterface {
+	return {
+		injectTaskAgentMessage: mock(async (_taskId: string, _message: string) => {}),
+		getTaskAgent: mock((_taskId: string) => (liveSession ?? undefined) as AgentSession | undefined),
+	};
+}
+
+function createMockDatabase(
+	task: SpaceTask | null,
+	dbMessages: SDKMessage[] = mockSDKMessages
+): Database {
+	return {
+		getDatabase: mock(() => ({
+			prepare: mock((_sql: string) => ({
+				get: mock((_id: string) => {
+					if (!task) return undefined;
+					// Simulate the repository row format
+					return {
+						id: task.id,
+						space_id: task.spaceId,
+						title: task.title,
+						description: task.description,
+						status: task.status,
+						priority: task.priority,
+						depends_on: '[]',
+						task_agent_session_id: task.taskAgentSessionId ?? null,
+						workflow_step_id: null,
+						workflow_run_id: null,
+						result: null,
+						error: null,
+						archived_at: null,
+						created_at: task.createdAt,
+						updated_at: task.updatedAt,
+					};
+				}),
+			})),
+		})),
+		getSDKMessages: mock((_sessionId: string, _limit?: number, _before?: number) => ({
+			messages: dbMessages,
+			hasMore: false,
+		})),
+	} as unknown as Database;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('setupSpaceTaskMessageHandlers', () => {
 	let hub: MessageHub;
 	let handlers: Map<string, RequestHandler>;
-	let taskAgentManager: TaskAgentManager;
+	let taskAgentManager: TaskAgentManagerInterface;
+	let db: Database;
 
-	beforeEach(() => {
-		({ hub, handlers } = createMockMessageHub());
-		taskAgentManager = createMockTaskAgentManager();
-		setupSpaceTaskSendMessageHandler(hub, taskAgentManager);
-	});
+	/**
+	 * Sets up all mocks and registers handlers.
+	 * @param task       Task to return from repository (null = "not found")
+	 * @param liveSession Live AgentSession to return from getTaskAgent (null = not in memory)
+	 */
+	function setup(
+		task: SpaceTask | null = mockTaskWithSession,
+		liveSession: Partial<AgentSession> | null = null
+	) {
+		const mh = createMockMessageHub();
+		hub = mh.hub;
+		handlers = mh.handlers;
+		taskAgentManager = createMockTaskAgentManager(liveSession);
+		db = createMockDatabase(task);
+		setupSpaceTaskMessageHandlers(hub, taskAgentManager, db);
+	}
 
-	it('registers space.task.sendMessage handler', () => {
-		expect(handlers.has('space.task.sendMessage')).toBe(true);
-	});
+	const call = (method: string, data: unknown) => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for ${method}`);
+		return handler(data);
+	};
 
-	it('injects message and returns { ok: true }', async () => {
-		const handler = handlers.get('space.task.sendMessage')!;
-		const result = await handler({ taskId: 'task-1', message: 'hello' });
+	// ─── Registration ──────────────────────────────────────────────────────────
 
-		expect(result).toEqual({ ok: true });
-		expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith('task-1', 'hello');
-	});
+	describe('handler registration', () => {
+		beforeEach(() => setup());
 
-	it('does not call isTaskAgentAlive (no TOCTOU pre-check)', async () => {
-		// The handler must not call isTaskAgentAlive — the single authoritative gate
-		// is injectTaskAgentMessage itself, which avoids a TOCTOU race with cleanupAll().
-		const isAliveMock = mock(() => true);
-		taskAgentManager = createMockTaskAgentManager({
-			isTaskAgentAlive: isAliveMock,
+		it('registers space.task.sendMessage handler', () => {
+			expect(handlers.has('space.task.sendMessage')).toBe(true);
 		});
-		const { hub: hub2, handlers: handlers2 } = createMockMessageHub();
-		setupSpaceTaskSendMessageHandler(hub2, taskAgentManager);
 
-		await handlers2.get('space.task.sendMessage')!({ taskId: 'task-1', message: 'hi' });
-		expect(isAliveMock).not.toHaveBeenCalled();
-	});
-
-	it('throws when taskId is missing', async () => {
-		const handler = handlers.get('space.task.sendMessage')!;
-		await expect(handler({ message: 'hello' })).rejects.toThrow('taskId is required');
-	});
-
-	it('throws when message is empty', async () => {
-		const handler = handlers.get('space.task.sendMessage')!;
-		await expect(handler({ taskId: 'task-1', message: '' })).rejects.toThrow('message is required');
-	});
-
-	it('throws when message is whitespace only', async () => {
-		const handler = handlers.get('space.task.sendMessage')!;
-		await expect(handler({ taskId: 'task-1', message: '   ' })).rejects.toThrow(
-			'message is required'
-		);
-	});
-
-	it('propagates error from injectTaskAgentMessage when session does not exist', async () => {
-		// The authoritative error comes from injectTaskAgentMessage, not a pre-check.
-		taskAgentManager = createMockTaskAgentManager({
-			injectTaskAgentMessage: mock(() =>
-				Promise.reject(new Error('Task Agent session not found for task task-missing'))
-			),
+		it('registers space.task.getMessages handler', () => {
+			expect(handlers.has('space.task.getMessages')).toBe(true);
 		});
-		const { hub: hub2, handlers: handlers2 } = createMockMessageHub();
-		setupSpaceTaskSendMessageHandler(hub2, taskAgentManager);
+	});
 
-		const handler = handlers2.get('space.task.sendMessage')!;
-		await expect(handler({ taskId: 'task-missing', message: 'hello' })).rejects.toThrow(
-			'Task Agent session not found for task task-missing'
-		);
+	// ─── space.task.sendMessage ────────────────────────────────────────────────
+
+	describe('space.task.sendMessage', () => {
+		beforeEach(() => setup());
+
+		it('injects a message and returns { ok: true }', async () => {
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue',
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Please continue'
+			);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(
+				call('space.task.sendMessage', { taskId: 'task-1', message: 'Hello' })
+			).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', message: 'Hello' })
+			).rejects.toThrow('taskId is required');
+		});
+
+		it('throws when message is missing', async () => {
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', taskId: 'task-1' })
+			).rejects.toThrow('message is required');
+		});
+
+		it('throws when message is whitespace-only', async () => {
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', taskId: 'task-1', message: '   ' })
+			).rejects.toThrow('message is required');
+		});
+
+		it('throws when message exceeds 10,000 characters', async () => {
+			const longMessage = 'x'.repeat(10_001);
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: longMessage,
+				})
+			).rejects.toThrow('Message is too long');
+		});
+
+		it('throws when task is not found', async () => {
+			setup(null);
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', taskId: 'ghost', message: 'Hello' })
+			).rejects.toThrow('Task not found: ghost');
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
+		});
+
+		it('throws when taskId belongs to a different space (cross-space isolation)', async () => {
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-other',
+					taskId: 'task-1',
+					message: 'Hello',
+				})
+			).rejects.toThrow('Task not found: task-1');
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
+		});
+
+		it('throws when Task Agent session is not started (no taskAgentSessionId)', async () => {
+			setup(mockTaskWithoutSession);
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', taskId: 'task-2', message: 'Hello' })
+			).rejects.toThrow('Task Agent session not started for task: task-2');
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
+		});
+
+		it('propagates errors from TaskAgentManager', async () => {
+			(taskAgentManager.injectTaskAgentMessage as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('Task Agent session not found for task task-1')
+			);
+
+			await expect(
+				call('space.task.sendMessage', { spaceId: 'space-1', taskId: 'task-1', message: 'Hello' })
+			).rejects.toThrow('Task Agent session not found');
+		});
+	});
+
+	// ─── space.task.getMessages ────────────────────────────────────────────────
+
+	describe('space.task.getMessages', () => {
+		it('returns messages from live session when Task Agent is active', async () => {
+			const liveSession = createMockAgentSession(mockSDKMessages);
+			setup(mockTaskWithSession, liveSession);
+
+			const result = await call('space.task.getMessages', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+			});
+
+			expect(result).toMatchObject({
+				messages: mockSDKMessages,
+				hasMore: false,
+				sessionId: 'space:space-1:task:task-1',
+			});
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(50, undefined);
+			expect(db.getSDKMessages).not.toHaveBeenCalled();
+		});
+
+		it('falls back to DB when Task Agent session is not in memory', async () => {
+			setup(mockTaskWithSession, null);
+			const dbMessages = mockSDKMessages;
+			(db.getSDKMessages as ReturnType<typeof mock>).mockReturnValue({
+				messages: dbMessages,
+				hasMore: false,
+			});
+
+			const result = await call('space.task.getMessages', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+			});
+
+			expect(result).toMatchObject({
+				messages: dbMessages,
+				hasMore: false,
+				sessionId: 'space:space-1:task:task-1',
+			});
+			expect(db.getSDKMessages).toHaveBeenCalledWith('space:space-1:task:task-1', 50, undefined);
+		});
+
+		it('uses default limit of 50 when not provided', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-1' });
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(50, undefined);
+		});
+
+		it('passes limit parameter to session', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-1', limit: 10 });
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(10, undefined);
+		});
+
+		it('caps limit at 200', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-1', limit: 999 });
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(200, undefined);
+		});
+
+		it('enforces minimum limit of 1', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-1', limit: 0 });
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(1, undefined);
+		});
+
+		it('parses numeric cursor and passes as before timestamp', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				cursor: '1700000000000',
+			});
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(50, 1700000000000);
+		});
+
+		it('ignores non-numeric cursor', async () => {
+			const liveSession = createMockAgentSession();
+			setup(mockTaskWithSession, liveSession);
+
+			await call('space.task.getMessages', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				cursor: 'invalid',
+			});
+
+			expect(liveSession.getSDKMessages).toHaveBeenCalledWith(50, undefined);
+		});
+
+		it('returns hasMore: true when session has more messages', async () => {
+			const liveSession: Partial<AgentSession> = {
+				getSDKMessages: mock(() => ({
+					messages: mockSDKMessages,
+					hasMore: true,
+				})),
+			};
+			setup(mockTaskWithSession, liveSession);
+
+			const result = (await call('space.task.getMessages', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+			})) as { hasMore: boolean };
+
+			expect(result.hasMore).toBe(true);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			setup(mockTaskWithSession);
+			await expect(call('space.task.getMessages', { taskId: 'task-1' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when taskId is missing', async () => {
+			setup(mockTaskWithSession);
+			await expect(
+				call('space.task.getMessages', { spaceId: 'space-1' })
+			).rejects.toThrow('taskId is required');
+		});
+
+		it('throws when task is not found', async () => {
+			setup(null);
+			await expect(
+				call('space.task.getMessages', { spaceId: 'space-1', taskId: 'ghost' })
+			).rejects.toThrow('Task not found: ghost');
+		});
+
+		it('throws when taskId belongs to a different space (cross-space isolation)', async () => {
+			await expect(
+				call('space.task.getMessages', { spaceId: 'space-other', taskId: 'task-1' })
+			).rejects.toThrow('Task not found: task-1');
+		});
+
+		it('throws when Task Agent session is not started (no taskAgentSessionId)', async () => {
+			setup(mockTaskWithoutSession);
+			await expect(
+				call('space.task.getMessages', { spaceId: 'space-1', taskId: 'task-2' })
+			).rejects.toThrow('Task Agent session not started for task: task-2');
+		});
 	});
 });


### PR DESCRIPTION
Adds two new RPC handlers to space-task-handlers.ts for direct human ↔
Task Agent communication:

- space.task.sendMessage: accepts {taskId, message}, validates that the
  task exists and has an active Task Agent session, then injects the
  message via TaskAgentManager.injectTaskAgentMessage()
- space.task.getMessages: accepts {taskId, cursor?, limit?}, returns a
  paginated snapshot of messages from the Task Agent session; prefers
  the live in-memory AgentSession when the Task Agent is active,
  falling back to the DB for completed or restarted sessions

Both handlers validate task existence, taskAgentSessionId presence,
and surface clear errors for task-not-found and session-not-started
cases. The new setupSpaceTaskMessageHandlers() function is separate
from setupSpaceTaskHandlers() because it requires a live
TaskAgentManager instance created after SpaceRuntimeService.

TaskAgentManager is now instantiated in rpc-handlers/index.ts after
SpaceRuntimeService, with all required dependencies wired up.

19 unit tests cover: happy paths, DB fallback, cursor parsing,
missing/invalid params, task-not-found, session-not-started, and
TaskAgentManager error propagation.
