### PR TITLE
feat: add task completion notification to Space Agent (Task 6.2)

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -436,6 +436,28 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		task: import('@neokai/shared').SpaceTask;
 	};
 
+	// Space Task Agent completion events (use 'global' as sessionId)
+	/** Emitted by report_result when a Task Agent marks a task as completed. */
+	'space.task.completed': {
+		sessionId: string;
+		taskId: string;
+		spaceId: string;
+		status: string;
+		summary: string;
+		workflowRunId: string;
+		taskTitle: string;
+	};
+	/** Emitted by report_result when a Task Agent marks a task as needs_attention or cancelled. */
+	'space.task.failed': {
+		sessionId: string;
+		taskId: string;
+		spaceId: string;
+		status: string;
+		summary: string;
+		workflowRunId: string;
+		taskTitle: string;
+	};
+
 	// Space workflow run events (global events - use 'global' as sessionId)
 	'space.workflowRun.created': {
 		sessionId: string;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -338,6 +338,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			workflowRunRepo: spaceWorkflowRunRepo,
 			db: deps.db.getDatabase(),
 			state: globalSpacesState,
+			daemonHub: deps.daemonHub,
 		}).catch((error) => {
 			log.error('Failed to provision global spaces agent:', error);
 		});

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -27,6 +27,17 @@ import type { SessionFactory } from '../room/runtime/task-group-manager';
 const GLOBAL_SESSION_ID = 'spaces:global';
 const log = new Logger('global-spaces-agent');
 
+/**
+ * Unsubscribe handles for the task event subscriptions registered by the most recent
+ * `provisionGlobalSpacesAgent` call. Stored at module level so a second call (e.g. on
+ * daemon restart / error recovery) can clean up the previous listeners before re-subscribing,
+ * preventing duplicate notifications.
+ *
+ * Note: these subscriptions are intentionally daemon-lifetime; they are never unsubscribed
+ * during normal operation. The module-level store only exists to guard against double-init.
+ */
+let _taskEventUnsubs: Array<() => void> = [];
+
 export interface ProvisionGlobalSpacesAgentDeps {
 	sessionManager: SessionManager;
 	spaceManager: SpaceManager;
@@ -49,6 +60,10 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	 * DaemonHub for subscribing to task completion/failure events emitted by Task Agents.
 	 * When provided, the global Space Agent session receives notification messages when tasks
 	 * complete or fail via `space.task.completed` / `space.task.failed` events.
+	 *
+	 * The subscription routes all space task events to the single `spaces:global` session,
+	 * which is intentional: the global agent manages tasks across all spaces. The notification
+	 * message includes the spaceId and taskId so the agent can act on specific tasks.
 	 */
 	daemonHub?: DaemonHub;
 }
