### PR TITLE
feat: wire TaskAgentManager into SpaceRuntimeService (Task 5.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -241,7 +241,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.daemonHub
 	);
 
-	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API
+	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API.
+	// Not started yet: TaskAgentManager is created next and injected before start().
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		spaceManager: deps.spaceManager,
@@ -250,7 +251,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		workflowRunRepo: spaceWorkflowRunRepo,
 		taskRepo: spaceTaskRepo,
 	});
-	spaceRuntimeService.start();
 
 	// Task Agent Manager — manages Task Agent session lifecycle and message injection.
 	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
@@ -269,6 +269,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
 	});
+
+	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn
+	// Task Agent sessions for pending tasks. Resolves circular dependency:
+	// SpaceRuntimeService → SpaceRuntime needed TaskAgentManager, which in turn
+	// needed SpaceRuntimeService. Both are now created; inject via setter.
+	spaceRuntimeService.setTaskAgentManager(taskAgentManager);
+	spaceRuntimeService.start();
 
 	// Human ↔ Task Agent message routing handlers (require taskAgentManager)
 	setupSpaceTaskMessageHandlers(deps.messageHub, taskAgentManager, deps.db);

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -16,6 +16,7 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { NotificationSink } from './notification-sink';
+import type { TaskAgentManager } from './task-agent-manager';
 import { SpaceRuntime } from './space-runtime';
 import { Logger } from '../../logger';
 
@@ -28,6 +29,15 @@ export interface SpaceRuntimeServiceConfig {
 	spaceWorkflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Optional Task Agent Manager to wire into the underlying SpaceRuntime.
+	 *
+	 * When provided, the tick loop delegates task workflow execution to Task Agent
+	 * sessions instead of calling advance() directly. If not provided at construction
+	 * time (e.g. due to circular dependency resolution), use setTaskAgentManager()
+	 * after both objects have been created.
+	 */
+	taskAgentManager?: TaskAgentManager;
 	tickIntervalMs?: number;
 }
 
@@ -37,6 +47,19 @@ export class SpaceRuntimeService {
 
 	constructor(private readonly config: SpaceRuntimeServiceConfig) {
 		this.runtime = new SpaceRuntime(config);
+	}
+
+	/**
+	 * Wire a TaskAgentManager into the underlying SpaceRuntime after construction.
+	 *
+	 * Resolves the circular dependency: SpaceRuntimeService must exist before
+	 * TaskAgentManager (which takes it as a constructor argument), so the manager
+	 * is injected back here once both are created.
+	 *
+	 * Mirrors the setNotificationSink() pattern.
+	 */
+	setTaskAgentManager(manager: TaskAgentManager): void {
+		this.runtime.setTaskAgentManager(manager);
 	}
 
 	/** Start the underlying SpaceRuntime tick loop. */

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -172,6 +172,19 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Wire a TaskAgentManager into the runtime after construction.
+	 *
+	 * Called after construction to resolve the circular dependency:
+	 * SpaceRuntimeService is created first (so TaskAgentManager can reference it),
+	 * then TaskAgentManager is created, then it is injected back here.
+	 * Once set, the tick loop will use Task Agent sessions to drive workflow execution
+	 * instead of calling advance() directly.
+	 */
+	setTaskAgentManager(manager: TaskAgentManager): void {
+		this.config.taskAgentManager = manager;
+	}
+
+	/**
 	 * Safely calls notificationSink.notify(), catching and logging any errors.
 	 *
 	 * By interface contract, NotificationSink implementations should handle their

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -7,6 +7,7 @@
  * - createOrGetRuntime(): returns the same runtime on repeated calls
  * - stopRuntime(): is a no-op (doesn't throw)
  * - start() / stop() lifecycle: idempotent, starts/stops underlying runtime
+ * - setTaskAgentManager(): wires TaskAgentManager into the underlying SpaceRuntime
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
@@ -20,6 +21,7 @@ import type { SpaceAgentManager } from '../../../src/lib/space/managers/space-ag
 import type { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import type { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import type { TaskAgentManager } from '../../../src/lib/space/runtime/task-agent-manager.ts';
 import type {
 	NotificationSink,
 	SpaceNotificationEvent,
@@ -161,6 +163,43 @@ describe('SpaceRuntimeService', () => {
 		test('method exists and is callable', () => {
 			// Verify the delegation method is present on SpaceRuntimeService
 			expect(typeof service.setNotificationSink).toBe('function');
+		});
+	});
+
+	// ─── setTaskAgentManager ─────────────────────────────────────────────────
+
+	describe('setTaskAgentManager()', () => {
+		test('method exists and is callable', () => {
+			expect(typeof service.setTaskAgentManager).toBe('function');
+		});
+
+		test('accepts a TaskAgentManager without throwing', () => {
+			const mockManager = {} as TaskAgentManager;
+			expect(() => service.setTaskAgentManager(mockManager)).not.toThrow();
+		});
+
+		test('delegates to the underlying SpaceRuntime', () => {
+			const mockManager = {} as TaskAgentManager;
+			// Access the private runtime to verify propagation
+			const runtime = (
+				service as unknown as { runtime: { config: { taskAgentManager?: TaskAgentManager } } }
+			).runtime;
+			expect(runtime.config.taskAgentManager).toBeUndefined();
+			service.setTaskAgentManager(mockManager);
+			expect(runtime.config.taskAgentManager).toBe(mockManager);
+		});
+
+		test('config.taskAgentManager is passed to SpaceRuntime when provided at construction', () => {
+			const mockManager = {} as TaskAgentManager;
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfig(spaceManager),
+				taskAgentManager: mockManager,
+			};
+			const svc = new SpaceRuntimeService(config);
+			const runtime = (
+				svc as unknown as { runtime: { config: { taskAgentManager?: TaskAgentManager } } }
+			).runtime;
+			expect(runtime.config.taskAgentManager).toBe(mockManager);
 		});
 	});
 


### PR DESCRIPTION
- Add `taskAgentManager?` field to `SpaceRuntimeServiceConfig` so the
  manager can optionally be provided at construction time
- Add `setTaskAgentManager()` to `SpaceRuntime` (post-construction
  setter, mirrors `setNotificationSink()` pattern) — writes directly
  into the config so the tick loop picks it up immediately
- Add `setTaskAgentManager()` to `SpaceRuntimeService` that delegates
  to the underlying `SpaceRuntime`
- In `rpc-handlers/index.ts`: move `spaceRuntimeService.start()` to
  after `TaskAgentManager` is created, then inject the manager via
  `setTaskAgentManager()` before starting — resolves the circular
  dependency (SpaceRuntimeService created first so TaskAgentManager can
  reference it, then injected back via setter)
- 4 new unit tests verifying the wiring: method existence, no-throw,
  delegation to SpaceRuntime, and config-level propagation
