### PR TITLE
Plan: Redesign RoomContextPanel goal-centric sidebar

### DIFF
--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/00-overview.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/00-overview.md
@@ -1,0 +1,36 @@
+# Redesign RoomContextPanel: Goal-Centric Sidebar
+
+## Goal
+
+Redesign the `RoomContextPanel` from a flat session-centric list into a structured, goal-and-task-centric sidebar with collapsible sections and URL-addressable navigation. Every clickable item that changes the main content view must have a URL that survives page refresh.
+
+## Current State
+
+- `RoomContextPanel.tsx` shows: back button, new session button, task stats strip, Dashboard/Room Agent pinned items, flat session list with archive toggle.
+- Router (`router.ts`) already supports `/room/:roomId`, `/room/:roomId/session/:sessionId`, `/room/:roomId/task/:taskId` routes.
+- `room-store.ts` has `goals`, `tasks`, and `sessions` signals. `RoomGoal.linkedTaskIds` tracks task-to-goal linkage.
+- `Room.tsx` renders `TaskView`, `ChatContainer`, or tabbed dashboard based on `sessionViewId`/`taskViewId` props.
+- No URL route exists for `/rooms/:roomId/agent` (Room Agent uses a synthetic session ID `room:chat:<roomId>`).
+
+## Approach
+
+Break this into 6 milestones working bottom-up: store/computed additions first, then router enhancements, then the main component redesign, integration into Room.tsx, unit tests, and finally E2E tests.
+
+## Milestones
+
+1. **Room Store Computed Signals** - Add computed signals to `room-store.ts` for orphan tasks (tasks not linked to any goal), tasks grouped by goal, and filtered task lists by status category.
+2. **Router: Room Agent URL Route** - Add `/room/:roomId/agent` route pattern so the Room Agent view is URL-addressable and survives page refresh. Update `navigateToRoomSession` or add a dedicated `navigateToRoomAgent` function.
+3. **RoomContextPanel Redesign** - Full rewrite of `RoomContextPanel.tsx` with the new layout: Dashboard + Room Agent pinned items, collapsible Goals section with expandable goals showing linked tasks, orphan Tasks section with tab filter, collapsible Sessions section with create button. Remove back button.
+4. **Room.tsx Integration** - Update `Room.tsx` to handle the new Room Agent route (detect `/room/:roomId/agent` and render Room Agent chat). Ensure all navigation from the new sidebar correctly drives main content.
+5. **Unit Tests** - Unit tests for new computed signals in room-store, the redesigned RoomContextPanel rendering (goals section, tasks section, sessions section, collapsible behavior), and router route parsing.
+6. **E2E Tests** - Playwright E2E tests for URL-addressable navigation (refresh persistence for dashboard, agent, task, session routes), goal expand/collapse interaction, and task tab filtering.
+
+## Cross-Milestone Dependencies
+
+- Milestone 2 (router) and Milestone 1 (store) are independent and can run in parallel.
+- Milestone 3 (component redesign) depends on both Milestone 1 and Milestone 2.
+- Milestone 4 (Room.tsx integration) depends on Milestone 2 and Milestone 3.
+- Milestone 5 (unit tests) depends on Milestones 1-3.
+- Milestone 6 (E2E tests) depends on Milestone 4.
+
+## Estimated Total Tasks: 11

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/00-overview.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/00-overview.md
@@ -29,8 +29,16 @@ Break this into 6 milestones working bottom-up: store/computed additions first, 
 
 - Milestone 2 (router) and Milestone 1 (store) are independent and can run in parallel.
 - Milestone 3 (component redesign) depends on both Milestone 1 and Milestone 2.
-- Milestone 4 (Room.tsx integration) depends on Milestone 2 and Milestone 3.
+- Milestone 4 (Room.tsx integration) depends on Milestone 2 and Milestone 3. Note: Task 4.1 is an integration validation task — its output may be a passing typecheck/test run plus minor wiring fixes rather than a large code PR. If no code changes are needed, the PR should document the verification performed.
 - Milestone 5 (unit tests) depends on Milestones 1-3.
 - Milestone 6 (E2E tests) depends on Milestone 4.
 
