### PR TITLE
feat: propagate goalId through workflow task creation (Task 3.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -39,6 +39,7 @@ export function setupSpaceWorkflowRunHandlers(
 			workflowId?: string;
 			title: string;
 			description?: string;
+			goalId?: string;
 		};
 
 		if (!params.spaceId) throw new Error('spaceId is required');
@@ -73,7 +74,8 @@ export function setupSpaceWorkflowRunHandlers(
 			params.spaceId,
 			workflowId,
 			params.title,
-			params.description
+			params.description,
+			params.goalId
 		);
 
 		daemonHub

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -284,7 +284,8 @@ export class SpaceRuntime {
 		spaceId: string,
 		workflowId: string,
 		title: string,
-		description?: string
+		description?: string,
+		goalId?: string
 	): Promise<{ run: SpaceWorkflowRun; tasks: SpaceTask[] }> {
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(workflowId);
 		if (!workflow) {
@@ -303,6 +304,7 @@ export class SpaceRuntime {
 			title,
 			description,
 			currentStepId: workflow.startStepId,
+			goalId,
 		});
 
 		const run = this.config.workflowRunRepo.updateStatus(pendingRun.id, 'in_progress')!;
@@ -334,6 +336,7 @@ export class SpaceRuntime {
 				taskType: resolved.taskType,
 				customAgentId: resolved.customAgentId,
 				status: 'pending',
+				goalId: run.goalId,
 			});
 		} catch (err) {
 			// Clean up the executor/meta entries so the run is not orphaned in the map.

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -373,6 +373,7 @@ export class WorkflowExecutor {
 			taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
 			customAgentId: resolved !== undefined ? resolved.customAgentId : nextStep.agentId,
 			status: 'pending',
+			goalId: this.run.goalId,
 		});
 
 		return { step: nextStep, tasks: [task] };

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -587,6 +587,7 @@ export function createGlobalSpacesMcpServer(
 				workflow_id: z.string().describe('ID of the workflow to run'),
 				title: z.string().describe('Short title for this workflow run'),
 				description: z.string().optional().describe('Description of the work'),
+				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
 			},
 			(args) => handlers.start_workflow_run(args)
 		),

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -227,6 +227,7 @@ export function createGlobalSpacesToolHandlers(
 			workflow_id: string;
 			title: string;
 			description?: string;
+			goal_id?: string;
 		}): Promise<ToolResult> {
 			const resolved = resolveSpaceId(args.space_id);
 			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });
@@ -235,7 +236,8 @@ export function createGlobalSpacesToolHandlers(
 					resolved.spaceId,
 					args.workflow_id,
 					args.title,
-					args.description
+					args.description,
+					args.goal_id
 				);
 				return jsonResult({ success: true, space_id: resolved.spaceId, run, tasks });
 			} catch (err) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -495,6 +495,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('ID of the workflow to run (required — choose from list_workflows)'),
 				title: z.string().describe('Short title for this workflow run'),
 				description: z.string().optional().describe('Detailed description of the work to be done'),
+				goal_id: z.string().optional().describe('Goal/mission ID to associate with this run'),
 			},
 			(args) => handlers.start_workflow_run(args)
 		),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -97,13 +97,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			workflow_id: string;
 			title: string;
 			description?: string;
