### PR TITLE
feat: update task tab grouping to Active/Review/Done/Archived

### DIFF
--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -6,9 +6,8 @@
  * - Model indicator showing current leader/worker model
  * - Archive button to archive the room
  * - Confirmation dialogs for pause, stop, and archive actions
- * - Stats overview (sessions, pending, active, completed, failed tasks)
  * - Sessions list
- * - Tasks list grouped by status
+ * - Tasks list grouped by status (Active/Review/Done/Archived tabs)
  */
 
 import { useState } from 'preact/hooks';

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import type { TaskSummary } from '@neokai/shared';
-import { RoomTasks, selectedTabSignal } from './RoomTasks';
+import { RoomTasks, selectedTabSignal, getInitialTab } from './RoomTasks';
 
 describe('RoomTasks', () => {
 	afterEach(() => {
@@ -337,12 +337,14 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Old task');
 		});
 
-		it('should show empty state when no archived tasks', () => {
+		it('should auto-reset to active tab when no archived tasks exist', () => {
 			const tasks = [createTask('t1', 'pending')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			expect(container.textContent).toContain('No archived tasks');
+			// Auto-reset kicks in, shows active tab content instead of archived empty state
+			expect(container.textContent).toContain('Pending (1)');
+			expect(selectedTabSignal.value).toBe('active');
 		});
 	});
 
@@ -958,6 +960,49 @@ describe('RoomTasks', () => {
 		});
 	});
 
+	describe('localStorage Migration (getInitialTab)', () => {
+		function mockStoredTab(value: string | null) {
+			vi.mocked(localStorage.getItem).mockImplementation((key) => {
+				if (key === 'neokai:room:taskFilterTab') return value;
+				return null;
+			});
+		}
+
+		it('should migrate "needs_attention" to "review"', () => {
+			mockStoredTab('needs_attention');
+			expect(getInitialTab()).toBe('review');
+		});
+
+		it('should migrate "failed" to "review"', () => {
+			mockStoredTab('failed');
+			expect(getInitialTab()).toBe('review');
+		});
+
+		it('should preserve valid tab values', () => {
+			mockStoredTab('active');
+			expect(getInitialTab()).toBe('active');
+
+			mockStoredTab('review');
+			expect(getInitialTab()).toBe('review');
+
+			mockStoredTab('done');
+			expect(getInitialTab()).toBe('done');
+
+			mockStoredTab('archived');
+			expect(getInitialTab()).toBe('archived');
+		});
+
+		it('should default to "active" for unknown values', () => {
+			mockStoredTab('garbage');
+			expect(getInitialTab()).toBe('active');
+		});
+
+		it('should default to "active" when no value stored', () => {
+			mockStoredTab(null);
+			expect(getInitialTab()).toBe('active');
+		});
+	});
+
 	describe('Tab Grouping Consistency', () => {
 		it('needs_attention tasks appear under review tab, not a separate tab', () => {
 			selectedTabSignal.value = 'review';
@@ -969,7 +1014,7 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Migrated task');
 		});
 
-		it('cancelled tasks appear under done tab, not needs_attention tab', () => {
+		it('cancelled tasks appear under done tab', () => {
 			selectedTabSignal.value = 'done';
 			const tasks = [createTask('t1', 'cancelled', { title: 'Cancelled task' })];
 
@@ -1005,6 +1050,31 @@ describe('RoomTasks', () => {
 				t.textContent?.replace(/\d/g, '').trim()
 			);
 			expect(tabButtonLabels).not.toContain('Needs Attention');
+		});
+	});
+
+	describe('Archived Tab Auto-Reset', () => {
+		it('should auto-reset to active when archived tab selected but no archived tasks', () => {
+			selectedTabSignal.value = 'archived';
+			const tasks = [createTask('t1', 'in_progress')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			// Should show active tab content, not archived empty state
+			expect(container.textContent).toContain('In Progress');
+			expect(container.textContent).not.toContain('No archived tasks');
+			// Signal should be reset
+			expect(selectedTabSignal.value).toBe('active');
+		});
+
+		it('should stay on archived tab when archived tasks exist', () => {
+			selectedTabSignal.value = 'archived';
+			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Archived (1)');
+			expect(selectedTabSignal.value).toBe('archived');
 		});
 	});
 });

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -2,7 +2,9 @@
  * Tests for RoomTasks Component
  *
  * Tests task filter tabs, tab switching, task grouping by status,
- * empty states, click handling, and section rendering for all tabs.
+ * empty states, click handling, and section rendering for all tabs:
+ * Active (draft + pending + in_progress), Review (review + needs_attention),
+ * Done (completed + cancelled), Archived (archived, hidden by default).
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
@@ -62,7 +64,7 @@ describe('RoomTasks', () => {
 			selectedTabSignal.value = 'active';
 		});
 
-		it('should show all four tabs with counts', () => {
+		it('should show Active, Review, Done tabs (Archived hidden when count is 0)', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
 				createTask('t2', 'review'),
@@ -75,24 +77,34 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Active');
 			expect(container.textContent).toContain('Review');
 			expect(container.textContent).toContain('Done');
-			expect(container.textContent).toContain('Needs Attention');
+			// Archived tab hidden when no archived tasks
+			expect(container.textContent).not.toContain('Archived');
+		});
+
+		it('should show Archived tab when there are archived tasks', () => {
+			const tasks = [createTask('t1', 'in_progress'), createTask('t2', 'archived')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Archived');
 		});
 
 		it('should show correct counts on tabs', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
 				createTask('t2', 'pending'),
-				createTask('t3', 'review'),
-				createTask('t4', 'completed'),
+				createTask('t3', 'draft'),
+				createTask('t4', 'review'),
 				createTask('t5', 'needs_attention'),
-				createTask('t6', 'cancelled'),
+				createTask('t6', 'completed'),
+				createTask('t7', 'cancelled'),
 			];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			// Active: 2 (in_progress + pending)
+			// Active: 3 (in_progress + pending + draft)
 			expect(container.textContent).toContain('Active');
-			expect(container.textContent).toContain('2');
+			expect(container.textContent).toContain('3');
 		});
 	});
 
@@ -219,6 +231,20 @@ describe('RoomTasks', () => {
 			expect(onTaskClick).not.toHaveBeenCalled();
 		});
 
+		it('should show needs_attention tasks under Review tab', () => {
+			const tasks = [
+				createTask('t1', 'review', { title: 'Review task' }),
+				createTask('t2', 'needs_attention', { title: 'Attention task', error: 'Something broke' }),
+			];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Awaiting Review');
+			expect(container.textContent).toContain('Needs Attention');
+			expect(container.textContent).toContain('Review task');
+			expect(container.textContent).toContain('Attention task');
+		});
+
 		it('should show empty state when no review tasks', () => {
 			const tasks = [createTask('t1', 'pending')];
 
@@ -264,106 +290,9 @@ describe('RoomTasks', () => {
 			expect(greenHeader).toBeTruthy();
 		});
 
-		it('should show empty state when no completed tasks', () => {
-			const tasks = [createTask('t1', 'pending')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('No completed tasks');
-		});
-	});
-
-	describe('Needs Attention Tab', () => {
-		beforeEach(() => {
-			selectedTabSignal.value = 'needs_attention';
-		});
-
-		it('should render needs attention section with red header', () => {
-			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const header = container.querySelector('h3.text-red-400');
-			expect(header).toBeTruthy();
-			expect(header?.textContent).toContain('Needs Attention (1)');
-		});
-
-		it('should show needs attention task titles', () => {
-			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Broken task');
-		});
-
-		it('should have red background header for needs attention section', () => {
-			const tasks = [createTask('t1', 'needs_attention')];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const redHeader = container.querySelector('.bg-red-900\\/20');
-			expect(redHeader).toBeTruthy();
-		});
-
-		it('should show error message for needs attention tasks with error', () => {
+		it('should show cancelled tasks under Done tab', () => {
 			const tasks = [
-				createTask('t1', 'needs_attention', {
-					title: 'Broken task',
-					error: 'Something went wrong',
-				}),
-			];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Something went wrong');
-		});
-
-		it('should not show error message for needs attention tasks without error', () => {
-			const tasks = [createTask('t1', 'needs_attention', { title: 'Broken task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			// No error paragraph should appear
-			const errorEls = container.querySelectorAll('.text-red-400');
-			// Only the header elements should have text-red-400, no error paragraph
-			for (const el of Array.from(errorEls)) {
-				expect(el.tagName.toLowerCase()).not.toBe('p');
-			}
-		});
-
-		it('should render cancelled section with muted gray header', () => {
-			const tasks = [createTask('t1', 'cancelled', { title: 'Stopped task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			const header = container.querySelector('.text-gray-500');
-			expect(header).toBeTruthy();
-			expect(header?.textContent).toContain('Cancelled (1)');
-		});
-
-		it('should show cancelled task titles', () => {
-			const tasks = [createTask('t1', 'cancelled', { title: 'Stopped task' })];
-
-			const { container } = render(<RoomTasks tasks={tasks} />);
-
-			expect(container.textContent).toContain('Stopped task');
-		});
-
-		it('should not show View details link for cancelled tasks', () => {
-			const onView = vi.fn();
-			const tasks = [createTask('t1', 'cancelled')];
-
-			const { container } = render(<RoomTasks tasks={tasks} onView={onView} />);
-
-			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('View details')
-			);
-			expect(viewBtn).toBeFalsy();
-		});
-
-		it('should render cancelled separately from needs attention tasks', () => {
-			const tasks = [
-				createTask('t1', 'needs_attention', { title: 'Error task' }),
+				createTask('t1', 'completed', { title: 'Finished task' }),
 				createTask('t2', 'cancelled', { title: 'Stopped task' }),
 			];
 
@@ -372,16 +301,48 @@ describe('RoomTasks', () => {
 			const headers = container.querySelectorAll('h3');
 			const headerTexts = Array.from(headers).map((h) => h.textContent);
 
-			expect(headerTexts).toContain('Needs Attention (1)');
+			expect(headerTexts).toContain('Completed (1)');
 			expect(headerTexts).toContain('Cancelled (1)');
 		});
 
-		it('should show empty state when no needs attention or cancelled tasks', () => {
+		it('should show empty state when no completed or cancelled tasks', () => {
 			const tasks = [createTask('t1', 'pending')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			expect(container.textContent).toContain('No tasks needing attention');
+			expect(container.textContent).toContain('No completed tasks');
+		});
+	});
+
+	describe('Archived Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'archived';
+		});
+
+		it('should render archived section with muted header', () => {
+			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const header = container.querySelector('h3.text-gray-500');
+			expect(header).toBeTruthy();
+			expect(header?.textContent).toContain('Archived (1)');
+		});
+
+		it('should show archived task titles', () => {
+			const tasks = [createTask('t1', 'archived', { title: 'Old task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Old task');
+		});
+
+		it('should show empty state when no archived tasks', () => {
+			const tasks = [createTask('t1', 'pending')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('No archived tasks');
 		});
 	});
 
@@ -423,21 +384,21 @@ describe('RoomTasks', () => {
 			expect(container.textContent).toContain('Completed (1)');
 		});
 
-		it('should switch to needs attention tab when clicked', () => {
+		it('should switch to archived tab when clicked', () => {
 			const tasks = [
 				createTask('t1', 'in_progress'),
-				createTask('t2', 'needs_attention', { title: 'Needs attention task' }),
+				createTask('t2', 'archived', { title: 'Archived task' }),
 			];
 
 			// Set to active BEFORE render
 			selectedTabSignal.value = 'active';
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
-			// Click needs attention tab
-			clickTab(container, 'Needs Attention');
+			// Click archived tab
+			clickTab(container, 'Archived');
 
-			// Should see needs attention section
-			expect(container.textContent).toContain('Needs Attention (1)');
+			// Should see archived section
+			expect(container.textContent).toContain('Archived (1)');
 		});
 	});
 
@@ -637,7 +598,7 @@ describe('RoomTasks', () => {
 		});
 
 		it('should render PR button for needs_attention task with prUrl', () => {
-			selectedTabSignal.value = 'needs_attention';
+			selectedTabSignal.value = 'review';
 			const tasks = [
 				createTask('t1', 'needs_attention', {
 					prUrl: 'https://github.com/org/repo/pull/30',
@@ -695,7 +656,7 @@ describe('RoomTasks', () => {
 		});
 
 		it('should apply red left border to needs_attention tasks', () => {
-			selectedTabSignal.value = 'needs_attention';
+			selectedTabSignal.value = 'review';
 			const tasks = [createTask('t1', 'needs_attention')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
@@ -705,12 +666,22 @@ describe('RoomTasks', () => {
 		});
 
 		it('should apply dark gray left border to cancelled tasks', () => {
-			selectedTabSignal.value = 'needs_attention';
+			selectedTabSignal.value = 'done';
 			const tasks = [createTask('t1', 'cancelled')];
 
 			const { container } = render(<RoomTasks tasks={tasks} />);
 
 			const item = container.querySelector('.border-l-gray-700');
+			expect(item).toBeTruthy();
+		});
+
+		it('should apply muted border to archived tasks', () => {
+			selectedTabSignal.value = 'archived';
+			const tasks = [createTask('t1', 'archived')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const item = container.querySelector('.border-l-gray-800');
 			expect(item).toBeTruthy();
 		});
 	});
@@ -984,6 +955,56 @@ describe('RoomTasks', () => {
 			// The review expanded section is not rendered for non-review tasks
 			const summaryEl = container.querySelector('p.italic');
 			expect(summaryEl).toBeFalsy();
+		});
+	});
+
+	describe('Tab Grouping Consistency', () => {
+		it('needs_attention tasks appear under review tab, not a separate tab', () => {
+			selectedTabSignal.value = 'review';
+			const tasks = [createTask('t1', 'needs_attention', { title: 'Migrated task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Needs Attention (1)');
+			expect(container.textContent).toContain('Migrated task');
+		});
+
+		it('cancelled tasks appear under done tab, not needs_attention tab', () => {
+			selectedTabSignal.value = 'done';
+			const tasks = [createTask('t1', 'cancelled', { title: 'Cancelled task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Cancelled (1)');
+			expect(container.textContent).toContain('Cancelled task');
+		});
+
+		it('draft tasks appear under active tab', () => {
+			selectedTabSignal.value = 'active';
+			const tasks = [createTask('t1', 'draft', { title: 'Draft task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			expect(container.textContent).toContain('Draft (1)');
+			expect(container.textContent).toContain('Draft task');
+		});
+
+		it('there is no needs_attention tab button in the tab bar', () => {
+			const tasks = [
+				createTask('t1', 'needs_attention'),
+				createTask('t2', 'in_progress'),
+				createTask('t3', 'review'),
+			];
+
+			selectedTabSignal.value = 'active';
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const tabBar = container.querySelector('.border-b.border-dark-700');
+			const tabButtons = tabBar?.querySelectorAll('button') ?? [];
+			const tabButtonLabels = Array.from(tabButtons).map((t) =>
+				t.textContent?.replace(/\d/g, '').trim()
+			);
+			expect(tabButtonLabels).not.toContain('Needs Attention');
 		});
 	});
 });

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -2,10 +2,10 @@
  * RoomTasks Component
  *
  * Displays tasks with filter tabs for organization:
- * - Active: pending + in_progress
- * - Review: review status (awaiting human action)
- * - Done: completed
- * - Needs Attention: needs_attention + cancelled
+ * - Active: draft + pending + in_progress
+ * - Review: review + needs_attention (awaiting human action)
+ * - Done: completed + cancelled
+ * - Archived: archived (hidden by default, expandable)
  */
 
 import { useState } from 'preact/hooks';
@@ -13,20 +13,15 @@ import { signal, effect } from '@preact/signals';
 import type { TaskSummary, TaskStatus } from '@neokai/shared';
 
 /** Tab filter types */
-export type TaskFilterTab = 'active' | 'review' | 'done' | 'needs_attention';
+export type TaskFilterTab = 'active' | 'review' | 'done' | 'archived';
 
 /** Get initial tab from localStorage */
 function getInitialTab(): TaskFilterTab {
 	if (typeof window === 'undefined') return 'active';
 	const stored = localStorage.getItem('neokai:room:taskFilterTab');
-	// Migrate old 'failed' tab value to 'needs_attention'
-	if (stored === 'failed') return 'needs_attention';
-	if (
-		stored === 'active' ||
-		stored === 'review' ||
-		stored === 'done' ||
-		stored === 'needs_attention'
-	) {
+	// Migrate old tab values: 'failed' and 'needs_attention' now live under 'review'
+	if (stored === 'failed' || stored === 'needs_attention') return 'review';
+	if (stored === 'active' || stored === 'review' || stored === 'done' || stored === 'archived') {
 		return stored;
 	}
 	return 'active';
@@ -54,11 +49,12 @@ interface RoomTasksProps {
 /** Get count of tasks for each filter tab */
 function getTabCounts(tasks: TaskSummary[]) {
 	return {
-		active: tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress').length,
-		review: tasks.filter((t) => t.status === 'review').length,
-		done: tasks.filter((t) => t.status === 'completed').length,
-		needs_attention: tasks.filter((t) => t.status === 'needs_attention' || t.status === 'cancelled')
-			.length,
+		active: tasks.filter(
+			(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+		).length,
+		review: tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention').length,
+		done: tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
+		archived: tasks.filter((t) => t.status === 'archived').length,
 	};
 }
 
@@ -66,19 +62,23 @@ function getTabCounts(tasks: TaskSummary[]) {
 function getFilteredTasks(tasks: TaskSummary[], tab: TaskFilterTab): TaskSummary[] {
 	switch (tab) {
 		case 'active':
-			return tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
+			return tasks.filter(
+				(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+			);
 		case 'review':
-			return tasks.filter((t) => t.status === 'review');
+			return tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention');
 		case 'done':
-			return tasks.filter((t) => t.status === 'completed');
-		case 'needs_attention':
-			return tasks.filter((t) => t.status === 'needs_attention' || t.status === 'cancelled');
+			return tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled');
+		case 'archived':
+			return tasks.filter((t) => t.status === 'archived');
 	}
 }
 
 /** Map task status to a left border color class */
 function getStatusBorderColor(status: TaskStatus): string {
 	switch (status) {
+		case 'draft':
+			return 'border-l-gray-600';
 		case 'pending':
 			return 'border-l-gray-500';
 		case 'in_progress':
@@ -91,6 +91,8 @@ function getStatusBorderColor(status: TaskStatus): string {
 			return 'border-l-red-500';
 		case 'cancelled':
 			return 'border-l-gray-700';
+		case 'archived':
+			return 'border-l-gray-800';
 		default:
 			return 'border-l-transparent';
 	}
@@ -138,13 +140,15 @@ export function RoomTasks({ tasks, onTaskClick, onView, onReject, onApprove }: R
 					onClick={() => handleTabClick('done')}
 					variant="green"
 				/>
-				<TabButton
-					label="Needs Attention"
-					count={tabCounts.needs_attention}
-					isActive={selectedTab === 'needs_attention'}
-					onClick={() => handleTabClick('needs_attention')}
-					variant="red"
-				/>
+				{tabCounts.archived > 0 && (
+					<TabButton
+						label="Archived"
+						count={tabCounts.archived}
+						isActive={selectedTab === 'archived'}
+						onClick={() => handleTabClick('archived')}
+						variant="gray"
+					/>
+				)}
 			</div>
 
 			{/* Task List */}
@@ -177,7 +181,7 @@ function TabButton({
 	count: number;
 	isActive: boolean;
 	onClick: () => void;
-	variant?: 'default' | 'purple' | 'green' | 'red';
+	variant?: 'default' | 'purple' | 'green' | 'red' | 'gray';
 }) {
 	const baseClasses =
 		'px-4 py-2 text-sm font-medium transition-colors relative flex items-center gap-1.5';
@@ -195,6 +199,9 @@ function TabButton({
 		red: isActive
 			? 'text-red-400 border-b-2 border-red-400'
 			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+		gray: isActive
+			? 'text-gray-500 border-b-2 border-gray-500'
+			: 'text-gray-500 hover:text-gray-400 border-b-2 border-transparent',
 	};
 
 	return (
@@ -209,7 +216,9 @@ function TabButton({
 								? 'bg-green-900/30'
 								: variant === 'red'
 									? 'bg-red-900/30'
-									: 'bg-dark-700'
+									: variant === 'gray'
+										? 'bg-dark-800'
+										: 'bg-dark-700'
 					}`}
 				>
 					{count}
@@ -232,11 +241,11 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 		},
 		done: {
 			title: 'No completed tasks',
-			description: 'Completed tasks will appear here',
+			description: 'Completed and cancelled tasks will appear here',
 		},
-		needs_attention: {
-			title: 'No tasks needing attention',
-			description: 'Tasks needing attention and cancelled tasks will appear here',
+		archived: {
+			title: 'No archived tasks',
+			description: 'Archived tasks will appear here',
 		},
 	};
 
@@ -270,14 +279,15 @@ function TaskList({
 }) {
 	const [rejectingTaskId, setRejectingTaskId] = useState<string | null>(null);
 
-	// For Active tab, group by in_progress and pending
-	// For Review tab - all are review status
-	// For Done tab - all are completed
-	// For Needs Attention tab - group by needs_attention and cancelled
+	// Active tab: group by in_progress, pending, draft
+	// Review tab: group by review and needs_attention
+	// Done tab: group by completed and cancelled
+	// Archived tab: all archived tasks
 
 	if (tab === 'active') {
 		const inProgress = tasks.filter((t) => t.status === 'in_progress');
 		const pending = tasks.filter((t) => t.status === 'pending');
+		const draft = tasks.filter((t) => t.status === 'draft');
 
 		return (
 			<div class="space-y-4">
@@ -305,78 +315,107 @@ function TaskList({
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
 				)}
+				{draft.length > 0 && (
+					<TaskGroup
+						title="Draft"
+						count={draft.length}
+						variant="gray"
+						tasks={draft}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
+					/>
+				)}
 			</div>
 		);
 	}
 
 	if (tab === 'review') {
+		const reviewTasks = tasks.filter((t) => t.status === 'review');
+		const needsAttention = tasks.filter((t) => t.status === 'needs_attention');
+
 		return (
 			<div class="space-y-4">
-				<TaskGroup
-					title="Awaiting Review"
-					count={tasks.length}
-					variant="purple"
-					tasks={tasks}
-					allTasks={allTasks}
-					onTaskClick={onTaskClick}
-					onView={onView}
-					onReject={onReject}
-					onApprove={onApprove}
-					rejectingTaskId={rejectingTaskId}
-					onSetRejectingTaskId={setRejectingTaskId}
-				/>
+				{reviewTasks.length > 0 && (
+					<TaskGroup
+						title="Awaiting Review"
+						count={reviewTasks.length}
+						variant="purple"
+						tasks={reviewTasks}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+						onView={onView}
+						onReject={onReject}
+						onApprove={onApprove}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
+					/>
+				)}
+				{needsAttention.length > 0 && (
+					<TaskGroup
+						title="Needs Attention"
+						count={needsAttention.length}
+						variant="red"
+						tasks={needsAttention}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+						showAlert
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
+					/>
+				)}
 			</div>
 		);
 	}
 
 	if (tab === 'done') {
+		const completed = tasks.filter((t) => t.status === 'completed');
+		const cancelled = tasks.filter((t) => t.status === 'cancelled');
+
 		return (
 			<div class="space-y-4">
-				<TaskGroup
-					title="Completed"
-					count={tasks.length}
-					variant="green"
-					tasks={tasks}
-					allTasks={allTasks}
-					onTaskClick={onTaskClick}
-					rejectingTaskId={rejectingTaskId}
-					onSetRejectingTaskId={setRejectingTaskId}
-				/>
+				{completed.length > 0 && (
+					<TaskGroup
+						title="Completed"
+						count={completed.length}
+						variant="green"
+						tasks={completed}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
+					/>
+				)}
+				{cancelled.length > 0 && (
+					<TaskGroup
+						title="Cancelled"
+						count={cancelled.length}
+						variant="gray"
+						tasks={cancelled}
+						allTasks={allTasks}
+						onTaskClick={onTaskClick}
+						rejectingTaskId={rejectingTaskId}
+						onSetRejectingTaskId={setRejectingTaskId}
+					/>
+				)}
 			</div>
 		);
 	}
 
-	// Needs Attention tab
-	const needsAttention = tasks.filter((t) => t.status === 'needs_attention');
-	const cancelled = tasks.filter((t) => t.status === 'cancelled');
-
+	// Archived tab
 	return (
 		<div class="space-y-4">
-			{needsAttention.length > 0 && (
-				<TaskGroup
-					title="Needs Attention"
-					count={needsAttention.length}
-					variant="red"
-					tasks={needsAttention}
-					allTasks={allTasks}
-					onTaskClick={onTaskClick}
-					showAlert
-					rejectingTaskId={rejectingTaskId}
-					onSetRejectingTaskId={setRejectingTaskId}
-				/>
-			)}
-			{cancelled.length > 0 && (
-				<TaskGroup
-					title="Cancelled"
-					count={cancelled.length}
-					variant="gray"
-					tasks={cancelled}
-					allTasks={allTasks}
-					onTaskClick={onTaskClick}
-					rejectingTaskId={rejectingTaskId}
-					onSetRejectingTaskId={setRejectingTaskId}
-				/>
-			)}
+			<TaskGroup
+				title="Archived"
+				count={tasks.length}
+				variant="gray"
+				tasks={tasks}
+				allTasks={allTasks}
+				onTaskClick={onTaskClick}
+				rejectingTaskId={rejectingTaskId}
+				onSetRejectingTaskId={setRejectingTaskId}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -15,8 +15,8 @@ import type { TaskSummary, TaskStatus } from '@neokai/shared';
 /** Tab filter types */
 export type TaskFilterTab = 'active' | 'review' | 'done' | 'archived';
 
-/** Get initial tab from localStorage */
-function getInitialTab(): TaskFilterTab {
+/** Get initial tab from localStorage - exported for testing */
+export function getInitialTab(): TaskFilterTab {
 	if (typeof window === 'undefined') return 'active';
 	const stored = localStorage.getItem('neokai:room:taskFilterTab');
 	// Migrate old tab values: 'failed' and 'needs_attention' now live under 'review'
@@ -99,8 +99,15 @@ function getStatusBorderColor(status: TaskStatus): string {
 }
 
 export function RoomTasks({ tasks, onTaskClick, onView, onReject, onApprove }: RoomTasksProps) {
-	const selectedTab = selectedTabSignal.value;
+	let selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
+
+	// Auto-reset to 'active' when archived tab is selected but no archived tasks exist
+	if (selectedTab === 'archived' && tabCounts.archived === 0) {
+		selectedTab = 'active';
+		selectedTabSignal.value = 'active';
+	}
+
 	const filteredTasks = getFilteredTasks(tasks, selectedTab);
 
 	const handleTabClick = (tab: TaskFilterTab) => {

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -81,10 +81,19 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	const [expandedGoals, setExpandedGoals] = useState<Set<string>>(() => new Set());
 	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
 
-	// Task stats
-	const pendingCount = useMemo(() => tasks.filter((t) => t.status === 'pending').length, [tasks]);
 	const activeCount = useMemo(
-		() => tasks.filter((t) => t.status === 'in_progress').length,
+		() =>
+			tasks.filter(
+				(t) => t.status === 'draft' || t.status === 'pending' || t.status === 'in_progress'
+			).length,
+		[tasks]
+	);
+	const reviewCount = useMemo(
+		() => tasks.filter((t) => t.status === 'review' || t.status === 'needs_attention').length,
+		[tasks]
+	);
+	const doneCount = useMemo(
+		() => tasks.filter((t) => t.status === 'completed' || t.status === 'cancelled').length,
 		[tasks]
 	);
 
@@ -169,7 +178,7 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 		[roomId, onNavigate]
 	);
 
-	const hasTasks = pendingCount > 0 || activeCount > 0;
+	const hasTasks = activeCount > 0 || reviewCount > 0 || doneCount > 0;
 
 	return (
 		<div class="flex-1 flex flex-col overflow-hidden">
@@ -177,9 +186,13 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 			<div class="px-3 py-2">
 				{hasTasks ? (
 					<span class="text-xs text-gray-500">
-						{pendingCount > 0 && <span class="text-yellow-500/80">{pendingCount} pending</span>}
-						{pendingCount > 0 && activeCount > 0 && <span class="text-gray-600"> · </span>}
-						{activeCount > 0 && <span class="text-green-500/80">{activeCount} active</span>}
+						{activeCount > 0 && <span class="text-blue-500/80">{activeCount} active</span>}
+						{activeCount > 0 && reviewCount > 0 && <span class="text-gray-600"> · </span>}
+						{reviewCount > 0 && <span class="text-purple-500/80">{reviewCount} review</span>}
+						{(activeCount > 0 || reviewCount > 0) && doneCount > 0 && (
+							<span class="text-gray-600"> · </span>
+						)}
+						{doneCount > 0 && <span>{doneCount} done</span>}
 					</span>
 				) : (
 					<span class="text-xs text-gray-600">No tasks</span>

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -5,6 +5,7 @@
  * - orphanTasksActive: Orphan tasks with draft/pending/in_progress
  * - orphanTasksReview: Orphan tasks with review/needs_attention
  * - orphanTasksDone: Orphan tasks with completed/cancelled
+ * - orphanTasksArchived: Orphan tasks with archived
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -194,7 +195,26 @@ describe('RoomStore — computed goal/task signals', () => {
 		});
 	});
 
-	describe('all 7 TaskStatus values are covered', () => {
+	describe('orphanTasksArchived', () => {
+		it('includes archived orphan tasks', () => {
+			roomStore.tasks.value = [
+				makeTask('t1', 'in_progress'),
+				makeTask('t2', 'archived'),
+				makeTask('t3', 'completed'),
+			];
+			roomStore.goals.value = [];
+			const ids = roomStore.orphanTasksArchived.value.map((t) => t.id);
+			expect(ids).toEqual(['t2']);
+		});
+
+		it('excludes archived tasks linked to a goal', () => {
+			roomStore.tasks.value = [makeTask('t1', 'archived')];
+			roomStore.goals.value = [makeGoal('g1', ['t1'])];
+			expect(roomStore.orphanTasksArchived.value).toEqual([]);
+		});
+	});
+
+	describe('all 8 TaskStatus values are covered', () => {
 		it('every status falls into exactly one bucket', () => {
 			roomStore.tasks.value = [
 				makeTask('draft', 'draft'),
@@ -204,24 +224,27 @@ describe('RoomStore — computed goal/task signals', () => {
 				makeTask('needs_attention', 'needs_attention'),
 				makeTask('completed', 'completed'),
 				makeTask('cancelled', 'cancelled'),
+				makeTask('archived', 'archived'),
 			];
 			roomStore.goals.value = [];
 
 			const active = new Set(roomStore.orphanTasksActive.value.map((t) => t.id));
 			const review = new Set(roomStore.orphanTasksReview.value.map((t) => t.id));
 			const done = new Set(roomStore.orphanTasksDone.value.map((t) => t.id));
+			const archived = new Set(roomStore.orphanTasksArchived.value.map((t) => t.id));
 
 			// No overlap
-			for (const id of active) {
-				expect(review.has(id)).toBe(false);
-				expect(done.has(id)).toBe(false);
-			}
-			for (const id of review) {
-				expect(done.has(id)).toBe(false);
+			const buckets = [active, review, done, archived];
+			for (let i = 0; i < buckets.length; i++) {
+				for (let j = i + 1; j < buckets.length; j++) {
+					for (const id of buckets[i]) {
+						expect(buckets[j].has(id)).toBe(false);
+					}
+				}
 			}
 
 			// All covered
-			expect(active.size + review.size + done.size).toBe(7);
+			expect(active.size + review.size + done.size + archived.size).toBe(8);
 		});
 	});
 

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -140,6 +140,9 @@ class RoomStore {
 		this.tasks.value.filter((t) => t.status === 'completed')
 	);
 
+	/** Archived tasks */
+	readonly archivedTasks = computed(() => this.tasks.value.filter((t) => t.status === 'archived'));
+
 	/** Tasks in review status */
 	readonly reviewTasks = computed(() => this.tasks.value.filter((t) => t.status === 'review'));
 
@@ -198,6 +201,11 @@ class RoomStore {
 	/** Orphan tasks that are done (completed or cancelled) */
 	readonly orphanTasksDone = computed(() =>
 		this.orphanTasks.value.filter((t) => t.status === 'completed' || t.status === 'cancelled')
+	);
+
+	/** Orphan tasks that are archived */
+	readonly orphanTasksArchived = computed(() =>
+		this.orphanTasks.value.filter((t) => t.status === 'archived')
 	);
 
 	// ========================================


### PR DESCRIPTION
## Summary

- **Active tab**: now includes `draft` + `pending` + `in_progress` (draft was previously ungrouped)
- **Review tab**: now includes `review` + `needs_attention` (needs_attention merged from its own tab)
- **Done tab**: now includes `completed` + `cancelled` (cancelled moved from needs_attention tab)
- **Archived tab**: new tab for `archived` tasks, hidden by default when count is 0
- localStorage migration: `'needs_attention'` and `'failed'` stored values migrate to `'review'`
- Added `archived` status border color (`border-l-gray-800`) and muted gray tab styling
- Added `archivedTasks` and `orphanTasksArchived` computed signals to `room-store.ts`
- Updated all tests for new tab groupings (73 RoomTasks tests pass, 14 computed signals tests pass)

## Test plan

- [x] `bunx vitest run src/components/room/RoomTasks.test.tsx` — 73 tests pass
- [x] `bunx vitest run src/lib/__tests__/room-store-computed-signals.test.ts` — 14 tests pass
- [x] `bun run typecheck` — no errors
- [x] `bun run lint` — no warnings
- [x] `bun run format` — no fixes needed