### PR TITLE
feat: add model switching in TaskView and auto-fallback on rate/usage limits

### DIFF
--- a/packages/daemon/src/lib/room/runtime/error-classifier.ts
+++ b/packages/daemon/src/lib/room/runtime/error-classifier.ts
@@ -3,7 +3,9 @@
  *
  * Single point of truth for classifying API errors from agent output:
  * - terminal:    unrecoverable errors (4xx) → fail task immediately
- * - rate_limit:  429 rate limits with parseable retry-after → pause with backoff
+ * - rate_limit:  HTTP 429 rate limits with parseable retry-after → pause with backoff
+ * - usage_limit: daily/weekly usage cap limits (e.g. "You've hit your limit · resets 2pm")
+ *                → immediately attempt fallback model, skip backoff
  * - recoverable: transient errors (5xx) → bounce/retry
  *
  * Detection strategy: match only structured "API Error: NNN" messages from the
@@ -12,13 +14,14 @@
  * (e.g. "implemented handling for invalid model errors").
  *
  * The Anthropic usage-limit text pattern ("You've hit your limit · resets …")
- * is kept as a rate_limit fallback because it is highly specific and not
- * something a worker would write as normal explanatory output.
+ * is classified as usage_limit (not rate_limit) because waiting for the reset
+ * can mean hours of downtime. Falling back to an alternative model keeps the
+ * task moving without requiring the user to wait.
  */
 
 import { parseRateLimitReset } from './rate-limit-utils';
 