+			goal_id?: string;
 		}): Promise<ToolResult> {
 			try {
 				const { run, tasks } = await runtime.startWorkflowRun(
 					spaceId,
 					args.workflow_id,
 					args.title,
-					args.description
+					args.description,
+					args.goal_id
 				);
 				return jsonResult({ success: true, run, tasks });
 			} catch (err) {
@@ -180,7 +182,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 						spaceId,
 						args.workflow_id,
 						run.title,
-						newDescription
+						newDescription,
+						run.goalId
 					);
 					return jsonResult({
 						success: true,

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -30,8 +30,8 @@ export class SpaceWorkflowRunRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -46,6 +46,7 @@ export class SpaceWorkflowRunRepository {
 			null,
 			0,
 			params.maxIterations ?? 5,
+			params.goalId ?? null,
 			now,
 			now
 		);
@@ -205,6 +206,7 @@ export class SpaceWorkflowRunRepository {
 			config,
 			iterationCount: (row.iteration_count as number | undefined) ?? 0,
 			maxIterations: (row.max_iterations as number | undefined) ?? 5,
+			goalId: (row.goal_id as string | null) ?? undefined,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 			completedAt: (row.completed_at as number | null) ?? undefined,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -138,6 +138,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 36: Add max_iterations column to space_workflows.
 	runMigration36(db);
+
+	// Migration 37: Add goal_id column to space_workflow_runs for goal/mission association.
+	runMigration37(db);
 }
 
 /**
@@ -2066,4 +2069,19 @@ function runMigration36(db: BunDatabase): void {
 	} catch {
 		db.exec(`ALTER TABLE space_workflows ADD COLUMN max_iterations INTEGER`);
 	}
+}
+
+/**
+ * Migration 37: Add goal_id column to space_workflow_runs for goal/mission association.
+ */
+function runMigration37(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflow_runs')) return;
+	try {
+		db.prepare(`SELECT goal_id FROM space_workflow_runs LIMIT 1`).all();
+	} catch {
+		db.exec(`ALTER TABLE space_workflow_runs ADD COLUMN goal_id TEXT`);
+	}
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_goal_id ON space_workflow_runs(goal_id)`
+	);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration36 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration37 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
  */
 
@@ -113,6 +113,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			config TEXT,
 			iteration_count INTEGER NOT NULL DEFAULT 0,
 			max_iterations INTEGER NOT NULL DEFAULT 5,
+			goal_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			completed_at INTEGER,

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -320,7 +320,8 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'My Run',
-				'Some context'
+				'Some context',
+				undefined
 			);
 			expect(daemonHub.emit).toHaveBeenCalledWith('space.workflowRun.created', {
 				sessionId: 'global',
@@ -336,6 +337,7 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'Auto',
+				undefined,
 				undefined
 			);
 		});
@@ -350,7 +352,23 @@ describe('space-workflow-run-handlers', () => {
 				'space-1',
 				'workflow-1',
 				'Explicit WF',
+				undefined,
 				undefined
+			);
+		});
+
+		it('passes goalId through to startWorkflowRun', async () => {
+			await call('spaceWorkflowRun.start', {
+				spaceId: 'space-1',
+				title: 'Goal Run',
+				goalId: 'goal-rpc-123',
+			});
+			expect(runtime.startWorkflowRun).toHaveBeenCalledWith(
+				'space-1',
+				'workflow-1',
+				'Goal Run',
+				undefined,
+				'goal-rpc-123'
 			);
 		});
 	});

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -413,6 +413,136 @@ describe('SpaceRuntime', () => {
 
 			expect(run.description).toBe('Some description');
 		});
+
+		test('stores goalId on run record and propagates to initial task', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Goal Run',
+				undefined,
+				'goal-abc'
+			);
+
+			expect(run.goalId).toBe('goal-abc');
+			expect(tasks[0].goalId).toBe('goal-abc');
+		});
+
+		test('goalId defaults to undefined when not provided', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'No Goal');
+
+			expect(run.goalId).toBeUndefined();
+			expect(tasks[0].goalId).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// goalId propagation through workflow advancement
+	// -------------------------------------------------------------------------
+
+	describe('goalId propagation through workflow advancement', () => {
+		test('goalId propagates to tasks created by followTransition on advance', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Goal Propagation Run',
+				undefined,
+				'goal-propagate'
+			);
+
+			// Initial task should have goalId
+			expect(tasks[0].goalId).toBe('goal-propagate');
+
+			// Complete step A → tick → step B task created with goalId
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(2);
+
+			const stepBTask = allTasks.find((t) => t.workflowStepId === STEP_B);
+			expect(stepBTask).toBeDefined();
+			expect(stepBTask!.goalId).toBe('goal-propagate');
+		});
+
+		test('goalId propagates through all steps of a three-step workflow', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+					{ id: STEP_C, name: 'Review', agentId: AGENT_GENERAL },
+				],
+				[{ type: 'always' }, { type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Full Goal Run',
+				undefined,
+				'goal-full'
+			);
+
+			// Complete step A → tick
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			// Complete step B → tick
+			const stepBTask = taskRepo
+				.listByWorkflowRun(run.id)
+				.find((t) => t.workflowStepId === STEP_B)!;
+			taskRepo.updateTask(stepBTask.id, { status: 'completed' });
+			await runtime.executeTick();
+
+			// All three tasks should have the goalId
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			expect(allTasks).toHaveLength(3);
+			for (const task of allTasks) {
+				expect(task.goalId).toBe('goal-full');
+			}
+		});
+
+		test('tasks have no goalId when run has no goalId', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[{ type: 'always' }]
+			);
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'No Goal Run');
+
+			// Complete step A → tick
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			await runtime.executeTick();
+
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			for (const task of allTasks) {
+				expect(task.goalId).toBeUndefined();
+			}
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-workflow-run-repository.test.ts
@@ -235,4 +235,100 @@ describe('SpaceWorkflowRunRepository', () => {
 			expect(repo.deleteRun('nonexistent')).toBe(false);
 		});
 	});
+
+	describe('goalId', () => {
+		it('creates a run with goalId and persists it', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Goal Run',
+				goalId: 'goal-123',
+			});
+
+			expect(run.goalId).toBe('goal-123');
+
+			// Verify persistence via re-fetch
+			const fetched = repo.getRun(run.id)!;
+			expect(fetched.goalId).toBe('goal-123');
+		});
+
+		it('creates a run without goalId — maps to undefined', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'No Goal',
+			});
+
+			expect(run.goalId).toBeUndefined();
+
+			// Re-fetch from DB to confirm persistence
+			expect(repo.getRun(run.id)!.goalId).toBeUndefined();
+		});
+
+		it('goalId survives status and step updates', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Goal Persist',
+				goalId: 'goal-456',
+			});
+
+			repo.updateStatus(run.id, 'in_progress');
+			repo.updateCurrentStep(run.id, 'step-xyz');
+
+			const updated = repo.getRun(run.id)!;
+			expect(updated.goalId).toBe('goal-456');
+			expect(updated.status).toBe('in_progress');
+			expect(updated.currentStepId).toBe('step-xyz');
+		});
+
+		it('goalId is included when listing runs by space', () => {
+			repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'G1',
+				goalId: 'goal-a',
+			});
+			repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'G2',
+			});
+
+			const runs = repo.listBySpace(spaceId);
+			expect(runs).toHaveLength(2);
+			const withGoal = runs.find((r) => r.title === 'G1')!;
+			const withoutGoal = runs.find((r) => r.title === 'G2')!;
+			expect(withGoal.goalId).toBe('goal-a');
+			expect(withoutGoal.goalId).toBeUndefined();
+		});
+
+		it('goalId is included in getActiveRuns results', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Active Goal',
+				goalId: 'goal-active',
+			});
+			repo.updateStatus(run.id, 'in_progress');
+
+			const active = repo.getActiveRuns(spaceId);
+			expect(active).toHaveLength(1);
+			expect(active[0].goalId).toBe('goal-active');
+		});
+
+		it('goalId is included in getRehydratableRuns results', () => {
+			const run = repo.createRun({
+				spaceId,
+				workflowId: WORKFLOW_ID,
+				title: 'Needs Attn',
+				goalId: 'goal-rehydrate',
+			});
+			repo.updateStatus(run.id, 'needs_attention');
+
+			const rehydratable = repo.getRehydratableRuns(spaceId);
+			expect(rehydratable).toHaveLength(1);
+			expect(rehydratable[0].goalId).toBe('goal-rehydrate');
+		});
+	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -310,6 +310,8 @@ export interface SpaceWorkflowRun {
 	iterationCount: number;
 	/** Maximum iterations before escalating to needs_attention */
 	maxIterations: number;
+	/** Optional goal/mission ID this run is associated with */
+	goalId?: string;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -334,6 +336,8 @@ export interface CreateWorkflowRunParams {
 	currentStepId?: string;
 	/** Maximum iterations before escalating to needs_attention (overrides workflow default) */
 	maxIterations?: number;
+	/** Optional goal/mission ID to associate with this run */
+	goalId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `goalId?: string` to `SpaceWorkflowRun` type and `CreateWorkflowRunParams` in shared types
- Adds migration 35 for `goal_id TEXT` column + index on `space_workflow_runs` table
- Updates `SpaceWorkflowRunRepository` to persist and read `goal_id` in `createRun()` and `rowToRun()`
- Passes `goalId` from the run record to tasks created in `WorkflowExecutor.followTransition()`
- Accepts optional `goalId` parameter in `SpaceRuntime.startWorkflowRun()` and propagates it to both the run record and the initial task

## Test plan

- [x] 6 new repository tests: goalId persistence, undefined default, survival across updates, inclusion in list/active/rehydratable queries
- [x] 5 new runtime tests: goalId on run + initial task, undefined default, propagation through multi-step advancement, no goalId when run has none
- [x] All 22 repository tests pass
- [x] All 54 runtime tests pass
- [x] Typecheck passes
- [x] Lint, format, and knip all pass