### PR TITLE
feat: add CollapsibleSection component for sidebar sections

### DIFF
--- a/packages/web/src/components/room/CollapsibleSection.test.tsx
+++ b/packages/web/src/components/room/CollapsibleSection.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for CollapsibleSection Component
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { CollapsibleSection } from './CollapsibleSection';
+
+describe('CollapsibleSection', () => {
+	afterEach(() => cleanup());
+
+	it('renders title and children when expanded by default', () => {
+		const { getByText } = render(
+			<CollapsibleSection title="Goals">
+				<div>Goal content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('Goals')).toBeTruthy();
+		expect(getByText('Goal content')).toBeTruthy();
+		expect(getByText('▼')).toBeTruthy();
+	});
+
+	it('hides children when defaultExpanded is false', () => {
+		const { getByText, queryByText } = render(
+			<CollapsibleSection title="Sessions" defaultExpanded={false}>
+				<div>Session content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('Sessions')).toBeTruthy();
+		expect(queryByText('Session content')).toBeNull();
+		expect(getByText('▶')).toBeTruthy();
+	});
+
+	it('toggles children visibility on header click', () => {
+		const { getByText, queryByText, getByRole } = render(
+			<CollapsibleSection title="Tasks">
+				<div>Task content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('Task content')).toBeTruthy();
+
+		// Collapse
+		fireEvent.click(getByRole('button'));
+		expect(queryByText('Task content')).toBeNull();
+		expect(getByText('▶')).toBeTruthy();
+
+		// Expand again
+		fireEvent.click(getByRole('button'));
+		expect(getByText('Task content')).toBeTruthy();
+		expect(getByText('▼')).toBeTruthy();
+	});
+
+	it('renders count badge when count is provided', () => {
+		const { getByText } = render(
+			<CollapsibleSection title="Goals" count={5}>
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('(5)')).toBeTruthy();
+	});
+
+	it('renders count badge with zero', () => {
+		const { getByText } = render(
+			<CollapsibleSection title="Goals" count={0}>
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('(0)')).toBeTruthy();
+	});
+
+	it('does not render count badge when count is undefined', () => {
+		const { queryByText } = render(
+			<CollapsibleSection title="Goals">
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		expect(queryByText('(', { exact: false })).toBeNull();
+	});
+
+	it('renders headerRight slot', () => {
+		const { getByText } = render(
+			<CollapsibleSection title="Sessions" headerRight={<button type="button">+</button>}>
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		expect(getByText('+')).toBeTruthy();
+	});
+
+	it('headerRight click does not toggle section', () => {
+		const { getByText, queryByText } = render(
+			<CollapsibleSection title="Sessions" headerRight={<button type="button">+</button>}>
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		// Click the + button in headerRight
+		fireEvent.click(getByText('+'));
+
+		// Section should still be expanded (not toggled)
+		expect(queryByText('Content')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/room/CollapsibleSection.test.tsx
+++ b/packages/web/src/components/room/CollapsibleSection.test.tsx
@@ -2,7 +2,7 @@
  * Tests for CollapsibleSection Component
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -53,6 +53,21 @@ describe('CollapsibleSection', () => {
 		expect(getByText('▼')).toBeTruthy();
 	});
 
+	it('sets aria-expanded attribute correctly', () => {
+		const { getByRole } = render(
+			<CollapsibleSection title="Goals">
+				<div>Content</div>
+			</CollapsibleSection>
+		);
+
+		const button = getByRole('button');
+		expect(button.getAttribute('aria-expanded')).toBe('true');
+		expect(button.getAttribute('aria-label')).toBe('Goals section');
+
+		fireEvent.click(button);
+		expect(button.getAttribute('aria-expanded')).toBe('false');
+	});
+
 	it('renders count badge when count is provided', () => {
 		const { getByText } = render(
 			<CollapsibleSection title="Goals" count={5}>
@@ -85,7 +100,7 @@ describe('CollapsibleSection', () => {
 
 	it('renders headerRight slot', () => {
 		const { getByText } = render(
-			<CollapsibleSection title="Sessions" headerRight={<button type="button">+</button>}>
+			<CollapsibleSection title="Sessions" headerRight={<span>+</span>}>
 				<div>Content</div>
 			</CollapsibleSection>
 		);
@@ -100,7 +115,7 @@ describe('CollapsibleSection', () => {
 			</CollapsibleSection>
 		);
 
-		// Click the + button in headerRight
+		// Click the + button in headerRight (separate from toggle button)
 		fireEvent.click(getByText('+'));
 
 		// Section should still be expanded (not toggled)

--- a/packages/web/src/components/room/CollapsibleSection.tsx
+++ b/packages/web/src/components/room/CollapsibleSection.tsx
@@ -1,0 +1,50 @@
+/**
+ * CollapsibleSection Component
+ *
+ * A reusable collapsible section with header, count badge, and expand/collapse toggle.
+ * Used for Goals, Tasks, and Sessions sections in the RoomContextPanel sidebar.
+ */
+
+import { useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+
+export interface CollapsibleSectionProps {
+	title: string;
+	count?: number;
+	defaultExpanded?: boolean;
+	headerRight?: ComponentChildren;
+	children: ComponentChildren;
+}
+
+// @public - Library export
+export function CollapsibleSection({
+	title,
+	count,
+	defaultExpanded = true,
+	headerRight,
+	children,
+}: CollapsibleSectionProps) {
+	const [expanded, setExpanded] = useState(defaultExpanded);
+
+	return (
+		<div class="collapsible-section">
+			<button
+				type="button"
+				class="w-full flex items-center justify-between px-3 py-2 hover:bg-dark-800 transition-colors"
+				onClick={() => setExpanded(!expanded)}
+			>
+				<div class="flex items-center gap-1.5">
+					<span class="text-gray-500 text-[10px] leading-none">{expanded ? '▼' : '▶'}</span>
+					<span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">{title}</span>
+					{count != null && <span class="text-xs text-gray-600 ml-0.5">({count})</span>}
+				</div>
+				{headerRight && (
+					<div class="flex items-center" onClick={(e: MouseEvent) => e.stopPropagation()}>
+						{headerRight}
+					</div>
+				)}
+			</button>
+			{expanded && <div class="collapsible-section-body">{children}</div>}
+		</div>
+	);
+}

--- a/packages/web/src/components/room/CollapsibleSection.tsx
+++ b/packages/web/src/components/room/CollapsibleSection.tsx
@@ -3,6 +3,11 @@
  *
  * A reusable collapsible section with header, count badge, and expand/collapse toggle.
  * Used for Goals, Tasks, and Sessions sections in the RoomContextPanel sidebar.
+ *
+ * Note: This does not compose ui/Collapsible because that component renders a fixed
+ * SVG chevron and applies border/animation styles unsuited to the compact sidebar layout.
+ * This component uses conditional rendering (no height animation) and a triangle indicator
+ * to match the sidebar's information-dense design.
  */
 
 import { useState } from 'preact/hooks';
@@ -28,22 +33,20 @@ export function CollapsibleSection({
 
 	return (
 		<div class="collapsible-section">
-			<button
-				type="button"
-				class="w-full flex items-center justify-between px-3 py-2 hover:bg-dark-800 transition-colors"
-				onClick={() => setExpanded(!expanded)}
-			>
-				<div class="flex items-center gap-1.5">
+			<div class="flex items-center justify-between px-3 py-2 hover:bg-dark-800 transition-colors">
+				<button
+					type="button"
+					class="flex items-center gap-1.5 flex-1 min-w-0"
+					aria-expanded={expanded}
+					aria-label={`${title} section`}
+					onClick={() => setExpanded(!expanded)}
+				>
 					<span class="text-gray-500 text-[10px] leading-none">{expanded ? '▼' : '▶'}</span>
 					<span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">{title}</span>
 					{count != null && <span class="text-xs text-gray-600 ml-0.5">({count})</span>}
-				</div>
-				{headerRight && (
-					<div class="flex items-center" onClick={(e: MouseEvent) => e.stopPropagation()}>
-						{headerRight}
-					</div>
-				)}
-			</button>
+				</button>
+				{headerRight && <div class="flex items-center">{headerRight}</div>}
+			</div>
 			{expanded && <div class="collapsible-section-body">{children}</div>}
 		</div>
 	);

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -5,6 +5,9 @@
  */
 
 // @public - Library export
+export { CollapsibleSection } from './CollapsibleSection';
+export type { CollapsibleSectionProps } from './CollapsibleSection';
+// @public - Library export
 export { GoalsEditor } from './GoalsEditor';
 // @public - Library export
 export { RoomContext } from './RoomContext';


### PR DESCRIPTION
## Summary

- Add reusable `CollapsibleSection` component with expand/collapse toggle, title, count badge, and `headerRight` slot for action buttons
- Export from `packages/web/src/components/room/index.ts` barrel file
- Add 8 unit tests covering expand/collapse toggle, count badge, headerRight slot, and default state

## Test plan

- [x] All 8 unit tests pass (`vitest run`)
- [x] TypeScript compiles without errors
- [x] Lint (oxlint) passes with 0 warnings/errors
- [x] Format (biome) passes
- [x] Knip reports no dead exports