### PR TITLE
feat: rewrite RoomContextPanel with goal-centric sidebar layout

### DIFF
--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -19,6 +19,7 @@ import {
 	navigateToRoomTask,
 } from '../lib/router';
 import { currentRoomSessionIdSignal, currentRoomTaskIdSignal } from '../lib/signals';
+import { toast } from '../lib/toast';
 import { cn } from '../lib/utils';
 
 function formatRelativeTime(timestamp: number): string {
@@ -76,7 +77,6 @@ interface RoomContextPanelProps {
 export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) {
 	const sessions = roomStore.sessions.value;
 	const tasks = roomStore.tasks.value;
-	const goals = roomStore.goals.value;
 	const [showArchived, setShowArchived] = useState(false);
 	const [expandedGoals, setExpandedGoals] = useState<Set<string>>(() => new Set());
 	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
@@ -88,7 +88,8 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 		[tasks]
 	);
 
-	// Goals data
+	// Goals data — show only active goals; count matches the rendered list
+	const activeGoals = roomStore.activeGoals.value;
 	const tasksByGoalId = roomStore.tasksByGoalId.value;
 
 	// Orphan tasks by tab — read signal .value directly (no useMemo) so Preact
@@ -162,8 +163,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 				navigateToRoomSession(roomId, sessionId);
 				onNavigate?.();
 			} catch {
-				// createSession can fail if not connected or RPC errors — silently ignore
-				// since the user will see the session list unchanged as feedback.
+				toast.error('Failed to create session');
 			}
 		},
 		[roomId, onNavigate]
@@ -243,11 +243,11 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 			{/* Scrollable sections */}
 			<div class="flex-1 overflow-y-auto">
 				{/* Goals section */}
