### PR TITLE
feat: auto-expand review TaskCards with Approve button and worker summary (Task 4.4)

### DIFF
--- a/packages/daemon/src/lib/room/managers/room-manager.ts
+++ b/packages/daemon/src/lib/room/managers/room-manager.ts
@@ -134,6 +134,7 @@ export class RoomManager {
 			status: task.status,
 			priority: task.priority,
 			progress: task.progress,
+			currentStep: task.currentStep,
 			dependsOn: task.dependsOn,
 			error: task.error,
 			activeSession: task.activeSession,

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -434,6 +434,8 @@ export interface TaskSummary {
 	status: TaskStatus;
 	priority: TaskPriority;
 	progress?: number | null;
+	/** Description of current step (for worker summary in review cards) */
+	currentStep?: string | null;
 	/** IDs of tasks this task depends on */
 	dependsOn: string[];
 	/** Error message for failed tasks */

--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -211,6 +211,13 @@ export function RoomDashboard() {
 							// Error handled by store
 						}
 					}}
+					onApprove={async (taskId) => {
+						try {
+							await roomStore.approveTask(taskId);
+						} catch {
+							// Error handled by store
+						}
+					}}
 				/>
 			</div>
 

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -152,56 +152,56 @@ describe('RoomTasks', () => {
 			expect(header?.textContent).toContain('Review');
 		});
 