-## Estimated Total Tasks: 11
+## Estimated Total Tasks: 10
+
+## Key Design Decisions
+
+- **`draft` and `pending` task statuses** are included in the "Active" tab filter bucket alongside `in_progress`. This ensures no tasks silently vanish from the sidebar.
+- **`isDashboardSelected`** must be true ONLY when both `currentRoomSessionIdSignal.value === null` AND `currentRoomTaskIdSignal.value === null`. Selecting a task or the Room Agent must NOT highlight the Dashboard.
+- **Room Agent page-load path**: When `initializeRouter` parses `/room/:roomId/agent`, it must set `currentRoomSessionIdSignal` to the synthetic `room:chat:${roomId}` value. Without this, the Room Agent chat will not render on page refresh (Room.tsx requires a non-null `sessionViewId`). This couples the clean URL to the synthetic ID mechanism — accepted as pragmatic technical debt.
+- **Mobile drawer**: All navigation actions in the redesigned panel must still call `onNavigate?.()` to close the mobile drawer, preserving existing mobile behavior.
+- **Goal-task linkage in E2E setup**: Use `goal.create` RPC to create goals, `task.create` to create tasks, then `goal.linkTask` RPC (`{ roomId, goalId, taskId }`) to link tasks to goals. The `goal.create` handler does NOT accept `linkedTaskIds` directly — linkage is always done via `goal.linkTask`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/01-room-store-computed-signals.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/01-room-store-computed-signals.md
@@ -17,9 +17,9 @@ Add computed signals to `room-store.ts` that derive goal-grouped tasks, orphan t
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. In `packages/web/src/lib/room-store.ts`, add the following computed signals to `RoomStore`:
-   - `tasksByGoalId`: `computed(() => Map<string, TaskSummary[]>)` - Iterate over `goals.value`, for each goal filter `tasks.value` by checking if `task.id` is in `goal.linkedTaskIds`. Return a Map keyed by goal ID.
-   - `orphanTasks`: `computed(() => TaskSummary[])` - Tasks whose ID does not appear in any goal's `linkedTaskIds`.
-   - `orphanTasksActive`: `computed(() => TaskSummary[])` - Orphan tasks with status `in_progress`.
+   - `tasksByGoalId`: `computed(() => Map<string, TaskSummary[]>)` - First build a `Set<string>` of all linked task IDs across all goals (single pass over goals), then for each goal resolve its linked tasks from the tasks signal using this Set for O(1) lookups. Return a Map keyed by goal ID. Performance note: build the linked-ID Set first to avoid O(goals × tasks) iteration.
+   - `orphanTasks`: `computed(() => TaskSummary[])` - Tasks whose ID does not appear in any goal's `linkedTaskIds`. Reuse the same linked-ID Set approach.
+   - `orphanTasksActive`: `computed(() => TaskSummary[])` - Orphan tasks with status `draft`, `pending`, or `in_progress`. These three statuses represent tasks that are not yet in review or completed.
    - `orphanTasksReview`: `computed(() => TaskSummary[])` - Orphan tasks with status `review` or `needs_attention`.
    - `orphanTasksDone`: `computed(() => TaskSummary[])` - Orphan tasks with status `completed` or `cancelled`.
 3. Ensure all new signals are `readonly` and placed in the "Computed Accessors" section.
@@ -29,6 +29,7 @@ Add computed signals to `room-store.ts` that derive goal-grouped tasks, orphan t
 **Acceptance criteria:**
 - `tasksByGoalId` returns a Map where each goal's linked tasks are resolved from the tasks signal.
 - `orphanTasks` correctly excludes tasks that appear in any goal's `linkedTaskIds`.
-- `orphanTasksActive`, `orphanTasksReview`, `orphanTasksDone` filter orphan tasks by the correct status values.
+- `orphanTasksActive` includes orphan tasks with `draft`, `pending`, or `in_progress` status (all 7 `TaskStatus` values are accounted for across the three buckets).
+- `orphanTasksReview` and `orphanTasksDone` filter orphan tasks by the correct status values.
 - TypeScript compiles without errors.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/01-room-store-computed-signals.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/01-room-store-computed-signals.md
