### PR TITLE
feat: add /room/:roomId/agent route pattern and navigation

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,6 +24,7 @@ import {
 	initializeRouter,
 	navigateToSession,
 	navigateToRoom,
+	navigateToRoomAgent,
 	navigateToRoomSession,
 	navigateToRoomTask,
 	navigateToHome,
@@ -33,6 +34,7 @@ import {
 	navigateToSpaceTask,
 	createSessionPath,
 	createRoomPath,
+	createRoomAgentPath,
 	createRoomSessionPath,
 	createRoomTaskPath,
 	createSpacePath,
@@ -97,6 +99,8 @@ export function App() {
 			const spaceTaskId = currentSpaceTaskIdSignal.value;
 			const navSection = navSectionSignal.value;
 			const currentPath = window.location.pathname;
+			// Detect agent route: synthetic session ID follows the pattern room:chat:<roomId>
+			const isAgentRoute = !!(roomSessionId && roomId && roomSessionId === `room:chat:${roomId}`);
 			const expectedPath = sessionId
 				? createSessionPath(sessionId)
 				: spaceTaskId && spaceId
@@ -107,15 +111,17 @@ export function App() {
 							? createSpacePath(spaceId)
 							: roomTaskId && roomId
 								? createRoomTaskPath(roomId, roomTaskId)
-								: roomSessionId && roomId
-									? createRoomSessionPath(roomId, roomSessionId)
-									: roomId
-										? createRoomPath(roomId)
-										: navSection === 'spaces'
-											? '/spaces'
-											: navSection === 'chats'
-												? '/sessions'
-												: '/';
+								: isAgentRoute
+									? createRoomAgentPath(roomId)
+									: roomSessionId && roomId
+										? createRoomSessionPath(roomId, roomSessionId)
+										: roomId
+											? createRoomPath(roomId)
+											: navSection === 'spaces'
+												? '/spaces'
+												: navSection === 'chats'
+													? '/sessions'
+													: '/';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops
@@ -130,6 +136,8 @@ export function App() {
 					navigateToSpace(spaceId, true);
 				} else if (roomTaskId && roomId) {
 					navigateToRoomTask(roomId, roomTaskId, true);
+				} else if (isAgentRoute) {
+					navigateToRoomAgent(roomId, true);
 				} else if (roomSessionId && roomId) {
 					navigateToRoomSession(roomId, roomSessionId, true);
 				} else if (roomId) {

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -11,7 +11,12 @@
 
 import { useMemo, useState } from 'preact/hooks';
 import { roomStore } from '../lib/room-store';
-import { navigateToRooms, navigateToRoom, navigateToRoomSession } from '../lib/router';
+import {
+	navigateToRooms,
+	navigateToRoom,
+	navigateToRoomAgent,
+	navigateToRoomSession,
+} from '../lib/router';
 import { currentRoomSessionIdSignal } from '../lib/signals';
 import { cn } from '../lib/utils';
 
@@ -71,7 +76,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	};
 
 	const handleRoomAgentClick = () => {
-		navigateToRoomSession(roomId, roomAgentSessionId);
+		navigateToRoomAgent(roomId);
 		onNavigate?.();
 	};
 

--- a/packages/web/src/lib/__tests__/room-agent-router.test.ts
+++ b/packages/web/src/lib/__tests__/room-agent-router.test.ts
@@ -1,0 +1,205 @@
+// @ts-nocheck
+/**
+ * Tests for Room Agent URL routing
+ *
+ * Tests the /room/:roomId/agent route pattern including:
+ * - Path extraction and creation
+ * - Navigation function
+ * - popstate handling
+ * - Page-load initialization with correct signals
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	getRoomIdFromPath,
+	getRoomAgentFromPath,
+	createRoomAgentPath,
+	navigateToRoomAgent,
+	initializeRouter,
+	cleanupRouter,
+} from '../router';
+import {
+	currentSessionIdSignal,
+	currentRoomIdSignal,
+	currentRoomSessionIdSignal,
+	currentRoomTaskIdSignal,
+	currentSpaceIdSignal,
+	currentSpaceSessionIdSignal,
+	currentSpaceTaskIdSignal,
+	navSectionSignal,
+} from '../signals';
+
+let originalHistory: unknown;
+let originalLocation: unknown;
+let mockHistory: unknown;
+let mockLocation: unknown;
+
+describe('Room Agent Router', () => {
+	beforeEach(() => {
+		originalHistory = window.history;
+		originalLocation = window.location;
+
+		mockHistory = {
+			pushState: vi.fn(),
+			replaceState: vi.fn(),
+			state: null,
+		};
+
+		mockLocation = {
+			pathname: '/',
+		};
+
+		Object.defineProperty(window, 'history', {
+			value: mockHistory,
+			writable: true,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'location', {
+			value: mockLocation,
+			writable: true,
+			configurable: true,
+		});
+
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'home';
+
+		vi.clearAllMocks();
+		cleanupRouter();
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, 'history', {
+			value: originalHistory,
+			writable: true,
+			configurable: true,
+		});
+		Object.defineProperty(window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		});
+		cleanupRouter();
+	});
+
+	describe('createRoomAgentPath', () => {
+		it('creates correct path', () => {
+			expect(createRoomAgentPath('abc-123')).toBe('/room/abc-123/agent');
+		});
+	});
+
+	describe('getRoomAgentFromPath', () => {
+		it('extracts roomId from agent route', () => {
+			expect(getRoomAgentFromPath('/room/abc-def-123/agent')).toBe('abc-def-123');
+		});
+
+		it('returns null for non-agent routes', () => {
+			expect(getRoomAgentFromPath('/room/abc-123')).toBeNull();
+			expect(getRoomAgentFromPath('/room/abc-123/session/xyz')).toBeNull();
+			expect(getRoomAgentFromPath('/room/abc-123/task/xyz')).toBeNull();
+			expect(getRoomAgentFromPath('/')).toBeNull();
+			expect(getRoomAgentFromPath('/session/abc-123')).toBeNull();
+		});
+
+		it('rejects paths with trailing content after agent', () => {
+			expect(getRoomAgentFromPath('/room/abc-123/agent/extra')).toBeNull();
+		});
+	});
+
+	describe('getRoomIdFromPath recognizes agent route', () => {
+		it('extracts roomId from agent path', () => {
+			expect(getRoomIdFromPath('/room/abc-def-123/agent')).toBe('abc-def-123');
+		});
+	});
+
+	describe('navigateToRoomAgent', () => {
+		it('pushes correct URL and sets signals', () => {
+			const roomId = 'abc-def-123';
+			navigateToRoomAgent(roomId);
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{ roomId, path: '/room/abc-def-123/agent' },
+				'',
+				'/room/abc-def-123/agent'
+			);
+			expect(currentRoomIdSignal.value).toBe(roomId);
+			expect(currentRoomSessionIdSignal.value).toBe(`room:chat:${roomId}`);
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentSpaceIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('rooms');
+		});
+
+		it('uses replaceState when replace=true', () => {
+			navigateToRoomAgent('abc-123', true);
+
+			expect(mockHistory.replaceState).toHaveBeenCalled();
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+		});
+
+		it('updates signals even when already on same path', () => {
+			const roomId = 'abc-def-123';
+			mockLocation.pathname = `/room/${roomId}/agent`;
+
+			navigateToRoomAgent(roomId);
+
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+			expect(currentRoomIdSignal.value).toBe(roomId);
+			expect(currentRoomSessionIdSignal.value).toBe(`room:chat:${roomId}`);
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('initializeRouter with agent route', () => {
+		it('sets correct signals on page load for agent route', () => {
+			const roomId = 'abc-def-123';
+			mockLocation.pathname = `/room/${roomId}/agent`;
+
+			initializeRouter();
+
+			expect(currentRoomIdSignal.value).toBe(roomId);
+			expect(currentRoomSessionIdSignal.value).toBe(`room:chat:${roomId}`);
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentSpaceIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('rooms');
+		});
+
+		it('does not set agent signals for plain room route', () => {
+			const roomId = 'abc-def-123';
+			mockLocation.pathname = `/room/${roomId}`;
+
+			initializeRouter();
+
+			expect(currentRoomIdSignal.value).toBe(roomId);
+			expect(currentRoomSessionIdSignal.value).toBeNull();
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('popstate handling for agent route', () => {
+		it('restores agent signals on back/forward navigation', () => {
+			const roomId = 'abc-def-123';
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			// Simulate popstate to agent route
+			mockLocation.pathname = `/room/${roomId}/agent`;
+			const event = new PopStateEvent('popstate', {
+				state: { roomId, path: `/room/${roomId}/agent` },
+			});
+			window.dispatchEvent(event);
+
+			expect(currentRoomIdSignal.value).toBe(roomId);
+			expect(currentRoomSessionIdSignal.value).toBe(`room:chat:${roomId}`);
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(navSectionSignal.value).toBe('rooms');
+		});
+	});
+});

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -4,6 +4,7 @@
  * Handles URL-based routing for sessions and rooms with patterns:
  * - Sessions: /session/:sessionId
  * - Rooms: /room/:roomId
+ * - Room Agent: /room/:roomId/agent
  *
  * Features:
  * - URL sync: Updates URL when session/room changes
@@ -842,6 +843,9 @@ function handlePopState(_event: PopStateEvent): void {
 
 	// Update the signals to match the URL
 	// Space routes take priority over room routes
+	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomTask/roomSession/roomId
+	// because getRoomIdFromPath also matches agent paths. If reordered, agent routes silently
+	// fall through to the plain room handler, losing the synthetic session ID.
 	if (spaceTask) {
 		currentSpaceIdSignal.value = spaceTask.spaceId;
 		currentSpaceTaskIdSignal.value = spaceTask.taskId;
@@ -976,6 +980,7 @@ export function initializeRouter(): string | null {
 	const initialSpaceId = getSpaceIdFromPath(initialPath);
 
 	// Set initial signals — space routes take priority, then room routes
+	// IMPORTANT: Order is load-bearing — see comment in handlePopState
 	if (initialSpaceTask) {
 		currentSpaceIdSignal.value = initialSpaceTask.spaceId;
 		currentSpaceTaskIdSignal.value = initialSpaceTask.taskId;

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -26,6 +26,7 @@ import {
 /** Route patterns */
 const SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/;
 const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
+const ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
@@ -67,6 +68,10 @@ export function getRoomIdFromPath(path: string): string | null {
 	const match = path.match(ROOM_ROUTE_PATTERN);
 	if (match) return match[1];
 
+	// Also check room agent pattern
+	const roomAgentMatch = path.match(ROOM_AGENT_ROUTE_PATTERN);
+	if (roomAgentMatch) return roomAgentMatch[1];
+
 	// Also check room session pattern
 	const roomSessionMatch = path.match(ROOM_SESSION_ROUTE_PATTERN);
 	if (roomSessionMatch) return roomSessionMatch[1];
@@ -100,6 +105,15 @@ export function getRoomTaskIdFromPath(path: string): { roomId: string; taskId: s
 	const match = path.match(ROOM_TASK_ROUTE_PATTERN);
 	if (!match) return null;
 	return { roomId: match[1], taskId: match[2] };
+}
+
+/**
+ * Extract room ID from agent route path
+ * Returns null if not on a room agent route
+ */
+export function getRoomAgentFromPath(path: string): string | null {
+	const match = path.match(ROOM_AGENT_ROUTE_PATTERN);
+	return match ? match[1] : null;
 }
 
 /**
@@ -158,6 +172,13 @@ export function createSessionPath(sessionId: string): string {
  */
 export function createRoomPath(roomId: string): string {
 	return `/room/${roomId}`;
+}
+
+/**
+ * Create room agent URL path
+ */
+export function createRoomAgentPath(roomId: string): string {
+	return `/room/${roomId}/agent`;
 }
 
 /**
@@ -335,6 +356,53 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		navSectionSignal.value = 'rooms';
 	} finally {
 		// Use setTimeout to break the synchronous cycle
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
+ * Navigate to the Room Agent view
+ * Updates URL to /room/:roomId/agent and sets signals for ChatContainer rendering
+ *
+ * @param roomId - The room ID
+ * @param replace - Whether to replace current history entry (default: false)
+ */
+export function navigateToRoomAgent(roomId: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	const targetPath = createRoomAgentPath(roomId);
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentRoomIdSignal.value = roomId;
+		currentRoomSessionIdSignal.value = `room:chat:${roomId}`;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ roomId, path: targetPath }, '', targetPath);
+
+		currentRoomIdSignal.value = roomId;
+		currentRoomSessionIdSignal.value = `room:chat:${roomId}`;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
+	} finally {
 		setTimeout(() => {
 			routerState.isNavigating = false;
 		}, 0);
@@ -765,6 +833,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const path = getCurrentPath();
 	const sessionId = getSessionIdFromPath(path);
 	const roomId = getRoomIdFromPath(path);
+	const roomAgent = getRoomAgentFromPath(path);
 	const roomSession = getRoomSessionIdFromPath(path);
 	const roomTask = getRoomTaskIdFromPath(path);
 	const spaceTask = getSpaceTaskIdFromPath(path);
@@ -800,6 +869,15 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
+	} else if (roomAgent) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = roomAgent;
+		currentRoomSessionIdSignal.value = `room:chat:${roomAgent}`;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
 	} else if (roomTask) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -890,6 +968,7 @@ export function initializeRouter(): string | null {
 	const initialPath = getCurrentPath();
 	const initialSessionId = getSessionIdFromPath(initialPath);
 	const initialRoomId = getRoomIdFromPath(initialPath);
+	const initialRoomAgent = getRoomAgentFromPath(initialPath);
 	const initialRoomSession = getRoomSessionIdFromPath(initialPath);
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
 	const initialSpaceTask = getSpaceTaskIdFromPath(initialPath);
@@ -924,6 +1003,15 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
+	} else if (initialRoomAgent) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = initialRoomAgent;
+		currentRoomSessionIdSignal.value = `room:chat:${initialRoomAgent}`;
+		currentRoomTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
 	} else if (initialRoomTask) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;


### PR DESCRIPTION
## Summary
- Add `ROOM_AGENT_ROUTE_PATTERN` (`/room/:roomId/agent`) and helpers (`createRoomAgentPath`, `getRoomAgentFromPath`)
- Add `navigateToRoomAgent(roomId)` that pushes the agent URL and sets the synthetic `room:chat:<roomId>` session signal so `ChatContainer` renders correctly
- Update `getRoomIdFromPath`, `handlePopState`, and `initializeRouter` to recognize the agent route on page load and back/forward navigation
- Update `RoomContextPanel` to use `navigateToRoomAgent` instead of `navigateToRoomSession` with a synthetic session ID

## Test plan
- [x] Unit tests for `createRoomAgentPath`, `getRoomAgentFromPath`, `getRoomIdFromPath` with agent paths
- [x] Unit tests for `navigateToRoomAgent` signal updates and history pushState
- [x] Unit tests for `initializeRouter` page-load signal restoration on agent route
- [x] Unit tests for popstate (back/forward) handling of agent route
- [x] TypeScript compiles without errors
- [x] Lint and format pass