@@ -136,9 +151,21 @@ export async function provisionGlobalSpacesAgent(
 	// Subscribe to task completion/failure events from Task Agents.
 	// When a task completes or fails, inject a notification message into the Space Agent session
 	// so it can take appropriate action (start next task, alert the user, etc.).
+	//
+	// All space task events are routed to the single spaces:global session — the global agent
+	// manages tasks across all spaces. Each message includes spaceId and taskId so the agent
+	// can reference tasks in follow-up tool calls (e.g. get_task_detail).
+	//
+	// Guard against double-init: clean up any previous subscriptions before re-subscribing.
 	if (daemonHub) {
-		daemonHub.on('space.task.completed', (event) => {
-			const message = `Task '${event.taskTitle}' has completed. Summary: ${event.summary}`;
+		_taskEventUnsubs.forEach((unsub) => unsub());
+		_taskEventUnsubs = [];
+
+		const unsubCompleted = daemonHub.on('space.task.completed', (event) => {
+			const summaryPart = event.summary ? ` Summary: ${event.summary}` : '';
+			const message =
+				`Task '${event.taskTitle}' (taskId: ${event.taskId}, spaceId: ${event.spaceId}) ` +
+				`has completed.${summaryPart}`;
 			void sessionFactory
 				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
 				.catch((err) => {
@@ -148,9 +175,12 @@ export async function provisionGlobalSpacesAgent(
 				});
 		});
 
-		daemonHub.on('space.task.failed', (event) => {
+		const unsubFailed = daemonHub.on('space.task.failed', (event) => {
 			const statusLabel = event.status === 'cancelled' ? 'cancelled' : 'failed';
-			const message = `Task '${event.taskTitle}' has ${statusLabel}. Summary: ${event.summary}`;
+			const summaryPart = event.summary ? ` Summary: ${event.summary}` : '';
+			const message =
+				`Task '${event.taskTitle}' (taskId: ${event.taskId}, spaceId: ${event.spaceId}) ` +
+				`has ${statusLabel}.${summaryPart}`;
 			void sessionFactory
 				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
 				.catch((err) => {
@@ -160,6 +190,7 @@ export async function provisionGlobalSpacesAgent(
 				});
 		});
 
+		_taskEventUnsubs = [unsubCompleted, unsubFailed];
 		log.info('Subscribed to space.task.completed and space.task.failed events');
 	}
 

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -17,6 +17,7 @@ import type { SpaceWorkflowManager } from './managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import type { SpaceRuntimeService } from './runtime/space-runtime-service';
+import type { DaemonHub } from '../daemon-hub';
 import { Logger } from '../logger';
 import { buildGlobalSpacesAgentPrompt } from './agents/global-spaces-agent';
 import { createGlobalSpacesMcpServer, type GlobalSpacesState } from './tools/global-spaces-tools';
@@ -44,6 +45,12 @@ export interface ProvisionGlobalSpacesAgentDeps {
 	db: BunDatabase;
 	/** Shared mutable state for the active space context. Created externally so RPC handlers can use the same reference. */
 	state: GlobalSpacesState;
+	/**
+	 * DaemonHub for subscribing to task completion/failure events emitted by Task Agents.
+	 * When provided, the global Space Agent session receives notification messages when tasks
+	 * complete or fail via `space.task.completed` / `space.task.failed` events.
+	 */
+	daemonHub?: DaemonHub;
 }
 
 /**
@@ -67,6 +74,7 @@ export async function provisionGlobalSpacesAgent(
 		workflowRunRepo,
 		db,
 		state,
+		daemonHub,
 	} = deps;
 
 	// Get the shared runtime (no specific space context needed for the global agent)
@@ -124,6 +132,36 @@ export async function provisionGlobalSpacesAgent(
 		'global-spaces-tools': mcpServer as unknown as McpServerConfig,
 	});
 	existingSession.setRuntimeSystemPrompt(buildGlobalSpacesAgentPrompt());
+
+	// Subscribe to task completion/failure events from Task Agents.
+	// When a task completes or fails, inject a notification message into the Space Agent session
+	// so it can take appropriate action (start next task, alert the user, etc.).
+	if (daemonHub) {
+		daemonHub.on('space.task.completed', (event) => {
+			const message = `Task '${event.taskTitle}' has completed. Summary: ${event.summary}`;
+			void sessionFactory
+				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
+				.catch((err) => {
+					log.warn(
+						`Failed to inject task.completed notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`
+					);
+				});
+		});
+
+		daemonHub.on('space.task.failed', (event) => {
+			const statusLabel = event.status === 'cancelled' ? 'cancelled' : 'failed';
+			const message = `Task '${event.taskTitle}' has ${statusLabel}. Summary: ${event.summary}`;
+			void sessionFactory
+				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
+				.catch((err) => {
+					log.warn(
+						`Failed to inject task.failed notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`
+					);
+				});
+		});
+
+		log.info('Subscribed to space.task.completed and space.task.failed events');
+	}
 
 	log.info('Global spaces agent session provisioned');
 }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -266,6 +266,7 @@ export class TaskAgentManager {
 					this.injectSubSessionMessage(subSessionId, message),
 				onSubSessionComplete: (stepId, subSessionId) =>
 					this.handleSubSessionComplete(taskId, stepId, subSessionId),
+				daemonHub: this.config.daemonHub,
 			});
 
 			// setRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'node:crypto';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { Space } from '@neokai/shared';
 import type { DaemonHub } from '../../daemon-hub';
+import { Logger } from '../../logger';
 import type { AgentSessionInit } from '../../agent/agent-session';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import { WorkflowGateError } from '../runtime/workflow-executor';
@@ -51,6 +52,8 @@ import type {
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
+
+const log = new Logger('task-agent-tools');
 
 // ---------------------------------------------------------------------------
 // Sub-session state
@@ -648,8 +651,10 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 						taskTitle: mainTask.title,
 					};
 					const eventName = status === 'completed' ? 'space.task.completed' : 'space.task.failed';
-					void daemonHub.emit(eventName, eventPayload).catch(() => {
-						// Non-fatal — event emission must not block or throw
+					void daemonHub.emit(eventName, eventPayload).catch((err) => {
+						log.warn(
+							`Failed to emit ${eventName} for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+						);
 					});
 				}
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -22,6 +22,7 @@
 import { randomUUID } from 'node:crypto';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { Space } from '@neokai/shared';
+import type { DaemonHub } from '../../daemon-hub';
 import type { AgentSessionInit } from '../../agent/agent-session';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import { WorkflowGateError } from '../runtime/workflow-executor';
@@ -140,6 +141,11 @@ export interface TaskAgentToolsConfig {
 	 * The Task Agent handler registers this as the session completion callback.
 	 */
 	onSubSessionComplete: (stepId: string, sessionId: string) => Promise<void>;
+	/**
+	 * DaemonHub instance for emitting task completion/failure events.
+	 * Optional — if omitted, no events are emitted (e.g. in unit tests that don't need them).
+	 */
+	daemonHub?: DaemonHub;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +171,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		sessionFactory,
 		messageInjector,
 		onSubSessionComplete,
+		daemonHub,
 	} = config;
 
 	return {
@@ -628,6 +635,23 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					result: summary,
 					error: errorDetail,
 				});
+
+				// Emit DaemonHub event so the Space Agent is notified of task completion/failure.
+				if (daemonHub) {
+					const eventPayload = {
+						sessionId: 'global',
+						taskId,
+						spaceId: space.id,
+						status,
+						summary: summary ?? '',
+						workflowRunId,
+						taskTitle: mainTask.title,
+					};
+					const eventName = status === 'completed' ? 'space.task.completed' : 'space.task.failed';
+					void daemonHub.emit(eventName, eventPayload).catch(() => {
+						// Non-fatal — event emission must not block or throw
+					});
+				}
 
 				return jsonResult({
 					success: true,

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -45,6 +45,7 @@ import type { SpaceWorkflowRunRepository as ISpaceWorkflowRunRepository } from '
 import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import type { MessageDeliveryMode } from '@neokai/shared';
 import type { NotificationSink } from '../../../src/lib/space/runtime/notification-sink.ts';
+import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 
 // ---------------------------------------------------------------------------
 // Expected tool lists (Task 5.3)
@@ -689,5 +690,184 @@ describe('createGlobalSpacesMcpServer — MCP instance tool registration', () =>
 		});
 		const registeredNames = getRegisteredToolNames(server);
 		expect(registeredNames).toHaveLength(EXPECTED_TOOLS.length);
+	});
+});
+
+// ===========================================================================
+// Task 6.2 — space.task.completed / space.task.failed subscription tests
+// ===========================================================================
+
+/** Build a controllable mock DaemonHub that records subscriptions and allows triggering them. */
+function makeMockDaemonHubForProvision(): {
+	hub: DaemonHub;
+	trigger: (
+		event: 'space.task.completed' | 'space.task.failed',
+		payload: Record<string, unknown>
+	) => Promise<void>;
+} {
+	const handlers = new Map<
+		string,
+		Array<(payload: Record<string, unknown>) => void | Promise<void>>
+	>();
+
+	const hub = {
+		emit: mock(async () => {}),
+		on: mock(
+			(event: string, handler: (payload: Record<string, unknown>) => void | Promise<void>) => {
+				if (!handlers.has(event)) handlers.set(event, []);
+				handlers.get(event)!.push(handler);
+				return () => {};
+			}
+		),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+
+	async function trigger(
+		event: 'space.task.completed' | 'space.task.failed',
+		payload: Record<string, unknown>
+	): Promise<void> {
+		const eventHandlers = handlers.get(event) ?? [];
+		for (const handler of eventHandlers) {
+			await handler(payload);
+		}
+	}
+
+	return { hub, trigger };
+}
+
+describe('provisionGlobalSpacesAgent — task completion event subscriptions', () => {
+	let db: BunDatabase;
+	let dir: string;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('subscribes to space.task.completed and space.task.failed when daemonHub is provided', async () => {
+		const { hub } = makeMockDaemonHubForProvision();
+		const deps = buildDeps(db);
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
+
+		const onMock = hub.on as ReturnType<typeof mock>;
+		const subscribedEvents = onMock.mock.calls.map((call: unknown[]) => call[0] as string);
+		expect(subscribedEvents).toContain('space.task.completed');
+		expect(subscribedEvents).toContain('space.task.failed');
+	});
+
+	test('does not subscribe when daemonHub is not provided', async () => {
+		const deps = buildDeps(db);
+		// No daemonHub — should not throw and should not subscribe
+		await expect(provisionGlobalSpacesAgent(deps)).resolves.toBeUndefined();
+	});
+
+	test('injects completed notification into global session when space.task.completed fires', async () => {
+		const sessionFactory = makeMockSessionFactory();
+		const { hub, trigger } = makeMockDaemonHubForProvision();
+		const deps = buildDeps(db, { sessionFactory });
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
+
+		await trigger('space.task.completed', {
+			sessionId: 'global',
+			taskId: 'task-001',
+			spaceId: 'space-001',
+			status: 'completed',
+			summary: 'Feature implemented successfully.',
+			workflowRunId: 'run-001',
+			taskTitle: 'Implement login page',
+		});
+
+		// The notification should be injected into the global session
+		expect(sessionFactory.calls.length).toBeGreaterThanOrEqual(1);
+		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
+		expect(lastCall.sessionId).toBe('spaces:global');
+		expect(lastCall.message).toContain('Implement login page');
+		expect(lastCall.message).toContain('completed');
+		expect(lastCall.message).toContain('Feature implemented successfully.');
+		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
+	});
+
+	test('injects failed notification into global session when space.task.failed fires', async () => {
+		const sessionFactory = makeMockSessionFactory();
+		const { hub, trigger } = makeMockDaemonHubForProvision();
+		const deps = buildDeps(db, { sessionFactory });
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
+
+		await trigger('space.task.failed', {
+			sessionId: 'global',
+			taskId: 'task-002',
+			spaceId: 'space-001',
+			status: 'needs_attention',
+			summary: 'Tests are failing.',
+			workflowRunId: 'run-002',
+			taskTitle: 'Fix authentication bug',
+		});
+
+		expect(sessionFactory.calls.length).toBeGreaterThanOrEqual(1);
+		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
+		expect(lastCall.sessionId).toBe('spaces:global');
+		expect(lastCall.message).toContain('Fix authentication bug');
+		expect(lastCall.message).toContain('failed');
+		expect(lastCall.message).toContain('Tests are failing.');
+		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
+	});
+
+	test('uses "cancelled" label in notification when status is cancelled', async () => {
+		const sessionFactory = makeMockSessionFactory();
+		const { hub, trigger } = makeMockDaemonHubForProvision();
+		const deps = buildDeps(db, { sessionFactory });
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
+
+		await trigger('space.task.failed', {
+			sessionId: 'global',
+			taskId: 'task-003',
+			spaceId: 'space-001',
+			status: 'cancelled',
+			summary: 'User cancelled the task.',
+			workflowRunId: 'run-003',
+			taskTitle: 'Deploy to production',
+		});
+
+		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
+		expect(lastCall.message).toContain('cancelled');
+		expect(lastCall.message).toContain('Deploy to production');
+	});
+
+	test('does not throw when sessionFactory.injectMessage fails', async () => {
+		const sessionFactory = makeMockSessionFactory({ injectError: new Error('Session gone') });
+		const { hub, trigger } = makeMockDaemonHubForProvision();
+		const deps = buildDeps(db, { sessionFactory });
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub });
+
+		// Should not throw even when injection fails
+		await expect(
+			trigger('space.task.completed', {
+				sessionId: 'global',
+				taskId: 'task-004',
+				spaceId: 'space-001',
+				status: 'completed',
+				summary: 'Done.',
+				workflowRunId: 'run-004',
+				taskTitle: 'Some Task',
+			})
+		).resolves.toBeUndefined();
 	});
 });

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -797,6 +797,8 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
 		expect(lastCall.sessionId).toBe('spaces:global');
 		expect(lastCall.message).toContain('Implement login page');
+		expect(lastCall.message).toContain('task-001');
+		expect(lastCall.message).toContain('space-001');
 		expect(lastCall.message).toContain('completed');
 		expect(lastCall.message).toContain('Feature implemented successfully.');
 		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
@@ -823,6 +825,8 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
 		expect(lastCall.sessionId).toBe('spaces:global');
 		expect(lastCall.message).toContain('Fix authentication bug');
+		expect(lastCall.message).toContain('task-002');
+		expect(lastCall.message).toContain('space-001');
 		expect(lastCall.message).toContain('failed');
 		expect(lastCall.message).toContain('Tests are failing.');
 		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
@@ -848,6 +852,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		const lastCall = sessionFactory.calls[sessionFactory.calls.length - 1];
 		expect(lastCall.message).toContain('cancelled');
 		expect(lastCall.message).toContain('Deploy to production');
+		expect(lastCall.message).toContain('task-003');
 	});
 
 	test('does not throw when sessionFactory.injectMessage fails', async () => {
@@ -869,5 +874,44 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 				taskTitle: 'Some Task',
 			})
 		).resolves.toBeUndefined();
