### PR TITLE
docs: plan for task status lifecycle redesign

### DIFF
--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/00-overview.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/00-overview.md
@@ -4,32 +4,41 @@
 
 Redesign the task status lifecycle so that `completed` and `cancelled` tasks retain their worktrees and agent session groups (paused), allowing users to reactivate them at any time. Introduce `archived` as the only true terminal state where worktrees are cleaned up and the task cannot be reverted.
 
+## Key Design Decision: `archived_at` vs `status = 'archived'`
+
+The current codebase uses `archived_at IS NOT NULL` as the sole archival signal:
+- `task-repository.ts` `listTasks()` filters by `archived_at IS NULL`
+- `task-repository.ts` `archiveTask()` only sets `archived_at`; no status update
+- `TaskFilter.includeArchived` in `neo.ts` refers to `archived_at` semantics
+
+**Resolution:** `status = 'archived'` becomes the **canonical source of truth** for the archived state. The `archived_at` column is kept as a **derived timestamp** (set simultaneously when status becomes `archived`). All queries and filters will check `status = 'archived'` instead of `archived_at IS NOT NULL`. A DB migration will backfill any existing rows where `archived_at IS NOT NULL` but status is not `archived`. The `includeArchived` filter parameter will be updated to check `status != 'archived'` (or passed through to the query appropriately).
+
+This unifies the dual model: there is one source of truth (`status`), and `archived_at` is kept only for the timestamp of when archiving occurred.
+
 ## Approach
 
 The change touches four layers of the stack:
 
-1. **Shared types** -- Add `archived` to both `TaskStatus` and `SpaceTaskStatus` union types.
-2. **Daemon (Room)** -- Update the status transition map, stop worktree cleanup on complete/cancel, only tear down on archive. Adjust `task-group-manager.ts` so `complete()` and `terminateGroup()` no longer call `cleanupWorktree()`. Update `room-runtime.ts` cancel flow to keep groups paused instead of terminated.
-3. **Daemon (Space)** -- Mirror the same transition map and lifecycle changes in `space-task-manager.ts` and `task-agent-manager.ts`.
-4. **Web UI** -- Update tab grouping (Review tab = review + needs_attention; Done tab = completed + cancelled; Archived tab = archived), add reactivate/archive actions, enable messaging for completed/cancelled tasks.
-
-A new DB migration adds support for `archived` as a valid task status value (the existing `archived_at` column remains for backward compatibility).
+1. **Shared types + DB migration** -- Add `archived` to both `TaskStatus` and `SpaceTaskStatus` union types. Create Migration 34 to add `archived` to the status CHECK constraints on `tasks` and `space_tasks` tables, and backfill existing `archived_at IS NOT NULL` rows.
+2. **Daemon (Room)** -- Update the status transition map, stop worktree cleanup on complete/cancel, only tear down on archive. Adjust `task-group-manager.ts` so `complete()` and `terminateGroup()` no longer call `cleanupWorktree()`. Update `room-runtime.ts` cancel flow to keep groups paused. Update daemon-side guards in `room-agent-tools.ts` and `task-handlers.ts` that block messaging to cancelled tasks. Update `task-repository.ts` to use `status = 'archived'` as primary filter. Wire `task.list` RPC handler to pass `includeArchived` through.
+3. **Daemon (Space)** -- Mirror the same transition map changes in `space-task-manager.ts`. Note: space tasks do NOT create worktrees (confirmed via codebase inspection of `task-agent-manager.ts`), so worktree cleanup is not relevant. The changes are limited to status transitions and archival semantics.
+4. **Web UI** -- Update tab grouping (Review tab = review + needs_attention; Done tab = completed + cancelled; Archived tab = archived), add reactivate/archive actions, add localStorage tab migration, enable messaging for completed/cancelled tasks.
 
 ## Milestones
 