@@ -1,0 +1,34 @@
+# Milestone 1: Room Store Computed Signals
+
+## Goal
+
+Add computed signals to `room-store.ts` that derive goal-grouped tasks, orphan tasks, and status-filtered task lists. These signals power the new sidebar sections.
+
+## Tasks
+
+### Task 1.1: Add Computed Signals for Goal-Task Grouping and Orphan Tasks
+
+**Description:** Add computed signals to the `RoomStore` class that the redesigned sidebar needs: tasks grouped by goal ID, orphan tasks (not linked to any goal), and orphan tasks filtered by status category (active, review, done).
+
+**Agent type:** coder
+
+**Depends on:** (none)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/lib/room-store.ts`, add the following computed signals to `RoomStore`:
+   - `tasksByGoalId`: `computed(() => Map<string, TaskSummary[]>)` - Iterate over `goals.value`, for each goal filter `tasks.value` by checking if `task.id` is in `goal.linkedTaskIds`. Return a Map keyed by goal ID.
+   - `orphanTasks`: `computed(() => TaskSummary[])` - Tasks whose ID does not appear in any goal's `linkedTaskIds`.
+   - `orphanTasksActive`: `computed(() => TaskSummary[])` - Orphan tasks with status `in_progress`.
+   - `orphanTasksReview`: `computed(() => TaskSummary[])` - Orphan tasks with status `review` or `needs_attention`.
+   - `orphanTasksDone`: `computed(() => TaskSummary[])` - Orphan tasks with status `completed` or `cancelled`.
+3. Ensure all new signals are `readonly` and placed in the "Computed Accessors" section.
+4. Run `bun run typecheck` to verify no type errors.
+5. Run `bun run lint` and `bun run format` to ensure code quality.
+
+**Acceptance criteria:**
+- `tasksByGoalId` returns a Map where each goal's linked tasks are resolved from the tasks signal.
+- `orphanTasks` correctly excludes tasks that appear in any goal's `linkedTaskIds`.
+- `orphanTasksActive`, `orphanTasksReview`, `orphanTasksDone` filter orphan tasks by the correct status values.
+- TypeScript compiles without errors.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/02-router-room-agent-url.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/02-router-room-agent-url.md
@@ -1,0 +1,36 @@
+# Milestone 2: Router - Room Agent URL Route
+
+## Goal
+
+Make the Room Agent view URL-addressable at `/room/:roomId/agent` so it survives page refresh. Currently, the Room Agent uses the synthetic session ID `room:chat:<roomId>` but has no dedicated URL -- navigating to it uses the same `/room/:roomId/session/:sessionId` pattern with this synthetic ID, which is fragile.
+
+## Tasks
+
+### Task 2.1: Add Room Agent Route Pattern and Navigation Function
+
+**Description:** Add a dedicated URL route `/room/:roomId/agent` for the Room Agent view. Add route pattern matching, path creation, extraction, and a `navigateToRoomAgent` function. Update the `initializeRouter` popstate handler to recognize this route.
+
+**Agent type:** coder
+
+**Depends on:** (none)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. In `packages/web/src/lib/router.ts`:
+   - Add `ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/` alongside existing route patterns.
+   - Add `createRoomAgentPath(roomId: string): string` returning `/room/${roomId}/agent`.
+   - Add `getRoomAgentFromPath(path: string): string | null` that extracts the roomId if the path matches the agent route pattern.
+   - Add `navigateToRoomAgent(roomId: string, replace = false): void` that pushes `/room/:roomId/agent` to history and sets `currentRoomIdSignal`, `currentRoomSessionIdSignal` to the synthetic `room:chat:<roomId>` value, and clears `currentRoomTaskIdSignal`.
+   - Update `getRoomIdFromPath` to also check the agent route pattern.
+   - Update the `handleRouteChange` / `initializeRouter` function to recognize the agent route on page load / popstate, setting signals accordingly.
+3. In `packages/web/src/islands/RoomContextPanel.tsx`, update `handleRoomAgentClick` to call `navigateToRoomAgent(roomId)` instead of `navigateToRoomSession(roomId, roomAgentSessionId)`.
+4. Run `bun run typecheck` to verify no type errors.
+5. Run `bun run lint` and `bun run format`.
+
+**Acceptance criteria:**
+- Navigating to `/room/<uuid>/agent` in the browser sets the correct signals for Room Agent view.
+- `navigateToRoomAgent(roomId)` pushes the correct URL and updates signals.
+- `getRoomIdFromPath` recognizes the agent route.
+- Page refresh on `/room/<uuid>/agent` restores Room Agent state.
+- TypeScript compiles without errors.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/02-router-room-agent-url.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/02-router-room-agent-url.md
@@ -22,7 +22,11 @@ Make the Room Agent view URL-addressable at `/room/:roomId/agent` so it survives
    - Add `getRoomAgentFromPath(path: string): string | null` that extracts the roomId if the path matches the agent route pattern.
    - Add `navigateToRoomAgent(roomId: string, replace = false): void` that pushes `/room/:roomId/agent` to history and sets `currentRoomIdSignal`, `currentRoomSessionIdSignal` to the synthetic `room:chat:<roomId>` value, and clears `currentRoomTaskIdSignal`.
    - Update `getRoomIdFromPath` to also check the agent route pattern.
-   - Update the `handleRouteChange` / `initializeRouter` function to recognize the agent route on page load / popstate, setting signals accordingly.
+   - **CRITICAL — page-load path**: Update the `handleRouteChange` / `initializeRouter` function to recognize the agent route on page load / popstate. When the agent route is detected, it MUST set:
+     - `currentRoomIdSignal` to the extracted `roomId`
+     - `currentRoomSessionIdSignal` to the synthetic ``room:chat:${roomId}`` value (NOT null)
+     - `currentRoomTaskIdSignal` to `null`
+   - Without setting the synthetic session ID on page load, Room.tsx will not render `ChatContainer` (it requires a non-null `sessionViewId`), causing a blank screen on refresh.
 3. In `packages/web/src/islands/RoomContextPanel.tsx`, update `handleRoomAgentClick` to call `navigateToRoomAgent(roomId)` instead of `navigateToRoomSession(roomId, roomAgentSessionId)`.
 4. Run `bun run typecheck` to verify no type errors.
 5. Run `bun run lint` and `bun run format`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/03-roomcontextpanel-redesign.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/03-roomcontextpanel-redesign.md
@@ -1,0 +1,84 @@
+# Milestone 3: RoomContextPanel Redesign
+
+## Goal
+
+Fully rewrite `RoomContextPanel.tsx` to implement the new goal-centric sidebar layout with collapsible sections and proper navigation.
+
+## Tasks
+
+### Task 3.1: Implement Collapsible Section Components
+
+**Description:** Create reusable collapsible section header components that will be used for Goals, Tasks, and Sessions sections. Each section has a header with title, count badge, and expand/collapse toggle.
+
+**Agent type:** coder
+
+**Depends on:** (none)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/web/src/components/room/CollapsibleSection.tsx`:
+   - Props: `title: string`, `count?: number`, `defaultExpanded?: boolean`, `headerRight?: ComponentChildren` (for action buttons like [+]), `children: ComponentChildren`.
+   - Renders a section header with the triangle toggle indicator (right-pointing when collapsed, down-pointing when expanded), title text in uppercase small caps style, optional count badge, and optional `headerRight` slot.
+   - Clicking the header toggles the section body visibility.
+   - Use local `useState` for expand/collapse state.
+   - Style: header text should be `text-xs font-semibold text-gray-500 uppercase tracking-wider`, consistent with existing sidebar styling.
+3. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- `CollapsibleSection` renders with expand/collapse toggle.
+- Default expansion state is configurable.
+- `headerRight` slot renders inline with the section title.
+- TypeScript compiles without errors.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+### Task 3.2: Rewrite RoomContextPanel with New Layout
+
+**Description:** Rewrite `RoomContextPanel.tsx` to implement the full new sidebar layout: pinned Dashboard and Room Agent items at top, then Goals section with expandable goals showing linked tasks, then orphan Tasks section with tab filter, then collapsible Sessions section.
+
+**Agent type:** coder
+
+**Depends on:** Task 1.1 (room store computed signals), Task 2.1 (room agent route), Task 3.1 (collapsible section)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Rewrite `packages/web/src/islands/RoomContextPanel.tsx`:
+   - **Remove** the "All Rooms" back button (nav rail handles this).
+   - **Remove** the standalone "New Session" button from the top (move to Sessions section header).
+   - **Keep** task stats strip below room name area showing `N pending . N active` summary.
+   - **Pinned items section** (no section header):
+     - Dashboard button (existing) - navigates to `/room/:roomId` via `navigateToRoom`.
+     - Room Agent button (existing) - navigates to `/room/:roomId/agent` via `navigateToRoomAgent`.
+     - Visual divider after pinned items.
+   - **Goals section** using `CollapsibleSection` with title "GOALS" and count of active goals:
+     - Default expanded.
+     - Each goal renders as an expandable row with triangle toggle, goal title, and status indicator.
+     - When expanded, shows linked tasks (from `roomStore.tasksByGoalId`) indented under the goal.
+     - Each linked task is clickable, navigating to `/room/:roomId/task/:taskId` via `navigateToRoomTask`.
+     - Task rows show a status dot (color by status) and task title.
+     - Goal expand/collapse uses local state (not URL-addressable).
+   - **Tasks section** using `CollapsibleSection` with title "TASKS":
+     - Default expanded.
+     - Tab bar inside the section: Active | Review | Done. Defaults to "Active".
+     - Lists orphan tasks from `roomStore.orphanTasksActive`, `roomStore.orphanTasksReview`, or `roomStore.orphanTasksDone` based on selected tab.
+     - Each task clickable, navigating to task view.
+     - Show "No orphan tasks" empty state when the filtered list is empty.
+   - **Sessions section** using `CollapsibleSection` with title "SESSIONS", count, and `headerRight` containing the [+] create session button:
+     - Default collapsed.
+     - Lists non-archived sessions (with "Show archived" toggle as before).
+     - Each session clickable, navigating to `/room/:roomId/session/:sessionId`.
+     - Session rows show status dot, title, and relative time.
+   - **Selection highlighting**: The currently active item (based on `currentRoomSessionIdSignal` and `currentRoomTaskIdSignal`) should have a highlighted background (`bg-dark-700`).
+3. Import and use `navigateToRoomAgent` from `router.ts` for the Room Agent button.
+4. Import computed signals (`tasksByGoalId`, `orphanTasksActive`, etc.) from `roomStore`.
+5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- The sidebar renders all five areas: stats, pinned items, goals, tasks, sessions.
+- Goals section shows goals with expandable linked tasks.
+- Tasks section shows only orphan tasks with tab filtering.
+- Sessions section is collapsible with create button in header.
+- Back button is removed.
+- All navigation targets produce correct URLs.
+- Current selection is visually highlighted.
+- TypeScript compiles without errors.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/03-roomcontextpanel-redesign.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/03-roomcontextpanel-redesign.md
@@ -22,12 +22,14 @@ Fully rewrite `RoomContextPanel.tsx` to implement the new goal-centric sidebar l
    - Clicking the header toggles the section body visibility.
    - Use local `useState` for expand/collapse state.
    - Style: header text should be `text-xs font-semibold text-gray-500 uppercase tracking-wider`, consistent with existing sidebar styling.
