### PR TITLE
feat: add Inbox view (inbox-store + Inbox.tsx + MainContent routing) (Task 3.2)

### DIFF
--- a/packages/web/src/components/inbox/Inbox.test.tsx
+++ b/packages/web/src/components/inbox/Inbox.test.tsx
@@ -36,14 +36,6 @@ vi.mock('../../lib/inbox-store.ts', () => ({
 	},
 }));
 
-// Mock signals
-vi.mock('../../lib/signals.ts', async (importOriginal) => {
-	const actual = await importOriginal();
-	return {
-		...actual,
-	};
-});
-
 import { Inbox } from './Inbox.tsx';
 import {
 	currentRoomIdSignal,

--- a/packages/web/src/components/inbox/Inbox.test.tsx
+++ b/packages/web/src/components/inbox/Inbox.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for Inbox Component
+ *
+ * Tests loading state, empty state, task card rendering,
+ * and "Review" button navigation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
+import { signal, computed } from '@preact/signals';
+import type { TaskSummary } from '@neokai/shared';
+import type { InboxTask } from '../../lib/inbox-store.ts';
+
+// Hoisted mocks
+const { mockRefresh } = vi.hoisted(() => ({
+	mockRefresh: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock inboxStore
+const mockItemsSignal = signal<InboxTask[]>([]);
+const mockIsLoadingSignal = signal<boolean>(false);
+const mockReviewCount = computed(() => mockItemsSignal.value.length);
+
+vi.mock('../../lib/inbox-store.ts', () => ({
+	inboxStore: {
+		get items() {
+			return mockItemsSignal;
+		},
+		get isLoading() {
+			return mockIsLoadingSignal;
+		},
+		get reviewCount() {
+			return mockReviewCount;
+		},
+		refresh: mockRefresh,
+	},
+}));
+
+// Mock signals
+vi.mock('../../lib/signals.ts', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+	};
+});
+
+import { Inbox } from './Inbox.tsx';
+import {
+	currentRoomIdSignal,
+	currentRoomTaskIdSignal,
+	navSectionSignal,
+} from '../../lib/signals.ts';
+
+function makeTask(id: string): TaskSummary {
+	return {
+		id,
+		title: `Task ${id}`,
+		status: 'review',
+		priority: 'normal',
+		progress: null,
+		dependsOn: [],
+		updatedAt: Date.now(),
+	};
+}
+
+function makeInboxTask(taskId: string, roomId: string, roomTitle: string): InboxTask {
+	return {
+		task: makeTask(taskId),
+		roomId,
+		roomTitle,
+	};
+}
+
+describe('Inbox', () => {
+	beforeEach(() => {
+		mockItemsSignal.value = [];
+		mockIsLoadingSignal.value = false;
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('Rendering', () => {
+		it('should render the header with title', () => {
+			render(<Inbox />);
+			expect(screen.getByText('Inbox')).toBeTruthy();
+		});
+
+		it('should show count of awaiting review tasks', () => {
+			mockItemsSignal.value = [makeInboxTask('t1', 'r1', 'Room 1')];
+			render(<Inbox />);
+			expect(screen.getByText('1 awaiting review')).toBeTruthy();
+		});
+
+		it('should show 0 awaiting review when empty', () => {
+			render(<Inbox />);
+			expect(screen.getByText('0 awaiting review')).toBeTruthy();
+		});
+	});
+
+	describe('Loading state', () => {
+		it('should show spinner when loading', () => {
+			mockIsLoadingSignal.value = true;
+			const { container } = render(<Inbox />);
+			// Spinner has role="status" and aria-label="Loading"
+			const spinner = container.querySelector('[role="status"]');
+			expect(spinner).toBeTruthy();
+		});
+
+		it('should not show empty state while loading', () => {
+			mockIsLoadingSignal.value = true;
+			render(<Inbox />);
+			expect(screen.queryByText('No tasks awaiting review')).toBeFalsy();
+		});
+	});
+
+	describe('Empty state', () => {
+		it('should show empty message when not loading and no items', () => {
+			mockIsLoadingSignal.value = false;
+			mockItemsSignal.value = [];
+			render(<Inbox />);
+			expect(screen.getByText('No tasks awaiting review')).toBeTruthy();
+		});
+	});
+
+	describe('InboxTaskCard', () => {
+		it('should render task title and room name', () => {
+			mockItemsSignal.value = [makeInboxTask('t1', 'r1', 'My Room')];
+			render(<Inbox />);
+			expect(screen.getByText('Task t1')).toBeTruthy();
+			expect(screen.getByText('My Room')).toBeTruthy();
+		});
+
+		it('should render a Review button for each task', () => {
+			mockItemsSignal.value = [
+				makeInboxTask('t1', 'r1', 'Room 1'),
+				makeInboxTask('t2', 'r2', 'Room 2'),
+			];
+			render(<Inbox />);
+			const buttons = screen.getAllByText('Review');
+			expect(buttons).toHaveLength(2);
+		});
+
+		it('should have amber left border styling', () => {
+			mockItemsSignal.value = [makeInboxTask('t1', 'r1', 'Room 1')];
+			const { container } = render(<Inbox />);
+			const card = container.querySelector('.border-l-amber-500');
+			expect(card).toBeTruthy();
+		});
+
+		it('should navigate to correct room and task on Review click', () => {
+			mockItemsSignal.value = [makeInboxTask('task-abc', 'room-xyz', 'Test Room')];
+			render(<Inbox />);
+
+			const reviewBtn = screen.getByText('Review');
+			fireEvent.click(reviewBtn);
+
+			expect(navSectionSignal.value).toBe('rooms');
+			expect(currentRoomIdSignal.value).toBe('room-xyz');
+			expect(currentRoomTaskIdSignal.value).toBe('task-abc');
+		});
+	});
+
+	describe('Lifecycle', () => {
+		it('should call inboxStore.refresh() on mount', () => {
+			render(<Inbox />);
+			expect(mockRefresh).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/web/src/components/inbox/Inbox.tsx
+++ b/packages/web/src/components/inbox/Inbox.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'preact/hooks';
+import { inboxStore, type InboxTask } from '../../lib/inbox-store.ts';
+import { Spinner } from '../ui/Spinner.tsx';
+import {
+	currentRoomIdSignal,
+	currentRoomTaskIdSignal,
+	navSectionSignal,
+} from '../../lib/signals.ts';
+
+function InboxTaskCard({ item }: { item: InboxTask }) {
+	const handleReview = () => {
+		navSectionSignal.value = 'rooms';
+		currentRoomIdSignal.value = item.roomId;
+		currentRoomTaskIdSignal.value = item.task.id;
+	};
+
+	return (
+		<div class="flex items-start gap-3 px-4 py-3 border-b border-dark-700 hover:bg-dark-800 transition-colors border-l-[3px] border-l-amber-500">
+			<div class="flex-1 min-w-0">
+				<p class="text-gray-100 font-medium text-sm truncate">{item.task.title}</p>
+				<p class="text-gray-500 text-xs mt-0.5">{item.roomTitle}</p>
+			</div>
+			<button
+				type="button"
+				onClick={handleReview}
+				class="shrink-0 px-3 py-1 text-xs font-medium rounded bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 transition-colors"
+			>
+				Review
+			</button>
+		</div>
+	);
+}
+
+function EmptyState() {
+	return (
+		<div class="flex flex-col items-center justify-center h-full gap-2 text-gray-500">
+			<p class="text-sm">No tasks awaiting review</p>
+		</div>
+	);
+}
+
+export function Inbox() {
+	const items = inboxStore.items.value;
+	const isLoading = inboxStore.isLoading.value;
+	const count = inboxStore.reviewCount.value;
+
+	useEffect(() => {
+		inboxStore.refresh();
+	}, []);
+
+	return (
+		<div class="flex flex-col h-full">
+			<div class="px-6 py-4 border-b border-dark-700 flex items-center justify-between">
+				<h1 class="text-lg font-semibold text-gray-100">Inbox</h1>
+				<span class="text-xs text-gray-500">{count} awaiting review</span>
+			</div>
+			<div class="flex-1 overflow-y-auto">
+				{isLoading && (
+					<div class="flex items-center justify-center p-8">
+						<Spinner size="md" />
+					</div>
+				)}
+				{!isLoading && items.length === 0 && <EmptyState />}
+				{!isLoading &&
+					items.map((item) => <InboxTaskCard key={item.task.id} item={item} />)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/inbox/Inbox.tsx
+++ b/packages/web/src/components/inbox/Inbox.tsx
@@ -61,8 +61,7 @@ export function Inbox() {
 					</div>
 				)}
 				{!isLoading && items.length === 0 && <EmptyState />}
-				{!isLoading &&
-					items.map((item) => <InboxTaskCard key={item.task.id} item={item} />)}
+				{!isLoading && items.map((item) => <InboxTaskCard key={item.task.id} item={item} />)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -20,6 +20,7 @@ import { McpServersSettings } from '../components/settings/McpServersSettings.ts
 import { UsageAnalytics } from '../components/settings/UsageAnalytics.tsx';
 import { AboutSection } from '../components/settings/AboutSection.tsx';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
+import { Inbox } from '../components/inbox/Inbox.tsx';
 
 export default function MainContent() {
 	// IMPORTANT: Access .value directly in component body to enable Preact Signals auto-tracking
@@ -90,9 +91,7 @@ export default function MainContent() {
 
 	// Inbox route
 	if (navSection === 'inbox') {
-		return (
-			<div class="flex-1 flex items-center justify-center text-gray-500">Inbox coming soon...</div>
-		);
+		return <Inbox />;
 	}
 
 	// Default: Show Lobby (home page)

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -11,12 +11,11 @@ import { NavIconButton } from '../components/ui/NavIconButton.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 import { DaemonStatusIndicator } from '../components/DaemonStatusIndicator.tsx';
 import { MAIN_NAV_ITEMS, SETTINGS_NAV_ITEM } from '../lib/nav-config.tsx';
-
-// Static badge count for inbox — Task 3.2 will provide dynamic data
-const inboxBadgeCount = 0;
+import { inboxStore } from '../lib/inbox-store.ts';
 
 export function NavRail() {
 	const navSection = navSectionSignal.value;
+	const inboxBadgeCount = inboxStore.reviewCount.value;
 
 	const handleNavClick = (section: NavSection) => {
 		switch (section) {

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -177,7 +177,10 @@ describe('InboxStore', () => {
 
 		it('should ignore archived rooms', async () => {
 			const activeRoom = makeRoom('active', 'Active Room');
-			const archivedRoom = { ...makeRoom('archived', 'Archived Room'), status: 'archived' as const };
+			const archivedRoom = {
+				...makeRoom('archived', 'Archived Room'),
+				status: 'archived' as const,
+			};
 			mockRoomsSignal.value = [activeRoom, archivedRoom];
 
 			const mockHub = {

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for InboxStore
+ *
+ * Tests task aggregation across rooms, filtering to review status,
+ * sorting, and computed reviewCount.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signal } from '@preact/signals';
+import type { Room, RoomOverview, TaskSummary } from '@neokai/shared';
+
+// Hoisted mocks
+const { mockGetHub } = vi.hoisted(() => ({
+	mockGetHub: vi.fn(),
+}));
+
+vi.mock('./connection-manager', () => ({
+	connectionManager: {
+		getHub: mockGetHub,
+	},
+}));
+
+// Lobby store mock rooms signal
+const mockRoomsSignal = signal<Room[]>([]);
+vi.mock('./lobby-store', () => ({
+	lobbyStore: {
+		get rooms() {
+			return mockRoomsSignal;
+		},
+	},
+}));
+
+// Import after mocks are set up
+const { inboxStore } = await import('./inbox-store.ts');
+
+function makeRoom(id: string, name: string): Room {
+	return {
+		id,
+		name,
+		allowedPaths: [],
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeTask(id: string, status: TaskSummary['status'], updatedAt = Date.now()): TaskSummary {
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		priority: 'normal',
+		progress: null,
+		dependsOn: [],
+		updatedAt,
+	};
+}
+
+function makeOverview(room: Room, tasks: TaskSummary[]): RoomOverview {
+	return {
+		room,
+		sessions: [],
+		activeTasks: tasks.filter((t) => !['completed', 'cancelled'].includes(t.status)),
+		allTasks: tasks,
+	};
+}
+
+describe('InboxStore', () => {
+	beforeEach(() => {
+		mockRoomsSignal.value = [];
+		inboxStore.items.value = [];
+		inboxStore.isLoading.value = false;
+		vi.clearAllMocks();
+	});
+
+	describe('refresh()', () => {
+		it('should set items to empty array when no rooms', async () => {
+			mockRoomsSignal.value = [];
+
+			await inboxStore.refresh();
+
+			expect(inboxStore.items.value).toEqual([]);
+			expect(mockGetHub).not.toHaveBeenCalled();
+		});
+
+		it('should aggregate review-status tasks across rooms', async () => {
+			const roomA = makeRoom('room-a', 'Room A');
+			const roomB = makeRoom('room-b', 'Room B');
+			mockRoomsSignal.value = [roomA, roomB];
+
+			const tasksA = [makeTask('t1', 'review', 1000), makeTask('t2', 'in_progress', 2000)];
+			const tasksB = [makeTask('t3', 'review', 3000), makeTask('t4', 'completed', 4000)];
+
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomA, tasksA)))
+					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomB, tasksB))),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.refresh();
+
+			const items = inboxStore.items.value;
+			expect(items).toHaveLength(2);
+
+			// Both should be review tasks
+			expect(items.every((item) => item.task.status === 'review')).toBe(true);
+
+			// Should include correct room metadata
+			const ids = items.map((i) => i.task.id);
+			expect(ids).toContain('t1');
+			expect(ids).toContain('t3');
+
+			const itemA = items.find((i) => i.task.id === 't1');
+			expect(itemA?.roomId).toBe('room-a');
+			expect(itemA?.roomTitle).toBe('Room A');
+		});
+
+		it('should sort items by updatedAt descending', async () => {
+			const room = makeRoom('room-1', 'Room 1');
+			mockRoomsSignal.value = [room];
+
+			const tasks = [
+				makeTask('early', 'review', 1000),
+				makeTask('latest', 'review', 3000),
+				makeTask('middle', 'review', 2000),
+			];
+
+			const mockHub = {
+				request: vi.fn().mockResolvedValue(makeOverview(room, tasks)),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.refresh();
+
+			const ids = inboxStore.items.value.map((i) => i.task.id);
+			expect(ids).toEqual(['latest', 'middle', 'early']);
+		});
+
+		it('should skip failed room requests gracefully', async () => {
+			const roomA = makeRoom('room-a', 'Room A');
+			const roomB = makeRoom('room-b', 'Room B');
+			mockRoomsSignal.value = [roomA, roomB];
+
+			const tasksB = [makeTask('t1', 'review')];
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.reject(new Error('Network error')))
+					.mockImplementationOnce(() => Promise.resolve(makeOverview(roomB, tasksB))),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.refresh();
+
+			// Should still have tasks from the successful room
+			expect(inboxStore.items.value).toHaveLength(1);
+			expect(inboxStore.items.value[0].task.id).toBe('t1');
+		});
+
+		it('should set isLoading to false after completion', async () => {
+			mockRoomsSignal.value = [makeRoom('r', 'R')];
+			const mockHub = {
+				request: vi.fn().mockResolvedValue(makeOverview(makeRoom('r', 'R'), [])),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			const refreshPromise = inboxStore.refresh();
+			// Loading should be true while in flight
+			expect(inboxStore.isLoading.value).toBe(true);
+
+			await refreshPromise;
+			expect(inboxStore.isLoading.value).toBe(false);
+		});
+
+		it('should ignore archived rooms', async () => {
+			const activeRoom = makeRoom('active', 'Active Room');
+			const archivedRoom = { ...makeRoom('archived', 'Archived Room'), status: 'archived' as const };
+			mockRoomsSignal.value = [activeRoom, archivedRoom];
+
+			const mockHub = {
+				request: vi.fn().mockResolvedValue(makeOverview(activeRoom, [])),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.refresh();
+
+			// Only one request — for the active room
+			expect(mockHub.request).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('reviewCount', () => {
+		it('should return 0 when items is empty', () => {
+			inboxStore.items.value = [];
+			expect(inboxStore.reviewCount.value).toBe(0);
+		});
+
+		it('should return the number of items', () => {
+			const room = makeRoom('r', 'R');
+			inboxStore.items.value = [
+				{ task: makeTask('t1', 'review'), roomId: 'r', roomTitle: 'R' },
+				{ task: makeTask('t2', 'review'), roomId: 'r', roomTitle: 'R' },
+			];
+			expect(inboxStore.reviewCount.value).toBe(2);
+		});
+
+		it('should update reactively when items change', () => {
+			inboxStore.items.value = [];
+			expect(inboxStore.reviewCount.value).toBe(0);
+
+			inboxStore.items.value = [{ task: makeTask('t1', 'review'), roomId: 'r', roomTitle: 'R' }];
+			expect(inboxStore.reviewCount.value).toBe(1);
+		});
+	});
+});

--- a/packages/web/src/lib/inbox-store.ts
+++ b/packages/web/src/lib/inbox-store.ts
@@ -1,0 +1,83 @@
+/**
+ * InboxStore - Aggregates review-status tasks across all rooms
+ *
+ * Data layer for the Inbox feature. Fans out room.get requests in parallel
+ * to collect all tasks with status === 'review', providing a unified inbox view.
+ *
+ * No dedicated inbox API exists on the backend; this store composes
+ * existing room.get RPC calls (same pattern as RoomStore.fetchInitialState).
+ */
+
+import { signal, computed } from '@preact/signals';
+import type { TaskSummary, RoomOverview } from '@neokai/shared';
+import { connectionManager } from './connection-manager';
+import { lobbyStore } from './lobby-store';
+
+/**
+ * A review-status task enriched with room metadata for inbox display
+ */
+export interface InboxTask {
+	task: TaskSummary;
+	roomId: string;
+	roomTitle: string;
+}
+
+const items = signal<InboxTask[]>([]);
+const isLoading = signal<boolean>(false);
+
+/**
+ * Computed count of tasks awaiting review
+ */
+const reviewCount = computed(() => items.value.length);
+
+/**
+ * Fan out room.get requests to all rooms in parallel, collect review-status tasks,
+ * and update the items signal sorted by updatedAt descending.
+ */
+async function refresh(): Promise<void> {
+	const rooms = lobbyStore.rooms.value.filter((r) => r.status === 'active');
+	if (rooms.length === 0) {
+		items.value = [];
+		return;
+	}
+
+	isLoading.value = true;
+	try {
+		const hub = await connectionManager.getHub();
+
+		const results = await Promise.all(
+			rooms.map((room) =>
+				hub
+					.request<RoomOverview>('room.get', { roomId: room.id })
+					.then((overview) => ({ overview, room }))
+					.catch(() => null)
+			)
+		);
+
+		const inbox: InboxTask[] = [];
+		for (const result of results) {
+			if (!result?.overview) continue;
+			const { overview, room } = result;
+			const tasks = overview.allTasks ?? overview.activeTasks;
+			for (const task of tasks) {
+				if (task.status === 'review') {
+					inbox.push({ task, roomId: room.id, roomTitle: room.name });
+				}
+			}
+		}
+
+		// Sort by updatedAt descending (most recently updated first)
+		inbox.sort((a, b) => b.task.updatedAt - a.task.updatedAt);
+
+		items.value = inbox;
+	} finally {
+		isLoading.value = false;
+	}
+}
+
+export const inboxStore = {
+	items,
+	isLoading,
+	refresh,
+	reviewCount,
+};


### PR DESCRIPTION
- Create inbox-store.ts: fans out room.get requests in parallel, collects
  review-status tasks across all active rooms, sorted by updatedAt desc;
  exposes items/isLoading signals and reviewCount computed signal
- Create Inbox.tsx: header with count badge, loading spinner, empty state,
  InboxTaskCard with amber left border, room title, and "Review" button that
  navigates to the correct room TaskView
- Update MainContent.tsx: replace inbox placeholder with real <Inbox /> component
- Update NavRail.tsx: wire inboxBadgeCount to inboxStore.reviewCount.value
  for live badge updates
- Add tests: inbox-store.test.ts (refresh logic, filtering, sorting, error
  resilience, reviewCount reactivity) and Inbox.test.tsx (rendering, loading
  state, empty state, card display, Review navigation)
- All 4582 web tests pass; typecheck and lint clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
