### PR TITLE
feat: add mobile BottomTabBar with iOS-style navigation (Task 4.6)

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { effect, batch } from '@preact/signals';
 import { NavRail } from './islands/NavRail.tsx';
+import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
 import MainContent from './islands/MainContent.tsx';
 import ToastContainer from './islands/ToastContainer.tsx';
@@ -132,9 +133,14 @@ export function App() {
 				{/* Context Panel - always visible */}
 				<ContextPanel />
 
-				{/* Main Content */}
-				<MainContent />
+				{/* Main Content — add bottom padding on mobile to avoid tab bar overlap */}
+				<div class="flex-1 flex flex-col overflow-hidden pb-16 md:pb-0 min-w-0">
+					<MainContent />
+				</div>
 			</div>
+
+			{/* Bottom Tab Bar (mobile only) */}
+			<BottomTabBar />
 
 			{/* Global Toast Container */}
 			<ToastContainer />

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -1,0 +1,144 @@
+import type { JSX } from 'preact';
+import { navSectionSignal, type NavSection } from '../lib/signals.ts';
+import {
+	navigateToSessions,
+	navigateToSettings,
+	navigateToRooms,
+	navigateToInbox,
+} from '../lib/router.ts';
+import { inboxStore } from '../lib/inbox-store.ts';
+
+interface TabItem {
+	id: NavSection;
+	label: string;
+	icon: () => JSX.Element;
+}
+
+const BOTTOM_TABS: TabItem[] = [
+	{
+		id: 'inbox',
+		label: 'Inbox',
+		icon: () => (
+			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+				/>
+			</svg>
+		),
+	},
+	{
+		id: 'rooms',
+		label: 'Rooms',
+		icon: () => (
+			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+				/>
+			</svg>
+		),
+	},
+	{
+		id: 'chats',
+		label: 'Chats',
+		icon: () => (
+			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+				/>
+			</svg>
+		),
+	},
+	{
+		id: 'settings',
+		label: 'Settings',
+		icon: () => (
+			<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+				/>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+				/>
+			</svg>
+		),
+	},
+];
+
+function handleTabClick(id: NavSection): void {
+	switch (id) {
+		case 'inbox':
+			navigateToInbox();
+			break;
+		case 'rooms':
+			navigateToRooms();
+			break;
+		case 'chats':
+			navigateToSessions();
+			break;
+		case 'settings':
+			navigateToSettings();
+			break;
+	}
+}
+
+export function BottomTabBar() {
+	const navSection = navSectionSignal.value;
+	const inboxBadgeCount = inboxStore.reviewCount.value;
+
+	return (
+		<div
+			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md border-t border-dark-700 pb-safe"
+			role="tablist"
+			aria-label="Main navigation"
+		>
+			{BOTTOM_TABS.map((tab) => {
+				const isActive = navSection === tab.id;
+				const isInbox = tab.id === 'inbox';
+				const badge = isInbox ? inboxBadgeCount : 0;
+
+				return (
+					<button
+						key={tab.id}
+						type="button"
+						role="tab"
+						aria-selected={isActive}
+						aria-label={tab.label}
+						onClick={() => handleTabClick(tab.id)}
+						class={`flex-1 flex flex-col items-center justify-center py-2 gap-0.5 transition-colors duration-150 ${
+							isActive ? 'text-indigo-400' : 'text-gray-500 active:text-gray-300'
+						}`}
+					>
+						<div class="relative">
+							<tab.icon />
+							{badge > 0 && (
+								<div class="w-2 h-2 rounded-full bg-red-500 absolute -top-0.5 -right-0.5 flex items-center justify-center">
+									{badge <= 9 ? (
+										<span class="text-white text-[8px] font-bold leading-none">{badge}</span>
+									) : (
+										<span class="text-white text-[8px] font-bold leading-none">9+</span>
+									)}
+								</div>
+							)}
+						</div>
+						<span class="text-[10px] font-medium leading-none">{tab.label}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
+++ b/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * Tests for BottomTabBar Component
+ *
+ * Tests mobile-only bottom navigation: rendering, active state highlighting,
+ * tab click navigation, and inbox badge display.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/preact';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signal, computed } from '@preact/signals';
+
+// Mock router functions
+vi.mock('../../lib/router.ts', () => ({
+	navigateToSessions: vi.fn(),
+	navigateToSettings: vi.fn(),
+	navigateToHome: vi.fn(),
+	navigateToRooms: vi.fn(),
+	navigateToInbox: vi.fn(),
+	navigateToSpaces: vi.fn(),
+}));
+
+// Mock inboxStore
+const mockItemsSignal = signal<unknown[]>([]);
+const mockReviewCount = computed(() => mockItemsSignal.value.length);
+
+vi.mock('../../lib/inbox-store.ts', () => ({
+	inboxStore: {
+		get items() {
+			return mockItemsSignal;
+		},
+		get isLoading() {
+			return signal(false);
+		},
+		get reviewCount() {
+			return mockReviewCount;
+		},
+		refresh: vi.fn().mockResolvedValue(undefined),
+	},
+}));
+
+import { BottomTabBar } from '../BottomTabBar.tsx';
+import { navSectionSignal } from '../../lib/signals.ts';
+import {
+	navigateToInbox,
+	navigateToRooms,
+	navigateToSessions,
+	navigateToSettings,
+} from '../../lib/router.ts';
+
+describe('BottomTabBar', () => {
+	beforeEach(() => {
+		navSectionSignal.value = 'chats';
+		mockItemsSignal.value = [];
+		vi.clearAllMocks();
+	});
+
+	describe('Rendering', () => {
+		it('should render all four tabs', () => {
+			render(<BottomTabBar />);
+
+			expect(screen.getByRole('tab', { name: 'Inbox' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Rooms' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Chats' })).toBeTruthy();
+			expect(screen.getByRole('tab', { name: 'Settings' })).toBeTruthy();
+		});
+
+		it('should render tab labels as visible text', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const labels = container.querySelectorAll('span.text-\\[10px\\]');
+			const texts = Array.from(labels).map((el) => el.textContent);
+			expect(texts).toContain('Inbox');
+			expect(texts).toContain('Rooms');
+			expect(texts).toContain('Chats');
+			expect(texts).toContain('Settings');
+		});
+
+		it('should have role="tablist" on the container', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const tablist = container.querySelector('[role="tablist"]');
+			expect(tablist).toBeTruthy();
+		});
+	});
+
+	describe('Mobile-only visibility', () => {
+		it('should have md:hidden class on the container', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const bar = container.querySelector('[role="tablist"]');
+			expect(bar?.className).toContain('md:hidden');
+		});
+
+		it('should have flex class for mobile display', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const bar = container.querySelector('[role="tablist"]');
+			expect(bar?.className).toContain('flex');
+		});
+
+		it('should be fixed positioned at the bottom', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const bar = container.querySelector('[role="tablist"]');
+			expect(bar?.className).toContain('fixed');
+			expect(bar?.className).toContain('bottom-0');
+		});
+	});
+
+	describe('Active State', () => {
+		it('should mark Chats tab as selected when navSection is chats', () => {
+			navSectionSignal.value = 'chats';
+			render(<BottomTabBar />);
+
+			const chatsTab = screen.getByRole('tab', { name: 'Chats' });
+			expect(chatsTab.getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('should mark Inbox tab as selected when navSection is inbox', () => {
+			navSectionSignal.value = 'inbox';
+			render(<BottomTabBar />);
+
+			const inboxTab = screen.getByRole('tab', { name: 'Inbox' });
+			expect(inboxTab.getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('should mark Rooms tab as selected when navSection is rooms', () => {
+			navSectionSignal.value = 'rooms';
+			render(<BottomTabBar />);
+
+			const roomsTab = screen.getByRole('tab', { name: 'Rooms' });
+			expect(roomsTab.getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('should mark Settings tab as selected when navSection is settings', () => {
+			navSectionSignal.value = 'settings';
+			render(<BottomTabBar />);
+
+			const settingsTab = screen.getByRole('tab', { name: 'Settings' });
+			expect(settingsTab.getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('should apply active color class to active tab', () => {
+			navSectionSignal.value = 'chats';
+			render(<BottomTabBar />);
+
+			const chatsTab = screen.getByRole('tab', { name: 'Chats' });
+			expect(chatsTab.className).toContain('text-indigo-400');
+		});
+
+		it('should apply inactive color class to non-active tabs', () => {
+			navSectionSignal.value = 'chats';
+			render(<BottomTabBar />);
+
+			const inboxTab = screen.getByRole('tab', { name: 'Inbox' });
+			expect(inboxTab.className).toContain('text-gray-500');
+		});
+
+		it('should only have one tab selected at a time', () => {
+			navSectionSignal.value = 'rooms';
+			render(<BottomTabBar />);
+
+			const tabs = screen.getAllByRole('tab');
+			const selectedTabs = tabs.filter((t) => t.getAttribute('aria-selected') === 'true');
+			expect(selectedTabs).toHaveLength(1);
+		});
+	});
+
+	describe('Navigation', () => {
+		it('should call navigateToInbox when Inbox tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const inboxTab = screen.getByRole('tab', { name: 'Inbox' });
+			fireEvent.click(inboxTab);
+
+			expect(navigateToInbox).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call navigateToRooms when Rooms tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const roomsTab = screen.getByRole('tab', { name: 'Rooms' });
+			fireEvent.click(roomsTab);
+
+			expect(navigateToRooms).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call navigateToSessions when Chats tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const chatsTab = screen.getByRole('tab', { name: 'Chats' });
+			fireEvent.click(chatsTab);
+
+			expect(navigateToSessions).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call navigateToSettings when Settings tab is clicked', () => {
+			render(<BottomTabBar />);
+
+			const settingsTab = screen.getByRole('tab', { name: 'Settings' });
+			fireEvent.click(settingsTab);
+
+			expect(navigateToSettings).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Inbox Badge', () => {
+		it('should not show badge when review count is zero', () => {
+			mockItemsSignal.value = [];
+			const { container } = render(<BottomTabBar />);
+
+			const badge = container.querySelector('.bg-red-500');
+			expect(badge).toBeNull();
+		});
+
+		it('should show badge when review count is greater than zero', () => {
+			mockItemsSignal.value = [{}];
+			const { container } = render(<BottomTabBar />);
+
+			const badge = container.querySelector('.bg-red-500');
+			expect(badge).toBeTruthy();
+		});
+
+		it('should display numeric count when badge count is 1-9', () => {
+			mockItemsSignal.value = Array.from({ length: 3 }, () => ({}));
+			const { container } = render(<BottomTabBar />);
+
+			const badgeSpan = container.querySelector('.bg-red-500 span');
+			expect(badgeSpan?.textContent).toBe('3');
+		});
+
+		it('should display "9+" when badge count exceeds 9', () => {
+			mockItemsSignal.value = Array.from({ length: 12 }, () => ({}));
+			const { container } = render(<BottomTabBar />);
+
+			const badgeSpan = container.querySelector('.bg-red-500 span');
+			expect(badgeSpan?.textContent).toBe('9+');
+		});
+
+		it('should only show badge on Inbox tab, not other tabs', () => {
+			mockItemsSignal.value = [{}];
+			render(<BottomTabBar />);
+
+			// Only the Inbox button wrapper should have a badge
+			const inboxTab = screen.getByRole('tab', { name: 'Inbox' });
+			const chatsTab = screen.getByRole('tab', { name: 'Chats' });
+
+			expect(inboxTab.querySelector('.bg-red-500')).toBeTruthy();
+			expect(chatsTab.querySelector('.bg-red-500')).toBeNull();
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('should have aria-selected on all tabs', () => {
+			render(<BottomTabBar />);
+
+			const tabs = screen.getAllByRole('tab');
+			for (const tab of tabs) {
+				expect(tab.hasAttribute('aria-selected')).toBe(true);
+			}
+		});
+
+		it('should have aria-label on all tabs', () => {
+			render(<BottomTabBar />);
+
+			const tabs = screen.getAllByRole('tab');
+			for (const tab of tabs) {
+				expect(tab.hasAttribute('aria-label')).toBe(true);
+			}
+		});
+
+		it('should have type="button" on all tab buttons', () => {
+			render(<BottomTabBar />);
+
+			const tabs = screen.getAllByRole('tab');
+			for (const tab of tabs) {
+				expect(tab.getAttribute('type')).toBe('button');
+			}
+		});
+
+		it('should have aria-label on the tablist', () => {
+			const { container } = render(<BottomTabBar />);
+
+			const tablist = container.querySelector('[role="tablist"]');
+			expect(tablist?.getAttribute('aria-label')).toBe('Main navigation');
+		});
+	});
+
+	describe('Signal Reactivity', () => {
+		it('should update active tab when navSectionSignal changes', () => {
+			navSectionSignal.value = 'chats';
+			const { rerender } = render(<BottomTabBar />);
+
+			let chatsTab = screen.getByRole('tab', { name: 'Chats' });
+			expect(chatsTab.getAttribute('aria-selected')).toBe('true');
+
+			navSectionSignal.value = 'rooms';
+			rerender(<BottomTabBar />);
+
+			chatsTab = screen.getByRole('tab', { name: 'Chats' });
+			const roomsTab = screen.getByRole('tab', { name: 'Rooms' });
+			expect(chatsTab.getAttribute('aria-selected')).toBe('false');
+			expect(roomsTab.getAttribute('aria-selected')).toBe('true');
+		});
+	});
+});

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -536,3 +536,8 @@ a:focus-visible {
 		border: none !important;
 	}
 }
+
+/* Safe area inset support for iOS notch/home indicator */
+.pb-safe {
+	padding-bottom: env(safe-area-inset-bottom);
+}


### PR DESCRIPTION
Implements a mobile-first bottom tab bar (< 768px) replacing the desktop
NavRail on small screens. Includes Inbox (with badge), Rooms, Chats, and
Settings tabs with active state highlighting, safe-area inset support for
iPhone notch, and bottom padding on MainContent to prevent content overlap.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