-3. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+3. Ensure the component is importable without knip dead-export warnings. Either add it to the barrel export in `packages/web/src/components/room/index.ts` (if one exists) or verify that direct file imports are allowed by the knip configuration.
+4. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
 **Acceptance criteria:**
 - `CollapsibleSection` renders with expand/collapse toggle.
 - Default expansion state is configurable.
 - `headerRight` slot renders inline with the section title.
+- No knip dead-export warnings for the new component.
 - TypeScript compiles without errors.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
@@ -68,8 +70,10 @@ Fully rewrite `RoomContextPanel.tsx` to implement the new goal-centric sidebar l
      - Each session clickable, navigating to `/room/:roomId/session/:sessionId`.
      - Session rows show status dot, title, and relative time.
    - **Selection highlighting**: The currently active item (based on `currentRoomSessionIdSignal` and `currentRoomTaskIdSignal`) should have a highlighted background (`bg-dark-700`).
+   - **`isDashboardSelected` logic** (CRITICAL): Must be `currentRoomSessionIdSignal.value === null && currentRoomTaskIdSignal.value === null`. The current code only checks `selectedSessionId === null`, which would incorrectly highlight Dashboard when a task is selected (since task navigation sets session ID to null). Both signals must be null for Dashboard to be selected.
+   - **Mobile drawer**: Every navigation action (Dashboard click, Room Agent click, task click, session click) must call `onNavigate?.()` to close the mobile drawer. The existing `onNavigate` prop from `ContextPanel` must be preserved.
 3. Import and use `navigateToRoomAgent` from `router.ts` for the Room Agent button.