-export type ErrorClass = 'terminal' | 'rate_limit' | 'recoverable';
+export type ErrorClass = 'terminal' | 'rate_limit' | 'usage_limit' | 'recoverable';
 
 export interface ErrorClassification {
 	class: ErrorClass;
@@ -26,8 +29,9 @@ export interface ErrorClassification {
 	/** HTTP status code extracted from the error message, if present */
 	statusCode?: number;
 	/**
-	 * For rate_limit: Unix timestamp (ms) when the limit resets.
-	 * Consumers should set a backoff until this time.
+	 * For rate_limit / usage_limit: Unix timestamp (ms) when the limit resets.
+	 * Consumers should set a backoff until this time for rate_limit;
+	 * for usage_limit this is informational only (backoff is skipped).
 	 */
 	resetsAt?: number;
 }
@@ -60,7 +64,7 @@ function extractHttpStatus(message: string): number | undefined {
  * Classify an error message from agent output.
  *
  * Only matches structured "API Error: NNN" messages produced by the Claude
- * Agent SDK, plus the Anthropic usage-limit text for rate_limit detection.
+ * Agent SDK, plus the Anthropic usage-limit text for usage_limit detection.
  * Free-form prose does NOT trigger classification.
  *
  * Evaluation order (first match wins):
@@ -68,7 +72,7 @@ function extractHttpStatus(message: string): number | undefined {
  *    - 400/401/403/404/422 → terminal
  *    - 429               → rate_limit (with resetsAt if parseable)
  *    - 5xx              → recoverable
- * 2. Anthropic usage-limit text → rate_limit (specific, not prose-writable)
+ * 2. Anthropic usage-limit text → usage_limit (immediate fallback, no backoff)
  *
  * Returns null when the message is not an API error.
  *
@@ -77,6 +81,9 @@ function extractHttpStatus(message: string): number | undefined {
  * // → { class: 'terminal', reason: '...', statusCode: 400 }
  *
  * classifyError("You've hit your limit · resets 1pm (America/New_York)")
+ * // → { class: 'usage_limit', reason: '...', resetsAt: <timestamp> }
+ *
+ * classifyError('API Error: 429 {"error":{"message":"rate limit exceeded"}}')
  * // → { class: 'rate_limit', reason: '...', resetsAt: <timestamp> }
  *
  * classifyError('API Error: 500 Internal Server Error')
@@ -118,13 +125,15 @@ export function classifyError(message: string): ErrorClassification | null {
 		}
 	}
 
-	// ── 2. Anthropic usage-limit text (specific, cannot appear in normal prose)
-	const resetsAt = parseRateLimitReset(message);
-	if (resetsAt !== null) {
+	// ── 2. Anthropic usage-limit text (specific, cannot appear in normal prose).
+	//     Classified as usage_limit — falling back to an alternative model keeps the
+	//     task moving instead of waiting hours until the daily/weekly cap resets.
+	const usageLimitResetsAt = parseRateLimitReset(message);
+	if (usageLimitResetsAt !== null) {
 		return {
-			class: 'rate_limit',
-			reason: `Rate limit reached — resets at ${new Date(resetsAt).toLocaleTimeString()}`,
-			resetsAt,
+			class: 'usage_limit',
+			reason: `Usage limit reached — would reset at ${new Date(usageLimitResetsAt).toLocaleTimeString()}`,
+			resetsAt: usageLimitResetsAt,
 		};
 	}
 

--- a/packages/daemon/src/lib/room/runtime/rate-limit-utils.ts
+++ b/packages/daemon/src/lib/room/runtime/rate-limit-utils.ts
@@ -31,7 +31,7 @@ export function parseRateLimitReset(errorMessage: string): number | null {
 	const hourStr = match[1]; // e.g., "1" or "12"
 	const minuteStr = match[2]; // e.g., "30" or undefined
 	const amPm = match[3]; // "am" or "pm"
-	// const timezoneStr = match[4]; // e.g., "America/New_York" - not used for simple parsing
+	const timezoneStr = match[4]; // e.g., "America/New_York"
 
 	try {
 		let hours = parseInt(hourStr, 10);
@@ -44,8 +44,114 @@ export function parseRateLimitReset(errorMessage: string): number | null {
 			hours = 0;
 		}
 
-		// Create reset time based on current date
 		const now = new Date();
+
+		// Calculate timezone offset for the specified timezone
+		// The error message contains a time in a specific timezone (e.g., "1pm (America/New_York)")
+		// We need to convert this to a UTC timestamp
+		let timezoneOffsetMs = 0;
+		if (timezoneStr) {
+			try {
+				// Get the timezone offset by finding what UTC time corresponds to
+				// "today at hours:minutes" in the target timezone
+				const targetDate = new Date(
+					now.getFullYear(),
+					now.getMonth(),
+					now.getDate(),
+					hours,
+					minutes,
+					0,
+					0
+				);
+
+				// Format this date in the target timezone to get its representation
+				const tzFormatter = new Intl.DateTimeFormat('en-US', {
+					timeZone: timezoneStr,
+					year: 'numeric',
+					month: 'numeric',
+					day: 'numeric',
+					hour: 'numeric',
+					minute: 'numeric',
+					second: 'numeric',
+					hour12: false,
+				});
+
+				const tzParts = tzFormatter.formatToParts(targetDate);
+				const tzDay = parseInt(tzParts.find((p) => p.type === 'day')?.value ?? '0', 10);
+
+				// The target date's local components should match the parsed time
+				// If tz shows a different day, it means we crossed a day boundary
+				// (e.g., "1pm UTC" when server is at 2am EST means the reset is tomorrow in UTC)
+				let dayOffset = 0;
+				if (tzDay !== now.getDate()) {
+					dayOffset = tzDay > now.getDate() ? 0 : 1; // tomorrow if tz is ahead
+				}
+
+				// Get offset between local time and target timezone in ms
+				const formatter = new Intl.DateTimeFormat('en-US', {
+					timeZone: timezoneStr,
+					hour: 'numeric',
+					minute: 'numeric',
+					hour12: false,
+				});
+
+				// Calculate offset: if target time is "earlier" in local time than now in tz,
+				// then the reset is tomorrow
+				const nowInTzParts = formatter.formatToParts(now);
+				const nowInTzHour = parseInt(nowInTzParts.find((p) => p.type === 'hour')?.value ?? '0', 10);
+				const nowInTzMinute = parseInt(
+					nowInTzParts.find((p) => p.type === 'minute')?.value ?? '0',
+					10
+				);
+
+				const targetMinutes = hours * 60 + minutes;
+				const nowInTzMinutes = nowInTzHour * 60 + nowInTzMinute;
+
+				if (targetMinutes <= nowInTzMinutes) {
+					dayOffset = 1;
+				}
+
+				// Create the reset date in the target timezone
+				const resetDate = new Date(
+					now.getFullYear(),
+					now.getMonth(),
+					now.getDate() + dayOffset,
+					hours,
+					minutes,
+					0
+				);
+
+				// Get UTC offset for the target timezone
+				const utcOffsetFormatter = new Intl.DateTimeFormat('en-US', {
+					timeZone: timezoneStr,
+					timeZoneName: 'short',
+				});
+				const offsetStr = utcOffsetFormatter.format(resetDate).split(' ').pop() ?? 'UTC';
+
+				// Parse offset like "GMT-5" or "GMT+0"
+				const offsetMatch = offsetStr.match(/GMT([+-])(\d+)/);
+				if (offsetMatch) {
+					const offsetSign = offsetMatch[1] === '+' ? 1 : -1;
+					const offsetHours = parseInt(offsetMatch[2], 10);
+					timezoneOffsetMs = offsetSign * offsetHours * 60 * 60 * 1000;
+				}
+
+				// Adjust reset time to UTC
+				const resetUtcDate = new Date(resetDate.getTime() - timezoneOffsetMs);
+
+				// If reset time is in the past, add another day
+				if (resetUtcDate.getTime() <= now.getTime()) {
+					resetDate.setDate(resetDate.getDate() + 1);
+				}
+
+				return new Date(resetDate.getTime() - timezoneOffsetMs).getTime();
+			} catch {
+				// Fallback: if timezone parsing fails, treat time as local time
+				timezoneOffsetMs = 0;
+			}
+		}
+
+		// Create reset time based on current date (treat time as local)
 		const resetDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, 0);
 
 		// If reset time is in the past, assume it's tomorrow

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -8,7 +8,7 @@
  * Follows the LobbyAgentService pattern.
  */
 
-import type { Room, McpServerConfig, RuntimeState } from '@neokai/shared';
+import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
 import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
@@ -43,6 +43,8 @@ export interface RoomRuntimeServiceConfig {
 	sessionManager: SessionManager;
 	defaultWorkspacePath: string;
 	defaultModel: string;
+	/** Get current global settings including fallbackModels for auto-fallback on rate limits */
+	getGlobalSettings: () => GlobalSettings;
 }
 
 export class RoomRuntimeService {
@@ -417,6 +419,7 @@ export class RoomRuntimeService {
 			getRoom: (roomId) => this.ctx.roomManager.getRoom(roomId),
 			getTask: (taskId) => taskManager.getTask(taskId),
 			getGoal: (goalId) => goalManager.getGoal(goalId),
+			getGlobalSettings: this.ctx.getGlobalSettings,
 		});
 
 		this.runtimes.set(room.id, runtime);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -22,6 +22,8 @@ import {
 	type TaskPriority,
 	type AgentType,
 	type RuntimeState,
+	type GlobalSettings,
+	type FallbackModelEntry,
 	MAX_CONCURRENT_GROUPS_LIMIT,
 	MAX_REVIEW_ROUNDS_LIMIT,
 } from '@neokai/shared';
@@ -36,6 +38,7 @@ import type { SessionObserver, TerminalState } from '../state/session-observer';
 import type { SessionFactory, WorkerConfig } from './task-group-manager';
 import { TaskGroupManager } from './task-group-manager';
 import type { DaemonHub } from '../../daemon-hub';
+import type { ModelSwitchResult } from '../../agent/model-switch-handler';
 import type { LeaderToolCallbacks, LeaderToolResult } from '../agents/leader-agent';
 import { createLeaderMcpServer } from '../agents/leader-agent';
 import type {
@@ -93,6 +96,12 @@ export interface WorkerMessage {
 	toolCallNames: string[];
 }
 
+/** Response from session.model.get RPC */
+interface SessionModelGetResult {
+	currentModel: string;
+	modelInfo?: { provider?: string };
+}
+
 export interface RoomRuntimeConfig {
 	room: Room;
 	groupRepo: SessionGroupRepository;
@@ -133,6 +142,8 @@ export interface RoomRuntimeConfig {
 	getTask: (taskId: string) => Promise<NeoTask | null>;
 	/** Fetch goal from DB by ID (for lazy leader init with current data) */
 	getGoal: (goalId: string) => Promise<RoomGoal | null>;
+	/** Get current global settings including fallbackModels for auto-fallback on rate limits */
+	getGlobalSettings: () => GlobalSettings;
 }
 
 function jsonResult(data: Record<string, unknown>): LeaderToolResult {
@@ -162,6 +173,7 @@ export class RoomRuntime {
 	private readonly deadLoopConfig: DeadLoopConfig;
 	private readonly getRoomById: (roomId: string) => Room | null;
 	private readonly defaultModel: string;
+	private readonly getGlobalSettings: () => GlobalSettings;
 
 	/** Mirroring unsub functions per group ID */
 	private mirroringCleanups = new Map<string, () => void>();
@@ -268,6 +280,7 @@ export class RoomRuntime {
 		this.deadLoopConfig = { ...DEFAULT_DEAD_LOOP_CONFIG, ...config.deadLoopConfig };
 		this.getRoomById = config.getRoom;
 		this.defaultModel = config.defaultModel ?? 'sonnet';
+		this.getGlobalSettings = config.getGlobalSettings;
 
 		this.taskGroupManager = new TaskGroupManager({
 			groupRepo: config.groupRepo,
@@ -294,6 +307,110 @@ export class RoomRuntime {
 			const leaderModel = this.resolveAgentModel(config.room, 'leader');
 			this.taskGroupManager.updateModel(leaderModel, this.resolveProviderForModel(leaderModel));
 		}
+	}
+
+	// =========================================================================
+	// Fallback Model Switching (for rate limit handling)
+	// =========================================================================
+
+	/**
+	 * Attempt to switch a session to a fallback model when a rate limit is detected.
+	 * Returns true if a fallback was attempted, false if no fallback is available.
+	 */
+	private async trySwitchToFallbackModel(
+		groupId: string,
+		sessionId: string,
+		sessionRole: 'worker' | 'leader'
+	): Promise<boolean> {
+		const settings = this.getGlobalSettings();
+		const fallbackModels = settings.fallbackModels ?? [];
+
+		if (fallbackModels.length === 0) {
+			return false;
+		}
+
+		// Get current model info from the session
+		let currentModel: string;
+		let currentProvider: string;
+		try {
+			const modelInfo = (await this.messageHub?.request('session.model.get', { sessionId })) as
+				| SessionModelGetResult
+				| undefined;
+			if (!modelInfo || !modelInfo.currentModel) {
+				log.warn(`Could not get current model for session ${sessionId}`);
+				return false;
+			}
+			currentModel = modelInfo.currentModel;
+			currentProvider = modelInfo.modelInfo?.provider ?? 'anthropic';
+		} catch (err) {
+			log.warn(`Error getting current model for session ${sessionId}:`, err);
+			return false;
+		}
+
+		// Find the index of the current model in the fallback chain
+		const currentIndex = fallbackModels.findIndex(
+			(f) => f.model === currentModel && f.provider === currentProvider
+		);
+
+		// Determine the next fallback model
+		let fallback: FallbackModelEntry | undefined;
+		if (currentIndex === -1) {
+			// Current model is not in fallback chain, use the first fallback
+			fallback = fallbackModels[0];
+		} else {
+			// Try the next one in the chain
+			const nextIndex = currentIndex + 1;
+			if (nextIndex < fallbackModels.length) {
+				fallback = fallbackModels[nextIndex];
+			}
+			// If current is the last in chain and there's only one fallback, no point switching
+			// to itself, so don't fall back
+		}
+
+		if (!fallback) {
+			log.info(
+				`No fallback model available for ${sessionRole} session ${sessionId} ` +
+					`(current: ${currentProvider}/${currentModel}, chain exhausted)`
+			);
+			return false;
+		}
+
+		// Don't switch to the same model
+		if (fallback.model === currentModel && fallback.provider === currentProvider) {
+			return false;
+		}
+
+		try {
+			const result = (await this.messageHub?.request('session.model.switch', {
+				sessionId,
+				model: fallback.model,
+				provider: fallback.provider,
+			})) as ModelSwitchResult | undefined;
+
+			if (result?.success) {
+				log.info(
+					`Switched ${sessionRole} session ${sessionId} from ${currentProvider}/${currentModel} ` +
+						`to ${fallback.provider}/${fallback.model} due to rate limit`
+				);
+				this.appendGroupEvent(groupId, 'model_fallback', {
+					text: `Switched from ${currentModel} to ${fallback.model} due to rate limit`,
+					fromModel: currentModel,
+					fromProvider: currentProvider,
+					toModel: fallback.model,
+					toProvider: fallback.provider,
+					sessionRole,
+				});
+				return true;
+			} else {
+				log.warn(
+					`Fallback model switch failed for ${sessionRole} session ${sessionId}: ${result?.error ?? 'unknown error'}`
+				);
+			}
+		} catch (err) {
+			log.error(`Error switching ${sessionRole} session ${sessionId} to fallback model:`, err);
+		}
+
+		return false;
 	}
 
 	// =========================================================================
@@ -530,8 +647,9 @@ export class RoomRuntime {
 		// worktree gate next would bounce the worker straight back into another failing API
 		// call — creating a rapid bounce loop.  Detecting the error first prevents that.
 		//
-		// terminal   → fail task immediately (4xx — unrecoverable, no point bouncing)
-		// rate_limit → set initial backoff and pause (only on first detection; re-triggers fall through)
+		// terminal    → fail task immediately (4xx — unrecoverable, no point bouncing)
+		// rate_limit  → set initial backoff and pause (only on first detection; re-triggers fall through)
+		// usage_limit → immediately try fallback model; if none available, fall through to fail
 		// recoverable / null → fall through to worktree check and exit gate
 		{
 			const errorClass = classifyError(workerOutputText);
@@ -576,10 +694,41 @@ export class RoomRuntime {
 						sessionRole: 'worker',
 					});
 					this.scheduleTickAfterRateLimitReset(groupId);
+					// Try to switch to a fallback model if configured
+					await this.trySwitchToFallbackModel(groupId, group.workerSessionId, 'worker');
 					return;
 				}
 				// group.rateLimit already set (even if expired): re-trigger after expiry.
 				// Fall through to the worktree check so the worker can attempt cleanup/retry.
+			}
+			if (errorClass?.class === 'usage_limit') {
+				// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
+				// If no fallback is configured or switch fails, fail the task so the user knows.
+				log.info(
+					`Usage limit detected in worker output for group ${groupId}: ${errorClass.reason}`
+				);
+				this.appendGroupEvent(groupId, 'status', {
+					text: `Usage limit reached — switching to fallback model`,
+				});
+				const switched = await this.trySwitchToFallbackModel(
+					groupId,
+					group.workerSessionId,
+					'worker'
+				);
+				if (!switched) {
+					// No fallback available — fail so the user sees a clear message
+					this.appendGroupEvent(groupId, 'status', {
+						text: `Usage limit reached and no fallback model configured. ${errorClass.reason}`,
+					});
+					await this.taskGroupManager.fail(groupId, errorClass.reason);
+					this.cleanupMirroring(groupId, `Usage limit: ${errorClass.reason}`);
+					await this.emitTaskUpdateById(group.taskId);
+					await this.emitGoalProgressForTask(group.taskId);
+					this.scheduleTick();
+					return;
+				}
+				// Fall through to normal routing — fallback model switch event was already appended
+				// in trySwitchToFallbackModel so the UI shows the switch clearly.
 			}
 		}
 
@@ -833,10 +982,11 @@ export class RoomRuntime {
 		}
 
 		// Classify any API errors in leader output.
-		// terminal   → fail task immediately (4xx, invalid model, etc. — won't fix on retry)
-		// rate_limit → mirroring sets the backoff for parseable-time 429s; for bare "API Error: 429"
-		//              (no parseable reset time) mirroring skips setRateLimit, so we must apply a
-		//              minimum backoff here to prevent the task stalling indefinitely.
+		// terminal    → fail task immediately (4xx, invalid model, etc. — won't fix on retry)
+		// rate_limit  → mirroring sets the backoff for parseable-time 429s; for bare "API Error: 429"
+		//               (no parseable reset time) mirroring skips setRateLimit, so we must apply a
+		//               minimum backoff here to prevent the task stalling indefinitely.
+		// usage_limit → immediately try fallback model; if none available, fall through to fail
 		// recoverable / null → fall through (leader finished without calling a tool — that's fine)
 		//
 		// Note: fetching with afterMessageId=null returns all leader messages since session start.
@@ -895,7 +1045,36 @@ export class RoomRuntime {
 						sessionRole: 'leader',
 					});
 					this.scheduleTickAfterRateLimitReset(groupId);
+					// Try to switch to a fallback model if configured
+					await this.trySwitchToFallbackModel(groupId, group.leaderSessionId, 'leader');
 					return;
+				}
+				if (errorClass?.class === 'usage_limit') {
+					// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
+					log.info(
+						`Usage limit detected in leader output for group ${groupId}: ${errorClass.reason}`
+					);
+					this.appendGroupEvent(groupId, 'status', {
+						text: `Usage limit reached in leader — switching to fallback model`,
+					});
+					const switched = await this.trySwitchToFallbackModel(
+						groupId,
+						group.leaderSessionId,
+						'leader'
+					);
+					if (!switched) {
+						// No fallback available — fail so the user sees a clear message
+						this.appendGroupEvent(groupId, 'status', {
+							text: `Usage limit reached in leader and no fallback model configured. ${errorClass.reason}`,
+						});
+						await this.taskGroupManager.fail(groupId, errorClass.reason);
+						this.cleanupMirroring(groupId, `Usage limit in leader: ${errorClass.reason}`);
+						await this.emitTaskUpdateById(group.taskId);
+						await this.emitGoalProgressForTask(group.taskId);
+						this.scheduleTick();
+						return;
+					}
+					// Fall through to normal completion — fallback model switch event was already appended
 				}
 			}
 		}
@@ -1946,12 +2125,24 @@ export class RoomRuntime {
 		});
 		if (this.messageHub) {
 			const now = Date.now();
+			// Map event kinds to message types for the frontend.
+			// 'leader_summary' is a special case (rendered as a distinct card).
+			// 'rate_limited' and 'model_fallback' get their own type so the frontend
+			// can render them as prominent notifications.
+			const messageType =
+				kind === 'leader_summary'
+					? 'leader_summary'
+					: kind === 'rate_limited'
+						? 'rate_limited'
+						: kind === 'model_fallback'
+							? 'model_fallback'
+							: 'status';
 			this.messageHub.event(
 				'state.groupMessages.delta',
 				{
 					added: [
 						{
-							type: kind === 'leader_summary' ? 'leader_summary' : 'status',
+							type: messageType,
 							text: payload?.text ?? kind,
 							timestamp: now,
 						},

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -649,7 +649,7 @@ export class RoomRuntime {
 		//
 		// terminal    → fail task immediately (4xx — unrecoverable, no point bouncing)
 		// rate_limit  → set initial backoff and pause (only on first detection; re-triggers fall through)
-		// usage_limit → immediately try fallback model; if none available, fall through to fail
+		// usage_limit → immediately try fallback model; if none available, fall through to rate_limit behavior (backoff + pause)
 		// recoverable / null → fall through to worktree check and exit gate
 		{
 			const errorClass = classifyError(workerOutputText);
@@ -703,7 +703,7 @@ export class RoomRuntime {
 			}
 			if (errorClass?.class === 'usage_limit') {
 				// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
-				// If no fallback is configured or switch fails, fail the task so the user knows.
+				// If no fallback is configured, fall through to rate_limit behavior (pause + backoff).
 				log.info(
 					`Usage limit detected in worker output for group ${groupId}: ${errorClass.reason}`
 				);
@@ -713,15 +713,23 @@ export class RoomRuntime {
 					'worker'
 				);
 				if (!switched) {
-					// No fallback available — fail so the user sees a clear message
-					this.appendGroupEvent(groupId, 'status', {
-						text: `Usage limit reached and no fallback model configured. ${errorClass.reason}`,
+					// No fallback available — fall through to rate_limit behavior (backoff + pause)
+					// Parse reset time from the usage limit message, or use 1-minute default
+					const rateLimitBackoff = errorClass.resetsAt
+						? createRateLimitBackoff(workerOutputText, 'worker')
+						: null;
+					const backoff: RateLimitBackoff = rateLimitBackoff ?? {
+						detectedAt: Date.now(),
+						resetsAt: Date.now() + 60 * 1000,
+						sessionRole: 'worker',
+					};
+					this.groupRepo.setRateLimit(groupId, backoff);
+					this.appendGroupEvent(groupId, 'rate_limited', {
+						text: `Usage limit reached. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
+						resetsAt: backoff.resetsAt,
+						sessionRole: 'worker',
 					});
-					await this.taskGroupManager.fail(groupId, errorClass.reason);
-					this.cleanupMirroring(groupId, `Usage limit: ${errorClass.reason}`);
-					await this.emitTaskUpdateById(group.taskId);
-					await this.emitGoalProgressForTask(group.taskId);
-					this.scheduleTick();
+					this.scheduleTickAfterRateLimitReset(groupId);
 					return;
 				}
 				// Fall through to normal routing — fallback model switch event was already appended
@@ -983,7 +991,7 @@ export class RoomRuntime {
 		// rate_limit  → mirroring sets the backoff for parseable-time 429s; for bare "API Error: 429"
 		//               (no parseable reset time) mirroring skips setRateLimit, so we must apply a
 		//               minimum backoff here to prevent the task stalling indefinitely.
-		// usage_limit → immediately try fallback model; if none available, fall through to fail
+		// usage_limit → immediately try fallback model; if none available, fall through to rate_limit behavior (backoff + pause)
 		// recoverable / null → fall through (leader finished without calling a tool — that's fine)
 		//
 		// Note: fetching with afterMessageId=null returns all leader messages since session start.
@@ -1048,6 +1056,7 @@ export class RoomRuntime {
 				}
 				if (errorClass?.class === 'usage_limit') {
 					// Usage limit (daily/weekly cap) — do NOT wait. Try fallback model immediately.
+					// If no fallback is configured, fall through to rate_limit behavior (backoff + pause).
 					log.info(
 						`Usage limit detected in leader output for group ${groupId}: ${errorClass.reason}`
 					);
@@ -1057,15 +1066,22 @@ export class RoomRuntime {
 						'leader'
 					);
 					if (!switched) {
-						// No fallback available — fail so the user sees a clear message
-						this.appendGroupEvent(groupId, 'status', {
-							text: `Usage limit reached in leader and no fallback model configured. ${errorClass.reason}`,
+						// No fallback available — fall through to rate_limit behavior (backoff + pause)
+						const rateLimitBackoff = errorClass.resetsAt
+							? createRateLimitBackoff(leaderOutputText, 'leader')
+							: null;
+						const backoff: RateLimitBackoff = rateLimitBackoff ?? {
+							detectedAt: Date.now(),
+							resetsAt: Date.now() + 60 * 1000,
+							sessionRole: 'leader',
+						};
+						this.groupRepo.setRateLimit(groupId, backoff);
+						this.appendGroupEvent(groupId, 'rate_limited', {
+							text: `Usage limit reached in leader. Pausing until ${new Date(backoff.resetsAt).toLocaleTimeString()}.`,
+							resetsAt: backoff.resetsAt,
+							sessionRole: 'leader',
 						});
-						await this.taskGroupManager.fail(groupId, errorClass.reason);
-						this.cleanupMirroring(groupId, `Usage limit in leader: ${errorClass.reason}`);
-						await this.emitTaskUpdateById(group.taskId);
-						await this.emitGoalProgressForTask(group.taskId);
-						this.scheduleTick();
+						this.scheduleTickAfterRateLimitReset(groupId);
 						return;
 					}
 					// Fall through to normal completion — fallback model switch event was already appended

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -707,9 +707,6 @@ export class RoomRuntime {
 				log.info(
 					`Usage limit detected in worker output for group ${groupId}: ${errorClass.reason}`
 				);
-				this.appendGroupEvent(groupId, 'status', {
-					text: `Usage limit reached — switching to fallback model`,
-				});
 				const switched = await this.trySwitchToFallbackModel(
 					groupId,
 					group.workerSessionId,
@@ -1054,9 +1051,6 @@ export class RoomRuntime {
 					log.info(
 						`Usage limit detected in leader output for group ${groupId}: ${errorClass.reason}`
 					);
-					this.appendGroupEvent(groupId, 'status', {
-						text: `Usage limit reached in leader — switching to fallback model`,
-					});
 					const switched = await this.trySwitchToFallbackModel(
 						groupId,
 						group.leaderSessionId,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -150,6 +150,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		sessionManager: deps.sessionManager,
 		defaultWorkspacePath: deps.config.workspaceRoot,
 		defaultModel: deps.config.defaultModel,
+		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
 	});
 	roomRuntimeService.start().catch((error) => {
 		log.error('Failed to start RoomRuntimeService:', error);

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -270,4 +270,38 @@ describe('RoomRuntime - terminal error detection', () => {
 			expect(updatedGroup!.feedbackIteration).toBe(1);
 		});
 	});
+
+	describe('usage_limit handling', () => {
+		it('fails task when usage_limit detected and no fallback model configured', async () => {
+			// No fallback models configured (default), so usage_limit should fail the task
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+			});
+
+			const { task } = await spawnAndSimulateWorkerOutput('');
+
+			// Task should be failed because no fallback model is available
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).toBe('needs_attention');
+		});
+
+		it('appends status event when usage_limit detected and no fallback model configured', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+			});
+
+			const { group, task } = await spawnAndSimulateWorkerOutput('');
+
+			// Check that a status event was appended with usage limit message
+			const { events } = ctx.groupRepo.getEvents(group.id);
+			const statusEvents = events.filter((e) => e.kind === 'status');
+			expect(statusEvents.length).toBeGreaterThan(0);
+			const payload = JSON.parse(statusEvents[0].payloadJson ?? '{}');
+			expect(payload.text).toContain('Usage limit');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-terminal-errors.test.ts
@@ -272,22 +272,9 @@ describe('RoomRuntime - terminal error detection', () => {
 	});
 
 	describe('usage_limit handling', () => {
-		it('fails task when usage_limit detected and no fallback model configured', async () => {
-			// No fallback models configured (default), so usage_limit should fail the task
-			ctx = createRuntimeTestContext({
-				getWorkerMessages: () => [
-					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
-				],
-			});
-
-			const { task } = await spawnAndSimulateWorkerOutput('');
-
-			// Task should be failed because no fallback model is available
-			const updatedTask = await ctx.taskManager.getTask(task.id);
-			expect(updatedTask!.status).toBe('needs_attention');
-		});
-
-		it('appends status event when usage_limit detected and no fallback model configured', async () => {
+		it('pauses task when usage_limit detected and no fallback model configured', async () => {
+			// No fallback models configured (default), so usage_limit should pause the task
+			// (like rate_limit behavior) instead of failing
 			ctx = createRuntimeTestContext({
 				getWorkerMessages: () => [
 					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
@@ -296,11 +283,30 @@ describe('RoomRuntime - terminal error detection', () => {
 
 			const { group, task } = await spawnAndSimulateWorkerOutput('');
 
-			// Check that a status event was appended with usage limit message
+			// Task should NOT be failed — it should pause (rate_limited)
+			const updatedTask = await ctx.taskManager.getTask(task.id);
+			expect(updatedTask!.status).not.toBe('needs_attention');
+
+			// Group should have a rate limit backoff set
+			const updatedGroup = ctx.groupRepo.getGroup(group.id);
+			expect(updatedGroup!.rateLimit).not.toBeNull();
+			expect(updatedGroup!.rateLimit!.resetsAt).toBeGreaterThan(Date.now());
+		});
+
+		it('appends rate_limited event when usage_limit detected and no fallback model configured', async () => {
+			ctx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage("You've hit your limit · resets 1pm (America/New_York)"),
+				],
+			});
+
+			const { group } = await spawnAndSimulateWorkerOutput('');
+
+			// Check that a rate_limited event was appended (not status)
 			const { events } = ctx.groupRepo.getEvents(group.id);
-			const statusEvents = events.filter((e) => e.kind === 'status');
-			expect(statusEvents.length).toBeGreaterThan(0);
-			const payload = JSON.parse(statusEvents[0].payloadJson ?? '{}');
+			const rateLimitedEvents = events.filter((e) => e.kind === 'rate_limited');
+			expect(rateLimitedEvents.length).toBeGreaterThan(0);
+			const payload = JSON.parse(rateLimitedEvents[0].payloadJson ?? '{}');
 			expect(payload.text).toContain('Usage limit');
 		});
 	});

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -4,7 +4,7 @@ import { SessionGroupRepository } from '../../../src/lib/room/state/session-grou
 import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
-import type { Room } from '@neokai/shared';
+import type { Room, GlobalSettings } from '@neokai/shared';
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { HookOptions } from '../../../src/lib/room/runtime/lifecycle-hooks';
@@ -227,6 +227,8 @@ export interface RuntimeTestContextOptions {
 		sessionId: string,
 		afterMessageId: string | null
 	) => Array<{ id: string; text: string; toolCallNames: string[] }>;
+	/** Get global settings for testing fallback model logic */
+	getGlobalSettings?: () => GlobalSettings;
 }
 
 export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): RuntimeTestContext {
@@ -266,6 +268,7 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 		getRoom: (roomId) => (roomId === 'room-1' ? room : null),
 		getTask: (taskId) => taskManager.getTask(taskId),
 		getGoal: (goalId) => goalManager.getGoal(goalId),
+		getGlobalSettings: opts?.getGlobalSettings ?? (() => ({}) as GlobalSettings),
 		daemonHub: mockHub as unknown as DaemonHub,
 	});
 

--- a/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/error-classifier.test.ts
@@ -74,10 +74,10 @@ describe('error-classifier', () => {
 				expect(result!.statusCode).toBe(429);
 			});
 
-			it('classifies Anthropic usage-limit message as rate_limit with resetsAt', () => {
+			it('classifies Anthropic usage-limit message as usage_limit with resetsAt', () => {
 				const result = classifyError("You've hit your limit · resets 1pm (America/New_York)");
 				expect(result).not.toBeNull();
-				expect(result!.class).toBe('rate_limit');
+				expect(result!.class).toBe('usage_limit');
 				expect(result!.resetsAt).toBeGreaterThan(Date.now() - 1000);
 			});
 

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -114,6 +114,17 @@ export interface McpServerSettings {
 }
 
 /**
+ * A single fallback model entry in the fallback chain.
+ * Used when the primary model fails due to rate limits or usage limits.
+ */
+export interface FallbackModelEntry {
+	/** Model ID (e.g., 'claude-sonnet-4-5-20250929') */
+	model: string;
+	/** Provider ID (e.g., 'anthropic', 'glm', 'minimax') */
+	provider: string;
+}
+
+/**
  * Global settings that apply across all sessions
  */
 export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
@@ -136,6 +147,9 @@ export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
 	// Room agent settings
 	/** Maximum number of concurrent worker sessions per room agent (default: 3) */
 	maxConcurrentWorkers?: number;
+
+	/** Ordered fallback model chain for automatic model switching on rate/usage limits */
+	fallbackModels?: FallbackModelEntry[];
 }
 
 /**

--- a/packages/web/src/components/ChatHeader.tsx
+++ b/packages/web/src/components/ChatHeader.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_WORKER_FEATURES } from '@neokai/shared';
 import { borderColors } from '../lib/design-tokens';
 import { formatTokens } from '../lib/utils';
 import { connectionState } from '../lib/state';
+import { getModelLabel } from '../lib/session-utils';
 import { navigateToRoom } from '../lib/router';
 import { IconButton } from './ui/IconButton';
 import { Dropdown } from './ui/Dropdown';
@@ -231,6 +232,14 @@ export function ChatHeader({
 						</span>
 						<span class="text-gray-500">•</span>
 						<span class="font-mono text-green-400">${displayStats.totalCost.toFixed(4)}</span>
+						{session?.config?.model && (
+							<>
+								<span class="text-gray-500">•</span>
+								<span class="text-blue-400 font-medium" title={session.config.model}>
+									{getModelLabel(session.config.model)}
+								</span>
+							</>
+						)}
 					</div>
 					{/* Git branch info */}
 					{(session?.worktree?.branch || session?.gitBranch) && (

--- a/packages/web/src/components/SessionListItem.tsx
+++ b/packages/web/src/components/SessionListItem.tsx
@@ -4,6 +4,7 @@ import { formatRelativeTime, formatTokens } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import { allSessionStatuses, getProcessingPhaseColor } from '../lib/session-status.ts';
 import { GitBranchIcon } from './icons/GitBranchIcon.tsx';
+import { getModelLabel } from '../lib/session-utils.ts';
 
 interface SessionListItemProps {
 	session: Session;
@@ -76,6 +77,14 @@ export default function SessionListItem({ session, onSessionClick }: SessionList
 						>
 							{session.title || 'New Session'}
 						</h3>
+						{session.config?.model && (
+							<span
+								class="text-[10px] px-1 py-0.5 rounded bg-dark-700 text-blue-400 font-medium flex-shrink-0"
+								title={session.config.model}
+							>
+								{getModelLabel(session.config.model)}
+							</span>
+						)}
 					</div>
 					<div class="flex items-center gap-1 flex-shrink-0">
 						{session.worktree && (

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -16,6 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import type { SessionInfo } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import {
 	useSessionQuestionState,
@@ -24,6 +25,7 @@ import {
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
+import { getModelLabel } from '../../lib/session-utils';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -71,8 +73,13 @@ const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: s
 };
 
 function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
+	// messageType is used for DB records; type is used for WebSocket real-time events.
+	// Normalize to whichever field is set.
+	const msgAny = msg as unknown as Record<string, unknown>;
+	const msgType = msgAny.messageType ?? msgAny.type;
+
 	// Status messages are plain text, not JSON
-	if (msg.messageType === 'status') {
+	if (msgType === 'status') {
 		return {
 			type: 'status',
 			text: msg.content,
@@ -85,8 +92,8 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Leader summary messages are plain text with distinct rendering
-	if (msg.messageType === 'leader_summary') {
+	// Leader summary messages: rendered as a distinct card
+	if (msgType === 'leader_summary') {
 		return {
 			type: 'leader_summary',
 			text: msg.content,
@@ -98,6 +105,35 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 			},
 		} as unknown as SDKMessage;
 	}
+
+	// Rate limited: rendered as an amber notification
+	if (msgType === 'rate_limited') {
+		return {
+			type: 'rate_limited',
+			text: msg.content,
+			_taskMeta: {
+				authorRole: 'system',
+				authorSessionId: '',
+				turnId: `rate-limited-${msg.id}`,
+				iteration: 0,
+			},
+		} as unknown as SDKMessage;
+	}
+
+	// Model fallback: rendered as an amber notification
+	if (msgType === 'model_fallback') {
+		return {
+			type: 'model_fallback',
+			text: msg.content,
+			_taskMeta: {
+				authorRole: 'system',
+				authorSessionId: '',
+				turnId: `model-fallback-${msg.id}`,
+				iteration: 0,
+			},
+		} as unknown as SDKMessage;
+	}
+
 	try {
 		return JSON.parse(msg.content) as SDKMessage;
 	} catch {
@@ -155,6 +191,70 @@ export function TaskConversationRenderer({
 	// buffered here and merged (with dedup) once the fetch resolves.
 	const fetchingRef = useRef(true);
 	const pendingDeltasRef = useRef<SDKMessage[]>([]);
+
+	// Fetch session model info for leader and worker
+	const [sessionModels, setSessionModels] = useState<{
+		leaderModel: string | null;
+		workerModel: string | null;
+	}>({ leaderModel: null, workerModel: null });
+
+	useEffect(() => {
+		let cancelled = false;
+		const fetchSessionModels = async () => {
+			try {
+				const [leaderRes, workerRes] = await Promise.all([
+					request<{ session: SessionInfo }>('session.get', { sessionId: leaderSessionId }),
+					request<{ session: SessionInfo }>('session.get', { sessionId: workerSessionId }),
+				]);
+				if (!cancelled) {
+					setSessionModels({
+						leaderModel: leaderRes.session?.config?.model ?? null,
+						workerModel: workerRes.session?.config?.model ?? null,
+					});
+				}
+			} catch {
+				// Silently ignore — model names just won't be shown
+			}
+		};
+
+		void fetchSessionModels();
+		return () => {
+			cancelled = true;
+		};
+	}, [leaderSessionId, workerSessionId, request]);
+
+	// Build role divider labels that include model names for leader/worker
+	function getRoleLabel(
+		role: string,
+		authorSessionId: string | undefined
+	): { label: string; labelColor: string } {
+		const base = ROLE_COLORS[role] ?? ROLE_COLORS.system;
+		if (role === 'leader') {
+			const modelLabel =
+				authorSessionId === leaderSessionId ? getModelLabel(sessionModels.leaderModel) : '';
+			return {
+				label: modelLabel ? `Leader · ${modelLabel}` : 'Leader',
+				labelColor: base.labelColor,
+			};
+		}
+		if (role === 'lead') {
+			const modelLabel =
+				authorSessionId === leaderSessionId ? getModelLabel(sessionModels.leaderModel) : '';
+			return {
+				label: modelLabel ? `Lead · ${modelLabel}` : 'Lead',
+				labelColor: base.labelColor,
+			};
+		}
+		if (role === 'coder' || role === 'craft') {
+			const modelLabel =
+				authorSessionId === workerSessionId ? getModelLabel(sessionModels.workerModel) : '';
+			return {
+				label: modelLabel ? `${base.label} · ${modelLabel}` : base.label,
+				labelColor: base.labelColor,
+			};
+		}
+		return { label: base.label, labelColor: base.labelColor };
+	}
 
 	useEffect(() => {
 		const channel = `group:${groupId}`;
@@ -401,6 +501,45 @@ export function TaskConversationRenderer({
 					);
 				}
 
+				// Rate limited event: render as an amber notification
+				if (raw.type === 'rate_limited') {
+					const text = typeof raw.text === 'string' ? raw.text : 'Rate limit reached';
+					const resetsAt =
+						typeof raw.resetsAt === 'number' ? new Date(raw.resetsAt).toLocaleTimeString() : null;
+					const sessionRole = typeof raw.sessionRole === 'string' ? raw.sessionRole : '';
+					const roleLabel =
+						sessionRole === 'leader' ? 'Leader' : sessionRole === 'worker' ? 'Worker' : 'Agent';
+					return (
+						<div
+							key={key}
+							class="my-2 rounded border border-amber-700/50 bg-amber-950/20 px-3 py-2"
+						>
+							<div class="flex items-center gap-2">
+								<svg
+									class="w-4 h-4 text-amber-400 flex-shrink-0"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+									/>
+								</svg>
+								<div class="flex-1 min-w-0">
+									<p class="text-sm text-amber-300 font-medium">{roleLabel} rate limited</p>
+									<p class="text-xs text-amber-400/80 mt-0.5">
+										{text}
+										{resetsAt ? ` Resets at ${resetsAt}.` : ''}
+									</p>
+								</div>
+							</div>
+						</div>
+					);
+				}
+
 				// Leader summary messages: render as a context card
 				if (raw.type === 'leader_summary') {
 					const rawText = typeof raw.text === 'string' ? raw.text : '';
@@ -433,6 +572,43 @@ export function TaskConversationRenderer({
 					);
 				}
 
+				// Model fallback event: show a prominent amber notification about the model switch
+				if (raw.type === 'model_fallback') {
+					const fromModel = typeof raw.fromModel === 'string' ? raw.fromModel : '';
+					const toModel = typeof raw.toModel === 'string' ? raw.toModel : '';
+					const sessionRole = typeof raw.sessionRole === 'string' ? raw.sessionRole : '';
+					const roleLabel =
+						sessionRole === 'leader' ? 'Leader' : sessionRole === 'worker' ? 'Worker' : 'Agent';
+					return (
+						<div
+							key={key}
+							class="my-2 rounded border border-amber-700/50 bg-amber-950/20 px-3 py-2"
+						>
+							<div class="flex items-center gap-2">
+								<svg
+									class="w-4 h-4 text-amber-400 flex-shrink-0"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+									/>
+								</svg>
+								<div class="flex-1 min-w-0">
+									<p class="text-sm text-amber-300 font-medium">{roleLabel} model switched</p>
+									<p class="text-xs text-amber-400/80 mt-0.5">
+										{fromModel || 'Previous model'} → {toModel || 'New model'}
+									</p>
+								</div>
+							</div>
+						</div>
+					);
+				}
+
 				// Insert a role transition divider when the agent changes
 				const showTransition = roleTransitions.has(i);
 
@@ -447,15 +623,18 @@ export function TaskConversationRenderer({
 					questionState = workerQuestionState;
 				}
 
+				// Get role label (includes model name for leader/worker/coder/craft roles)
+				const roleLabel = getRoleLabel(role, authorSessionId);
+
 				return (
 					<div key={key}>
 						{showTransition && (
 							<div class="flex items-center gap-2 py-1.5 mt-1">
 								<div class="flex-1 h-px bg-dark-700" />
 								<span
-									class={`text-[10px] font-semibold uppercase tracking-wide ${style.labelColor}`}
+									class={`text-[10px] font-semibold uppercase tracking-wide ${roleLabel.labelColor}`}
 								>
-									{style.label}
+									{roleLabel.label}
 								</span>
 								<div class="flex-1 h-px bg-dark-700" />
 							</div>

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -22,6 +22,7 @@ import { useMessageHub } from '../../hooks/useMessageHub';
 import { useModal } from '../../hooks/useModal';
 import { useTaskInputDraft } from '../../hooks/useTaskInputDraft';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { getModelLabel } from '../../lib/session-utils';
 import { toast } from '../../lib/toast.ts';
 import { copyToClipboard } from '../../lib/utils';
 import { ActionBar } from '../ui/ActionBar';
@@ -30,6 +31,7 @@ import { RejectModal } from '../ui/RejectModal';
 import { InputTextarea } from '../InputTextarea';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
 import { TaskConversationRenderer } from './TaskConversationRenderer';
+import { TaskViewModelSelector } from './TaskViewModelSelector';
 
 interface CopyButtonProps {
 	text: string;
@@ -555,6 +557,24 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		setAutoScrollEnabled(true);
 	}, [scrollToBottom]);
 
+	// Refresh worker session info after model switch
+	const handleWorkerModelSwitched = useCallback(() => {
+		if (group) {
+			void request<{ session: SessionInfo }>('session.get', { sessionId: group.workerSessionId })
+				.then((res) => setWorkerSession(res.session))
+				.catch(() => {});
+		}
+	}, [group, request]);
+
+	// Refresh leader session info after model switch
+	const handleLeaderModelSwitched = useCallback(() => {
+		if (group) {
+			void request<{ session: SessionInfo }>('session.get', { sessionId: group.leaderSessionId })
+				.then((res) => setLeaderSession(res.session))
+				.catch(() => {});
+		}
+	}, [group, request]);
+
 	useEffect(() => {
 		const channel = `room:${roomId}`;
 		joinRoom(channel);
@@ -951,31 +971,51 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 							</>
 						)}
 						{workerSession && (
-							<div class="md:col-span-2">
-								<span class="text-gray-500">Worker worktree:</span>
-								<span class="text-gray-300 ml-2 font-mono break-all">
+							<div class="md:col-span-2 flex items-center gap-2 flex-wrap">
+								<span class="text-gray-500">Worker:</span>
+								<span class="text-gray-300 font-mono break-all">
 									{workerSession.worktree?.worktreePath ?? workerSession.workspacePath}
 								</span>
 								<CopyButton
 									text={workerSession.worktree?.worktreePath ?? workerSession.workspacePath}
 								/>
-								{workerSession.config.model && (
-									<span class="text-gray-500 ml-2">(model: {workerSession.config.model})</span>
-								)}
+								<span
+									class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-blue-400 font-medium"
+									title={workerSession.config.model ?? undefined}
+								>
+									{getModelLabel(workerSession.config.model)}
+								</span>
+								<TaskViewModelSelector
+									sessionId={workerSession.id}
+									currentModel={workerSession.config.model ?? ''}
+									currentProvider={workerSession.config.provider}
+									disabled={task.status !== 'in_progress' && task.status !== 'review'}
+									onModelSwitched={handleWorkerModelSwitched}
+								/>
 							</div>
 						)}
 						{leaderSession && (
-							<div class="md:col-span-2">
-								<span class="text-gray-500">Leader worktree:</span>
-								<span class="text-gray-300 ml-2 font-mono break-all">
+							<div class="md:col-span-2 flex items-center gap-2 flex-wrap">
+								<span class="text-gray-500">Leader:</span>
+								<span class="text-gray-300 font-mono break-all">
 									{leaderSession.worktree?.worktreePath ?? leaderSession.workspacePath}
 								</span>
 								<CopyButton
 									text={leaderSession.worktree?.worktreePath ?? leaderSession.workspacePath}
 								/>
-								{leaderSession.config.model && (
-									<span class="text-gray-500 ml-2">(model: {leaderSession.config.model})</span>
-								)}
+								<span
+									class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-purple-400 font-medium"
+									title={leaderSession.config.model ?? undefined}
+								>
+									{getModelLabel(leaderSession.config.model)}
+								</span>
+								<TaskViewModelSelector
+									sessionId={leaderSession.id}
+									currentModel={leaderSession.config.model ?? ''}
+									currentProvider={leaderSession.config.provider}
+									disabled={task.status !== 'in_progress' && task.status !== 'review'}
+									onModelSwitched={handleLeaderModelSwitched}
+								/>
 							</div>
 						)}
 					</div>

--- a/packages/web/src/components/room/TaskViewModelSelector.tsx
+++ b/packages/web/src/components/room/TaskViewModelSelector.tsx
@@ -1,0 +1,243 @@
+/**
+ * TaskViewModelSelector Component
+ *
+ * Provides a compact model selector dropdown for use in the TaskView info panel.
+ * Allows switching between available models grouped by provider.
+ */
+
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import type { ModelInfo } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
+import { connectionManager } from '../../lib/connection-manager';
+import { toast } from '../../lib/toast.ts';
+import {
+	groupModelsByProvider,
+	filterModelsForPicker,
+	getModelFamilyIcon,
+	mapRawModelsToModelInfos,
+	PROVIDER_LABELS,
+} from '../../hooks/useModelSwitcher.ts';
+import { Spinner } from '../ui/Spinner';
+import { listProviderAuthStatus } from '../../lib/api-helpers.ts';
+
+interface RawModelEntry {
+	id: string;
+	display_name: string;
+	description: string;
+	alias?: string;
+	provider?: string;
+}
+
+export interface TaskViewModelSelectorProps {
+	sessionId: string;
+	currentModel: string;
+	currentProvider?: string;
+	disabled?: boolean;
+	/** Called after a model switch succeeds, with the new model ID */
+	onModelSwitched?: (model: string, provider: string) => void;
+}
+
+export function TaskViewModelSelector({
+	sessionId,
+	currentModel,
+	currentProvider,
+	disabled = false,
+	onModelSwitched,
+}: TaskViewModelSelectorProps) {
+	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
+		new Map()
+	);
+	const [loading, setLoading] = useState(true);
+	const [switching, setSwitching] = useState(false);
+	const [dropdownOpen, setDropdownOpen] = useState(false);
+
+	// Fetch available models and provider auth statuses
+	useEffect(() => {
+		const fetchData = async () => {
+			setLoading(true);
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) return;
+
+				// Fetch models and auth status in parallel
+				const [modelsResponse, authResponse] = await Promise.all([
+					hub.request('models.list', { useCache: true }) as Promise<{ models: RawModelEntry[] }>,
+					listProviderAuthStatus().catch(() => ({ providers: [] as ProviderAuthStatus[] })),
+				]);
+
+				setAvailableModels(mapRawModelsToModelInfos(modelsResponse.models));
+
+				// Build auth status map
+				const authMap = new Map<string, ProviderAuthStatus>();
+				for (const p of authResponse.providers) {
+					authMap.set(p.id, p);
+				}
+				setProviderAuthStatuses(authMap);
+			} catch {
+				// Error handled silently
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		void fetchData();
+	}, []);
+
+	// Switch model handler
+	const switchModel = useCallback(
+		async (model: ModelInfo) => {
+			if (!model.provider) {
+				toast.error('Model provider information is missing');
+				return;
+			}
+
+			setDropdownOpen(false);
+			setSwitching(true);
+
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) {
+					toast.error('Not connected to server');
+					return;
+				}
+
+				const result = (await hub.request('session.model.switch', {
+					sessionId,
+					model: model.id,
+					provider: model.provider,
+				})) as {
+					success: boolean;
+					model: string;
+					error?: string;
+				};
+
+				if (result.success) {
+					toast.success(`Switched to ${model.name}`);
+					onModelSwitched?.(model.id, model.provider ?? '');
+				} else {
+					toast.error(result.error || 'Failed to switch model');
+				}
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : 'Failed to switch model';
+				toast.error(errorMessage);
+			} finally {
+				setSwitching(false);
+			}
+		},
+		[sessionId]
+	);
+
+	// Get current model info
+	const currentModelInfo =
+		availableModels.find((m) => m.id === currentModel && m.provider === currentProvider) ??
+		availableModels.find((m) => m.id === currentModel);
+
+	const filteredModels = filterModelsForPicker(
+		availableModels,
+		providerAuthStatuses,
+		currentProvider
+	);
+	const groupedModels = groupModelsByProvider(filteredModels);
+
+	const handleToggleDropdown = () => {
+		if (!disabled && !loading) {
+			setDropdownOpen((open) => !open);
+		}
+	};
+
+	return (
+		<div class="relative inline-block">
+			<button
+				class={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs transition-colors ${
+					disabled
+						? 'text-gray-500 cursor-not-allowed'
+						: 'text-blue-400 hover:text-blue-300 hover:bg-dark-700 cursor-pointer'
+				}`}
+				onClick={handleToggleDropdown}
+				disabled={disabled || loading}
+				title="Click to switch model"
+			>
+				{loading || switching ? (
+					<Spinner size="xs" />
+				) : (
+					<>
+						<span>{currentModelInfo ? getModelFamilyIcon(currentModelInfo.family) : '💎'}</span>
+						<span class="max-w-[120px] truncate">
+							{currentModelInfo?.name || currentModel || 'Unknown'}
+						</span>
+						<svg
+							class={`w-3 h-3 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					</>
+				)}
+			</button>
+
+			{dropdownOpen && (
+				<div class="absolute left-0 top-full mt-1 bg-dark-800 border border-dark-600 rounded-lg shadow-xl w-56 max-h-64 overflow-y-auto z-50 animate-slideIn">
+					<div class="py-1">
+						{Array.from(groupedModels.entries()).map(([provider, models]) => {
+							const authStatus = providerAuthStatuses.get(provider);
+							const isAuthenticated = authStatus?.isAuthenticated ?? false;
+							const needsRefresh = authStatus?.needsRefresh ?? false;
+
+							return (
+								<div key={provider}>
+									{/* Provider header */}
+									<div class="px-3 py-1.5 text-xs font-semibold text-gray-400 flex items-center gap-2 sticky top-0 bg-dark-800">
+										<span>{PROVIDER_LABELS[provider] || provider}</span>
+										{!isAuthenticated && (
+											<span class="text-xs text-gray-600">(not authenticated)</span>
+										)}
+										{needsRefresh && <span class="text-xs text-yellow-500">(needs refresh)</span>}
+									</div>
+
+									{/* Models for this provider */}
+									{models.map((model) => {
+										const isCurrent =
+											model.id === currentModelInfo?.id &&
+											model.provider === currentModelInfo?.provider;
+
+										return (
+											<button
+												key={`${model.provider}:${model.id}`}
+												class={`w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 transition-colors ${
+													isCurrent
+														? 'text-blue-400 bg-dark-700/50'
+														: 'text-gray-200 hover:bg-dark-700'
+												}`}
+												onClick={() => switchModel(model)}
+												disabled={switching}
+											>
+												<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+												<span class="flex-1 truncate">{model.name}</span>
+												{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+											</button>
+										);
+									})}
+								</div>
+							);
+						})}
+
+						{filteredModels.length === 0 && (
+							<div class="px-3 py-2 text-xs text-gray-500">No models available</div>
+						)}
+					</div>
+				</div>
+			)}
+
+			{/* Click outside handler */}
+			{dropdownOpen && <div class="fixed inset-0 z-40" onClick={() => setDropdownOpen(false)} />}
+		</div>
+	);
+}

--- a/packages/web/src/components/settings/FallbackModelsSettings.tsx
+++ b/packages/web/src/components/settings/FallbackModelsSettings.tsx
@@ -1,0 +1,346 @@
+/**
+ * FallbackModelsSettings Component
+ *
+ * Allows configuring the fallback model chain for automatic model switching
+ * when rate limits or usage limits are hit.
+ */
+
+import { useEffect, useState } from 'preact/hooks';
+import type { FallbackModelEntry, ModelInfo } from '@neokai/shared';
+import type { ProviderAuthStatus } from '@neokai/shared/provider';
+import { globalSettings } from '../../lib/state.ts';
+import { updateGlobalSettings } from '../../lib/api-helpers.ts';
+import { toast } from '../../lib/toast.ts';
+import { connectionManager } from '../../lib/connection-manager';
+import {
+	groupModelsByProvider,
+	filterModelsForPicker,
+	getModelFamilyIcon,
+	mapRawModelsToModelInfos,
+	PROVIDER_LABELS,
+} from '../../hooks/useModelSwitcher.ts';
+import { SettingsSection } from './SettingsSection.tsx';
+import { Spinner } from '../ui/Spinner';
+import { listProviderAuthStatus } from '../../lib/api-helpers.ts';
+
+interface RawModelEntry {
+	id: string;
+	display_name: string;
+	description: string;
+	alias?: string;
+	provider?: string;
+}
+
+export function FallbackModelsSettings() {
+	const settings = globalSettings.value;
+	const [fallbackModels, setFallbackModels] = useState<FallbackModelEntry[]>(
+		settings?.fallbackModels ?? []
+	);
+	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
+		new Map()
+	);
+	const [loading, setLoading] = useState(true);
+	const [isUpdating, setIsUpdating] = useState(false);
+	const [showAddModal, setShowAddModal] = useState(false);
+
+	// Sync with global settings when they change
+	useEffect(() => {
+		if (settings) {
+			setFallbackModels(settings.fallbackModels ?? []);
+		}
+	}, [settings]);
+
+	// Fetch available models
+	useEffect(() => {
+		const fetchData = async () => {
+			setLoading(true);
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) return;
+
+				const [modelsResponse, authResponse] = await Promise.all([
+					hub.request('models.list', { useCache: true }) as Promise<{ models: RawModelEntry[] }>,
+					listProviderAuthStatus().catch(() => ({ providers: [] })),
+				]);
+
+				setAvailableModels(mapRawModelsToModelInfos(modelsResponse.models));
+
+				const authMap = new Map<string, ProviderAuthStatus>();
+				for (const p of authResponse.providers) {
+					authMap.set(p.id, p);
+				}
+				setProviderAuthStatuses(authMap);
+			} catch {
+				// Error handled silently
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		void fetchData();
+	}, []);
+
+	// Save fallback models to settings
+	const saveFallbackModels = async (models: FallbackModelEntry[]) => {
+		setIsUpdating(true);
+		try {
+			await updateGlobalSettings({ fallbackModels: models });
+			setFallbackModels(models);
+			toast.success('Fallback models updated');
+		} catch {
+			toast.error('Failed to update fallback models');
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
+	// Remove a fallback model
+	const handleRemove = async (index: number) => {
+		const newModels = [...fallbackModels];
+		newModels.splice(index, 1);
+		await saveFallbackModels(newModels);
+	};
+
+	// Move a fallback model up or down
+	const handleMove = async (index: number, direction: 'up' | 'down') => {
+		const newIndex = direction === 'up' ? index - 1 : index + 1;
+		if (newIndex < 0 || newIndex >= fallbackModels.length) return;
+
+		const newModels = [...fallbackModels];
+		[newModels[index], newModels[newIndex]] = [newModels[newIndex], newModels[index]];
+		await saveFallbackModels(newModels);
+	};
+
+	// Add a new fallback model
+	const handleAdd = async (model: ModelInfo) => {
+		// Check if model is already in the list
+		if (fallbackModels.some((m) => m.model === model.id && m.provider === model.provider)) {
+			toast.error('Model is already in the fallback chain');
+			return;
+		}
+
+		const newModels = [
+			...fallbackModels,
+			{ model: model.id, provider: model.provider ?? 'anthropic' },
+		];
+		await saveFallbackModels(newModels);
+		setShowAddModal(false);
+	};
+
+	// Get model info for display
+	const getModelDisplayInfo = (entry: FallbackModelEntry): { name: string; family: string } => {
+		const model = availableModels.find(
+			(m) => m.id === entry.model && m.provider === entry.provider
+		);
+		return {
+			name: model?.name ?? entry.model,
+			family: model?.family ?? 'sonnet',
+		};
+	};
+
+	const filteredModels = filterModelsForPicker(availableModels, providerAuthStatuses, undefined);
+	const groupedModels = groupModelsByProvider(filteredModels);
+
+	return (
+		<SettingsSection title="Fallback Models">
+			<div class="space-y-3">
+				<p class="text-xs text-gray-500 mb-3">
+					Configure an ordered list of fallback models. When the primary model hits a rate limit or
+					usage limit, NeoKai will automatically switch to the next model in the chain.
+				</p>
+
+				{loading ? (
+					<div class="flex items-center gap-2 text-xs text-gray-500">
+						<Spinner size="xs" />
+						<span>Loading models...</span>
+					</div>
+				) : fallbackModels.length === 0 ? (
+					<div class="text-xs text-gray-500 italic">No fallback models configured</div>
+				) : (
+					<div class="space-y-2">
+						{fallbackModels.map((entry, index) => {
+							const displayInfo = getModelDisplayInfo(entry);
+							return (
+								<div
+									key={`${entry.provider}:${entry.model}`}
+									class="flex items-center gap-2 bg-dark-800 border border-dark-700 rounded-lg px-3 py-2"
+								>
+									{/* Priority number */}
+									<span class="text-xs text-gray-500 font-medium w-4">{index + 1}.</span>
+
+									{/* Model icon */}
+									<span class="text-base">{getModelFamilyIcon(displayInfo.family)}</span>
+
+									{/* Model name and provider */}
+									<div class="flex-1 min-w-0">
+										<div class="text-sm text-gray-200 truncate">{displayInfo.name}</div>
+										<div class="text-xs text-gray-500">
+											{PROVIDER_LABELS[entry.provider] || entry.provider}
+										</div>
+									</div>
+
+									{/* Move buttons */}
+									<div class="flex items-center gap-1">
+										<button
+											class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
+											onClick={() => handleMove(index, 'up')}
+											disabled={index === 0 || isUpdating}
+											title="Move up"
+										>
+											<svg
+												class="w-4 h-4 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke="currentColor"
+											>
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width="2"
+													d="M5 15l7-7 7 7"
+												/>
+											</svg>
+										</button>
+										<button
+											class="p-1 rounded hover:bg-dark-700 disabled:opacity-30 disabled:cursor-not-allowed"
+											onClick={() => handleMove(index, 'down')}
+											disabled={index === fallbackModels.length - 1 || isUpdating}
+											title="Move down"
+										>
+											<svg
+												class="w-4 h-4 text-gray-400"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke="currentColor"
+											>
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width="2"
+													d="M19 9l-7 7-7-7"
+												/>
+											</svg>
+										</button>
+									</div>
+
+									{/* Remove button */}
+									<button
+										class="p-1 rounded hover:bg-red-900/30 disabled:opacity-30 disabled:cursor-not-allowed"
+										onClick={() => handleRemove(index)}
+										disabled={isUpdating}
+										title="Remove"
+									>
+										<svg
+											class="w-4 h-4 text-red-400"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M6 18L18 6M6 6l12 12"
+											/>
+										</svg>
+									</button>
+								</div>
+							);
+						})}
+					</div>
+				)}
+
+				{/* Add button */}
+				<button
+					class="flex items-center gap-2 px-3 py-2 text-sm text-blue-400 hover:text-blue-300 hover:bg-dark-800 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 transition-colors disabled:opacity-50"
+					onClick={() => setShowAddModal(true)}
+					disabled={loading}
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 4v16m8-8H4"
+						/>
+					</svg>
+					Add Fallback Model
+				</button>
+			</div>
+
+			{/* Add Model Modal */}
+			{showAddModal && (
+				<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+					<div class="bg-dark-850 border border-dark-600 rounded-lg shadow-xl w-80 max-h-[80vh] overflow-hidden flex flex-col">
+						<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700">
+							<h3 class="text-sm font-medium text-gray-100">Add Fallback Model</h3>
+							<button class="p-1 rounded hover:bg-dark-700" onClick={() => setShowAddModal(false)}>
+								<svg
+									class="w-4 h-4 text-gray-400"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</button>
+						</div>
+
+						<div class="flex-1 overflow-y-auto py-2">
+							{Array.from(groupedModels.entries()).map(([provider, models]) => {
+								const authStatus = providerAuthStatuses.get(provider);
+								const isAuthenticated = authStatus?.isAuthenticated ?? false;
+
+								return (
+									<div key={provider}>
+										<div class="px-4 py-1.5 text-xs font-semibold text-gray-400">
+											{PROVIDER_LABELS[provider] || provider}
+											{!isAuthenticated && (
+												<span class="text-gray-600 ml-1">(not authenticated)</span>
+											)}
+										</div>
+										{models.map((model) => {
+											// Don't show models already in fallback chain
+											if (
+												fallbackModels.some(
+													(m) => m.model === model.id && m.provider === model.provider
+												)
+											) {
+												return null;
+											}
+
+											return (
+												<button
+													key={`${model.provider}:${model.id}`}
+													class="w-full text-left px-4 py-2 text-sm flex items-center gap-2 hover:bg-dark-700 transition-colors"
+													onClick={() => handleAdd(model)}
+												>
+													<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+													<span class="flex-1 text-gray-200 truncate">{model.name}</span>
+												</button>
+											);
+										})}
+									</div>
+								);
+							})}
+
+							{filteredModels.filter(
+								(m) => !fallbackModels.some((f) => f.model === m.id && f.provider === m.provider)
+							).length === 0 && (
+								<div class="px-4 py-4 text-sm text-gray-500 text-center">
+									All available models are already in the fallback chain
+								</div>
+							)}
+						</div>
+					</div>
+				</div>
+			)}
+		</SettingsSection>
+	);
+}

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -44,6 +44,7 @@ const SETTINGS_SECTIONS: Array<{
 	{ id: 'general', label: 'General', icon: 'settings' },
 	{ id: 'providers', label: 'Providers', icon: 'cloud' },
 	{ id: 'mcp-servers', label: 'MCP Servers', icon: 'server' },
+	{ id: 'fallback-models', label: 'Fallback Models', icon: 'swap' },
 	{ id: 'usage', label: 'Usage', icon: 'chart' },
 	{ id: 'about', label: 'About', icon: 'info' },
 ];
@@ -109,6 +110,17 @@ function SectionIcon({ type }: { type: string }) {
 						stroke-linejoin="round"
 						stroke-width={2}
 						d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+					/>
+				</svg>
+			);
+		case 'swap':
+			return (
+				<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2}
+						d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
 					/>
 				</svg>
 			);

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -17,6 +17,7 @@ import { SpacesPage } from './SpacesPage.tsx';
 import { GeneralSettings } from '../components/settings/GeneralSettings.tsx';
 import { ProvidersSettings } from '../components/settings/ProvidersSettings.tsx';
 import { McpServersSettings } from '../components/settings/McpServersSettings.tsx';
+import { FallbackModelsSettings } from '../components/settings/FallbackModelsSettings.tsx';
 import { UsageAnalytics } from '../components/settings/UsageAnalytics.tsx';
 import { AboutSection } from '../components/settings/AboutSection.tsx';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
@@ -82,6 +83,7 @@ export default function MainContent() {
 					{settingsSection === 'general' && <GeneralSettings />}
 					{settingsSection === 'providers' && <ProvidersSettings />}
 					{settingsSection === 'mcp-servers' && <McpServersSettings />}
+					{settingsSection === 'fallback-models' && <FallbackModelsSettings />}
 					{settingsSection === 'usage' && <UsageAnalytics />}
 					{settingsSection === 'about' && <AboutSection />}
 				</div>

--- a/packages/web/src/lib/session-utils.ts
+++ b/packages/web/src/lib/session-utils.ts
@@ -16,3 +16,47 @@ const USER_SESSION_TYPES = new Set<string | undefined>(['worker', undefined]);
 export function isUserSession(session: Session): boolean {
 	return USER_SESSION_TYPES.has(session.type) && !session.context?.roomId;
 }
+
+/**
+ * Returns a human-readable model label from a model ID string.
+ *
+ * e.g.
+ *   "claude-sonnet-4-5-20250929" → "Sonnet 4"
+ *   "claude-opus-4-20251120"       → "Opus 4"
+ *   "claude-haiku-3-20250730"      → "Haiku 3"
+ *   "glm-4-flash"                  → "GLM 4 Flash"
+ *   "deepseek-chat"                → "Deepseek Chat"
+ */
+export function getModelLabel(modelId: string | null | undefined): string {
+	if (!modelId) return '';
+	const lower = modelId.toLowerCase();
+
+	// Anthropic models: claude-{family}-{number}(-...) → "{Family} {number}"
+	if (lower.startsWith('claude-')) {
+		const rest = modelId.slice('claude-'.length);
+		// Strip date suffix (e.g. -20250929)
+		const withoutDate = rest.replace(/-\d{8}$/, '');
+		const parts = withoutDate.split('-');
+		if (parts.length >= 2) {
+			const family = parts[0]!;
+			const number = parts[1]!;
+			return `${family.charAt(0).toUpperCase() + family.slice(1)} ${number}`;
+		}
+		return rest.charAt(0).toUpperCase() + rest.slice(1);
+	}
+
+	// GLM models: glm-4-flash → GLM 4 Flash
+	if (lower.startsWith('glm-')) {
+		const rest = modelId.slice('glm-'.length);
+		const parts = rest.split('-');
+		if (parts.length >= 2) {
+			const family = parts[0]!;
+			const suffix = parts.slice(1).join(' ');
+			return `GLM ${family.charAt(0).toUpperCase() + family.slice(1)}${suffix ? ' ' + suffix : ''}`;
+		}
+		return `GLM ${rest.charAt(0).toUpperCase() + rest.slice(1)}`;
+	}
+
+	// Unknown models: clean up dashes and camelCase for readability
+	return modelId.replace(/-/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+}

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -47,5 +47,11 @@ export const contextPanelOpenSignal = signal<boolean>(false);
 export const createRoomModalSignal = signal<boolean>(false);
 
 // Settings section signal - which settings section is active
-export type SettingsSection = 'general' | 'providers' | 'mcp-servers' | 'usage' | 'about';
+export type SettingsSection =
+	| 'general'
+	| 'providers'
+	| 'mcp-servers'
+	| 'fallback-models'
+	| 'usage'
+	| 'about';
 export const settingsSectionSignal = signal<SettingsSection>('general');


### PR DESCRIPTION
- Add FallbackModelsSettings component in Settings UI for configuring ordered fallback model chain
- Add TaskViewModelSelector component in TaskView for worker and leader model switching
- Add auto-fallback logic in room-runtime: when rate limit (HTTP 429) or usage limit detected, automatically switch to next fallback model
- Add usage_limit error class in error-classifier for daily/weekly usage caps (immediate fallback without backoff)
- Add fallbackModels field to GlobalSettings type
- Add Fallback Models section in ContextPanel settings navigation
- Update unit tests for error-classifier and room-runtime-test-helpers

Implements model selector in TaskView info panel, Fallback Models settings UI, and automatic model switching on rate/usage limits.
