### PR TITLE
feat: add Inbox navigation infrastructure (Task 3.1)

### DIFF
--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -425,9 +425,7 @@ export function ContextPanel() {
 						onCreateSpace={() => setCreateSpaceOpen(true)}
 					/>
 				)}
-				{navSection === 'inbox' && (
-					<div class="p-4 text-gray-400 text-sm">Inbox</div>
-				)}
+				{navSection === 'inbox' && <div class="p-4 text-gray-400 text-sm">Inbox</div>}
 				{navSection === 'projects' && (
 					<div class="flex-1 flex items-center justify-center p-6">
 						<div class="text-center">

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -17,6 +17,7 @@ import {
 	navigateToSettings,
 	navigateToHome,
 	navigateToRooms,
+	navigateToInbox,
 	navigateToSpaces,
 } from '../lib/router.ts';
 import { roomStore } from '../lib/room-store.ts';
@@ -167,6 +168,13 @@ export function ContextPanel() {
 			emptyDesc: 'Create a space to orchestrate agents',
 			actionLabel: 'Create Space',
 		},
+		inbox: {
+			title: 'Inbox',
+			emptyIcon: '📥',
+			emptyTitle: 'No items',
+			emptyDesc: 'Tasks awaiting review will appear here',
+			actionLabel: 'Inbox',
+		},
 		projects: {
 			title: 'Projects',
 			emptyIcon: '📁',
@@ -256,6 +264,9 @@ export function ContextPanel() {
 			case 'rooms':
 				navigateToRooms();
 				break;
+			case 'inbox':
+				navigateToInbox();
+				break;
 			case 'spaces':
 				navigateToSpaces();
 				break;
@@ -268,6 +279,7 @@ export function ContextPanel() {
 	const isActionDisabled =
 		connectionState.value !== 'connected' ||
 		!authStatus.value?.isAuthenticated ||
+		navSection === 'inbox' ||
 		navSection === 'projects' ||
 		navSection === 'settings';
 
@@ -412,6 +424,9 @@ export function ContextPanel() {
 						onSpaceSelect={() => (contextPanelOpenSignal.value = false)}
 						onCreateSpace={() => setCreateSpaceOpen(true)}
 					/>
+				)}
+				{navSection === 'inbox' && (
+					<div class="p-4 text-gray-400 text-sm">Inbox</div>
 				)}
 				{navSection === 'projects' && (
 					<div class="flex-1 flex items-center justify-center p-6">

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -88,6 +88,15 @@ export default function MainContent() {
 		);
 	}
 
+	// Inbox route
+	if (navSection === 'inbox') {
+		return (
+			<div class="flex-1 flex items-center justify-center text-gray-500">
+				Inbox coming soon...
+			</div>
+		);
+	}
+
 	// Default: Show Lobby (home page)
 	return <Lobby />;
 }

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -91,9 +91,7 @@ export default function MainContent() {
 	// Inbox route
 	if (navSection === 'inbox') {
 		return (
-			<div class="flex-1 flex items-center justify-center text-gray-500">
-				Inbox coming soon...
-			</div>
+			<div class="flex-1 flex items-center justify-center text-gray-500">Inbox coming soon...</div>
 		);
 	}
 

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -4,12 +4,16 @@ import {
 	navigateToSettings,
 	navigateToHome,
 	navigateToRooms,
+	navigateToInbox,
 	navigateToSpaces,
 } from '../lib/router.ts';
 import { NavIconButton } from '../components/ui/NavIconButton.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 import { DaemonStatusIndicator } from '../components/DaemonStatusIndicator.tsx';
 import { MAIN_NAV_ITEMS, SETTINGS_NAV_ITEM } from '../lib/nav-config.tsx';
+
+// Static badge count for inbox — Task 3.2 will provide dynamic data
+const inboxBadgeCount = 0;
 
 export function NavRail() {
 	const navSection = navSectionSignal.value;
@@ -25,6 +29,9 @@ export function NavRail() {
 				break;
 			case 'rooms':
 				navigateToRooms();
+				break;
+			case 'inbox':
+				navigateToInbox();
 				break;
 			case 'spaces':
 				navigateToSpaces();
@@ -51,16 +58,43 @@ export function NavRail() {
 
 			{/* Nav Items */}
 			<nav class="flex-1 flex flex-col gap-1">
-				{MAIN_NAV_ITEMS.map((item) => (
-					<NavIconButton
-						key={item.id}
-						active={navSection === item.id}
-						onClick={() => handleNavClick(item.id)}
-						label={item.label}
-					>
-						{item.icon}
-					</NavIconButton>
-				))}
+				{MAIN_NAV_ITEMS.map((item) => {
+					if (item.id === 'inbox') {
+						const badge = inboxBadgeCount;
+						return (
+							<div key={item.id} class="relative">
+								<NavIconButton
+									active={navSection === item.id}
+									onClick={() => handleNavClick(item.id)}
+									label={item.label}
+								>
+									{item.icon}
+								</NavIconButton>
+								{badge > 0 && (
+									<div class="w-2 h-2 rounded-full bg-red-500 absolute top-1 right-1 flex items-center justify-center">
+										{badge <= 9 ? (
+											<span class="text-white text-[8px] font-bold leading-none">
+												{badge}
+											</span>
+										) : (
+											<span class="text-white text-[8px] font-bold leading-none">9+</span>
+										)}
+									</div>
+								)}
+							</div>
+						);
+					}
+					return (
+						<NavIconButton
+							key={item.id}
+							active={navSection === item.id}
+							onClick={() => handleNavClick(item.id)}
+							label={item.label}
+						>
+							{item.icon}
+						</NavIconButton>
+					);
+				})}
 			</nav>
 
 			{/* Bottom - Daemon Status & Settings */}

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -73,9 +73,7 @@ export function NavRail() {
 								{badge > 0 && (
 									<div class="w-2 h-2 rounded-full bg-red-500 absolute top-1 right-1 flex items-center justify-center">
 										{badge <= 9 ? (
-											<span class="text-white text-[8px] font-bold leading-none">
-												{badge}
-											</span>
+											<span class="text-white text-[8px] font-bold leading-none">{badge}</span>
 										) : (
 											<span class="text-white text-[8px] font-bold leading-none">9+</span>
 										)}

--- a/packages/web/src/lib/nav-config.tsx
+++ b/packages/web/src/lib/nav-config.tsx
@@ -37,6 +37,20 @@ export const MAIN_NAV_ITEMS: NavItemConfig[] = [
 		),
 	},
 	{
+		id: 'inbox',
+		label: 'Inbox',
+		icon: (
+			<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+				/>
+			</svg>
+		),
+	},
+	{
 		id: 'chats',
 		label: 'Chats',
 		icon: (

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -29,6 +29,7 @@ const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
+const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
 /** Legacy: /room/:id/chat was removed — treat as plain room route for backwards compat */
 const ROOM_CHAT_COMPAT_PATTERN = /^\/room\/([a-f0-9-]+)\/chat$/;
@@ -511,6 +512,49 @@ export function navigateToRooms(): void {
 }
 
 /**
+ * Navigate to Inbox section
+ * Sets nav section to 'inbox' and updates URL to /inbox
+ */
+export function navigateToInbox(replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	const currentPath = getCurrentPath();
+	if (currentPath === '/inbox') {
+		navSectionSignal.value = 'inbox';
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ path: '/inbox' }, '', '/inbox');
+
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'inbox';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
  * Navigate to Settings section
  * Sets nav section to 'settings' and navigates home
  */
@@ -785,6 +829,15 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
+	} else if (INBOX_ROUTE_PATTERN.test(path)) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(path)) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -895,6 +948,15 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
+	} else if (INBOX_ROUTE_PATTERN.test(initialPath)) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(initialPath)) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -32,7 +32,7 @@ export const sessionsSignal = signal<Session[]>([]);
 export const slashCommandsSignal = signal<string[]>([]);
 
 // Navigation section signal - which nav item is active
-export type NavSection = 'home' | 'chats' | 'rooms' | 'projects' | 'spaces' | 'settings';
+export type NavSection = 'home' | 'chats' | 'rooms' | 'inbox' | 'projects' | 'spaces' | 'settings';
 export const navSectionSignal = signal<NavSection>('home');
 
 // Space navigation signals


### PR DESCRIPTION
- Extend NavSection type to include 'inbox' between 'rooms' and 'projects'
- Add navigateToInbox() function and /inbox route handling in router.ts
- Add Inbox nav item with heroicons inbox SVG to nav-config.tsx MAIN_NAV_ITEMS
- Update NavRail.tsx to handle 'inbox' click and render badge infrastructure (static count=0 for now)
- Add inbox placeholder panel to ContextPanel.tsx
- Add inbox placeholder branch to MainContent.tsx

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
