### PR TITLE
fix: fix flaky online tests in CI

### DIFF
--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -32,8 +32,9 @@ import {
 
 export interface DaemonServerOptions {
 	/**
-	 * Port for the daemon server
-	 * Default: 0 (OS-assigned) for in-process mode, random for spawned mode
+	 * Port for the daemon server.
+	 * Default: 0 (OS-assigned). The actual port is read back from the server
+	 * after startup (via server.port for in-process, stdout parsing for spawned).
 	 */
 	port?: number;
 
@@ -348,7 +349,7 @@ async function acquireDevProxyLease(
  */
 async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<DaemonServerContext> {
 	const {
-		port: userPort = 19400 + Math.floor(Math.random() * 1000),
+		port: userPort = 0, // Use port 0 for OS-assigned port; actual port parsed from stdout
 		env: customEnv = {},
 		devProxy: devProxyOptions,
 		useDevProxy = false,
@@ -390,9 +391,10 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 		detached: false,
 	});
 
-	// Wait for the server to be ready
+	// Wait for the server to be ready and parse the actual port from stdout
 	let stderrOutput = '';
 	let stdoutOutput = '';
+	let actualPort = userPort;
 	await new Promise<void>((resolve, reject) => {
 		const timeout = setTimeout(() => reject(new Error('Daemon server startup timeout')), 20000);
 
@@ -403,7 +405,10 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 			if (process.env.TEST_VERBOSE) {
 				console.error(`[DAEMON-PROCESS] ${output.trim()}`);
 			}
-			if (output.includes('Running on port')) {
+			// Parse actual port from "Running on port XXXX" output
+			const portMatch = output.match(/Running on port (\d+)/);
+			if (portMatch) {
+				actualPort = Number.parseInt(portMatch[1], 10);
 				clearTimeout(timeout);
 				daemonProcess.stdout!.off('data', onData);
 				daemonProcess.stderr!.off('data', onData);
@@ -430,7 +435,7 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 	});
 
 	// Create WebSocket client to communicate with the daemon
-	const wsUrl = `ws://127.0.0.1:${userPort}/ws`;
+	const wsUrl = `ws://127.0.0.1:${actualPort}/ws`;
 	const transport = new WebSocketClientTransport({
 		url: wsUrl,
 		autoReconnect: false, // Don't auto-reconnect in tests
@@ -461,7 +466,7 @@ async function spawnDaemonServer(options: DaemonServerOptions = {}): Promise<Dae
 	return {
 		pid: daemonProcess.pid!,
 		messageHub,
-		baseUrl: `http://127.0.0.1:${userPort}`,
+		baseUrl: `http://127.0.0.1:${actualPort}`,
 		devProxy,
 		kill: (signal: NodeJS.Signals = 'SIGTERM') => daemonProcess.kill(signal),
 		waitForExit: async () => {

--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -33,7 +33,7 @@ import {
 export interface DaemonServerOptions {
 	/**
 	 * Port for the daemon server
-	 * Default: random port in 19400-20400 range
+	 * Default: 0 (OS-assigned) for in-process mode, random for spawned mode
 	 */
 	port?: number;
 
@@ -499,7 +499,7 @@ async function createInProcessDaemonServer(
 	options: DaemonServerOptions = {}
 ): Promise<DaemonServerContext & { daemonContext: DaemonAppContext }> {
 	const {
-		port: userPort = 19400 + Math.floor(Math.random() * 1000),
+		port: userPort = 0, // Use port 0 for OS-assigned port to avoid collisions in CI
 		env: customEnv = {},
 		devProxy: devProxyOptions,
 		useDevProxy = false,
@@ -576,8 +576,11 @@ async function createInProcessDaemonServer(
 		});
 	}
 
+	// Read back the actual port from the server (handles port 0 / OS-assigned ports)
+	const actualPort = daemonContext.server.port;
+
 	// Connect to the daemon's WebSocket server (just like a real client)
-	const wsUrl = `ws://127.0.0.1:${userPort}/ws`;
+	const wsUrl = `ws://127.0.0.1:${actualPort}/ws`;
 	const transport = new WebSocketClientTransport({
 		url: wsUrl,
 		autoReconnect: false, // Don't auto-reconnect in tests
@@ -614,7 +617,7 @@ async function createInProcessDaemonServer(
 	return {
 		pid: process.pid, // Same process
 		messageHub,
-		baseUrl: `http://127.0.0.1:${userPort}`,
+		baseUrl: `http://127.0.0.1:${actualPort}`,
 		daemonContext, // Expose for advanced usage
 		devProxy,
 		kill: () => {

--- a/packages/daemon/tests/helpers/standalone-server.ts
+++ b/packages/daemon/tests/helpers/standalone-server.ts
@@ -11,12 +11,12 @@
  * The SDK reads these environment variables directly.
  */
 
-const PORT = parseInt(process.env.PORT || '19400', 10);
+const PORT = parseInt(process.env.PORT || '0', 10);
 
 import { createDaemonApp } from '../../src/app';
 
 async function main() {
-	const { cleanup } = await createDaemonApp({
+	const { cleanup, server } = await createDaemonApp({
 		config: {
 			host: '127.0.0.1',
 			port: PORT,
@@ -50,7 +50,9 @@ async function main() {
 		process.exit(0);
 	});
 
-	console.error(`[DAEMON-SERVER] Running on port ${PORT}, PID: ${process.pid}`);
+	// Log actual bound port (not the requested port) so the parent process
+	// can parse it when using port 0 (OS-assigned).
+	console.error(`[DAEMON-SERVER] Running on port ${server.port}, PID: ${process.pid}`);
 }
 
 main().catch((error) => {

--- a/packages/daemon/tests/online/git/archive-session.test.ts
+++ b/packages/daemon/tests/online/git/archive-session.test.ts
@@ -41,6 +41,7 @@ describe('Archive Session', () => {
 	}, SETUP_TIMEOUT);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, SETUP_TIMEOUT);
 

--- a/packages/daemon/tests/online/lifecycle/sigint-cleanup.test.ts
+++ b/packages/daemon/tests/online/lifecycle/sigint-cleanup.test.ts
@@ -38,13 +38,14 @@ describe('SDK SIGINT Cleanup (Online)', () => {
 	}, 30000);
 
 	afterEach(async () => {
-		// Reset spawned mode flag
+		// Always reset spawned mode flag (even if daemon is undefined)
 		delete process.env.DAEMON_TEST_SPAWN;
 		if (!daemon) return;
 		// Kill the daemon server after each test
+		// Spawned mode graceful shutdown may take longer than in-process
 		daemon.kill('SIGTERM');
 		await daemon.waitForExit();
-	}, 15_000);
+	}, 30_000);
 
 	describe('SIGINT during active SDK query', () => {
 		test(

--- a/packages/daemon/tests/online/lifecycle/sigint-cleanup.test.ts
+++ b/packages/daemon/tests/online/lifecycle/sigint-cleanup.test.ts
@@ -38,14 +38,13 @@ describe('SDK SIGINT Cleanup (Online)', () => {
 	}, 30000);
 
 	afterEach(async () => {
-		// Kill the daemon server after each test
-		if (daemon) {
-			daemon.kill('SIGTERM');
-			await daemon.waitForExit();
-		}
 		// Reset spawned mode flag
 		delete process.env.DAEMON_TEST_SPAWN;
-	});
+		if (!daemon) return;
+		// Kill the daemon server after each test
+		daemon.kill('SIGTERM');
+		await daemon.waitForExit();
+	}, 15_000);
 
 	describe('SIGINT during active SDK query', () => {
 		test(

--- a/packages/daemon/tests/online/mcp/mcp-tools-toggle.integration.test.ts
+++ b/packages/daemon/tests/online/mcp/mcp-tools-toggle.integration.test.ts
@@ -54,11 +54,10 @@ describe('MCP Tools Toggle Integration', () => {
 	});
 
 	afterEach(async () => {
-		if (daemon) {
-			daemon.kill('SIGTERM');
-			await daemon.waitForExit();
-		}
-	});
+		if (!daemon) return;
+		daemon.kill('SIGTERM');
+		await daemon.waitForExit();
+	}, 15_000);
 
 	test(
 		'disabledMcpServers is written to settings.local.json',

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -323,7 +323,7 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 
 				const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
 					minCount: 1,
-					timeout: PER_ATTEMPT_TIMEOUT,
+					timeout: 10_000, // Messages should be ready shortly after idle
 				});
 				const assistantMessages = sdkMessages.filter(
 					(m) => (m as { type?: string }).type === 'assistant'
@@ -337,6 +337,8 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 				return; // Success, exit retry loop
 			}
 		},
+		// Budget: attempt1 timeout (60s) + overhead (~5s) + attempt2 idle (60s)
+		// + sdkMessages (10s) = ~135s. 150s TEST_TIMEOUT provides margin.
 		TEST_TIMEOUT
 	);
 

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -38,7 +38,12 @@ import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
-import { sendMessage, waitForIdle, waitForSdkMessages } from '../../helpers/daemon-actions';
+import {
+	sendMessage,
+	waitForIdle,
+	waitForSdkMessages,
+	interrupt,
+} from '../../helpers/daemon-actions';
 import { AnthropicToCopilotBridgeProvider } from '../../../src/lib/providers/anthropic-copilot/index';
 
 const TMP_DIR = process.env.TMPDIR || '/tmp';
@@ -285,32 +290,52 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 	test(
 		'basic conversation: model responds correctly',
 		async () => {
-			const workspacePath = join(TMP_DIR, `copilot-anthropic-basic-${Date.now()}`);
-			mkdirSync(workspacePath, { recursive: true });
+			const MAX_ATTEMPTS = 2;
+			const PER_ATTEMPT_TIMEOUT = 60_000;
 
-			const { sessionId } = (await daemon.messageHub.request('session.create', {
-				workspacePath,
-				title: 'Copilot Anthropic Basic Test',
-				config: { model: testModelId, permissionMode: 'acceptEdits' },
-			})) as { sessionId: string };
-			daemon.trackSession(sessionId);
+			for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+				const workspacePath = join(TMP_DIR, `copilot-anthropic-basic-${Date.now()}`);
+				mkdirSync(workspacePath, { recursive: true });
 
-			await sendMessage(daemon, sessionId, 'What is 6+7? Reply with just the number.');
-			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
+				const { sessionId } = (await daemon.messageHub.request('session.create', {
+					workspacePath,
+					title: 'Copilot Anthropic Basic Test',
+					config: { model: testModelId, permissionMode: 'acceptEdits' },
+				})) as { sessionId: string };
+				daemon.trackSession(sessionId);
 
-			const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
-				minCount: 1,
-				timeout: IDLE_TIMEOUT,
-			});
-			const assistantMessages = sdkMessages.filter(
-				(m) => (m as { type?: string }).type === 'assistant'
-			);
-			expect(assistantMessages.length).toBeGreaterThanOrEqual(1);
+				await sendMessage(daemon, sessionId, 'What is 6+7? Reply with just the number.');
 
-			const text = assistantMessages
-				.map((m) => extractAssistantText(m as Record<string, unknown>))
-				.join('');
-			expect(text).toContain('13');
+				try {
+					await waitForIdle(daemon, sessionId, PER_ATTEMPT_TIMEOUT);
+				} catch (error) {
+					if (attempt < MAX_ATTEMPTS) {
+						// Interrupt stuck session and retry with a fresh one
+						try {
+							await interrupt(daemon, sessionId);
+						} catch {
+							/* ignore */
+						}
+						continue;
+					}
+					throw error;
+				}
+
+				const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
+					minCount: 1,
+					timeout: PER_ATTEMPT_TIMEOUT,
+				});
+				const assistantMessages = sdkMessages.filter(
+					(m) => (m as { type?: string }).type === 'assistant'
+				);
+				expect(assistantMessages.length).toBeGreaterThanOrEqual(1);
+
+				const text = assistantMessages
+					.map((m) => extractAssistantText(m as Record<string, unknown>))
+					.join('');
+				expect(text).toContain('13');
+				return; // Success, exit retry loop
+			}
 		},
 		TEST_TIMEOUT
 	);

--- a/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
+++ b/packages/daemon/tests/online/room/room-planner-two-phase.test.ts
@@ -85,7 +85,7 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 
 		// Allow event propagation so runtime picks up the updated room config
 		await Bun.sleep(100);
-	}, 30_000);
+	}, 60_000);
 
 	afterAll(
 		async () => {
@@ -95,10 +95,9 @@ describe('Room Two-Phase Planner Flow (API-dependent)', () => {
 				delete process.env.DEFAULT_MODEL;
 			}
 
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
+			if (!daemon) return;
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
 		},
 		{ timeout: 20_000 }
 	);

--- a/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
+++ b/packages/daemon/tests/online/room/room-reviewer-flow.test.ts
@@ -82,7 +82,7 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 		// Allow event propagation so runtime picks up the updated room config
 		// (runtime subscribes to room.updated and refreshes its room reference)
 		await Bun.sleep(100);
-	}, 30_000);
+	}, 60_000);
 
 	afterAll(
 		async () => {
@@ -92,10 +92,9 @@ describe('Room Reviewer Sub-Agent Flow (API-dependent)', () => {
 				delete process.env.DEFAULT_MODEL;
 			}
 
-			if (daemon) {
-				daemon.kill('SIGTERM');
-				await daemon.waitForExit();
-			}
+			if (!daemon) return;
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
 		},
 		{ timeout: 20_000 }
 	);

--- a/packages/daemon/tests/online/rpc/rpc-agent-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-agent-handlers.test.ts
@@ -14,9 +14,10 @@ describe('Agent RPC Handlers', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-config-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-config-handlers.test.ts
@@ -23,9 +23,10 @@ describe('SDK Config RPC Handlers', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-file-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-file-handlers.test.ts
@@ -23,9 +23,10 @@ describe('File RPC Handlers', () => {
 		mkdirSync(`${testDir}/subdir`, { recursive: true });
 		writeFileSync(`${testDir}/test.txt`, 'Hello File');
 		writeFileSync(`${testDir}/subdir/nested.txt`, 'Nested');
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 		try {
 			rmSync(testDir, { recursive: true, force: true });

--- a/packages/daemon/tests/online/rpc/rpc-mcp-toggle.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-mcp-toggle.test.ts
@@ -19,9 +19,10 @@ describe('MCP Toggle', () => {
 		daemon = await createDaemonServer();
 		testDir = `/tmp/mcp-toggle-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		mkdirSync(testDir, { recursive: true });
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 		try {
 			rmSync(testDir, { recursive: true, force: true });

--- a/packages/daemon/tests/online/rpc/rpc-message-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-message-handlers.test.ts
@@ -25,9 +25,10 @@ describe('Message RPC Handlers', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
@@ -35,10 +35,13 @@ describe('Message Remove Output', () => {
 		daemon = (await createDaemonServer()) as DaemonServerContext & {
 			daemonContext: DaemonAppContext;
 		};
-	});
+	}, 30_000);
 
 	afterEach(async () => {
-		await daemon.waitForExit();
+		// Guard: daemon may be undefined if beforeEach timed out or failed
+		if (daemon) {
+			await daemon.waitForExit();
+		}
 
 		// Clean up test SDK session directory
 		if (process.env.TEST_SDK_SESSION_DIR && existsSync(process.env.TEST_SDK_SESSION_DIR)) {

--- a/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
@@ -38,7 +38,8 @@ describe('Message Remove Output', () => {
 	}, 30_000);
 
 	afterEach(async () => {
-		// Guard: daemon may be undefined if beforeEach timed out or failed
+		// Guard: daemon may be undefined if beforeEach timed out.
+		// Uses wrapped-if (not early return) because env cleanup below must always run.
 		if (daemon) {
 			await daemon.waitForExit();
 		}

--- a/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-remove-output.test.ts
@@ -59,7 +59,7 @@ describe('Message Remove Output', () => {
 		} else {
 			delete process.env.TEST_SDK_SESSION_DIR;
 		}
-	}, 15_000);
+	}, 30_000);
 	async function createSession(): Promise<string> {
 		const { sessionId } = (await daemon.messageHub.request('session.create', {
 			workspacePath: process.cwd(),

--- a/packages/daemon/tests/online/rpc/rpc-rewind-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-rewind-handlers.test.ts
@@ -15,9 +15,10 @@ describe('Rewind RPC Handlers', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-session-filtering.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-session-filtering.test.ts
@@ -15,9 +15,10 @@ describe('Session Filtering', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-session-handlers-extended.test.ts
@@ -18,9 +18,10 @@ describe('Session RPC Handlers - Extended', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-session-workflow.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-session-workflow.test.ts
@@ -19,9 +19,10 @@ describe('End-to-End Session Workflow', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-settings-handlers.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-settings-handlers.test.ts
@@ -19,9 +19,10 @@ describe('Settings RPC Handlers', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/rpc/rpc-state-sync.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-state-sync.test.ts
@@ -17,9 +17,10 @@ describe('State Sync', () => {
 
 	beforeEach(async () => {
 		daemon = await createDaemonServer();
-	});
+	}, 30_000);
 
 	afterEach(async () => {
+		if (!daemon) return;
 		await daemon.waitForExit();
 	}, 15_000);
 

--- a/packages/daemon/tests/online/sandbox/sandbox-restriction.test.ts
+++ b/packages/daemon/tests/online/sandbox/sandbox-restriction.test.ts
@@ -48,15 +48,15 @@ describe('Sandbox Restrictions', { skip: skipTest }, () => {
 
 		// Create daemon server
 		daemon = await createDaemonServer();
-	}, 30000);
+	}, 60_000);
 
 	afterAll(async () => {
-		// Cleanup sessions
-		await daemon.cleanup();
-
-		// Kill daemon
-		daemon.kill('SIGTERM');
-		await daemon.waitForExit();
+		// Cleanup sessions and daemon
+		if (daemon) {
+			await daemon.cleanup();
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
 
 		// Cleanup directories
 		try {


### PR DESCRIPTION
## Summary
- **Null guards in afterEach/afterAll**: Added `if (!daemon) return;` to 18 online test files that crashed when `createDaemonServer()` timed out in `beforeEach`, leaving `daemon` undefined. Also increased `beforeEach` timeouts to 30s.
- **Port collision fix**: Changed in-process daemon server to use port 0 (OS-assigned) instead of `19400 + random(1000)`, eliminating port collisions when 17+ test shards run in parallel. Reads back actual port from `daemonContext.server.port`.
- **Copilot bridge retry**: Added retry-on-timeout for the "basic conversation" test which intermittently hangs when the Copilot API (gpt-5-mini) is slow. First attempt uses 60s timeout; on failure, interrupts and retries with a fresh session.

## CI Failure Analysis
- `Daemon Online (providers-anthropic-copilot)`: Consistent timeout at 120s in `waitForIdle` — Copilot API hangs
- `Daemon Online (rpc-2)`: `TypeError: undefined is not an object (evaluating 'daemon.waitForExit')` — `beforeEach` timeout cascades

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] `bun run format:check` passes
- [x] `rpc-remove-output.test.ts` passes locally (9/9 tests)
- [x] `rpc-agent-handlers.test.ts` passes locally (6/6 tests)
- [x] `rpc-state-sync.test.ts` passes locally (10/10 tests)
- [ ] CI online test shards pass