-				<CollapsibleSection title="Goals" count={goals.length}>
-					{goals.length === 0 ? (
+				<CollapsibleSection title="Goals" count={activeGoals.length}>
+					{activeGoals.length === 0 ? (
 						<div class="px-4 py-3 text-xs text-gray-600">No goals</div>
 					) : (
-						goals.map((goal) => {
+						activeGoals.map((goal) => {
 							const isExpanded = expandedGoals.has(goal.id);
 							const linkedTasks = tasksByGoalId.get(goal.id) ?? [];
 							return (

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -1,23 +1,24 @@
 /**
  * RoomContextPanel
  *
- * Context panel content shown when viewing a specific room.
- * Replaces the generic RoomList with room-specific information:
- * - Back navigation to rooms list
- * - Task stats strip
- * - Room Dashboard pinned at top
- * - Sessions list below (with filter toggle for archived sessions)
+ * Goal-centric sidebar for a specific room. Layout (top to bottom):
+ * 1. Task stats strip (pending · active counts)
+ * 2. Pinned items: Dashboard, Room Agent
+ * 3. Goals section (collapsible) with expandable linked tasks
+ * 4. Tasks section (orphan tasks with tab filter)
+ * 5. Sessions section (collapsible, default collapsed)
  */
 
 import { useMemo, useState } from 'preact/hooks';
+import { CollapsibleSection } from '../components/room/CollapsibleSection';
 import { roomStore } from '../lib/room-store';
 import {
-	navigateToRooms,
 	navigateToRoom,
 	navigateToRoomAgent,
 	navigateToRoomSession,
+	navigateToRoomTask,
 } from '../lib/router';
-import { currentRoomSessionIdSignal } from '../lib/signals';
+import { currentRoomSessionIdSignal, currentRoomTaskIdSignal } from '../lib/signals';
 import { cn } from '../lib/utils';
 
 function formatRelativeTime(timestamp: number): string {
@@ -28,7 +29,7 @@ function formatRelativeTime(timestamp: number): string {
 	return `${Math.floor(seconds / 86400)}d`;
 }
 
-function StatusDot({ status }: { status: string }) {
+function SessionStatusDot({ status }: { status: string }) {
 	const colors: Record<string, string> = {
 		idle: 'bg-gray-500',
 		active: 'bg-green-500',
@@ -40,6 +41,33 @@ function StatusDot({ status }: { status: string }) {
 	return <div class={cn('w-2 h-2 rounded-full flex-shrink-0', colors[status] ?? colors.idle)} />;
 }
 
+const taskStatusColors: Record<string, string> = {
+	draft: 'bg-gray-500',
+	pending: 'bg-yellow-500',
+	in_progress: 'bg-blue-500',
+	review: 'bg-purple-500',
+	needs_attention: 'bg-orange-500',
+	completed: 'bg-green-500',
+	cancelled: 'bg-gray-600',
+};
+
+function TaskStatusDot({ status }: { status: string }) {
+	return (
+		<div
+			class={cn('w-2 h-2 rounded-full flex-shrink-0', taskStatusColors[status] ?? 'bg-gray-500')}
+		/>
+	);
+}
+
+const goalStatusColors: Record<string, string> = {
+	active: 'text-green-400',
+	needs_human: 'text-yellow-400',
+	completed: 'text-gray-500',
+	archived: 'text-gray-600',
+};
+
+type OrphanTab = 'active' | 'review' | 'done';
+
 interface RoomContextPanelProps {
 	roomId: string;
 	onNavigate?: () => void;
@@ -48,16 +76,30 @@ interface RoomContextPanelProps {
 export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) {
 	const sessions = roomStore.sessions.value;
 	const tasks = roomStore.tasks.value;
+	const goals = roomStore.goals.value;
 	const [showArchived, setShowArchived] = useState(false);
+	const [expandedGoals, setExpandedGoals] = useState<Set<string>>(() => new Set());
+	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
 
+	// Task stats
 	const pendingCount = useMemo(() => tasks.filter((t) => t.status === 'pending').length, [tasks]);
 	const activeCount = useMemo(
 		() => tasks.filter((t) => t.status === 'in_progress').length,
 		[tasks]
 	);
-	const doneCount = useMemo(() => tasks.filter((t) => t.status === 'completed').length, [tasks]);
 
-	// Filter sessions based on showArchived toggle
+	// Goals data
+	const activeGoals = roomStore.activeGoals.value;
+	const tasksByGoalId = roomStore.tasksByGoalId.value;
+
+	// Orphan tasks by tab
+	const orphanTasksForTab = useMemo(() => {
+		if (orphanTab === 'active') return roomStore.orphanTasksActive.value;
+		if (orphanTab === 'review') return roomStore.orphanTasksReview.value;
+		return roomStore.orphanTasksDone.value;
+	}, [orphanTab]);
+
+	// Sessions
 	const filteredSessions = useMemo(() => {
 		if (showArchived) return sessions;
 		return sessions.filter((s) => s.status !== 'archived');
@@ -68,8 +110,28 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 		[sessions]
 	);
 
+	// Selection state
+	const selectedSessionId = currentRoomSessionIdSignal.value;
+	const selectedTaskId = currentRoomTaskIdSignal.value;
 	const roomAgentSessionId = `room:chat:${roomId}`;
 
+	const isDashboardSelected = selectedSessionId === null && selectedTaskId === null;
+	const isRoomAgentSelected = selectedSessionId === roomAgentSessionId;
+
+	// Goal expand/collapse
+	const toggleGoal = (goalId: string) => {
+		setExpandedGoals((prev) => {
+			const next = new Set(prev);
+			if (next.has(goalId)) {
+				next.delete(goalId);
+			} else {
+				next.add(goalId);
+			}
+			return next;
+		});
+	};
+
+	// Navigation handlers
 	const handleDashboardClick = () => {
 		navigateToRoom(roomId);
 		onNavigate?.();
@@ -80,175 +142,237 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 		onNavigate?.();
 	};
 
+	const handleTaskClick = (taskId: string) => {
+		navigateToRoomTask(roomId, taskId);
+		onNavigate?.();
+	};
+
 	const handleSessionClick = (sessionId: string) => {
 		navigateToRoomSession(roomId, sessionId);
 		onNavigate?.();
 	};
 
-	const hasTasks = pendingCount > 0 || activeCount > 0 || doneCount > 0;
-
-	const selectedSessionId = currentRoomSessionIdSignal.value;
-	const isDashboardSelected = selectedSessionId === null;
-	const isRoomAgentSelected = selectedSessionId === roomAgentSessionId;
+	const hasTasks = pendingCount > 0 || activeCount > 0;
 
 	return (
 		<div class="flex-1 flex flex-col overflow-hidden">
-			{/* Back button */}
-			<div class="px-3 pt-2 pb-1">
-				<button
-					onClick={() => navigateToRooms()}
-					class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-300 transition-colors"
-				>
-					<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M15 19l-7-7 7-7"
-						/>
-					</svg>
-					All Rooms
-				</button>
-			</div>
-
-			{/* Create Session button */}
-			<div class="px-3 py-2">
-				<button
-					onClick={async () => {
-						const sessionId = await roomStore.createSession();
-						navigateToRoomSession(roomId, sessionId);
-						onNavigate?.();
-					}}
-					class="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-blue-400 bg-blue-900/20 hover:bg-blue-900/30 border border-blue-700/50 rounded-md transition-colors"
-				>
-					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M12 4v16m8-8H4"
-						/>
-					</svg>
-					New Session
-				</button>
-			</div>
-
-			{/* Task stats */}
+			{/* Task stats strip */}
 			<div class="px-3 py-2">
 				{hasTasks ? (
 					<span class="text-xs text-gray-500">
 						{pendingCount > 0 && <span class="text-yellow-500/80">{pendingCount} pending</span>}
 						{pendingCount > 0 && activeCount > 0 && <span class="text-gray-600"> · </span>}
 						{activeCount > 0 && <span class="text-green-500/80">{activeCount} active</span>}
-						{(pendingCount > 0 || activeCount > 0) && doneCount > 0 && (
-							<span class="text-gray-600"> · </span>
-						)}
-						{doneCount > 0 && <span>{doneCount} done</span>}
 					</span>
 				) : (
 					<span class="text-xs text-gray-600">No tasks</span>
 				)}
 			</div>
 
-			{/* Divider */}
-			<div class="border-t border-dark-700 mx-3 mb-1" />
-
-			{/* Sessions filter toggle */}
-			{hasArchivedSessions && (
-				<div class="px-3 py-1.5 flex items-center justify-between">
-					<span class="text-xs text-gray-500">
-						{filteredSessions.length} session{filteredSessions.length !== 1 ? 's' : ''}
-					</span>
-					<button
-						onClick={() => setShowArchived(!showArchived)}
-						class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
-					>
-						{showArchived ? 'Hide archived' : 'Show archived'}
-					</button>
-				</div>
-			)}
-
-			{/* Sessions */}
-			<div class="flex-1 overflow-y-auto">
-				{/* Pinned: Room Dashboard */}
-				<button
-					onClick={handleDashboardClick}
-					class={cn(
-						'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
-						isDashboardSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
-					)}
-				>
-					<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-blue-900/40 rounded">
-						<svg
-							class="w-3.5 h-3.5 text-blue-400"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width={2}
-								d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
-							/>
-						</svg>
-					</div>
-					<span class="flex-1 text-sm text-gray-200 text-left truncate">Room Dashboard</span>
-				</button>
-
-				{/* Room Agent */}
-				<button
-					onClick={handleRoomAgentClick}
-					class={cn(
-						'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors border-b border-dark-700/40',
-						isRoomAgentSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
-					)}
-				>
-					<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-purple-900/40 rounded">
-						<svg
-							class="w-3.5 h-3.5 text-purple-400"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width={2}
-								d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
-							/>
-						</svg>
-					</div>
-					<span class="flex-1 text-sm text-gray-200 text-left truncate">Room Agent</span>
-				</button>
-
-				{/* Sessions */}
-				{filteredSessions.length === 0 ? (
-					<div class="px-4 py-5 text-center">
-						<p class="text-xs text-gray-500">No sessions yet</p>
-					</div>
-				) : (
-					filteredSessions.map((session) => (
-						<button
-							key={session.id}
-							onClick={() => handleSessionClick(session.id)}
-							class={cn(
-								'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
-								selectedSessionId === session.id ? 'bg-dark-700' : 'hover:bg-dark-800'
-							)}
-						>
-							<StatusDot status={session.status} />
-							<span class="flex-1 text-sm text-gray-300 truncate text-left">
-								{session.title || session.id.slice(0, 8)}
-							</span>
-							{session.lastActiveAt != null && (
-								<span class="text-xs text-gray-500 flex-shrink-0 tabular-nums">
-									{formatRelativeTime(session.lastActiveAt)}
-								</span>
-							)}
-						</button>
-					))
+			{/* Pinned items */}
+			<button
+				onClick={handleDashboardClick}
+				class={cn(
+					'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
+					isDashboardSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
 				)}
+			>
+				<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-blue-900/40 rounded">
+					<svg
+						class="w-3.5 h-3.5 text-blue-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+						/>
+					</svg>
+				</div>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Dashboard</span>
+			</button>
+
+			<button
+				onClick={handleRoomAgentClick}
+				class={cn(
+					'w-full px-3 py-2.5 flex items-center gap-2.5 transition-colors',
+					isRoomAgentSelected ? 'bg-dark-700' : 'hover:bg-dark-800'
+				)}
+			>
+				<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-purple-900/40 rounded">
+					<svg
+						class="w-3.5 h-3.5 text-purple-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+						/>
+					</svg>
+				</div>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Room Agent</span>
+			</button>
+
+			{/* Visual divider after pinned items */}
+			<div class="border-t border-dark-700 mx-3 my-1" />
+
+			{/* Scrollable sections */}
+			<div class="flex-1 overflow-y-auto">
+				{/* Goals section */}
+				<CollapsibleSection title="Goals" count={activeGoals.length}>
+					{goals.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No goals</div>
+					) : (
+						goals.map((goal) => {
+							const isExpanded = expandedGoals.has(goal.id);
+							const linkedTasks = tasksByGoalId.get(goal.id) ?? [];
+							return (
+								<div key={goal.id}>
+									<button
+										onClick={() => toggleGoal(goal.id)}
+										class="w-full px-3 py-1.5 flex items-center gap-2 hover:bg-dark-800 transition-colors text-left"
+									>
+										<span class="text-gray-500 text-[10px] leading-none w-3 flex-shrink-0">
+											{isExpanded ? '▼' : '▶'}
+										</span>
+										<span class="flex-1 text-sm text-gray-300 truncate">{goal.title}</span>
+										<span
+											class={cn(
+												'text-[10px] flex-shrink-0',
+												goalStatusColors[goal.status] ?? 'text-gray-500'
+											)}
+										>
+											●
+										</span>
+									</button>
+									{isExpanded &&
+										linkedTasks.map((task) => (
+											<button
+												key={task.id}
+												onClick={() => handleTaskClick(task.id)}
+												class={cn(
+													'w-full pl-8 pr-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+													selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+												)}
+											>
+												<TaskStatusDot status={task.status} />
+												<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
+											</button>
+										))}
+								</div>
+							);
+						})
+					)}
+				</CollapsibleSection>
+
+				{/* Tasks section (orphan tasks) */}
+				<CollapsibleSection title="Tasks">
+					{/* Tab bar */}
+					<div class="flex items-center gap-1 px-3 py-1.5">
+						{(['active', 'review', 'done'] as const).map((tab) => (
+							<button
+								key={tab}
+								onClick={() => setOrphanTab(tab)}
+								class={cn(
+									'px-2 py-0.5 text-xs rounded transition-colors capitalize',
+									orphanTab === tab
+										? 'bg-dark-600 text-gray-200'
+										: 'text-gray-500 hover:text-gray-300'
+								)}
+							>
+								{tab}
+							</button>
+						))}
+					</div>
+					{orphanTasksForTab.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No orphan tasks</div>
+					) : (
+						orphanTasksForTab.map((task) => (
+							<button
+								key={task.id}
+								onClick={() => handleTaskClick(task.id)}
+								class={cn(
+									'w-full px-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+									selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+								)}
+							>
+								<TaskStatusDot status={task.status} />
+								<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
+							</button>
+						))
+					)}
+				</CollapsibleSection>
+
+				{/* Sessions section */}
+				<CollapsibleSection
+					title="Sessions"
+					count={filteredSessions.length}
+					defaultExpanded={false}
+					headerRight={
+						<button
+							onClick={async (e) => {
+								e.stopPropagation();
+								const sessionId = await roomStore.createSession();
+								navigateToRoomSession(roomId, sessionId);
+								onNavigate?.();
+							}}
+							class="text-gray-500 hover:text-gray-300 transition-colors p-0.5"
+							aria-label="Create session"
+						>
+							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M12 4v16m8-8H4"
+								/>
+							</svg>
+						</button>
+					}
+				>
+					{/* Archived toggle */}
+					{hasArchivedSessions && (
+						<div class="px-3 py-1.5 flex items-center justify-end">
+							<button
+								onClick={() => setShowArchived(!showArchived)}
+								class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+							>
+								{showArchived ? 'Hide archived' : 'Show archived'}
+							</button>
+						</div>
+					)}
+					{filteredSessions.length === 0 ? (
+						<div class="px-4 py-3 text-xs text-gray-600">No sessions yet</div>
+					) : (
+						filteredSessions.map((session) => (
+							<button
+								key={session.id}
+								onClick={() => handleSessionClick(session.id)}
+								class={cn(
+									'w-full px-3 py-2 flex items-center gap-2.5 transition-colors',
+									selectedSessionId === session.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+								)}
+							>
+								<SessionStatusDot status={session.status} />
+								<span class="flex-1 text-sm text-gray-300 truncate text-left">
+									{session.title || session.id.slice(0, 8)}
+								</span>
+								{session.lastActiveAt != null && (
+									<span class="text-xs text-gray-500 flex-shrink-0 tabular-nums">
+										{formatRelativeTime(session.lastActiveAt)}
+									</span>
+								)}
+							</button>
+						))
+					)}
+				</CollapsibleSection>
 			</div>
 		</div>
 	);

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -9,7 +9,7 @@
  * 5. Sessions section (collapsible, default collapsed)
  */
 
-import { useMemo, useState } from 'preact/hooks';
+import { useCallback, useMemo, useState } from 'preact/hooks';
 import { CollapsibleSection } from '../components/room/CollapsibleSection';
 import { roomStore } from '../lib/room-store';
 import {
@@ -89,15 +89,16 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	);
 
 	// Goals data
-	const activeGoals = roomStore.activeGoals.value;
 	const tasksByGoalId = roomStore.tasksByGoalId.value;
 
-	// Orphan tasks by tab
-	const orphanTasksForTab = useMemo(() => {
-		if (orphanTab === 'active') return roomStore.orphanTasksActive.value;
-		if (orphanTab === 'review') return roomStore.orphanTasksReview.value;
-		return roomStore.orphanTasksDone.value;
-	}, [orphanTab]);
+	// Orphan tasks by tab — read signal .value directly (no useMemo) so Preact
+	// Signals auto-tracking picks up changes when the underlying task list updates.
+	const orphanTasksForTab =
+		orphanTab === 'active'
+			? roomStore.orphanTasksActive.value
+			: orphanTab === 'review'
+				? roomStore.orphanTasksReview.value
+				: roomStore.orphanTasksDone.value;
 
 	// Sessions
 	const filteredSessions = useMemo(() => {
@@ -116,6 +117,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	const roomAgentSessionId = `room:chat:${roomId}`;
 
 	const isDashboardSelected = selectedSessionId === null && selectedTaskId === null;
+	// Router clears taskId when navigating to agent, so checking sessionId alone is safe.
 	const isRoomAgentSelected = selectedSessionId === roomAgentSessionId;
 
 	// Goal expand/collapse
@@ -151,6 +153,21 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 		navigateToRoomSession(roomId, sessionId);
 		onNavigate?.();
 	};
+
+	const handleCreateSession = useCallback(
+		async (e: Event) => {
+			e.stopPropagation();
+			try {
+				const sessionId = await roomStore.createSession();
+				navigateToRoomSession(roomId, sessionId);
+				onNavigate?.();
+			} catch {
+				// createSession can fail if not connected or RPC errors — silently ignore
+				// since the user will see the session list unchanged as feedback.
+			}
+		},
+		[roomId, onNavigate]
+	);
 
 	const hasTasks = pendingCount > 0 || activeCount > 0;
 
@@ -226,7 +243,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 			{/* Scrollable sections */}
 			<div class="flex-1 overflow-y-auto">
 				{/* Goals section */}
-				<CollapsibleSection title="Goals" count={activeGoals.length}>
+				<CollapsibleSection title="Goals" count={goals.length}>
 					{goals.length === 0 ? (
 						<div class="px-4 py-3 text-xs text-gray-600">No goals</div>
 					) : (
@@ -317,12 +334,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 					defaultExpanded={false}
 					headerRight={
 						<button
-							onClick={async (e) => {
-								e.stopPropagation();
-								const sessionId = await roomStore.createSession();
-								navigateToRoomSession(roomId, sessionId);
-								onNavigate?.();
-							}}
+							onClick={handleCreateSession}
 							class="text-gray-500 hover:text-gray-300 transition-colors p-0.5"
 							aria-label="Create session"
 						>

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -21,12 +21,18 @@ const {
 	mockNavigateToRoom,
 	mockNavigateToRoomAgent,
 	mockNavigateToRoomTask,
+	mockToast,
 } = vi.hoisted(() => ({
 	mockCreateSession: vi.fn().mockResolvedValue('new-session-id'),
 	mockNavigateToRoomSession: vi.fn(),
 	mockNavigateToRoom: vi.fn(),
 	mockNavigateToRoomAgent: vi.fn(),
 	mockNavigateToRoomTask: vi.fn(),
+	mockToast: vi.fn(),
+}));
+
+vi.mock('../../lib/toast.ts', () => ({
+	toast: { error: mockToast },
 }));
 
 // -------------------------------------------------------
@@ -40,6 +46,7 @@ let mockCurrentRoomSessionIdSignal: ReturnType<typeof signal<string | null>>;
 let mockCurrentRoomTaskIdSignal: ReturnType<typeof signal<string | null>>;
 
 // Computed signals derived from the mocks
+let mockActiveGoals: ReturnType<typeof computed>;
 let mockTasksByGoalId: ReturnType<typeof computed>;
 let mockOrphanTasks: ReturnType<typeof computed>;
 let mockOrphanTasksActive: ReturnType<typeof computed>;
@@ -52,6 +59,8 @@ function initSignals() {
 	mockGoalsSignal = signal([]);
 	mockCurrentRoomSessionIdSignal = signal(null);
 	mockCurrentRoomTaskIdSignal = signal(null);
+
+	mockActiveGoals = computed(() => mockGoalsSignal.value.filter((g) => g.status === 'active'));
 
 	mockTasksByGoalId = computed(() => {
 		const taskMap = new Map();
@@ -98,7 +107,7 @@ vi.mock('../../lib/room-store.ts', () => ({
 		return {
 			tasks: mockTasksSignal,
 			sessions: mockSessionsSignal,
-			goals: mockGoalsSignal,
+			activeGoals: mockActiveGoals,
 			tasksByGoalId: mockTasksByGoalId,
 			orphanTasksActive: mockOrphanTasksActive,
 			orphanTasksReview: mockOrphanTasksReview,
@@ -244,16 +253,26 @@ describe('RoomContextPanel', () => {
 
 	// -- Goals section --
 
-	it('renders Goals section with count of all goals', () => {
+	it('renders Goals section with count of active goals only', () => {
 		mockGoalsSignal.value = [
 			makeGoal('g1', 'Goal 1'),
 			makeGoal('g2', 'Goal 2'),
 			makeGoal('g3', 'Archived Goal', [], 'archived'),
 		];
 		render(<RoomContextPanel roomId="room-1" />);
-		// The CollapsibleSection shows title and count matching total goals shown
 		expect(screen.getByText('Goals')).toBeTruthy();
-		expect(screen.getByText('(3)')).toBeTruthy();
+		// Count matches active goals (excludes archived)
+		expect(screen.getByText('(2)')).toBeTruthy();
+	});
+
+	it('does not render archived goals in the list', () => {
+		mockGoalsSignal.value = [
+			makeGoal('g1', 'Active Goal'),
+			makeGoal('g2', 'Archived Goal', [], 'archived'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('Active Goal')).toBeTruthy();
+		expect(screen.queryByText('Archived Goal')).toBeNull();
 	});
 
 	it('expands a goal to show linked tasks on click', () => {
@@ -409,6 +428,19 @@ describe('RoomContextPanel', () => {
 		expect(mockCreateSession).toHaveBeenCalledWith();
 		expect(mockNavigateToRoomSession).toHaveBeenCalledWith('room-1', 'new-session-id');
 		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('shows toast and does not navigate when createSession fails', async () => {
+		mockCreateSession.mockRejectedValue(new Error('not connected'));
+		render(<RoomContextPanel roomId="room-1" />);
+
+		const createBtn = screen.getByLabelText('Create session');
+		fireEvent.click(createBtn);
+
+		await vi.waitFor(() => {
+			expect(mockToast).toHaveBeenCalledWith('Failed to create session');
+		});
+		expect(mockNavigateToRoomSession).not.toHaveBeenCalled();
 	});
 
 	it('navigates to session on click and calls onNavigate', () => {

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -40,7 +40,6 @@ let mockCurrentRoomSessionIdSignal: ReturnType<typeof signal<string | null>>;
 let mockCurrentRoomTaskIdSignal: ReturnType<typeof signal<string | null>>;
 
 // Computed signals derived from the mocks
-let mockActiveGoals: ReturnType<typeof computed>;
 let mockTasksByGoalId: ReturnType<typeof computed>;
 let mockOrphanTasks: ReturnType<typeof computed>;
 let mockOrphanTasksActive: ReturnType<typeof computed>;
@@ -53,8 +52,6 @@ function initSignals() {
 	mockGoalsSignal = signal([]);
 	mockCurrentRoomSessionIdSignal = signal(null);
 	mockCurrentRoomTaskIdSignal = signal(null);
-
-	mockActiveGoals = computed(() => mockGoalsSignal.value.filter((g) => g.status === 'active'));
 
 	mockTasksByGoalId = computed(() => {
 		const taskMap = new Map();
@@ -102,7 +99,6 @@ vi.mock('../../lib/room-store.ts', () => ({
 			tasks: mockTasksSignal,
 			sessions: mockSessionsSignal,
 			goals: mockGoalsSignal,
-			activeGoals: mockActiveGoals,
 			tasksByGoalId: mockTasksByGoalId,
 			orphanTasksActive: mockOrphanTasksActive,
 			orphanTasksReview: mockOrphanTasksReview,
@@ -218,7 +214,7 @@ describe('RoomContextPanel', () => {
 	it('highlights Dashboard only when both session and task signals are null', () => {
 		mockCurrentRoomSessionIdSignal.value = null;
 		mockCurrentRoomTaskIdSignal.value = null;
-		const { container } = render(<RoomContextPanel roomId="room-1" />);
+		render(<RoomContextPanel roomId="room-1" />);
 		const dashboardBtn = screen.getByText('Dashboard').closest('button');
 		expect(dashboardBtn?.className).toContain('bg-dark-700');
 	});
@@ -248,16 +244,16 @@ describe('RoomContextPanel', () => {
 
 	// -- Goals section --
 
-	it('renders Goals section with count of active goals', () => {
+	it('renders Goals section with count of all goals', () => {
 		mockGoalsSignal.value = [
 			makeGoal('g1', 'Goal 1'),
 			makeGoal('g2', 'Goal 2'),
 			makeGoal('g3', 'Archived Goal', [], 'archived'),
 		];
 		render(<RoomContextPanel roomId="room-1" />);
-		// The CollapsibleSection shows title and count
+		// The CollapsibleSection shows title and count matching total goals shown
 		expect(screen.getByText('Goals')).toBeTruthy();
-		expect(screen.getByText('(2)')).toBeTruthy();
+		expect(screen.getByText('(3)')).toBeTruthy();
 	});
 
 	it('expands a goal to show linked tasks on click', () => {
@@ -400,8 +396,9 @@ describe('RoomContextPanel', () => {
 		expect(screen.getByText('Session 1')).toBeTruthy();
 	});
 
-	it('creates a session via the [+] button and navigates to it', async () => {
-		render(<RoomContextPanel roomId="room-1" />);
+	it('creates a session via the [+] button, navigates to it, and calls onNavigate', async () => {
+		const onNavigate = vi.fn();
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
 
 		const createBtn = screen.getByLabelText('Create session');
 		fireEvent.click(createBtn);
@@ -411,6 +408,7 @@ describe('RoomContextPanel', () => {
 		});
 		expect(mockCreateSession).toHaveBeenCalledWith();
 		expect(mockNavigateToRoomSession).toHaveBeenCalledWith('room-1', 'new-session-id');
+		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 
 	it('navigates to session on click and calls onNavigate', () => {

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -1,27 +1,33 @@
 // @ts-nocheck
 /**
- * UI-level tests for RoomContextPanel
+ * Tests for the rewritten RoomContextPanel component.
  *
- * Specifically guards against the regression where the "+ New Session" button
- * passed a hardcoded title to roomStore.createSession(), which permanently
- * disabled auto-title generation for the session.
+ * Covers: pinned items, goals section with expandable tasks,
+ * orphan tasks with tab filter, sessions section with create button,
+ * selection highlighting, isDashboardSelected logic, and onNavigate calls.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
-import { signal } from '@preact/signals';
+import { render, fireEvent, cleanup, screen, within } from '@testing-library/preact';
+import { signal, computed } from '@preact/signals';
 
 // -------------------------------------------------------
 // Hoisted mocks
 // -------------------------------------------------------
 
-const { mockCreateSession, mockNavigateToRoomSession, mockNavigateToRooms, mockNavigateToRoom } =
-	vi.hoisted(() => ({
-		mockCreateSession: vi.fn().mockResolvedValue('new-session-id'),
-		mockNavigateToRoomSession: vi.fn(),
-		mockNavigateToRooms: vi.fn(),
-		mockNavigateToRoom: vi.fn(),
-	}));
+const {
+	mockCreateSession,
+	mockNavigateToRoomSession,
+	mockNavigateToRoom,
+	mockNavigateToRoomAgent,
+	mockNavigateToRoomTask,
+} = vi.hoisted(() => ({
+	mockCreateSession: vi.fn().mockResolvedValue('new-session-id'),
+	mockNavigateToRoomSession: vi.fn(),
+	mockNavigateToRoom: vi.fn(),
+	mockNavigateToRoomAgent: vi.fn(),
+	mockNavigateToRoomTask: vi.fn(),
+}));
 
 // -------------------------------------------------------
 // Signals used in mocks
@@ -29,22 +35,88 @@ const { mockCreateSession, mockNavigateToRoomSession, mockNavigateToRooms, mockN
 
 let mockTasksSignal: ReturnType<typeof signal<any[]>>;
 let mockSessionsSignal: ReturnType<typeof signal<any[]>>;
+let mockGoalsSignal: ReturnType<typeof signal<any[]>>;
 let mockCurrentRoomSessionIdSignal: ReturnType<typeof signal<string | null>>;
+let mockCurrentRoomTaskIdSignal: ReturnType<typeof signal<string | null>>;
+
+// Computed signals derived from the mocks
+let mockActiveGoals: ReturnType<typeof computed>;
+let mockTasksByGoalId: ReturnType<typeof computed>;
+let mockOrphanTasks: ReturnType<typeof computed>;
+let mockOrphanTasksActive: ReturnType<typeof computed>;
+let mockOrphanTasksReview: ReturnType<typeof computed>;
+let mockOrphanTasksDone: ReturnType<typeof computed>;
+
+function initSignals() {
+	mockTasksSignal = signal([]);
+	mockSessionsSignal = signal([]);
+	mockGoalsSignal = signal([]);
+	mockCurrentRoomSessionIdSignal = signal(null);
+	mockCurrentRoomTaskIdSignal = signal(null);
+
+	mockActiveGoals = computed(() => mockGoalsSignal.value.filter((g) => g.status === 'active'));
+
+	mockTasksByGoalId = computed(() => {
+		const taskMap = new Map();
+		for (const t of mockTasksSignal.value) taskMap.set(t.id, t);
+		const result = new Map();
+		for (const goal of mockGoalsSignal.value) {
+			const linked = [];
+			for (const taskId of goal.linkedTaskIds) {
+				const task = taskMap.get(taskId);
+				if (task) linked.push(task);
+			}
+			result.set(goal.id, linked);
+		}
+		return result;
+	});
+
+	mockOrphanTasks = computed(() => {
+		const linkedIds = new Set();
+		for (const goal of mockGoalsSignal.value) {
+			for (const taskId of goal.linkedTaskIds) linkedIds.add(taskId);
+		}
+		return mockTasksSignal.value.filter((t) => !linkedIds.has(t.id));
+	});
+
+	mockOrphanTasksActive = computed(() =>
+		mockOrphanTasks.value.filter(
+			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+		)
+	);
+
+	mockOrphanTasksReview = computed(() =>
+		mockOrphanTasks.value.filter((t) => t.status === 'review' || t.status === 'needs_attention')
+	);
+
+	mockOrphanTasksDone = computed(() =>
+		mockOrphanTasks.value.filter((t) => t.status === 'completed' || t.status === 'cancelled')
+	);
+}
+
+initSignals();
 
 vi.mock('../../lib/room-store.ts', () => ({
 	get roomStore() {
 		return {
 			tasks: mockTasksSignal,
 			sessions: mockSessionsSignal,
+			goals: mockGoalsSignal,
+			activeGoals: mockActiveGoals,
+			tasksByGoalId: mockTasksByGoalId,
+			orphanTasksActive: mockOrphanTasksActive,
+			orphanTasksReview: mockOrphanTasksReview,
+			orphanTasksDone: mockOrphanTasksDone,
 			createSession: mockCreateSession,
 		};
 	},
 }));
 
 vi.mock('../../lib/router.ts', () => ({
-	navigateToRooms: mockNavigateToRooms,
 	navigateToRoom: mockNavigateToRoom,
+	navigateToRoomAgent: mockNavigateToRoomAgent,
 	navigateToRoomSession: mockNavigateToRoomSession,
+	navigateToRoomTask: mockNavigateToRoomTask,
 }));
 
 vi.mock('../../lib/signals.ts', async (importOriginal) => {
@@ -54,27 +126,39 @@ vi.mock('../../lib/signals.ts', async (importOriginal) => {
 		get currentRoomSessionIdSignal() {
 			return mockCurrentRoomSessionIdSignal;
 		},
+		get currentRoomTaskIdSignal() {
+			return mockCurrentRoomTaskIdSignal;
+		},
 	};
 });
 
-// Initialize signals before importing the component
-mockTasksSignal = signal([]);
-mockSessionsSignal = signal([]);
-mockCurrentRoomSessionIdSignal = signal(null);
-
 import { RoomContextPanel } from '../RoomContextPanel';
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeTask(id: string, title: string, status = 'pending') {
+	return { id, title, status, priority: 'normal', dependsOn: [] };
+}
+
+function makeGoal(id: string, title: string, linkedTaskIds: string[] = [], status = 'active') {
+	return { id, title, status, priority: 'medium', linkedTaskIds, progress: 0 };
+}
+
+function makeSession(id: string, title: string, status = 'idle', lastActiveAt?: number) {
+	return { id, title, status, lastActiveAt };
+}
 
 // -------------------------------------------------------
 // Tests
 // -------------------------------------------------------
 
-describe('RoomContextPanel — New Session button', () => {
+describe('RoomContextPanel', () => {
 	beforeEach(() => {
 		cleanup();
 		vi.clearAllMocks();
-		mockTasksSignal.value = [];
-		mockSessionsSignal.value = [];
-		mockCurrentRoomSessionIdSignal.value = null;
+		initSignals();
 		mockCreateSession.mockResolvedValue('new-session-id');
 	});
 
@@ -82,29 +166,300 @@ describe('RoomContextPanel — New Session button', () => {
 		cleanup();
 	});
 
-	it('calls roomStore.createSession() without a title when the button is clicked', async () => {
+	// -- Layout --
+
+	it('does not render a back button', () => {
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.queryByText('All Rooms')).toBeNull();
+	});
+
+	it('renders task stats strip', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'T1', 'pending'),
+			makeTask('t2', 'T2', 'in_progress'),
+			makeTask('t3', 'T3', 'pending'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('2 pending')).toBeTruthy();
+		expect(screen.getByText('1 active')).toBeTruthy();
+	});
+
+	it('renders "No tasks" when there are no tasks', () => {
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('No tasks')).toBeTruthy();
+	});
+
+	// -- Pinned items --
+
+	it('renders Dashboard and Room Agent buttons', () => {
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('Dashboard')).toBeTruthy();
+		expect(screen.getByText('Room Agent')).toBeTruthy();
+	});
+
+	it('navigates to room dashboard and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Dashboard'));
+		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('navigates to room agent and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
+		fireEvent.click(screen.getByText('Room Agent'));
+		expect(mockNavigateToRoomAgent).toHaveBeenCalledWith('room-1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	// -- isDashboardSelected --
+
+	it('highlights Dashboard only when both session and task signals are null', () => {
+		mockCurrentRoomSessionIdSignal.value = null;
+		mockCurrentRoomTaskIdSignal.value = null;
+		const { container } = render(<RoomContextPanel roomId="room-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).toContain('bg-dark-700');
+	});
+
+	it('does NOT highlight Dashboard when a task is selected', () => {
+		mockCurrentRoomSessionIdSignal.value = null;
+		mockCurrentRoomTaskIdSignal.value = 'task-1';
+		render(<RoomContextPanel roomId="room-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
+	});
+
+	it('does NOT highlight Dashboard when a session is selected', () => {
+		mockCurrentRoomSessionIdSignal.value = 'some-session';
+		mockCurrentRoomTaskIdSignal.value = null;
+		render(<RoomContextPanel roomId="room-1" />);
+		const dashboardBtn = screen.getByText('Dashboard').closest('button');
+		expect(dashboardBtn?.className).not.toContain('bg-dark-700');
+	});
+
+	it('highlights Room Agent when its synthetic session ID is selected', () => {
+		mockCurrentRoomSessionIdSignal.value = 'room:chat:room-1';
+		render(<RoomContextPanel roomId="room-1" />);
+		const agentBtn = screen.getByText('Room Agent').closest('button');
+		expect(agentBtn?.className).toContain('bg-dark-700');
+	});
+
+	// -- Goals section --
+
+	it('renders Goals section with count of active goals', () => {
+		mockGoalsSignal.value = [
+			makeGoal('g1', 'Goal 1'),
+			makeGoal('g2', 'Goal 2'),
+			makeGoal('g3', 'Archived Goal', [], 'archived'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+		// The CollapsibleSection shows title and count
+		expect(screen.getByText('Goals')).toBeTruthy();
+		expect(screen.getByText('(2)')).toBeTruthy();
+	});
+
+	it('expands a goal to show linked tasks on click', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Task A', 'pending'),
+			makeTask('t2', 'Task B', 'in_progress'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2'])];
 		render(<RoomContextPanel roomId="room-1" />);
 
-		const button = screen.getByRole('button', { name: /New Session/i });
-		fireEvent.click(button);
+		// Tasks not visible initially
+		expect(screen.queryByText('Task A')).toBeNull();
+
+		// Click the goal to expand
+		fireEvent.click(screen.getByText('My Goal'));
+		expect(screen.getByText('Task A')).toBeTruthy();
+		expect(screen.getByText('Task B')).toBeTruthy();
+	});
+
+	it('collapses an expanded goal on second click', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Task A')];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand
+		fireEvent.click(screen.getByText('My Goal'));
+		expect(screen.getByText('Task A')).toBeTruthy();
+
+		// Collapse
+		fireEvent.click(screen.getByText('My Goal'));
+		expect(screen.queryByText('Task A')).toBeNull();
+	});
+
+	it('navigates to task when clicking a linked task and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		mockTasksSignal.value = [makeTask('t1', 'Linked Task')];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1'])];
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
+
+		fireEvent.click(screen.getByText('My Goal'));
+		fireEvent.click(screen.getByText('Linked Task'));
+
+		expect(mockNavigateToRoomTask).toHaveBeenCalledWith('room-1', 't1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('shows "No goals" when goal list is empty', () => {
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('No goals')).toBeTruthy();
+	});
+
+	// -- Tasks section (orphan tasks) --
+
+	it('shows orphan tasks under Active tab by default', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Orphan Active', 'in_progress'),
+			makeTask('t2', 'Orphan Done', 'completed'),
+		];
+		// No goals, so all tasks are orphan
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('Orphan Active')).toBeTruthy();
+		expect(screen.queryByText('Orphan Done')).toBeNull();
+	});
+
+	it('switches to Review tab to show review orphan tasks', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Review Task', 'review'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Click review tab (find by role since there are multiple "review" texts)
+		const reviewTab = screen.getAllByRole('button').find((b) => b.textContent === 'review');
+		fireEvent.click(reviewTab!);
+
+		expect(screen.getByText('Review Task')).toBeTruthy();
+		expect(screen.queryByText('Active Task')).toBeNull();
+	});
+
+	it('switches to Done tab to show completed/cancelled orphan tasks', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Done Task', 'completed'),
+			makeTask('t3', 'Cancelled Task', 'cancelled'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		const doneTab = screen.getAllByRole('button').find((b) => b.textContent === 'done');
+		fireEvent.click(doneTab!);
+
+		expect(screen.getByText('Done Task')).toBeTruthy();
+		expect(screen.getByText('Cancelled Task')).toBeTruthy();
+		expect(screen.queryByText('Active Task')).toBeNull();
+	});
+
+	it('shows "No orphan tasks" when filtered list is empty', () => {
+		render(<RoomContextPanel roomId="room-1" />);
+		expect(screen.getByText('No orphan tasks')).toBeTruthy();
+	});
+
+	it('navigates to orphan task on click and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		mockTasksSignal.value = [makeTask('t1', 'Click Me', 'pending')];
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
+
+		fireEvent.click(screen.getByText('Click Me'));
+		expect(mockNavigateToRoomTask).toHaveBeenCalledWith('room-1', 't1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('highlights selected task in orphan tasks list', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Selected Task', 'pending')];
+		mockCurrentRoomTaskIdSignal.value = 't1';
+		render(<RoomContextPanel roomId="room-1" />);
+
+		const taskBtn = screen.getByText('Selected Task').closest('button');
+		expect(taskBtn?.className).toContain('bg-dark-700');
+	});
+
+	// -- Sessions section --
+
+	it('renders Sessions section collapsed by default', () => {
+		mockSessionsSignal.value = [makeSession('s1', 'Session 1')];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// The section header should show Sessions with count
+		expect(screen.getByText('Sessions')).toBeTruthy();
+		// But session content should not be visible (collapsed)
+		expect(screen.queryByText('Session 1')).toBeNull();
+	});
+
+	it('expands Sessions section when header is clicked', () => {
+		mockSessionsSignal.value = [makeSession('s1', 'Session 1')];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Click the Sessions header to expand
+		const sessionsHeader = screen.getByLabelText('Sessions section');
+		fireEvent.click(sessionsHeader);
+
+		expect(screen.getByText('Session 1')).toBeTruthy();
+	});
+
+	it('creates a session via the [+] button and navigates to it', async () => {
+		render(<RoomContextPanel roomId="room-1" />);
+
+		const createBtn = screen.getByLabelText('Create session');
+		fireEvent.click(createBtn);
 
 		await vi.waitFor(() => {
 			expect(mockCreateSession).toHaveBeenCalledOnce();
 		});
-
-		// Must be called with no arguments so title is undefined and the daemon
-		// sets titleGenerated: false, enabling auto-title generation
 		expect(mockCreateSession).toHaveBeenCalledWith();
+		expect(mockNavigateToRoomSession).toHaveBeenCalledWith('room-1', 'new-session-id');
 	});
 
-	it('navigates to the new session after creation', async () => {
+	it('navigates to session on click and calls onNavigate', () => {
+		const onNavigate = vi.fn();
+		mockSessionsSignal.value = [makeSession('s1', 'My Session')];
+		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
+
+		// Expand sessions
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		fireEvent.click(screen.getByText('My Session'));
+
+		expect(mockNavigateToRoomSession).toHaveBeenCalledWith('room-1', 's1');
+		expect(onNavigate).toHaveBeenCalledOnce();
+	});
+
+	it('highlights selected session', () => {
+		mockSessionsSignal.value = [makeSession('s1', 'My Session')];
+		mockCurrentRoomSessionIdSignal.value = 's1';
 		render(<RoomContextPanel roomId="room-1" />);
 
-		const button = screen.getByRole('button', { name: /New Session/i });
-		fireEvent.click(button);
+		// Expand sessions
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		const sessionBtn = screen.getByText('My Session').closest('button');
+		expect(sessionBtn?.className).toContain('bg-dark-700');
+	});
 
-		await vi.waitFor(() => {
-			expect(mockNavigateToRoomSession).toHaveBeenCalledWith('room-1', 'new-session-id');
-		});
+	it('filters out archived sessions by default', () => {
+		mockSessionsSignal.value = [
+			makeSession('s1', 'Active Session', 'idle'),
+			makeSession('s2', 'Archived Session', 'archived'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand sessions
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		expect(screen.getByText('Active Session')).toBeTruthy();
+		expect(screen.queryByText('Archived Session')).toBeNull();
+	});
+
+	it('shows archived sessions when toggle is clicked', () => {
+		mockSessionsSignal.value = [
+			makeSession('s1', 'Active Session', 'idle'),
+			makeSession('s2', 'Archived Session', 'archived'),
+		];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand sessions
+		fireEvent.click(screen.getByLabelText('Sessions section'));
+		fireEvent.click(screen.getByText('Show archived'));
+		expect(screen.getByText('Archived Session')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## Summary
- Rewrites `RoomContextPanel.tsx` with the new goal-centric sidebar layout
- Removes back button and standalone New Session button (nav rail handles navigation)
- Adds pinned Dashboard and Room Agent items at top with visual divider
- Adds collapsible Goals section showing goals with expandable linked tasks
- Adds Tasks section with Active/Review/Done tab filter for orphan tasks
- Adds Sessions section (collapsed by default) with [+] create button in header
- Fixes `isDashboardSelected` to check both `currentRoomSessionIdSignal` and `currentRoomTaskIdSignal` are null
- All navigation actions call `onNavigate?.()` to close mobile drawer

## Test plan
- [x] 28 unit tests covering all sections, selection highlighting, navigation, and tab filtering
- [x] TypeScript compiles without errors
- [x] Lint passes (oxlint)
- [x] Format passes (biome)
- [x] Knip passes (no dead exports)