### PR TITLE
test: verify space task manager archival and reactivation lifecycle

### DIFF
--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -225,13 +225,34 @@ describe('SpaceTaskManager', () => {
 	});
 
 	describe('archiveTask', () => {
-		it('archives a completed task', async () => {
+		it('archives a completed task and sets both status and archivedAt', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
 			await manager.setTaskStatus(task.id, 'in_progress');
 			await manager.setTaskStatus(task.id, 'completed');
 			const archived = await manager.archiveTask(task.id);
 			expect(archived.status).toBe('archived');
 			expect(archived.archivedAt).toBeDefined();
+			expect(typeof archived.archivedAt).toBe('number');
+		});
+
+		it('archives a cancelled task and sets both status and archivedAt', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.cancelTask(task.id);
+			const archived = await manager.archiveTask(task.id);
+			expect(archived.status).toBe('archived');
+			expect(archived.archivedAt).toBeDefined();
+			expect(typeof archived.archivedAt).toBe('number');
+		});
+
+		it('archives a needs_attention task and sets both status and archivedAt', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.setTaskStatus(task.id, 'needs_attention', { error: 'err' });
+			const archived = await manager.archiveTask(task.id);
+			expect(archived.status).toBe('archived');
+			expect(archived.archivedAt).toBeDefined();
+			expect(typeof archived.archivedAt).toBe('number');
 		});
 
 		it('throws when archiving a task in pending status', async () => {
@@ -465,6 +486,47 @@ describe('SpaceTaskManager', () => {
 			await expect(manager.reassignTask('nonexistent', 'agent-id')).rejects.toThrow(
 				'Task not found'
 			);
+		});
+	});
+
+	describe('completion does not prevent reactivation', () => {
+		it('completed task can be reactivated to in_progress', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.completeTask(task.id, 'done');
+
+			// Verify completed state
+			const completed = await manager.getTask(task.id);
+			expect(completed!.status).toBe('completed');
+			expect(completed!.result).toBe('done');
+			expect(completed!.progress).toBe(100);
+
+			// Reactivate — should succeed without any cleanup blocking it
+			const reactivated = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(reactivated.status).toBe('in_progress');
+			expect(reactivated.result).toBeUndefined();
+			expect(reactivated.progress).toBeUndefined();
+		});
+
+		it('cancelled task can be reactivated to in_progress', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.cancelTask(task.id);
+
+			const reactivated = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(reactivated.status).toBe('in_progress');
+			expect(reactivated.error).toBeUndefined();
+		});
+
+		it('completed task can be retried via retryTask()', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.completeTask(task.id, 'previous result');
+
+			const retried = await manager.retryTask(task.id);
+			expect(retried.status).toBe('in_progress');
+			expect(retried.result).toBeUndefined();
+			expect(retried.progress).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Verified that `archiveTask()` in `space-task-repository.ts` already correctly sets both `status = 'archived'` AND `archived_at` (done in PR #566).
- Verified that `completeTask()` only calls `setTaskStatus` — no irreversible cleanup that would prevent reactivation.
- Verified that `handleSubSessionComplete()` in `task-agent-manager.ts` only marks step tasks as completed and notifies the agent — no cleanup preventing reactivation.
- Verified that `retryTask()` and `reassignTask()` error messages already reflect the new lifecycle (completed/cancelled are retryable/reassignable).
- Verified space RPC handlers have no guards blocking actions on completed/cancelled tasks.
- Added tests for `archiveTask()` from all valid source statuses (completed, cancelled, needs_attention), verifying both `status` and `archivedAt` are set.
- Added tests confirming completion does not prevent reactivation — completed/cancelled tasks can transition back to `in_progress` with fields properly cleared.

## Test plan

- [x] `bun test tests/unit/lib/space-task-manager.test.ts` — 64 tests pass
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run format` — passes