### PR TITLE
feat: add task_result condition type and isCyclic to workflow transitions

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -35,7 +35,7 @@ import type {
 
 const workflowConditionSchema = z
 	.object({
-		type: z.enum(['always', 'human', 'condition']),
+		type: z.enum(['always', 'human', 'condition', 'task_result']),
 		expression: z.string().optional(),
 		description: z.string().optional(),
 		maxRetries: z.number().int().nonnegative().optional(),
@@ -62,6 +62,7 @@ const exportedWorkflowTransitionSchema = z.object({
 	toStep: z.string().min(1),
 	condition: workflowConditionSchema.optional(),
 	order: z.number().int().optional(),
+	isCyclic: z.boolean().optional(),
 });
 
 const exportedWorkflowRuleSchema = z.object({
@@ -195,6 +196,7 @@ export function exportWorkflow(
 		const exported: ExportedWorkflowTransition = { fromStep, toStep };
 		if (t.condition !== undefined) exported.condition = t.condition;
 		if (t.order !== undefined) exported.order = t.order;
+		if (t.isCyclic !== undefined) exported.isCyclic = t.isCyclic;
 		return exported;
 	});
 

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -49,6 +49,13 @@ const workflowConditionSchema = z
 				path: ['expression'],
 			});
 		}
+		if (val.type === 'task_result' && (!val.expression || !val.expression.trim())) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "'task_result' type requires a non-empty expression (match value)",
+				path: ['expression'],
+			});
+		}
 	});
 
 const exportedWorkflowStepSchema = z.object({

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -233,6 +233,11 @@ export class WorkflowExecutor {
 				);
 			}
 
+			case 'task_result': {
+				// Task 1.2 implements full evaluation — for now, always fail
+				return { passed: false, reason: 'task_result evaluation not yet implemented' };
+			}
+
 			default: {
 				const _exhaustive: never = condition.type;
 				return { passed: false, reason: `Unknown condition type: ${_exhaustive}` };

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -6,7 +6,7 @@
  * Storage layout:
  *   space_workflows             — id, space_id, name, description, start_step_id, config (JSON), layout (JSON), created_at, updated_at
  *   space_workflow_steps        — id, workflow_id, name, agent_id, order_index, config (JSON), created_at, updated_at
- *   space_workflow_transitions  — id, workflow_id, from_step_id, to_step_id, condition (JSON), order_index, created_at, updated_at
+ *   space_workflow_transitions  — id, workflow_id, from_step_id, to_step_id, condition (JSON), order_index, is_cyclic, created_at, updated_at
  *
  * The `config` column on space_workflows stores: { tags, rules, ...extra }
  * The `config` column on space_workflow_steps stores: { instructions? }
@@ -63,6 +63,7 @@ interface TransitionRow {
 	to_step_id: string;
 	condition: string | null;
 	order_index: number;
+	is_cyclic: number | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -113,6 +114,7 @@ function rowToTransition(row: TransitionRow): WorkflowTransition {
 		to: row.to_step_id,
 		condition: condition ?? undefined,
 		order: row.order_index,
+		isCyclic: Boolean(row.is_cyclic),
 	};
 }
 
@@ -422,12 +424,13 @@ export class SpaceWorkflowRepository {
 	): void {
 		const transitionId = generateUUID();
 		const conditionJson = input.condition ? JSON.stringify(input.condition) : null;
+		const isCyclicValue = input.isCyclic !== undefined ? (input.isCyclic ? 1 : 0) : null;
 
 		this.db
 			.prepare(
 				`INSERT INTO space_workflow_transitions
-           (id, workflow_id, from_step_id, to_step_id, condition, order_index, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+           (id, workflow_id, from_step_id, to_step_id, condition, order_index, is_cyclic, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				transitionId,
@@ -436,6 +439,7 @@ export class SpaceWorkflowRepository {
 				input.to,
 				conditionJson,
 				input.order ?? index,
+				isCyclicValue,
 				now,
 				now
 			);

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -114,7 +114,7 @@ function rowToTransition(row: TransitionRow): WorkflowTransition {
 		to: row.to_step_id,
 		condition: condition ?? undefined,
 		order: row.order_index,
-		isCyclic: Boolean(row.is_cyclic),
+		isCyclic: row.is_cyclic !== null ? Boolean(row.is_cyclic) : undefined,
 	};
 }
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -141,6 +141,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 37: Add goal_id column to space_workflow_runs for goal/mission association.
 	runMigration37(db);
+
+	// Migration 38: Add is_cyclic column to space_workflow_transitions.
+	runMigration38(db);
 }
 
 /**
@@ -2084,4 +2087,22 @@ function runMigration37(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_goal_id ON space_workflow_runs(goal_id)`
 	);
+}
+
+/**
+ * Migration 38: Add `is_cyclic` column to `space_workflow_transitions`.
+ *
+ * When a transition is marked as cyclic, following it increments `iterationCount`
+ * on the workflow run. This enables explicit cycle detection for iterative workflows
+ * without relying on heuristics that would misfire on DAG merge paths.
+ *
+ * Nullable INTEGER (SQLite boolean): 0 = not cyclic, 1 = cyclic, NULL = not cyclic.
+ */
+function runMigration38(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflow_transitions')) return;
+	try {
+		db.prepare(`SELECT is_cyclic FROM space_workflow_transitions LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_workflow_transitions ADD COLUMN is_cyclic INTEGER`);
+	}
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -91,6 +91,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			to_step_id TEXT NOT NULL,
 			condition TEXT,
 			order_index INTEGER NOT NULL DEFAULT 0,
+			is_cyclic INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -106,6 +106,7 @@ function createSchema(db: Database): void {
 			to_step_id TEXT NOT NULL,
 			condition TEXT,
 			order_index INTEGER NOT NULL DEFAULT 0,
+			is_cyclic INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -935,6 +935,33 @@ describe('validateExportedWorkflow', () => {
 			expect('unknownField' in result.value.transitions[0]).toBe(false);
 		}
 	});
+
+	test('rejects task_result condition without expression', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [
+				{
+					fromStep: 'Step A',
+					toStep: 'Step B',
+					condition: { type: 'task_result' },
+				},
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('expression');
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -375,6 +375,29 @@ describe('exportWorkflow', () => {
 		expect(exported.version).toBe(1);
 		expect(exported.type).toBe('workflow');
 	});
+
+	test('includes isCyclic in exported transitions', () => {
+		const workflow = makeWorkflow({
+			steps: [
+				{ id: 'step-uuid-1', agentId: 'agent-uuid-1', name: 'Step A' },
+				{ id: 'step-uuid-2', agentId: 'agent-uuid-2', name: 'Step B' },
+			],
+			transitions: [
+				{
+					id: 'trans-uuid-1',
+					from: 'step-uuid-1',
+					to: 'step-uuid-2',
+					isCyclic: true,
+				},
+			],
+			startStepId: 'step-uuid-1',
+			rules: [],
+		});
+		const exported = exportWorkflow(workflow, []);
+
+		expect(exported.transitions).toHaveLength(1);
+		expect(exported.transitions[0].isCyclic).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -831,6 +854,86 @@ describe('validateExportedWorkflow', () => {
 		};
 		const result = validateExportedWorkflow(data);
 		expect(result.ok).toBe(false);
+	});
+
+	test('accepts transition with isCyclic: true', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [{ fromStep: 'Step A', toStep: 'Step B', isCyclic: true }],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].isCyclic).toBe(true);
+		}
+	});
+
+	test('accepts transition with task_result condition type', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [
+				{
+					fromStep: 'Step A',
+					toStep: 'Step B',
+					condition: { type: 'task_result', expression: 'passed' },
+				},
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].condition).toEqual({
+				type: 'task_result',
+				expression: 'passed',
+			});
+		}
+	});
+
+	test('strips unknown fields but preserves isCyclic', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{ agentRef: 'Agent A', name: 'Step A' },
+				{ agentRef: 'Agent B', name: 'Step B' },
+			],
+			transitions: [
+				{
+					fromStep: 'Step A',
+					toStep: 'Step B',
+					isCyclic: true,
+					unknownField: 'should be stripped',
+				},
+			],
+			startStep: 'Step A',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.transitions[0].isCyclic).toBe(true);
+			expect('unknownField' in result.value.transitions[0]).toBe(false);
+		}
 	});
 });
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
@@ -1,0 +1,205 @@
+/**
+ * Migration 38 Tests
+ *
+ * Tests for Migration 38: Add is_cyclic column to space_workflow_transitions.
+ *
+ * Covers:
+ * - Fresh DB (full migration chain): column exists
+ * - Fresh DB: is_cyclic defaults to NULL (nullable INTEGER, no default)
+ * - Fresh DB: is_cyclic can be set to 1
+ * - Legacy DB path: column is added to an existing table that lacks it
+ * - Idempotency: running migration twice does not error
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return rows.some((r) => r.name === column);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-38', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Fresh DB — full migration chain
+	// -------------------------------------------------------------------------
+
+	test('fresh DB: is_cyclic column exists after full migration', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_workflow_transitions', 'is_cyclic')).toBe(true);
+	});
+
+	test('fresh DB: is_cyclic defaults to NULL', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step A', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-2', 'wf-1', 'Step B', 1, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('trans-1', 'wf-1', 'step-1', 'step-2', 0, now, now);
+
+		const row = db
+			.prepare(`SELECT is_cyclic FROM space_workflow_transitions WHERE id = 'trans-1'`)
+			.get() as { is_cyclic: number | null };
+		expect(row.is_cyclic).toBeNull();
+	});
+
+	test('fresh DB: is_cyclic can be set to 1', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step A', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-2', 'wf-1', 'Step B', 1, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('trans-1', 'wf-1', 'step-1', 'step-2', 1, 0, now, now);
+
+		const row = db
+			.prepare(`SELECT is_cyclic FROM space_workflow_transitions WHERE id = 'trans-1'`)
+			.get() as { is_cyclic: number | null };
+		expect(row.is_cyclic).toBe(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// Legacy DB path — simulate pre-migration-38 state without the column
+	// -------------------------------------------------------------------------
+
+	test('legacy DB: column is added to existing table that lacks it', () => {
+		// Create prerequisite tables and space_workflow_transitions as it existed before migration 38
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)');
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				start_step_id TEXT,
+				config TEXT,
+				layout TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_steps (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				agent_id TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_transitions (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				from_step_id TEXT NOT NULL,
+				to_step_id TEXT NOT NULL,
+				condition TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		// Confirm column is absent before migration
+		expect(columnExists(db, 'space_workflow_transitions', 'is_cyclic')).toBe(false);
+
+		// Run migrations
+		runMigrations(db, () => {});
+
+		// Column should now exist
+		expect(columnExists(db, 'space_workflow_transitions', 'is_cyclic')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency — column already exists
+	// -------------------------------------------------------------------------
+
+	test('idempotency: running migration twice does not error', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+		expect(columnExists(db, 'space_workflow_transitions', 'is_cyclic')).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-workflow-repository-is-cyclic.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-repository-is-cyclic.test.ts
@@ -64,7 +64,7 @@ describe('SpaceWorkflowRepository — isCyclic', () => {
 		});
 	});
 
-	it('round-trips isCyclic: false (defaults) through insert and read', () => {
+	it('round-trips isCyclic: undefined (absent) through insert and read', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId,
 			name: 'Linear Workflow',
@@ -79,7 +79,7 @@ describe('SpaceWorkflowRepository — isCyclic', () => {
 		const fetched = workflowRepo.getWorkflow(workflow.id);
 		expect(fetched).not.toBeNull();
 		expect(fetched!.transitions).toHaveLength(1);
-		expect(fetched!.transitions[0].isCyclic).toBe(false);
+		expect(fetched!.transitions[0].isCyclic).toBeUndefined();
 	});
 
 	it('persists task_result condition type correctly', () => {

--- a/packages/daemon/tests/unit/storage/space-workflow-repository-is-cyclic.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-repository-is-cyclic.test.ts
@@ -1,0 +1,112 @@
+/**
+ * SpaceWorkflowRepository — isCyclic round-trip test
+ *
+ * Verifies that `isCyclic` on WorkflowTransition persists correctly
+ * through insertTransition() and reads back via getWorkflow().
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('SpaceWorkflowRepository — isCyclic', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as any);
+		workflowRepo = new SpaceWorkflowRepository(db as any);
+
+		const space = spaceRepo.createSpace({ workspacePath: '/workspace/test', name: 'Test' });
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('round-trips isCyclic: true through insert and read', () => {
+		const workflow = workflowRepo.createWorkflow({
+			spaceId,
+			name: 'Cyclic Workflow',
+			steps: [
+				{ id: 'step-plan', agentId: 'agent-1', name: 'Plan' },
+				{ id: 'step-verify', agentId: 'agent-2', name: 'Verify' },
+			],
+			transitions: [
+				{ from: 'step-plan', to: 'step-verify', order: 0 },
+				{
+					from: 'step-verify',
+					to: 'step-plan',
+					order: 1,
+					isCyclic: true,
+					condition: { type: 'task_result', expression: 'failed' },
+				},
+			],
+			rules: [],
+		});
+
+		const fetched = workflowRepo.getWorkflow(workflow.id);
+		expect(fetched).not.toBeNull();
+
+		const cyclicTransition = fetched!.transitions.find((t) => t.isCyclic === true);
+		expect(cyclicTransition).toBeDefined();
+		expect(cyclicTransition!.isCyclic).toBe(true);
+		expect(cyclicTransition!.condition).toEqual({
+			type: 'task_result',
+			expression: 'failed',
+		});
+	});
+
+	it('round-trips isCyclic: false (defaults) through insert and read', () => {
+		const workflow = workflowRepo.createWorkflow({
+			spaceId,
+			name: 'Linear Workflow',
+			steps: [
+				{ id: 'step-code', agentId: 'agent-1', name: 'Code' },
+				{ id: 'step-review', agentId: 'agent-2', name: 'Review' },
+			],
+			transitions: [{ from: 'step-code', to: 'step-review', order: 0 }],
+			rules: [],
+		});
+
+		const fetched = workflowRepo.getWorkflow(workflow.id);
+		expect(fetched).not.toBeNull();
+		expect(fetched!.transitions).toHaveLength(1);
+		expect(fetched!.transitions[0].isCyclic).toBe(false);
+	});
+
+	it('persists task_result condition type correctly', () => {
+		const workflow = workflowRepo.createWorkflow({
+			spaceId,
+			name: 'Task Result Workflow',
+			steps: [
+				{ id: 'step-verify', agentId: 'agent-1', name: 'Verify' },
+				{ id: 'step-done', agentId: 'agent-2', name: 'Done' },
+			],
+			transitions: [
+				{
+					from: 'step-verify',
+					to: 'step-done',
+					order: 0,
+					condition: { type: 'task_result', expression: 'passed' },
+				},
+			],
+			rules: [],
+		});
+
+		const fetched = workflowRepo.getWorkflow(workflow.id);
+		expect(fetched).not.toBeNull();
+		const trans = fetched!.transitions[0];
+		expect(trans.condition).toEqual({
+			type: 'task_result',
+			expression: 'passed',
+		});
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -485,8 +485,11 @@ export interface UpdateSpaceAgentParams {
  * - `human`: Blocks until a human explicitly approves (via a signal / run config update).
  * - `condition`: A user-supplied shell expression; the transition fires when it exits with code 0.
  *   NeoKai is a framework — no allowlist is applied. Users are responsible for what they run.
+ * - `task_result`: Matches against the `result` field of the most recently completed task on the
+ *   current step. The transition fires when the task result starts with or equals the condition's
+ *   `expression` value (e.g., `'passed'`, `'failed'`).
  */
