### PR TITLE
feat: wire step_result through advance_workflow to executor (Task 1.3)

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -95,6 +95,8 @@ function formatTransition(t: WorkflowTransition): string {
 			conditionLabel = ' [HUMAN GATE]';
 		} else if (t.condition.type === 'condition') {
 			conditionLabel = ` [condition: ${t.condition.expression ?? '?'}]`;
+		} else if (t.condition.type === 'task_result') {
+			conditionLabel = ` [result matches "${t.condition.expression ?? '?'}"]`;
 		}
 		// 'always' transitions produce no label — they are unconditional, semantically
 		// identical to a transition with no condition object. Any future WorkflowConditionType
@@ -172,13 +174,15 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`- **advance_workflow** — Evaluate transitions from the current workflow step and move ` +
-			`to the next step. Pass the \`result\` of the completed step. ` +
+			`to the next step. Pass the \`step_result\` of the completed step. ` +
 			`Returns the next step ID (or indicates terminal state / human gate). ` +
-			`Call this after a step agent completes successfully.`
+			`Call this after a step agent completes successfully. ` +
+			`When a verify, review, or test step completes, set \`step_result\` to 'passed' ` +
+			`if the work is acceptable, or 'failed: <reason>' if issues were found.`
 	);
 	sections.push(
 		`- **report_result** — Mark the task as completed or failed and record a result summary. ` +
-			`Pass \`status\` (\`completed\` or \`failed\`) and a \`summary\` string. ` +
+			`Pass \`status\` (\`completed\`, \`needs_attention\`, or \`cancelled\`) and a \`summary\` string. ` +
 			`Call this when the workflow reaches a terminal step or an unrecoverable error occurs.`
 	);
 	sections.push(
@@ -186,6 +190,19 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`Pass a \`prompt\` describing what decision or approval is needed. ` +
 			`Returns the human's response. ` +
 			`Call this when \`advance_workflow\` returns a \`human\` gate condition.`
+	);
+
+	// ---- step_result vs report_result status ---------------------------------
+	sections.push(`\n## Result Fields: \`step_result\` vs \`report_result.status\`\n`);
+	sections.push(`These are two different fields with different purposes:\n`);
+	sections.push(
+		`- **\`step_result\`** (in \`advance_workflow\`): A free-form string ` +
+			`(e.g. 'passed', 'failed: tests failed') used to evaluate ` +
+			`\`task_result\` transition conditions. It controls which path the workflow takes next.\n`
+	);
+	sections.push(
+		`- **\`report_result.status\`**: A named task status (completed/needs_attention/cancelled) ` +
+			`that marks the overall task outcome. Set via \`report_result\` when the workflow ends.\n`
 	);
 
 	// ---- Workflow execution instructions ------------------------------------

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -219,7 +219,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`   - If it returns **terminal** (no outgoing transitions), call \`report_result\` to ` +
 			`complete the task.\n` +
 			`4. **Handle errors** — If a step agent errors, call \`report_result\` with ` +
-			`\`status: "failed"\` and the error details.`
+			`\`status: "cancelled"\` and the error details.`
 	);
 
 	// ---- Human gate handling -------------------------------------------------
