### PR TITLE
feat: add computed signals for goal-task grouping and orphan tasks

### DIFF
--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mocks
 // -------------------------------------------------------
 
-let mockEventHandlers: Map<string, (event: unknown) => void>;
+let mockEventHandlers: Array<{ name: string; handler: (event: unknown) => void }>;
 let mockHub: ReturnType<typeof makeMockHub>;
 
 function makeMockHub() {
@@ -22,8 +22,12 @@ function makeMockHub() {
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),
 		onEvent: vi.fn((eventName: string, handler: (e: unknown) => void) => {
-			mockEventHandlers.set(eventName, handler);
-			return () => mockEventHandlers.delete(eventName);
+			const entry = { name: eventName, handler };
+			mockEventHandlers.push(entry);
+			return () => {
+				const idx = mockEventHandlers.indexOf(entry);
+				if (idx >= 0) mockEventHandlers.splice(idx, 1);
+			};
 		}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
@@ -72,7 +76,7 @@ describe('RoomStore — computed goal/task signals', () => {
 	let roomStore: typeof import('../room-store').roomStore;
 
 	beforeEach(async () => {
-		mockEventHandlers = new Map();
+		mockEventHandlers = [];
 		mockHub = makeMockHub();
 		vi.resetModules();
 		const mod = await import('../room-store');
@@ -104,7 +108,18 @@ describe('RoomStore — computed goal/task signals', () => {
 			roomStore.tasks.value = [makeTask('t1', 'pending')];
 			roomStore.goals.value = [makeGoal('g1', ['t1', 'nonexistent'])];
 			const map = roomStore.tasksByGoalId.value;
+			expect(map.has('g1')).toBe(true);
 			expect(map.get('g1')?.map((t) => t.id)).toEqual(['t1']);
+		});
+
+		it('includes goal with empty linkedTaskIds as a key with empty array', () => {
+			roomStore.tasks.value = [makeTask('t1', 'pending')];
+			roomStore.goals.value = [makeGoal('g1', []), makeGoal('g2', ['t1'])];
+			const map = roomStore.tasksByGoalId.value;
+			expect(map.has('g1')).toBe(true);
+			expect(map.get('g1')).toEqual([]);
+			expect(map.has('g2')).toBe(true);
+			expect(map.get('g2')?.map((t) => t.id)).toEqual(['t1']);
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -1,0 +1,224 @@
+// @ts-nocheck
+/**
+ * Tests for RoomStore computed signals:
+ * - tasksByGoalId: Map of goal ID → linked TaskSummary[]
+ * - orphanTasks: Tasks not linked to any goal
+ * - orphanTasksActive: Orphan tasks with draft/pending/in_progress
+ * - orphanTasksReview: Orphan tasks with review/needs_attention
+ * - orphanTasksDone: Orphan tasks with completed/cancelled
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// -------------------------------------------------------
+// Mocks
+// -------------------------------------------------------
+
+let mockEventHandlers: Map<string, (event: unknown) => void>;
+let mockHub: ReturnType<typeof makeMockHub>;
+
+function makeMockHub() {
+	return {
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		onEvent: vi.fn((eventName: string, handler: (e: unknown) => void) => {
+			mockEventHandlers.set(eventName, handler);
+			return () => mockEventHandlers.delete(eventName);
+		}),
+		request: vi.fn(async (method: string) => {
+			if (method === 'room.get') {
+				return { room: { id: 'room-1' }, sessions: [], allTasks: [] };
+			}
+			if (method === 'goal.list') return { goals: [] };
+			if (method === 'room.runtime.state') throw new Error('no runtime');
+			return {};
+		}),
+	};
+}
+
+vi.mock('../connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(async () => mockHub),
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeTask(id: string, status: string, title = `Task ${id}`) {
+	return { id, title, status, priority: 'normal', progress: 0, dependsOn: [] };
+}
+
+function makeGoal(id: string, linkedTaskIds: string[] = []) {
+	return {
+		id,
+		roomId: 'room-1',
+		title: `Goal ${id}`,
+		description: '',
+		status: 'active',
+		priority: 'normal',
+		linkedTaskIds,
+		metrics: {},
+	};
+}
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+describe('RoomStore — computed goal/task signals', () => {
+	let roomStore: typeof import('../room-store').roomStore;
+
+	beforeEach(async () => {
+		mockEventHandlers = new Map();
+		mockHub = makeMockHub();
+		vi.resetModules();
+		const mod = await import('../room-store');
+		roomStore = mod.roomStore;
+		await roomStore.select('room-1');
+	});
+
+	describe('tasksByGoalId', () => {
+		it('returns empty map when no goals', () => {
+			roomStore.tasks.value = [makeTask('t1', 'pending')];
+			roomStore.goals.value = [];
+			const map = roomStore.tasksByGoalId.value;
+			expect(map.size).toBe(0);
+		});
+
+		it('maps goals to their linked tasks', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'pending'),
+				makeTask('t2', 'in_progress'),
+				makeTask('t3', 'completed'),
+			];
+			roomStore.goals.value = [makeGoal('g1', ['t1', 't2']), makeGoal('g2', ['t3'])];
+			const map = roomStore.tasksByGoalId.value;
+			expect(map.get('g1')?.map((t) => t.id)).toEqual(['t1', 't2']);
+			expect(map.get('g2')?.map((t) => t.id)).toEqual(['t3']);
+		});
+
+		it('skips linked task IDs that do not exist in tasks signal', () => {
+			roomStore.tasks.value = [makeTask('t1', 'pending')];
+			roomStore.goals.value = [makeGoal('g1', ['t1', 'nonexistent'])];
+			const map = roomStore.tasksByGoalId.value;
+			expect(map.get('g1')?.map((t) => t.id)).toEqual(['t1']);
+		});
+	});
+
+	describe('orphanTasks', () => {
+		it('returns all tasks when no goals exist', () => {
+			roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'draft')];
+			roomStore.goals.value = [];
+			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+		});
+
+		it('excludes tasks linked to any goal', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'pending'),
+				makeTask('t2', 'in_progress'),
+				makeTask('t3', 'completed'),
+			];
+			roomStore.goals.value = [makeGoal('g1', ['t1', 't3'])];
+			expect(roomStore.orphanTasks.value.map((t) => t.id)).toEqual(['t2']);
+		});
+
+		it('returns empty when all tasks are linked', () => {
+			roomStore.tasks.value = [makeTask('t1', 'pending')];
+			roomStore.goals.value = [makeGoal('g1', ['t1'])];
+			expect(roomStore.orphanTasks.value).toEqual([]);
+		});
+	});
+
+	describe('orphanTasksActive', () => {
+		it('includes draft, pending, and in_progress orphan tasks', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'draft'),
+				makeTask('t2', 'pending'),
+				makeTask('t3', 'in_progress'),
+				makeTask('t4', 'review'),
+				makeTask('t5', 'completed'),
+				makeTask('t6', 'needs_attention'),
+				makeTask('t7', 'cancelled'),
+			];
+			roomStore.goals.value = [];
+			const ids = roomStore.orphanTasksActive.value.map((t) => t.id);
+			expect(ids).toEqual(['t1', 't2', 't3']);
+		});
+	});
+
+	describe('orphanTasksReview', () => {
+		it('includes review and needs_attention orphan tasks', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'draft'),
+				makeTask('t2', 'review'),
+				makeTask('t3', 'needs_attention'),
+				makeTask('t4', 'completed'),
+			];
+			roomStore.goals.value = [];
+			const ids = roomStore.orphanTasksReview.value.map((t) => t.id);
+			expect(ids).toEqual(['t2', 't3']);
+		});
+	});
+
+	describe('orphanTasksDone', () => {
+		it('includes completed and cancelled orphan tasks', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'in_progress'),
+				makeTask('t2', 'completed'),
+				makeTask('t3', 'cancelled'),
+			];
+			roomStore.goals.value = [];
+			const ids = roomStore.orphanTasksDone.value.map((t) => t.id);
+			expect(ids).toEqual(['t2', 't3']);
+		});
+	});
+
+	describe('all 7 TaskStatus values are covered', () => {
+		it('every status falls into exactly one bucket', () => {
+			roomStore.tasks.value = [
+				makeTask('draft', 'draft'),
+				makeTask('pending', 'pending'),
+				makeTask('in_progress', 'in_progress'),
+				makeTask('review', 'review'),
+				makeTask('needs_attention', 'needs_attention'),
+				makeTask('completed', 'completed'),
+				makeTask('cancelled', 'cancelled'),
+			];
+			roomStore.goals.value = [];
+
+			const active = new Set(roomStore.orphanTasksActive.value.map((t) => t.id));
+			const review = new Set(roomStore.orphanTasksReview.value.map((t) => t.id));
+			const done = new Set(roomStore.orphanTasksDone.value.map((t) => t.id));
+
+			// No overlap
+			for (const id of active) {
+				expect(review.has(id)).toBe(false);
+				expect(done.has(id)).toBe(false);
+			}
+			for (const id of review) {
+				expect(done.has(id)).toBe(false);
+			}
+
+			// All covered
+			expect(active.size + review.size + done.size).toBe(7);
+		});
+	});
+
+	describe('filtered orphan tasks exclude linked tasks', () => {
+		it('does not include linked tasks in any orphan bucket', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'draft'),
+				makeTask('t2', 'review'),
+				makeTask('t3', 'completed'),
+			];
+			roomStore.goals.value = [makeGoal('g1', ['t1', 't2', 't3'])];
+
+			expect(roomStore.orphanTasksActive.value).toEqual([]);
+			expect(roomStore.orphanTasksReview.value).toEqual([]);
+			expect(roomStore.orphanTasksDone.value).toEqual([]);
+		});
+	});
+});

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -152,6 +152,54 @@ class RoomStore {
 	/** Active goals */
 	readonly activeGoals = computed(() => this.goals.value.filter((g) => g.status === 'active'));
 
+	/** Tasks grouped by goal ID (Map<goalId, TaskSummary[]>) */
+	readonly tasksByGoalId = computed(() => {
+		const goals = this.goals.value;
+		const tasks = this.tasks.value;
+		const taskMap = new Map<string, TaskSummary>();
+		for (const t of tasks) {
+			taskMap.set(t.id, t);
+		}
+		const result = new Map<string, TaskSummary[]>();
+		for (const goal of goals) {
+			const linked: TaskSummary[] = [];
+			for (const taskId of goal.linkedTaskIds) {
+				const task = taskMap.get(taskId);
+				if (task) linked.push(task);
+			}
+			result.set(goal.id, linked);
+		}
+		return result;
+	});
+
+	/** Tasks not linked to any goal */
+	readonly orphanTasks = computed(() => {
+		const linkedIds = new Set<string>();
+		for (const goal of this.goals.value) {
+			for (const taskId of goal.linkedTaskIds) {
+				linkedIds.add(taskId);
+			}
+		}
+		return this.tasks.value.filter((t) => !linkedIds.has(t.id));
+	});
+
+	/** Orphan tasks that are active (draft, pending, or in_progress) */
+	readonly orphanTasksActive = computed(() =>
+		this.orphanTasks.value.filter(
+			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+		)
+	);
+
+	/** Orphan tasks in review (review or needs_attention) */
+	readonly orphanTasksReview = computed(() =>
+		this.orphanTasks.value.filter((t) => t.status === 'review' || t.status === 'needs_attention')
+	);
+
+	/** Orphan tasks that are done (completed or cancelled) */
+	readonly orphanTasksDone = computed(() =>
+		this.orphanTasks.value.filter((t) => t.status === 'completed' || t.status === 'cancelled')
+	);
+
 	// ========================================
 	// Private State
 	// ========================================


### PR DESCRIPTION
## Summary
- Add `tasksByGoalId` computed signal mapping goal IDs to their linked `TaskSummary[]`
- Add `orphanTasks` computed signal for tasks not linked to any goal
- Add `orphanTasksActive`, `orphanTasksReview`, `orphanTasksDone` computed signals filtering orphan tasks by status category (all 7 `TaskStatus` values covered)
- Add comprehensive unit tests (11 test cases) covering all new signals

## Test plan
- [x] `bunx vitest run` passes all 11 new tests
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (0 errors)
- [x] `bun run format:check` passes