-export type WorkflowConditionType = 'always' | 'human' | 'condition';
+export type WorkflowConditionType = 'always' | 'human' | 'condition' | 'task_result';
 
 /**
  * A condition that guards a workflow transition.
@@ -496,9 +499,13 @@ export interface WorkflowCondition {
 	/** Condition type. */
 	type: WorkflowConditionType;
 	/**
-	 * Shell expression to evaluate for the `condition` type.
-	 * The transition fires when the expression exits with code 0.
-	 * No allowlist is applied — users are responsible for the expression content.
+	 * Expression to evaluate for the `condition` and `task_result` types.
+	 *
+	 * - For `condition`: a shell expression; the transition fires when it exits with code 0.
+	 *   No allowlist is applied — users are responsible for the expression content.
+	 * - For `task_result`: the match value to compare against the completed task's `result`
+	 *   field (e.g., `'passed'`, `'failed'`). The transition fires when the task result
+	 *   starts with or equals this value.
 	 */
 	expression?: string;
 	/** Human-readable description of what this condition checks */
@@ -533,6 +540,12 @@ export interface WorkflowTransition {
 	condition?: WorkflowCondition;
 	/** Sort order among transitions with the same `from` step. Lower = evaluated first. */
 	order?: number;
+	/**
+	 * When `true`, following this transition increments `iterationCount` on the run.
+	 * Used for cycle detection in iterative workflows — avoids heuristic-based detection
+	 * that would misfire on DAG merge paths.
+	 */
+	isCyclic?: boolean;
 }
 
 /**
@@ -767,6 +780,11 @@ export interface ExportedWorkflowTransition {
 	condition?: WorkflowCondition;
 	/** Sort order among transitions with the same source step. Lower = evaluated first. */
 	order?: number;
