### PR TITLE
feat: add archived status to TaskStatus and SpaceTaskStatus unions

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -28,9 +28,10 @@ export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	pending: ['in_progress', 'cancelled'],
 	in_progress: ['review', 'completed', 'needs_attention', 'cancelled'],
 	review: ['completed', 'needs_attention', 'in_progress'],
-	completed: [], // Terminal state
-	needs_attention: ['pending', 'in_progress', 'review'], // Restart allowed + revive to review via message
-	cancelled: ['pending', 'in_progress'], // Restart only — worktree is cleaned up on cancel
+	completed: ['in_progress', 'archived'], // Reactivate or archive
+	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
+	cancelled: ['pending', 'in_progress', 'archived'], // Restart or archive
+	archived: [], // True terminal state — no going back
 };
 
 /**

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -410,14 +410,20 @@ export class TaskManager {
 	}
 
 	/**
-	 * Archive task - sets archivedAt timestamp.
-	 * Archived tasks are hidden from UI by default.
-	 * This is orthogonal to task status - any task can be archived.
+	 * Archive task - transitions to 'archived' status and sets archivedAt timestamp.
+	 * Validates that the current status allows transitioning to 'archived'.
 	 */
 	async archiveTask(taskId: string): Promise<NeoTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		if (!isValidStatusTransition(task.status, 'archived')) {
+			throw new Error(
+				`Cannot archive task in '${task.status}' status. ` +
+					`Allowed transitions: ${VALID_STATUS_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
 		}
 
 		const updatedTask = this.taskRepo.archiveTask(taskId);

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -4,7 +4,7 @@
  * Handles:
  * - Creating tasks
  * - Listing and filtering tasks
- * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review)
+ * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review -> archived)
  * - Task assignment to sessions
  */
 
@@ -214,12 +214,12 @@ export class TaskManager {
 			}
 		}
 
-		// Clear error/result when restarting from needs_attention/cancelled, or when reviving
-		// a needs_attention task to review. The 'review' case only applies to 'needs_attention' since
-		// 'cancelled → review' is not a valid transition (worktree is cleaned up).
+		// Clear error/result/progress when restarting from a terminal/failed state.
+		// Covers needs_attention, cancelled, and completed → reactivation transitions.
 		if (
-			(task.status === 'needs_attention' || task.status === 'cancelled') &&
-			(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')
+			((task.status === 'needs_attention' || task.status === 'cancelled') &&
+				(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')) ||
+			(task.status === 'completed' && newStatus === 'in_progress')
 		) {
 			// Use null to explicitly clear these fields in the database
 			updates.error = null;

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -132,6 +132,7 @@ export function setupTaskHandlers(
 			roomId: string;
 			status?: TaskStatus;
 			priority?: TaskPriority;
+			includeArchived?: boolean;
 		};
 
 		if (!params.roomId) {
@@ -142,6 +143,7 @@ export function setupTaskHandlers(
 		const tasks = await taskManager.listTasks({
 			status: params.status,
 			priority: params.priority,
+			includeArchived: params.includeArchived,
 		});
 
 		return { tasks };

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -3,7 +3,7 @@
  *
  * Handles:
  * - Creating space tasks with dependency validation
- * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review)
+ * - Status transitions (draft -> pending -> in_progress -> completed/needs_attention/cancelled/review -> archived)
  * - Task assignment and progress tracking
  */
 
@@ -128,13 +128,13 @@ export class SpaceTaskManager {
 			updates.error = options.error;
 		}
 
-		// Clear error/result/progress when restarting from a failed/cancelled state.
-		// For needs_attention: allowed targets are pending, in_progress, review.
-		// For cancelled: allowed targets are pending, in_progress (review is not valid from cancelled).
+		// Clear error/result/progress when restarting from a terminal/failed state.
+		// Covers needs_attention, cancelled, and completed → reactivation transitions.
 		if (
 			(task.status === 'needs_attention' &&
 				(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')) ||
-			(task.status === 'cancelled' && (newStatus === 'pending' || newStatus === 'in_progress'))
+			(task.status === 'cancelled' && (newStatus === 'pending' || newStatus === 'in_progress')) ||
+			(task.status === 'completed' && newStatus === 'in_progress')
 		) {
 			updates.error = null;
 			updates.result = null;
@@ -323,7 +323,8 @@ export class SpaceTaskManager {
 	}
 
 	/**
-	 * Retry a failed or cancelled task by resetting it to pending.
+	 * Retry a failed, cancelled, or completed task.
+	 * Completed/cancelled tasks are reactivated to in_progress; needs_attention tasks reset to pending.
 	 * Optionally updates the description on retry.
 	 *
 	 * This is a daemon-internal method called by Space Agent MCP tools (not exposed via RPC handlers).
@@ -345,7 +346,6 @@ export class SpaceTaskManager {
 		const targetStatus: SpaceTaskStatus =
 			task.status === 'completed' || task.status === 'cancelled' ? 'in_progress' : 'pending';
 		// Transition first — if this fails, the description is untouched (no partial state)
-		// setTaskStatus handles clearing error/result/progress on transition
 		const retried = await this.setTaskStatus(taskId, targetStatus);
 
 		// Apply optional description update after successful status transition

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -261,12 +261,20 @@ export class SpaceTaskManager {
 	}
 
 	/**
-	 * Archive a task
+	 * Archive a task - transitions to 'archived' status and sets archivedAt timestamp.
+	 * Validates that the current status allows transitioning to 'archived'.
 	 */
 	async archiveTask(taskId: string): Promise<SpaceTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
+		}
+
+		if (!isValidSpaceTaskTransition(task.status, 'archived')) {
+			throw new Error(
+				`Cannot archive task in '${task.status}' status. ` +
+					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
 		}
 
 		const updated = this.taskRepo.archiveTask(taskId);

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -358,8 +358,8 @@ export class SpaceTaskManager {
 
 	/**
 	 * Reassign a task to a different agent.
-	 * Only allowed for tasks in 'pending', 'needs_attention', or 'cancelled' status.
-	 * Tasks in 'in_progress', 'review', 'completed', or 'draft' cannot be reassigned.
+	 * Only allowed for tasks in 'pending', 'needs_attention', 'cancelled', or 'completed' status.
+	 * Tasks in 'in_progress', 'review', or 'draft' cannot be reassigned.
 	 *
 	 * This is a daemon-internal method called by Space Agent MCP tools (not exposed via RPC handlers).
 	 */

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -25,9 +25,10 @@ export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStat
 	pending: ['in_progress', 'cancelled'],
 	in_progress: ['review', 'completed', 'needs_attention', 'cancelled'],
 	review: ['completed', 'needs_attention', 'in_progress'],
-	completed: [],
-	needs_attention: ['pending', 'in_progress', 'review'],
-	cancelled: ['pending', 'in_progress'],
+	completed: ['in_progress', 'archived'], // Reactivate or archive
+	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
+	cancelled: ['pending', 'in_progress', 'archived'], // Restart or archive
+	archived: [], // True terminal state — no going back
 };
 
 /**
@@ -325,15 +326,19 @@ export class SpaceTaskManager {
 			throw new Error(`Task not found: ${taskId}`);
 		}
 
-		if (task.status !== 'needs_attention' && task.status !== 'cancelled') {
+		const retryableStatuses: SpaceTaskStatus[] = ['needs_attention', 'cancelled', 'completed'];
+		if (!retryableStatuses.includes(task.status)) {
 			throw new Error(
-				`Cannot retry task in '${task.status}' status. Task must be in 'needs_attention' or 'cancelled' status.`
+				`Cannot retry task in '${task.status}' status. Task must be in 'needs_attention', 'cancelled', or 'completed' status.`
 			);
 		}
 
+		// Transition to in_progress for completed/cancelled (reactivation), pending for needs_attention
+		const targetStatus: SpaceTaskStatus =
+			task.status === 'completed' || task.status === 'cancelled' ? 'in_progress' : 'pending';
 		// Transition first — if this fails, the description is untouched (no partial state)
-		// setTaskStatus handles clearing error/result/progress on transition from needs_attention/cancelled -> pending
-		const retried = await this.setTaskStatus(taskId, 'pending');
+		// setTaskStatus handles clearing error/result/progress on transition
+		const retried = await this.setTaskStatus(taskId, targetStatus);
 
 		// Apply optional description update after successful status transition
 		if (options?.description !== undefined) {
@@ -360,10 +365,15 @@ export class SpaceTaskManager {
 			throw new Error(`Task not found: ${taskId}`);
 		}
 
-		const allowedStatuses: SpaceTaskStatus[] = ['pending', 'needs_attention', 'cancelled'];
+		const allowedStatuses: SpaceTaskStatus[] = [
+			'pending',
+			'needs_attention',
+			'cancelled',
+			'completed',
+		];
 		if (!allowedStatuses.includes(task.status)) {
 			throw new Error(
-				`Cannot reassign task in '${task.status}' status. Task must be in 'pending', 'needs_attention', or 'cancelled' status.`
+				`Cannot reassign task in '${task.status}' status. Task must be in 'pending', 'needs_attention', 'cancelled', or 'completed' status.`
 			);
 		}
 

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -69,7 +69,7 @@ export class SpaceTaskRepository {
 	listBySpace(spaceId: string, includeArchived = false): SpaceTask[] {
 		let query = `SELECT * FROM space_tasks WHERE space_id = ?`;
 		if (!includeArchived) {
-			query += ` AND archived_at IS NULL`;
+			query += ` AND status != 'archived'`;
 		}
 		query += ` ORDER BY updated_at DESC`;
 
@@ -83,7 +83,7 @@ export class SpaceTaskRepository {
 	 */
 	listByWorkflowRun(workflowRunId: string): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE workflow_run_id = ? AND archived_at IS NULL ORDER BY created_at ASC`
+			`SELECT * FROM space_tasks WHERE workflow_run_id = ? AND status != 'archived' ORDER BY created_at ASC`
 		);
 		const rows = stmt.all(workflowRunId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
@@ -107,7 +107,7 @@ export class SpaceTaskRepository {
 	listStandaloneBySpace(spaceId: string, includeArchived = false): SpaceTask[] {
 		let query = `SELECT * FROM space_tasks WHERE space_id = ? AND workflow_run_id IS NULL`;
 		if (!includeArchived) {
-			query += ` AND archived_at IS NULL`;
+			query += ` AND status != 'archived'`;
 		}
 		query += ` ORDER BY updated_at DESC`;
 
@@ -121,7 +121,7 @@ export class SpaceTaskRepository {
 	 */
 	listByStatus(spaceId: string, status: SpaceTaskStatus): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? AND archived_at IS NULL ORDER BY updated_at DESC`
+			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? AND status != 'archived' ORDER BY updated_at DESC`
 		);
 		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
@@ -256,12 +256,13 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * Archive a task by setting archived_at timestamp
+	 * Archive a task by setting status to 'archived' and archived_at timestamp.
+	 * status = 'archived' is the canonical source of truth; archived_at is a derived timestamp.
 	 */
 	archiveTask(id: string): SpaceTask | null {
 		const now = Date.now();
 		const stmt = this.db.prepare(
-			`UPDATE space_tasks SET archived_at = ?, updated_at = ? WHERE id = ?`
+			`UPDATE space_tasks SET status = 'archived', archived_at = ?, updated_at = ? WHERE id = ?`
 		);
 		stmt.run(now, now, id);
 		return this.getTask(id);
@@ -304,7 +305,7 @@ export class SpaceTaskRepository {
 	 */
 	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'needs_attention') AND task_agent_session_id IS NOT NULL AND archived_at IS NULL`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'needs_attention') AND task_agent_session_id IS NOT NULL AND status != 'archived'`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -159,6 +159,9 @@ export class SpaceTaskRepository {
 			) {
 				fields.push('completed_at = ?');
 				values.push(Date.now());
+			} else if (params.status === 'archived') {
+				fields.push('archived_at = ?');
+				values.push(Date.now());
 			}
 		}
 		if (params.priority !== undefined) {
@@ -214,7 +217,8 @@ export class SpaceTaskRepository {
 			params.activeSession === undefined &&
 			(params.status === 'completed' ||
 				params.status === 'needs_attention' ||
-				params.status === 'cancelled')
+				params.status === 'cancelled' ||
+				params.status === 'archived')
 		) {
 			fields.push('active_session = ?');
 			values.push(null);

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -121,7 +121,7 @@ export class SpaceTaskRepository {
 	 */
 	listByStatus(spaceId: string, status: SpaceTaskStatus): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? AND status != 'archived' ORDER BY updated_at DESC`
+			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC`
 		);
 		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -309,7 +309,7 @@ export class SpaceTaskRepository {
 	 */
 	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'needs_attention') AND task_agent_session_id IS NOT NULL AND status != 'archived'`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'needs_attention') AND task_agent_session_id IS NOT NULL`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -126,6 +126,9 @@ export class TaskRepository {
 			) {
 				fields.push('completed_at = ?');
 				values.push(Date.now());
+			} else if (params.status === 'archived') {
+				fields.push('archived_at = ?');
+				values.push(Date.now());
 			}
 		}
 		if (params.priority !== undefined) {

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -161,7 +161,8 @@ export class TaskRepository {
 			params.activeSession === undefined &&
 			(params.status === 'completed' ||
 				params.status === 'needs_attention' ||
-				params.status === 'cancelled')
+				params.status === 'cancelled' ||
+				params.status === 'archived')
 		) {
 			fields.push('active_session = ?');
 			values.push(null);
@@ -236,11 +237,11 @@ export class TaskRepository {
 	}
 
 	/**
-	 * Count all active (non-completed, non-needs_attention, non-cancelled) tasks for a room
+	 * Count all active (non-completed, non-needs_attention, non-cancelled, non-archived) tasks for a room
 	 */
 	countActiveTasks(roomId: string): number {
 		const stmt = this.db.prepare(
-			`SELECT COUNT(*) as count FROM tasks WHERE room_id = ? AND status NOT IN ('completed', 'needs_attention', 'cancelled')`
+			`SELECT COUNT(*) as count FROM tasks WHERE room_id = ? AND status NOT IN ('completed', 'needs_attention', 'cancelled', 'archived')`
 		);
 		const result = stmt.get(roomId) as { count: number };
 		return result.count;

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -69,7 +69,7 @@ export class TaskRepository {
 
 	/**
 	 * List tasks for a room, optionally filtered.
-	 * By default, archived tasks (archived_at IS NOT NULL) are excluded.
+	 * By default, archived tasks (status = 'archived') are excluded.
 	 * Use filter.includeArchived = true to include archived tasks.
 	 */
 	listTasks(roomId: string, filter?: TaskFilter): NeoTask[] {

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -76,9 +76,9 @@ export class TaskRepository {
 		let query = `SELECT * FROM tasks WHERE room_id = ?`;
 		const params: SQLiteValue[] = [roomId];
 
-		// Exclude archived tasks by default
+		// Exclude archived tasks by default (status is the source of truth for archival)
 		if (!filter?.includeArchived) {
-			query += ` AND archived_at IS NULL`;
+			query += ` AND status != 'archived'`;
 		}
 
 		if (filter?.status) {
@@ -202,13 +202,16 @@ export class TaskRepository {
 	}
 
 	/**
-	 * Archive a task by setting archived_at timestamp.
+	 * Archive a task by setting status to 'archived' and archived_at timestamp.
+	 * status = 'archived' is the canonical source of truth; archived_at is a derived timestamp.
 	 * Archived tasks are hidden from UI by default.
 	 * Returns the updated task or null if not found.
 	 */
 	archiveTask(id: string): NeoTask | null {
 		const now = Date.now();
-		const stmt = this.db.prepare(`UPDATE tasks SET archived_at = ?, updated_at = ? WHERE id = ?`);
+		const stmt = this.db.prepare(
+			`UPDATE tasks SET status = 'archived', archived_at = ?, updated_at = ? WHERE id = ?`
+		);
 		stmt.run(now, now, id);
 		return this.getTask(id);
 	}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -142,7 +142,7 @@ export function createTables(db: BunDatabase): void {
         room_id TEXT NOT NULL,
         title TEXT NOT NULL,
         description TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
         priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
         progress INTEGER,
         current_step TEXT,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -144,6 +144,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 38: Add is_cyclic column to space_workflow_transitions.
 	runMigration38(db);
+
+	// Migration 39: Add 'archived' to status CHECK constraints on tasks and space_tasks.
+	runMigration39(db);
 }
 
 /**
@@ -1645,7 +1648,7 @@ function runMigration29(db: BunDatabase): void {
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'pending'
-				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
 			priority TEXT NOT NULL DEFAULT 'normal'
 				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
 			task_type TEXT
@@ -2104,5 +2107,209 @@ function runMigration38(db: BunDatabase): void {
 		db.prepare(`SELECT is_cyclic FROM space_workflow_transitions LIMIT 1`).all();
 	} catch {
 		db.exec(`ALTER TABLE space_workflow_transitions ADD COLUMN is_cyclic INTEGER`);
+	}
+}
+
+/**
+ * Migration 39: Add 'archived' to the status CHECK constraint on `tasks` and `space_tasks`.
+ *
+ * Uses the SQLite table-rebuild pattern (same as migration 18) because SQLite does not
+ * support ALTER TABLE … ALTER CONSTRAINT.
+ *
+ * After the rebuild, backfills any rows where `archived_at IS NOT NULL` to
+ * `status = 'archived'` so the status column becomes the canonical source of truth.
+ */
+function runMigration39(db: BunDatabase): void {
+	// --- tasks table ---
+	if (tableExists(db, 'tasks')) {
+		const tableInfo = db
+			.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'`)
+			.get() as { sql: string } | null;
+		const needsMigration = tableInfo !== null && !tableInfo.sql.includes("'archived'");
+
+		if (needsMigration) {
+			db.exec('PRAGMA foreign_keys = OFF');
+			try {
+				db.exec(`DROP TABLE IF EXISTS tasks_new`);
+				db.exec(`
+					CREATE TABLE tasks_new (
+						id TEXT PRIMARY KEY,
+						room_id TEXT NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL,
+						status TEXT NOT NULL DEFAULT 'pending'
+							CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+						priority TEXT NOT NULL DEFAULT 'normal'
+							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+						progress INTEGER,
+						current_step TEXT,
+						result TEXT,
+						error TEXT,
+						depends_on TEXT DEFAULT '[]',
+						created_at INTEGER NOT NULL,
+						started_at INTEGER,
+						completed_at INTEGER,
+						task_type TEXT DEFAULT 'coding'
+							CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'goal_review')),
+						assigned_agent TEXT DEFAULT 'coder',
+						created_by_task_id TEXT,
+						archived_at INTEGER,
+						active_session TEXT,
+						pr_url TEXT,
+						pr_number INTEGER,
+						pr_created_at INTEGER,
+						input_draft TEXT,
+						updated_at INTEGER,
+						FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+					)
+				`);
+
+				const cols = [
+					'id',
+					'room_id',
+					'title',
+					'description',
+					'status',
+					'priority',
+					'progress',
+					'current_step',
+					'result',
+					'error',
+					'depends_on',
+					'created_at',
+					'started_at',
+					'completed_at',
+				];
+				const optionalCols = [
+					'task_type',
+					'assigned_agent',
+					'created_by_task_id',
+					'archived_at',
+					'active_session',
+					'pr_url',
+					'pr_number',
+					'pr_created_at',
+					'input_draft',
+					'updated_at',
+				];
+				for (const col of optionalCols) {
+					if (tableHasColumn(db, 'tasks', col)) cols.push(col);
+				}
+				const selectCols = cols.join(', ');
+				db.exec(`INSERT INTO tasks_new (${selectCols}) SELECT ${selectCols} FROM tasks`);
+				db.exec(`DROP TABLE tasks`);
+				db.exec(`ALTER TABLE tasks_new RENAME TO tasks`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+
+		// Backfill: set status = 'archived' for rows with archived_at IS NOT NULL
+		db.exec(
+			`UPDATE tasks SET status = 'archived' WHERE archived_at IS NOT NULL AND status != 'archived'`
+		);
+	}
+
+	// --- space_tasks table ---
+	if (tableExists(db, 'space_tasks')) {
+		const tableInfo = db
+			.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='space_tasks'`)
+			.get() as { sql: string } | null;
+		const needsMigration = tableInfo !== null && !tableInfo.sql.includes("'archived'");
+
+		if (needsMigration) {
+			db.exec('PRAGMA foreign_keys = OFF');
+			try {
+				db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
+				db.exec(`
+					CREATE TABLE space_tasks_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						status TEXT NOT NULL DEFAULT 'pending'
+							CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+						priority TEXT NOT NULL DEFAULT 'normal'
+							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+						task_type TEXT
+							CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+						assigned_agent TEXT
+							CHECK(assigned_agent IN ('coder', 'general')),
+						custom_agent_id TEXT,
+						workflow_run_id TEXT,
+						workflow_step_id TEXT,
+						created_by_task_id TEXT,
+						goal_id TEXT,
+						progress INTEGER,
+						current_step TEXT,
+						result TEXT,
+						error TEXT,
+						depends_on TEXT NOT NULL DEFAULT '[]',
+						input_draft TEXT,
+						active_session TEXT
+							CHECK(active_session IN ('worker', 'leader')),
+						task_agent_session_id TEXT,
+						pr_url TEXT,
+						pr_number INTEGER,
+						pr_created_at INTEGER,
+						archived_at INTEGER,
+						created_at INTEGER NOT NULL,
+						started_at INTEGER,
+						completed_at INTEGER,
+						updated_at INTEGER NOT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+						FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+						FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+					)
+				`);
+
+				const cols = ['id', 'space_id', 'title', 'description', 'status', 'priority'];
+				const optionalCols = [
+					'task_type',
+					'assigned_agent',
+					'custom_agent_id',
+					'workflow_run_id',
+					'workflow_step_id',
+					'created_by_task_id',
+					'goal_id',
+					'progress',
+					'current_step',
+					'result',
+					'error',
+					'depends_on',
+					'input_draft',
+					'active_session',
+					'task_agent_session_id',
+					'pr_url',
+					'pr_number',
+					'pr_created_at',
+					'archived_at',
+					'created_at',
+					'started_at',
+					'completed_at',
+					'updated_at',
+				];
+				for (const col of optionalCols) {
+					if (tableHasColumn(db, 'space_tasks', col)) cols.push(col);
+				}
+				const selectCols = cols.join(', ');
+				db.exec(
+					`INSERT INTO space_tasks_new (${selectCols}) SELECT ${selectCols} FROM space_tasks`
+				);
+				db.exec(`DROP TABLE space_tasks`);
+				db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+
+		// Backfill: set status = 'archived' for rows with archived_at IS NOT NULL
+		db.exec(
+			`UPDATE space_tasks SET status = 'archived' WHERE archived_at IS NOT NULL AND status != 'archived'`
+		);
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1648,7 +1648,7 @@ function runMigration29(db: BunDatabase): void {
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'pending'
-				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
 			priority TEXT NOT NULL DEFAULT 'normal'
 				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
 			task_type TEXT

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2201,6 +2201,9 @@ function runMigration39(db: BunDatabase): void {
 				db.exec(`ALTER TABLE tasks_new RENAME TO tasks`);
 				db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
 				db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`
+				);
 			} finally {
 				db.exec('PRAGMA foreign_keys = ON');
 			}
@@ -2302,6 +2305,18 @@ function runMigration39(db: BunDatabase): void {
 				db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
 				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
 				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+				);
 			} finally {
 				db.exec('PRAGMA foreign_keys = ON');
 			}

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -130,7 +130,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'pending'
-				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+				CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
 			priority TEXT NOT NULL DEFAULT 'normal'
 				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
 			task_type TEXT

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -287,14 +287,23 @@ describe('SpaceTaskManager', () => {
 			expect(retried.progress).toBeUndefined();
 		});
 
-		it('retries a cancelled task -> pending', async () => {
+		it('retries a cancelled task -> in_progress (reactivation)', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
 			await manager.startTask(task.id);
 			await manager.cancelTask(task.id);
 
 			const retried = await manager.retryTask(task.id);
-			expect(retried.status).toBe('pending');
+			expect(retried.status).toBe('in_progress');
 			expect(retried.error).toBeUndefined();
+		});
+
+		it('retries a completed task -> in_progress (reactivation)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.completeTask(task.id, 'done');
+
+			const retried = await manager.retryTask(task.id);
+			expect(retried.status).toBe('in_progress');
 		});
 
 		it('updates description when provided', async () => {
@@ -320,14 +329,6 @@ describe('SpaceTaskManager', () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
 
 			await expect(manager.retryTask(task.id)).rejects.toThrow("Cannot retry task in 'pending'");
-		});
-
-		it('throws when task is completed', async () => {
-			const task = await manager.createTask({ title: 'T', description: '' });
-			await manager.startTask(task.id);
-			await manager.completeTask(task.id, 'done');
-
-			await expect(manager.retryTask(task.id)).rejects.toThrow("Cannot retry task in 'completed'");
 		});
 
 		it('throws when task is in review', async () => {
@@ -398,14 +399,14 @@ describe('SpaceTaskManager', () => {
 			);
 		});
 
-		it('throws when task is completed', async () => {
+		it('reassigns a completed task', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
 			await manager.startTask(task.id);
 			await manager.completeTask(task.id, 'done');
 
-			await expect(manager.reassignTask(task.id, 'new-agent')).rejects.toThrow(
-				"Cannot reassign task in 'completed'"
-			);
+			const reassigned = await manager.reassignTask(task.id, 'new-agent');
+			expect(reassigned.customAgentId).toBe('new-agent');
+			expect(reassigned.status).toBe('completed');
 		});
 
 		it('throws when task is in review (has open PR)', async () => {
@@ -434,12 +435,88 @@ describe('SpaceTaskManager', () => {
 	});
 
 	describe('VALID_SPACE_TASK_TRANSITIONS', () => {
-		it('completed is a terminal state with no transitions', () => {
-			expect(VALID_SPACE_TASK_TRANSITIONS.completed).toEqual([]);
+		it('completed allows reactivation and archival', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.completed).toEqual(['in_progress', 'archived']);
+		});
+
+		it('cancelled allows restart and archival', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.cancelled).toEqual([
+				'pending',
+				'in_progress',
+				'archived',
+			]);
+		});
+
+		it('needs_attention allows restart and archival', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.needs_attention).toEqual([
+				'pending',
+				'in_progress',
+				'review',
+				'archived',
+			]);
+		});
+
+		it('archived is a true terminal state with no transitions', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.archived).toEqual([]);
 		});
 
 		it('draft can only go to pending', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.draft).toEqual(['pending']);
+		});
+	});
+
+	describe('archived status transitions', () => {
+		it('transitions completed -> archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'completed', { result: 'done' });
+			const archived = await manager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('transitions cancelled -> archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.cancelTask(task.id);
+			const archived = await manager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('transitions needs_attention -> archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'needs_attention', { error: 'err' });
+			const archived = await manager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('rejects transition from archived to any status', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'completed');
+			await manager.setTaskStatus(task.id, 'archived');
+
+			await expect(manager.setTaskStatus(task.id, 'in_progress')).rejects.toThrow(
+				'Invalid status transition'
+			);
+			await expect(manager.setTaskStatus(task.id, 'pending')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+
+		it('rejects transition from pending -> archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await expect(manager.setTaskStatus(task.id, 'archived')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+
+		it('rejects transition from in_progress -> archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await expect(manager.setTaskStatus(task.id, 'archived')).rejects.toThrow(
+				'Invalid status transition'
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -225,10 +225,28 @@ describe('SpaceTaskManager', () => {
 	});
 
 	describe('archiveTask', () => {
-		it('archives a task', async () => {
+		it('archives a completed task', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'completed');
 			const archived = await manager.archiveTask(task.id);
+			expect(archived.status).toBe('archived');
 			expect(archived.archivedAt).toBeDefined();
+		});
+
+		it('throws when archiving a task in pending status', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await expect(manager.archiveTask(task.id)).rejects.toThrow(
+				"Cannot archive task in 'pending'"
+			);
+		});
+
+		it('throws when archiving a task in in_progress status', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await expect(manager.archiveTask(task.id)).rejects.toThrow(
+				"Cannot archive task in 'in_progress'"
+			);
 		});
 	});
 

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -324,6 +324,22 @@ describe('SpaceTaskManager', () => {
 			expect(retried.status).toBe('in_progress');
 		});
 
+		it('clears stale result and progress when retrying a completed task', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.completeTask(task.id, 'previous result');
+
+			// Verify fields are set before retry
+			const completed = await manager.getTask(task.id);
+			expect(completed!.result).toBe('previous result');
+			expect(completed!.progress).toBe(100);
+
+			const retried = await manager.retryTask(task.id);
+			expect(retried.status).toBe('in_progress');
+			expect(retried.result).toBeUndefined();
+			expect(retried.progress).toBeUndefined();
+		});
+
 		it('updates description when provided', async () => {
 			const task = await manager.createTask({ title: 'T', description: 'original' });
 			await manager.startTask(task.id);

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -913,6 +913,21 @@ describe('TaskManager', () => {
 			expect(reactivated.status).toBe('in_progress');
 		});
 
+		it('should clear result and progress when reactivating a completed task', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'previous result');
+
+			const completed = await taskManager.getTask(task.id);
+			expect(completed!.result).toBe('previous result');
+			expect(completed!.progress).toBe(100);
+
+			const reactivated = await taskManager.setTaskStatus(task.id, 'in_progress');
+			expect(reactivated.status).toBe('in_progress');
+			expect(reactivated.result).toBeUndefined();
+			expect(reactivated.progress).toBeUndefined();
+		});
+
 		it('should reject archived → any transition (true terminal)', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -16,7 +16,11 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
-import { TaskManager, extractPrNumber } from '../../../src/lib/room/managers/task-manager';
+import {
+	TaskManager,
+	extractPrNumber,
+	VALID_STATUS_TRANSITIONS,
+} from '../../../src/lib/room/managers/task-manager';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 
 describe('TaskManager', () => {
@@ -869,6 +873,96 @@ describe('TaskManager', () => {
 			await expect(taskManager.setTaskStatus(task.id, 'review')).rejects.toThrow(
 				'Invalid status transition'
 			);
+		});
+	});
+
+	describe('archived status transitions', () => {
+		it('should allow completed → archived transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+
+			const archived = await taskManager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('should allow cancelled → archived transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.cancelTask(task.id);
+
+			const archived = await taskManager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('should allow needs_attention → archived transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.failTask(task.id, 'error');
+
+			const archived = await taskManager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+		});
+
+		it('should allow completed → in_progress reactivation', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+
+			const reactivated = await taskManager.setTaskStatus(task.id, 'in_progress');
+			expect(reactivated.status).toBe('in_progress');
+		});
+
+		it('should reject archived → any transition (true terminal)', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+			await taskManager.setTaskStatus(task.id, 'archived');
+
+			await expect(taskManager.setTaskStatus(task.id, 'in_progress')).rejects.toThrow(
+				'Invalid status transition'
+			);
+			await expect(taskManager.setTaskStatus(task.id, 'pending')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+
+		it('should reject pending → archived transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await expect(taskManager.setTaskStatus(task.id, 'archived')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+
+		it('should reject in_progress → archived transition', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await expect(taskManager.setTaskStatus(task.id, 'archived')).rejects.toThrow(
+				'Invalid status transition'
+			);
+		});
+	});
+
+	describe('VALID_STATUS_TRANSITIONS map', () => {
+		it('archived is a true terminal state with no transitions', () => {
+			expect(VALID_STATUS_TRANSITIONS.archived).toEqual([]);
+		});
+
+		it('completed allows reactivation and archival', () => {
+			expect(VALID_STATUS_TRANSITIONS.completed).toEqual(['in_progress', 'archived']);
+		});
+
+		it('cancelled allows restart and archival', () => {
+			expect(VALID_STATUS_TRANSITIONS.cancelled).toEqual(['pending', 'in_progress', 'archived']);
+		});
+
+		it('needs_attention allows restart, review, and archival', () => {
+			expect(VALID_STATUS_TRANSITIONS.needs_attention).toEqual([
+				'pending',
+				'in_progress',
+				'review',
+				'archived',
+			]);
 		});
 	});
 

--- a/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/space/global-spaces-tools.test.ts
@@ -678,7 +678,7 @@ describe('createGlobalSpacesToolHandlers — retry_task', () => {
 		expect(parsed.error).toContain('ghost-task');
 	});
 
-	test('returns error when task is in completed status', async () => {
+	test('retries a completed task to in_progress (reactivation)', async () => {
 		const handlers = makeHandlers(ctx, { activeSpaceId: null });
 
 		const createResult = await handlers.create_standalone_task({
@@ -693,8 +693,8 @@ describe('createGlobalSpacesToolHandlers — retry_task', () => {
 		const result = await handlers.retry_task({ task_id: taskId });
 		const parsed = JSON.parse(result.content[0].text);
 
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('completed');
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('in_progress');
 	});
 
 	test('returns error when task belongs to different space', async () => {

--- a/packages/daemon/tests/unit/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/space-agent-tools.test.ts
@@ -848,7 +848,7 @@ describe('createSpaceAgentToolHandlers — retry_task', () => {
 		expect(parsed.task.error ?? null).toBeNull();
 	});
 
-	test('resets a cancelled task to pending', async () => {
+	test('resets a cancelled task to in_progress (reactivation)', async () => {
 		const createResult = await makeHandlers(ctx).create_standalone_task({
 			title: 'Cancelled task',
 			description: 'Will be retried',
@@ -859,7 +859,7 @@ describe('createSpaceAgentToolHandlers — retry_task', () => {
 		const result = await makeHandlers(ctx).retry_task({ task_id: taskId });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
-		expect(parsed.task.status).toBe('pending');
+		expect(parsed.task.status).toBe('in_progress');
 	});
 
 	test('updates description on retry when provided', async () => {

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -1,0 +1,362 @@
+/**
+ * Migration 34 Tests
+ *
+ * Tests for Migration 34: Add 'archived' to status CHECK constraints on tasks and space_tasks.
+ *
+ * Covers:
+ * - Fresh DB: tasks and space_tasks CHECK constraints include 'archived'
+ * - Legacy DB: table-rebuild adds 'archived' to existing CHECK constraints
+ * - Backfill: rows with archived_at IS NOT NULL are set to status = 'archived'
+ * - Idempotency: running migration twice does not error or duplicate data
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables, runMigrations } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTableSql(db: BunDatabase, table: string): string | null {
+	const row = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(table) as { sql: string } | null;
+	return row?.sql ?? null;
+}
+
+function tableExists(db: BunDatabase, table: string): boolean {
+	return getTableSql(db, table) !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 34: Add archived to status CHECK constraints', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-34', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Fresh DB — full migration chain
+	// -------------------------------------------------------------------------
+
+	test('fresh DB: tasks CHECK constraint includes archived', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+		const sql = getTableSql(db, 'tasks');
+		expect(sql).not.toBeNull();
+		expect(sql!).toContain("'archived'");
+	});
+
+	test('fresh DB: space_tasks CHECK constraint includes archived', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+		expect(tableExists(db, 'space_tasks')).toBe(true);
+		const sql = getTableSql(db, 'space_tasks')!;
+		expect(sql).toContain("'archived'");
+	});
+
+	test('fresh DB: can insert a task with status = archived', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Create a room first (FK requirement)
+		db.prepare(
+			`INSERT INTO rooms (id, name, allowed_paths, status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('room-1', 'Test Room', '[]', 'active', now, now);
+
+		// Insert a task with archived status
+		expect(() => {
+			db.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`
+			).run('task-1', 'room-1', 'Test Task', 'desc', 'archived', now, now);
+		}).not.toThrow();
+
+		const row = db.prepare(`SELECT status FROM tasks WHERE id = 'task-1'`).get() as {
+			status: string;
+		};
+		expect(row.status).toBe('archived');
+	});
+
+	test('fresh DB: can insert a space_task with status = archived', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Create a space first (FK requirement)
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace', 'Test Space', now, now);
+
+		expect(() => {
+			db.prepare(
+				`INSERT INTO space_tasks (id, space_id, title, description, status, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`
+			).run('st-1', 'space-1', 'Test Task', 'desc', 'archived', now, now);
+		}).not.toThrow();
+
+		const row = db.prepare(`SELECT status FROM space_tasks WHERE id = 'st-1'`).get() as {
+			status: string;
+		};
+		expect(row.status).toBe('archived');
+	});
+
+	// -------------------------------------------------------------------------
+	// Legacy DB — backfill
+	// -------------------------------------------------------------------------
+
+	test('legacy DB: tasks with archived_at are backfilled to status = archived', () => {
+		// Create a minimal pre-migration-34 tasks table (without 'archived' in CHECK)
+		db.exec(`
+			CREATE TABLE rooms (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				allowed_paths TEXT DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+				priority TEXT NOT NULL DEFAULT 'normal',
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				task_type TEXT DEFAULT 'coding',
+				assigned_agent TEXT DEFAULT 'coder',
+				created_by_task_id TEXT,
+				archived_at INTEGER,
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				input_draft TEXT,
+				updated_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec('CREATE INDEX idx_tasks_room ON tasks(room_id)');
+		db.exec('CREATE INDEX idx_tasks_status ON tasks(status)');
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO rooms (id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('room-1', 'R', 'active', now, now);
+
+		// Insert a completed task with archived_at set
+		db.prepare(
+			`INSERT INTO tasks (id, room_id, title, description, status, archived_at, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'room-1', 'Old task', 'desc', 'completed', now - 1000, now);
+
+		// Insert a normal task without archived_at
+		db.prepare(
+			`INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('task-2', 'room-1', 'Active task', 'desc', 'in_progress', now);
+
+		// Verify the CHECK constraint doesn't include 'archived' yet
+		const sqlBefore = getTableSql(db, 'tasks')!;
+		expect(sqlBefore).not.toContain("'archived'");
+
+		// Run migrations
+		runMigrations(db, () => {});
+
+		// Check that the constraint now includes 'archived'
+		const sqlAfter = getTableSql(db, 'tasks')!;
+		expect(sqlAfter).toContain("'archived'");
+
+		// Check backfill: task-1 should be archived, task-2 should remain in_progress
+		const task1 = db.prepare(`SELECT status FROM tasks WHERE id = 'task-1'`).get() as {
+			status: string;
+		};
+		expect(task1.status).toBe('archived');
+
+		const task2 = db.prepare(`SELECT status FROM tasks WHERE id = 'task-2'`).get() as {
+			status: string;
+		};
+		expect(task2.status).toBe('in_progress');
+	});
+
+	test('legacy DB: space_tasks with archived_at are backfilled to status = archived', () => {
+		// Create minimal pre-migration-34 space tables
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled')),
+				priority TEXT NOT NULL DEFAULT 'normal',
+				task_type TEXT,
+				assigned_agent TEXT,
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT,
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace', 'S', now, now);
+
+		// Space task with archived_at set
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, status, archived_at, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('st-1', 'space-1', 'Old task', 'completed', now - 1000, now, now);
+
+		// Space task without archived_at
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('st-2', 'space-1', 'Active task', 'in_progress', now, now);
+
+		runMigrations(db, () => {});
+
+		const st1 = db.prepare(`SELECT status FROM space_tasks WHERE id = 'st-1'`).get() as {
+			status: string;
+		};
+		expect(st1.status).toBe('archived');
+
+		const st2 = db.prepare(`SELECT status FROM space_tasks WHERE id = 'st-2'`).get() as {
+			status: string;
+		};
+		expect(st2.status).toBe('in_progress');
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency
+	// -------------------------------------------------------------------------
+
+	test('idempotency: running migration twice does not error', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+
+		const tasksSql = getTableSql(db, 'tasks')!;
+		expect(tasksSql).toContain("'archived'");
+	});
+
+	test('idempotency: data is not duplicated on second migration run', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO rooms (id, name, allowed_paths, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('room-1', 'R', '[]', 'active', now, now);
+		db.prepare(
+			`INSERT INTO tasks (id, room_id, title, description, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'room-1', 'T', 'd', 'pending', now, now);
+
+		runMigrations(db, () => {});
+
+		const rows = db.prepare(`SELECT id FROM tasks`).all();
+		expect(rows).toHaveLength(1);
+	});
+
+	test('idempotency: backfill does not change already-archived tasks', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO rooms (id, name, allowed_paths, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('room-1', 'R', '[]', 'active', now, now);
+
+		// Insert a task already with status = 'archived' and archived_at
+		db.prepare(
+			`INSERT INTO tasks (id, room_id, title, description, status, archived_at, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'room-1', 'T', 'd', 'archived', now - 5000, now, now);
+
+		// Run again — should not error
+		runMigrations(db, () => {});
+
+		const row = db.prepare(`SELECT status, archived_at FROM tasks WHERE id = 'task-1'`).get() as {
+			status: string;
+			archived_at: number;
+		};
+		expect(row.status).toBe('archived');
+		expect(row.archived_at).toBe(now - 5000);
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -31,6 +31,13 @@ function tableExists(db: BunDatabase, table: string): boolean {
 	return getTableSql(db, table) !== null;
 }
 
+function getIndexNames(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? ORDER BY name`)
+		.all(table) as { name: string }[];
+	return rows.map((r) => r.name).filter((n) => !n.startsWith('sqlite_'));
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -301,6 +308,82 @@ describe('Migration 34: Add archived to status CHECK constraints', () => {
 			status: string;
 		};
 		expect(st2.status).toBe('in_progress');
+	});
+
+	// -------------------------------------------------------------------------
+	// Index preservation after table rebuild
+	// -------------------------------------------------------------------------
+
+	test('tasks indexes are recreated after table rebuild', () => {
+		// Use createTables to get the full schema, then downgrade the CHECK constraint
+		// to simulate a pre-migration-34 state that migration 34 will rebuild
+		createTables(db);
+
+		// Downgrade tasks table: rebuild without 'archived' in CHECK
+		db.exec('PRAGMA foreign_keys = OFF');
+		const tasksSql = getTableSql(db, 'tasks')!;
+		const downgradedSql = tasksSql.replace(", 'archived'", '');
+		db.exec(`DROP TABLE tasks`);
+		db.exec(downgradedSql);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)');
+		db.exec('CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)');
+		db.exec('CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)');
+		db.exec('PRAGMA foreign_keys = ON');
+
+		// Verify CHECK doesn't include 'archived' yet
+		expect(getTableSql(db, 'tasks')!).not.toContain("'archived'");
+
+		// Run migrations — migration 34 should rebuild and recreate all indexes
+		runMigrations(db, () => {});
+
+		const indexes = getIndexNames(db, 'tasks');
+		expect(indexes).toContain('idx_tasks_room');
+		expect(indexes).toContain('idx_tasks_status');
+		expect(indexes).toContain('idx_tasks_room_updated');
+	});
+
+	test('space_tasks indexes are recreated after table rebuild', () => {
+		// createTables + runMigrations creates space_tasks via migration 27-29
+		// Then we downgrade it to trigger migration 34's rebuild
+		createTables(db);
+		runMigrations(db, () => {});
+
+		expect(tableExists(db, 'space_tasks')).toBe(true);
+
+		// Downgrade space_tasks: remove 'archived' from CHECK to trigger rebuild
+		db.exec('PRAGMA foreign_keys = OFF');
+		const spaceSql = getTableSql(db, 'space_tasks')!;
+		const downgradedSql = spaceSql.replace(", 'archived'", '');
+		db.exec(`DROP TABLE space_tasks`);
+		db.exec(downgradedSql);
+		db.exec('CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)');
+		db.exec('CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)');
+		db.exec(
+			'CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)'
+		);
+		db.exec(
+			'CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)'
+		);
+		db.exec(
+			'CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)'
+		);
+		db.exec(
+			'CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)'
+		);
+		db.exec('PRAGMA foreign_keys = ON');
+
+		expect(getTableSql(db, 'space_tasks')!).not.toContain("'archived'");
+
+		// Run migrations again — migration 34 detects missing 'archived' and rebuilds
+		runMigrations(db, () => {});
+
+		const indexes = getIndexNames(db, 'space_tasks');
+		expect(indexes).toContain('idx_space_tasks_space_id');
+		expect(indexes).toContain('idx_space_tasks_status');
+		expect(indexes).toContain('idx_space_tasks_workflow_run_id');
+		expect(indexes).toContain('idx_space_tasks_custom_agent_id');
+		expect(indexes).toContain('idx_space_tasks_workflow_step_id');
+		expect(indexes).toContain('idx_space_tasks_task_agent_session_id');
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -265,10 +265,60 @@ describe('SpaceTaskRepository', () => {
 	});
 
 	describe('archiveTask', () => {
-		it('sets archivedAt timestamp', () => {
+		it('sets status to archived and stamps archivedAt', () => {
 			const task = repo.createTask({ spaceId, title: 'T', description: '' });
 			const archived = repo.archiveTask(task.id);
+			expect(archived!.status).toBe('archived');
 			expect(archived!.archivedAt).toBeDefined();
+			expect(archived!.archivedAt).toBeGreaterThan(0);
+		});
+
+		it('archived tasks are excluded from listBySpace by default', () => {
+			repo.createTask({ spaceId, title: 'Active', description: '' });
+			const toArchive = repo.createTask({ spaceId, title: 'Archived', description: '' });
+			repo.archiveTask(toArchive.id);
+
+			const tasks = repo.listBySpace(spaceId);
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].title).toBe('Active');
+		});
+
+		it('archived tasks are excluded from listByStatus', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '', status: 'pending' });
+			repo.archiveTask(task.id);
+
+			const pending = repo.listByStatus(spaceId, 'pending');
+			expect(pending).toHaveLength(0);
+		});
+
+		it('archived tasks are excluded from listByWorkflowRun', () => {
+			const task = repo.createTask({
+				spaceId,
+				title: 'WF Task',
+				description: '',
+				workflowRunId,
+			});
+			repo.archiveTask(task.id);
+
+			const tasks = repo.listByWorkflowRun(workflowRunId);
+			expect(tasks).toHaveLength(0);
+		});
+	});
+
+	describe('updateTask archived_at stamping', () => {
+		it('stamps archived_at when status is set to archived via updateTask', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			const updated = repo.updateTask(task.id, { status: 'archived' });
+			expect(updated!.status).toBe('archived');
+			expect(updated!.archivedAt).toBeDefined();
+			expect(updated!.archivedAt).toBeGreaterThan(0);
+		});
+
+		it('auto-clears active_session when status is set to archived', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			repo.updateTask(task.id, { status: 'in_progress', activeSession: 'worker' });
+			const updated = repo.updateTask(task.id, { status: 'archived' });
+			expect(updated!.activeSession).toBeNull();
 		});
 	});
 

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -688,6 +688,34 @@ describe('TaskRepository', () => {
 		});
 	});
 
+	describe('updateTask archived_at stamping', () => {
+		it('should stamp archived_at when status is set to archived via updateTask', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'T',
+				description: '',
+			});
+			const updated = repository.updateTask(task.id, { status: 'archived' });
+			expect(updated!.status).toBe('archived');
+			expect(updated!.archivedAt).toBeDefined();
+			expect(updated!.archivedAt).toBeGreaterThan(0);
+		});
+
+		it('should auto-clear active_session when status is set to archived', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'T',
+				description: '',
+			});
+			repository.updateTask(task.id, {
+				status: 'in_progress',
+				activeSession: 'worker',
+			});
+			const updated = repository.updateTask(task.id, { status: 'archived' });
+			expect(updated!.activeSession).toBeNull();
+		});
+	});
+
 	describe('PR fields', () => {
 		it('should default PR fields to undefined on creation', () => {
 			const task = repository.createTask({

--- a/packages/daemon/tests/unit/storage/task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/task-repository.test.ts
@@ -621,6 +621,73 @@ describe('TaskRepository', () => {
 		});
 	});
 
+	describe('archiveTask', () => {
+		it('should set status to archived and archived_at', () => {
+			const task = repository.createTask({
+				roomId: 'room-1',
+				title: 'Archive me',
+				description: '',
+			});
+
+			const archived = repository.archiveTask(task.id);
+			expect(archived).not.toBeNull();
+			expect(archived!.status).toBe('archived');
+			expect(archived!.archivedAt).toBeDefined();
+			expect(archived!.archivedAt).toBeGreaterThan(0);
+		});
+
+		it('should return null for non-existent task', () => {
+			const result = repository.archiveTask('nonexistent');
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('listTasks archive filtering', () => {
+		it('should exclude archived tasks by default', () => {
+			repository.createTask({ roomId: 'room-1', title: 'Active', description: '' });
+			const toArchive = repository.createTask({
+				roomId: 'room-1',
+				title: 'To archive',
+				description: '',
+			});
+			repository.archiveTask(toArchive.id);
+
+			const tasks = repository.listTasks('room-1');
+			expect(tasks.length).toBe(1);
+			expect(tasks[0].title).toBe('Active');
+		});
+
+		it('should include archived tasks when includeArchived is true', () => {
+			repository.createTask({ roomId: 'room-1', title: 'Active', description: '' });
+			const toArchive = repository.createTask({
+				roomId: 'room-1',
+				title: 'Archived',
+				description: '',
+			});
+			repository.archiveTask(toArchive.id);
+
+			const tasks = repository.listTasks('room-1', { includeArchived: true });
+			expect(tasks.length).toBe(2);
+		});
+
+		it('should filter by status = archived when includeArchived and status filter', () => {
+			repository.createTask({ roomId: 'room-1', title: 'Active', description: '' });
+			const toArchive = repository.createTask({
+				roomId: 'room-1',
+				title: 'Archived',
+				description: '',
+			});
+			repository.archiveTask(toArchive.id);
+
+			const tasks = repository.listTasks('room-1', {
+				includeArchived: true,
+				status: 'archived',
+			});
+			expect(tasks.length).toBe(1);
+			expect(tasks[0].status).toBe('archived');
+		});
+	});
+
 	describe('PR fields', () => {
 		it('should default PR fields to undefined on creation', () => {
 			const task = repository.createTask({

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -307,7 +307,7 @@ export interface NeoTask {
 	startedAt?: number;
 	/** Completion timestamp (milliseconds since epoch) */
 	completedAt?: number;
-	/** Archive timestamp (milliseconds since epoch) - orthogonal to status */
+	/** Archive timestamp (milliseconds since epoch) - derived from status='archived' */
 	archivedAt?: number | null;
 	/**
 	 * Which agent session is currently active (generating output).

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -249,7 +249,8 @@ export type TaskStatus =
 	| 'review'
 	| 'completed'
 	| 'needs_attention'
-	| 'cancelled';
+	| 'cancelled'
+	| 'archived';
 
 /**
  * Task priority

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -123,7 +123,8 @@ export type SpaceTaskStatus =
 	| 'review'
 	| 'completed'
 	| 'needs_attention'
-	| 'cancelled';
+	| 'cancelled'
+	| 'archived';
 
 /**
  * Space task priority

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -191,7 +191,7 @@ export interface SpaceTask {
 	prNumber?: number | null;
 	/** When PR was created/submitted (milliseconds since epoch) */
 	prCreatedAt?: number | null;
-	/** Archive timestamp (milliseconds since epoch) — orthogonal to status */
+	/** Archive timestamp (milliseconds since epoch) — derived from status='archived' */
 	archivedAt?: number | null;
 	/**
 	 * ID of the Task Agent session that orchestrates this task's workflow execution.

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -262,6 +262,7 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 		draft: 'bg-dark-600 text-gray-400',
 		review: 'bg-purple-900/50 text-purple-300',
 		cancelled: 'bg-gray-800 text-gray-400',
+		archived: 'bg-gray-900 text-gray-600',
 	};
 	const label =
 		status === 'in_progress' ? 'active' : status === 'needs_attention' ? 'needs attention' : status;

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -23,6 +23,7 @@ const STATUS_LABELS: Record<SpaceTaskStatus, string> = {
 	completed: 'Completed',
 	needs_attention: 'Needs Attention',
 	cancelled: 'Cancelled',
+	archived: 'Archived',
 };
 
 const STATUS_CLASSES: Record<SpaceTaskStatus, string> = {
@@ -33,6 +34,7 @@ const STATUS_CLASSES: Record<SpaceTaskStatus, string> = {
 	completed: 'bg-green-900/30 text-green-300 border-green-700/50',
 	needs_attention: 'bg-yellow-900/30 text-yellow-300 border-yellow-700/50',
 	cancelled: 'bg-gray-800 text-gray-500 border-gray-700',
+	archived: 'bg-gray-900 text-gray-600 border-gray-800',
 };
 
 const PRIORITY_LABELS: Record<SpaceTaskPriority, string> = {


### PR DESCRIPTION
## Summary

- Add `archived` as a new terminal state to `TaskStatus` and `SpaceTaskStatus` union types
- Create Migration 34 to rebuild tasks/space_tasks CHECK constraints and backfill `archived_at IS NOT NULL` rows
- Update `VALID_STATUS_TRANSITIONS` and `VALID_SPACE_TASK_TRANSITIONS` with archived lifecycle
- Update `task-repository.ts` to use `status != 'archived'` as default filter and set both `status` and `archived_at` on archive
- Pass `includeArchived` through `task.list` RPC handler
- Update `retryTask()` and `reassignTask()` in space-task-manager for completed/cancelled reactivation
- Fix exhaustiveness in `SpaceTaskPane.tsx` status maps
- Add comprehensive unit tests for migration, transitions, repository, and tool handler changes

## Test plan

- [x] Migration 34 test: fresh DB constraints, legacy backfill, idempotency
- [x] TaskManager tests: archived transitions (completed/cancelled/needs_attention → archived), terminal state validation
- [x] SpaceTaskManager tests: same transition tests + retryTask/reassignTask with completed status
- [x] TaskRepository tests: archiveTask sets status + archived_at, listTasks excludes archived by default
- [x] Space agent tools tests: retry_task reactivation behavior updated
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format` passes