### PR TITLE
feat: add direct approve/reject to Inbox without TaskView navigation (Task 4.3)

### DIFF
--- a/packages/web/src/components/inbox/Inbox.tsx
+++ b/packages/web/src/components/inbox/Inbox.tsx
@@ -144,9 +144,7 @@ export function Inbox() {
 		<div class="flex flex-col h-full">
 			<div class="px-6 py-4 border-b border-dark-700 flex items-center justify-between">
 				<h1 class="text-lg font-semibold text-gray-100">Inbox</h1>
-				<span class="text-xs text-gray-500">
-					{count} awaiting review · approve or reject below
-				</span>
+				<span class="text-xs text-gray-500">{count} awaiting review · approve or reject below</span>
 			</div>
 			<div class="flex-1 overflow-y-auto">
 				{isLoading && (

--- a/packages/web/src/components/inbox/Inbox.tsx
+++ b/packages/web/src/components/inbox/Inbox.tsx
@@ -32,17 +32,19 @@ function InboxTaskCard({
 
 	const handleApprove = async () => {
 		onStartApprove(item.task.id);
-		await inboxStore.approveTask(item.task.id, item.roomId);
-		toast.approved();
+		const ok = await inboxStore.approveTask(item.task.id, item.roomId);
+		if (ok) toast.approved();
 		onFinishApprove();
 	};
 
 	const handleRejectSubmit = async () => {
 		if (!feedback.trim()) return;
-		await inboxStore.rejectTask(item.task.id, item.roomId, feedback.trim());
-		toast.rejected();
-		setFeedback('');
-		setIsRejecting(false);
+		const ok = await inboxStore.rejectTask(item.task.id, item.roomId, feedback.trim());
+		if (ok) {
+			toast.rejected();
+			setFeedback('');
+			setIsRejecting(false);
+		}
 	};
 
 	return (

--- a/packages/web/src/components/inbox/Inbox.tsx
+++ b/packages/web/src/components/inbox/Inbox.tsx
@@ -1,32 +1,121 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { inboxStore, type InboxTask } from '../../lib/inbox-store.ts';
 import { Spinner } from '../ui/Spinner.tsx';
+import { toast } from '../../lib/toast.ts';
 import {
 	currentRoomIdSignal,
 	currentRoomTaskIdSignal,
 	navSectionSignal,
 } from '../../lib/signals.ts';
 
-function InboxTaskCard({ item }: { item: InboxTask }) {
-	const handleReview = () => {
+function InboxTaskCard({
+	item,
+	approvingId,
+	onStartApprove,
+	onFinishApprove,
+}: {
+	item: InboxTask;
+	approvingId: string | null;
+	onStartApprove: (id: string) => void;
+	onFinishApprove: () => void;
+}) {
+	const [isRejecting, setIsRejecting] = useState(false);
+	const [feedback, setFeedback] = useState('');
+	const isApproving = approvingId === item.task.id;
+	const anyApproving = approvingId !== null;
+
+	const handleView = () => {
 		navSectionSignal.value = 'rooms';
 		currentRoomIdSignal.value = item.roomId;
 		currentRoomTaskIdSignal.value = item.task.id;
 	};
 
+	const handleApprove = async () => {
+		onStartApprove(item.task.id);
+		await inboxStore.approveTask(item.task.id, item.roomId);
+		toast.approved();
+		onFinishApprove();
+	};
+
+	const handleRejectSubmit = async () => {
+		if (!feedback.trim()) return;
+		await inboxStore.rejectTask(item.task.id, item.roomId, feedback.trim());
+		toast.rejected();
+		setFeedback('');
+		setIsRejecting(false);
+	};
+
 	return (
-		<div class="flex items-start gap-3 px-4 py-3 border-b border-dark-700 hover:bg-dark-800 transition-colors border-l-[3px] border-l-amber-500">
-			<div class="flex-1 min-w-0">
-				<p class="text-gray-100 font-medium text-sm truncate">{item.task.title}</p>
-				<p class="text-gray-500 text-xs mt-0.5">{item.roomTitle}</p>
+		<div class="flex flex-col px-4 py-3 border-b border-dark-700 hover:bg-dark-800 transition-colors border-l-[3px] border-l-amber-500">
+			<div class="flex items-start gap-3">
+				<div class="flex-1 min-w-0">
+					<p class="text-gray-100 font-medium text-sm truncate">{item.task.title}</p>
+					<p class="text-gray-500 text-xs mt-0.5">{item.roomTitle}</p>
+				</div>
+				<div class="flex items-center gap-2 shrink-0">
+					<button
+						type="button"
+						onClick={handleApprove}
+						disabled={anyApproving}
+						class="bg-green-600 hover:bg-green-700 text-white text-xs px-3 py-1 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1 transition-colors"
+					>
+						{isApproving ? (
+							<>
+								<Spinner size="sm" />
+								<span>Approving…</span>
+							</>
+						) : (
+							'Approve'
+						)}
+					</button>
+					<button
+						type="button"
+						onClick={() => setIsRejecting((v) => !v)}
+						disabled={anyApproving}
+						class="border border-red-600 text-red-400 hover:bg-red-900/20 text-xs px-3 py-1 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Reject
+					</button>
+					<button
+						type="button"
+						onClick={handleView}
+						class="text-gray-400 hover:text-gray-200 hover:bg-dark-700 text-xs px-3 py-1 rounded-lg transition-colors"
+					>
+						View
+					</button>
+				</div>
 			</div>
-			<button
-				type="button"
-				onClick={handleReview}
-				class="shrink-0 px-3 py-1 text-xs font-medium rounded bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 transition-colors"
-			>
-				Review
-			</button>
+			{isRejecting && (
+				<div class="mt-3 pt-3 border-t border-dark-700">
+					<textarea
+						rows={2}
+						placeholder="Provide feedback..."
+						value={feedback}
+						onInput={(e) => setFeedback((e.target as HTMLTextAreaElement).value)}
+						class="w-full text-sm bg-dark-900 border border-dark-600 rounded px-3 py-2 text-gray-200 placeholder-gray-500 resize-none focus:outline-none focus:border-red-500/60"
+					/>
+					<div class="flex justify-end gap-2 mt-2">
+						<button
+							type="button"
+							onClick={() => {
+								setFeedback('');
+								setIsRejecting(false);
+							}}
+							class="px-3 py-1.5 text-xs font-medium text-gray-400 bg-dark-800 hover:bg-dark-700 border border-dark-600 rounded transition-colors"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={handleRejectSubmit}
+							disabled={!feedback.trim()}
+							class="px-3 py-1.5 text-xs font-medium text-red-400 bg-red-900/20 hover:bg-red-900/30 border border-red-700/50 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Send Feedback
+						</button>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }
@@ -43,6 +132,7 @@ export function Inbox() {
 	const items = inboxStore.items.value;
 	const isLoading = inboxStore.isLoading.value;
 	const count = inboxStore.reviewCount.value;
+	const [approvingId, setApprovingId] = useState<string | null>(null);
 
 	useEffect(() => {
 		inboxStore.refresh();
@@ -52,7 +142,9 @@ export function Inbox() {
 		<div class="flex flex-col h-full">
 			<div class="px-6 py-4 border-b border-dark-700 flex items-center justify-between">
 				<h1 class="text-lg font-semibold text-gray-100">Inbox</h1>
-				<span class="text-xs text-gray-500">{count} awaiting review</span>
+				<span class="text-xs text-gray-500">
+					{count} awaiting review · approve or reject below
+				</span>
 			</div>
 			<div class="flex-1 overflow-y-auto">
 				{isLoading && (
@@ -61,7 +153,16 @@ export function Inbox() {
 					</div>
 				)}
 				{!isLoading && items.length === 0 && <EmptyState />}
-				{!isLoading && items.map((item) => <InboxTaskCard key={item.task.id} item={item} />)}
+				{!isLoading &&
+					items.map((item) => (
+						<InboxTaskCard
+							key={item.task.id}
+							item={item}
+							approvingId={approvingId}
+							onStartApprove={setApprovingId}
+							onFinishApprove={() => setApprovingId(null)}
+						/>
+					))}
 			</div>
 		</div>
 	);

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -203,7 +203,7 @@ describe('InboxStore', () => {
 	});
 
 	describe('approveTask()', () => {
-		it('should call room.task.approve and refresh on success', async () => {
+		it('should call room.task.approve, refresh, and return true on success', async () => {
 			const room = makeRoom('r', 'R');
 			mockRoomsSignal.value = [room];
 
@@ -215,28 +215,30 @@ describe('InboxStore', () => {
 			};
 			mockGetHub.mockResolvedValue(mockHub);
 
-			await inboxStore.approveTask('task-1', 'r');
+			const result = await inboxStore.approveTask('task-1', 'r');
 
+			expect(result).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('room.task.approve', {
 				roomId: 'r',
 				taskId: 'task-1',
 			});
 		});
 
-		it('should show toast.error when approve fails', async () => {
+		it('should show toast.error and return false when approve fails', async () => {
 			const mockHub = {
 				request: vi.fn().mockRejectedValue(new Error('Server error')),
 			};
 			mockGetHub.mockResolvedValue(mockHub);
 
-			await inboxStore.approveTask('task-1', 'r');
+			const result = await inboxStore.approveTask('task-1', 'r');
 
+			expect(result).toBe(false);
 			expect(mockToastError).toHaveBeenCalledWith('Server error');
 		});
 	});
 
 	describe('rejectTask()', () => {
-		it('should call room.task.reject with feedback and refresh on success', async () => {
+		it('should call room.task.reject with feedback, refresh, and return true on success', async () => {
 			const room = makeRoom('r', 'R');
 			mockRoomsSignal.value = [room];
 
@@ -248,8 +250,9 @@ describe('InboxStore', () => {
 			};
 			mockGetHub.mockResolvedValue(mockHub);
 
-			await inboxStore.rejectTask('task-1', 'r', 'needs more work');
+			const result = await inboxStore.rejectTask('task-1', 'r', 'needs more work');
 
+			expect(result).toBe(true);
 			expect(mockHub.request).toHaveBeenCalledWith('room.task.reject', {
 				roomId: 'r',
 				taskId: 'task-1',
@@ -257,14 +260,15 @@ describe('InboxStore', () => {
 			});
 		});
 
-		it('should show toast.error when reject fails', async () => {
+		it('should show toast.error and return false when reject fails', async () => {
 			const mockHub = {
 				request: vi.fn().mockRejectedValue(new Error('Reject failed')),
 			};
 			mockGetHub.mockResolvedValue(mockHub);
 
-			await inboxStore.rejectTask('task-1', 'r', 'feedback');
+			const result = await inboxStore.rejectTask('task-1', 'r', 'feedback');
 
+			expect(result).toBe(false);
 			expect(mockToastError).toHaveBeenCalledWith('Reject failed');
 		});
 	});

--- a/packages/web/src/lib/inbox-store.test.ts
+++ b/packages/web/src/lib/inbox-store.test.ts
@@ -10,13 +10,20 @@ import { signal } from '@preact/signals';
 import type { Room, RoomOverview, TaskSummary } from '@neokai/shared';
 
 // Hoisted mocks
-const { mockGetHub } = vi.hoisted(() => ({
+const { mockGetHub, mockToastError } = vi.hoisted(() => ({
 	mockGetHub: vi.fn(),
+	mockToastError: vi.fn(),
 }));
 
 vi.mock('./connection-manager', () => ({
 	connectionManager: {
 		getHub: mockGetHub,
+	},
+}));
+
+vi.mock('./toast', () => ({
+	toast: {
+		error: mockToastError,
 	},
 }));
 
@@ -192,6 +199,73 @@ describe('InboxStore', () => {
 
 			// Only one request — for the active room
 			expect(mockHub.request).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('approveTask()', () => {
+		it('should call room.task.approve and refresh on success', async () => {
+			const room = makeRoom('r', 'R');
+			mockRoomsSignal.value = [room];
+
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.resolve(undefined)) // approve
+					.mockImplementationOnce(() => Promise.resolve(makeOverview(room, []))), // refresh
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.approveTask('task-1', 'r');
+
+			expect(mockHub.request).toHaveBeenCalledWith('room.task.approve', {
+				roomId: 'r',
+				taskId: 'task-1',
+			});
+		});
+
+		it('should show toast.error when approve fails', async () => {
+			const mockHub = {
+				request: vi.fn().mockRejectedValue(new Error('Server error')),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.approveTask('task-1', 'r');
+
+			expect(mockToastError).toHaveBeenCalledWith('Server error');
+		});
+	});
+
+	describe('rejectTask()', () => {
+		it('should call room.task.reject with feedback and refresh on success', async () => {
+			const room = makeRoom('r', 'R');
+			mockRoomsSignal.value = [room];
+
+			const mockHub = {
+				request: vi
+					.fn()
+					.mockImplementationOnce(() => Promise.resolve(undefined)) // reject
+					.mockImplementationOnce(() => Promise.resolve(makeOverview(room, []))), // refresh
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.rejectTask('task-1', 'r', 'needs more work');
+
+			expect(mockHub.request).toHaveBeenCalledWith('room.task.reject', {
+				roomId: 'r',
+				taskId: 'task-1',
+				feedback: 'needs more work',
+			});
+		});
+
+		it('should show toast.error when reject fails', async () => {
+			const mockHub = {
+				request: vi.fn().mockRejectedValue(new Error('Reject failed')),
+			};
+			mockGetHub.mockResolvedValue(mockHub);
+
+			await inboxStore.rejectTask('task-1', 'r', 'feedback');
+
+			expect(mockToastError).toHaveBeenCalledWith('Reject failed');
 		});
 	});
 

--- a/packages/web/src/lib/inbox-store.ts
+++ b/packages/web/src/lib/inbox-store.ts
@@ -12,6 +12,7 @@ import { signal, computed } from '@preact/signals';
 import type { TaskSummary, RoomOverview } from '@neokai/shared';
 import { connectionManager } from './connection-manager';
 import { lobbyStore } from './lobby-store';
+import { toast } from './toast';
 
 /**
  * A review-status task enriched with room metadata for inbox display
@@ -75,9 +76,31 @@ async function refresh(): Promise<void> {
 	}
 }
 
+async function approveTask(taskId: string, roomId: string): Promise<void> {
+	try {
+		const hub = await connectionManager.getHub();
+		await hub.request('room.task.approve', { roomId, taskId });
+		await refresh();
+	} catch (err) {
+		toast.error(err instanceof Error ? err.message : 'Failed to approve task');
+	}
+}
+
+async function rejectTask(taskId: string, roomId: string, feedback: string): Promise<void> {
+	try {
+		const hub = await connectionManager.getHub();
+		await hub.request('room.task.reject', { roomId, taskId, feedback });
+		await refresh();
+	} catch (err) {
+		toast.error(err instanceof Error ? err.message : 'Failed to reject task');
+	}
+}
+
 export const inboxStore = {
 	items,
 	isLoading,
 	refresh,
 	reviewCount,
+	approveTask,
+	rejectTask,
 };

--- a/packages/web/src/lib/inbox-store.ts
+++ b/packages/web/src/lib/inbox-store.ts
@@ -76,23 +76,27 @@ async function refresh(): Promise<void> {
 	}
 }
 
-async function approveTask(taskId: string, roomId: string): Promise<void> {
+async function approveTask(taskId: string, roomId: string): Promise<boolean> {
 	try {
 		const hub = await connectionManager.getHub();
 		await hub.request('room.task.approve', { roomId, taskId });
 		await refresh();
+		return true;
 	} catch (err) {
 		toast.error(err instanceof Error ? err.message : 'Failed to approve task');
+		return false;
 	}
 }
 
-async function rejectTask(taskId: string, roomId: string, feedback: string): Promise<void> {
+async function rejectTask(taskId: string, roomId: string, feedback: string): Promise<boolean> {
 	try {
 		const hub = await connectionManager.getHub();
 		await hub.request('room.task.reject', { roomId, taskId, feedback });
 		await refresh();
+		return true;
 	} catch (err) {
 		toast.error(err instanceof Error ? err.message : 'Failed to reject task');
+		return false;
 	}
 }
 


### PR DESCRIPTION
- Add approveTask/rejectTask methods to inboxStore (calls room.task.approve/reject RPC, refreshes on success, shows toast.error on failure)
- Replace "Review" button in InboxTaskCard with Approve (green) + Reject (red outline) + View (ghost) action row
- Reject button expands an inline textarea form; submitting calls rejectTask and collapses
- Loading state (approvingId) disables all buttons while an approve is in flight
- Update Inbox header subtitle to include hint text "approve or reject below"
- Add tests for approveTask and rejectTask (success and failure paths)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