-4. Import computed signals (`tasksByGoalId`, `orphanTasksActive`, etc.) from `roomStore`.
+4. Import both `currentRoomSessionIdSignal` and `currentRoomTaskIdSignal` from signals. The current `RoomContextPanel.tsx` only imports `currentRoomSessionIdSignal` — the task signal import must be added explicitly.
 5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
 **Acceptance criteria:**
@@ -80,5 +84,7 @@ Fully rewrite `RoomContextPanel.tsx` to implement the new goal-centric sidebar l
 - Back button is removed.
 - All navigation targets produce correct URLs.
 - Current selection is visually highlighted.
+- Dashboard is NOT highlighted when a task or Room Agent is selected (`isDashboardSelected` checks both signals are null).
+- Mobile drawer closes on every navigation action (`onNavigate?.()` called).
 - TypeScript compiles without errors.
 - Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/04-room-integration.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/04-room-integration.md
@@ -1,0 +1,29 @@
+# Milestone 4: Room.tsx Integration
+
+## Goal
+
+Ensure the `Room.tsx` component correctly handles the new Room Agent URL route and that all sidebar navigation targets drive the correct main content views.
+
+## Tasks
+
+### Task 4.1: Update Room.tsx to Handle Room Agent Route
+
+**Description:** The Room Agent view currently relies on `sessionViewId` being the synthetic `room:chat:<roomId>` string. With the new `/room/:roomId/agent` route, `MainContent.tsx` passes `roomSessionId` signal which is set by the router. Verify this works end-to-end, and if the synthetic session ID approach needs adjustment, update accordingly. Also clean up any references to the removed back button.
+
+**Agent type:** coder
+
+**Depends on:** Task 2.1 (room agent route), Task 3.2 (RoomContextPanel rewrite)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Verify in `packages/web/src/islands/MainContent.tsx` that the `roomSessionId` signal (from `currentRoomSessionIdSignal`) correctly passes the synthetic `room:chat:<roomId>` value to the `Room` component's `sessionViewId` prop when navigating via the agent URL. The `navigateToRoomAgent` function (from Milestone 2) sets `currentRoomSessionIdSignal` to the synthetic ID, so `Room.tsx` should already receive it as `sessionViewId` and render `ChatContainer`.
+3. Test the flow manually or with a quick sanity check: navigating to `/room/<uuid>/agent` should show the Room Agent chat. Confirm the `isRoomAgentSelected` logic in `RoomContextPanel` still correctly highlights the Room Agent button when viewing the agent URL.
+4. In `packages/web/src/islands/ContextPanel.tsx`, verify that `RoomContextPanel` is still rendered correctly when a room is selected (the `onNavigate` prop from `ContextPanel` should still close the mobile drawer).
+5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
+
+**Acceptance criteria:**
+- Navigating to `/room/<uuid>/agent` renders the Room Agent chat view in the main content area.
+- The Room Agent sidebar item is highlighted when viewing the agent route.
+- All sidebar navigation items (Dashboard, Room Agent, goal tasks, orphan tasks, sessions) correctly switch the main content.
+- TypeScript compiles without errors.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/04-room-integration.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/04-room-integration.md
@@ -2,13 +2,13 @@
 
 ## Goal
 
-Ensure the `Room.tsx` component correctly handles the new Room Agent URL route and that all sidebar navigation targets drive the correct main content views.
+Ensure the `Room.tsx` component correctly handles the new Room Agent URL route and that all sidebar navigation targets drive the correct main content views. This is an integration validation task — its output may be minor wiring fixes plus a passing typecheck, or it may require no code changes if Milestones 2 and 3 work correctly end-to-end.
 
 ## Tasks
 
-### Task 4.1: Update Room.tsx to Handle Room Agent Route
+### Task 4.1: Validate and Fix Room.tsx Integration with New Routes
 
-**Description:** The Room Agent view currently relies on `sessionViewId` being the synthetic `room:chat:<roomId>` string. With the new `/room/:roomId/agent` route, `MainContent.tsx` passes `roomSessionId` signal which is set by the router. Verify this works end-to-end, and if the synthetic session ID approach needs adjustment, update accordingly. Also clean up any references to the removed back button.
+**Description:** Verify the end-to-end flow from new sidebar navigation to main content rendering. Fix any wiring issues found. The `Room.tsx` component renders `TaskView`, `ChatContainer`, or the tabbed dashboard based on `sessionViewId`/`taskViewId` props. Ensure the new Room Agent route, task navigation, and dashboard selection all produce the correct rendering.
 
 **Agent type:** coder
 
