### PR TITLE
feat: add iteration tracking columns to DB and types (Task 2.1)

### DIFF
--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -40,6 +40,7 @@ interface WorkflowRow {
 	start_step_id: string | null;
 	config: string | null;
 	layout: string | null;
+	max_iterations: number | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -135,6 +136,7 @@ function rowToWorkflow(
 		rules: cfg.rules ?? [],
 		tags: cfg.tags ?? [],
 		config: cfg.extra,
+		maxIterations: row.max_iterations ?? undefined,
 		layout: layout ?? undefined,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -178,8 +180,8 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, max_iterations, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -189,6 +191,7 @@ export class SpaceWorkflowRepository {
 				startStepId,
 				JSON.stringify(cfg),
 				layoutJson,
+				params.maxIterations ?? null,
 				now,
 				now
 			);
@@ -277,6 +280,11 @@ export class SpaceWorkflowRepository {
 		if (cfgChanged) {
 			fields.push('config = ?');
 			values.push(JSON.stringify(newCfg));
+		}
+
+		if (params.maxIterations !== undefined) {
+			fields.push('max_iterations = ?');
+			values.push(params.maxIterations);
 		}
 
 		if (params.layout !== undefined) {

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -15,6 +15,8 @@ export interface UpdateWorkflowRunParams {
 	status?: WorkflowRunStatus;
 	currentStepId?: string;
 	config?: Record<string, unknown>;
+	iterationCount?: number;
+	maxIterations?: number;
 }
 
 export class SpaceWorkflowRunRepository {
@@ -28,8 +30,8 @@ export class SpaceWorkflowRunRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -42,6 +44,8 @@ export class SpaceWorkflowRunRepository {
 			params.currentStepId ?? null,
 			'pending',
 			null,
+			0,
+			params.maxIterations ?? 5,
 			now,
 			now
 		);
@@ -138,6 +142,14 @@ export class SpaceWorkflowRunRepository {
 			fields.push('config = ?');
 			values.push(JSON.stringify(params.config));
 		}
+		if (params.iterationCount !== undefined) {
+			fields.push('iteration_count = ?');
+			values.push(params.iterationCount);
+		}
+		if (params.maxIterations !== undefined) {
+			fields.push('max_iterations = ?');
+			values.push(params.maxIterations);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -191,6 +203,8 @@ export class SpaceWorkflowRunRepository {
 			currentStepId: (row.current_step_id as string | null) ?? undefined,
 			status: row.status as WorkflowRunStatus,
 			config,
+			iterationCount: (row.iteration_count as number | undefined) ?? 0,
+			maxIterations: (row.max_iterations as number | undefined) ?? 5,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 			completedAt: (row.completed_at as number | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -132,6 +132,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 34: Add goal_id column to space_tasks for goal/mission association.
 	runMigration34(db);
+
+	// Migration 35: Add iteration tracking columns to space_workflow_runs.
+	runMigration35(db);
+
+	// Migration 36: Add max_iterations column to space_workflows.
+	runMigration36(db);
 }
 
 /**
@@ -2023,4 +2029,41 @@ function runMigration34(db: BunDatabase): void {
 		db.exec(`ALTER TABLE space_tasks ADD COLUMN goal_id TEXT`);
 	}
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+}
+
+/**
+ * Migration 35: Add iteration tracking columns to `space_workflow_runs`.
+ *
+ * - `iteration_count`: how many times the run has looped back (default 0).
+ * - `max_iterations`: safety cap before escalating to needs_attention (default 5).
+ */
+function runMigration35(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflow_runs')) return;
+	try {
+		db.prepare(`SELECT iteration_count FROM space_workflow_runs LIMIT 1`).all();
+	} catch {
+		db.exec(
+			`ALTER TABLE space_workflow_runs ADD COLUMN iteration_count INTEGER NOT NULL DEFAULT 0`
+		);
+	}
+	try {
+		db.prepare(`SELECT max_iterations FROM space_workflow_runs LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_workflow_runs ADD COLUMN max_iterations INTEGER NOT NULL DEFAULT 5`);
+	}
+}
+
+/**
+ * Migration 36: Add `max_iterations` column to `space_workflows`.
+ *
+ * Template-level default for the maximum number of cyclic iterations.
+ * Nullable — workflows without cyclic transitions don't need a cap.
+ */
+function runMigration36(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+	try {
+		db.prepare(`SELECT max_iterations FROM space_workflows LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN max_iterations INTEGER`);
+	}
 }

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -58,6 +58,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			start_step_id TEXT,
 			config TEXT,
 			layout TEXT,
+			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration34 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration36 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
  */
 
@@ -61,6 +61,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			start_step_id TEXT,
 			config TEXT,
 			layout TEXT,
+			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -110,6 +111,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			status TEXT NOT NULL DEFAULT 'pending'
 				CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
 			config TEXT,
+			iteration_count INTEGER NOT NULL DEFAULT 0,
+			max_iterations INTEGER NOT NULL DEFAULT 5,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			completed_at INTEGER,

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -76,6 +76,7 @@ function createSchema(db: Database): void {
 			start_step_id TEXT,
 			config TEXT,
 			layout TEXT,
+			max_iterations INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -476,6 +476,56 @@ describe('SpaceWorkflowRepository', () => {
 		expect(updated?.layout).toBeUndefined();
 	});
 
+	test('createWorkflow stores maxIterations', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Cyclic WF',
+			steps: [coderStep],
+			maxIterations: 3,
+		});
+		expect(wf.maxIterations).toBe(3);
+
+		const fetched = repo.getWorkflow(wf.id)!;
+		expect(fetched.maxIterations).toBe(3);
+	});
+
+	test('createWorkflow without maxIterations returns undefined', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'No Iterations WF',
+			steps: [coderStep],
+		});
+		expect(wf.maxIterations).toBeUndefined();
+	});
+
+	test('updateWorkflow sets maxIterations on an existing workflow', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF Iter',
+			steps: [coderStep],
+		});
+		expect(wf.maxIterations).toBeUndefined();
+
+		const updated = repo.updateWorkflow(wf.id, { maxIterations: 10 });
+		expect(updated?.maxIterations).toBe(10);
+
+		const fetched = repo.getWorkflow(wf.id)!;
+		expect(fetched.maxIterations).toBe(10);
+	});
+
+	test('updateWorkflow clears maxIterations when null is passed', () => {
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF Clear Iter',
+			steps: [coderStep],
+			maxIterations: 5,
+		});
+		expect(wf.maxIterations).toBe(5);
+
+		const updated = repo.updateWorkflow(wf.id, { maxIterations: null });
+		expect(updated?.maxIterations).toBeUndefined();
+	});
+
 	test('layout column contains raw JSON in the DB', () => {
 		const layout = { [coderStep.id!]: { x: 1, y: 2 } };
 		const wf = repo.createWorkflow({

--- a/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
@@ -1,0 +1,260 @@
+/**
+ * Migration 35 & 36 Tests
+ *
+ * Migration 35: Add iteration_count and max_iterations columns to space_workflow_runs.
+ * Migration 36: Add max_iterations column to space_workflows.
+ *
+ * Covers:
+ * - Fresh DB: columns exist with correct defaults after full migration
+ * - Idempotency: running migrations twice does not error
+ * - Default values: iteration_count defaults to 0, max_iterations defaults to 5 for runs
+ * - Nullable: space_workflows.max_iterations is nullable
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+	return rows.some((r) => r.name === column);
+}
+
+function getColumnDefault(db: BunDatabase, table: string, column: string): string | null {
+	const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+		name: string;
+		dflt_value: string | null;
+	}>;
+	return rows.find((r) => r.name === column)?.dflt_value ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 35: Add iteration tracking to space_workflow_runs', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-35-36', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB: iteration_count column exists after full migration', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_workflow_runs', 'iteration_count')).toBe(true);
+	});
+
+	test('fresh DB: max_iterations column exists on space_workflow_runs', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_workflow_runs', 'max_iterations')).toBe(true);
+	});
+
+	test('fresh DB: iteration_count has default value of 0', () => {
+		runMigrations(db, () => {});
+		expect(getColumnDefault(db, 'space_workflow_runs', 'iteration_count')).toBe('0');
+	});
+
+	test('fresh DB: max_iterations on runs has default value of 5', () => {
+		runMigrations(db, () => {});
+		expect(getColumnDefault(db, 'space_workflow_runs', 'max_iterations')).toBe('5');
+	});
+
+	test('fresh DB: new runs default to iteration_count=0 and max_iterations=5', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Run #1', now, now);
+
+		const row = db
+			.prepare(`SELECT iteration_count, max_iterations FROM space_workflow_runs WHERE id = 'run-1'`)
+			.get() as { iteration_count: number; max_iterations: number };
+		expect(row.iteration_count).toBe(0);
+		expect(row.max_iterations).toBe(5);
+	});
+
+	test('idempotency: running migration twice does not error', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+		expect(columnExists(db, 'space_workflow_runs', 'iteration_count')).toBe(true);
+		expect(columnExists(db, 'space_workflow_runs', 'max_iterations')).toBe(true);
+	});
+
+	test('upgrade path: existing rows get default iteration_count=0 and max_iterations=5', () => {
+		// Simulate a pre-migration-35 database with the space_workflow_runs table
+		// but without iteration columns
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY, workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL, description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '', instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT, allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'active',
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY, space_id TEXT NOT NULL, name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '', start_step_id TEXT, config TEXT, layout TEXT,
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY, space_id TEXT NOT NULL, workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL, description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0, current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending', config TEXT,
+				created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		// Confirm new columns are absent
+		expect(columnExists(db, 'space_workflow_runs', 'iteration_count')).toBe(false);
+		expect(columnExists(db, 'space_workflow_runs', 'max_iterations')).toBe(false);
+
+		// Insert existing rows before migration
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace', 'S', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'WF', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Old Run', 'in_progress', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('run-2', 'space-1', 'wf-1', 'Completed Run', 'completed', now, now);
+
+		// Run migrations
+		runMigrations(db, () => {});
+
+		// Verify columns now exist
+		expect(columnExists(db, 'space_workflow_runs', 'iteration_count')).toBe(true);
+		expect(columnExists(db, 'space_workflow_runs', 'max_iterations')).toBe(true);
+
+		// Verify existing rows got correct defaults
+		const rows = db
+			.prepare(
+				`SELECT id, iteration_count, max_iterations FROM space_workflow_runs ORDER BY id`
+			)
+			.all() as Array<{ id: string; iteration_count: number; max_iterations: number }>;
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toMatchObject({ id: 'run-1', iteration_count: 0, max_iterations: 5 });
+		expect(rows[1]).toMatchObject({ id: 'run-2', iteration_count: 0, max_iterations: 5 });
+	});
+});
+
+describe('Migration 36: Add max_iterations to space_workflows', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-35-36', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB: max_iterations column exists on space_workflows', () => {
+		runMigrations(db, () => {});
+		expect(columnExists(db, 'space_workflows', 'max_iterations')).toBe(true);
+	});
+
+	test('fresh DB: max_iterations on workflows is nullable (no default)', () => {
+		runMigrations(db, () => {});
+		expect(getColumnDefault(db, 'space_workflows', 'max_iterations')).toBeNull();
+	});
+
+	test('fresh DB: new workflows default to max_iterations=NULL', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', now, now);
+
+		const row = db
+			.prepare(`SELECT max_iterations FROM space_workflows WHERE id = 'wf-1'`)
+			.get() as { max_iterations: number | null };
+		expect(row.max_iterations).toBeNull();
+	});
+
+	test('fresh DB: max_iterations can be set on workflows', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/project', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, max_iterations, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Cyclic Workflow', 3, now, now);
+
+		const row = db
+			.prepare(`SELECT max_iterations FROM space_workflows WHERE id = 'wf-1'`)
+			.get() as { max_iterations: number | null };
+		expect(row.max_iterations).toBe(3);
+	});
+
+	test('idempotency: running migration twice does not error', () => {
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+		expect(columnExists(db, 'space_workflows', 'max_iterations')).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-35-36_test.ts
@@ -173,9 +173,7 @@ describe('Migration 35: Add iteration tracking to space_workflow_runs', () => {
 
 		// Verify existing rows got correct defaults
 		const rows = db
-			.prepare(
-				`SELECT id, iteration_count, max_iterations FROM space_workflow_runs ORDER BY id`
-			)
+			.prepare(`SELECT id, iteration_count, max_iterations FROM space_workflow_runs ORDER BY id`)
 			.all() as Array<{ id: string; iteration_count: number; max_iterations: number }>;
 		expect(rows).toHaveLength(2);
 		expect(rows[0]).toMatchObject({ id: 'run-1', iteration_count: 0, max_iterations: 5 });

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -179,6 +179,51 @@ describe('SpaceWorkflowRunRepository', () => {
 		});
 	});
 
+	describe('iteration tracking', () => {
+		it('defaults iterationCount to 0 and maxIterations to 5', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			expect(run.iterationCount).toBe(0);
+			expect(run.maxIterations).toBe(5);
+		});
+
+		it('creates a run with custom maxIterations', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Custom cap',
+				maxIterations: 3,
+			});
+			expect(run.maxIterations).toBe(3);
+			expect(run.iterationCount).toBe(0);
+		});
+
+		it('updates iterationCount via updateRun', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateRun(run.id, { iterationCount: 2 });
+			expect(updated!.iterationCount).toBe(2);
+			// Re-fetch to confirm persistence
+			expect(repo.getRun(run.id)!.iterationCount).toBe(2);
+		});
+
+		it('updates maxIterations via updateRun', () => {
+			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });
+			const updated = repo.updateRun(run.id, { maxIterations: 10 });
+			expect(updated!.maxIterations).toBe(10);
+		});
+
+		it('round-trips iteration fields through create → get', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Round-trip',
+				maxIterations: 7,
+			});
+			const fetched = repo.getRun(run.id)!;
+			expect(fetched.iterationCount).toBe(0);
+			expect(fetched.maxIterations).toBe(7);
+		});
+	});
+
 	describe('deleteRun', () => {
 		it('deletes a run', () => {
 			const run = repo.createRun({ spaceId, workflowId: WORKFLOW_ID, title: 'R' });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -306,6 +306,10 @@ export interface SpaceWorkflowRun {
 	status: WorkflowRunStatus;
 	/** Optional runtime configuration for this run */
 	config?: Record<string, unknown>;
+	/** Number of times the run has looped back to a previously visited step */
+	iterationCount: number;
+	/** Maximum iterations before escalating to needs_attention */
+	maxIterations: number;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -328,6 +332,8 @@ export interface CreateWorkflowRunParams {
 	 * updateCurrentStep() before calling advance().
 	 */
 	currentStepId?: string;
+	/** Maximum iterations before escalating to needs_attention (overrides workflow default) */
+	maxIterations?: number;
 }
 
 // ============================================================================
@@ -622,6 +628,8 @@ export interface SpaceWorkflow {
 	tags: string[];
 	/** Additional runtime configuration (opaque bag for future extensibility) */
 	config?: Record<string, unknown>;
+	/** Maximum iterations for cyclic workflows before escalating to needs_attention */
+	maxIterations?: number;
 	/** Visual editor node positions: maps step ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;
 	/** Creation timestamp (milliseconds since epoch) */
@@ -663,6 +671,8 @@ export interface CreateSpaceWorkflowParams {
 	/** Tags for organizational categorization (default: []). Not used for automatic workflow selection. */
 	tags?: string[];
 	config?: Record<string, unknown>;
+	/** Maximum iterations for cyclic workflows before escalating to needs_attention */
+	maxIterations?: number;
 	/** Visual editor node positions: maps step ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;
 }
@@ -705,6 +715,8 @@ export interface UpdateSpaceWorkflowParams {
 	 */
 	tags?: string[] | null;
 	config?: Record<string, unknown> | null;
+	/** Maximum iterations for cyclic workflows. Pass `null` to clear. */
+	maxIterations?: number | null;
 	/** Visual editor node positions. Pass `null` to clear. */
 	layout?: Record<string, { x: number; y: number }> | null;
 }

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -65,6 +65,8 @@ function makeRun(id: string, status = 'pending'): SpaceWorkflowRun {
 		workflowId: 'wf-1',
 		title: `Run ${id}`,
 		status: status as SpaceWorkflowRun['status'],
+		iterationCount: 0,
+		maxIterations: 5,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 	};


### PR DESCRIPTION
## Summary

- Add `iterationCount` and `maxIterations` fields to `SpaceWorkflowRun` type for tracking cyclic workflow iterations
- Add `maxIterations` to `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`, and `CreateWorkflowRunParams` as first-class typed fields
- Add Migration 35: `iteration_count` (default 0) and `max_iterations` (default 5) columns on `space_workflow_runs`
- Add Migration 36: `max_iterations` (nullable) column on `space_workflows`
- Update `SpaceWorkflowRunRepository` to persist and read `iteration_count` and `max_iterations`
- Update `SpaceWorkflowRepository` to persist and read `max_iterations`
- Update `space-test-db.ts` helper to include new columns

## Test plan

- [x] Migration 35/36 unit tests: column existence, defaults, idempotency
- [x] Workflow run repository tests: default values, custom maxIterations, updateRun with iteration fields, round-trip
- [x] Workflow repository tests: createWorkflow with maxIterations, updateWorkflow set/clear maxIterations
- [x] Typecheck passes
- [x] All pre-commit checks pass (lint, format, typecheck, knip)