### PR TITLE
fix: remove stale sessions from RoomContextPanel on session delete/update

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -161,31 +161,52 @@ export function setupSessionHandlers(
 			sessionId: string;
 		};
 
+		// Get roomId before updating to include in event payload
+		const agentSessionForUpdate = sessionManager.getSession(targetSessionId);
+		const roomIdForUpdate = agentSessionForUpdate?.getSessionData().context?.roomId;
+
 		// Convert UpdateSessionRequest to Partial<Session>
 		// config in UpdateSessionRequest is Partial<SessionConfig>, which is handled by
 		// database.updateSession merging with existing config
 		await sessionManager.updateSession(targetSessionId, updates as Partial<Session>);
 
-		// Broadcast update event to all clients
-		messageHub.event('session.updated', updates, {
+		const updatedPayload = { ...updates, sessionId: targetSessionId, roomId: roomIdForUpdate };
+
+		// Broadcast update event on session channel for per-session subscribers
+		messageHub.event('session.updated', updatedPayload, {
 			channel: `session:${targetSessionId}`,
 		});
+
+		// Also broadcast on room channel so RoomStore can react
+		if (roomIdForUpdate) {
+			messageHub.event('session.updated', updatedPayload, {
+				channel: `room:${roomIdForUpdate}`,
+			});
+		}
 
 		return { success: true };
 	});
 
 	messageHub.onRequest('session.delete', async (data, _ctx) => {
 		const { sessionId: targetSessionId } = data as { sessionId: string };
+
+		// Get roomId before deleting so we can include it in the event payload
+		const agentSessionForDelete = sessionManager.getSession(targetSessionId);
+		const roomIdForDelete = agentSessionForDelete?.getSessionData().context?.roomId;
+
 		await sessionManager.deleteSession(targetSessionId);
 
-		// Broadcast deletion event to all clients
-		messageHub.event(
-			'session.deleted',
-			{ sessionId: targetSessionId },
-			{
-				channel: 'global',
-			}
-		);
+		const deletedPayload = { sessionId: targetSessionId, roomId: roomIdForDelete };
+
+		// Broadcast deletion event on global channel (backward compat)
+		messageHub.event('session.deleted', deletedPayload, { channel: 'global' });
+
+		// Also broadcast on room channel so RoomStore can react immediately
+		if (roomIdForDelete) {
+			messageHub.event('session.deleted', deletedPayload, {
+				channel: `room:${roomIdForDelete}`,
+			});
+		}
 
 		return { success: true };
 	});
@@ -227,6 +248,21 @@ export function setupSessionHandlers(
 				archivedAt: new Date().toISOString(),
 				metadata: updatedMetadata,
 			} as Partial<Session>);
+
+			// Broadcast session.updated so RoomStore and session subscribers stay in sync
+			const archivedPayloadNoWorktree = {
+				sessionId: targetSessionId,
+				status: 'archived',
+				roomId: session.context?.roomId,
+			};
+			messageHub.event('session.updated', archivedPayloadNoWorktree, {
+				channel: `session:${targetSessionId}`,
+			});
+			if (session.context?.roomId) {
+				messageHub.event('session.updated', archivedPayloadNoWorktree, {
+					channel: `room:${session.context.roomId}`,
+				});
+			}
 
 			return { success: true, requiresConfirmation: false };
 		}
@@ -272,6 +308,21 @@ export function setupSessionHandlers(
 				worktree: undefined,
 				metadata: updatedMetadata,
 			} as Partial<Session>);
