### PR TITLE
feat: add Task Agent session rehydration on daemon restart (Task 5.3)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -430,11 +430,15 @@ export class SpaceRuntime {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Rehydrates WorkflowExecutors from the DB for all in-progress workflow runs.
+	 * Rehydrates WorkflowExecutors from the DB for all in-progress workflow runs,
+	 * then rehydrates Task Agent sessions if a TaskAgentManager is configured.
 	 *
 	 * Called once at the start of the first executeTick(). Reconstructs
 	 * executors with the run's persisted currentStepId so the tick loop can
 	 * resume advancement from where it left off.
+	 *
+	 * Executor rehydration runs first so that SpaceRuntimeService executors are
+	 * ready when Task Agents try to use them via their MCP tools.
 	 *
 	 * Runs that reference a missing workflow are skipped silently.
 	 */
@@ -469,6 +473,13 @@ export class SpaceRuntime {
 				const executor = this.buildExecutor(workflow, run, space.id, space.workspacePath);
 				this.executors.set(run.id, executor);
 			}
+		}
+
+		// Rehydrate Task Agent sessions after executors are ready.
+		// Executors must be loaded first so Task Agents can use advance_workflow
+		// and other MCP tools that rely on the SpaceRuntimeService executor map.
+		if (this.config.taskAgentManager) {
+			await this.config.taskAgentManager.rehydrate();
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -427,6 +427,56 @@ export class TaskAgentManager {
 	// Public — cleanup
 	// -------------------------------------------------------------------------
 
+	// -------------------------------------------------------------------------
+	// Public — rehydration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Rehydrate Task Agent sessions after a daemon restart.
+	 *
+	 * Queries `space_tasks` for tasks with status `in_progress` or `needs_attention`
+	 * that have a non-null `taskAgentSessionId`. For each such task that has a
+	 * `space_task_agent` session type in the DB, recreates the Task Agent session
+	 * (using `createTaskAgentInit()` + `AgentSession.fromInit()`), re-attaches the
+	 * MCP server and system prompt, restarts the streaming query, and injects a
+	 * re-orientation message so the agent resumes from where it left off.
+	 *
+	 * Sub-sessions are NOT fully rehydrated — the Task Agent will re-spawn them
+	 * via its MCP tools after receiving the re-orientation message. The in-memory
+	 * `subSessions` map is rebuilt from sub-session tasks found in the DB (so
+	 * cleanup works correctly), but their streaming queries are not restarted.
+	 *
+	 * This method is called from `SpaceRuntime.rehydrateExecutors()` after
+	 * WorkflowExecutors are loaded, so executors are ready when Task Agents run.
+	 */
+	async rehydrate(): Promise<void> {
+		const activeTasks = this.config.taskRepo.listActiveWithTaskAgentSession();
+
+		for (const task of activeTasks) {
+			const sessionId = task.taskAgentSessionId;
+			if (!sessionId) continue;
+
+			// Skip if already in the map (e.g. double rehydrate call)
+			if (this.taskAgentSessions.has(task.id)) continue;
+
+			// Only rehydrate tasks whose session is a space_task_agent session.
+			// Step sub-sessions (UUID) are stored on step tasks — skip those.
+			const dbSession = this.config.db.getSession(sessionId);
+			if (!dbSession || dbSession.type !== 'space_task_agent') continue;
+
+			try {
+				await this.rehydrateTaskAgent(task, sessionId);
+			} catch (err) {
+				log.warn(
+					`TaskAgentManager.rehydrate: failed to rehydrate task ${task.id} (session ${sessionId}):`,
+					err
+				);
+			}
+		}
+
+		log.info(`TaskAgentManager.rehydrate: rehydrated ${this.taskAgentSessions.size} task agent(s)`);
+	}
+
 	/**
 	 * Stop and clean up all active Task Agent sessions and their sub-sessions.
 	 * Called on daemon shutdown to release all resources.
@@ -677,6 +727,146 @@ export class TaskAgentManager {
 		}
 		throw new Error(
 			`Could not find available session ID for base "${baseId}" after ${MAX_ATTEMPTS} attempts`
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Private — rehydration helper
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Rehydrate a single Task Agent session after daemon restart.
+	 *
+	 * 1. Loads the associated Space, Workflow, and WorkflowRun from the DB.
+	 * 2. Recreates the AgentSession via `createTaskAgentInit()` + `AgentSession.fromInit()`
+	 *    — `fromInit()` loads the existing DB record without creating a duplicate.
+	 * 3. Re-attaches MCP server and system prompt (runtime-only, not persisted).
+	 * 4. Adds the session to `taskAgentSessions` before streaming starts.
+	 * 5. Restarts the streaming query so the SDK resumes from conversation history.
+	 * 6. Injects a re-orientation message so the agent checks its current state and
+	 *    continues from where it left off.
+	 * 7. Rebuilds the `subSessions` map from step tasks in the same workflow run.
+	 */
+	private async rehydrateTaskAgent(task: SpaceTask, sessionId: string): Promise<void> {
+		const taskId = task.id;
+		const spaceId = task.spaceId;
+
+		// --- Load Space
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space) {
+			log.warn(
+				`TaskAgentManager.rehydrate: space ${spaceId} not found for task ${taskId}, skipping`
+			);
+			return;
+		}
+
+		// --- Load Workflow and WorkflowRun (if applicable)
+		let workflow: SpaceWorkflow | null = null;
+		let workflowRun: SpaceWorkflowRun | null = null;
+		if (task.workflowRunId) {
+			workflowRun = this.config.workflowRunRepo.getRun(task.workflowRunId);
+			if (workflowRun) {
+				workflow = this.config.spaceWorkflowManager.getWorkflow(workflowRun.workflowId);
+			}
+		}
+
+		// --- Recreate AgentSession using createTaskAgentInit() + fromInit()
+		// fromInit() gracefully handles an already-existing DB session (no duplicate created)
+		const init = createTaskAgentInit({
+			task,
+			space,
+			workflow,
+			workflowRun,
+			sessionId,
+			workspacePath: space.workspacePath,
+		});
+
+		const agentSession = AgentSession.fromInit(
+			init,
+			this.config.db,
+			this.config.messageHub,
+			this.config.daemonHub,
+			this.config.getApiKey,
+			this.config.defaultModel
+		);
+
+		// --- Build the SpaceTaskManager for this space
+		const taskManager = new SpaceTaskManager(this.config.db.getDatabase(), spaceId);
+
+		// --- Build and attach MCP server
+		const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
+		const subSessionFactory = this.createSubSessionFactory(taskId);
+
+		const mcpServer = createTaskAgentMcpServer({
+			taskId,
+			space,
+			workflowRunId: workflowRun?.id ?? '',
+			workspacePath: space.workspacePath,
+			runtime,
+			workflowManager: this.config.spaceWorkflowManager,
+			taskRepo: this.config.taskRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			agentManager: this.config.spaceAgentManager,
+			taskManager,
+			sessionFactory: subSessionFactory,
+			messageInjector: (subSessionId, message) =>
+				this.injectSubSessionMessage(subSessionId, message),
+			onSubSessionComplete: (stepId, subSessionId) =>
+				this.handleSubSessionComplete(taskId, stepId, subSessionId),
+		});
+
+		agentSession.setRuntimeMcpServers({
+			'task-agent': mcpServer as unknown as McpServerConfig,
+		});
+
+		// Re-attach system prompt from the init (runtime-only, not persisted)
+		if (init.systemPrompt) {
+			agentSession.setRuntimeSystemPrompt(init.systemPrompt);
+		}
+
+		// --- Store in map before streaming start
+		this.taskAgentSessions.set(taskId, agentSession);
+
+		// --- Restart the streaming query (SDK resumes from conversation history in DB)
+		await agentSession.startStreamingQuery();
+
+		// --- Inject re-orientation message so the agent checks state and continues
+		const reorientMessage =
+			'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
+			'Please use `check_step_status` to determine the current state of your workflow and continue from where you left off.';
+		await this.injectMessageIntoSession(agentSession, reorientMessage);
+
+		// --- Rebuild subSessions map from step tasks in the same workflow run
+		// Sub-sessions are not fully rehydrated (no streaming restart) — the Task Agent
+		// will re-spawn them as needed after receiving the re-orientation message.
+		if (task.workflowRunId) {
+			const stepTasks = this.config.taskRepo.listByWorkflowRun(task.workflowRunId);
+			for (const stepTask of stepTasks) {
+				const subSessionId = stepTask.taskAgentSessionId;
+				if (!subSessionId || stepTask.id === taskId) continue;
+
+				// Only restore sessions with UUID-style IDs (sub-sessions, not Task Agent sessions)
+				const subDbSession = this.config.db.getSession(subSessionId);
+				if (!subDbSession || subDbSession.type === 'space_task_agent') continue;
+
+				const subSession = AgentSession.restore(
+					subSessionId,
+					this.config.db,
+					this.config.messageHub,
+					this.config.daemonHub,
+					this.config.getApiKey
+				);
+				if (!subSession) continue;
+
+				if (!this.subSessions.has(taskId)) {
+					this.subSessions.set(taskId, new Map());
+				}
+				this.subSessions.get(taskId)!.set(subSessionId, subSession);
+			}
+		}
+
+		log.info(
+			`TaskAgentManager.rehydrate: rehydrated task agent for task ${taskId} (session ${sessionId})`
 		);
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -452,6 +452,9 @@ export class TaskAgentManager {
 	async rehydrate(): Promise<void> {
 		const activeTasks = this.config.taskRepo.listActiveWithTaskAgentSession();
 
+		let attempted = 0;
+		let failed = 0;
+
 		for (const task of activeTasks) {
 			const sessionId = task.taskAgentSessionId;
 			if (!sessionId) continue;
@@ -464,9 +467,11 @@ export class TaskAgentManager {
 			const dbSession = this.config.db.getSession(sessionId);
 			if (!dbSession || dbSession.type !== 'space_task_agent') continue;
 
+			attempted++;
 			try {
 				await this.rehydrateTaskAgent(task, sessionId);
 			} catch (err) {
+				failed++;
 				log.warn(
 					`TaskAgentManager.rehydrate: failed to rehydrate task ${task.id} (session ${sessionId}):`,
 					err
@@ -474,7 +479,10 @@ export class TaskAgentManager {
 			}
 		}
 
-		log.info(`TaskAgentManager.rehydrate: rehydrated ${this.taskAgentSessions.size} task agent(s)`);
+		const succeeded = attempted - failed;
+		log.info(
+			`TaskAgentManager.rehydrate: attempted=${attempted} succeeded=${succeeded} failed=${failed}`
+		);
 	}
 
 	/**
@@ -738,8 +746,9 @@ export class TaskAgentManager {
 	 * Rehydrate a single Task Agent session after daemon restart.
 	 *
 	 * 1. Loads the associated Space, Workflow, and WorkflowRun from the DB.
-	 * 2. Recreates the AgentSession via `createTaskAgentInit()` + `AgentSession.fromInit()`
-	 *    — `fromInit()` loads the existing DB record without creating a duplicate.
+	 * 2. Restores the AgentSession via `AgentSession.restore()` — the session
+	 *    already exists in the DB; `restore()` skips fingerprint comparison and
+	 *    avoids any risk of invalidating `sdkSessionId` across restarts.
 	 * 3. Re-attaches MCP server and system prompt (runtime-only, not persisted).
 	 * 4. Adds the session to `taskAgentSessions` before streaming starts.
 	 * 5. Restarts the streaming query so the SDK resumes from conversation history.
@@ -770,30 +779,28 @@ export class TaskAgentManager {
 			}
 		}
 
-		// --- Recreate AgentSession using createTaskAgentInit() + fromInit()
-		// fromInit() gracefully handles an already-existing DB session (no duplicate created)
-		const init = createTaskAgentInit({
-			task,
-			space,
-			workflow,
-			workflowRun,
+		// --- Restore the existing AgentSession from DB via restore().
+		// restore() is the correct path for daemon-restart rehydration of an already-persisted
+		// session: it skips fingerprint comparison and avoids invalidating sdkSessionId
+		// (which would break conversation continuity for tasks resuming mid-execution).
+		const agentSession = AgentSession.restore(
 			sessionId,
-			workspacePath: space.workspacePath,
-		});
-
-		const agentSession = AgentSession.fromInit(
-			init,
 			this.config.db,
 			this.config.messageHub,
 			this.config.daemonHub,
-			this.config.getApiKey,
-			this.config.defaultModel
+			this.config.getApiKey
 		);
+		if (!agentSession) {
+			log.warn(
+				`TaskAgentManager.rehydrate: session ${sessionId} not found in DB for task ${taskId}, skipping`
+			);
+			return;
+		}
 
 		// --- Build the SpaceTaskManager for this space
 		const taskManager = new SpaceTaskManager(this.config.db.getDatabase(), spaceId);
 
-		// --- Build and attach MCP server
+		// --- Build and attach MCP server (runtime-only, not persisted)
 		const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
 		const subSessionFactory = this.createSubSessionFactory(taskId);
 
@@ -819,7 +826,16 @@ export class TaskAgentManager {
 			'task-agent': mcpServer as unknown as McpServerConfig,
 		});
 
-		// Re-attach system prompt from the init (runtime-only, not persisted)
+		// Re-attach system prompt (runtime-only, not persisted).
+		// Generated fresh from createTaskAgentInit() so it reflects the current task/workflow state.
+		const init = createTaskAgentInit({
+			task,
+			space,
+			workflow,
+			workflowRun,
+			sessionId,
+			workspacePath: space.workspacePath,
+		});
 		if (init.systemPrompt) {
 			agentSession.setRuntimeSystemPrompt(init.systemPrompt);
 		}
@@ -830,10 +846,14 @@ export class TaskAgentManager {
 		// --- Restart the streaming query (SDK resumes from conversation history in DB)
 		await agentSession.startStreamingQuery();
 
-		// --- Inject re-orientation message so the agent checks state and continues
-		const reorientMessage =
-			'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
-			'Please use `check_step_status` to determine the current state of your workflow and continue from where you left off.';
+		// --- Inject re-orientation message so the agent checks state and continues.
+		// For workflow tasks: ask the agent to use check_step_status to resume workflow execution.
+		// For standalone tasks (no workflowRunId): ask the agent to check status and continue.
+		const reorientMessage = task.workflowRunId
+			? 'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
+				'Please use `check_step_status` to determine the current state of your workflow and continue from where you left off.'
+			: 'You are resuming after a daemon restart. Your previous conversation state has been restored. ' +
+				'Please check the current task status and continue from where you left off.';
 		await this.injectMessageIntoSession(agentSession, reorientMessage);
 
 		// --- Rebuild subSessions map from step tasks in the same workflow run

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -436,10 +436,10 @@ export class TaskAgentManager {
 	 *
 	 * Queries `space_tasks` for tasks with status `in_progress` or `needs_attention`
 	 * that have a non-null `taskAgentSessionId`. For each such task that has a
-	 * `space_task_agent` session type in the DB, recreates the Task Agent session
-	 * (using `createTaskAgentInit()` + `AgentSession.fromInit()`), re-attaches the
-	 * MCP server and system prompt, restarts the streaming query, and injects a
-	 * re-orientation message so the agent resumes from where it left off.
+	 * `space_task_agent` session type in the DB, restores the Task Agent session via
+	 * `AgentSession.restore()`, re-attaches the MCP server and system prompt,
+	 * restarts the streaming query, and injects a re-orientation message so the
+	 * agent resumes from where it left off.
 	 *
 	 * Sub-sessions are NOT fully rehydrated — the Task Agent will re-spawn them
 	 * via its MCP tools after receiving the re-orientation message. The in-memory

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -280,6 +280,21 @@ export class SpaceTaskRepository {
 	}
 
 	/**
+	 * List all tasks that have an active Task Agent session.
+	 *
+	 * Returns tasks with status `in_progress` or `needs_attention` that have a
+	 * non-null `task_agent_session_id`. Used by `TaskAgentManager.rehydrate()` on
+	 * daemon restart to find Task Agent sessions that need to be restarted.
+	 */
+	listActiveWithTaskAgentSession(): SpaceTask[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'needs_attention') AND task_agent_session_id IS NOT NULL AND archived_at IS NULL`
+		);
+		const rows = stmt.all() as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
 	 * Get a task by its Task Agent session ID
 	 */
 	getTaskBySessionId(sessionId: string): SpaceTask | null {

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1034,7 +1034,7 @@ describe('SpaceRuntime', () => {
 	describe('Task Agent integration', () => {
 		/**
 		 * Minimal mock for TaskAgentManager — only implements the methods that
-		 * SpaceRuntime calls: isSpawning(), isTaskAgentAlive(), spawnTaskAgent().
+		 * SpaceRuntime calls: isSpawning(), isTaskAgentAlive(), spawnTaskAgent(), rehydrate().
 		 *
 		 * The default spawnTaskAgent mirrors the real TaskAgentManager's DB side-effect:
 		 * it writes taskAgentSessionId to the task row. SpaceRuntime relies on this
@@ -1046,6 +1046,7 @@ describe('SpaceRuntime', () => {
 				isSpawning?: (taskId: string) => boolean;
 				isTaskAgentAlive?: (taskId: string) => boolean;
 				spawnTaskAgent?: (task: unknown) => Promise<string>;
+				rehydrate?: () => Promise<void>;
 			} = {}
 		) {
 			const spawned: string[] = [];
@@ -1061,6 +1062,7 @@ describe('SpaceRuntime', () => {
 						taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
 						return `session:${t.id}`;
 					}),
+				rehydrate: overrides.rehydrate ?? (async () => {}),
 				_spawned: spawned,
 			};
 		}

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -81,6 +81,7 @@ interface MockAgentSession {
 	session: { id: string; context?: Record<string, unknown> };
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
+	getSessionData: () => { id: string; context?: Record<string, unknown> };
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
@@ -115,6 +116,9 @@ function makeMockSession(
 		},
 		getSDKMessageCount() {
 			return this._sdkMessageCount;
+		},
+		getSessionData() {
+			return this.session;
 		},
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -306,6 +306,18 @@ function makeCtx(): TestCtx {
 		}
 	);
 
+	// Spy on AgentSession.restore to return mock sessions for rehydration tests.
+	// rehydrateTaskAgent() uses restore() (not fromInit()) to reload persisted sessions.
+	spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+		// Only restore if the session exists in the mock DB
+		if (!mockDb.getSession(sessionId)) return null;
+		const existing = createdSessions.get(sessionId);
+		if (existing) return existing as unknown as AgentSession;
+		const mockSession = makeMockSession(sessionId);
+		createdSessions.set(sessionId, mockSession);
+		return mockSession as unknown as AgentSession;
+	});
+
 	const manager = new TaskAgentManager({
 		db: mockDb as unknown as import('../../../src/storage/database.ts').Database,
 		sessionManager:
@@ -1308,7 +1320,8 @@ describe('TaskAgentManager', () => {
 			expect(session._startCalled).toBe(true);
 		});
 
-		test('re-orientation message is injected after rehydration', async () => {
+		test('re-orientation message is injected after rehydration (standalone task)', async () => {
+			// Standalone task has no workflowRunId — re-orientation uses generic resume message
 			const { agentSessionId } = await seedInProgressTask(ctx);
 
 			await ctx.manager.rehydrate();
@@ -1318,7 +1331,82 @@ describe('TaskAgentManager', () => {
 			expect(session._enqueuedMessages.length).toBeGreaterThan(0);
 			const msgs = session._enqueuedMessages.map((m) => m.msg);
 			expect(msgs.some((m) => m.includes('resuming after a daemon restart'))).toBe(true);
+			// Standalone tasks get a generic re-orientation — no check_step_status reference
+			expect(msgs.some((m) => m.includes('check_step_status'))).toBe(false);
+			expect(msgs.some((m) => m.includes('current task status'))).toBe(true);
+		});
+
+		test('re-orientation message for workflow task contains check_step_status', async () => {
+			// Seed a workflow run
+			const wfId = 'wf-reorient-workflow';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Reorient', now, now);
+			const wfRunId = 'run-reorient-workflow';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const task = await ctx.taskManager.createTask({
+				title: 'Workflow task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const agentSessionId = `space:${ctx.spaceId}:task:${task.id}`;
+			ctx.taskRepo.updateTask(task.id, { taskAgentSessionId: agentSessionId });
+			ctx.mockDb.createSession({ id: agentSessionId, type: 'space_task_agent' });
+
+			await ctx.manager.rehydrate();
+
+			const session = ctx.createdSessions.get(agentSessionId)!;
+			expect(session._enqueuedMessages.length).toBeGreaterThan(0);
+			const msgs = session._enqueuedMessages.map((m) => m.msg);
+			expect(msgs.some((m) => m.includes('resuming after a daemon restart'))).toBe(true);
+			// Workflow tasks should reference check_step_status to resume the workflow
 			expect(msgs.some((m) => m.includes('check_step_status'))).toBe(true);
+		});
+
+		test('restore returning null skips task and does not add to map', async () => {
+			// Seed task whose session is in the mock DB (so filter passes) but restore returns null
+			const task = await ctx.taskManager.createTask({
+				title: 'Restore-null task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+			});
+			const agentSessionId = `space:${ctx.spaceId}:task:${task.id}`;
+			ctx.taskRepo.updateTask(task.id, { taskAgentSessionId: agentSessionId });
+			ctx.mockDb.createSession({ id: agentSessionId, type: 'space_task_agent' });
+
+			// Override restore to return null for this session only
+			const restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				if (sessionId === agentSessionId) return null;
+				// Fallback for any other session
+				if (!ctx.mockDb.getSession(sessionId)) return null;
+				const mockSession = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, mockSession);
+				return mockSession as unknown as AgentSession;
+			});
+
+			const sessionsBefore = ctx.createdSessions.size;
+			await ctx.manager.rehydrate();
+
+			// Task agent should NOT have been added to the map
+			expect(ctx.manager.getTaskAgent(task.id)).toBeUndefined();
+			// No new sessions should have been created for this task
+			expect(ctx.createdSessions.has(agentSessionId)).toBe(false);
+			expect(ctx.createdSessions.size).toBe(sessionsBefore);
+
+			restoreSpy.mockRestore();
 		});
 
 		test('MCP server is re-attached on rehydrated session', async () => {

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -230,6 +230,7 @@ interface TestCtx {
 	};
 	manager: TaskAgentManager;
 	createdSessions: Map<string, MockAgentSession>;
+	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
 }
 
 function makeCtx(): TestCtx {
@@ -292,7 +293,7 @@ function makeCtx(): TestCtx {
 	};
 
 	// Spy on AgentSession.fromInit to return mock sessions
-	spyOn(AgentSession, 'fromInit').mockImplementation(
+	const fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation(
 		(
 			init: unknown,
 			_db: unknown,
@@ -345,6 +346,7 @@ function makeCtx(): TestCtx {
 		mockDb,
 		manager,
 		createdSessions,
+		fromInitSpy,
 	};
 }
 
@@ -360,6 +362,7 @@ describe('TaskAgentManager', () => {
 	});
 
 	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
 		try {
 			rmSync(ctx.dir, { recursive: true, force: true });
 		} catch {

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -82,6 +82,7 @@ interface MockAgentSession {
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
 	handleInterrupt: () => Promise<void>;
@@ -118,6 +119,7 @@ function makeMockSession(
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;
 		},
+		setRuntimeSystemPrompt(_systemPrompt: unknown) {},
 		async startStreamingQuery() {
 			this._startCalled = true;
 		},
@@ -1244,6 +1246,297 @@ describe('TaskAgentManager', () => {
 			expect(sessionId).toBeDefined();
 
 			fromInitSpy.mockRestore();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// rehydrate — session restoration on daemon restart
+	// -----------------------------------------------------------------------
+
+	describe('rehydrate', () => {
+		/**
+		 * Helper: seed a task with status in_progress and a pre-existing task agent session.
+		 * The session is stored in the mock DB with `type: 'space_task_agent'` so the
+		 * rehydrate filter correctly identifies it.
+		 */
+		async function seedInProgressTask(
+			c: TestCtx,
+			status: 'in_progress' | 'needs_attention' = 'in_progress'
+		) {
+			const task = await c.taskManager.createTask({
+				title: 'Rehydrate test task',
+				description: 'A task that was in progress before restart',
+				taskType: 'coding',
+				status,
+			});
+
+			const agentSessionId = `space:${c.spaceId}:task:${task.id}`;
+
+			// Persist the session ID on the task
+			c.taskRepo.updateTask(task.id, { taskAgentSessionId: agentSessionId });
+
+			// Seed the session in the mock DB with type: 'space_task_agent'
+			c.mockDb.createSession({ id: agentSessionId, type: 'space_task_agent' });
+
+			return { task, agentSessionId };
+		}
+
+		test('restores Task Agent session for an in_progress task', async () => {
+			const { task, agentSessionId } = await seedInProgressTask(ctx);
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(task.id)).toBeDefined();
+			expect(ctx.createdSessions.has(agentSessionId)).toBe(true);
+		});
+
+		test('restores Task Agent session for a needs_attention task', async () => {
+			const { task, agentSessionId } = await seedInProgressTask(ctx, 'needs_attention');
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(task.id)).toBeDefined();
+			expect(ctx.createdSessions.has(agentSessionId)).toBe(true);
+		});
+
+		test('rehydrated session has streaming query restarted', async () => {
+			const { agentSessionId } = await seedInProgressTask(ctx);
+
+			await ctx.manager.rehydrate();
+
+			const session = ctx.createdSessions.get(agentSessionId)!;
+			expect(session._startCalled).toBe(true);
+		});
+
+		test('re-orientation message is injected after rehydration', async () => {
+			const { agentSessionId } = await seedInProgressTask(ctx);
+
+			await ctx.manager.rehydrate();
+
+			const session = ctx.createdSessions.get(agentSessionId)!;
+			// At least one message enqueued (the re-orientation message)
+			expect(session._enqueuedMessages.length).toBeGreaterThan(0);
+			const msgs = session._enqueuedMessages.map((m) => m.msg);
+			expect(msgs.some((m) => m.includes('resuming after a daemon restart'))).toBe(true);
+			expect(msgs.some((m) => m.includes('check_step_status'))).toBe(true);
+		});
+
+		test('MCP server is re-attached on rehydrated session', async () => {
+			const { agentSessionId } = await seedInProgressTask(ctx);
+
+			await ctx.manager.rehydrate();
+
+			const session = ctx.createdSessions.get(agentSessionId)!;
+			expect(Object.keys(session._mcpServers)).toContain('task-agent');
+		});
+
+		test('tasks without taskAgentSessionId are skipped', async () => {
+			// Create a task with no session ID set
+			const task = await ctx.taskManager.createTask({
+				title: 'No session task',
+				description: 'Should be skipped',
+				taskType: 'coding',
+				status: 'in_progress',
+			});
+
+			const sessionsBefore = ctx.createdSessions.size;
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(task.id)).toBeUndefined();
+			expect(ctx.createdSessions.size).toBe(sessionsBefore);
+		});
+
+		test('completed/cancelled tasks are not rehydrated', async () => {
+			const completedTask = await ctx.taskManager.createTask({
+				title: 'Completed task',
+				description: '',
+				taskType: 'coding',
+				status: 'completed',
+			});
+			const agentSessionId = `space:${ctx.spaceId}:task:${completedTask.id}`;
+			ctx.taskRepo.updateTask(completedTask.id, { taskAgentSessionId: agentSessionId });
+			ctx.mockDb.createSession({ id: agentSessionId, type: 'space_task_agent' });
+
+			const cancelledTask = await ctx.taskManager.createTask({
+				title: 'Cancelled task',
+				description: '',
+				taskType: 'coding',
+				status: 'cancelled',
+			});
+			const agentSessionId2 = `space:${ctx.spaceId}:task:${cancelledTask.id}`;
+			ctx.taskRepo.updateTask(cancelledTask.id, { taskAgentSessionId: agentSessionId2 });
+			ctx.mockDb.createSession({ id: agentSessionId2, type: 'space_task_agent' });
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(completedTask.id)).toBeUndefined();
+			expect(ctx.manager.getTaskAgent(cancelledTask.id)).toBeUndefined();
+		});
+
+		test('sub-session tasks (UUID session IDs) are not rehydrated as Task Agents', async () => {
+			// A step task has a UUID sub-session ID — should NOT be treated as a Task Agent
+			const stepTask = await ctx.taskManager.createTask({
+				title: 'Step task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+			});
+			const uuidSubSessionId = '550e8400-e29b-41d4-a716-446655440000';
+			ctx.taskRepo.updateTask(stepTask.id, { taskAgentSessionId: uuidSubSessionId });
+			// Session has type 'worker', not 'space_task_agent'
+			ctx.mockDb.createSession({ id: uuidSubSessionId, type: 'worker' });
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(stepTask.id)).toBeUndefined();
+		});
+
+		test('skips if Task Agent session is already in the map (idempotent)', async () => {
+			const { task } = await seedInProgressTask(ctx);
+
+			// Spawn first
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			const sessionsAfterSpawn = ctx.createdSessions.size;
+
+			// Rehydrate should see the task already in map and skip
+			await ctx.manager.rehydrate();
+
+			expect(ctx.createdSessions.size).toBe(sessionsAfterSpawn);
+		});
+
+		test('rehydrates multiple tasks independently', async () => {
+			const { task: task1 } = await seedInProgressTask(ctx);
+			const { task: task2 } = await seedInProgressTask(ctx, 'needs_attention');
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(task1.id)).toBeDefined();
+			expect(ctx.manager.getTaskAgent(task2.id)).toBeDefined();
+		});
+
+		test('rebuilds subSessions map from workflow run step tasks', async () => {
+			// Seed a workflow run so we can test sub-session map rebuild
+			const wfId = 'wf-rehydrate-sub';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Rehydrate Sub', now, now);
+			const stepId = 'step-rehydrate-1';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_steps (id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at)
+           VALUES (?, ?, ?, '', ?, 0, null, ?, ?)`
+				)
+				.run(stepId, wfId, 'Step 1', ctx.agentId, now, now);
+			const wfRunId = 'run-rehydrate-sub';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			// Create main task for the run
+			const mainTask = await ctx.taskManager.createTask({
+				title: 'Main task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const mainSessionId = `space:${ctx.spaceId}:task:${mainTask.id}`;
+			ctx.taskRepo.updateTask(mainTask.id, { taskAgentSessionId: mainSessionId });
+			ctx.mockDb.createSession({ id: mainSessionId, type: 'space_task_agent' });
+
+			// Create a step task with a UUID sub-session
+			const subSessionId = '550e8400-e29b-41d4-a716-sub-session-01';
+			const stepTask = await ctx.taskManager.createTask({
+				title: 'Step task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+				workflowStepId: stepId,
+				taskAgentSessionId: subSessionId,
+			});
+			ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+			// Mock AgentSession.restore to return a session for the sub-session
+			const restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				const session = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, session);
+				return session as unknown as AgentSession;
+			});
+
+			await ctx.manager.rehydrate();
+
+			// Sub-session should be in the subSessions map for the main task
+			expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
+
+			restoreSpy.mockRestore();
+			// avoid unused var warning
+			void stepTask;
+		});
+
+		test('does not restart streaming for sub-sessions during rehydration', async () => {
+			// Sub-sessions in the map after rehydration should NOT have _startCalled = true
+			// (they are stubs that the Task Agent will re-spawn as needed)
+			const wfId = 'wf-rehydrate-no-start';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Sub No Start', now, now);
+			const wfRunId = 'run-rehydrate-no-start';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const mainTask = await ctx.taskManager.createTask({
+				title: 'Main task no-start',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const mainSessionId = `space:${ctx.spaceId}:task:${mainTask.id}`;
+			ctx.taskRepo.updateTask(mainTask.id, { taskAgentSessionId: mainSessionId });
+			ctx.mockDb.createSession({ id: mainSessionId, type: 'space_task_agent' });
+
+			const subSessionId = '550e8400-e29b-41d4-a716-nostart-sub-01';
+			await ctx.taskManager.createTask({
+				title: 'Sub task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+				taskAgentSessionId: subSessionId,
+			});
+			ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+			const restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				const session = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, session);
+				return session as unknown as AgentSession;
+			});
+
+			await ctx.manager.rehydrate();
+
+			// The sub-session stub should NOT have startStreamingQuery called
+			const subSession = ctx.createdSessions.get(subSessionId);
+			if (subSession) {
+				expect(subSession._startCalled).toBe(false);
+			}
+
+			restoreSpy.mockRestore();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -310,18 +310,6 @@ function makeCtx(): TestCtx {
 		}
 	);
 
-	// Spy on AgentSession.restore to return mock sessions for rehydration tests.
-	// rehydrateTaskAgent() uses restore() (not fromInit()) to reload persisted sessions.
-	spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
-		// Only restore if the session exists in the mock DB
-		if (!mockDb.getSession(sessionId)) return null;
-		const existing = createdSessions.get(sessionId);
-		if (existing) return existing as unknown as AgentSession;
-		const mockSession = makeMockSession(sessionId);
-		createdSessions.set(sessionId, mockSession);
-		return mockSession as unknown as AgentSession;
-	});
-
 	const manager = new TaskAgentManager({
 		db: mockDb as unknown as import('../../../src/storage/database.ts').Database,
 		sessionManager:
@@ -1270,6 +1258,27 @@ describe('TaskAgentManager', () => {
 	// -----------------------------------------------------------------------
 
 	describe('rehydrate', () => {
+		// Scoped spy for AgentSession.restore — only active inside this describe block.
+		// rehydrateTaskAgent() uses restore() (not fromInit()) to reload persisted sessions.
+		// We restore the spy after each test so it does not leak into other test files.
+		let restoreSpyScoped: ReturnType<typeof spyOn<typeof AgentSession, 'restore'>>;
+
+		beforeEach(() => {
+			restoreSpyScoped = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				// Only restore if the session exists in the mock DB
+				if (!ctx.mockDb.getSession(sessionId)) return null;
+				const existing = ctx.createdSessions.get(sessionId);
+				if (existing) return existing as unknown as AgentSession;
+				const mockSession = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, mockSession);
+				return mockSession as unknown as AgentSession;
+			});
+		});
+
+		afterEach(() => {
+			restoreSpyScoped.mockRestore();
+		});
+
 		/**
 		 * Helper: seed a task with status in_progress and a pre-existing task agent session.
 		 * The session is stored in the mock DB with `type: 'space_task_agent'` so the


### PR DESCRIPTION
- Add listActiveWithTaskAgentSession() to SpaceTaskRepository: queries tasks with
  status in_progress/needs_attention and non-null task_agent_session_id
- Add rehydrate() to TaskAgentManager: restores active Task Agent sessions after restart
  by recreating AgentSession via fromInit(), re-attaching MCP server and system prompt,
  restarting streaming query, injecting re-orientation message, and rebuilding subSessions map
- Wire rehydrate() into SpaceRuntime.rehydrateExecutors() after executor rehydration
  so WorkflowExecutors are ready before Task Agents try to use them
- Add 14 unit tests: in_progress/needs_attention rehydration, streaming restart,
  re-orientation message injection, MCP server attachment, skip conditions (no session,
  completed/cancelled tasks, UUID sub-sessions), idempotency, multi-task rehydration,
  sub-session map rebuild, and no streaming-restart for sub-session stubs
- Fix space-runtime.test.ts mock to include rehydrate() method