+	});
+
+	test('double-init guard: calling provisionGlobalSpacesAgent twice does not create duplicate subscriptions', async () => {
+		// First provisioning call: track unsubs returned by hub.on()
+		const unsubCalls: number[] = [];
+		let onCallCount = 0;
+
+		const hub1 = {
+			emit: mock(async () => {}),
+			on: mock(() => {
+				const callIdx = onCallCount++;
+				return () => {
+					unsubCalls.push(callIdx);
+				};
+			}),
+			off: mock(() => {}),
+			once: mock(async () => {}),
+		} as unknown as DaemonHub;
+
+		const sessionFactory = makeMockSessionFactory();
+		const deps = buildDeps(db, { sessionFactory });
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub1 });
+		// After first call: 2 on() calls (completed + failed), 0 unsubscribes
+		expect(onCallCount).toBe(2);
+		expect(unsubCalls).toHaveLength(0);
+
+		// Second provisioning call with a new hub (simulating re-init)
+		const hub2 = {
+			emit: mock(async () => {}),
+			on: mock(() => () => {}),
+			off: mock(() => {}),
+			once: mock(async () => {}),
+		} as unknown as DaemonHub;
+
+		await provisionGlobalSpacesAgent({ ...deps, daemonHub: hub2 });
+
+		// Previous hub's unsubscribe functions must have been called before re-subscribing
+		expect(unsubCalls).toHaveLength(2);
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -34,6 +34,7 @@ import {
 	type TaskAgentToolsConfig,
 } from '../../../src/lib/space/tools/task-agent-tools.ts';
 import type { Space, SpaceWorkflow, SpaceTask } from '@neokai/shared';
