### PR TITLE
fix: replace fixed sleep with Playwright auto-retrying assertion in worktree-isolation E2E test

### DIFF
--- a/packages/e2e/tests/features/worktree-isolation.e2e.ts
+++ b/packages/e2e/tests/features/worktree-isolation.e2e.ts
@@ -109,12 +109,8 @@ test.describe('Worktree Isolation', () => {
 		const confirmButton = page.locator('[data-testid="confirm-delete-session"]');
 		await confirmButton.click();
 
-		// Wait for deletion to complete
-		await page.waitForTimeout(2000);
-
-		// Session should be gone - verify by checking URL
-		const url = page.url();
-		expect(url).not.toContain(deletedSessionId);
+		// Session should be gone - URL should no longer contain the deleted session ID
+		await expect(page).not.toHaveURL(new RegExp(deletedSessionId!), { timeout: 10000 });
 
 		// Don't try to cleanup in afterEach since it's already deleted
 		sessionId = null;


### PR DESCRIPTION
## Summary
- Replace `page.waitForTimeout(2000)` + manual URL check with `expect(page).not.toHaveURL()` in the "should cleanup worktree when session is deleted" test
- The Playwright auto-retrying assertion waits up to 10s for the URL to no longer contain the deleted session ID, eliminating flaky failures from the fixed 2-second sleep
- No source code changes needed — the existing signal → effect navigation chain in `useSessionActions.ts` / `App.tsx` already works correctly

## Test plan
- [ ] `make run-e2e TEST=tests/features/worktree-isolation.e2e.ts` passes (requires devproxy or real API credentials)