@@ -414,7 +414,7 @@ export function buildTaskAgentInitialMessage(context: TaskAgentContext): string 
 		parts.push(
 			`**Warning:** The assigned workflow "${context.workflow.name}" has no steps defined. ` +
 				`There is nothing to execute. Call \`report_result\` immediately with ` +
-				`\`status: "failed"\` and a summary explaining that the workflow has no steps.`
+				`\`status: "cancelled"\` and a summary explaining that the workflow has no steps.`
 		);
 	} else {
 		// No workflow assigned — spawn the most appropriate agent directly.

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -66,13 +66,21 @@ export type CheckStepStatusInput = z.infer<typeof CheckStepStatusSchema>;
 /**
  * Schema for `advance_workflow` input.
  * Advances the workflow to the next step after the current step completes.
+ * When a `task_result` transition condition is present on the outgoing transitions,
+ * supply `step_result` to evaluate it — e.g. `'passed'` or `'failed: <reason>'`.
  */
 export const AdvanceWorkflowSchema = z.object({
-	/** Optional result summary from the completed step, used for transition condition evaluation. */
+	/**
+	 * Result from the completed step, used for `task_result` transition condition evaluation.
+	 * Example values: `'passed'`, `'failed: tests failed'`, `'approved'`.
+	 * When evaluating a `task_result` condition, the executor matches this value
+	 * (prefix match) against the condition's `expression` field.
+	 */
 	step_result: z
 		.string()
 		.describe(
-			'Optional result or output summary from the completed step, used when evaluating transition conditions'
+			"Result of the completed step — used for 'task_result' condition evaluation. " +
+				"Example: 'passed' or 'failed: <reason>'. Prefix-match against the condition's expression."
 		)
 		.optional(),
 });

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -503,13 +503,13 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * 5. Handle WorkflowGateError → return gate-blocked status (caller calls request_human_input)
 		 * 6. Return next step info (or terminal state)
 		 *
-		 * Note: WorkflowExecutor.advance() now accepts `{ stepResult?: string }` for
-		 * task_result condition evaluation. The `step_result` field in AdvanceWorkflowInput
-		 * is not yet forwarded here — Task 1.3 will wire `_args.step_result` through to
-		 * `executor.advance({ stepResult: _args.step_result })`. In the meantime, advance()
-		 * resolves the task result from the DB (most recently completed task on the step).
+		 * Note: WorkflowExecutor.advance() accepts `{ stepResult?: string }` for
+		 * task_result condition evaluation. The `step_result` field from the tool input
+		 * is forwarded to the executor, which uses it as a fallback when the DB result
+		 * is absent (DB result takes precedence — the most recently completed task on
+		 * the step is queried first).
 		 */
-		async advance_workflow(_args: AdvanceWorkflowInput): Promise<ToolResult> {
+		async advance_workflow(args: AdvanceWorkflowInput): Promise<ToolResult> {
 			const executor = runtime.getExecutor(workflowRunId);
 			if (!executor) {
 				return jsonResult({
@@ -568,7 +568,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			}
 
 			try {
-				const { step: nextStep, tasks: newTasks } = await executor.advance();
+				const { step: nextStep, tasks: newTasks } = await executor.advance({
+					stepResult: args.step_result,
+				});
 
 				if (newTasks.length === 0) {
 					// Terminal step reached — executor marked run as completed.

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -155,6 +155,33 @@ function buildHumanGateWorkflow(
 	});
 }
 
+function buildTaskResultWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	agentId: string,
+	conditionExpression = 'passed'
+): SpaceWorkflow {
+	const step1Id = `step-1-${Math.random().toString(36).slice(2)}`;
+	const step2Id = `step-2-${Math.random().toString(36).slice(2)}`;
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: 'Task Result WF',
+		steps: [
+			{ id: step1Id, name: 'Verify Step', agentId },
+			{ id: step2Id, name: 'Next Step', agentId },
+		],
+		transitions: [
+			{
+				from: step1Id,
+				to: step2Id,
+				condition: { type: 'task_result', expression: conditionExpression },
+			},
+		],
+		startStepId: step1Id,
+		rules: [],
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Mock SubSessionFactory
 // ---------------------------------------------------------------------------
@@ -910,6 +937,49 @@ describe('createTaskAgentToolHandlers — advance_workflow', () => {
 
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('complete');
+	});
+
+	test('forwards step_result to executor.advance() and follows matching task_result transition', async () => {
+		// Build a workflow where the transition from step1→step2 requires task_result='passed'
+		const wf = buildTaskResultWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'passed');
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick(); // Rehydrate executor
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the first step task as completed
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		// Advance with step_result='passed' — should match the 'passed' condition and go to step2
+		const result = await handlers.advance_workflow({ step_result: 'passed' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.terminal).toBe(false);
+		expect(parsed.nextStep.name).toBe('Next Step');
+	});
+
+	test('forwards step_result fallback when no DB result exists', async () => {
+		// Same workflow as above — but we DON'T set the task result in the DB
+		// The step_result passed to advance_workflow should be used as fallback
+		const wf = buildTaskResultWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'verified');
+		const { run, mainTask, stepTask } = await startRun(ctx, wf);
+		await ctx.runtime.executeTick(); // Rehydrate executor
+		const factory = makeMockSessionFactory();
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		// Mark the step as completed but DON'T set result in DB
+		ctx.taskRepo.updateTask(stepTask.id, { status: 'completed', completedAt: Date.now() });
+
+		// Advance with step_result='verified' — should match the 'verified' condition and go to step2
+		const result = await handlers.advance_workflow({ step_result: 'verified' });
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.terminal).toBe(false);
+		expect(parsed.nextStep.name).toBe('Next Step');
 	});
 });
 

--- a/packages/daemon/tests/unit/space/task-agent.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent.test.ts
@@ -237,6 +237,32 @@ describe('buildTaskAgentSystemPrompt — human gate handling', () => {
 	});
 });
 
