### PR TITLE
feat: hide ContextPanel when inbox is active (Task 4.2)

### DIFF
--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -282,7 +282,6 @@ export function ContextPanel() {
 	const isActionDisabled =
 		connectionState.value !== 'connected' ||
 		!authStatus.value?.isAuthenticated ||
-		navSection === 'inbox' ||
 		navSection === 'projects' ||
 		navSection === 'settings';
 
@@ -428,8 +427,7 @@ export function ContextPanel() {
 						onCreateSpace={() => setCreateSpaceOpen(true)}
 					/>
 				)}
-				{navSection === 'inbox' && <div class="p-4 text-gray-400 text-sm">Inbox</div>}
-				{navSection === 'projects' && (
+		{navSection === 'projects' && (
 					<div class="flex-1 flex items-center justify-center p-6">
 						<div class="text-center">
 							<div class="text-4xl mb-3">📁</div>

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -135,6 +135,9 @@ export function ContextPanel() {
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentRoomId = currentRoomIdSignal.value;
 
+	// Inbox takes full content width — no sidebar needed
+	if (navSection === 'inbox') return null;
+
 	// When a specific room is selected in the rooms section, show room-specific panel
 	const isRoomDetail = navSection === 'rooms' && currentRoomId !== null;
 

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -427,7 +427,7 @@ export function ContextPanel() {
 						onCreateSpace={() => setCreateSpaceOpen(true)}
 					/>
 				)}
-		{navSection === 'projects' && (
+				{navSection === 'projects' && (
 					<div class="flex-1 flex items-center justify-center p-6">
 						<div class="text-center">
 							<div class="text-4xl mb-3">📁</div>


### PR DESCRIPTION
Return null from ContextPanel when navSection === 'inbox', giving the
Inbox view the full content width (NavRail + MainContent only).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