@@ -17,7 +17,7 @@ Ensure the `Room.tsx` component correctly handles the new Room Agent URL route a
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. Verify in `packages/web/src/islands/MainContent.tsx` that the `roomSessionId` signal (from `currentRoomSessionIdSignal`) correctly passes the synthetic `room:chat:<roomId>` value to the `Room` component's `sessionViewId` prop when navigating via the agent URL. The `navigateToRoomAgent` function (from Milestone 2) sets `currentRoomSessionIdSignal` to the synthetic ID, so `Room.tsx` should already receive it as `sessionViewId` and render `ChatContainer`.
-3. Test the flow manually or with a quick sanity check: navigating to `/room/<uuid>/agent` should show the Room Agent chat. Confirm the `isRoomAgentSelected` logic in `RoomContextPanel` still correctly highlights the Room Agent button when viewing the agent URL.
+3. Verify by running `bun run typecheck` and reviewing the signal flow: navigating to `/room/<uuid>/agent` should result in `sessionViewId` being the synthetic ID, which causes Room.tsx to render `ChatContainer`. If the flow is broken, fix the signal wiring.
 4. In `packages/web/src/islands/ContextPanel.tsx`, verify that `RoomContextPanel` is still rendered correctly when a room is selected (the `onNavigate` prop from `ContextPanel` should still close the mobile drawer).
 5. Run `bun run typecheck`, `bun run lint`, `bun run format`.
 
@@ -26,4 +26,4 @@ Ensure the `Room.tsx` component correctly handles the new Room Agent URL route a
 - The Room Agent sidebar item is highlighted when viewing the agent route.
 - All sidebar navigation items (Dashboard, Room Agent, goal tasks, orphan tasks, sessions) correctly switch the main content.
 - TypeScript compiles without errors.
-- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+- If code changes were needed, they must be on a feature branch with a GitHub PR created via `gh pr create`. If no changes were needed, document the verification performed in the PR description.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/05-unit-tests.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/05-unit-tests.md
@@ -19,7 +19,7 @@ Add unit tests covering the new computed signals, router route parsing, and the 
 2. Create `packages/web/src/lib/room-store.test.ts` (or add to existing test file if one exists):
    - Test `tasksByGoalId`: Set `roomStore.goals` and `roomStore.tasks` with known data where some tasks are in goal `linkedTaskIds`. Verify the computed Map has the correct entries.
    - Test `orphanTasks`: Verify tasks not in any goal's `linkedTaskIds` appear in this signal.
-   - Test `orphanTasksActive`: Verify only orphan tasks with status `in_progress` are included.
+   - Test `orphanTasksActive`: Verify orphan tasks with status `draft`, `pending`, or `in_progress` are included (all three statuses).
    - Test `orphanTasksReview`: Verify orphan tasks with status `review` or `needs_attention` are included.
    - Test `orphanTasksDone`: Verify orphan tasks with status `completed` or `cancelled` are included.
    - Test reactivity: Changing `tasks` or `goals` signals updates the computed signals.
@@ -62,11 +62,13 @@ Add unit tests covering the new computed signals, router route parsing, and the 
 
 **Subtasks:**
 1. Run `bun install` at the worktree root.
-2. Create or update `packages/web/src/islands/__tests__/RoomContextPanel.test.tsx`:
+2. Update `packages/web/src/islands/__tests__/RoomContextPanel.test.tsx`. **IMPORTANT:** An existing test file covers the old "New Session" button behavior — these tests WILL break after the component rewrite (the button moves to Sessions section header and becomes an icon). The existing tests must be migrated/rewritten, not just supplemented with new ones. Failure to do so will produce failing tests on `make test-web`.
+   - Remove or rewrite existing tests that reference the old "New Session" button in the top-level layout.
    - Test that the "All Rooms" back button is NOT rendered.
    - Test that Dashboard and Room Agent pinned items are rendered.
+   - Test that Dashboard is NOT highlighted when `currentRoomTaskIdSignal` is set (verifies `isDashboardSelected` logic).
    - Test Goals section: renders with correct goal count, goals are listed, expanding a goal shows linked tasks.
-   - Test Tasks section: renders orphan tasks, tab filter switches between Active/Review/Done views.
+   - Test Tasks section: renders orphan tasks, tab filter switches between Active/Review/Done views. Verify `draft`/`pending` tasks appear under "Active" tab.
    - Test Sessions section: renders with session count, has create button in header, defaults to collapsed.
    - Test selection highlighting: when `currentRoomTaskIdSignal` is set, the corresponding task item has the highlighted style.
 3. Mock `roomStore` signals and `router` navigation functions appropriately for the test environment.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/05-unit-tests.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/05-unit-tests.md
