### PR TITLE
feat: implement task_result evaluation in WorkflowExecutor

### DIFF
--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -44,6 +44,11 @@ export interface ConditionContext {
 	 * Set externally (e.g. via RPC) into run.config.humanApproved before retry.
 	 */
 	humanApproved?: boolean;
+	/**
+	 * Result string from the most recently completed task on the current step.
+	 * Used by `task_result` conditions for prefix matching.
+	 */
+	taskResult?: string;
 }
 
 /** Result of a single condition evaluation attempt */
@@ -234,10 +239,25 @@ export class WorkflowExecutor {
 			}
 
 			case 'task_result': {
-				// TODO(Task 1.2): Implement prefix matching against completed task's result field.
-				// Until then, Verify step transitions (task_result conditions) will not fire,
-				// causing the run to go to needs_attention. This is intentional for phased rollout.
-				return { passed: false, reason: 'task_result evaluation not yet implemented' };
+				if (!condition.expression || !condition.expression.trim()) {
+					return {
+						passed: false,
+						reason: 'task_result type requires a non-empty expression',
+					};
+				}
+				if (context.taskResult === undefined) {
+					return {
+						passed: false,
+						reason: 'No task result available for evaluation',
+					};
+				}
+				if (context.taskResult.startsWith(condition.expression)) {
+					return { passed: true };
+				}
+				return {
+					passed: false,
+					reason: `Task result "${context.taskResult}" does not match "${condition.expression}"`,
+				};
 			}
 
 			default: {
@@ -267,7 +287,9 @@ export class WorkflowExecutor {
 	 *
 	 * Does NOT spawn session groups — that is SpaceRuntime's responsibility.
 	 */
-	async advance(): Promise<{ step: WorkflowStep; tasks: SpaceTask[] }> {
+	async advance(options?: {
+		stepResult?: string;
+	}): Promise<{ step: WorkflowStep; tasks: SpaceTask[] }> {
 		if (this.isComplete()) {
 			throw new Error('Cannot advance: workflow run is already complete');
 		}
@@ -294,11 +316,18 @@ export class WorkflowExecutor {
 			return { step: current, tasks: [] };
 		}
 
+		// Only resolve taskResult when at least one transition uses task_result conditions.
+		// This avoids an unnecessary DB query on the common path (always/human/condition).
+		const needsTaskResult = transitions.some((t) => t.condition?.type === 'task_result');
+		const taskResult = needsTaskResult
+			? await this.resolveTaskResult(current.id, options?.stepResult)
+			: undefined;
+
 		// Evaluate transitions in order; follow the first one whose condition passes.
 		// A failing condition does NOT stop evaluation — the next transition is tried.
 		// Only when every transition has been evaluated and none passed is the run marked
 		// needs_attention and a WorkflowTransitionError thrown.
-		const context = this.getConditionContext();
+		const context = this.getConditionContext(taskResult);
 		let lastReason: string | undefined;
 		let blockedByHumanGate = false;
 
@@ -343,11 +372,12 @@ export class WorkflowExecutor {
 	// -------------------------------------------------------------------------
 
 	/** Builds a ConditionContext from the current run's config and workspacePath. */
-	private getConditionContext(): ConditionContext {
+	private getConditionContext(taskResult?: string): ConditionContext {
 		const config = (this.run.config ?? {}) as Record<string, unknown>;
 		return {
 			workspacePath: this.workspacePath,
 			humanApproved: config.humanApproved === true,
+			taskResult,
 		};
 	}
 
@@ -398,9 +428,12 @@ export class WorkflowExecutor {
 		condition: WorkflowCondition,
 		context: ConditionContext
 	): Promise<ConditionResult> {
-		// human conditions cannot change between retries in the same advance() call;
-		// short-circuit after the first evaluation to avoid redundant checks.
-		const maxAttempts = condition.type === 'human' ? 1 : 1 + (condition.maxRetries ?? 0);
+		// human and task_result conditions cannot change between retries in the same advance()
+		// call; short-circuit after the first evaluation to avoid redundant checks.
+		const maxAttempts =
+			condition.type === 'human' || condition.type === 'task_result'
+				? 1
+				: 1 + (condition.maxRetries ?? 0);
 		let lastResult: ConditionResult = { passed: false, reason: 'Condition never evaluated' };
 
 		for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -429,6 +462,27 @@ export class WorkflowExecutor {
 			const updated = this.workflowRunRepo.updateRun(this.run.id, { config: rest });
 			if (updated) this.run = updated;
 		}
+	}
+
+	/**
+	 * Resolves the task result for the current step from the most recently completed task.
+	 * DB task `result` takes priority; `fallback` is used when the DB result is empty.
+	 */
+	private async resolveTaskResult(stepId: string, fallback?: string): Promise<string | undefined> {
+		const allTasks = await this.taskManager.listTasksByWorkflowRun(this.run.id);
+		const completedOnStep = allTasks.filter(
+			(t) => t.workflowStepId === stepId && t.status === 'completed'
+		);
+
+		// Sort by completedAt descending to get the most recently completed task
+		completedOnStep.sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0));
+
+		const latestTask = completedOnStep[0];
+		const dbResult = latestTask?.result;
+
+		// Use DB result if present (including empty string), otherwise fall back to options.stepResult
+		if (dbResult != null) return dbResult;
+		return fallback;
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -503,11 +503,11 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * 5. Handle WorkflowGateError → return gate-blocked status (caller calls request_human_input)
 		 * 6. Return next step info (or terminal state)
 		 *
-		 * Note: AdvanceWorkflowInput includes a `step_result` field which is currently a
-		 * placeholder. WorkflowExecutor.advance() does not yet accept a result parameter;
-		 * transition conditions are evaluated against run.config (e.g. humanApproved).
-		 * The field is retained in the schema for forward compatibility but is not forwarded
-		 * to the executor in this implementation.
+		 * Note: WorkflowExecutor.advance() now accepts `{ stepResult?: string }` for
+		 * task_result condition evaluation. The `step_result` field in AdvanceWorkflowInput
+		 * is not yet forwarded here — Task 1.3 will wire `_args.step_result` through to
+		 * `executor.advance({ stepResult: _args.step_result })`. In the meantime, advance()
+		 * resolves the task result from the DB (most recently completed task on the step).
 		 */
 		async advance_workflow(_args: AdvanceWorkflowInput): Promise<ToolResult> {
 			const executor = runtime.getExecutor(workflowRunId);

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -1306,6 +1306,58 @@ describe('WorkflowExecutor', () => {
 			expect(result.reason).toContain('non-empty expression');
 		});
 
+		test('task_result retries are short-circuited (maxRetries has no effect)', async () => {
+			// task_result context doesn't change between retries, so maxRetries should be ignored.
+			// Verify that advance() only evaluates the condition once even with maxRetries set.
+			const steps = [
+				{ id: STEP_A, name: 'Verify', agentId: AGENT_A },
+				{ id: STEP_B, name: 'Next', agentId: AGENT_B },
+			];
+			const transitions = [
+				{
+					from: STEP_A,
+					to: STEP_B,
+					condition: {
+						type: 'task_result' as const,
+						expression: 'passed',
+						maxRetries: 5,
+					},
+					order: 0,
+				},
+			];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-retry-${Date.now()}`,
+				steps,
+				transitions,
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Retry Test',
+				currentStepId: workflow.startStepId,
+			});
+
+			// Complete a task with 'failed' — won't match 'passed'
+			const verifyStepId = workflow.steps.find((s) => s.name === 'Verify')!.id;
+			const task = await taskManager.createTask({
+				title: 'Verify',
+				description: '',
+				workflowRunId: run.id,
+				workflowStepId: verifyStepId,
+				status: 'pending',
+			});
+			await taskManager.setTaskStatus(task.id, 'in_progress');
+			await taskManager.completeTask(task.id, 'failed');
+
+			const executor = makeExecutor(workflow, run);
+			// Should fail immediately (not retry 5 times) since taskResult won't change
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+		});
+
 		test('evaluateCondition: fails when taskResult is undefined', async () => {
 			const { workflow, run } = createLinearWorkflow([
 				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
@@ -1544,9 +1596,8 @@ describe('WorkflowExecutor', () => {
 			});
 			await taskManager.setTaskStatus(task1.id, 'in_progress');
 			await taskManager.completeTask(task1.id, 'failed: first attempt');
-
-			// Small delay to ensure different completedAt timestamps
-			await new Promise((r) => setTimeout(r, 10));
+			// Force a deterministic earlier completedAt via direct DB update
+			db.prepare('UPDATE space_tasks SET completed_at = ? WHERE id = ?').run(1000, task1.id);
 
 			// Create second task, complete with 'passed'
 			const task2 = await taskManager.createTask({
@@ -1558,6 +1609,8 @@ describe('WorkflowExecutor', () => {
 			});
 			await taskManager.setTaskStatus(task2.id, 'in_progress');
 			await taskManager.completeTask(task2.id, 'passed');
+			// Force a deterministic later completedAt via direct DB update
+			db.prepare('UPDATE space_tasks SET completed_at = ? WHERE id = ?').run(2000, task2.id);
 
 			const executor = makeExecutor(workflow, run);
 			// Should use 'passed' from the most recently completed task

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -1221,4 +1221,364 @@ describe('WorkflowExecutor', () => {
 			expect(r3.tasks[0].goalId).toBe('goal-cycle');
 		});
 	});
+
+	// =========================================================================
+	// Condition type: task_result
+	// =========================================================================
+
+	describe('condition type: task_result', () => {
+		test('evaluateCondition: passes when taskResult starts with expression', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = {
+				workspacePath: WORKSPACE,
+				taskResult: 'passed',
+			};
+			const result = await executor.evaluateCondition(
+				{ type: 'task_result', expression: 'passed' },
+				ctx
+			);
+			expect(result.passed).toBe(true);
+		});
+
+		test('evaluateCondition: passes with prefix match (failed: tests broken)', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = {
+				workspacePath: WORKSPACE,
+				taskResult: 'failed: tests broken',
+			};
+			const result = await executor.evaluateCondition(
+				{ type: 'task_result', expression: 'failed' },
+				ctx
+			);
+			expect(result.passed).toBe(true);
+		});
+
+		test('evaluateCondition: fails when taskResult does not match expression', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = {
+				workspacePath: WORKSPACE,
+				taskResult: 'failed: tests broken',
+			};
+			const result = await executor.evaluateCondition(
+				{ type: 'task_result', expression: 'passed' },
+				ctx
+			);
+			expect(result.passed).toBe(false);
+			expect(result.reason).toContain('does not match');
+			expect(result.reason).toContain('failed: tests broken');
+			expect(result.reason).toContain('passed');
+		});
+
+		test('evaluateCondition: fails when expression is empty', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = {
+				workspacePath: WORKSPACE,
+				taskResult: 'passed',
+			};
+			const result = await executor.evaluateCondition({ type: 'task_result', expression: '' }, ctx);
+			expect(result.passed).toBe(false);
+			expect(result.reason).toContain('non-empty expression');
+		});
+
+		test('evaluateCondition: fails when expression is undefined', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = {
+				workspacePath: WORKSPACE,
+				taskResult: 'passed',
+			};
+			const result = await executor.evaluateCondition({ type: 'task_result' }, ctx);
+			expect(result.passed).toBe(false);
+			expect(result.reason).toContain('non-empty expression');
+		});
+
+		test('evaluateCondition: fails when taskResult is undefined', async () => {
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+			]);
+			const executor = makeExecutor(workflow, run);
+			const ctx: ConditionContext = { workspacePath: WORKSPACE };
+			const result = await executor.evaluateCondition(
+				{ type: 'task_result', expression: 'passed' },
+				ctx
+			);
+			expect(result.passed).toBe(false);
+			expect(result.reason).toContain('No task result available');
+		});
+	});
+
+	// =========================================================================
+	// advance() with task_result — DB and fallback resolution
+	// =========================================================================
+
+	describe('advance() with task_result conditions', () => {
+		/**
+		 * Helper: creates a workflow with A → B where A→B has a task_result condition,
+		 * creates a completed task on step A with the given result, then returns the executor.
+		 */
+		async function setupTaskResultWorkflow(opts: {
+			taskResultOnStep?: string;
+			conditionExpression: string;
+		}) {
+			const steps = [
+				{ id: STEP_A, name: 'Verify', agentId: AGENT_A },
+				{ id: STEP_B, name: 'Next', agentId: AGENT_B },
+			];
+			const transitions = [
+				{
+					from: STEP_A,
+					to: STEP_B,
+					condition: {
+						type: 'task_result' as const,
+						expression: opts.conditionExpression,
+					},
+					order: 0,
+				},
+			];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-task-result-${Date.now()}`,
+				steps,
+				transitions,
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Task Result Test Run',
+				currentStepId: workflow.startStepId,
+			});
+
+			// Create a task on step A and complete it with a result
+			if (opts.taskResultOnStep !== undefined) {
+				const task = await taskManager.createTask({
+					title: 'Verify Task',
+					description: 'Verify work',
+					workflowRunId: run.id,
+					workflowStepId: workflow.steps.find((s) => s.name === 'Verify')!.id,
+					status: 'pending',
+				});
+				await taskManager.setTaskStatus(task.id, 'in_progress');
+				await taskManager.completeTask(task.id, opts.taskResultOnStep);
+			}
+
+			const executor = makeExecutor(workflow, run);
+			return { workflow, run, executor };
+		}
+
+		test('advance() resolves taskResult from DB and follows matching transition', async () => {
+			const { executor } = await setupTaskResultWorkflow({
+				taskResultOnStep: 'passed',
+				conditionExpression: 'passed',
+			});
+
+			const result = await executor.advance();
+			expect(result.step.name).toBe('Next');
+			expect(result.tasks).toHaveLength(1);
+		});
+
+		test('advance() resolves taskResult from DB with prefix match', async () => {
+			const { executor } = await setupTaskResultWorkflow({
+				taskResultOnStep: 'failed: linting errors found',
+				conditionExpression: 'failed',
+			});
+
+			const result = await executor.advance();
+			expect(result.step.name).toBe('Next');
+		});
+
+		test('advance() uses stepResult fallback when no DB result', async () => {
+			// No completed task on the step — taskResult comes from options.stepResult
+			const steps = [
+				{ id: STEP_A, name: 'Verify', agentId: AGENT_A },
+				{ id: STEP_B, name: 'Next', agentId: AGENT_B },
+			];
+			const transitions = [
+				{
+					from: STEP_A,
+					to: STEP_B,
+					condition: {
+						type: 'task_result' as const,
+						expression: 'passed',
+					},
+					order: 0,
+				},
+			];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-fallback-${Date.now()}`,
+				steps,
+				transitions,
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Fallback Test Run',
+				currentStepId: workflow.startStepId,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance({ stepResult: 'passed' });
+			expect(result.step.name).toBe('Next');
+		});
+
+		test('advance() DB result takes priority over stepResult fallback', async () => {
+			const { executor } = await setupTaskResultWorkflow({
+				taskResultOnStep: 'failed: real DB result',
+				conditionExpression: 'failed',
+			});
+
+			// Even though stepResult says 'passed', the DB result 'failed: ...' is used
+			const result = await executor.advance({ stepResult: 'passed' });
+			expect(result.step.name).toBe('Next');
+		});
+
+		test('advance() sets needs_attention when task_result does not match', async () => {
+			const { executor, run } = await setupTaskResultWorkflow({
+				taskResultOnStep: 'failed: tests broken',
+				conditionExpression: 'passed',
+			});
+
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
+		});
+
+		test('advance() sets needs_attention when no task result and no fallback', async () => {
+			// No completed task on step, no stepResult fallback
+			const steps = [
+				{ id: STEP_A, name: 'Verify', agentId: AGENT_A },
+				{ id: STEP_B, name: 'Next', agentId: AGENT_B },
+			];
+			const transitions = [
+				{
+					from: STEP_A,
+					to: STEP_B,
+					condition: {
+						type: 'task_result' as const,
+						expression: 'passed',
+					},
+					order: 0,
+				},
+			];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-no-result-${Date.now()}`,
+				steps,
+				transitions,
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'No Result Test Run',
+				currentStepId: workflow.startStepId,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			await expect(executor.advance()).rejects.toThrow(WorkflowTransitionError);
+			expect(runRepo.getRun(run.id)?.status).toBe('needs_attention');
+		});
+
+		test('advance() picks most recently completed task when multiple exist', async () => {
+			const steps = [
+				{ id: STEP_A, name: 'Verify', agentId: AGENT_A },
+				{ id: STEP_B, name: 'Next', agentId: AGENT_B },
+			];
+			const transitions = [
+				{
+					from: STEP_A,
+					to: STEP_B,
+					condition: {
+						type: 'task_result' as const,
+						expression: 'passed',
+					},
+					order: 0,
+				},
+			];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-multi-tasks-${Date.now()}`,
+				steps,
+				transitions,
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Multi Tasks Run',
+				currentStepId: workflow.startStepId,
+			});
+
+			const verifyStepId = workflow.steps.find((s) => s.name === 'Verify')!.id;
+
+			// Create first task, complete with 'failed'
+			const task1 = await taskManager.createTask({
+				title: 'Verify 1',
+				description: 'First try',
+				workflowRunId: run.id,
+				workflowStepId: verifyStepId,
+				status: 'pending',
+			});
+			await taskManager.setTaskStatus(task1.id, 'in_progress');
+			await taskManager.completeTask(task1.id, 'failed: first attempt');
+
+			// Small delay to ensure different completedAt timestamps
+			await new Promise((r) => setTimeout(r, 10));
+
+			// Create second task, complete with 'passed'
+			const task2 = await taskManager.createTask({
+				title: 'Verify 2',
+				description: 'Second try',
+				workflowRunId: run.id,
+				workflowStepId: verifyStepId,
+				status: 'pending',
+			});
+			await taskManager.setTaskStatus(task2.id, 'in_progress');
+			await taskManager.completeTask(task2.id, 'passed');
+
+			const executor = makeExecutor(workflow, run);
+			// Should use 'passed' from the most recently completed task
+			const result = await executor.advance();
+			expect(result.step.name).toBe('Next');
+		});
+
+		test('existing condition types continue to work unchanged', async () => {
+			// Verify that 'always', 'human', and 'condition' still work
+			const { workflow, run } = createLinearWorkflow([
+				{ id: STEP_A, name: 'Step A', agentId: AGENT_A },
+				{
+					id: STEP_B,
+					name: 'Step B',
+					agentId: AGENT_B,
+					incomingCondition: { type: 'always' },
+				},
+			]);
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+			expect(result.step.name).toBe('Step B');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- Adds `taskResult?: string` to `ConditionContext` interface for passing task results to condition evaluation
- Implements the `task_result` case in `evaluateCondition()` with prefix matching logic (`startsWith`)
- Updates `advance()` to accept optional `{ stepResult?: string }` parameter and automatically resolve task results from the DB (most recently completed task on current step), with fallback to `options.stepResult`
- Updates `getConditionContext()` to accept and forward `taskResult`

This is the foundational change for Task 1.3 (wiring `step_result` from the tool handler) — the `advance()` signature change enables callers to pass step results through.

## Test plan

- [x] `evaluateCondition()` with `task_result`: exact match passes
- [x] `evaluateCondition()` with `task_result`: prefix match passes (`'failed'` matches `'failed: tests broken'`)
- [x] `evaluateCondition()` with `task_result`: mismatch fails with descriptive reason
- [x] `evaluateCondition()` with `task_result`: empty expression fails
- [x] `evaluateCondition()` with `task_result`: undefined expression fails
- [x] `evaluateCondition()` with `task_result`: undefined taskResult fails
- [x] `advance()` resolves taskResult from DB completed task
- [x] `advance()` uses stepResult fallback when no DB result exists
- [x] `advance()` DB result takes priority over stepResult fallback
- [x] `advance()` sets needs_attention when task_result doesn't match
- [x] `advance()` sets needs_attention when no task result and no fallback
- [x] `advance()` picks most recently completed task when multiple exist
- [x] Existing condition types (always, human, condition) continue unchanged
- [x] TypeScript compiles cleanly (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] All 61 tests pass