### PR TITLE
feat: add semantic status border and inline reject form to RoomTasks (Task 2.4)

### DIFF
--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -204,6 +204,13 @@ export function RoomDashboard() {
 					tasks={tasks}
 					onTaskClick={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
 					onView={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
+					onReject={async (taskId, feedback) => {
+						try {
+							await roomStore.rejectTask(taskId, feedback);
+						} catch {
+							// Error handled by store
+						}
+					}}
 				/>
 			</div>
 

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -726,8 +726,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			);
 			expect(rejectBtn).toBeTruthy();
 		});
@@ -737,8 +737,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			);
 			expect(rejectBtn).toBeFalsy();
 		});
@@ -750,8 +750,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			);
 			expect(rejectBtn).toBeFalsy();
 		});
@@ -762,8 +762,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 
@@ -779,15 +779,15 @@ describe('RoomTasks', () => {
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
 			// Open form
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 			expect(container.querySelector('textarea')).toBeTruthy();
 
 			// Cancel
-			const cancelBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Cancel'
+			const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Cancel'
 			) as HTMLButtonElement;
 			fireEvent.click(cancelBtn);
 
@@ -800,13 +800,13 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 
-			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Confirm Reject'
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Confirm Reject'
 			) as HTMLButtonElement;
 			expect(confirmBtn.disabled).toBe(true);
 		});
@@ -818,8 +818,8 @@ describe('RoomTasks', () => {
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
 			// Open form
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 
@@ -828,8 +828,8 @@ describe('RoomTasks', () => {
 			fireEvent.input(textarea, { target: { value: 'Needs more work' } });
 
 			// Confirm
-			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Confirm Reject'
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Confirm Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(confirmBtn);
 
@@ -843,16 +843,16 @@ describe('RoomTasks', () => {
 			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
 
 			// Open form
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 
 			// Type feedback and confirm
 			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 			fireEvent.input(textarea, { target: { value: 'Feedback here' } });
-			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Confirm Reject'
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Confirm Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(confirmBtn);
 
@@ -868,8 +868,8 @@ describe('RoomTasks', () => {
 				<RoomTasks tasks={tasks} onReject={onReject} onTaskClick={onTaskClick} />
 			);
 
-			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Reject'
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -652,4 +652,228 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('PR #30');
 		});
 	});
+
+	describe('Semantic Status Border', () => {
+		it('should apply blue left border to in_progress tasks', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'in_progress')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-blue-500');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply gray left border to pending tasks', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-gray-500');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply amber left border to review tasks', () => {
+			selectedTabSignal.value = 'review';
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-amber-500');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply green left border to completed tasks', () => {
+			selectedTabSignal.value = 'done';
+			const tasks = [createTask('t1', 'completed')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-green-500');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply red left border to needs_attention tasks', () => {
+			selectedTabSignal.value = 'needs_attention';
+			const tasks = [createTask('t1', 'needs_attention')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-red-500');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply dark gray left border to cancelled tasks', () => {
+			selectedTabSignal.value = 'needs_attention';
+			const tasks = [createTask('t1', 'cancelled')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-gray-700');
+			expect(item).toBeTruthy();
+		});
+	});
+
+	describe('Inline Reject Form', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
+		it('should show Reject button for review tasks when onReject is provided', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			);
+			expect(rejectBtn).toBeTruthy();
+		});
+
+		it('should NOT show Reject button when onReject is not provided', () => {
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			);
+			expect(rejectBtn).toBeFalsy();
+		});
+
+		it('should NOT show Reject button for non-review tasks', () => {
+			selectedTabSignal.value = 'active';
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'in_progress')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			);
+			expect(rejectBtn).toBeFalsy();
+		});
+
+		it('should expand inline form when Reject button is clicked', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+
+			expect(container.querySelector('textarea')).toBeTruthy();
+			expect(container.textContent).toContain('Confirm Reject');
+			expect(container.textContent).toContain('Cancel');
+		});
+
+		it('should hide inline form when Cancel is clicked', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			// Open form
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+			expect(container.querySelector('textarea')).toBeTruthy();
+
+			// Cancel
+			const cancelBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Cancel'
+			) as HTMLButtonElement;
+			fireEvent.click(cancelBtn);
+
+			expect(container.querySelector('textarea')).toBeFalsy();
+		});
+
+		it('Confirm Reject button should be disabled when feedback is empty', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Confirm Reject'
+			) as HTMLButtonElement;
+			expect(confirmBtn.disabled).toBe(true);
+		});
+
+		it('should call onReject with taskId and feedback when Confirm Reject is clicked', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('task-99', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			// Open form
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+
+			// Type feedback
+			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+			fireEvent.input(textarea, { target: { value: 'Needs more work' } });
+
+			// Confirm
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Confirm Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(confirmBtn);
+
+			expect(onReject).toHaveBeenCalledWith('task-99', 'Needs more work');
+		});
+
+		it('should close form after Confirm Reject is clicked', () => {
+			const onReject = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReject={onReject} />);
+
+			// Open form
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+
+			// Type feedback and confirm
+			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+			fireEvent.input(textarea, { target: { value: 'Feedback here' } });
+			const confirmBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Confirm Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(confirmBtn);
+
+			expect(container.querySelector('textarea')).toBeFalsy();
+		});
+
+		it('should NOT call onTaskClick when Reject button is clicked', () => {
+			const onReject = vi.fn();
+			const onTaskClick = vi.fn();
+			const tasks = [createTask('task-42', 'review')];
+
+			const { container } = render(
+				<RoomTasks tasks={tasks} onReject={onReject} onTaskClick={onTaskClick} />
+			);
+
+			const rejectBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Reject'
+			) as HTMLButtonElement;
+			fireEvent.click(rejectBtn);
+
+			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -8,8 +8,9 @@
  * - Needs Attention: needs_attention + cancelled
  */
 
+import { useState } from 'preact/hooks';
 import { signal, effect } from '@preact/signals';
-import type { TaskSummary } from '@neokai/shared';
+import type { TaskSummary, TaskStatus } from '@neokai/shared';
 
 /** Tab filter types */
 export type TaskFilterTab = 'active' | 'review' | 'done' | 'needs_attention';
@@ -46,6 +47,7 @@ interface RoomTasksProps {
 	tasks: TaskSummary[];
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
+	onReject?: (taskId: string, feedback: string) => void;
 }
 
 /** Get count of tasks for each filter tab */
@@ -73,7 +75,27 @@ function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary
 	}
 }
 
