### PR TITLE
feat: add goalId column to space_tasks and types (Task 3.1)

### DIFF
--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,8 +25,8 @@ export class SpaceTaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -42,6 +42,7 @@ export class SpaceTaskRepository {
 			params.workflowRunId ?? null,
 			params.workflowStepId ?? null,
 			params.createdByTaskId ?? null,
+			params.goalId ?? null,
 			JSON.stringify(params.dependsOn ?? []),
 			params.taskAgentSessionId ?? null,
 			now,
@@ -85,6 +86,17 @@ export class SpaceTaskRepository {
 			`SELECT * FROM space_tasks WHERE workflow_run_id = ? AND archived_at IS NULL ORDER BY created_at ASC`
 		);
 		const rows = stmt.all(workflowRunId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * List all non-archived tasks associated with a goal/mission.
+	 */
+	findByGoalId(goalId: string): SpaceTask[] {
+		const stmt = this.db.prepare(
+			`SELECT * FROM space_tasks WHERE goal_id = ? AND archived_at IS NULL ORDER BY created_at ASC`
+		);
+		const rows = stmt.all(goalId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
 	}
 
@@ -227,6 +239,10 @@ export class SpaceTaskRepository {
 			fields.push('task_agent_session_id = ?');
 			values.push(params.taskAgentSessionId ?? null);
 		}
+		if (params.goalId !== undefined) {
+			fields.push('goal_id = ?');
+			values.push(params.goalId ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -335,6 +351,7 @@ export class SpaceTaskRepository {
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			workflowStepId: (row.workflow_step_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
+			goalId: (row.goal_id as string | null) ?? undefined,
 			progress: (row.progress as number | null) ?? undefined,
 			currentStep: (row.current_step as string | null) ?? undefined,
 			result: (row.result as string | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1679,6 +1679,7 @@ function runMigration29(db: BunDatabase): void {
 	);
 	// Note: idx_space_tasks_task_agent_session_id is created by migration 32,
 	// which first adds the column via ALTER TABLE for existing databases.
+	// Note: goal_id column is added by migration 34 (ALTER TABLE for existing DBs).
 
 	// -------------------------------------------------------------------------
 	// space_session_groups

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -129,6 +129,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 33: Add autonomy_level column to spaces table.
 	runMigration33(db);
+
+	// Migration 34: Add goal_id column to space_tasks for goal/mission association.
+	runMigration34(db);
 }
 
 /**
@@ -2003,4 +2006,20 @@ function runMigration33(db: BunDatabase): void {
 	} catch {
 		db.exec(`ALTER TABLE spaces ADD COLUMN autonomy_level TEXT NOT NULL DEFAULT 'supervised'`);
 	}
+}
+
+/**
+ * Migration 34: Add goal_id column to space_tasks.
+ *
+ * Links space tasks to goals/missions for cross-workflow-run querying.
+ * Nullable — existing tasks will have goal_id as NULL.
+ */
+function runMigration34(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+	try {
+		db.prepare(`SELECT goal_id FROM space_tasks LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN goal_id TEXT`);
+	}
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration33 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration34 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
  */
 

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -136,6 +136,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_run_id TEXT,
 			workflow_step_id TEXT,
 			created_by_task_id TEXT,
+			goal_id TEXT,
 			progress INTEGER,
 			current_step TEXT,
 			result TEXT,

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -308,4 +308,79 @@ describe('SpaceTaskRepository', () => {
 			expect(tasks.every((t) => t.status !== 'draft')).toBe(true);
 		});
 	});
+
+	describe('goalId', () => {
+		it('creates a task with goalId', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Goal task',
+				description: '',
+				goalId: 'goal-123',
+			});
+			expect(task.goalId).toBe('goal-123');
+		});
+
+		it('leaves goalId undefined when not provided', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			expect(task.goalId).toBeUndefined();
+		});
+
+		it('updates goalId on existing task', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, { goalId: 'goal-456' });
+			expect(updated!.goalId).toBe('goal-456');
+		});
+
+		it('clears goalId with null', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'T',
+				description: '',
+				goalId: 'goal-789',
+			});
+			const updated = repo.updateTask(task.id, { goalId: null });
+			expect(updated!.goalId).toBeUndefined();
+		});
+	});
+
+	describe('findByGoalId', () => {
+		it('returns tasks for a given goal', () => {
+			repo.createTask({ spaceId, title: 'A', description: '', goalId: 'goal-1' });
+			repo.createTask({ spaceId, title: 'B', description: '', goalId: 'goal-1' });
+			repo.createTask({ spaceId, title: 'C', description: '', goalId: 'goal-2' });
+			repo.createTask({ spaceId, title: 'D', description: '' });
+
+			const tasks = repo.findByGoalId('goal-1');
+			expect(tasks).toHaveLength(2);
+			expect(tasks.map((t) => t.title)).toEqual(['A', 'B']);
+		});
+
+		it('excludes archived tasks', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'Archived',
+				description: '',
+				goalId: 'goal-1',
+			});
+			repo.createTask({ spaceId, title: 'Active', description: '', goalId: 'goal-1' });
+			repo.archiveTask(task.id);
+
+			const tasks = repo.findByGoalId('goal-1');
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe('Active');
+		});
+
+		it('returns empty array when no tasks match', () => {
+			expect(repo.findByGoalId('nonexistent')).toEqual([]);
+		});
+
+		it('orders results by created_at ascending', () => {
+			repo.createTask({ spaceId, title: 'First', description: '', goalId: 'goal-1' });
+			repo.createTask({ spaceId, title: 'Second', description: '', goalId: 'goal-1' });
+			repo.createTask({ spaceId, title: 'Third', description: '', goalId: 'goal-1' });
+
+			const tasks = repo.findByGoalId('goal-1');
+			expect(tasks.map((t) => t.title)).toEqual(['First', 'Second', 'Third']);
+		});
+	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -165,6 +165,8 @@ export interface SpaceTask {
 	workflowStepId?: string;
 	/** ID of the planning task that created this task */
 	createdByTaskId?: string;
+	/** ID of the goal/mission this task is associated with */
+	goalId?: string;
 	/** Progress percentage (0-100) */
 	progress?: number | null;
 	/** Description of current step */
@@ -227,6 +229,8 @@ export interface CreateSpaceTaskParams {
 	status?: SpaceTaskStatus;
 	/** ID of planning task that created this task */
 	createdByTaskId?: string;
+	/** Goal/mission this task is associated with */
+	goalId?: string;
 	/**
 	 * ID of the Task Agent session that orchestrates this task's workflow execution.
 	 * Set when the task transitions from 'pending' to 'in_progress'.
@@ -257,6 +261,8 @@ export interface UpdateSpaceTaskParams {
 	prNumber?: number | null;
 	prCreatedAt?: number | null;
 	inputDraft?: string | null;
+	/** Goal/mission this task is associated with; null to clear */
+	goalId?: string | null;
 	/**
 	 * ID of the Task Agent session that orchestrates this task's workflow execution.
 	 * Set when spawning a Task Agent; null to clear the reference.


### PR DESCRIPTION
## Summary
- Add `goalId?: string` to `SpaceTask`, `CreateSpaceTaskParams`, and `UpdateSpaceTaskParams` interfaces
- Add migration 34: `goal_id TEXT` column + index on `space_tasks` table
- Update `createTask()`, `updateTask()`, and `rowToSpaceTask()` in `SpaceTaskRepository`
- Add `findByGoalId(goalId)` method returning non-archived tasks ordered by `created_at ASC`

## Test plan
- [x] Unit tests for creating tasks with goalId
- [x] Unit tests for updating/clearing goalId
- [x] Unit tests for findByGoalId (filtering, archived exclusion, ordering)
- [x] Typecheck passes
- [x] All existing tests continue to pass