+describe('buildTaskAgentSystemPrompt — step_result vs report_result.status', () => {
+	test('includes section distinguishing step_result from report_result.status', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toContain('step_result');
+		expect(prompt).toContain('report_result.status');
+	});
+
+	test('describes step_result as free-form string for transition evaluation', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toContain('task_result');
+	});
+
+	test('advance_workflow description mentions passing step_result on verify/review/test steps', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toContain('step_result');
+		expect(prompt).toContain('passed');
+	});
+
+	test('uses cancelled instead of failed for error handling in Workflow Execution Instructions', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toContain('cancelled');
+		// Should not contain the stale "failed" status
+		expect(prompt).not.toMatch(/status: "failed"/);
+	});
+});
+
 describe('buildTaskAgentSystemPrompt — behavioral rules', () => {
 	test('includes no direct code execution rule', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
@@ -619,5 +645,38 @@ describe('buildTaskAgentInitialMessage — start instruction', () => {
 		const ctx = makeContext({ workflow: undefined, workflowRun: undefined });
 		const msg = buildTaskAgentInitialMessage(ctx);
 		expect(msg).toContain('spawn_step_agent');
+	});
+});
+
+describe('buildTaskAgentInitialMessage — formatTransition task_result', () => {
+	test('formatTransition labels task_result transitions with result matches expression', () => {
+		// Create a workflow with a task_result transition
+		const wf: SpaceWorkflow = {
+			id: 'wf-task-result',
+			spaceId: 'space-1',
+			name: 'Task Result WF',
+			description: 'Test workflow',
+			steps: [
+				{ id: 'step-plan', name: 'Plan', agentId: 'agent-planner' },
+				{ id: 'step-code', name: 'Code', agentId: 'agent-1' },
+			],
+			transitions: [
+				{
+					id: 't1',
+					from: 'step-plan',
+					to: 'step-code',
+					condition: { type: 'task_result', expression: 'passed' },
+				},
+			],
+			startStepId: 'step-plan',
+			rules: [],
+			isDefault: false,
+			tags: [],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+		const ctx = makeContext({ workflow: wf });
+		const msg = buildTaskAgentInitialMessage(ctx);
+		expect(msg).toContain('[result matches "passed"]');
 	});
 });


### PR DESCRIPTION
- Forward args.step_result from advance_workflow handler to executor.advance({ stepResult })
- Remove underscore prefix from _args now that args are used
- Update AdvanceWorkflowSchema JSDoc to clarify step_result is for task_result condition evaluation
- Fix stale text in Task Agent system prompt: result → step_result
- Add instruction to pass step_result on verify/review/test steps (passed/failed)
- Add section distinguishing step_result (free-form string for transitions) from report_result.status (task status)
- Add task_result branch to formatTransition() helper showing [result matches "..."] label

PR #575