-export function RoomTasks({ tasks, onTaskClick, onView }: RoomTasksProps) {
+/** Map task status to a left border color class */
+function getStatusBorderColor(status: TaskStatus): string {
+	switch (status) {
+		case 'pending':
+			return 'border-l-gray-500';
+		case 'in_progress':
+			return 'border-l-blue-500';
+		case 'review':
+			return 'border-l-amber-500';
+		case 'completed':
+			return 'border-l-green-500';
+		case 'needs_attention':
+			return 'border-l-red-500';
+		case 'cancelled':
+			return 'border-l-gray-700';
+		default:
+			return 'border-l-transparent';
+	}
+}
+
+export function RoomTasks({ tasks, onTaskClick, onView, onReject }: RoomTasksProps) {
 	const selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 	const filteredTasks = getFilteredTasks(tasks, selectedTab);
@@ -134,6 +156,7 @@ export function RoomTasks({ tasks, onTaskClick, onView }: RoomTasksProps) {
 					tab={selectedTab}
 					onTaskClick={onTaskClick}
 					onView={onView}
+					onReject={onReject}
 				/>
 			)}
 		</div>
@@ -232,13 +255,17 @@ function TaskList({
 	tab,
 	onTaskClick,
 	onView,
+	onReject,
 }: {
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
 	tab: TaskFilterTab;
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
+	onReject?: (taskId: string, feedback: string) => void;
 }) {
+	const [rejectingTaskId, setRejectingTaskId] = useState<string | null>(null);
+
 	// For Active tab, group by in_progress and pending
 	// For Review tab - all are review status
 	// For Done tab - all are completed
@@ -258,6 +285,8 @@ function TaskList({
 						tasks={inProgress}
 						allTasks={allTasks}
 						onTaskClick={onTaskClick}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
 					/>
 				)}
 				{pending.length > 0 && (
@@ -268,6 +297,8 @@ function TaskList({
 						tasks={pending}
 						allTasks={allTasks}
 						onTaskClick={onTaskClick}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
 					/>
 				)}
 			</div>
@@ -285,6 +316,9 @@ function TaskList({
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
 					onView={onView}
+					onReject={onReject}
+					rejectingTaskId={rejectingTaskId}
+					onSetRejectingTaskId={setRejectingTaskId}
 				/>
 			</div>
 		);
@@ -300,6 +334,8 @@ function TaskList({
 					tasks={tasks}
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
+					rejectingTaskId={rejectingTaskId}
+					onSetRejectingTaskId={setRejectingTaskId}
 				/>
 			</div>
 		);
@@ -320,6 +356,8 @@ function TaskList({
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
 					showAlert
+					rejectingTaskId={rejectingTaskId}
+					onSetRejectingTaskId={setRejectingTaskId}
 				/>
 			)}
 			{cancelled.length > 0 && (
@@ -330,6 +368,8 @@ function TaskList({
 					tasks={cancelled}
 					allTasks={allTasks}
 					onTaskClick={onTaskClick}
+					rejectingTaskId={rejectingTaskId}
+					onSetRejectingTaskId={setRejectingTaskId}
 				/>
 			)}
 		</div>
@@ -345,7 +385,10 @@ function TaskGroup({
 	allTasks,
 	onTaskClick,
 	onView,
+	onReject,
 	showAlert = false,
+	rejectingTaskId,
+	onSetRejectingTaskId,
 }: {
 	title: string;
 	count: number;
@@ -354,7 +397,10 @@ function TaskGroup({
 	allTasks: TaskSummary[];
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
+	onReject?: (taskId: string, feedback: string) => void;
 	showAlert?: boolean;
+	rejectingTaskId?: string | null;
+	onSetRejectingTaskId?: (id: string | null) => void;
 }) {
 	const headerStyles: Record<string, string> = {
 		default: '',
@@ -415,6 +461,9 @@ function TaskGroup({
 						allTasks={allTasks}
 						onClick={onTaskClick}
 						onView={onView}
+						onReject={onReject}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={onSetRejectingTaskId}
 					/>
 				))}
 			</div>
@@ -435,22 +484,30 @@ function TaskItem({
 	allTasks,
 	onClick,
 	onView,
+	onReject,
+	rejectingTaskId,
+	onSetRejectingTaskId,
 }: {
 	task: TaskSummary;
 	allTasks: TaskSummary[];
 	onClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
+	onReject?: (taskId: string, feedback: string) => void;
+	rejectingTaskId?: string | null;
+	onSetRejectingTaskId?: (id: string | null) => void;
 }) {
+	const [feedback, setFeedback] = useState('');
 	const isClickable = !!onClick;
 	const showView = task.status === 'review' && !!onView;
+	const showReject = task.status === 'review' && !!onReject;
 	const blocked = task.status === 'pending' && isBlocked(task, allTasks);
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
-
 	const isWorking = task.status === 'review' && !!task.activeSession;
+	const isRejecting = rejectingTaskId === task.id;
 
 	return (
 		<div
-			class={`px-4 py-3 ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
+			class={`px-4 py-3 border-l-2 ${getStatusBorderColor(task.status)} ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
 			onClick={isClickable ? () => onClick(task.id) : undefined}
 		>
 			<div class="flex items-start justify-between">
@@ -500,6 +557,22 @@ function TaskItem({
 							审阅
 						</button>
 					)}
+					{showReject && (
+						<button
+							onClick={(e) => {
+								e.stopPropagation();
+								if (isRejecting) {
+									setFeedback('');
+									onSetRejectingTaskId?.(null);
+								} else {
+									onSetRejectingTaskId?.(task.id);
+								}
+							}}
+							class="px-2 py-1 text-xs font-medium text-red-400 bg-red-900/20 hover:bg-red-900/40 border border-red-700/50 rounded transition-colors"
+						>
+							Reject
+						</button>
+					)}
 					{isClickable && <span class="text-xs text-gray-600">&rarr;</span>}
 				</div>
 			</div>
@@ -535,6 +608,44 @@ function TaskItem({
 						class="h-full bg-blue-500 transition-all duration-300"
 						style={{ width: `${task.progress}%` }}
 					/>
+				</div>
+			)}
+			{isRejecting && (
+				<div
+					class="mt-3 pt-3 border-t border-dark-700"
+					onClick={(e) => e.stopPropagation()}
+				>
+					<textarea
+						rows={2}
+						placeholder="Please provide feedback..."
+						value={feedback}
+						onInput={(e) => setFeedback((e.target as HTMLTextAreaElement).value)}
+						class="w-full text-sm bg-dark-900 border border-dark-600 rounded px-3 py-2 text-gray-200 placeholder-gray-500 resize-none focus:outline-none focus:border-red-500/60"
+					/>
+					<div class="flex justify-end gap-2 mt-2">
+						<button
+							onClick={(e) => {
+								e.stopPropagation();
+								setFeedback('');
+								onSetRejectingTaskId?.(null);
+							}}
+							class="px-3 py-1.5 text-xs font-medium text-gray-400 bg-dark-800 hover:bg-dark-700 border border-dark-600 rounded transition-colors"
+						>
+							Cancel
+						</button>
+						<button
+							onClick={(e) => {
+								e.stopPropagation();
+								onReject?.(task.id, feedback);
+								setFeedback('');
+								onSetRejectingTaskId?.(null);
+							}}
+							disabled={!feedback.trim()}
+							class="px-3 py-1.5 text-xs font-medium text-red-400 bg-red-900/20 hover:bg-red-900/30 border border-red-700/50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Confirm Reject
+						</button>
+					</div>
 				</div>
 			)}
 		</div>

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -611,10 +611,7 @@ function TaskItem({
 				</div>
 			)}
 			{isRejecting && (
-				<div
-					class="mt-3 pt-3 border-t border-dark-700"
-					onClick={(e) => e.stopPropagation()}
-				>
+				<div class="mt-3 pt-3 border-t border-dark-700" onClick={(e) => e.stopPropagation()}>
 					<textarea
 						rows={2}
 						placeholder="Please provide feedback..."

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -498,6 +498,29 @@ class RoomStore {
 		// Task state updates arrive via room.task.update events
 	}
 
+	/**
+	 * Reject a task in review status with feedback.
+	 */
+	async rejectTask(taskId: string, feedback: string): Promise<void> {
+		const roomId = this.roomId.value;
+		if (!roomId) {
+			throw new Error('No room selected');
+		}
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			throw new Error('Not connected');
+		}
+
+		await hub.request<{ success: boolean }>('task.reject', {
+			roomId,
+			taskId,
+			feedback,
+		});
+
+		// Task state updates arrive via room.task.update events
+	}
+
 	// ========================================
 	// Session Methods
 	// ========================================


### PR DESCRIPTION
- Add getStatusBorderColor() helper mapping TaskStatus to border-l-* colors
- Apply border-l-2 with status color to each TaskItem root element
- Add onReject prop through RoomTasksProps → TaskList → TaskGroup → TaskItem
- Show Reject button next to 审阅 for review-status tasks when onReject provided
- Inline reject form expands within card (textarea + Confirm/Cancel buttons)
- Manage rejectingTaskId state at TaskList level (one form open at a time)
- Add rejectTask(taskId, feedback) method to RoomStore via task.reject RPC
- Wire onReject in RoomDashboard to roomStore.rejectTask
- Add 15 new tests covering borders and reject form behavior (64 total, all pass)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