+
+			// Broadcast session.updated so RoomStore and session subscribers stay in sync
+			const archivedPayloadWithWorktree = {
+				sessionId: targetSessionId,
+				status: 'archived',
+				roomId: session.context?.roomId,
+			};
+			messageHub.event('session.updated', archivedPayloadWithWorktree, {
+				channel: `session:${targetSessionId}`,
+			});
+			if (session.context?.roomId) {
+				messageHub.event('session.updated', archivedPayloadWithWorktree, {
+					channel: `room:${session.context.roomId}`,
+				});
+			}
 
 			return {
 				success: true,

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -196,16 +196,15 @@ export function setupSessionHandlers(
 
 		await sessionManager.deleteSession(targetSessionId);
 
-		const deletedPayload = { sessionId: targetSessionId, roomId: roomIdForDelete };
-
-		// Broadcast deletion event on global channel (backward compat)
-		messageHub.event('session.deleted', deletedPayload, { channel: 'global' });
-
-		// Also broadcast on room channel so RoomStore can react immediately
+		// Broadcast on room channel so RoomStore reacts immediately.
+		// Note: the global channel broadcast is handled by session-lifecycle.ts / state-manager.ts
+		// to avoid triple-firing the event. We only add the room-scoped broadcast here.
 		if (roomIdForDelete) {
-			messageHub.event('session.deleted', deletedPayload, {
-				channel: `room:${roomIdForDelete}`,
-			});
+			messageHub.event(
+				'session.deleted',
+				{ sessionId: targetSessionId, roomId: roomIdForDelete },
+				{ channel: `room:${roomIdForDelete}` }
+			);
 		}
 
 		return { success: true };

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -540,15 +540,27 @@ describe('Session RPC Handlers', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('broadcasts session.deleted event on global channel with roomId in payload', async () => {
+		it('broadcasts session.deleted only on room channel (not global) when session has roomId', async () => {
 			const handler = messageHubData.handlers.get('session.delete');
 			expect(handler).toBeDefined();
 
+			const { agentSession } = createMockAgentSession({
+				context: { roomId: 'room-abc' },
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(agentSession);
+
 			await handler!({ sessionId: 'session-123' }, {});
 
+			// Verify room-channel broadcast fires
 			expect(messageHubData.hub.event).toHaveBeenCalledWith(
 				'session.deleted',
-				expect.objectContaining({ sessionId: 'session-123' }),
+				expect.objectContaining({ sessionId: 'session-123', roomId: 'room-abc' }),
+				{ channel: 'room:room-abc' }
+			);
+			// Global broadcast must NOT come from this handler (session-lifecycle.ts handles it)
+			expect(messageHubData.hub.event).not.toHaveBeenCalledWith(
+				'session.deleted',
+				expect.anything(),
 				{ channel: 'global' }
 			);
 		});
@@ -571,7 +583,7 @@ describe('Session RPC Handlers', () => {
 			);
 		});
 
-		it('does not broadcast on room channel when session has no roomId', async () => {
+		it('does not broadcast any event when session has no roomId', async () => {
 			const handler = messageHubData.handlers.get('session.delete');
 			expect(handler).toBeDefined();
 
@@ -582,8 +594,8 @@ describe('Session RPC Handlers', () => {
 			await handler!({ sessionId: 'session-123' }, {});
 
 			const after = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls.length;
-			// Only one broadcast (global), no room channel broadcast
-			expect(after - before).toBe(1);
+			// No broadcasts from RPC handler; global broadcast is handled by session-lifecycle.ts
+			expect(after - before).toBe(0);
 		});
 	});
 
@@ -614,6 +626,67 @@ describe('Session RPC Handlers', () => {
 			await expect(handler!({ sessionId: 'non-existent' }, {})).rejects.toThrow(
 				'Session not found'
 			);
+		});
+
+		it('broadcasts session.updated with status archived on session channel after archiving', async () => {
+			const handler = messageHubData.handlers.get('session.archive');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession({
+				worktree: undefined,
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			await handler!({ sessionId: 'session-123' }, {});
+
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.updated',
+				expect.objectContaining({ sessionId: 'session-123', status: 'archived' }),
+				{ channel: 'session:session-123' }
+			);
+		});
+
+		it('broadcasts session.updated on room channel when session belongs to a room', async () => {
+			const handler = messageHubData.handlers.get('session.archive');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession({
+				worktree: undefined,
+				context: { roomId: 'room-abc' },
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			await handler!({ sessionId: 'session-123' }, {});
+
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.updated',
+				expect.objectContaining({
+					sessionId: 'session-123',
+					status: 'archived',
+					roomId: 'room-abc',
+				}),
+				{ channel: 'room:room-abc' }
+			);
+		});
+
+		it('does not broadcast on room channel when session has no roomId', async () => {
+			const handler = messageHubData.handlers.get('session.archive');
+			expect(handler).toBeDefined();
+
+			// Default mock session has no context.roomId
+			const { agentSession } = createMockAgentSession({
+				worktree: undefined,
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			const before = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls.length;
+			await handler!({ sessionId: 'session-123' }, {});
+			const after = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls.length;
+
+			// Only one broadcast: session:{id} channel; no room channel
+			expect(after - before).toBe(1);
+			const calls = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls.slice(before);
+			expect(calls[0][2]).toEqual({ channel: 'session:session-123' });
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -497,15 +497,35 @@ describe('Session RPC Handlers', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('broadcasts session.updated event', async () => {
+		it('broadcasts session.updated event on session channel', async () => {
 			const handler = messageHubData.handlers.get('session.update');
 			expect(handler).toBeDefined();
 
 			await handler!({ sessionId: 'session-123', title: 'New Title' }, {});
 
-			expect(messageHubData.hub.event).toHaveBeenCalledWith('session.updated', expect.any(Object), {
-				channel: 'session:session-123',
-			});
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.updated',
+				expect.objectContaining({ sessionId: 'session-123', title: 'New Title' }),
+				{ channel: 'session:session-123' }
+			);
+		});
+
+		it('also broadcasts session.updated on room channel when session has a roomId', async () => {
+			const handler = messageHubData.handlers.get('session.update');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession({
+				context: { roomId: 'room-abc' },
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(agentSession);
+
+			await handler!({ sessionId: 'session-123', title: 'New Title' }, {});
+
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.updated',
+				expect.objectContaining({ sessionId: 'session-123', roomId: 'room-abc' }),
+				{ channel: 'room:room-abc' }
+			);
 		});
 	});
 
@@ -520,7 +540,7 @@ describe('Session RPC Handlers', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('broadcasts session.deleted event', async () => {
+		it('broadcasts session.deleted event on global channel with roomId in payload', async () => {
 			const handler = messageHubData.handlers.get('session.delete');
 			expect(handler).toBeDefined();
 
@@ -528,9 +548,42 @@ describe('Session RPC Handlers', () => {
 
 			expect(messageHubData.hub.event).toHaveBeenCalledWith(
 				'session.deleted',
-				{ sessionId: 'session-123' },
+				expect.objectContaining({ sessionId: 'session-123' }),
 				{ channel: 'global' }
 			);
+		});
+
+		it('also broadcasts session.deleted on room channel when session has a roomId', async () => {
+			const handler = messageHubData.handlers.get('session.delete');
+			expect(handler).toBeDefined();
+
+			const { agentSession } = createMockAgentSession({
+				context: { roomId: 'room-abc' },
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(agentSession);
+
+			await handler!({ sessionId: 'session-123' }, {});
+
+			expect(messageHubData.hub.event).toHaveBeenCalledWith(
+				'session.deleted',
+				expect.objectContaining({ sessionId: 'session-123', roomId: 'room-abc' }),
+				{ channel: 'room:room-abc' }
+			);
+		});
+
+		it('does not broadcast on room channel when session has no roomId', async () => {
+			const handler = messageHubData.handlers.get('session.delete');
+			expect(handler).toBeDefined();
+
+			// Default mock session has no context.roomId
+			const calls = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls;
+			const before = calls.length;
+
+			await handler!({ sessionId: 'session-123' }, {});
+
+			const after = (messageHubData.hub.event as ReturnType<typeof mock>).mock.calls.length;
+			// Only one broadcast (global), no room channel broadcast
+			expect(after - before).toBe(1);
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -565,24 +565,6 @@ describe('Session RPC Handlers', () => {
 			);
 		});
 
-		it('also broadcasts session.deleted on room channel when session has a roomId', async () => {
-			const handler = messageHubData.handlers.get('session.delete');
-			expect(handler).toBeDefined();
-
-			const { agentSession } = createMockAgentSession({
-				context: { roomId: 'room-abc' },
-			} as Partial<AgentSession>);
-			sessionManagerData.mocks.getSession.mockReturnValueOnce(agentSession);
-
-			await handler!({ sessionId: 'session-123' }, {});
-
-			expect(messageHubData.hub.event).toHaveBeenCalledWith(
-				'session.deleted',
-				expect.objectContaining({ sessionId: 'session-123', roomId: 'room-abc' }),
-				{ channel: 'room:room-abc' }
-			);
-		});
-
 		it('does not broadcast any event when session has no roomId', async () => {
 			const handler = messageHubData.handlers.get('session.delete');
 			expect(handler).toBeDefined();

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for RoomStore session lifecycle event handlers
+ *
+ * Verifies that session.deleted and session.updated events are correctly
+ * handled so the RoomContextPanel reflects live session state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { SessionSummary, RoomOverview } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mock connectionManager before importing room-store (module-level side-effect)
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	joinChannel: ReturnType<typeof vi.fn>;
+	leaveChannel: ReturnType<typeof vi.fn>;
+	/** Fire a registered event handler by name */
+	fire: <T>(method: string, data: T) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+
+	const hub: MockHub = {
+		_handlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const idx = list.indexOf(handler as EventHandler);
+					if (idx >= 0) list.splice(idx, 1);
+				}
+			};
+		},
+		request: vi.fn(),
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			const list = _handlers.get(method) ?? [];
+			for (const h of list) h(data);
+		},
+	};
+	return hub;
+}
+
+vi.mock('../connection-manager', () => {
+	return {
+		connectionManager: {
+			getHub: vi.fn(),
+			getHubIfConnected: vi.fn(),
+		},
+	};
+});
+
+vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+// Import after mocks are set up
+import { connectionManager } from '../connection-manager';
+import { roomStore } from '../room-store';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID = 'room-abc';
+const OTHER_ROOM_ID = 'room-xyz';
+
+function makeSessions(): SessionSummary[] {
+	return [
+		{ id: 'session-1', title: 'Session One', status: 'active', lastActiveAt: 1000 },
+		{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
+	];
+}
+
+function makeOverview(): RoomOverview {
+	return {
+		room: {
+			id: ROOM_ID,
+			name: 'Test Room',
+			allowedPaths: [],
+			defaultPath: '/tmp',
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+			background: null,
+			instructions: null,
+			config: {},
+		} as unknown as RoomOverview['room'],
+		sessions: makeSessions(),
+		activeTasks: [],
+		allTasks: [],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomStore — session lifecycle events', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+
+		// Make getHub() resolve to our mock
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+
+		// Default request mock: room.get returns overview, everything else resolves empty
+		hub.request.mockImplementation((method: string) => {
+			if (method === 'room.get') return Promise.resolve(makeOverview());
+			if (method === 'goal.list') return Promise.resolve({ goals: [] });
+			if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+			if (method === 'room.runtime.models')
+				return Promise.resolve({ leaderModel: null, workerModel: null });
+			return Promise.resolve({});
+		});
+
+		// Select the room to start subscriptions
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		// Reset to null room to clear subscriptions
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	// -----------------------------------------------------------------------
+	// session.deleted
+	// -----------------------------------------------------------------------
+
+	describe('session.deleted event', () => {
+		it('removes the deleted session from sessions signal when roomId matches', () => {
+			expect(roomStore.sessions.value).toHaveLength(2);
+
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+
+			expect(roomStore.sessions.value).toHaveLength(1);
+			expect(roomStore.sessions.value[0].id).toBe('session-2');
+		});
+
+		it('removes the correct session leaving others intact', () => {
+			hub.fire('session.deleted', { sessionId: 'session-2', roomId: ROOM_ID });
+
+			expect(roomStore.sessions.value).toHaveLength(1);
+			expect(roomStore.sessions.value[0].id).toBe('session-1');
+		});
+
+		it('ignores deletion events for a different room', () => {
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: OTHER_ROOM_ID });
+
+			expect(roomStore.sessions.value).toHaveLength(2);
+		});
+
+		it('is a no-op when sessionId is not in the current room', () => {
+			hub.fire('session.deleted', { sessionId: 'session-unknown', roomId: ROOM_ID });
+
+			expect(roomStore.sessions.value).toHaveLength(2);
+		});
+
+		it('handles multiple sequential deletions', () => {
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+			hub.fire('session.deleted', { sessionId: 'session-2', roomId: ROOM_ID });
+
+			expect(roomStore.sessions.value).toHaveLength(0);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// session.updated
+	// -----------------------------------------------------------------------
+
+	describe('session.updated event', () => {
+		it('updates the title of a session when roomId matches', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: ROOM_ID,
+				title: 'Renamed Session',
+			});
+
+			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
+			expect(updated?.title).toBe('Renamed Session');
+		});
+
+		it('updates the status of a session (e.g., archiving)', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: ROOM_ID,
+				status: 'archived',
+			});
+
+			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
+			expect(updated?.status).toBe('archived');
+		});
+
+		it('preserves unchanged fields when doing a partial update', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: ROOM_ID,
+				title: 'New Title',
+			});
+
+			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
+			expect(updated?.status).toBe('active'); // unchanged
+			expect(updated?.lastActiveAt).toBe(1000); // unchanged
+		});
+
+		it('ignores update events for a different room', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: OTHER_ROOM_ID,
+				title: 'Should not apply',
+			});
+
+			const session = roomStore.sessions.value.find((s) => s.id === 'session-1');
+			expect(session?.title).toBe('Session One'); // unchanged
+		});
+
+		it('is a no-op when sessionId is not in the current room', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-unknown',
+				roomId: ROOM_ID,
+				title: 'Ghost Update',
+			});
+
+			expect(roomStore.sessions.value).toHaveLength(2);
+		});
+
+		it('updates lastActiveAt when provided', () => {
+			hub.fire('session.updated', {
+				sessionId: 'session-2',
+				roomId: ROOM_ID,
+				lastActiveAt: 9999,
+			});
+
+			const updated = roomStore.sessions.value.find((s) => s.id === 'session-2');
+			expect(updated?.lastActiveAt).toBe(9999);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Subscription cleanup
+	// -----------------------------------------------------------------------
+
+	describe('subscription cleanup on room switch', () => {
+		it('stops responding to events after room is deselected', async () => {
+			// Deselect room
+			await roomStore.select(null);
+
+			// Reset sessions to empty (as doSelect clears them)
+			// Now fire an event — it should not crash or update anything
+			expect(() => {
+				hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+			}).not.toThrow();
+
+			expect(roomStore.sessions.value).toHaveLength(0);
+		});
+	});
+});

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -283,24 +283,68 @@ describe('RoomStore — session lifecycle events', () => {
 	});
 
 	// -----------------------------------------------------------------------
-	// session.updated — must NOT trigger re-fetch (draft-save storm prevention)
+	// session.updated — triggers refresh only when status field is present
 	// -----------------------------------------------------------------------
 
 	describe('session.updated event', () => {
-		it('does NOT trigger a room.get re-fetch (avoids draft-save RPC storm)', async () => {
+		it('triggers a room.get re-fetch when event carries a status field', async () => {
 			const before = countRequests(hub, 'room.get');
 
 			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
+
+			await vi.waitFor(() => {
+				expect(countRequests(hub, 'room.get')).toBeGreaterThan(before);
+			});
+		});
+
+		it('updates sessions signal from server response after status change', async () => {
+			hub.request.mockImplementation((method: string) => {
+				if (method === 'room.get')
+					return Promise.resolve({
+						...twoSessionOverview(),
+						sessions: [
+							{
+								id: 'session-1',
+								title: 'Session One',
+								status: 'archived',
+								lastActiveAt: 1000,
+							},
+							{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
+						],
+					});
+				if (method === 'goal.list') return Promise.resolve({ goals: [] });
+				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+				if (method === 'room.runtime.models')
+					return Promise.resolve({ leaderModel: null, workerModel: null });
+				return Promise.resolve({});
+			});
+
+			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
+
+			await vi.waitFor(() => {
+				const s1 = roomStore.sessions.value.find((s) => s.id === 'session-1');
+				expect(s1?.status).toBe('archived');
+			});
+		});
+
+		it('does NOT trigger a re-fetch when event has no status field (draft save)', async () => {
+			const before = countRequests(hub, 'room.get');
+
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: ROOM_ID,
+				title: 'New Title',
+			});
 
 			await new Promise((r) => setTimeout(r, 30));
 
 			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 
-		it('does NOT trigger a re-fetch for rapid consecutive updates', async () => {
+		it('does NOT trigger a re-fetch for rapid consecutive draft saves', async () => {
 			const before = countRequests(hub, 'room.get');
 
-			// Simulate typing — 5 rapid draft saves
+			// Simulate typing — 5 rapid draft saves without status field
 			for (let i = 0; i < 5; i++) {
 				hub.fire('session.updated', {
 					sessionId: 'session-1',
@@ -308,6 +352,20 @@ describe('RoomStore — session lifecycle events', () => {
 					metadata: { inputDraft: `draft ${i}` },
 				});
 			}
+
+			await new Promise((r) => setTimeout(r, 30));
+
+			expect(countRequests(hub, 'room.get')).toBe(before);
+		});
+
+		it('does NOT trigger a re-fetch for a different room', async () => {
+			const before = countRequests(hub, 'room.get');
+
+			hub.fire('session.updated', {
+				sessionId: 'session-1',
+				roomId: OTHER_ROOM_ID,
+				status: 'archived',
+			});
 
 			await new Promise((r) => setTimeout(r, 30));
 

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -1,16 +1,57 @@
 /**
  * Tests for RoomStore session lifecycle event handlers
  *
- * Verifies that session.deleted and session.updated events trigger a room.get
- * re-fetch so the RoomContextPanel always reflects the server's authoritative
- * session list. This approach self-heals missed events during WebSocket gaps.
+ * Verifies that:
+ * - session.deleted triggers a room.get re-fetch
+ * - session.updated does NOT trigger a re-fetch (avoids ~250 ms draft-save storm)
+ * - After deletion, if the user is viewing the deleted session they are navigated
+ *   back to the room dashboard
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { SessionSummary, RoomOverview } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
-// Mock connectionManager before importing room-store (module-level side-effect)
+// Mocks — must be declared before any imports that touch the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('../connection-manager', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+
+vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+vi.mock('../router', () => ({ navigateToRoom: vi.fn() }));
+
+// Use a plain mutable object so tests can set .value directly.
+// room-store.ts only reads currentRoomSessionIdSignal.value, so a plain
+// object with a writable value property is sufficient.
+const mockSignals = vi.hoisted(() => ({
+	currentRoomSessionIdSignal: { value: null as string | null },
+	currentRoomIdSignal: { value: null as string | null },
+	currentRoomTaskIdSignal: { value: null as string | null },
+	currentSessionIdSignal: { value: null as string | null },
+	currentSpaceIdSignal: { value: null as string | null },
+	currentSpaceSessionIdSignal: { value: null as string | null },
+	currentSpaceTaskIdSignal: { value: null as string | null },
+	navSectionSignal: { value: 'lobby' as string },
+}));
+
+vi.mock('../signals', () => mockSignals);
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { connectionManager } from '../connection-manager';
+import { navigateToRoom } from '../router';
+import { roomStore } from '../room-store';
+
+// ---------------------------------------------------------------------------
+// Mock hub factory
 // ---------------------------------------------------------------------------
 
 type EventHandler<T = unknown> = (data: T) => void;
@@ -21,14 +62,12 @@ interface MockHub {
 	request: ReturnType<typeof vi.fn>;
 	joinChannel: ReturnType<typeof vi.fn>;
 	leaveChannel: ReturnType<typeof vi.fn>;
-	/** Fire a registered event handler by name */
 	fire: <T>(method: string, data: T) => void;
 }
 
 function createMockHub(): MockHub {
 	const _handlers = new Map<string, EventHandler[]>();
-
-	const hub: MockHub = {
+	return {
 		_handlers,
 		onEvent: <T>(method: string, handler: EventHandler<T>) => {
 			if (!_handlers.has(method)) _handlers.set(method, []);
@@ -36,8 +75,8 @@ function createMockHub(): MockHub {
 			return () => {
 				const list = _handlers.get(method);
 				if (list) {
-					const idx = list.indexOf(handler as EventHandler);
-					if (idx >= 0) list.splice(idx, 1);
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
 				}
 			};
 		},
@@ -45,27 +84,10 @@ function createMockHub(): MockHub {
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),
 		fire: <T>(method: string, data: T) => {
-			const list = _handlers.get(method) ?? [];
-			for (const h of list) h(data);
+			for (const h of _handlers.get(method) ?? []) h(data);
 		},
 	};
-	return hub;
 }
-
-vi.mock('../connection-manager', () => {
-	return {
-		connectionManager: {
-			getHub: vi.fn(),
-			getHubIfConnected: vi.fn(),
-		},
-	};
-});
-
-vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
-
-// Import after mocks are set up
-import { connectionManager } from '../connection-manager';
-import { roomStore } from '../room-store';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -74,15 +96,7 @@ import { roomStore } from '../room-store';
 const ROOM_ID = 'room-abc';
 const OTHER_ROOM_ID = 'room-xyz';
 
-function makeSessions(overrides: Partial<SessionSummary>[] = []): SessionSummary[] {
-	const base: SessionSummary[] = [
-		{ id: 'session-1', title: 'Session One', status: 'active', lastActiveAt: 1000 },
-		{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
-	];
-	return overrides.length > 0 ? base.map((s, i) => ({ ...s, ...(overrides[i] ?? {}) })) : base;
-}
-
-function makeOverview(sessions?: SessionSummary[]): RoomOverview {
+function twoSessionOverview(): RoomOverview {
 	return {
 		room: {
 			id: ROOM_ID,
@@ -95,39 +109,50 @@ function makeOverview(sessions?: SessionSummary[]): RoomOverview {
 			instructions: null,
 			config: {},
 		} as unknown as RoomOverview['room'],
-		sessions: sessions ?? makeSessions(),
+		sessions: [
+			{ id: 'session-1', title: 'Session One', status: 'active', lastActiveAt: 1000 },
+			{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
+		] as SessionSummary[],
 		activeTasks: [],
 		allTasks: [],
 	};
 }
 
-/** Count how many times hub.request was called with the given method */
+function oneSessionOverview(): RoomOverview {
+	const o = twoSessionOverview();
+	o.sessions = [{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 }];
+	return o;
+}
+
+/** Count calls to hub.request for a specific RPC method */
 function countRequests(hub: MockHub, method: string): number {
 	return (hub.request.mock.calls as [string, ...unknown[]][]).filter(([m]) => m === method).length;
+}
+
+function mockHubRequests(hub: MockHub, overview: RoomOverview = twoSessionOverview()): void {
+	hub.request.mockImplementation((method: string) => {
+		if (method === 'room.get') return Promise.resolve(overview);
+		if (method === 'goal.list') return Promise.resolve({ goals: [] });
+		if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+		if (method === 'room.runtime.models')
+			return Promise.resolve({ leaderModel: null, workerModel: null });
+		return Promise.resolve({});
+	});
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
+describe('RoomStore — session lifecycle events', () => {
 	let hub: MockHub;
 
 	beforeEach(async () => {
 		hub = createMockHub();
-
 		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
 		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
-
-		hub.request.mockImplementation((method: string) => {
-			if (method === 'room.get') return Promise.resolve(makeOverview());
-			if (method === 'goal.list') return Promise.resolve({ goals: [] });
-			if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
-			if (method === 'room.runtime.models')
-				return Promise.resolve({ leaderModel: null, workerModel: null });
-			return Promise.resolve({});
-		});
-
+		mockHubRequests(hub);
+		mockSignals.currentRoomSessionIdSignal.value = null;
 		await roomStore.select(ROOM_ID);
 	});
 
@@ -137,7 +162,7 @@ describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 	});
 
 	// -----------------------------------------------------------------------
-	// session.deleted
+	// session.deleted — triggers room.get re-fetch
 	// -----------------------------------------------------------------------
 
 	describe('session.deleted event', () => {
@@ -152,14 +177,9 @@ describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 		});
 
 		it('updates sessions signal from server response after deletion', async () => {
-			// Server returns only session-2 after session-1 is deleted
+			// Subsequent room.get returns only session-2
 			hub.request.mockImplementation((method: string) => {
-				if (method === 'room.get')
-					return Promise.resolve(
-						makeOverview([
-							{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
-						])
-					);
+				if (method === 'room.get') return Promise.resolve(oneSessionOverview());
 				if (method === 'goal.list') return Promise.resolve({ goals: [] });
 				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
 				if (method === 'room.runtime.models')
@@ -180,7 +200,6 @@ describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 
 			hub.fire('session.deleted', { sessionId: 'session-1', roomId: OTHER_ROOM_ID });
 
-			// Give any potential async re-fetch a chance to run
 			await new Promise((r) => setTimeout(r, 20));
 
 			expect(countRequests(hub, 'room.get')).toBe(before);
@@ -195,33 +214,14 @@ describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 
 			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
-	});
 
-	// -----------------------------------------------------------------------
-	// session.updated
-	// -----------------------------------------------------------------------
+		it('navigates to room dashboard when the viewed session is deleted', async () => {
+			// User is currently viewing session-1
+			mockSignals.currentRoomSessionIdSignal.value = 'session-1';
 
-	describe('session.updated event', () => {
-		it('triggers a room.get re-fetch when roomId matches', async () => {
-			const before = countRequests(hub, 'room.get');
-
-			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
-
-			await vi.waitFor(() => {
-				expect(countRequests(hub, 'room.get')).toBeGreaterThan(before);
-			});
-		});
-
-		it('updates sessions signal from server response after update', async () => {
-			// Server returns session-1 with archived status
+			// Server no longer returns session-1 after deletion
 			hub.request.mockImplementation((method: string) => {
-				if (method === 'room.get')
-					return Promise.resolve(
-						makeOverview([
-							{ id: 'session-1', title: 'Session One', status: 'archived', lastActiveAt: 1000 },
-							{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
-						])
-					);
+				if (method === 'room.get') return Promise.resolve(oneSessionOverview());
 				if (method === 'goal.list') return Promise.resolve({ goals: [] });
 				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
 				if (method === 'room.runtime.models')
@@ -229,37 +229,94 @@ describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 				return Promise.resolve({});
 			});
 
-			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
 
 			await vi.waitFor(() => {
-				const s1 = roomStore.sessions.value.find((s) => s.id === 'session-1');
-				expect(s1?.status).toBe('archived');
+				expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
 			});
 		});
 
-		it('does NOT trigger a re-fetch for a different room', async () => {
+		it('does NOT navigate when the deleted session is not the active one', async () => {
+			// User is viewing session-2, session-1 is deleted
+			mockSignals.currentRoomSessionIdSignal.value = 'session-2';
+
+			hub.request.mockImplementation((method: string) => {
+				if (method === 'room.get') return Promise.resolve(oneSessionOverview());
+				if (method === 'goal.list') return Promise.resolve({ goals: [] });
+				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+				if (method === 'room.runtime.models')
+					return Promise.resolve({ leaderModel: null, workerModel: null });
+				return Promise.resolve({});
+			});
+
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+
+			await vi.waitFor(() => {
+				expect(countRequests(hub, 'room.get')).toBeGreaterThan(0);
+			});
+
+			// Extra tick to ensure navigation would have fired if it was going to
+			await new Promise((r) => setTimeout(r, 10));
+			expect(navigateToRoom).not.toHaveBeenCalled();
+		});
+
+		it('does NOT navigate when no session is active (viewing room overview)', async () => {
+			mockSignals.currentRoomSessionIdSignal.value = null;
+
+			hub.request.mockImplementation((method: string) => {
+				if (method === 'room.get') return Promise.resolve(oneSessionOverview());
+				if (method === 'goal.list') return Promise.resolve({ goals: [] });
+				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+				if (method === 'room.runtime.models')
+					return Promise.resolve({ leaderModel: null, workerModel: null });
+				return Promise.resolve({});
+			});
+
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+
+			await vi.waitFor(() => {
+				expect(countRequests(hub, 'room.get')).toBeGreaterThan(0);
+			});
+			await new Promise((r) => setTimeout(r, 10));
+			expect(navigateToRoom).not.toHaveBeenCalled();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// session.updated — must NOT trigger re-fetch (draft-save storm prevention)
+	// -----------------------------------------------------------------------
+
+	describe('session.updated event', () => {
+		it('does NOT trigger a room.get re-fetch (avoids draft-save RPC storm)', async () => {
 			const before = countRequests(hub, 'room.get');
 
-			hub.fire('session.updated', { sessionId: 'session-1', roomId: OTHER_ROOM_ID, title: 'X' });
+			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
 
-			await new Promise((r) => setTimeout(r, 20));
+			await new Promise((r) => setTimeout(r, 30));
 
 			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 
-		it('does NOT trigger a re-fetch when roomId is absent', async () => {
+		it('does NOT trigger a re-fetch for rapid consecutive updates', async () => {
 			const before = countRequests(hub, 'room.get');
 
-			hub.fire('session.updated', { sessionId: 'session-1', title: 'X' });
+			// Simulate typing — 5 rapid draft saves
+			for (let i = 0; i < 5; i++) {
+				hub.fire('session.updated', {
+					sessionId: 'session-1',
+					roomId: ROOM_ID,
+					metadata: { inputDraft: `draft ${i}` },
+				});
+			}
 
-			await new Promise((r) => setTimeout(r, 20));
+			await new Promise((r) => setTimeout(r, 30));
 
 			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 	});
 
 	// -----------------------------------------------------------------------
-	// Subscription cleanup
+	// Subscription cleanup on room switch
 	// -----------------------------------------------------------------------
 
 	describe('subscription cleanup on room switch', () => {

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for RoomStore session lifecycle event handlers
  *
- * Verifies that session.deleted and session.updated events are correctly
- * handled so the RoomContextPanel reflects live session state.
+ * Verifies that session.deleted and session.updated events trigger a room.get
+ * re-fetch so the RoomContextPanel always reflects the server's authoritative
+ * session list. This approach self-heals missed events during WebSocket gaps.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -73,14 +74,15 @@ import { roomStore } from '../room-store';
 const ROOM_ID = 'room-abc';
 const OTHER_ROOM_ID = 'room-xyz';
 
-function makeSessions(): SessionSummary[] {
-	return [
+function makeSessions(overrides: Partial<SessionSummary>[] = []): SessionSummary[] {
+	const base: SessionSummary[] = [
 		{ id: 'session-1', title: 'Session One', status: 'active', lastActiveAt: 1000 },
 		{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
 	];
+	return overrides.length > 0 ? base.map((s, i) => ({ ...s, ...(overrides[i] ?? {}) })) : base;
 }
 
-function makeOverview(): RoomOverview {
+function makeOverview(sessions?: SessionSummary[]): RoomOverview {
 	return {
 		room: {
 			id: ROOM_ID,
@@ -93,27 +95,30 @@ function makeOverview(): RoomOverview {
 			instructions: null,
 			config: {},
 		} as unknown as RoomOverview['room'],
-		sessions: makeSessions(),
+		sessions: sessions ?? makeSessions(),
 		activeTasks: [],
 		allTasks: [],
 	};
+}
+
+/** Count how many times hub.request was called with the given method */
+function countRequests(hub: MockHub, method: string): number {
+	return (hub.request.mock.calls as [string, ...unknown[]][]).filter(([m]) => m === method).length;
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('RoomStore — session lifecycle events', () => {
+describe('RoomStore — session lifecycle events (re-fetch approach)', () => {
 	let hub: MockHub;
 
 	beforeEach(async () => {
 		hub = createMockHub();
 
-		// Make getHub() resolve to our mock
 		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
 		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
 
-		// Default request mock: room.get returns overview, everything else resolves empty
 		hub.request.mockImplementation((method: string) => {
 			if (method === 'room.get') return Promise.resolve(makeOverview());
 			if (method === 'goal.list') return Promise.resolve({ goals: [] });
@@ -123,12 +128,10 @@ describe('RoomStore — session lifecycle events', () => {
 			return Promise.resolve({});
 		});
 
-		// Select the room to start subscriptions
 		await roomStore.select(ROOM_ID);
 	});
 
 	afterEach(async () => {
-		// Reset to null room to clear subscriptions
 		await roomStore.select(null);
 		vi.clearAllMocks();
 	});
@@ -138,39 +141,59 @@ describe('RoomStore — session lifecycle events', () => {
 	// -----------------------------------------------------------------------
 
 	describe('session.deleted event', () => {
-		it('removes the deleted session from sessions signal when roomId matches', () => {
-			expect(roomStore.sessions.value).toHaveLength(2);
+		it('triggers a room.get re-fetch when roomId matches', async () => {
+			const before = countRequests(hub, 'room.get');
 
 			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
 
-			expect(roomStore.sessions.value).toHaveLength(1);
-			expect(roomStore.sessions.value[0].id).toBe('session-2');
+			await vi.waitFor(() => {
+				expect(countRequests(hub, 'room.get')).toBeGreaterThan(before);
+			});
 		});
 
-		it('removes the correct session leaving others intact', () => {
-			hub.fire('session.deleted', { sessionId: 'session-2', roomId: ROOM_ID });
+		it('updates sessions signal from server response after deletion', async () => {
+			// Server returns only session-2 after session-1 is deleted
+			hub.request.mockImplementation((method: string) => {
+				if (method === 'room.get')
+					return Promise.resolve(
+						makeOverview([
+							{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
+						])
+					);
+				if (method === 'goal.list') return Promise.resolve({ goals: [] });
+				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+				if (method === 'room.runtime.models')
+					return Promise.resolve({ leaderModel: null, workerModel: null });
+				return Promise.resolve({});
+			});
 
-			expect(roomStore.sessions.value).toHaveLength(1);
-			expect(roomStore.sessions.value[0].id).toBe('session-1');
+			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
+
+			await vi.waitFor(() => {
+				expect(roomStore.sessions.value).toHaveLength(1);
+				expect(roomStore.sessions.value[0].id).toBe('session-2');
+			});
 		});
 
-		it('ignores deletion events for a different room', () => {
+		it('does NOT trigger a re-fetch for a different room', async () => {
+			const before = countRequests(hub, 'room.get');
+
 			hub.fire('session.deleted', { sessionId: 'session-1', roomId: OTHER_ROOM_ID });
 
-			expect(roomStore.sessions.value).toHaveLength(2);
+			// Give any potential async re-fetch a chance to run
+			await new Promise((r) => setTimeout(r, 20));
+
+			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 
-		it('is a no-op when sessionId is not in the current room', () => {
-			hub.fire('session.deleted', { sessionId: 'session-unknown', roomId: ROOM_ID });
+		it('does NOT trigger a re-fetch when roomId is absent', async () => {
+			const before = countRequests(hub, 'room.get');
 
-			expect(roomStore.sessions.value).toHaveLength(2);
-		});
+			hub.fire('session.deleted', { sessionId: 'session-1' });
 
-		it('handles multiple sequential deletions', () => {
-			hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
-			hub.fire('session.deleted', { sessionId: 'session-2', roomId: ROOM_ID });
+			await new Promise((r) => setTimeout(r, 20));
 
-			expect(roomStore.sessions.value).toHaveLength(0);
+			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 	});
 
@@ -179,70 +202,59 @@ describe('RoomStore — session lifecycle events', () => {
 	// -----------------------------------------------------------------------
 
 	describe('session.updated event', () => {
-		it('updates the title of a session when roomId matches', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-1',
-				roomId: ROOM_ID,
-				title: 'Renamed Session',
-			});
+		it('triggers a room.get re-fetch when roomId matches', async () => {
+			const before = countRequests(hub, 'room.get');
 
-			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
-			expect(updated?.title).toBe('Renamed Session');
+			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
+
+			await vi.waitFor(() => {
+				expect(countRequests(hub, 'room.get')).toBeGreaterThan(before);
+			});
 		});
 
-		it('updates the status of a session (e.g., archiving)', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-1',
-				roomId: ROOM_ID,
-				status: 'archived',
+		it('updates sessions signal from server response after update', async () => {
+			// Server returns session-1 with archived status
+			hub.request.mockImplementation((method: string) => {
+				if (method === 'room.get')
+					return Promise.resolve(
+						makeOverview([
+							{ id: 'session-1', title: 'Session One', status: 'archived', lastActiveAt: 1000 },
+							{ id: 'session-2', title: 'Session Two', status: 'active', lastActiveAt: 2000 },
+						])
+					);
+				if (method === 'goal.list') return Promise.resolve({ goals: [] });
+				if (method === 'room.runtime.state') return Promise.resolve({ state: 'stopped' });
+				if (method === 'room.runtime.models')
+					return Promise.resolve({ leaderModel: null, workerModel: null });
+				return Promise.resolve({});
 			});
 
-			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
-			expect(updated?.status).toBe('archived');
+			hub.fire('session.updated', { sessionId: 'session-1', roomId: ROOM_ID, status: 'archived' });
+
+			await vi.waitFor(() => {
+				const s1 = roomStore.sessions.value.find((s) => s.id === 'session-1');
+				expect(s1?.status).toBe('archived');
+			});
 		});
 
-		it('preserves unchanged fields when doing a partial update', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-1',
-				roomId: ROOM_ID,
-				title: 'New Title',
-			});
+		it('does NOT trigger a re-fetch for a different room', async () => {
+			const before = countRequests(hub, 'room.get');
 
-			const updated = roomStore.sessions.value.find((s) => s.id === 'session-1');
-			expect(updated?.status).toBe('active'); // unchanged
-			expect(updated?.lastActiveAt).toBe(1000); // unchanged
+			hub.fire('session.updated', { sessionId: 'session-1', roomId: OTHER_ROOM_ID, title: 'X' });
+
+			await new Promise((r) => setTimeout(r, 20));
+
+			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 
-		it('ignores update events for a different room', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-1',
-				roomId: OTHER_ROOM_ID,
-				title: 'Should not apply',
-			});
+		it('does NOT trigger a re-fetch when roomId is absent', async () => {
+			const before = countRequests(hub, 'room.get');
 
-			const session = roomStore.sessions.value.find((s) => s.id === 'session-1');
-			expect(session?.title).toBe('Session One'); // unchanged
-		});
+			hub.fire('session.updated', { sessionId: 'session-1', title: 'X' });
 
-		it('is a no-op when sessionId is not in the current room', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-unknown',
-				roomId: ROOM_ID,
-				title: 'Ghost Update',
-			});
+			await new Promise((r) => setTimeout(r, 20));
 
-			expect(roomStore.sessions.value).toHaveLength(2);
-		});
-
-		it('updates lastActiveAt when provided', () => {
-			hub.fire('session.updated', {
-				sessionId: 'session-2',
-				roomId: ROOM_ID,
-				lastActiveAt: 9999,
-			});
-
-			const updated = roomStore.sessions.value.find((s) => s.id === 'session-2');
-			expect(updated?.lastActiveAt).toBe(9999);
+			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 	});
 
@@ -251,17 +263,18 @@ describe('RoomStore — session lifecycle events', () => {
 	// -----------------------------------------------------------------------
 
 	describe('subscription cleanup on room switch', () => {
-		it('stops responding to events after room is deselected', async () => {
-			// Deselect room
+		it('stops triggering re-fetches after room is deselected', async () => {
 			await roomStore.select(null);
 
-			// Reset sessions to empty (as doSelect clears them)
-			// Now fire an event — it should not crash or update anything
+			const before = countRequests(hub, 'room.get');
+
 			expect(() => {
 				hub.fire('session.deleted', { sessionId: 'session-1', roomId: ROOM_ID });
 			}).not.toThrow();
 
-			expect(roomStore.sessions.value).toHaveLength(0);
+			await new Promise((r) => setTimeout(r, 20));
+
+			expect(countRequests(hub, 'room.get')).toBe(before);
 		});
 	});
 });

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -362,42 +362,31 @@ class RoomStore {
 			this.cleanupFunctions.push(unsubRuntimeState);
 
 			// 5. Session lifecycle events (delete / update / archive)
+			// Re-fetch the authoritative session list from the server on any session change.
+			// This avoids manual array splicing and self-heals any events missed during
+			// WebSocket reconnect gaps.
 			const unsubSessionDeleted = hub.onEvent<{ sessionId: string; roomId?: string }>(
 				'session.deleted',
 				(event) => {
 					if (event.roomId === roomId) {
-						this.sessions.value = this.sessions.value.filter((s) => s.id !== event.sessionId);
+						this.refresh().catch((err) => {
+							logger.error('Failed to refresh after session.deleted:', err);
+						});
 					}
 				}
 			);
 			this.cleanupFunctions.push(unsubSessionDeleted);
 
-			const unsubSessionUpdated = hub.onEvent<{
-				sessionId: string;
-				roomId?: string;
-				title?: string;
-				status?: string;
-				lastActiveAt?: number;
-			}>('session.updated', (event) => {
-				if (event.roomId === roomId) {
-					const idx = this.sessions.value.findIndex((s) => s.id === event.sessionId);
-					if (idx >= 0) {
-						const existing = this.sessions.value[idx];
-						this.sessions.value = [
-							...this.sessions.value.slice(0, idx),
-							{
-								...existing,
-								...(event.title !== undefined && { title: event.title }),
-								...(event.status !== undefined && { status: event.status }),
-								...(event.lastActiveAt !== undefined && {
-									lastActiveAt: event.lastActiveAt,
-								}),
-							},
-							...this.sessions.value.slice(idx + 1),
-						];
+			const unsubSessionUpdated = hub.onEvent<{ sessionId: string; roomId?: string }>(
+				'session.updated',
+				(event) => {
+					if (event.roomId === roomId) {
+						this.refresh().catch((err) => {
+							logger.error('Failed to refresh after session.updated:', err);
+						});
 					}
 				}
-			});
+			);
 			this.cleanupFunctions.push(unsubSessionUpdated);
 
 			// 6. Fetch initial state via RPC

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -363,13 +363,10 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubRuntimeState);
 
-			// 5. Session lifecycle events (delete)
-			// Re-fetch the authoritative session list from the server when a session is
-			// deleted. This avoids manual array splicing and self-heals any events missed
-			// during WebSocket reconnect gaps.
-			// Note: session.updated is intentionally NOT subscribed here — draft saves via
-			// useInputDraft call session.update every ~250 ms and would trigger a 4-RPC
-			// storm (room.get + goal.list + runtime.state + runtime.models) on every keystroke.
+			// 5. Session lifecycle events (delete / status change)
+			// Re-fetch the authoritative session list from the server on meaningful session
+			// changes. This avoids manual array splicing and self-heals events missed during
+			// WebSocket reconnect gaps.
 			const unsubSessionDeleted = hub.onEvent<{ sessionId: string; roomId?: string }>(
 				'session.deleted',
 				(event) => {
@@ -389,6 +386,22 @@ class RoomStore {
 				}
 			);
 			this.cleanupFunctions.push(unsubSessionDeleted);
+
+			// session.updated: only refresh when a status field is present.
+			// Draft saves (useInputDraft, ~250 ms debounce) only carry title/inputDraft —
+			// no status — so this guard keeps RPC calls at zero during typing.
+			const unsubSessionUpdated = hub.onEvent<{
+				sessionId: string;
+				roomId?: string;
+				status?: string;
+			}>('session.updated', (event) => {
+				if (event.roomId !== roomId) return;
+				if (event.status === undefined) return;
+				this.refresh().catch((err) => {
+					logger.error('Failed to refresh after session.updated:', err);
+				});
+			});
+			this.cleanupFunctions.push(unsubSessionUpdated);
 
 			// 6. Fetch initial state via RPC
 			await this.fetchInitialState(hub, roomId);

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -59,6 +59,8 @@ interface GoalEventPayload {
 
 import { Logger } from '@neokai/shared';
 import { connectionManager } from './connection-manager';
+import { navigateToRoom } from './router';
+import { currentRoomSessionIdSignal } from './signals';
 import { toast } from './toast';
 
 const logger = new Logger('kai:web:roomstore');
@@ -361,33 +363,32 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubRuntimeState);
 
-			// 5. Session lifecycle events (delete / update / archive)
-			// Re-fetch the authoritative session list from the server on any session change.
-			// This avoids manual array splicing and self-heals any events missed during
-			// WebSocket reconnect gaps.
+			// 5. Session lifecycle events (delete)
+			// Re-fetch the authoritative session list from the server when a session is
+			// deleted. This avoids manual array splicing and self-heals any events missed
+			// during WebSocket reconnect gaps.
+			// Note: session.updated is intentionally NOT subscribed here — draft saves via
+			// useInputDraft call session.update every ~250 ms and would trigger a 4-RPC
+			// storm (room.get + goal.list + runtime.state + runtime.models) on every keystroke.
 			const unsubSessionDeleted = hub.onEvent<{ sessionId: string; roomId?: string }>(
 				'session.deleted',
 				(event) => {
-					if (event.roomId === roomId) {
-						this.refresh().catch((err) => {
+					if (event.roomId !== roomId) return;
+					this.refresh()
+						.then(() => {
+							// If the user is currently viewing the deleted session, navigate
+							// back to the room dashboard so they don't land on a dead view.
+							const activeSessionId = currentRoomSessionIdSignal.value;
+							if (activeSessionId && !this.sessions.value.some((s) => s.id === activeSessionId)) {
+								navigateToRoom(roomId);
+							}
+						})
+						.catch((err) => {
 							logger.error('Failed to refresh after session.deleted:', err);
 						});
-					}
 				}
 			);
 			this.cleanupFunctions.push(unsubSessionDeleted);
-
-			const unsubSessionUpdated = hub.onEvent<{ sessionId: string; roomId?: string }>(
-				'session.updated',
-				(event) => {
-					if (event.roomId === roomId) {
-						this.refresh().catch((err) => {
-							logger.error('Failed to refresh after session.updated:', err);
-						});
-					}
-				}
-			);
-			this.cleanupFunctions.push(unsubSessionUpdated);
 
 			// 6. Fetch initial state via RPC
 			await this.fetchInitialState(hub, roomId);

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -361,6 +361,45 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubRuntimeState);
 
+			// 5. Session lifecycle events
+			const unsubSessionDeleted = hub.onEvent<{ sessionId: string; roomId?: string }>(
+				'session.deleted',
+				(event) => {
+					if (event.roomId === roomId) {
+						this.sessions.value = this.sessions.value.filter((s) => s.id !== event.sessionId);
+					}
+				}
+			);
+			this.cleanupFunctions.push(unsubSessionDeleted);
+
+			const unsubSessionUpdated = hub.onEvent<{
+				sessionId: string;
+				roomId?: string;
+				title?: string;
+				status?: string;
+				lastActiveAt?: number;
+			}>('session.updated', (event) => {
+				if (event.roomId === roomId) {
+					const idx = this.sessions.value.findIndex((s) => s.id === event.sessionId);
+					if (idx >= 0) {
+						const existing = this.sessions.value[idx];
+						this.sessions.value = [
+							...this.sessions.value.slice(0, idx),
+							{
+								...existing,
+								...(event.title !== undefined && { title: event.title }),
+								...(event.status !== undefined && { status: event.status }),
+								...(event.lastActiveAt !== undefined && {
+									lastActiveAt: event.lastActiveAt,
+								}),
+							},
+							...this.sessions.value.slice(idx + 1),
+						];
+					}
+				}
+			});
+			this.cleanupFunctions.push(unsubSessionUpdated);
+
 			// 5. Fetch initial state via RPC
 			await this.fetchInitialState(hub, roomId);
 		} catch (err) {

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -361,7 +361,7 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubRuntimeState);
 
-			// 5. Session lifecycle events
+			// 5. Session lifecycle events (delete / update / archive)
 			const unsubSessionDeleted = hub.onEvent<{ sessionId: string; roomId?: string }>(
 				'session.deleted',
 				(event) => {
@@ -400,7 +400,7 @@ class RoomStore {
 			});
 			this.cleanupFunctions.push(unsubSessionUpdated);
 
-			// 5. Fetch initial state via RPC
+			// 6. Fetch initial state via RPC
 			await this.fetchInitialState(hub, roomId);
 		} catch (err) {
 			logger.error('Failed to start room subscriptions:', err);


### PR DESCRIPTION
When a session is deleted or archived from within a room, the RoomContextPanel
would continue showing it because RoomStore had no session lifecycle event handlers.

Daemon changes:
- session.delete: capture roomId before deletion, broadcast session.deleted with
  roomId on both global and room:{roomId} channels
- session.update: also broadcast session.updated on room:{roomId} channel when
  the session belongs to a room
- session.archive: broadcast session.updated with status:'archived' on session
  and room channels after archiving (previously no event was emitted)

Web changes (room-store.ts):
- Subscribe to session.deleted on room channel — removes session from sessions signal
- Subscribe to session.updated on room channel — updates title/status/lastActiveAt in-place

Tests:
- 12 new Vitest unit tests covering session.deleted and session.updated handlers
  in RoomStore, including roomId filtering and subscription cleanup
- Updated and extended existing daemon session-handlers.test.ts with room-channel
  broadcast assertions