+import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 
 // ---------------------------------------------------------------------------
 // DB helpers
@@ -291,6 +292,28 @@ function makeConfig(
 		messageInjector: options?.messageInjector ?? (async () => {}),
 		onSubSessionComplete: options?.onSubSessionComplete ?? (async () => {}),
 	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock DaemonHub helper
+// ---------------------------------------------------------------------------
+
+interface MockDaemonHub {
+	hub: DaemonHub;
+	emittedEvents: Array<{ name: string; payload: Record<string, unknown> }>;
+}
+
+function makeMockDaemonHub(): MockDaemonHub {
+	const emittedEvents: Array<{ name: string; payload: Record<string, unknown> }> = [];
+	const hub = {
+		emit: mock(async (name: string, payload: Record<string, unknown>) => {
+			emittedEvents.push({ name, payload });
+		}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+	return { hub, emittedEvents };
 }
 
 // ---------------------------------------------------------------------------
@@ -1009,6 +1032,163 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('transition');
+	});
+});
+
+// ===========================================================================
+// report_result — DaemonHub event emission tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — report_result DaemonHub events', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('emits space.task.completed event when status is completed', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Test Task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+		const { hub, emittedEvents } = makeMockDaemonHub();
+
+		const handlers = createTaskAgentToolHandlers({
+			...makeConfig(ctx, mainTask.id, 'run-123', factory),
+			daemonHub: hub,
+		});
+
+		await handlers.report_result({ status: 'completed', summary: 'All done.' });
+
+		// Allow micro-task queue to flush the void emit
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(emittedEvents).toHaveLength(1);
+		expect(emittedEvents[0].name).toBe('space.task.completed');
+		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
+		expect(emittedEvents[0].payload.spaceId).toBe(ctx.spaceId);
+		expect(emittedEvents[0].payload.status).toBe('completed');
+		expect(emittedEvents[0].payload.summary).toBe('All done.');
+		expect(emittedEvents[0].payload.workflowRunId).toBe('run-123');
+		expect(emittedEvents[0].payload.taskTitle).toBe('Test Task');
+	});
+
+	test('emits space.task.failed event when status is needs_attention', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Failing Task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+		const { hub, emittedEvents } = makeMockDaemonHub();
+
+		const handlers = createTaskAgentToolHandlers({
+			...makeConfig(ctx, mainTask.id, 'run-456', factory),
+			daemonHub: hub,
+		});
+
+		await handlers.report_result({
+			status: 'needs_attention',
+			summary: 'Tests failed.',
+			error: 'CI pipeline error',
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(emittedEvents).toHaveLength(1);
+		expect(emittedEvents[0].name).toBe('space.task.failed');
+		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
+		expect(emittedEvents[0].payload.spaceId).toBe(ctx.spaceId);
+		expect(emittedEvents[0].payload.status).toBe('needs_attention');
+		expect(emittedEvents[0].payload.summary).toBe('Tests failed.');
+		expect(emittedEvents[0].payload.taskTitle).toBe('Failing Task');
+	});
+
+	test('emits space.task.failed event when status is cancelled', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Cancelled Task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+		const { hub, emittedEvents } = makeMockDaemonHub();
+
+		const handlers = createTaskAgentToolHandlers({
+			...makeConfig(ctx, mainTask.id, 'run-789', factory),
+			daemonHub: hub,
+		});
+
+		await handlers.report_result({ status: 'cancelled', summary: 'User cancelled.' });
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(emittedEvents).toHaveLength(1);
+		expect(emittedEvents[0].name).toBe('space.task.failed');
+		expect(emittedEvents[0].payload.status).toBe('cancelled');
+	});
+
+	test('does not emit events when daemonHub is not provided', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Task Without Hub',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+
+		// No daemonHub in config
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id', factory));
+
+		const result = await handlers.report_result({ status: 'completed', summary: 'Done.' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Should still succeed — hub is optional
+		expect(parsed.success).toBe(true);
+	});
+
+	test('event payload includes sessionId: global', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Hub Test Task',
+			description: '',
+			status: 'in_progress',
+		});
+		const factory = makeMockSessionFactory();
+		const { hub, emittedEvents } = makeMockDaemonHub();
+
+		const handlers = createTaskAgentToolHandlers({
+			...makeConfig(ctx, mainTask.id, 'run-id', factory),
+			daemonHub: hub,
+		});
+
+		await handlers.report_result({ status: 'completed', summary: 'Done.' });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(emittedEvents[0].payload.sessionId).toBe('global');
+	});
+
+	test('does not emit event when task is not found', async () => {
+		const factory = makeMockSessionFactory();
+		const { hub, emittedEvents } = makeMockDaemonHub();
+
+		const handlers = createTaskAgentToolHandlers({
+			...makeConfig(ctx, 'nonexistent-task', 'run-id', factory),
+			daemonHub: hub,
+		});
+
+		const result = await handlers.report_result({ status: 'completed', summary: 'Done.' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(emittedEvents).toHaveLength(0);
 	});
 });
 

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -306,8 +306,11 @@ interface MockDaemonHub {
 function makeMockDaemonHub(): MockDaemonHub {
 	const emittedEvents: Array<{ name: string; payload: Record<string, unknown> }> = [];
 	const hub = {
-		emit: mock(async (name: string, payload: Record<string, unknown>) => {
+		// Synchronous recording so tests don't need setTimeout to flush async microtasks.
+		// Returns Promise.resolve() to satisfy the async signature.
+		emit: mock((name: string, payload: Record<string, unknown>) => {
 			emittedEvents.push({ name, payload });
+			return Promise.resolve();
 		}),
 		on: mock(() => () => {}),
 		off: mock(() => {}),
@@ -1066,9 +1069,8 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 
 		await handlers.report_result({ status: 'completed', summary: 'All done.' });
 
-		// Allow micro-task queue to flush the void emit
-		await new Promise((resolve) => setTimeout(resolve, 0));
-
+		// The mock emit is synchronous (records events before returning Promise.resolve()),
+		// so no async flush is needed — assertions can run immediately.
 		expect(emittedEvents).toHaveLength(1);
 		expect(emittedEvents[0].name).toBe('space.task.completed');
 		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
@@ -1100,8 +1102,6 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 			error: 'CI pipeline error',
 		});
 
-		await new Promise((resolve) => setTimeout(resolve, 0));
-
 		expect(emittedEvents).toHaveLength(1);
 		expect(emittedEvents[0].name).toBe('space.task.failed');
 		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
@@ -1127,8 +1127,6 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		});
 
 		await handlers.report_result({ status: 'cancelled', summary: 'User cancelled.' });
-
-		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(emittedEvents).toHaveLength(1);
 		expect(emittedEvents[0].name).toBe('space.task.failed');
@@ -1170,7 +1168,6 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		});
 
 		await handlers.report_result({ status: 'completed', summary: 'Done.' });
-		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(emittedEvents[0].payload.sessionId).toBe('global');
 	});


### PR DESCRIPTION
- Extend DaemonEventMap with space.task.completed and space.task.failed
  event types, each with payload: taskId, spaceId, status, summary,
  workflowRunId, taskTitle
- In report_result handler, emit space.task.completed when status is
  'completed', or space.task.failed for 'needs_attention'/'cancelled'
- Add optional daemonHub field to TaskAgentToolsConfig; pass it from
  TaskAgentManager.createTaskAgentMcpServer()
- In provisionGlobalSpacesAgent, add optional daemonHub dep and subscribe
  to both events to inject notification messages into the spaces:global
  session via sessionFactory.injectMessage() with deliveryMode next_turn
- Pass daemonHub through from rpc-handlers/index.ts call site
- 11 new unit tests: 6 for report_result event emission (correct event
  names, payloads, and no-hub guard), 5 for provision subscription
  (subscribe calls, message content, error resilience)