-		it('should show 审阅 button for review tasks when onView is provided', () => {
+		it('should show View details link for review tasks when onView is provided', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('t1', 'review', { title: 'Review me' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			);
 			expect(viewBtn).toBeTruthy();
 		});
 
-		it('should NOT show 审阅 button when onView is not provided', () => {
+		it('should NOT show View details link when onView is not provided', () => {
 			const tasks = [createTask('t1', 'review')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			);
 			expect(viewBtn).toBeFalsy();
 		});
 
-		it('should call onView with task id when 审阅 button is clicked', () => {
+		it('should call onView with task id when View details link is clicked', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('task-42', 'review', { title: 'Review me' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			) as HTMLButtonElement;
 			fireEvent.click(viewBtn);
 
 			expect(onView).toHaveBeenCalledWith('task-42');
 		});
 
-		it('should NOT show 审阅 button for non-review tasks', () => {
+		it('should NOT show View details link for non-review tasks', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('t1', 'in_progress')];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			);
 			expect(viewBtn).toBeFalsy();
 		});
 
-		it('should NOT call onTaskClick when 审阅 button is clicked (stopPropagation)', () => {
+		it('should NOT call onTaskClick when View details link is clicked (stopPropagation)', () => {
 			const onView = vi.fn();
 			const onTaskClick = vi.fn();
 			const tasks = [createTask('task-42', 'review', { title: 'Review me' })];
@@ -211,7 +211,7 @@ describe('RoomTasks', () => {
 			);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			) as HTMLButtonElement;
 			fireEvent.click(viewBtn);
 
@@ -349,14 +349,14 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Stopped task');
 		});
 
-		it('should not show 审阅 button for cancelled tasks', () => {
+		it('should not show View details link for cancelled tasks', () => {
 			const onView = vi.fn();
 			const tasks = [createTask('t1', 'cancelled')];
 
 			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			);
 			expect(viewBtn).toBeFalsy();
 		});
@@ -876,4 +876,117 @@ describe('RoomTasks', () => {
 			expect(onTaskClick).not.toHaveBeenCalled();
 		});
 	});
+	describe('Approve Button', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
+		it('should show Approve button for review tasks when onApprove is provided', () => {
+			const onApprove = vi.fn();
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Approve'
+			);
+			expect(approveBtn).toBeTruthy();
+		});
+
+		it('should NOT show Approve button when onApprove is not provided', () => {
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Approve'
+			);
+			expect(approveBtn).toBeFalsy();
+		});
+
+		it('should call onApprove with task id when Approve button is clicked', () => {
+			const onApprove = vi.fn();
+			const tasks = [createTask('task-77', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			expect(onApprove).toHaveBeenCalledWith('task-77');
+		});
+
+		it('should NOT show Approve button for non-review tasks', () => {
+			selectedTabSignal.value = 'active';
+			const onApprove = vi.fn();
+			const tasks = [createTask('t1', 'in_progress')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Approve'
+			);
+			expect(approveBtn).toBeFalsy();
+		});
+
+		it('should NOT call onTaskClick when Approve button is clicked (stopPropagation)', () => {
+			const onApprove = vi.fn();
+			const onTaskClick = vi.fn();
+			const tasks = [createTask('task-55', 'review')];
+
+			const { container } = render(
+				<RoomTasks tasks={tasks} onApprove={onApprove} onTaskClick={onTaskClick} />
+			);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			expect(onApprove).toHaveBeenCalledWith('task-55');
+			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Worker Summary (currentStep)', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'review';
+		});
+
+		it('should show currentStep as worker summary for review tasks', () => {
+			const tasks = [
+				createTask('t1', 'review', { currentStep: 'Implementing authentication module' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Implementing authentication module');
+		});
+
+		it('should NOT show worker summary when currentStep is not set', () => {
+			const tasks = [createTask('t1', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// No italic summary element
+			const summaryEl = container.querySelector('p.italic');
+			expect(summaryEl).toBeFalsy();
+		});
+
+		it('should NOT show worker summary for non-review tasks with currentStep', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [
+				createTask('t1', 'in_progress', { currentStep: 'Should not appear' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// The review expanded section is not rendered for non-review tasks
+			const summaryEl = container.querySelector('p.italic');
+			expect(summaryEl).toBeFalsy();
+		});
+	});
+
 });

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -887,8 +887,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Approve'
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
 			);
 			expect(approveBtn).toBeTruthy();
 		});
@@ -898,8 +898,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Approve'
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
 			);
 			expect(approveBtn).toBeFalsy();
 		});
@@ -910,8 +910,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Approve'
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
 			) as HTMLButtonElement;
 			fireEvent.click(approveBtn);
 
@@ -925,8 +925,8 @@ describe('RoomTasks', () => {
 
 			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Approve'
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
 			);
 			expect(approveBtn).toBeFalsy();
 		});
@@ -940,8 +940,8 @@ describe('RoomTasks', () => {
 				<RoomTasks tasks={tasks} onApprove={onApprove} onTaskClick={onTaskClick} />
 			);
 
-			const approveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.trim() === 'Approve'
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
 			) as HTMLButtonElement;
 			fireEvent.click(approveBtn);
 
@@ -977,9 +977,7 @@ describe('RoomTasks', () => {
 
 		it('should NOT show worker summary for non-review tasks with currentStep', () => {
 			selectedTabSignal.value = 'active';
-			const tasks = [
-				createTask('t1', 'in_progress', { currentStep: 'Should not appear' }),
-			];
+			const tasks = [createTask('t1', 'in_progress', { currentStep: 'Should not appear' })];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
@@ -988,5 +986,4 @@ describe('RoomTasks', () => {
 			expect(summaryEl).toBeFalsy();
 		});
 	});
-
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -48,6 +48,7 @@ interface RoomTasksProps {
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
+	onApprove?: (taskId: string) => void;
 }
 
 /** Get count of tasks for each filter tab */
@@ -95,7 +96,7 @@ function getStatusBorderColor(status: TaskStatus): string {
 	}
 }
 
-export function RoomTasks({ tasks, onTaskClick, onView, onReject }: RoomTasksProps) {
+export function RoomTasks({ tasks, onTaskClick, onView, onReject, onApprove }: RoomTasksProps) {
 	const selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 	const filteredTasks = getFilteredTasks(tasks, selectedTab);
@@ -157,6 +158,7 @@ export function RoomTasks({ tasks, onTaskClick, onView, onReject }: RoomTasksPro
 					onTaskClick={onTaskClick}
 					onView={onView}
 					onReject={onReject}
+					onApprove={onApprove}
 				/>
 			)}
 		</div>
@@ -256,6 +258,7 @@ function TaskList({
 	onTaskClick,
 	onView,
 	onReject,
+	onApprove,
 }: {
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
@@ -263,6 +266,7 @@ function TaskList({
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
+	onApprove?: (taskId: string) => void;
 }) {
 	const [rejectingTaskId, setRejectingTaskId] = useState<string | null>(null);
 
@@ -317,6 +321,7 @@ function TaskList({
 					onTaskClick={onTaskClick}
 					onView={onView}
 					onReject={onReject}
+					onApprove={onApprove}
 					rejectingTaskId={rejectingTaskId}
 					onSetRejectingTaskId={setRejectingTaskId}
 				/>
@@ -386,6 +391,7 @@ function TaskGroup({
 	onTaskClick,
 	onView,
 	onReject,
+	onApprove,
 	showAlert = false,
 	rejectingTaskId,
 	onSetRejectingTaskId,
@@ -398,6 +404,7 @@ function TaskGroup({
 	onTaskClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
+	onApprove?: (taskId: string) => void;
 	showAlert?: boolean;
 	rejectingTaskId?: string | null;
 	onSetRejectingTaskId?: (id: string | null) => void;
@@ -462,6 +469,7 @@ function TaskGroup({
 						onClick={onTaskClick}
 						onView={onView}
 						onReject={onReject}
+						onApprove={onApprove}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={onSetRejectingTaskId}
 					/>
@@ -485,6 +493,7 @@ function TaskItem({
 	onClick,
 	onView,
 	onReject,
+	onApprove,
 	rejectingTaskId,
 	onSetRejectingTaskId,
 }: {
@@ -493,16 +502,19 @@ function TaskItem({
 	onClick?: (taskId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
+	onApprove?: (taskId: string) => void;
 	rejectingTaskId?: string | null;
 	onSetRejectingTaskId?: (id: string | null) => void;
 }) {
 	const [feedback, setFeedback] = useState('');
 	const isClickable = !!onClick;
-	const showView = task.status === 'review' && !!onView;
-	const showReject = task.status === 'review' && !!onReject;
+	const isReview = task.status === 'review';
+	const showView = isReview && !!onView;
+	const showReject = isReview && !!onReject;
+	const showApprove = isReview && !!onApprove;
 	const blocked = task.status === 'pending' && isBlocked(task, allTasks);
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
-	const isWorking = task.status === 'review' && !!task.activeSession;
+	const isWorking = isReview && !!task.activeSession;
 	const isRejecting = rejectingTaskId === task.id;
 
 	return (
@@ -546,36 +558,59 @@ function TaskItem({
 							<span>PR #{task.prNumber ?? '?'}</span>
 						</a>
 					)}
-					{showView && (
-						<button
-							onClick={(e) => {
-								e.stopPropagation();
-								onView(task.id);
-							}}
-							class="px-2 py-1 text-xs font-medium text-amber-400 bg-amber-900/20 hover:bg-amber-900/40 border border-amber-700/50 rounded transition-colors"
-						>
-							审阅
-						</button>
-					)}
-					{showReject && (
-						<button
-							onClick={(e) => {
-								e.stopPropagation();
-								if (isRejecting) {
-									setFeedback('');
-									onSetRejectingTaskId?.(null);
-								} else {
-									onSetRejectingTaskId?.(task.id);
-								}
-							}}
-							class="px-2 py-1 text-xs font-medium text-red-400 bg-red-900/20 hover:bg-red-900/40 border border-red-700/50 rounded transition-colors"
-						>
-							Reject
-						</button>
-					)}
-					{isClickable && <span class="text-xs text-gray-600">&rarr;</span>}
+					{isClickable && !isReview && <span class="text-xs text-gray-600">&rarr;</span>}
 				</div>
 			</div>
+			{/* Review: auto-expanded action section */}
+			{isReview && (
+				<div class="mt-2 space-y-2" onClick={(e) => e.stopPropagation()}>
+					{task.currentStep && (
+						<p class="text-xs text-gray-400 italic line-clamp-2">{task.currentStep}</p>
+					)}
+					{(showApprove || showReject || showView) && (
+						<div class="flex items-center gap-2">
+							{showApprove && (
+								<button
+									onClick={(e) => {
+										e.stopPropagation();
+										onApprove(task.id);
+									}}
+									class="bg-green-600 hover:bg-green-700 text-white text-xs px-3 py-1.5 rounded-lg transition-colors"
+								>
+									Approve
+								</button>
+							)}
+							{showReject && (
+								<button
+									onClick={(e) => {
+										e.stopPropagation();
+										if (isRejecting) {
+											setFeedback('');
+											onSetRejectingTaskId?.(null);
+										} else {
+											onSetRejectingTaskId?.(task.id);
+										}
+									}}
+									class="px-3 py-1.5 text-xs font-medium text-red-400 border border-red-700/50 hover:bg-red-900/20 rounded-lg transition-colors"
+								>
+									Reject
+								</button>
+							)}
+							{showView && (
+								<button
+									onClick={(e) => {
+										e.stopPropagation();
+										onView(task.id);
+									}}
+									class="ml-auto text-xs text-gray-500 hover:text-gray-300 transition-colors"
+								>
+									View details →
+								</button>
+							)}
+						</div>
+					)}
+				</div>
+			)}
 			{task.status === 'needs_attention' && task.error && (
 				<p class="text-xs text-red-400 mt-1.5 line-clamp-2" title={task.error}>
 					{task.error}


### PR DESCRIPTION
- Add `currentStep` to `TaskSummary` type and include it in `toSummary` mapper
- Review-status TaskCards auto-show expanded action section without clicking:
  - Worker summary (currentStep) displayed as italic text when available
  - Approve button (green) calls `onApprove(taskId)` prop
  - Reject button (red outline) toggles the inline reject form
  - "View details →" text link replaces the old "审阅" amber button
- Non-review cards retain compact layout and `→` nav indicator unchanged
- Wire `onApprove` through RoomTasks → TaskList → TaskGroup → TaskItem
- RoomDashboard passes `onApprove` that calls `roomStore.approveTask`
- Update tests: rename 审阅 button tests, add Approve + worker summary suites

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
