### PR TITLE
fix: remove premature task_agent_session_id index from migration 29

### DIFF
--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1674,9 +1674,8 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
 	);
-	db.exec(
-		`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
-	);
+	// Note: idx_space_tasks_task_agent_session_id is created by migration 32,
+	// which first adds the column via ALTER TABLE for existing databases.
 
 	// -------------------------------------------------------------------------
 	// space_session_groups


### PR DESCRIPTION
## Summary

- Migration 29 included `task_agent_session_id` in the `CREATE TABLE IF NOT EXISTS space_tasks` statement and also tried to create an index on it inline
- For existing databases, `CREATE TABLE IF NOT EXISTS` is a no-op (table already exists without that column), so the inline index creation crashed with `SQLiteError: no such column: task_agent_session_id`
- Migration 32 already handles adding the column (`ALTER TABLE`) and creating the index (`CREATE INDEX IF NOT EXISTS`) in the correct order
- Removed the duplicate index creation from migration 29; added a comment pointing to migration 32

## Test plan

- [ ] Start server against an existing database (pre-migration-32) — should boot without error
- [ ] Start server with a fresh database — `space_tasks` created with `task_agent_session_id`, migration 32 creates the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)