-1. **Shared types and status transitions** -- Add `archived` to type unions, update `VALID_STATUS_TRANSITIONS` in both room and space task managers, add unit tests for new transitions.
-2. **Room daemon lifecycle changes** -- Stop worktree cleanup on complete/cancel in `task-group-manager.ts`, keep groups paused in `room-runtime.ts`, wire archive as the only cleanup trigger. Update RPC handlers.
-3. **Space daemon lifecycle changes** -- Mirror room changes in `space-task-manager.ts` and `task-agent-manager.ts`. Update space RPC handlers.
-4. **Web UI updates** -- Update tab grouping, add reactivate/archive actions, enable messaging for completed/cancelled tasks.
+1. **Shared types, DB migration, and status transitions** -- Add `archived` to type unions, create Migration 34, update `VALID_STATUS_TRANSITIONS` in both room and space task managers, update `task-repository.ts` and `task.list` RPC to use status-based archival filtering, add unit tests.
+2. **Room daemon lifecycle changes** -- Stop worktree cleanup on complete/cancel in `task-group-manager.ts`, keep groups paused in `room-runtime.ts`, wire archive as the only cleanup trigger. Update daemon-side message guards. Update RPC handlers for reactivation and archive.
+3. **Space daemon lifecycle changes** -- Update `space-task-manager.ts` status transitions and archival. No worktree changes needed (space tasks don't use worktrees).
+4. **Web UI updates** -- Update tab grouping with localStorage migration, add reactivate/archive actions, resolve messaging contract for completed/cancelled tasks.
 5. **Integration and E2E tests** -- Online tests for reactivation flow, E2E tests for new UI actions.
 
 ## Cross-Milestone Dependencies
 
-- Milestone 2 depends on Milestone 1 (needs the new type).
-- Milestone 3 depends on Milestone 1 (needs the new type).
+- Milestone 2 depends on Milestone 1 (needs the new type and migration).
+- Milestone 3 depends on Milestone 1 (needs the new type and migration).
 - Milestone 4 depends on Milestones 2 and 3 (UI must reflect daemon behavior).
 - Milestone 5 depends on all previous milestones.
 
 ## Estimated Task Count
 
-14 tasks across 5 milestones.
+16 tasks across 5 milestones.

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/00-overview.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/00-overview.md
@@ -1,0 +1,35 @@
+# Redesign Task Status Lifecycle: Keep Worktrees Alive, Add Archived
+
+## Goal
+
+Redesign the task status lifecycle so that `completed` and `cancelled` tasks retain their worktrees and agent session groups (paused), allowing users to reactivate them at any time. Introduce `archived` as the only true terminal state where worktrees are cleaned up and the task cannot be reverted.
+
+## Approach
+
+The change touches four layers of the stack:
+
+1. **Shared types** -- Add `archived` to both `TaskStatus` and `SpaceTaskStatus` union types.
+2. **Daemon (Room)** -- Update the status transition map, stop worktree cleanup on complete/cancel, only tear down on archive. Adjust `task-group-manager.ts` so `complete()` and `terminateGroup()` no longer call `cleanupWorktree()`. Update `room-runtime.ts` cancel flow to keep groups paused instead of terminated.
+3. **Daemon (Space)** -- Mirror the same transition map and lifecycle changes in `space-task-manager.ts` and `task-agent-manager.ts`.
+4. **Web UI** -- Update tab grouping (Review tab = review + needs_attention; Done tab = completed + cancelled; Archived tab = archived), add reactivate/archive actions, enable messaging for completed/cancelled tasks.
+
+A new DB migration adds support for `archived` as a valid task status value (the existing `archived_at` column remains for backward compatibility).
+
+## Milestones
+
+1. **Shared types and status transitions** -- Add `archived` to type unions, update `VALID_STATUS_TRANSITIONS` in both room and space task managers, add unit tests for new transitions.
+2. **Room daemon lifecycle changes** -- Stop worktree cleanup on complete/cancel in `task-group-manager.ts`, keep groups paused in `room-runtime.ts`, wire archive as the only cleanup trigger. Update RPC handlers.
+3. **Space daemon lifecycle changes** -- Mirror room changes in `space-task-manager.ts` and `task-agent-manager.ts`. Update space RPC handlers.
+4. **Web UI updates** -- Update tab grouping, add reactivate/archive actions, enable messaging for completed/cancelled tasks.
+5. **Integration and E2E tests** -- Online tests for reactivation flow, E2E tests for new UI actions.
+
+## Cross-Milestone Dependencies
+
+- Milestone 2 depends on Milestone 1 (needs the new type).
+- Milestone 3 depends on Milestone 1 (needs the new type).
+- Milestone 4 depends on Milestones 2 and 3 (UI must reflect daemon behavior).
+- Milestone 5 depends on all previous milestones.
+
+## Estimated Task Count
+
+14 tasks across 5 milestones.

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/01-shared-types-and-status-transitions.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/01-shared-types-and-status-transitions.md
@@ -1,0 +1,77 @@
+# Milestone 1: Shared Types and Status Transitions
+
+## Goal
+
+Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, update all status transition maps to reflect the new lifecycle, and cover the changes with unit tests.
+
+## Scope
+
+- Shared type definitions in `packages/shared/src/types/neo.ts` and `packages/shared/src/types/space.ts`
+- Room task manager transitions in `packages/daemon/src/lib/room/managers/task-manager.ts`
+- Space task manager transitions in `packages/daemon/src/lib/space/managers/space-task-manager.ts`
+- Unit tests for both managers
+
+---
+
+### Task 1.1: Add `archived` to shared type unions and update transition maps
+
+**Description:** Add `archived` as a new value to both `TaskStatus` and `SpaceTaskStatus` union types. Update `VALID_STATUS_TRANSITIONS` in `task-manager.ts` and `VALID_SPACE_TASK_TRANSITIONS` in `space-task-manager.ts` to reflect the new lifecycle where `completed` and `cancelled` are no longer terminal.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/shared/src/types/neo.ts`, add `| 'archived'` to the `TaskStatus` union (after `cancelled`).
+3. In `packages/shared/src/types/space.ts`, add `| 'archived'` to the `SpaceTaskStatus` union (after `cancelled`).
+4. In `packages/daemon/src/lib/room/managers/task-manager.ts`, update `VALID_STATUS_TRANSITIONS` to:
+   - `completed: ['in_progress', 'archived']` (was `[]`)
+   - `cancelled: ['in_progress', 'archived']` (was `['pending', 'in_progress']`)
+   - `needs_attention: ['in_progress', 'review', 'archived']` (was `['pending', 'in_progress', 'review']`)
+   - `archived: []` (new entry -- true terminal state)
+5. In `packages/daemon/src/lib/space/managers/space-task-manager.ts`, update `VALID_SPACE_TASK_TRANSITIONS` with the same changes as above.
+6. In `space-task-manager.ts`, update the `retryTask` method to also allow retrying from `completed` and `cancelled` via `in_progress` (the transition is now valid), and update the `reassignTask` method's `allowedStatuses` to include `completed` and `cancelled`.
+7. Run `bun run typecheck` to ensure no type errors from the new union member. Fix any exhaustiveness checks or switch statements that need an `archived` case.
+8. Run `bun run lint` and `bun run format` to fix any style issues.
+
+**Acceptance criteria:**
+- `TaskStatus` and `SpaceTaskStatus` both include `archived`.
+- Both transition maps match the specified lifecycle.
+- `bun run typecheck` passes with zero errors.
+- `bun run lint` passes.
+
+**Dependencies:** None
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 1.2: Unit tests for new status transitions
+
+**Description:** Update existing unit tests and add new test cases for the `archived` status transitions in both room and space task managers.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/tests/unit/room/task-manager.test.ts`:
+   - Add test cases verifying `completed -> in_progress` is valid.
+   - Add test cases verifying `completed -> archived` is valid.
+   - Add test cases verifying `cancelled -> in_progress` is valid.
+   - Add test cases verifying `cancelled -> archived` is valid.
+   - Add test cases verifying `needs_attention -> archived` is valid.
+   - Add test cases verifying `archived -> *` (any status) is invalid.
+   - Remove or update any tests that assert `completed` and `cancelled` are terminal with no transitions.
+3. In `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
+   - Add equivalent test cases for `VALID_SPACE_TASK_TRANSITIONS`.
+   - Test that `retryTask` works from `completed` and `cancelled` states.
+4. Run `cd packages/daemon && bun test tests/unit/room/task-manager.test.ts` and `bun test tests/unit/lib/space-task-manager.test.ts` to verify all tests pass.
+5. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All new transition test cases pass.
+- No existing tests broken (or updated to match new behavior).
+- Tests explicitly verify `archived` is a dead-end state.
+
+**Dependencies:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/01-shared-types-and-status-transitions.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/01-shared-types-and-status-transitions.md
@@ -1,21 +1,24 @@
-# Milestone 1: Shared Types and Status Transitions
+# Milestone 1: Shared Types, DB Migration, and Status Transitions
 
 ## Goal
 
-Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, update all status transition maps to reflect the new lifecycle, and cover the changes with unit tests.
+Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, create a DB migration for the CHECK constraints, update all status transition maps, update repository archival filtering to use `status = 'archived'`, and cover the changes with unit tests.
 
 ## Scope
 
 - Shared type definitions in `packages/shared/src/types/neo.ts` and `packages/shared/src/types/space.ts`
+- DB migration in `packages/daemon/src/storage/schema/migrations.ts` and fresh-DB schema in `packages/daemon/src/storage/schema/index.ts`
 - Room task manager transitions in `packages/daemon/src/lib/room/managers/task-manager.ts`
 - Space task manager transitions in `packages/daemon/src/lib/space/managers/space-task-manager.ts`
+- Task repository archival filtering in `packages/daemon/src/storage/repositories/task-repository.ts`
+- `task.list` RPC handler in `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`
 - Unit tests for both managers
 
 ---
 
-### Task 1.1: Add `archived` to shared type unions and update transition maps
+### Task 1.1: Add `archived` to shared type unions, create DB migration, and update transition maps
 
-**Description:** Add `archived` as a new value to both `TaskStatus` and `SpaceTaskStatus` union types. Update `VALID_STATUS_TRANSITIONS` in `task-manager.ts` and `VALID_SPACE_TASK_TRANSITIONS` in `space-task-manager.ts` to reflect the new lifecycle where `completed` and `cancelled` are no longer terminal.
+**Description:** Add `archived` as a new value to both `TaskStatus` and `SpaceTaskStatus` union types. Create Migration 34 to add `archived` to the CHECK constraints on `tasks` and `space_tasks` tables, backfilling any rows with `archived_at IS NOT NULL`. Update `VALID_STATUS_TRANSITIONS` in `task-manager.ts` and `VALID_SPACE_TASK_TRANSITIONS` in `space-task-manager.ts` to reflect the new lifecycle. Update `task-repository.ts` to use `status`-based archival filtering.
 
 **Agent type:** coder
 
@@ -23,19 +26,36 @@ Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, update all
 1. Run `bun install` at the worktree root.
 2. In `packages/shared/src/types/neo.ts`, add `| 'archived'` to the `TaskStatus` union (after `cancelled`).
 3. In `packages/shared/src/types/space.ts`, add `| 'archived'` to the `SpaceTaskStatus` union (after `cancelled`).
-4. In `packages/daemon/src/lib/room/managers/task-manager.ts`, update `VALID_STATUS_TRANSITIONS` to:
+4. **DB Migration (Migration 34):** In `packages/daemon/src/storage/schema/migrations.ts`:
+   - Add `runMigration34()` following the established pattern (see `runMigration18` / `runMigration24` for table rebuild examples).
+   - For the `tasks` table: rebuild with `'archived'` added to the status CHECK constraint: `CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived'))`.
+   - For the `space_tasks` table: same CHECK constraint update.
+   - Backfill: `UPDATE tasks SET status = 'archived' WHERE archived_at IS NOT NULL AND status != 'archived'` (and same for `space_tasks`).
+   - Register the migration in the migrations array.
+5. **Fresh-DB schema:** In `packages/daemon/src/storage/schema/index.ts`, update the `tasks` table CHECK constraint to include `'archived'`.
+6. In `packages/daemon/src/lib/room/managers/task-manager.ts`, update `VALID_STATUS_TRANSITIONS` to:
    - `completed: ['in_progress', 'archived']` (was `[]`)
-   - `cancelled: ['in_progress', 'archived']` (was `['pending', 'in_progress']`)
-   - `needs_attention: ['in_progress', 'review', 'archived']` (was `['pending', 'in_progress', 'review']`)
-   - `archived: []` (new entry -- true terminal state)
-5. In `packages/daemon/src/lib/space/managers/space-task-manager.ts`, update `VALID_SPACE_TASK_TRANSITIONS` with the same changes as above.
-6. In `space-task-manager.ts`, update the `retryTask` method to also allow retrying from `completed` and `cancelled` via `in_progress` (the transition is now valid), and update the `reassignTask` method's `allowedStatuses` to include `completed` and `cancelled`.
-7. Run `bun run typecheck` to ensure no type errors from the new union member. Fix any exhaustiveness checks or switch statements that need an `archived` case.
-8. Run `bun run lint` and `bun run format` to fix any style issues.
+   - `cancelled: ['pending', 'in_progress', 'archived']` (was `['pending', 'in_progress']` — **preserves the existing `pending` target**)
+   - `needs_attention: ['pending', 'in_progress', 'review', 'archived']` (was `['pending', 'in_progress', 'review']` — **preserves the existing `pending` target**)
+   - `archived: []` (new entry — true terminal state)
+7. In `packages/daemon/src/lib/space/managers/space-task-manager.ts`, update `VALID_SPACE_TASK_TRANSITIONS` with the same changes as above.
+8. **Update archival filtering in `task-repository.ts`:**
+   - In `listTasks()`, change the default filter from `archived_at IS NULL` to `status != 'archived'`. This makes `status` the source of truth for archival.
+   - In `archiveTask()`, update to set **both** `status = 'archived'` and `archived_at = ?` in a single UPDATE statement.
+9. **Update `task.list` RPC handler** in `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`: the handler currently only passes `status` and `priority` to `listTasks()`. Add `includeArchived: params.includeArchived` to the filter object so callers can opt in to seeing archived tasks.
+10. In `space-task-manager.ts`, update `retryTask()` to also allow retrying from `completed` and `cancelled` via `in_progress`, and update `reassignTask()`'s `allowedStatuses` to include `completed` and `cancelled`.
+11. Run `bun run typecheck` to ensure no type errors from the new union member. Fix any exhaustiveness checks or switch statements that need an `archived` case.
+12. Run `bun run lint` and `bun run format` to fix any style issues.
 
 **Acceptance criteria:**
 - `TaskStatus` and `SpaceTaskStatus` both include `archived`.
-- Both transition maps match the specified lifecycle.
+- Migration 34 exists and correctly updates CHECK constraints on both `tasks` and `space_tasks`.
+- Migration 34 backfills existing `archived_at IS NOT NULL` rows with `status = 'archived'`.
+- Fresh-DB schema in `index.ts` includes `archived` in the CHECK constraint.
+- Both transition maps include `archived` as terminal and preserve existing `pending` targets for `cancelled` and `needs_attention`.
+- `task-repository.ts` `listTasks()` uses `status != 'archived'` as default filter.
+- `task-repository.ts` `archiveTask()` sets both `status = 'archived'` and `archived_at`.
+- `task.list` RPC handler passes `includeArchived` through to the repository.
 - `bun run typecheck` passes with zero errors.
 - `bun run lint` passes.
 
@@ -45,9 +65,9 @@ Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, update all
 
 ---
 
-### Task 1.2: Unit tests for new status transitions
+### Task 1.2: Unit tests for new status transitions and archival filtering
 
-**Description:** Update existing unit tests and add new test cases for the `archived` status transitions in both room and space task managers.
+**Description:** Update existing unit tests and add new test cases for the `archived` status transitions in both room and space task managers. Add tests for the updated archival filtering in `task-repository.ts`.
 
 **Agent type:** coder
 
@@ -56,21 +76,28 @@ Add `archived` to the `TaskStatus` and `SpaceTaskStatus` type unions, update all
 2. In `packages/daemon/tests/unit/room/task-manager.test.ts`:
    - Add test cases verifying `completed -> in_progress` is valid.
    - Add test cases verifying `completed -> archived` is valid.
+   - Add test cases verifying `cancelled -> pending` is valid (preserved from existing behavior).
    - Add test cases verifying `cancelled -> in_progress` is valid.
    - Add test cases verifying `cancelled -> archived` is valid.
+   - Add test cases verifying `needs_attention -> pending` is valid (preserved).
    - Add test cases verifying `needs_attention -> archived` is valid.
    - Add test cases verifying `archived -> *` (any status) is invalid.
    - Remove or update any tests that assert `completed` and `cancelled` are terminal with no transitions.
 3. In `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
    - Add equivalent test cases for `VALID_SPACE_TASK_TRANSITIONS`.
    - Test that `retryTask` works from `completed` and `cancelled` states.
-4. Run `cd packages/daemon && bun test tests/unit/room/task-manager.test.ts` and `bun test tests/unit/lib/space-task-manager.test.ts` to verify all tests pass.
-5. Run `bun run lint` and `bun run format`.
+4. Add tests for `task-repository.ts` archival filtering:
+   - Test: `listTasks()` without `includeArchived` excludes tasks with `status = 'archived'`.
+   - Test: `listTasks()` with `includeArchived: true` includes archived tasks.
+   - Test: `archiveTask()` sets both `status = 'archived'` and `archived_at`.
+5. Run `cd packages/daemon && bun test tests/unit/room/task-manager.test.ts` and `bun test tests/unit/lib/space-task-manager.test.ts` to verify all tests pass.
+6. Run `bun run lint` and `bun run format`.
 
 **Acceptance criteria:**
 - All new transition test cases pass.
 - No existing tests broken (or updated to match new behavior).
 - Tests explicitly verify `archived` is a dead-end state.
+- Tests verify the dual-model resolution (status-based filtering, `archiveTask` sets both fields).
 
 **Dependencies:** Task 1.1
 

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/02-room-daemon-lifecycle.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/02-room-daemon-lifecycle.md
@@ -1,0 +1,109 @@
+# Milestone 2: Room Daemon Lifecycle Changes
+
+## Goal
+
+Update the room daemon so that `completed` and `cancelled` tasks keep their worktrees and session groups paused. Only `archived` triggers worktree cleanup and group teardown.
+
+## Scope
+
+- `packages/daemon/src/lib/room/runtime/task-group-manager.ts` -- Stop worktree cleanup on complete/fail/terminate
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- Keep groups paused on complete/cancel, only tear down on archive
+- `packages/daemon/src/lib/rpc-handlers/task-handlers.ts` -- Update setStatus handler to support reactivation and archive transitions
+- `packages/daemon/src/storage/repositories/task-repository.ts` -- Ensure archive sets both `archivedAt` and status
+- Unit tests for task-group-manager and room-runtime changes
+
+---
+
+### Task 2.1: Stop worktree cleanup on complete and cancel in task-group-manager
+
+**Description:** Modify `task-group-manager.ts` so the `complete()` method no longer calls `cleanupWorktree()`. The `terminateGroup()` method (used by cancel) should also stop cleaning up worktrees. Only `archiveGroup()` should call `cleanupWorktree()`. The `fail()` method already skips cleanup (kept for debugging), so no change there.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/room/runtime/task-group-manager.ts`:
+   - In the `complete()` method (line ~561), remove the `await this.cleanupWorktree(group)` call. Update the comment to explain worktree is preserved for potential reactivation.
+   - In the `terminateGroup()` method (line ~724), remove both `cleanupWorktree()` calls (line ~732 for already-terminal groups and line ~743 for newly terminated groups). Update comments.
+   - Verify `archiveGroup()` (line ~771) still calls `cleanupWorktree()` -- this is the only path that should clean up.
+3. Update `packages/daemon/tests/unit/room/task-group-manager.test.ts`:
+   - Adjust any tests that assert worktree cleanup happens on complete or terminate.
+   - Add a test verifying `complete()` does NOT call `removeWorktree`.
+   - Add a test verifying `terminateGroup()` does NOT call `removeWorktree`.
+   - Add a test verifying `archiveGroup()` DOES call `removeWorktree`.
+4. Run `cd packages/daemon && bun test tests/unit/room/task-group-manager.test.ts`.
+5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- `complete()` no longer cleans up the worktree.
+- `terminateGroup()` no longer cleans up the worktree.
+- `archiveGroup()` remains the only method that cleans up worktrees.
+- All existing and new unit tests pass.
+
+**Dependencies:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.2: Update room-runtime cancel and complete flows
+
+**Description:** Update `room-runtime.ts` so that the `cancelTask()` method keeps the group paused (not fully torn down) and the complete flow preserves the group. Update the `archiveTaskGroup()` method to also terminate active sessions and tear down the group before cleaning the worktree. Update the `terminateTaskGroup()` method to stop sessions but keep the group.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`, update `cancelTask()` (line ~1570):
+   - Instead of calling `taskGroupManager.terminateGroup()`, call `taskGroupManager.cancel()` which already handles the task status change, but modify the flow to NOT terminate the group -- instead pause it. Concretely: stop agent sessions (via `terminateGroupSessions()`), cleanup mirroring, but do NOT call `terminateGroup()`. Instead mark the group as paused by setting `completedAt` (this already happens in the current flow via `failGroup`).
+   - Actually, review the current flow carefully: `cancelTask()` calls `terminateGroup()` for active groups and then `terminateGroupSessions()` + `cleanupMirroring()`. Since `terminateGroup()` now no longer cleans worktrees (from Task 2.1), the behavior is already correct -- the group gets marked terminal but the worktree survives. Verify this is the case and adjust only if needed.
+3. Update `archiveTaskGroup()` to ensure it:
+   - Terminates active sessions if the group is still active.
+   - Calls `taskGroupManager.archiveGroup()` (which calls `cleanupWorktree`).
+   - Sets the task status to `archived`.
+4. Update the `task.setStatus` RPC handler in `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`:
+   - When transitioning TO `archived`: call `runtime.archiveTaskGroup()` if a runtime exists, otherwise call `taskManager.archiveTask()`.
+   - When transitioning FROM `completed` or `cancelled` TO `in_progress` (reactivation): call `runtime.reviveTaskGroup()` to restore the paused group and its agent sessions.
+   - Ensure the existing `task.archive` RPC handler still works (it should set status to `archived`).
+5. Update `packages/daemon/src/storage/repositories/task-repository.ts` `archiveTask()` to also set `status = 'archived'` in addition to `archived_at`.
+6. Run all related daemon unit tests: `cd packages/daemon && bun test tests/unit/room/ tests/unit/rpc-handlers/task-handlers.test.ts`.
+7. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- Cancelling a task stops agent sessions and mirroring but preserves the worktree.
+- Completing a task preserves the worktree and group (paused).
+- Archiving a task cleans up the worktree and is the only path that does so.
+- Reactivation from `completed`/`cancelled` to `in_progress` revives the group.
+- All unit tests pass.
+
+**Dependencies:** Task 2.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.3: Unit tests for room-runtime lifecycle changes
+
+**Description:** Add unit tests covering the new lifecycle behavior in room-runtime: reactivation from completed/cancelled, archive triggering cleanup, and verifying worktree preservation on complete/cancel.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In the appropriate test file (likely `packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts` or `packages/daemon/tests/unit/rpc/task-handlers.test.ts`):
+   - Add test: `task.setStatus` from `completed` to `in_progress` succeeds (reactivation).
+   - Add test: `task.setStatus` from `cancelled` to `in_progress` succeeds (reactivation).
+   - Add test: `task.setStatus` from `completed` to `archived` succeeds and triggers worktree cleanup.
+   - Add test: `task.setStatus` from `archived` to any other status fails.
+   - Add test: `task.archive` RPC sets status to `archived` and cleans up worktree.
+3. Run `cd packages/daemon && bun test tests/unit/rpc-handlers/task-handlers.test.ts tests/unit/rpc/task-handlers.test.ts`.
+4. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All new test cases pass.
+- Tests verify both the status transition and the worktree cleanup (or lack thereof).
+- Tests verify archived is truly terminal.
+
+**Dependencies:** Task 2.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/02-room-daemon-lifecycle.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/02-room-daemon-lifecycle.md
@@ -2,30 +2,49 @@
 
 ## Goal
 
-Update the room daemon so that `completed` and `cancelled` tasks keep their worktrees and session groups paused. Only `archived` triggers worktree cleanup and group teardown.
+Update the room daemon so that `completed` and `cancelled` tasks keep their worktrees and session groups paused. Only `archived` triggers worktree cleanup and group teardown. Update all daemon-side guards that block messaging to cancelled/completed tasks.
 
 ## Scope
 
-- `packages/daemon/src/lib/room/runtime/task-group-manager.ts` -- Stop worktree cleanup on complete/fail/terminate
-- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- Keep groups paused on complete/cancel, only tear down on archive
-- `packages/daemon/src/lib/rpc-handlers/task-handlers.ts` -- Update setStatus handler to support reactivation and archive transitions
-- `packages/daemon/src/storage/repositories/task-repository.ts` -- Ensure archive sets both `archivedAt` and status
-- Unit tests for task-group-manager and room-runtime changes
+- `packages/daemon/src/lib/room/runtime/task-group-manager.ts` -- Stop worktree cleanup on complete/terminate
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- Keep groups paused on complete/cancel, only tear down on archive, update reactivation logic
+- `packages/daemon/src/lib/rpc-handlers/task-handlers.ts` -- Update `task.setStatus` handler for reactivation and archive, update `task.sendHumanMessage` guard
+- `packages/daemon/src/lib/room/tools/room-agent-tools.ts` -- Update `send_message_to_task` guard and stale comments
+- `packages/daemon/src/storage/repositories/task-repository.ts` -- Ensure archive sets both `archived_at` and status
+- Unit tests for all changes
+
+## Key Design Notes
+
+### Reactivation Architecture
+
+The codebase already has two relevant methods for reviving task groups:
+- **`reviveTaskForMessage(taskId, message)`** in `room-runtime.ts` (line ~1420): Revives a failed task's session group by clearing `completedAt`, restoring sessions from persisted state, restoring MCP servers, and injecting a message. This is the **lightweight revive** path — it preserves conversation history.
+- **`resetGroupForRestart(groupId)`** in `SessionGroupRepository`: Full wipe — resets the group for a fresh start. Currently used by `task.setStatus` handler for `needs_attention → in_progress` and `cancelled → in_progress/pending` transitions (lines 432-446 in `task-handlers.ts`).
+
+For **`completed → in_progress`** reactivation: use `reviveTaskForMessage()` (lightweight, preserves conversation) since the task completed successfully and the user wants to continue from where it left off. For **`cancelled → in_progress`**: continue using `resetGroupForRestart()` (fresh start) since the task was explicitly cancelled and may need a clean slate.
+
+### Messaging Contract for Completed/Cancelled Tasks
+
+When a user sends a message to a `completed` or `cancelled` task, the daemon should **auto-reactivate** the task to `in_progress` before injecting the message. This uses `reviveTaskForMessage()` which already handles revival + message injection in one atomic operation. The UI simply needs to enable the message input; the daemon handles the status transition transparently.
+
+### Cascade Behavior
+
+`cancelTaskCascade()` only cascades to `pending` dependents. Archiving does NOT cascade — it is an explicit per-task action. Reactivating a task does NOT un-cascade previously cancelled dependents.
 
 ---
 
 ### Task 2.1: Stop worktree cleanup on complete and cancel in task-group-manager
 
-**Description:** Modify `task-group-manager.ts` so the `complete()` method no longer calls `cleanupWorktree()`. The `terminateGroup()` method (used by cancel) should also stop cleaning up worktrees. Only `archiveGroup()` should call `cleanupWorktree()`. The `fail()` method already skips cleanup (kept for debugging), so no change there.
+**Description:** Modify `task-group-manager.ts` so the `complete()` method no longer calls `cleanupWorktree()`. The `terminateGroup()` method (used by cancel) should also stop cleaning up worktrees. Only `archiveGroup()` should call `cleanupWorktree()`.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. In `packages/daemon/src/lib/room/runtime/task-group-manager.ts`:
-   - In the `complete()` method (line ~561), remove the `await this.cleanupWorktree(group)` call. Update the comment to explain worktree is preserved for potential reactivation.
-   - In the `terminateGroup()` method (line ~724), remove both `cleanupWorktree()` calls (line ~732 for already-terminal groups and line ~743 for newly terminated groups). Update comments.
-   - Verify `archiveGroup()` (line ~771) still calls `cleanupWorktree()` -- this is the only path that should clean up.
+   - In the `complete()` method, remove the `await this.cleanupWorktree(group)` call. Add comment: `// Worktree preserved for potential reactivation — only archiveGroup() cleans up`.
+   - In the `terminateGroup()` method, remove both `cleanupWorktree()` calls (for already-terminal groups and newly terminated groups). Add similar comment.
+   - Verify `archiveGroup()` still calls `cleanupWorktree()` — this is the only path that should clean up.
 3. Update `packages/daemon/tests/unit/room/task-group-manager.test.ts`:
    - Adjust any tests that assert worktree cleanup happens on complete or terminate.
    - Add a test verifying `complete()` does NOT call `removeWorktree`.
@@ -46,34 +65,35 @@ Update the room daemon so that `completed` and `cancelled` tasks keep their work
 
 ---
 
-### Task 2.2: Update room-runtime cancel and complete flows
+### Task 2.2: Update room-runtime and RPC handlers for new lifecycle
 
-**Description:** Update `room-runtime.ts` so that the `cancelTask()` method keeps the group paused (not fully torn down) and the complete flow preserves the group. Update the `archiveTaskGroup()` method to also terminate active sessions and tear down the group before cleaning the worktree. Update the `terminateTaskGroup()` method to stop sessions but keep the group.
+**Description:** Update `room-runtime.ts` cancel/complete/archive flows, update `task.setStatus` RPC handler to support reactivation from `completed` and archive transitions, and update `task.sendHumanMessage` to allow messaging completed/cancelled tasks (with auto-reactivation).
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
-2. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`, update `cancelTask()` (line ~1570):
-   - Instead of calling `taskGroupManager.terminateGroup()`, call `taskGroupManager.cancel()` which already handles the task status change, but modify the flow to NOT terminate the group -- instead pause it. Concretely: stop agent sessions (via `terminateGroupSessions()`), cleanup mirroring, but do NOT call `terminateGroup()`. Instead mark the group as paused by setting `completedAt` (this already happens in the current flow via `failGroup`).
-   - Actually, review the current flow carefully: `cancelTask()` calls `terminateGroup()` for active groups and then `terminateGroupSessions()` + `cleanupMirroring()`. Since `terminateGroup()` now no longer cleans worktrees (from Task 2.1), the behavior is already correct -- the group gets marked terminal but the worktree survives. Verify this is the case and adjust only if needed.
-3. Update `archiveTaskGroup()` to ensure it:
+2. **Verify cancel flow in `room-runtime.ts`:** The `cancelTask()` method calls `terminateGroup()` for active groups. Since Task 2.1 removes worktree cleanup from `terminateGroup()`, the cancel flow now correctly preserves worktrees with no further changes needed. Verify this by reading the `cancelTask()` method and confirming the worktree survives after the `terminateGroup()` call. If any other cleanup paths exist, update them.
+3. **Update `archiveTaskGroup()` in `room-runtime.ts`** to ensure it:
    - Terminates active sessions if the group is still active.
    - Calls `taskGroupManager.archiveGroup()` (which calls `cleanupWorktree`).
-   - Sets the task status to `archived`.
-4. Update the `task.setStatus` RPC handler in `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`:
-   - When transitioning TO `archived`: call `runtime.archiveTaskGroup()` if a runtime exists, otherwise call `taskManager.archiveTask()`.
-   - When transitioning FROM `completed` or `cancelled` TO `in_progress` (reactivation): call `runtime.reviveTaskGroup()` to restore the paused group and its agent sessions.
-   - Ensure the existing `task.archive` RPC handler still works (it should set status to `archived`).
-5. Update `packages/daemon/src/storage/repositories/task-repository.ts` `archiveTask()` to also set `status = 'archived'` in addition to `archived_at`.
+   - Sets the task status to `archived` via `taskManager.archiveTask()`.
+4. **Update `task.setStatus` RPC handler** in `packages/daemon/src/lib/rpc-handlers/task-handlers.ts`:
+   - When transitioning TO `archived`: call `runtime.archiveTaskGroup()` if a runtime exists, otherwise call `taskManager.archiveTask()` directly.
+   - When transitioning FROM `completed` TO `in_progress`: use `runtime.reviveTaskForMessage()` (the existing method at line ~1420 of `room-runtime.ts`) for lightweight revival that preserves conversation history. If no message is provided, call `reviveTaskForMessage()` with an empty/system message or use a simpler revival path.
+   - When transitioning FROM `cancelled` TO `in_progress` or `pending`: continue using the existing `resetGroupForRestart()` path (lines 432-446 of `task-handlers.ts`), which performs a full wipe. This is correct for cancelled tasks.
+   - Ensure the existing `task.archive` RPC handler calls the updated `archiveTask()` which now sets `status = 'archived'`.
+5. **Update `task.sendHumanMessage` handler** in `task-handlers.ts` (lines 804-810): Remove the guard that throws for `cancelled` tasks ("Cancelled tasks cannot receive messages because their workspace has been cleaned up"). Replace with logic that auto-reactivates the task via `runtime.reviveTaskForMessage()` before injecting the message. Apply the same logic for `completed` tasks if they are currently blocked.
 6. Run all related daemon unit tests: `cd packages/daemon && bun test tests/unit/room/ tests/unit/rpc-handlers/task-handlers.test.ts`.
 7. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
 **Acceptance criteria:**
 - Cancelling a task stops agent sessions and mirroring but preserves the worktree.
 - Completing a task preserves the worktree and group (paused).
-- Archiving a task cleans up the worktree and is the only path that does so.
-- Reactivation from `completed`/`cancelled` to `in_progress` revives the group.
+- Archiving a task cleans up the worktree, tears down the group, and sets `status = 'archived'`.
+- Reactivation from `completed` to `in_progress` uses lightweight revival (preserves conversation).
+- Reactivation from `cancelled` to `in_progress` uses full reset (clean slate).
+- `task.sendHumanMessage` works for completed and cancelled tasks (auto-reactivates).
 - All unit tests pass.
 
 **Dependencies:** Task 2.1
@@ -82,28 +102,60 @@ Update the room daemon so that `completed` and `cancelled` tasks keep their work
 
 ---
 
-### Task 2.3: Unit tests for room-runtime lifecycle changes
+### Task 2.3: Update room-agent-tools.ts daemon-side guards and comments
 
-**Description:** Add unit tests covering the new lifecycle behavior in room-runtime: reactivation from completed/cancelled, archive triggering cleanup, and verifying worktree preservation on complete/cancel.
+**Description:** Update the agent-facing tool guards in `room-agent-tools.ts` that block messaging to cancelled tasks, and fix stale comments about worktree cleanup semantics.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
-2. In the appropriate test file (likely `packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts` or `packages/daemon/tests/unit/rpc/task-handlers.test.ts`):
-   - Add test: `task.setStatus` from `completed` to `in_progress` succeeds (reactivation).
-   - Add test: `task.setStatus` from `cancelled` to `in_progress` succeeds (reactivation).
+2. In `packages/daemon/src/lib/room/tools/room-agent-tools.ts`:
+   - **Update `send_message_to_task` guard** (lines 515-522): The current guard throws an error for `status === 'cancelled'` saying "Cancelled tasks cannot receive messages because their workspace has been cleaned up." Since cancelled tasks now keep their worktrees, update this to either:
+     - Allow messaging and auto-reactivate (preferred, consistent with `task.sendHumanMessage`), OR
+     - Update the error message to reflect new semantics (e.g., "Task is cancelled. Use set_task_status to reactivate it first.") if agent-initiated messaging should still require explicit reactivation.
+   - **Update stale comment** (lines 398-400): The comment says "Only supported for failed tasks — cancelled tasks have their worktree cleaned up so reviving the group would point sessions at a gone workspace." This is no longer true. Update to: "Lightweight revive: clear completedAt without resetting metadata. Supported for failed and completed tasks. Cancelled tasks use resetGroupForRestart() for a clean slate."
+3. Search for any other references to "workspace has been cleaned up" or "worktree cleaned up" in `room-agent-tools.ts` and update them.
+4. Run `cd packages/daemon && bun test tests/unit/room/`.
+5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- `send_message_to_task` no longer blocks cancelled tasks with a stale worktree error.
+- All comments about worktree cleanup for cancelled tasks are updated to reflect new semantics.
+- All unit tests pass.
+
+**Dependencies:** Task 2.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.4: Unit tests for room-runtime lifecycle changes
+
+**Description:** Add unit tests covering the new lifecycle behavior in room-runtime: reactivation from completed/cancelled, archive triggering cleanup, messaging to completed/cancelled tasks, and verifying worktree preservation on complete/cancel.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts`:
+   - Add test: `task.setStatus` from `completed` to `in_progress` succeeds (reactivation via lightweight revival).
+   - Add test: `task.setStatus` from `cancelled` to `in_progress` succeeds (reactivation via full reset).
    - Add test: `task.setStatus` from `completed` to `archived` succeeds and triggers worktree cleanup.
    - Add test: `task.setStatus` from `archived` to any other status fails.
    - Add test: `task.archive` RPC sets status to `archived` and cleans up worktree.
-3. Run `cd packages/daemon && bun test tests/unit/rpc-handlers/task-handlers.test.ts tests/unit/rpc/task-handlers.test.ts`.
+   - Add test: `task.sendHumanMessage` to a `completed` task succeeds (auto-reactivates).
+   - Add test: `task.sendHumanMessage` to a `cancelled` task succeeds (auto-reactivates).
+   - Add test: `task.sendHumanMessage` to an `archived` task fails.
+3. Run `cd packages/daemon && bun test tests/unit/rpc-handlers/task-handlers.test.ts`.
 4. Run `bun run lint` and `bun run format`.
 
 **Acceptance criteria:**
 - All new test cases pass.
 - Tests verify both the status transition and the worktree cleanup (or lack thereof).
 - Tests verify archived is truly terminal.
+- Tests verify messaging auto-reactivation for completed/cancelled.
 
-**Dependencies:** Task 2.2
+**Dependencies:** Task 2.3
 
 **Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/03-space-daemon-lifecycle.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/03-space-daemon-lifecycle.md
@@ -1,0 +1,79 @@
+# Milestone 3: Space Daemon Lifecycle Changes
+
+## Goal
+
+Mirror the room daemon lifecycle changes in the space layer: keep worktrees alive for completed/cancelled space tasks, only clean up on archive.
+
+## Scope
+
+- `packages/daemon/src/lib/space/managers/space-task-manager.ts` -- Update complete/cancel behavior
+- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- Update task completion handling
+- Space RPC handlers (if any handle worktree cleanup on complete/cancel)
+- Unit tests
+
+---
+
+### Task 3.1: Update space task manager and task-agent-manager lifecycle
+
+**Description:** Update the space task lifecycle so completed and cancelled tasks retain worktrees. Only archiving triggers cleanup. Update `task-agent-manager.ts` to not tear down worktrees when sub-sessions complete.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/src/lib/space/managers/space-task-manager.ts`:
+   - Verify that `completeTask()` does not trigger worktree cleanup (check if it delegates to `setTaskStatus` only -- if so, no change needed here).
+   - Update `archiveTask()` to set `status = 'archived'` in addition to setting `archived_at`.
+   - Update `retryTask()` error message to reflect that tasks can now be retried from `completed` and `cancelled` (the transition map already allows it from Task 1.1).
+3. In `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
+   - Review `handleSubSessionComplete()` -- it marks step tasks as completed. Verify it does NOT trigger worktree cleanup. If it does, remove that cleanup.
+   - Review the main task completion flow to ensure worktrees survive.
+4. Check space RPC handlers in `packages/daemon/src/lib/rpc-handlers/` for any space-task-specific handlers that clean up worktrees on complete/cancel. Update them to only clean up on archive.
+5. Update `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
+   - Add test: `archiveTask()` sets status to `archived`.
+   - Add test: completing a task does not trigger worktree cleanup.
+   - Update any tests that assumed completed/cancelled were terminal.
+6. Update `packages/daemon/tests/unit/space/task-agent-manager.test.ts` if relevant tests exist.
+7. Run `cd packages/daemon && bun test tests/unit/lib/space-task-manager.test.ts tests/unit/space/`.
+8. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- Space tasks keep worktrees on complete and cancel.
+- Only `archiveTask()` triggers worktree cleanup.
+- `archiveTask()` sets status to `archived`.
+- All unit tests pass.
+
+**Dependencies:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 3.2: Unit tests for space task lifecycle
+
+**Description:** Add comprehensive unit tests for the space task lifecycle changes, especially around reactivation from completed/cancelled and the archive terminal state.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
+   - Add test: transition from `completed` to `in_progress` succeeds.
+   - Add test: transition from `cancelled` to `in_progress` succeeds.
+   - Add test: transition from `completed` to `archived` succeeds.
+   - Add test: transition from `archived` to any status fails.
+   - Add test: `retryTask()` from `completed` works.
+   - Add test: `reassignTask()` from `completed` works.
+3. In `packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts`:
+   - Add tests for space task archive RPC handler if it exists.
+   - Add tests for space task reactivation via RPC.
+4. Run tests: `cd packages/daemon && bun test tests/unit/lib/space-task-manager.test.ts tests/unit/rpc-handlers/space-task-handlers.test.ts`.
+5. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All new tests pass.
+- Coverage of the complete lifecycle including reactivation and archive.
+
+**Dependencies:** Task 3.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/03-space-daemon-lifecycle.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/03-space-daemon-lifecycle.md
@@ -2,45 +2,49 @@
 
 ## Goal
 
-Mirror the room daemon lifecycle changes in the space layer: keep worktrees alive for completed/cancelled space tasks, only clean up on archive.
+Update the space daemon status transitions and archival semantics to match the new lifecycle. Space tasks do **not** create worktrees (confirmed: `task-agent-manager.ts` manages agent sessions only, not worktrees), so the changes here are limited to status transitions and archival filtering.
 
 ## Scope
 
-- `packages/daemon/src/lib/space/managers/space-task-manager.ts` -- Update complete/cancel behavior
-- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- Update task completion handling
-- Space RPC handlers (if any handle worktree cleanup on complete/cancel)
+- `packages/daemon/src/lib/space/managers/space-task-manager.ts` -- Update archival to set status, update error messages
+- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- Verify no worktree cleanup on complete (confirm no-op)
+- Space RPC handlers (if any handle status-specific logic)
+- Space task repository (verify `archiveTask()` sets both `status` and `archived_at`)
 - Unit tests
+
+## Important Note
+
+Space tasks do NOT create worktrees. The `task-agent-manager.ts` only manages agent sub-sessions for task execution. Therefore, the "keep worktree alive" aspect of this plan is a no-op for space tasks. The changes focus on:
+1. Ensuring `archiveTask()` sets `status = 'archived'` (matching the room task behavior from Task 1.1).
+2. Updating error messages and `retryTask()`/`reassignTask()` to reflect the new lifecycle.
+3. Verifying completion does not trigger any cleanup that would prevent reactivation.
 
 ---
 
 ### Task 3.1: Update space task manager and task-agent-manager lifecycle
 
-**Description:** Update the space task lifecycle so completed and cancelled tasks retain worktrees. Only archiving triggers cleanup. Update `task-agent-manager.ts` to not tear down worktrees when sub-sessions complete.
+**Description:** Update the space task lifecycle so archival sets `status = 'archived'`. Verify that `task-agent-manager.ts` does not perform any cleanup on completion that would prevent reactivation.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. In `packages/daemon/src/lib/space/managers/space-task-manager.ts`:
-   - Verify that `completeTask()` does not trigger worktree cleanup (check if it delegates to `setTaskStatus` only -- if so, no change needed here).
-   - Update `archiveTask()` to set `status = 'archived'` in addition to setting `archived_at`.
+   - Verify that `completeTask()` does not trigger any irreversible cleanup (it should only update status via `setTaskStatus`).
+   - Update `archiveTask()` to set `status = 'archived'` in addition to `archived_at`. The space task repository's `archiveTask()` method (check `packages/daemon/src/storage/repositories/space-task-repository.ts`) needs the same update as the room task repository: set both `status = 'archived'` AND `archived_at` in one UPDATE.
    - Update `retryTask()` error message to reflect that tasks can now be retried from `completed` and `cancelled` (the transition map already allows it from Task 1.1).
 3. In `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
-   - Review `handleSubSessionComplete()` -- it marks step tasks as completed. Verify it does NOT trigger worktree cleanup. If it does, remove that cleanup.
-   - Review the main task completion flow to ensure worktrees survive.
-4. Check space RPC handlers in `packages/daemon/src/lib/rpc-handlers/` for any space-task-specific handlers that clean up worktrees on complete/cancel. Update them to only clean up on archive.
+   - Review `handleSubSessionComplete()` — it marks step tasks as completed. Confirm it does NOT trigger any cleanup that would prevent reactivation. This should be a verification step with no code changes needed.
+4. Check space RPC handlers in `packages/daemon/src/lib/rpc-handlers/` for any space-task-specific handlers that have guards blocking actions on completed/cancelled tasks. Update them if needed.
 5. Update `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
-   - Add test: `archiveTask()` sets status to `archived`.
-   - Add test: completing a task does not trigger worktree cleanup.
+   - Add test: `archiveTask()` sets both `status = 'archived'` and `archived_at`.
    - Update any tests that assumed completed/cancelled were terminal.
-6. Update `packages/daemon/tests/unit/space/task-agent-manager.test.ts` if relevant tests exist.
-7. Run `cd packages/daemon && bun test tests/unit/lib/space-task-manager.test.ts tests/unit/space/`.
-8. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+6. Run `cd packages/daemon && bun test tests/unit/lib/space-task-manager.test.ts`.
+7. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
 **Acceptance criteria:**
-- Space tasks keep worktrees on complete and cancel.
-- Only `archiveTask()` triggers worktree cleanup.
-- `archiveTask()` sets status to `archived`.
+- `archiveTask()` sets both `status = 'archived'` and `archived_at`.
+- No irreversible cleanup happens on task completion that would prevent reactivation.
 - All unit tests pass.
 
 **Dependencies:** Task 1.1
@@ -60,6 +64,7 @@ Mirror the room daemon lifecycle changes in the space layer: keep worktrees aliv
 2. In `packages/daemon/tests/unit/lib/space-task-manager.test.ts`:
    - Add test: transition from `completed` to `in_progress` succeeds.
    - Add test: transition from `cancelled` to `in_progress` succeeds.
+   - Add test: transition from `cancelled` to `pending` succeeds (preserved from existing behavior).
    - Add test: transition from `completed` to `archived` succeeds.
    - Add test: transition from `archived` to any status fails.
    - Add test: `retryTask()` from `completed` works.
@@ -73,6 +78,7 @@ Mirror the room daemon lifecycle changes in the space layer: keep worktrees aliv
 **Acceptance criteria:**
 - All new tests pass.
 - Coverage of the complete lifecycle including reactivation and archive.
+- Tests verify `pending` is preserved as a valid target for `cancelled` and `needs_attention`.
 
 **Dependencies:** Task 3.1
 

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/04-web-ui-updates.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/04-web-ui-updates.md
@@ -1,0 +1,103 @@
+# Milestone 4: Web UI Updates
+
+## Goal
+
+Update the frontend to reflect the new task lifecycle: new tab grouping, reactivate/archive actions, and enable messaging for completed/cancelled tasks.
+
+## Scope
+
+- `packages/web/src/components/room/TaskView.tsx` -- Add reactivate/archive actions, enable messaging
+- `packages/web/src/components/room/RoomDashboard.tsx` -- Update stats/task grouping
+- `packages/web/src/lib/room-store.ts` -- Update filters and computed values for new statuses
+- Any other components that reference task status for display or filtering
+
+---
+
+### Task 4.1: Update task tab grouping and status display
+
+**Description:** Update the room dashboard and any task list components to group tasks into the new tabs: Active (draft + pending + in_progress), Review (review + needs_attention), Done (completed + cancelled), Archived (archived, hidden by default). Update status badge colors to include `archived`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Search for all components that group or filter tasks by status (grep for `completed`, `cancelled`, `review`, `needs_attention` in `packages/web/src/`).
+3. In `packages/web/src/components/room/RoomDashboard.tsx`:
+   - Update the stats overview to reflect the new groupings.
+   - Add an "Archived" count if not already present.
+4. In any task list component that renders tabs or groups:
+   - **Active tab**: `draft`, `pending`, `in_progress`
+   - **Review tab**: `review`, `needs_attention`
+   - **Done tab**: `completed`, `cancelled`
+   - **Archived tab**: `archived` (collapsed/hidden by default, expandable)
+5. Add `archived` to the status color map (e.g., `archived: 'text-gray-600'` in `TaskView.tsx` line ~97).
+6. In `packages/web/src/lib/room-store.ts`, update any computed signals that filter by task status to handle `archived` correctly (e.g., exclude archived from default task counts).
+7. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- Tasks are grouped into four tabs: Active, Review, Done, Archived.
+- `needs_attention` appears under Review (not its own separate category).
+- `archived` tasks are hidden by default but viewable.
+- Status badge for `archived` has appropriate styling.
+- No type errors.
+
+**Dependencies:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.2: Add reactivate and archive actions to TaskView
+
+**Description:** Add "Reactivate" and "Archive" action buttons to the TaskView component. Reactivate transitions completed/cancelled tasks to `in_progress`. Archive transitions completed/cancelled/needs_attention tasks to `archived`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/components/room/TaskView.tsx`:
+   - Add a "Reactivate" button visible when task status is `completed` or `cancelled`. On click, call `task.setStatus` RPC with `status: 'in_progress'`.
+   - Add an "Archive" button visible when task status is `completed`, `cancelled`, or `needs_attention`. On click, show a confirmation dialog (similar to the existing cancel confirmation) warning that archiving is permanent and will clean up the worktree.
+   - Update the existing complete/cancel confirmation dialogs to note that the action is reversible (task can be reactivated later).
+   - Remove or update the "This action cannot be undone" warning from the cancel dialog (since cancel is now reversible).
+3. Enable the message input for `completed` and `cancelled` tasks. Currently the chat input is likely disabled for terminal states. Allow users to send messages which triggers reactivation to `in_progress`.
+4. Add a "Reactivate" option to any task action dropdowns that exist.
+5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+6. Visually verify the UI renders correctly (manual check -- describe expected behavior in the PR).
+
+**Acceptance criteria:**
+- Reactivate button appears for completed and cancelled tasks.
+- Archive button appears for completed, cancelled, and needs_attention tasks.
+- Archive confirmation dialog warns about permanent worktree cleanup.
+- Message input is enabled for completed and cancelled tasks.
+- No type errors.
+
+**Dependencies:** Tasks 2.2, 3.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.3: Web unit tests for new UI behavior
+
+**Description:** Add Vitest tests for the new UI components and behaviors: tab grouping logic, action button visibility, and status transitions triggered from the UI.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Add or update web tests (in `packages/web/src/`) to verify:
+   - Task grouping function correctly categorizes tasks into Active/Review/Done/Archived tabs.
+   - Reactivate button renders only for `completed` and `cancelled` tasks.
+   - Archive button renders only for `completed`, `cancelled`, and `needs_attention` tasks.
+   - `archived` status displays with correct styling.
+3. Run `cd packages/web && bunx vitest run`.
+4. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All web unit tests pass.
+- New test cases cover the tab grouping and action visibility logic.
+
+**Dependencies:** Task 4.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/04-web-ui-updates.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/04-web-ui-updates.md
@@ -2,43 +2,48 @@
 
 ## Goal
 
-Update the frontend to reflect the new task lifecycle: new tab grouping, reactivate/archive actions, and enable messaging for completed/cancelled tasks.
+Update the frontend to reflect the new task lifecycle: new tab grouping, reactivate/archive actions, localStorage tab migration, and enable messaging for completed/cancelled tasks.
 
 ## Scope
 
 - `packages/web/src/components/room/TaskView.tsx` -- Add reactivate/archive actions, enable messaging
+- `packages/web/src/components/room/RoomTasks.tsx` -- Update `TaskFilterTab` type and tab grouping, add localStorage migration
 - `packages/web/src/components/room/RoomDashboard.tsx` -- Update stats/task grouping
 - `packages/web/src/lib/room-store.ts` -- Update filters and computed values for new statuses
 - Any other components that reference task status for display or filtering
 
 ---
 
-### Task 4.1: Update task tab grouping and status display
+### Task 4.1: Update task tab grouping, localStorage migration, and status display
 
-**Description:** Update the room dashboard and any task list components to group tasks into the new tabs: Active (draft + pending + in_progress), Review (review + needs_attention), Done (completed + cancelled), Archived (archived, hidden by default). Update status badge colors to include `archived`.
+**Description:** Update the room dashboard and task list components to group tasks into the new tabs: Active (draft + pending + in_progress), Review (review + needs_attention), Done (completed + cancelled), Archived (archived, hidden by default). Add localStorage migration for the persisted tab value. Update status badge colors to include `archived`.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
-2. Search for all components that group or filter tasks by status (grep for `completed`, `cancelled`, `review`, `needs_attention` in `packages/web/src/`).
-3. In `packages/web/src/components/room/RoomDashboard.tsx`:
+2. Search for all components that group or filter tasks by status (grep for `TaskFilterTab`, `completed`, `cancelled`, `review`, `needs_attention` in `packages/web/src/`).
+3. In `packages/web/src/components/room/RoomTasks.tsx`:
+   - Update the `TaskFilterTab` type. The current type is `'active' | 'review' | 'done' | 'needs_attention'`. Change to `'active' | 'review' | 'done' | 'archived'` (merging `needs_attention` into the `review` tab).
+   - **Add localStorage migration:** In the `getInitialTab()` function (which already has a migration from `'failed'` to `'needs_attention'`), add: if `stored === 'needs_attention'`, return `'review'` (since `needs_attention` tasks now appear under the Review tab). This prevents existing users from landing on a removed tab.
+   - Update tab filtering logic:
+     - **Active tab**: `draft`, `pending`, `in_progress`
+     - **Review tab**: `review`, `needs_attention`
+     - **Done tab**: `completed`, `cancelled`
+     - **Archived tab**: `archived` (collapsed/hidden by default, expandable)
+4. In `packages/web/src/components/room/RoomDashboard.tsx`:
    - Update the stats overview to reflect the new groupings.
    - Add an "Archived" count if not already present.
-4. In any task list component that renders tabs or groups:
-   - **Active tab**: `draft`, `pending`, `in_progress`
-   - **Review tab**: `review`, `needs_attention`
-   - **Done tab**: `completed`, `cancelled`
-   - **Archived tab**: `archived` (collapsed/hidden by default, expandable)
-5. Add `archived` to the status color map (e.g., `archived: 'text-gray-600'` in `TaskView.tsx` line ~97).
+5. Add `archived` to the status color map (e.g., `archived: 'text-gray-500'` with a muted/dimmed style).
 6. In `packages/web/src/lib/room-store.ts`, update any computed signals that filter by task status to handle `archived` correctly (e.g., exclude archived from default task counts).
 7. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
 **Acceptance criteria:**
 - Tasks are grouped into four tabs: Active, Review, Done, Archived.
 - `needs_attention` appears under Review (not its own separate category).
-- `archived` tasks are hidden by default but viewable.
-- Status badge for `archived` has appropriate styling.
+- `archived` tasks are hidden by default but viewable via the Archived tab.
+- Status badge for `archived` has appropriate muted styling.
+- localStorage migration handles `'needs_attention'` → `'review'` and `'failed'` → `'review'`.
 - No type errors.
 
 **Dependencies:** Task 1.1
@@ -49,7 +54,7 @@ Update the frontend to reflect the new task lifecycle: new tab grouping, reactiv
 
 ### Task 4.2: Add reactivate and archive actions to TaskView
 
-**Description:** Add "Reactivate" and "Archive" action buttons to the TaskView component. Reactivate transitions completed/cancelled tasks to `in_progress`. Archive transitions completed/cancelled/needs_attention tasks to `archived`.
+**Description:** Add "Reactivate" and "Archive" action buttons to the TaskView component. Reactivate transitions completed/cancelled tasks to `in_progress`. Archive transitions completed/cancelled/needs_attention tasks to `archived`. Enable the message input for completed/cancelled tasks — the daemon auto-reactivates on message send (no explicit UI reactivation required).
 
 **Agent type:** coder
 
@@ -57,19 +62,20 @@ Update the frontend to reflect the new task lifecycle: new tab grouping, reactiv
 1. Run `bun install` at the worktree root.
 2. In `packages/web/src/components/room/TaskView.tsx`:
    - Add a "Reactivate" button visible when task status is `completed` or `cancelled`. On click, call `task.setStatus` RPC with `status: 'in_progress'`.
-   - Add an "Archive" button visible when task status is `completed`, `cancelled`, or `needs_attention`. On click, show a confirmation dialog (similar to the existing cancel confirmation) warning that archiving is permanent and will clean up the worktree.
-   - Update the existing complete/cancel confirmation dialogs to note that the action is reversible (task can be reactivated later).
-   - Remove or update the "This action cannot be undone" warning from the cancel dialog (since cancel is now reversible).
-3. Enable the message input for `completed` and `cancelled` tasks. Currently the chat input is likely disabled for terminal states. Allow users to send messages which triggers reactivation to `in_progress`.
-4. Add a "Reactivate" option to any task action dropdowns that exist.
+   - Add an "Archive" button visible when task status is `completed`, `cancelled`, or `needs_attention`. On click, show a confirmation dialog warning that archiving is **permanent** and will clean up the worktree (for room tasks). Use a pattern similar to the existing cancel confirmation.
+   - Update the existing cancel confirmation dialog to note that the action is **reversible** (task can be reactivated later). Remove or update the "This action cannot be undone" warning.
+3. **Enable messaging for completed/cancelled tasks:** The chat input is currently disabled for terminal states (likely gated by `canSend = hasGroup` or similar). Enable the message input for `completed` and `cancelled` tasks. The daemon's `task.sendHumanMessage` handler (updated in Task 2.2) will auto-reactivate the task when a message is sent — no explicit reactivation step is needed from the UI. Add a subtle hint near the input (e.g., "Sending a message will reactivate this task") so the user understands the behavior.
+4. Add a "Reactivate" option to any task action dropdowns that exist (e.g., in `TaskCard` or task list context menus).
 5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
-6. Visually verify the UI renders correctly (manual check -- describe expected behavior in the PR).
+6. Visually verify the UI renders correctly (manual check — describe expected behavior in the PR).
 
 **Acceptance criteria:**
 - Reactivate button appears for completed and cancelled tasks.
 - Archive button appears for completed, cancelled, and needs_attention tasks.
 - Archive confirmation dialog warns about permanent worktree cleanup.
-- Message input is enabled for completed and cancelled tasks.
+- Cancel confirmation dialog notes reversibility.
+- Message input is enabled for completed and cancelled tasks with a reactivation hint.
+- Message input is disabled for archived tasks.
 - No type errors.
 
 **Dependencies:** Tasks 2.2, 3.1
@@ -80,7 +86,7 @@ Update the frontend to reflect the new task lifecycle: new tab grouping, reactiv
 
 ### Task 4.3: Web unit tests for new UI behavior
 
-**Description:** Add Vitest tests for the new UI components and behaviors: tab grouping logic, action button visibility, and status transitions triggered from the UI.
+**Description:** Add Vitest tests for the new UI components and behaviors: tab grouping logic, localStorage migration, action button visibility, and status transitions triggered from the UI.
 
 **Agent type:** coder
 
@@ -88,15 +94,17 @@ Update the frontend to reflect the new task lifecycle: new tab grouping, reactiv
 1. Run `bun install` at the worktree root.
 2. Add or update web tests (in `packages/web/src/`) to verify:
    - Task grouping function correctly categorizes tasks into Active/Review/Done/Archived tabs.
+   - `getInitialTab()` localStorage migration: `'needs_attention'` → `'review'`, `'failed'` → `'review'`.
    - Reactivate button renders only for `completed` and `cancelled` tasks.
    - Archive button renders only for `completed`, `cancelled`, and `needs_attention` tasks.
    - `archived` status displays with correct styling.
+   - Message input is enabled for `completed`/`cancelled` and disabled for `archived`.
 3. Run `cd packages/web && bunx vitest run`.
 4. Run `bun run lint` and `bun run format`.
 
 **Acceptance criteria:**
 - All web unit tests pass.
-- New test cases cover the tab grouping and action visibility logic.
+- New test cases cover the tab grouping, localStorage migration, and action visibility logic.
 
 **Dependencies:** Task 4.2
 

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/05-integration-and-e2e-tests.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/05-integration-and-e2e-tests.md
@@ -21,10 +21,12 @@ Add online integration tests and Playwright E2E tests to validate the full lifec
 1. Run `bun install` at the worktree root.
 2. Create `packages/daemon/tests/online/rpc/rpc-task-lifecycle.test.ts` (or add to existing `rpc-task-draft-handlers.test.ts` if appropriate):
    - Test: Create a task, move through `pending -> in_progress -> completed`, then reactivate to `in_progress`, verify the task group is revived and worktree exists.
-   - Test: Create a task, move through `pending -> in_progress -> cancelled`, then reactivate to `in_progress`, verify the task group is revived and worktree exists.
+   - Test: Create a task, move through `pending -> in_progress -> cancelled`, then reactivate to `in_progress`, verify the task group is reset and worktree exists.
    - Test: Create a task, complete it, then archive it. Verify the worktree is cleaned up and status is `archived`.
-   - Test: Verify that `archived` tasks cannot transition to any other status.
-   - Test: Verify `task.list` with `includeArchived: false` excludes archived tasks, and `includeArchived: true` includes them.
+   - Test: Verify that `archived` tasks cannot transition to any other status (returns error).
+   - Test: Verify `task.list` excludes archived tasks by default, and includes them with `includeArchived: true`.
+   - Test: Send a human message to a `completed` task, verify it auto-reactivates to `in_progress`.
+   - Test: Send a human message to an `archived` task, verify it fails.
 3. Use `NEOKAI_USE_DEV_PROXY=1` for mocked SDK tests.
 4. Run: `NEOKAI_USE_DEV_PROXY=1 cd packages/daemon && bun test tests/online/rpc/rpc-task-lifecycle.test.ts`.
 5. Run `bun run lint` and `bun run format`.
@@ -33,8 +35,10 @@ Add online integration tests and Playwright E2E tests to validate the full lifec
 - All online tests pass with dev proxy.
 - Tests cover the full lifecycle: create -> complete -> reactivate -> archive.
 - Tests verify worktree preservation on complete/cancel and cleanup on archive.
+- Tests verify `task.list` filtering with `includeArchived`.
+- Tests verify messaging auto-reactivation.
 
-**Dependencies:** Tasks 2.2, 2.3
+**Dependencies:** Tasks 2.4, 3.2
 
 **Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
 
@@ -46,22 +50,28 @@ Add online integration tests and Playwright E2E tests to validate the full lifec
 
 **Agent type:** coder
 
+**Setup note:** Getting a task into `completed` state through the full UI flow is expensive. Per CLAUDE.md E2E rules, RPC calls are **allowed for setup/teardown** (e.g., `beforeEach`/`afterEach`). Use RPC to create a room, create a task, and advance it to `completed`/`cancelled` state in the test setup. All **test actions and assertions** must go through the UI (clicks, visible DOM state).
+
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. Create `packages/e2e/tests/features/task-lifecycle.e2e.ts`:
-   - Test: Navigate to a completed task, click "Reactivate", verify the task status changes to `in_progress` in the UI.
-   - Test: Navigate to a completed task, click "Archive", confirm the dialog, verify the task moves to the Archived tab.
-   - Test: Verify that archived tasks appear under the Archived tab and not in the Done tab.
-   - Test: Verify that the Archive confirmation dialog mentions permanent worktree cleanup.
-3. Follow E2E test rules from CLAUDE.md: all actions through UI clicks, all assertions on visible DOM state. No direct RPC calls except for setup/teardown.
+   - **Setup (RPC allowed):** Create a room and tasks in various states (`completed`, `cancelled`, `needs_attention`) via RPC calls in `beforeEach`.
+   - **Test:** Navigate to a completed task, click "Reactivate", verify the task status changes to `in_progress` in the UI (visible status badge update).
+   - **Test:** Navigate to a completed task, click "Archive", confirm the dialog, verify the task disappears from the Done tab and appears in the Archived tab.
+   - **Test:** Verify that archived tasks appear under the Archived tab and not in the Done tab.
+   - **Test:** Verify that the Archive confirmation dialog mentions permanent worktree cleanup.
+   - **Test:** Navigate to a completed task, type a message and send it, verify the task auto-reactivates (status changes in the UI).
+   - **Teardown (RPC allowed):** Clean up rooms and tasks via RPC.
+3. Follow E2E test rules from CLAUDE.md: all test actions through UI clicks, all assertions on visible DOM state. RPC only for setup/teardown.
 4. Run: `make run-e2e TEST=tests/features/task-lifecycle.e2e.ts`.
 5. Run `bun run lint` and `bun run format`.
 
 **Acceptance criteria:**
 - All E2E tests pass.
-- Tests exercise real browser interactions (no RPC shortcuts).
-- Tests verify visible UI state changes.
+- Tests exercise real browser interactions for all assertions (no RPC shortcuts in test body).
+- Tests verify visible UI state changes (status badges, tab membership, dialog content).
+- Test setup uses RPC to efficiently create tasks in desired states.
 
-**Dependencies:** Tasks 4.2, 4.3, 5.1
+**Dependencies:** Tasks 4.3, 5.1
 
 **Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/05-integration-and-e2e-tests.md
+++ b/docs/plans/redesign-task-status-lifecycle-keep-worktrees-alive-add-arch/05-integration-and-e2e-tests.md
@@ -1,0 +1,67 @@
+# Milestone 5: Integration and E2E Tests
+
+## Goal
+
+Add online integration tests and Playwright E2E tests to validate the full lifecycle: reactivation from completed/cancelled, archive as terminal state with worktree cleanup, and the new UI tab grouping.
+
+## Scope
+
+- Online integration tests in `packages/daemon/tests/online/`
+- E2E Playwright tests in `packages/e2e/tests/`
+
+---
+
+### Task 5.1: Online integration tests for task reactivation and archive
+
+**Description:** Add online tests that exercise the full task lifecycle including reactivation from completed/cancelled and archiving. These tests run against a real daemon with mocked SDK (dev proxy).
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/daemon/tests/online/rpc/rpc-task-lifecycle.test.ts` (or add to existing `rpc-task-draft-handlers.test.ts` if appropriate):
+   - Test: Create a task, move through `pending -> in_progress -> completed`, then reactivate to `in_progress`, verify the task group is revived and worktree exists.
+   - Test: Create a task, move through `pending -> in_progress -> cancelled`, then reactivate to `in_progress`, verify the task group is revived and worktree exists.
+   - Test: Create a task, complete it, then archive it. Verify the worktree is cleaned up and status is `archived`.
+   - Test: Verify that `archived` tasks cannot transition to any other status.
+   - Test: Verify `task.list` with `includeArchived: false` excludes archived tasks, and `includeArchived: true` includes them.
+3. Use `NEOKAI_USE_DEV_PROXY=1` for mocked SDK tests.
+4. Run: `NEOKAI_USE_DEV_PROXY=1 cd packages/daemon && bun test tests/online/rpc/rpc-task-lifecycle.test.ts`.
+5. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All online tests pass with dev proxy.
+- Tests cover the full lifecycle: create -> complete -> reactivate -> archive.
+- Tests verify worktree preservation on complete/cancel and cleanup on archive.
+
+**Dependencies:** Tasks 2.2, 2.3
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 5.2: E2E Playwright tests for reactivate and archive UI actions
+
+**Description:** Add Playwright E2E tests that exercise the new UI actions: reactivating a completed/cancelled task and archiving a task through the browser UI.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/e2e/tests/features/task-lifecycle.e2e.ts`:
+   - Test: Navigate to a completed task, click "Reactivate", verify the task status changes to `in_progress` in the UI.
+   - Test: Navigate to a completed task, click "Archive", confirm the dialog, verify the task moves to the Archived tab.
+   - Test: Verify that archived tasks appear under the Archived tab and not in the Done tab.
+   - Test: Verify that the Archive confirmation dialog mentions permanent worktree cleanup.
+3. Follow E2E test rules from CLAUDE.md: all actions through UI clicks, all assertions on visible DOM state. No direct RPC calls except for setup/teardown.
+4. Run: `make run-e2e TEST=tests/features/task-lifecycle.e2e.ts`.
+5. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- All E2E tests pass.
+- Tests exercise real browser interactions (no RPC shortcuts).
+- Tests verify visible UI state changes.
+
+**Dependencies:** Tasks 4.2, 4.3, 5.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**


### PR DESCRIPTION
## Summary
- Adds a structured plan (5 milestones, 14 tasks) to redesign the task status lifecycle
- `completed` and `cancelled` tasks will retain worktrees and paused session groups for reactivation
- `archived` becomes the only true terminal state that triggers worktree cleanup
- Covers shared types, room daemon, space daemon, web UI, and integration/E2E tests

## Test plan
- [ ] Review plan files for completeness and accuracy
- [ ] Verify milestone dependencies are correctly sequenced
- [ ] Confirm task descriptions match current codebase patterns