+	/**
+	 * When `true`, following this transition increments `iterationCount` on the run.
+	 * Used for cycle detection in iterative workflows.
+	 */
+	isCyclic?: boolean;
 }
 
 /**

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -27,6 +27,7 @@ const GATE_COLORS: Record<WorkflowConditionType, string> = {
 	always: 'bg-blue-500',
 	human: 'bg-yellow-400',
 	condition: 'bg-purple-400',
+	task_result: 'bg-orange-500',
 };
 
 function MiniStepDot({ isStart }: { isStart: boolean }) {

--- a/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
@@ -72,7 +72,8 @@ export function EdgeConfigPanel({
 			// don't persist a stale expression string under a non-expression condition.
 			// Note: the parent is responsible for preserving the expression across
 			// two-way type switches if that behaviour is desired.
-			onUpdateCondition(id, type, type === 'condition' ? condition.expression : undefined);
+			const preserveExpression = type === 'condition' || type === 'task_result';
+			onUpdateCondition(id, type, preserveExpression ? condition.expression : undefined);
 		},
 		[id, condition.expression, onUpdateCondition]
 	);
@@ -80,9 +81,9 @@ export function EdgeConfigPanel({
 	const handleExpressionChange = useCallback(
 		(e: Event) => {
 			const expression = (e.target as HTMLInputElement).value;
-			onUpdateCondition(id, 'condition', expression);
+			onUpdateCondition(id, condition.type, expression);
 		},
-		[id, onUpdateCondition]
+		[id, condition.type, onUpdateCondition]
 	);
 
 	const handleDelete = useCallback(() => {

--- a/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
@@ -149,18 +149,20 @@ export function EdgeConfigPanel({
 				</select>
 			</div>
 
-			{/* Expression input — only shown for 'condition' type */}
-			{condition.type === 'condition' && (
+			{/* Expression input — shown for 'condition' and 'task_result' types */}
+			{(condition.type === 'condition' || condition.type === 'task_result') && (
 				<div class="flex flex-col gap-1">
 					<label class="text-xs text-gray-400 font-medium" for="condition-expression">
-						Expression
+						{condition.type === 'task_result' ? 'Match value' : 'Expression'}
 					</label>
 					<input
 						id="condition-expression"
 						data-testid="condition-expression"
 						type="text"
 						class="bg-dark-700 border border-dark-600 rounded px-2 py-1 text-sm text-white font-mono focus:outline-none focus:border-blue-500"
-						placeholder="e.g. test -f output.txt"
+						placeholder={
+							condition.type === 'task_result' ? 'e.g. passed, failed' : 'e.g. test -f output.txt'
+						}
 						value={condition.expression ?? ''}
 						onInput={handleExpressionChange}
 					/>

--- a/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeConfigPanel.tsx
@@ -46,10 +46,16 @@ const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
 	always: 'Always',
 	human: 'Human approval',
 	condition: 'Expression',
+	task_result: 'Task Result',
 };
 
 /** Explicit ordering for the condition type <select> options. */
-const CONDITION_TYPE_ORDER: WorkflowConditionType[] = ['always', 'human', 'condition'];
+const CONDITION_TYPE_ORDER: WorkflowConditionType[] = [
+	'always',
+	'human',
+	'condition',
+	'task_result',
+];
 
 export function EdgeConfigPanel({
 	transition,

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -42,6 +42,7 @@ export const EDGE_COLORS: Record<WorkflowConditionType, string> = {
 	always: '#3b82f6', // blue-500
 	human: '#facc15', // yellow-400
 	condition: '#c084fc', // purple-400
+	task_result: '#f97316', // orange-500
 };
 
 export const NORMAL_STROKE_WIDTH = 1.5;

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -49,7 +49,10 @@ export function GateConfig({ condition, onChange, label, terminalMessage }: Gate
 						value={condition.type}
 						onChange={(e) => {
 							const type = (e.currentTarget as HTMLSelectElement).value as WorkflowConditionType;
-							onChange({ type, expression: type === 'condition' ? '' : undefined });
+							onChange({
+								type,
+								expression: type === 'condition' || type === 'task_result' ? '' : undefined,
+							});
 						}}
 						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
 					>
@@ -60,12 +63,16 @@ export function GateConfig({ condition, onChange, label, terminalMessage }: Gate
 						))}
 					</select>
 
-					{condition.type === 'condition' && (
+					{(condition.type === 'condition' || condition.type === 'task_result') && (
 						<div class="space-y-1">
 							<input
 								type="text"
 								required
-								placeholder="e.g. bun test && git diff --quiet"
+								placeholder={
+									condition.type === 'task_result'
+										? 'e.g. passed, failed'
+										: 'e.g. bun test && git diff --quiet'
+								}
 								value={condition.expression ?? ''}
 								onInput={(e) =>
 									onChange({
@@ -76,7 +83,9 @@ export function GateConfig({ condition, onChange, label, terminalMessage }: Gate
 								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 font-mono focus:outline-none focus:border-blue-500 placeholder-gray-700"
 							/>
 							<p class="text-xs text-gray-600">
-								Transition fires when the shell command exits with code 0.
+								{condition.type === 'task_result'
+									? 'Fires when the task result matches this value.'
+									: 'Transition fires when the shell command exits with code 0.'}
 							</p>
 						</div>
 					)}

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -14,7 +14,7 @@ import type { WorkflowConditionType } from '@neokai/shared';
 
 export interface ConditionDraft {
 	type: WorkflowConditionType;
-	/** Shell expression for 'condition' type */
+	/** Expression: shell command for 'condition' type, match value for 'task_result' type */
 	expression?: string;
 }
 

--- a/packages/web/src/components/space/visual-editor/GateConfig.tsx
+++ b/packages/web/src/components/space/visual-editor/GateConfig.tsx
@@ -22,6 +22,7 @@ export const CONDITION_LABELS: Record<WorkflowConditionType, string> = {
 	always: 'Automatic',
 	human: 'Human Approval',
 	condition: 'Shell Condition',
+	task_result: 'Task Result',
 };
 
 // ============================================================================

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeConfigPanel.test.tsx
@@ -14,6 +14,9 @@
  * - Switching away from 'condition' type clears expression
  * - Switching to 'condition' type preserves existing expression
  * - Editing expression calls onUpdateCondition with updated expression
+ * - Shows expression input for 'task_result' type with "Match value" label
+ * - Editing task_result expression calls onUpdateCondition with 'task_result' type (not 'condition')
+ * - Switching from 'condition' to 'task_result' preserves expression
  * - Clicking delete button calls onDelete with transition id
  * - Clicking close button calls onClose
  */
@@ -176,6 +179,46 @@ describe('EdgeConfigPanel', () => {
 		const input = getByTestId('condition-expression') as HTMLInputElement;
 		fireEvent.input(input, { target: { value: 'new-expr' } });
 		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'condition', 'new-expr');
+	});
+
+	it('shows expression input for task_result type with Match value label', () => {
+		const { getByTestId, getByText } = render(
+			<EdgeConfigPanel
+				{...makeProps(makeTransition({ condition: { type: 'task_result', expression: 'passed' } }))}
+			/>
+		);
+		expect(getByTestId('condition-expression')).toBeTruthy();
+		expect(getByText('Match value')).toBeTruthy();
+	});
+
+	it('editing task_result expression calls onUpdateCondition with task_result type', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(
+					makeTransition({ condition: { type: 'task_result', expression: 'passed' } }),
+					{ onUpdateCondition }
+				)}
+			/>
+		);
+		const input = getByTestId('condition-expression') as HTMLInputElement;
+		fireEvent.input(input, { target: { value: 'failed' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'task_result', 'failed');
+	});
+
+	it('switching from condition to task_result preserves expression', () => {
+		const onUpdateCondition = vi.fn();
+		const { getByTestId } = render(
+			<EdgeConfigPanel
+				{...makeProps(
+					makeTransition({ condition: { type: 'condition', expression: 'test -f out.txt' } }),
+					{ onUpdateCondition }
+				)}
+			/>
+		);
+		const select = getByTestId('condition-type-select') as HTMLSelectElement;
+		fireEvent.change(select, { target: { value: 'task_result' } });
+		expect(onUpdateCondition).toHaveBeenCalledWith('trans-1', 'task_result', 'test -f out.txt');
 	});
 
 	it('clicking delete button calls onDelete with transition id', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -185,8 +185,8 @@ describe('EdgeRenderer — rendering', () => {
 		const { container } = renderEdges();
 		const defs = container.querySelector('defs');
 		expect(defs).not.toBeNull();
-		// Should have 4 markers: always, human, condition, selected
-		expect(defs!.querySelectorAll('marker')).toHaveLength(4);
+		// Should have 5 markers: always, human, condition, task_result, selected
+		expect(defs!.querySelectorAll('marker')).toHaveLength(5);
 	});
 
 	it('uses testid data-testid="edge-{id}" on each group', () => {


### PR DESCRIPTION
## Summary

- Add `'task_result'` to `WorkflowConditionType` union type with JSDoc describing its semantics
- Add `isCyclic?: boolean` to `WorkflowTransition` and `ExportedWorkflowTransition` interfaces
- Update Zod schemas (`workflowConditionSchema`, `exportedWorkflowTransitionSchema`) and export logic to handle `task_result` and `isCyclic`
- Add migration 34: `is_cyclic INTEGER` column on `space_workflow_transitions`
- Update `SpaceWorkflowRepository` (`insertTransition`, `rowToTransition`, `TransitionRow`) for DB persistence
- Add stub `task_result` case in `evaluateCondition()` (full implementation in Task 1.2)
- Update UI `Record<WorkflowConditionType, string>` maps in 4 web components
- Fix `EdgeRenderer` test marker count (4 → 5)

## Test plan

- [x] Migration 34 test: fresh DB column exists, defaults to NULL, can be set to 1, legacy DB path, idempotency
- [x] Repository round-trip test: isCyclic true/false persists through insert/read, task_result condition persists
- [x] Export format test: isCyclic in exported transitions, task_result condition validation, Zod preserves isCyclic
- [x] EdgeRenderer test updated for 5 markers
- [x] Typecheck passes (executor stub added for task_result)
- [x] Lint, format, and knip all pass