### PR TITLE
feat: add Task Agent spawning to SpaceRuntime tick loop (Task 5.1)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -32,6 +32,7 @@ import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { TaskAgentManager } from './task-agent-manager';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { WorkflowExecutor, WorkflowTransitionError } from './workflow-executor';
 import { selectWorkflow } from './workflow-selector';
@@ -57,6 +58,15 @@ export interface SpaceRuntimeConfig {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	/** Task repository for querying tasks by run/step */
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Optional TaskAgentManager for Task Agent mode.
+	 *
+	 * When provided, SpaceRuntime spawns Task Agent sessions for pending tasks
+	 * instead of calling advance() directly. Task Agents drive the workflow
+	 * via their MCP tools. When absent, the original direct-advance behavior
+	 * is preserved for backward compatibility.
+	 */
+	taskAgentManager?: TaskAgentManager;
 	/**
 	 * Interval between executeTick() calls in milliseconds.
 	 * Used by start(). Default: 5000 (5 seconds).
@@ -563,6 +573,64 @@ export class SpaceRuntime {
 				}
 			}
 		}
+
+		// ─── Task Agent integration ───────────────────────────────────────────────
+		// When a TaskAgentManager is configured, Task Agents drive the workflow.
+		// SpaceRuntime's role here is lifecycle management only: spawn for pending
+		// tasks, check liveness, and recover from crashes. advance() is never called
+		// directly — the Task Agent calls it via the advance_workflow MCP tool.
+		if (this.config.taskAgentManager) {
+			const tam = this.config.taskAgentManager;
+
+			// Step 1: Check tasks that already have a Task Agent session (in_progress).
+			// If the agent is alive, skip this tick — it is driving the workflow.
+			// If the agent is gone (crashed/stopped), reset the task to pending so the
+			// next tick will spawn a fresh agent to resume from the current workflow state.
+			for (const task of stepTasks) {
+				if (!task.taskAgentSessionId) continue;
+
+				if (tam.isTaskAgentAlive(task.id)) {
+					return; // Task Agent is running — skip this tick entirely
+				}
+
+				// Task Agent session is gone — reset for re-spawn
+				log.warn(
+					`SpaceRuntime: task agent for task ${task.id} is gone ` +
+						`(session ${task.taskAgentSessionId}), resetting to pending for re-spawn`
+				);
+				this.config.taskRepo.updateTask(task.id, {
+					taskAgentSessionId: null,
+					status: 'pending',
+				});
+			}
+
+			// Step 2: Spawn Task Agents for pending tasks without an agent session.
+			// Re-read from DB to pick up status resets applied in Step 1.
+			const pendingTasksNeedingAgent = this.config.taskRepo
+				.listByWorkflowRun(runId)
+				.filter(
+					(t) =>
+						t.workflowStepId === currentStep.id && t.status === 'pending' && !t.taskAgentSessionId
+				);
+
+			if (pendingTasksNeedingAgent.length > 0) {
+				if (space) {
+					for (const task of pendingTasksNeedingAgent) {
+						if (tam.isSpawning(task.id)) continue; // spawn already in progress
+						try {
+							await tam.spawnTaskAgent(task, space, meta.workflow, run);
+							this.config.taskRepo.updateTask(task.id, { status: 'in_progress' });
+						} catch (err) {
+							log.error(`SpaceRuntime: failed to spawn task agent for task ${task.id}:`, err);
+						}
+					}
+				}
+			}
+
+			// Never call advance() directly — Task Agent drives the workflow.
+			return;
+		}
+		// ─────────────────────────────────────────────────────────────────────────
 
 		if (!stepTasks.every((t) => t.status === 'completed')) return;
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -583,17 +583,19 @@ export class SpaceRuntime {
 			const tam = this.config.taskAgentManager;
 
 			// Step 1: Check tasks that already have a Task Agent session (in_progress).
-			// If the agent is alive, skip this tick — it is driving the workflow.
-			// If the agent is gone (crashed/stopped), reset the task to pending so the
-			// next tick will spawn a fresh agent to resume from the current workflow state.
+			// Full loop always completes so that dead-agent resets are applied to ALL
+			// tasks before deciding whether to skip. Early-returning on the first alive
+			// agent would leave dead-agent tasks unrecovered if a step has multiple tasks.
+			let anyAgentAlive = false;
 			for (const task of stepTasks) {
 				if (!task.taskAgentSessionId) continue;
 
 				if (tam.isTaskAgentAlive(task.id)) {
-					return; // Task Agent is running — skip this tick entirely
+					anyAgentAlive = true;
+					continue; // still check remaining tasks for dead agents
 				}
 
-				// Task Agent session is gone — reset for re-spawn
+				// Task Agent session is gone — reset for re-spawn on next tick
 				log.warn(
 					`SpaceRuntime: task agent for task ${task.id} is gone ` +
 						`(session ${task.taskAgentSessionId}), resetting to pending for re-spawn`
@@ -603,6 +605,9 @@ export class SpaceRuntime {
 					status: 'pending',
 				});
 			}
+
+			// If any Task Agent is actively running, skip this tick — it drives the workflow.
+			if (anyAgentAlive) return;
 
 			// Step 2: Spawn Task Agents for pending tasks without an agent session.
 			// Re-read from DB to pick up status resets applied in Step 1.
@@ -614,10 +619,18 @@ export class SpaceRuntime {
 				);
 
 			if (pendingTasksNeedingAgent.length > 0) {
-				if (space) {
+				if (!space) {
+					// Space was deleted while the run was in progress — log and wait.
+					// The run will remain stuck until the space is restored or cancelled.
+					log.warn(
+						`SpaceRuntime: cannot spawn task agents for run ${runId} — space ${meta.spaceId} not found`
+					);
+				} else {
 					for (const task of pendingTasksNeedingAgent) {
 						if (tam.isSpawning(task.id)) continue; // spawn already in progress
 						try {
+							// spawnTaskAgent writes taskAgentSessionId to the DB as a side effect.
+							// SpaceRuntime owns the status transition to 'in_progress' after spawn.
 							await tam.spawnTaskAgent(task, space, meta.workflow, run);
 							this.config.taskRepo.updateTask(task.id, { status: 'in_progress' });
 						} catch (err) {

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1028,6 +1028,313 @@ describe('SpaceRuntime', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Task Agent integration (taskAgentManager configured)
+	// -------------------------------------------------------------------------
+
+	describe('Task Agent integration', () => {
+		/**
+		 * Minimal mock for TaskAgentManager — only implements the methods that
+		 * SpaceRuntime calls: isSpawning(), isTaskAgentAlive(), spawnTaskAgent().
+		 */
+		function makeMockTaskAgentManager(
+			overrides: {
+				isSpawning?: (taskId: string) => boolean;
+				isTaskAgentAlive?: (taskId: string) => boolean;
+				spawnTaskAgent?: (task: unknown) => Promise<string>;
+			} = {}
+		) {
+			const spawned: string[] = [];
+			return {
+				isSpawning: overrides.isSpawning ?? (() => false),
+				isTaskAgentAlive: overrides.isTaskAgentAlive ?? (() => false),
+				spawnTaskAgent:
+					overrides.spawnTaskAgent ??
+					(async (task: unknown) => {
+						const t = task as { id: string };
+						spawned.push(t.id);
+						// Simulate: spawnTaskAgent sets taskAgentSessionId in DB
+						taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+						return `session:${t.id}`;
+					}),
+				_spawned: spawned,
+			};
+		}
+
+		function buildRuntimeWithMockTAM(tam: ReturnType<typeof makeMockTaskAgentManager>) {
+			return new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				taskAgentManager: tam as never,
+			});
+		}
+
+		test('spawns Task Agent for pending task when taskAgentManager is configured', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const tam = makeMockTaskAgentManager();
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks[0].status).toBe('pending');
+
+			await rt.executeTick();
+
+			// Task Agent should have been spawned
+			expect(tam._spawned).toContain(tasks[0].id);
+			// Task should be in_progress
+			const updated = taskRepo.getTask(tasks[0].id)!;
+			expect(updated.status).toBe('in_progress');
+			expect(updated.taskAgentSessionId).toBe(`session:${tasks[0].id}`);
+		});
+
+		test('preserves direct advance() when taskAgentManager is NOT configured', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			// No taskAgentManager — runtime is the plain one from beforeEach
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			// Step B task should have been created by direct advance()
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(2);
+			expect(allTasks.find((t) => t.workflowStepId === STEP_B)).toBeDefined();
+		});
+
+		test('skips tick when Task Agent is alive (in_progress task with taskAgentSessionId)', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			let spawnCount = 0;
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: () => true, // always alive
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnCount++;
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// First tick: spawns Task Agent (no taskAgentSessionId yet)
+			await rt.executeTick();
+			expect(spawnCount).toBe(1);
+
+			// Mark task as in_progress (set by SpaceRuntime after spawn)
+			// taskAgentSessionId is already set by mock spawnTaskAgent
+			const taskAfterSpawn = taskRepo.getTask(tasks[0].id)!;
+			expect(taskAfterSpawn.taskAgentSessionId).toBeTruthy();
+
+			// Subsequent ticks: agent is alive → skip, no re-spawn
+			await rt.executeTick();
+			await rt.executeTick();
+			expect(spawnCount).toBe(1); // still only spawned once
+		});
+
+		test('does NOT advance when Task Agent mode is active (never calls advance())', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: () => false, // appears dead after spawn (returns false after 1st call)
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Mark task as completed — in TAM mode, advance() should NOT be called
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+
+			await rt.executeTick();
+
+			// No step B task should exist — SpaceRuntime never calls advance() in TAM mode
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(1);
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+		});
+
+		test('detects crashed Task Agent and resets task to pending for re-spawn', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			let callCount = 0;
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: () => false, // agent always reports as dead
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					callCount++;
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}:v${callCount}` });
+					return `session:${t.id}:v${callCount}`;
+				},
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Manually set taskAgentSessionId to simulate a previously spawned (now dead) agent
+			taskRepo.updateTask(tasks[0].id, {
+				taskAgentSessionId: 'session:dead',
+				status: 'in_progress',
+			});
+
+			// Tick: detect dead agent → reset to pending → spawn new agent
+			await rt.executeTick();
+
+			// Task should be in_progress with a fresh session
+			const updated = taskRepo.getTask(tasks[0].id)!;
+			expect(updated.status).toBe('in_progress');
+			expect(updated.taskAgentSessionId).toContain('v1');
+			expect(callCount).toBe(1); // spawned once for recovery
+		});
+
+		test('concurrency guard: isSpawning() prevents duplicate spawns during concurrent ticks', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			let spawnCount = 0;
+			const spawningSet = new Set<string>();
+			const tam = makeMockTaskAgentManager({
+				isSpawning: (taskId: string) => spawningSet.has(taskId),
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnCount++;
+					spawningSet.add(t.id);
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					spawningSet.delete(t.id);
+					return `session:${t.id}`;
+				},
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Simulate concurrent tick while first is "spawning"
+			spawningSet.add(tasks[0].id); // pretend spawn is in progress
+
+			await rt.executeTick();
+
+			// No additional spawn should happen while isSpawning() returns true
+			expect(spawnCount).toBe(0);
+		});
+
+		test('idempotent spawn: pending task without taskAgentSessionId only spawns once per tick', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+				{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+			]);
+
+			let spawnCount = 0;
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: (taskId: string) => {
+					// Alive after spawn (taskAgentSessionId is set)
+					const task = taskRepo.getTask(taskId);
+					return !!task?.taskAgentSessionId;
+				},
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnCount++;
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Multiple ticks — should only spawn once (agent is alive after first spawn)
+			await rt.executeTick();
+			await rt.executeTick();
+			await rt.executeTick();
+
+			expect(spawnCount).toBe(1);
+			// Task should still be in_progress
+			expect(taskRepo.getTask(tasks[0].id)!.status).toBe('in_progress');
+		});
+
+		test('new pending task from next workflow step gets a fresh Task Agent spawned', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const spawnedTasks: string[] = [];
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: (taskId: string) => {
+					const task = taskRepo.getTask(taskId);
+					return !!task?.taskAgentSessionId;
+				},
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnedTasks.push(t.id);
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Tick 1: spawns Task Agent for step A
+			await rt.executeTick();
+			expect(spawnedTasks).toContain(tasks[0].id);
+
+			// Simulate Task Agent completing step A:
+			// - calls advance_workflow → creates step B task (pending, no taskAgentSessionId)
+			// - calls report_result → marks step A task as completed
+			// - advance() creates the step B task and advances the run's currentStepId
+			taskRepo.updateTask(tasks[0].id, { status: 'completed', taskAgentSessionId: null });
+			// Manually call advance to simulate Task Agent's advance_workflow tool
+			await rt.getExecutor(run.id)!.advance();
+
+			const stepBTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+
+			// Tick 2: should spawn Task Agent for step B
+			await rt.executeTick();
+			expect(spawnedTasks).toContain(stepBTask!.id);
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// seedPresetAgents + seedBuiltInWorkflows wiring (space-handlers)
 	// -------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1035,6 +1035,11 @@ describe('SpaceRuntime', () => {
 		/**
 		 * Minimal mock for TaskAgentManager — only implements the methods that
 		 * SpaceRuntime calls: isSpawning(), isTaskAgentAlive(), spawnTaskAgent().
+		 *
+		 * The default spawnTaskAgent mirrors the real TaskAgentManager's DB side-effect:
+		 * it writes taskAgentSessionId to the task row. SpaceRuntime relies on this
+		 * contract and only writes status: 'in_progress' itself. If this side-effect
+		 * were absent, the liveness check (Step 1) would never fire for the task.
 		 */
 		function makeMockTaskAgentManager(
 			overrides: {
@@ -1052,7 +1057,7 @@ describe('SpaceRuntime', () => {
 					(async (task: unknown) => {
 						const t = task as { id: string };
 						spawned.push(t.id);
-						// Simulate: spawnTaskAgent sets taskAgentSessionId in DB
+						// Mirror real TaskAgentManager: writes taskAgentSessionId as a side-effect
 						taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
 						return `session:${t.id}`;
 					}),
@@ -1060,10 +1065,16 @@ describe('SpaceRuntime', () => {
 			};
 		}
 
-		function buildRuntimeWithMockTAM(tam: ReturnType<typeof makeMockTaskAgentManager>) {
+		function buildRuntimeWithMockTAM(
+			tam: ReturnType<typeof makeMockTaskAgentManager>,
+			overrideSpaceManager?: {
+				getSpace: (id: string) => Promise<unknown>;
+				listSpaces: () => Promise<unknown[]>;
+			}
+		) {
 			return new SpaceRuntime({
 				db,
-				spaceManager,
+				spaceManager: (overrideSpaceManager ?? spaceManager) as never,
 				spaceAgentManager: agentManager,
 				spaceWorkflowManager: workflowManager,
 				workflowRunRepo,
@@ -1216,7 +1227,7 @@ describe('SpaceRuntime', () => {
 			// Task should be in_progress with a fresh session
 			const updated = taskRepo.getTask(tasks[0].id)!;
 			expect(updated.status).toBe('in_progress');
-			expect(updated.taskAgentSessionId).toContain('v1');
+			expect(updated.taskAgentSessionId).toBe(`session:${tasks[0].id}:v1`);
 			expect(callCount).toBe(1); // spawned once for recovery
 		});
 
@@ -1331,6 +1342,106 @@ describe('SpaceRuntime', () => {
 			// Tick 2: should spawn Task Agent for step B
 			await rt.executeTick();
 			expect(spawnedTasks).toContain(stepBTask!.id);
+		});
+
+		test('logs warning and skips spawn when space is null (space deleted mid-run)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			// Start the run with the real space manager so startWorkflowRun() works.
+			const tam = makeMockTaskAgentManager({
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+			});
+			const realRt = buildRuntimeWithMockTAM(tam);
+			const { tasks } = await realRt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			let spawnCount = 0;
+			const tamForNull = makeMockTaskAgentManager({
+				spawnTaskAgent: async (task: unknown) => {
+					const t = task as { id: string };
+					spawnCount++;
+					taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+					return `session:${t.id}`;
+				},
+			});
+
+			// Build a fresh runtime that uses a null space manager for getSpace().
+			// startWorkflowRun already created the run and executor in the DB; the fresh
+			// runtime rehydrates it on first executeTick() and then hits the null space path.
+			const nullSpaceManager = {
+				getSpace: async () => null,
+				listSpaces: async () => [{ id: SPACE_ID, workspacePath: WORKSPACE }],
+			};
+			const rtWithNullSpace = buildRuntimeWithMockTAM(tamForNull, nullSpaceManager);
+
+			// executeTick() rehydrates the run but getSpace() returns null → spawn skipped
+			await rtWithNullSpace.executeTick();
+
+			// No Task Agent spawned — space is null
+			expect(spawnCount).toBe(0);
+			// Task stays pending
+			expect(taskRepo.getTask(tasks[0].id)!.status).toBe('pending');
+		});
+
+		test('liveness loop resets all dead-agent tasks before deciding to skip tick', async () => {
+			// Two tasks for the same step: task A alive, task B dead.
+			// The dead-agent reset for task B must still happen even though task A is alive.
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const tam = makeMockTaskAgentManager({
+				isTaskAgentAlive: (taskId: string) => taskId === 'task-alive',
+			});
+			const rt = buildRuntimeWithMockTAM(tam);
+
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Insert a second task for the same step directly via repo (multi-task scenario)
+			const taskB = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Plan B',
+				description: '',
+				workflowRunId: run.id,
+				workflowStepId: STEP_A,
+				status: 'in_progress',
+			});
+
+			// Simulate: task B has a dead agent session; we override its id to match mock
+			// Use DB update + a custom tam that keys liveness by taskId
+			const taskBId = taskB.id;
+			taskRepo.updateTask(taskBId, { taskAgentSessionId: 'session:dead-b' });
+
+			// Create alive task separately by injecting its id into the mock
+			const firstTask = taskRepo.listByWorkflowRun(run.id).find((t) => t.id !== taskBId)!;
+			taskRepo.updateTask(firstTask.id, {
+				taskAgentSessionId: 'session:alive-a',
+				status: 'in_progress',
+			});
+
+			// Override the mock to know which task is alive
+			const aliveId = firstTask.id;
+			const customTam = makeMockTaskAgentManager({
+				isTaskAgentAlive: (taskId: string) => taskId === aliveId,
+			});
+			const rt2 = buildRuntimeWithMockTAM(customTam);
+
+			await rt2.executeTick();
+
+			// Dead task B should have been reset to pending (dead-agent recovery happened)
+			const updatedB = taskRepo.getTask(taskBId)!;
+			expect(updatedB.status).toBe('pending');
+			expect(updatedB.taskAgentSessionId).toBeFalsy(); // cleared (null stored as undefined by repo)
+
+			// Alive task A should be untouched
+			const updatedA = taskRepo.getTask(aliveId)!;
+			expect(updatedA.status).toBe('in_progress');
+			expect(updatedA.taskAgentSessionId).toBe('session:alive-a');
 		});
 	});
 


### PR DESCRIPTION
- Add optional `taskAgentManager` field to SpaceRuntimeConfig for backward compat
- In processRunTick(), detect pending tasks with no taskAgentSessionId and spawn via TaskAgentManager
- Skip advance() entirely when TaskAgentManager is configured — Task Agent drives the workflow
- Check liveness of active Task Agent sessions; skip tick when agent is alive
- Detect dead/crashed Task Agent sessions, reset task to pending, re-spawn on next tick
- Guard concurrent ticks via isSpawning() to prevent duplicate session creation
- Add 9 unit tests covering all new behaviors:
  spawn on pending, backward-compat direct-advance, active-agent skip, no-advance in TAM mode,
  crash recovery, concurrency guard, idempotent spawn, and next-step agent spawning
