### PR TITLE
fix: replace crypto.randomUUID with browser-compatible generateUUID

### DIFF
--- a/packages/web/src/components/space/WorkflowEditor.tsx
+++ b/packages/web/src/components/space/WorkflowEditor.tsx
@@ -13,6 +13,7 @@
 
 import { useState } from 'preact/hooks';
 import type { SpaceWorkflow, SpaceAgent } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { WorkflowStepCard } from './WorkflowStepCard';
 import type { StepDraft, ConditionDraft } from './WorkflowStepCard';
@@ -59,7 +60,7 @@ export const TEMPLATES: WorkflowTemplate[] = [
 // ============================================================================
 
 function makeLocalId(): string {
-	return crypto.randomUUID();
+	return generateUUID();
 }
 
 function makeEmptyStep(): StepDraft {
@@ -322,7 +323,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 
 		try {
 			// Generate IDs for new steps
-			const stepIds = steps.map((s) => s.id ?? crypto.randomUUID());
+			const stepIds = steps.map((s) => s.id ?? generateUUID());
 
 			// Map from the display ID used in WorkflowRulesEditor (s.id ?? s.localId)
 			// to the final persisted step ID, so appliesTo references survive the save.
@@ -356,7 +357,7 @@ export function WorkflowEditor({ workflow, onSave, onCancel }: WorkflowEditorPro
 			if (isEditing && workflow) {
 				// Update needs full WorkflowRule objects with IDs
 				const updateRules = filteredRuleDrafts.map((r) => ({
-					id: r.id ?? crypto.randomUUID(),
+					id: r.id ?? generateUUID(),
 					name: r.name.trim() || 'Untitled Rule',
 					content: r.content,
 					// Remap display IDs (localId for new steps) to final persisted step IDs

--- a/packages/web/src/components/space/WorkflowRulesEditor.tsx
+++ b/packages/web/src/components/space/WorkflowRulesEditor.tsx
@@ -12,6 +12,7 @@
  */
 
 import type { WorkflowRule, WorkflowStep } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
 
 // ============================================================================
 // Types
@@ -35,7 +36,7 @@ export interface RuleDraft {
 
 export function makeEmptyRule(): RuleDraft {
 	return {
-		localId: crypto.randomUUID(),
+		localId: generateUUID(),
 		name: '',
 		content: '',
 		appliesTo: [],
@@ -45,7 +46,7 @@ export function makeEmptyRule(): RuleDraft {
 /** Convert saved WorkflowRules to drafts */
 export function rulesToDrafts(rules: WorkflowRule[]): RuleDraft[] {
 	return rules.map((r) => ({
-		localId: crypto.randomUUID(),
+		localId: generateUUID(),
 		id: r.id,
 		name: r.name,
 		content: r.content,

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -27,6 +27,7 @@ import type {
 	WorkflowTransition,
 	WorkflowConditionType,
 } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
 import { spaceStore } from '../../../lib/space-store';
 import { filterAgents, TEMPLATES } from '../WorkflowEditor';
 import type { WorkflowTemplate } from '../WorkflowEditor';
@@ -239,7 +240,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// ------------------------------------------------------------------
 
 	function addStep() {
-		const newLocalId = crypto.randomUUID();
+		const newLocalId = generateUUID();
 		const newStep: StepDraft = { localId: newLocalId, name: '', agentId: '', instructions: '' };
 
 		// Capture emptiness before the setNodes call so we can call setStartStepId
@@ -426,7 +427,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	// ------------------------------------------------------------------
 
 	function applyTemplate(template: WorkflowTemplate) {
-		const localIds = template.stepRoles.map(() => crypto.randomUUID());
+		const localIds = template.stepRoles.map(() => generateUUID());
 		const firstLocalId = localIds[0];
 
 		const newNodes: VisualNode[] = template.stepRoles.map((role, i) => {

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -32,6 +32,7 @@ import type {
 	UpdateSpaceWorkflowParams,
 	WorkflowCondition,
 } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
 import type { StepDraft } from '../WorkflowStepCard';
 import type { RuleDraft } from '../WorkflowRulesEditor';
 import { rulesToDrafts } from '../WorkflowRulesEditor';
@@ -116,7 +117,7 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 			position = layoutFallback.get(s.id) ?? { x: 0, y: 0 };
 		}
 		const step: StepDraft = {
-			localId: crypto.randomUUID(),
+			localId: generateUUID(),
 			id: s.id,
 			name: s.name,
 			agentId: s.agentId,
@@ -176,7 +177,7 @@ function resolveStepId(node: VisualNode, generatedIds: Map<string, string>): str
 	if (node.step.id) return node.step.id;
 	const key = node.step.localId;
 	if (!generatedIds.has(key)) {
-		generatedIds.set(key, crypto.randomUUID());
+		generatedIds.set(key, generateUUID());
 	}
 	return generatedIds.get(key)!;
 }
@@ -364,7 +365,7 @@ export function visualStateToUpdateParams(
 		startStepId: fields.startStepId || null,
 		// WorkflowRule requires `id` — generate one for new rules that lack a persisted id
 		rules: fields.rules.map((r) => ({
-			id: r.id ?? crypto.randomUUID(),
+			id: r.id ?? generateUUID(),
 			name: r.name,
 			content: r.content,
 			appliesTo: r.appliesTo,


### PR DESCRIPTION
crypto.randomUUID() is not available in all browser environments.
Replace all usages in web components with the generateUUID() polyfill
from @neokai/shared which falls back to a manual UUID generation when
crypto.randomUUID is unavailable.

Affected files:
- WorkflowEditor.tsx
- WorkflowRulesEditor.tsx
- VisualWorkflowEditor.tsx
- serialization.ts