@@ -1,0 +1,78 @@
+# Milestone 5: Unit Tests
+
+## Goal
+
+Add unit tests covering the new computed signals, router route parsing, and the redesigned RoomContextPanel rendering.
+
+## Tasks
+
+### Task 5.1: Unit Tests for Room Store Computed Signals
+
+**Description:** Add unit tests for the new computed signals (`tasksByGoalId`, `orphanTasks`, `orphanTasksActive`, `orphanTasksReview`, `orphanTasksDone`) in room-store.
+
+**Agent type:** coder
+
+**Depends on:** Task 1.1 (room store computed signals)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/web/src/lib/room-store.test.ts` (or add to existing test file if one exists):
+   - Test `tasksByGoalId`: Set `roomStore.goals` and `roomStore.tasks` with known data where some tasks are in goal `linkedTaskIds`. Verify the computed Map has the correct entries.
+   - Test `orphanTasks`: Verify tasks not in any goal's `linkedTaskIds` appear in this signal.
+   - Test `orphanTasksActive`: Verify only orphan tasks with status `in_progress` are included.
+   - Test `orphanTasksReview`: Verify orphan tasks with status `review` or `needs_attention` are included.
+   - Test `orphanTasksDone`: Verify orphan tasks with status `completed` or `cancelled` are included.
+   - Test reactivity: Changing `tasks` or `goals` signals updates the computed signals.
+3. Run `cd packages/web && bunx vitest run src/lib/room-store.test.ts` to verify tests pass.
+
+**Acceptance criteria:**
+- All computed signal tests pass.
+- Edge cases covered: empty tasks, empty goals, all tasks linked, no tasks linked.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+### Task 5.2: Unit Tests for Router Room Agent Route
+
+**Description:** Add unit tests for the new Room Agent route pattern and navigation function.
+
+**Agent type:** coder
+
+**Depends on:** Task 2.1 (room agent route)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Add tests to the appropriate router test file (check for existing `packages/web/src/lib/router.test.ts` or create one):
+   - Test `getRoomAgentFromPath('/room/<uuid>/agent')` returns the room ID.
+   - Test `getRoomAgentFromPath('/room/<uuid>')` returns null.
+   - Test `getRoomIdFromPath('/room/<uuid>/agent')` returns the room ID (since it should also recognize the agent route).
+   - Test `createRoomAgentPath(roomId)` returns the correct path string.
+3. Run tests to verify they pass.
+
+**Acceptance criteria:**
+- All route parsing tests pass.
+- Both positive and negative cases covered.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+### Task 5.3: Unit Tests for Redesigned RoomContextPanel
+
+**Description:** Add unit tests for the redesigned `RoomContextPanel` component rendering, verifying the goals section, tasks section, sessions section, and navigation behavior.
+
+**Agent type:** coder
+
+**Depends on:** Task 3.2 (RoomContextPanel rewrite)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create or update `packages/web/src/islands/__tests__/RoomContextPanel.test.tsx`:
+   - Test that the "All Rooms" back button is NOT rendered.
+   - Test that Dashboard and Room Agent pinned items are rendered.
+   - Test Goals section: renders with correct goal count, goals are listed, expanding a goal shows linked tasks.
+   - Test Tasks section: renders orphan tasks, tab filter switches between Active/Review/Done views.
+   - Test Sessions section: renders with session count, has create button in header, defaults to collapsed.
+   - Test selection highlighting: when `currentRoomTaskIdSignal` is set, the corresponding task item has the highlighted style.
+3. Mock `roomStore` signals and `router` navigation functions appropriately for the test environment.
+4. Run tests to verify they pass.
+
+**Acceptance criteria:**
+- All rendering and interaction tests pass.
+- Coverage includes: section visibility, collapsible behavior, tab filtering, navigation calls, selection highlighting.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/06-e2e-tests.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/06-e2e-tests.md
@@ -18,7 +18,11 @@ Add Playwright E2E tests that verify URL-addressable navigation survives page re
 1. Run `bun install` at the worktree root.
 2. Create `packages/e2e/tests/features/room-sidebar-navigation.e2e.ts`:
    - Use the existing E2E helpers to create a room via RPC in `beforeEach` (infrastructure pattern) and delete in `afterEach`.
-   - Create at least one goal and one task in the room via RPC setup (infrastructure).
+   - Create goals and tasks via RPC setup (infrastructure). **Call sequence:**
+     1. `hub.request('task.create', { roomId, title, description })` — create tasks first
+     2. `hub.request('goal.create', { roomId, title })` — create goals (note: `goal.create` does NOT accept `linkedTaskIds`)
+     3. `hub.request('goal.linkTask', { roomId, goalId, taskId })` — link tasks to goals after creation
+   - Also create at least one orphan task (not linked to any goal) for the Tasks section tests.
    - **Test: Dashboard URL persistence** - Navigate to the room, verify URL is `/room/<id>`, reload page, verify Dashboard view is shown.
    - **Test: Room Agent URL persistence** - Click Room Agent in sidebar, verify URL changes to `/room/<id>/agent`, reload page, verify Room Agent chat is shown and Room Agent sidebar item is highlighted.
    - **Test: Task URL persistence** - Click a task in the sidebar (either under a goal or in orphan tasks), verify URL changes to `/room/<id>/task/<taskId>`, reload page, verify TaskView is shown.
@@ -43,7 +47,7 @@ Add Playwright E2E tests that verify URL-addressable navigation survives page re
 **Subtasks:**
 1. Run `bun install` at the worktree root.
 2. Create `packages/e2e/tests/features/room-sidebar-sections.e2e.ts`:
-   - Set up room with goals, linked tasks, and orphan tasks in various statuses via RPC (infrastructure).
+   - Set up room with goals, linked tasks, and orphan tasks in various statuses via RPC (infrastructure). Use the same call sequence as Task 6.1: `task.create` → `goal.create` → `goal.linkTask`. Create orphan tasks with various statuses (`in_progress`, `review`, `completed`) to test tab filtering.
    - **Test: Goals section expand/collapse** - Verify goals section is visible, click a goal to expand it, verify linked tasks are visible. Click again to collapse, verify tasks are hidden.
    - **Test: Tasks tab filtering** - Verify the Tasks section shows the Active tab by default. Click Review tab, verify only review-status tasks are shown. Click Done tab, verify only completed/cancelled tasks are shown.
    - **Test: Sessions section collapsible** - Verify the Sessions section is collapsed by default. Click to expand, verify sessions are visible. Verify the [+] button in the header is visible.

--- a/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/06-e2e-tests.md
+++ b/docs/plans/redesign-roomcontextpanel-goal-centric-sidebar-with-tasks-co/06-e2e-tests.md
@@ -1,0 +1,57 @@
+# Milestone 6: E2E Tests
+
+## Goal
+
+Add Playwright E2E tests that verify URL-addressable navigation survives page refresh, and that the sidebar's interactive features (goal expand/collapse, task tab filtering) work correctly through the browser.
+
+## Tasks
+
+### Task 6.1: E2E Test for Room Sidebar URL Navigation
+
+**Description:** Write a Playwright E2E test that verifies all room sidebar navigation targets produce correct URLs and survive page refresh.
+
+**Agent type:** coder
+
+**Depends on:** Task 4.1 (Room.tsx integration)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/e2e/tests/features/room-sidebar-navigation.e2e.ts`:
+   - Use the existing E2E helpers to create a room via RPC in `beforeEach` (infrastructure pattern) and delete in `afterEach`.
+   - Create at least one goal and one task in the room via RPC setup (infrastructure).
+   - **Test: Dashboard URL persistence** - Navigate to the room, verify URL is `/room/<id>`, reload page, verify Dashboard view is shown.
+   - **Test: Room Agent URL persistence** - Click Room Agent in sidebar, verify URL changes to `/room/<id>/agent`, reload page, verify Room Agent chat is shown and Room Agent sidebar item is highlighted.
+   - **Test: Task URL persistence** - Click a task in the sidebar (either under a goal or in orphan tasks), verify URL changes to `/room/<id>/task/<taskId>`, reload page, verify TaskView is shown.
+   - **Test: Session URL persistence** - Create a session, click it in sidebar, verify URL changes to `/room/<id>/session/<sessionId>`, reload page, verify session chat is shown.
+   - All assertions must verify visible DOM state (text content, element visibility).
+3. Run `make run-e2e TEST=tests/features/room-sidebar-navigation.e2e.ts` to verify.
+
+**Acceptance criteria:**
+- All four URL persistence tests pass.
+- Tests only use UI interactions for navigation (clicks, not direct signal manipulation).
+- Tests verify DOM state, not internal signals.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+### Task 6.2: E2E Test for Goal Expand/Collapse and Task Tab Filtering
+
+**Description:** Write a Playwright E2E test that verifies sidebar interactive features: goal expand/collapse toggles and task tab filtering.
+
+**Agent type:** coder
+
+**Depends on:** Task 4.1 (Room.tsx integration)
+
+**Subtasks:**
+1. Run `bun install` at the worktree root.
+2. Create `packages/e2e/tests/features/room-sidebar-sections.e2e.ts`:
+   - Set up room with goals, linked tasks, and orphan tasks in various statuses via RPC (infrastructure).
+   - **Test: Goals section expand/collapse** - Verify goals section is visible, click a goal to expand it, verify linked tasks are visible. Click again to collapse, verify tasks are hidden.
+   - **Test: Tasks tab filtering** - Verify the Tasks section shows the Active tab by default. Click Review tab, verify only review-status tasks are shown. Click Done tab, verify only completed/cancelled tasks are shown.
+   - **Test: Sessions section collapsible** - Verify the Sessions section is collapsed by default. Click to expand, verify sessions are visible. Verify the [+] button in the header is visible.
+   - **Test: Goals section shows correct count** - Verify the Goals section header shows the correct number of active goals.
+3. Run `make run-e2e TEST=tests/features/room-sidebar-sections.e2e.ts` to verify.
+
+**Acceptance criteria:**
+- All interactive feature tests pass.
+- Tests use only UI interactions (clicking section headers, tab buttons).
+- Tests verify visible DOM state.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.


### PR DESCRIPTION
## Summary
- 6-milestone plan to redesign the RoomContextPanel from session-centric to goal-and-task-centric layout
- Adds collapsible Goals/Tasks/Sessions sections, URL-addressable navigation for all views, and orphan task filtering
- Includes computed store signals, router enhancements, component redesign, integration, unit tests, and E2E tests

## Test plan
- [ ] Review plan structure and milestone ordering
- [ ] Verify task dependencies are correct
- [ ] Confirm scope covers all requirements from the goal description