### PR TITLE
feat: Phase 4 micro-animations — badge pop, card approve/reject, panel & page fade-in

### DIFF
--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -6,9 +6,20 @@
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { TaskSummary } from '@neokai/shared';
 import { RoomTasks, selectedTabSignal } from './RoomTasks';
+
+// Mock toast to prevent side effects from toast.rejected() calls
+vi.mock('../../lib/toast.ts', () => ({
+	toast: {
+		rejected: vi.fn(),
+		approved: vi.fn(),
+		error: vi.fn(),
+		success: vi.fn(),
+		info: vi.fn(),
+	},
+}));
 
 describe('RoomTasks', () => {
 	afterEach(() => {
@@ -767,7 +778,9 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
 
-			expect(container.querySelector('textarea')).toBeTruthy();
+			// Form wrapper should be expanded (max-h-48 replaces max-h-0)
+			const formWrapper = container.querySelector('.overflow-hidden.transition-all');
+			expect(formWrapper?.classList.contains('max-h-48')).toBe(true);
 			expect(container.textContent).toContain('Confirm Reject');
 			expect(container.textContent).toContain('Cancel');
 		});
@@ -783,15 +796,16 @@ describe('RoomTasks', () => {
 				(b) => b.textContent?.trim() === 'Reject'
 			) as HTMLButtonElement;
 			fireEvent.click(rejectBtn);
-			expect(container.querySelector('textarea')).toBeTruthy();
+			const formWrapper = container.querySelector('.overflow-hidden.transition-all');
+			expect(formWrapper?.classList.contains('max-h-48')).toBe(true);
 
-			// Cancel
+			// Cancel — form should collapse (max-h-0)
 			const cancelBtn = Array.from(container.querySelectorAll('button')).find(
 				(b) => b.textContent?.trim() === 'Cancel'
 			) as HTMLButtonElement;
 			fireEvent.click(cancelBtn);
 
-			expect(container.querySelector('textarea')).toBeFalsy();
+			expect(formWrapper?.classList.contains('max-h-0')).toBe(true);
 		});
 
 		it('Confirm Reject button should be disabled when feedback is empty', () => {
@@ -836,7 +850,7 @@ describe('RoomTasks', () => {
 			expect(onReject).toHaveBeenCalledWith('task-99', 'Needs more work');
 		});
 
-		it('should close form after Confirm Reject is clicked', () => {
+		it('should collapse form after Confirm Reject is clicked', () => {
 			const onReject = vi.fn();
 			const tasks = [createTask('t1', 'review')];
 
@@ -856,7 +870,9 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(confirmBtn);
 
-			expect(container.querySelector('textarea')).toBeFalsy();
+			// Form should be collapsed (max-h-0)
+			const formWrapper = container.querySelector('.overflow-hidden.transition-all');
+			expect(formWrapper?.classList.contains('max-h-0')).toBe(true);
 		});
 
 		it('should NOT call onTaskClick when Reject button is clicked', () => {
@@ -947,6 +963,74 @@ describe('RoomTasks', () => {
 
 			expect(onApprove).toHaveBeenCalledWith('task-55');
 			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+
+		it('should show "✓ Approved" on button and disable it immediately after click', () => {
+			const onApprove = vi.fn();
+			const tasks = [createTask('task-99', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			expect(approveBtn.textContent?.trim()).toContain('Approved');
+			expect(approveBtn.disabled).toBe(true);
+		});
+
+		it('should add opacity-40 to card after Approve is clicked', () => {
+			const onApprove = vi.fn();
+			const tasks = [createTask('task-98', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			const fadedCard = container.querySelector('.opacity-40');
+			expect(fadedCard).toBeTruthy();
+		});
+
+		it('should add border-l-green-500 to card after Approve is clicked', () => {
+			const onApprove = vi.fn();
+			const tasks = [createTask('task-97', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			const greenCard = container.querySelector('.border-l-green-500');
+			expect(greenCard).toBeTruthy();
+		});
+
+		it('should revert Approve button text to "Approve" after 300ms', async () => {
+			vi.useFakeTimers();
+			const onApprove = vi.fn();
+			const tasks = [createTask('task-96', 'review')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onApprove={onApprove} />);
+
+			const approveBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent?.trim() === 'Approve'
+			) as HTMLButtonElement;
+			fireEvent.click(approveBtn);
+
+			expect(approveBtn.textContent?.trim()).toContain('Approved');
+
+			await act(async () => {
+				vi.advanceTimersByTime(310);
+			});
+			expect(approveBtn.textContent?.trim()).toBe('Approve');
+			expect(approveBtn.disabled).toBe(false);
+
+			vi.useRealTimers();
 		});
 	});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -11,6 +11,7 @@
 import { useState } from 'preact/hooks';
 import { signal, effect } from '@preact/signals';
 import type { TaskSummary, TaskStatus } from '@neokai/shared';
+import { toast } from '../../lib/toast.ts';
 
 /** Tab filter types */
 export type TaskFilterTab = 'active' | 'review' | 'done' | 'needs_attention';
@@ -507,6 +508,10 @@ function TaskItem({
 	onSetRejectingTaskId?: (id: string | null) => void;
 }) {
 	const [feedback, setFeedback] = useState('');
+	// Approve animation: button shows "✓ Approved" for 300ms, card fades to opacity-40
+	const [buttonApproved, setButtonApproved] = useState(false);
+	const [cardFading, setCardFading] = useState(false);
+
 	const isClickable = !!onClick;
 	const isReview = task.status === 'review';
 	const showView = isReview && !!onView;
@@ -517,9 +522,12 @@ function TaskItem({
 	const isWorking = isReview && !!task.activeSession;
 	const isRejecting = rejectingTaskId === task.id;
 
+	// Compute border color: when approve animation active, switch to green
+	const borderColor = cardFading ? 'border-l-green-500' : getStatusBorderColor(task.status);
+
 	return (
 		<div
-			class={`px-4 py-3 border-l-2 ${getStatusBorderColor(task.status)} ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
+			class={`px-4 py-3 border-l-2 ${borderColor} transition-[opacity,border-color] duration-500 ${cardFading ? 'opacity-40' : ''} ${isClickable ? 'cursor-pointer hover:bg-dark-800/50 transition-colors' : ''}`}
 			onClick={isClickable ? () => onClick(task.id) : undefined}
 		>
 			<div class="flex items-start justify-between">
@@ -573,11 +581,17 @@ function TaskItem({
 								<button
 									onClick={(e) => {
 										e.stopPropagation();
+										// Start approve animation: button text + card fade
+										setButtonApproved(true);
+										setCardFading(true);
 										onApprove(task.id);
+										// Reset button text after 300ms
+										setTimeout(() => setButtonApproved(false), 300);
 									}}
-									class="bg-green-600 hover:bg-green-700 text-white text-xs px-3 py-1.5 rounded-lg transition-colors"
+									disabled={buttonApproved}
+									class="bg-green-600 hover:bg-green-700 text-white text-xs px-3 py-1.5 rounded-lg transition-colors disabled:cursor-default"
 								>
-									Approve
+									{buttonApproved ? '✓ Approved' : 'Approve'}
 								</button>
 							)}
 							{showReject && (
@@ -645,8 +659,12 @@ function TaskItem({
 					/>
 				</div>
 			)}
-			{isRejecting && (
-				<div class="mt-3 pt-3 border-t border-dark-700" onClick={(e) => e.stopPropagation()}>
+			{/* Reject form — always rendered; max-height controls collapse with transition-all duration-200 */}
+			<div
+				class={`overflow-hidden transition-all duration-200 ${isRejecting ? 'max-h-48' : 'max-h-0 pointer-events-none'}`}
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div class="mt-3 pt-3 border-t border-dark-700">
 					<textarea
 						rows={2}
 						placeholder="Please provide feedback..."
@@ -669,6 +687,7 @@ function TaskItem({
 							onClick={(e) => {
 								e.stopPropagation();
 								onReject?.(task.id, feedback);
+								toast.rejected();
 								setFeedback('');
 								onSetRejectingTaskId?.(null);
 							}}
@@ -679,7 +698,7 @@ function TaskItem({
 						</button>
 					</div>
 				</div>
-			)}
+			</div>
 		</div>
 	);
 }

--- a/packages/web/src/components/ui/InboxBadge.test.tsx
+++ b/packages/web/src/components/ui/InboxBadge.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for InboxBadge animation component (plan 8.3)
+ *
+ * Verifies:
+ * - Badge renders when count > 0
+ * - Badge does not render when count is 0
+ * - Scale animation class (animate-badge-pop) is applied on mount
+ * - Badge fades to opacity-0 when count reaches 0
+ * - 9+ label is used for counts above 9
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { InboxBadge } from './InboxBadge';
+
+describe('InboxBadge', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it('renders badge when count is positive', () => {
+		const { container } = render(<InboxBadge count={3} />);
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toBe('3');
+	});
+
+	it('does not render badge when count is 0', () => {
+		const { container } = render(<InboxBadge count={0} />);
+		expect(container.querySelector('.bg-red-500')).toBeFalsy();
+	});
+
+	it('shows 9+ when count exceeds 9', () => {
+		const { container } = render(<InboxBadge count={10} />);
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge?.textContent).toBe('9+');
+	});
+
+	it('applies animate-badge-pop class on initial mount', () => {
+		const { container } = render(<InboxBadge count={1} />);
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge?.classList.contains('animate-badge-pop')).toBe(true);
+	});
+
+	it('applies additional positioning class when provided', () => {
+		const { container } = render(<InboxBadge count={2} class="absolute top-1 right-1" />);
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge?.classList.contains('absolute')).toBe(true);
+		expect(badge?.classList.contains('top-1')).toBe(true);
+		expect(badge?.classList.contains('right-1')).toBe(true);
+	});
+
+	it('is initially visible (opacity-100) when count is positive', () => {
+		const { container } = render(<InboxBadge count={1} />);
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge?.classList.contains('opacity-100')).toBe(true);
+		expect(badge?.classList.contains('opacity-0')).toBe(false);
+	});
+
+	it('fades out (opacity-0) when count drops to 0', async () => {
+		const { container, rerender } = render(<InboxBadge count={3} />);
+		expect(container.querySelector('.bg-red-500')).toBeTruthy();
+
+		// Drop count to 0 — badge should start fading
+		await act(async () => {
+			rerender(<InboxBadge count={0} />);
+		});
+
+		const badge = container.querySelector('.bg-red-500');
+		// Badge still in DOM but opacity-0
+		expect(badge).toBeTruthy();
+		expect(badge?.classList.contains('opacity-0')).toBe(true);
+	});
+
+	it('removes badge from DOM after fade-out timeout (200ms)', async () => {
+		const { container, rerender } = render(<InboxBadge count={3} />);
+
+		await act(async () => {
+			rerender(<InboxBadge count={0} />);
+		});
+		// Badge still visible (fading)
+		expect(container.querySelector('.bg-red-500')).toBeTruthy();
+
+		// Advance past the 200ms fade-out timeout
+		await act(async () => {
+			vi.advanceTimersByTime(210);
+		});
+
+		expect(container.querySelector('.bg-red-500')).toBeFalsy();
+	});
+
+	it('re-shows badge (opacity-100) when count becomes positive again after fade-out', async () => {
+		const { container, rerender } = render(<InboxBadge count={3} />);
+
+		await act(async () => {
+			rerender(<InboxBadge count={0} />);
+		});
+
+		// Before timeout, bump count back up
+		await act(async () => {
+			rerender(<InboxBadge count={2} />);
+		});
+
+		const badge = container.querySelector('.bg-red-500');
+		expect(badge).toBeTruthy();
+		expect(badge?.classList.contains('opacity-0')).toBe(false);
+	});
+});

--- a/packages/web/src/components/ui/InboxBadge.tsx
+++ b/packages/web/src/components/ui/InboxBadge.tsx
@@ -1,0 +1,62 @@
+/**
+ * InboxBadge — animated inbox review-count badge.
+ *
+ * Behaviour (plan 8.3):
+ *  - When count increases: badge scales from 0.5 → 1 via CSS keyframe (animate-badge-pop).
+ *    Implemented by changing `key` on the inner div so Preact unmounts/remounts it,
+ *    replaying the CSS animation without any JS animation library.
+ *  - When count reaches 0: badge fades out with transition-opacity duration-200 before
+ *    being removed from the DOM.
+ */
+import { useState, useEffect, useRef } from 'preact/hooks';
+
+interface InboxBadgeProps {
+	count: number;
+	/** Additional Tailwind classes for absolute positioning, e.g. "absolute top-1 right-1" */
+	class?: string;
+}
+
+export function InboxBadge({ count, class: className = '' }: InboxBadgeProps) {
+	const prevCountRef = useRef(count);
+	// Increment to remount the inner div and replay the CSS keyframe animation
+	const [popKey, setPopKey] = useState(0);
+	const [visible, setVisible] = useState(count > 0);
+	const [fading, setFading] = useState(false);
+
+	useEffect(() => {
+		const prev = prevCountRef.current;
+		prevCountRef.current = count;
+
+		if (count > 0) {
+			setVisible(true);
+			setFading(false);
+			if (count > prev) {
+				// Trigger scale-in animation by remounting the inner element
+				setPopKey((k) => k + 1);
+			}
+		} else if (prev > 0) {
+			// Count reached zero — fade out then hide
+			setFading(true);
+			const t = setTimeout(() => {
+				setVisible(false);
+				setFading(false);
+			}, 200);
+			return () => clearTimeout(t);
+		}
+	}, [count]);
+
+	if (!visible) return null;
+
+	return (
+		<div
+			key={String(popKey)}
+			class={`w-2 h-2 rounded-full bg-red-500 flex items-center justify-center animate-badge-pop transition-opacity duration-200 ${fading ? 'opacity-0' : 'opacity-100'} ${className}`}
+		>
+			{count <= 9 ? (
+				<span class="text-white text-[8px] font-bold leading-none">{count}</span>
+			) : (
+				<span class="text-white text-[8px] font-bold leading-none">9+</span>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -7,6 +7,7 @@ import {
 	navigateToInbox,
 } from '../lib/router.ts';
 import { inboxStore } from '../lib/inbox-store.ts';
+import { InboxBadge } from '../components/ui/InboxBadge.tsx';
 
 interface TabItem {
 	id: NavSection;
@@ -125,15 +126,7 @@ export function BottomTabBar() {
 					>
 						<div class="relative">
 							<tab.icon />
-							{badge > 0 && (
-								<div class="w-2 h-2 rounded-full bg-red-500 absolute -top-0.5 -right-0.5 flex items-center justify-center">
-									{badge <= 9 ? (
-										<span class="text-white text-[8px] font-bold leading-none">{badge}</span>
-									) : (
-										<span class="text-white text-[8px] font-bold leading-none">9+</span>
-									)}
-								</div>
-							)}
+							<InboxBadge count={badge} class="absolute -top-0.5 -right-0.5" />
 						</div>
 						<span class="text-[10px] font-medium leading-none">{tab.label}</span>
 					</button>

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -405,80 +405,82 @@ export function ContextPanel() {
 					)}
 				</div>
 
-				{/* Content - switches based on section */}
-				{navSection === 'home' && (
-					<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
-				)}
-				{navSection === 'chats' && (
-					<SessionList onSessionSelect={() => (contextPanelOpenSignal.value = false)} />
-				)}
-				{navSection === 'rooms' && isRoomDetail && (
-					<RoomContextPanel
-						roomId={currentRoomId!}
-						onNavigate={() => (contextPanelOpenSignal.value = false)}
-					/>
-				)}
-				{navSection === 'rooms' && !isRoomDetail && (
-					<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
-				)}
-				{navSection === 'spaces' && (
-					<SpaceContextPanel
-						onSpaceSelect={() => (contextPanelOpenSignal.value = false)}
-						onCreateSpace={() => setCreateSpaceOpen(true)}
-					/>
-				)}
-				{navSection === 'projects' && (
-					<div class="flex-1 flex items-center justify-center p-6">
-						<div class="text-center">
-							<div class="text-4xl mb-3">📁</div>
-							<p class="text-sm text-gray-400">Projects coming soon</p>
-							<p class="text-xs text-gray-500 mt-1">Organize rooms into projects</p>
+				{/* Content — key triggers fade-in (animate-fadeIn) on section change */}
+				<div key={navSection + (isRoomDetail ? '-detail' : '')} class="flex-1 overflow-hidden flex flex-col animate-fadeIn">
+					{navSection === 'home' && (
+						<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
+					)}
+					{navSection === 'chats' && (
+						<SessionList onSessionSelect={() => (contextPanelOpenSignal.value = false)} />
+					)}
+					{navSection === 'rooms' && isRoomDetail && (
+						<RoomContextPanel
+							roomId={currentRoomId!}
+							onNavigate={() => (contextPanelOpenSignal.value = false)}
+						/>
+					)}
+					{navSection === 'rooms' && !isRoomDetail && (
+						<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
+					)}
+					{navSection === 'spaces' && (
+						<SpaceContextPanel
+							onSpaceSelect={() => (contextPanelOpenSignal.value = false)}
+							onCreateSpace={() => setCreateSpaceOpen(true)}
+						/>
+					)}
+					{navSection === 'projects' && (
+						<div class="flex-1 flex items-center justify-center p-6">
+							<div class="text-center">
+								<div class="text-4xl mb-3">📁</div>
+								<p class="text-sm text-gray-400">Projects coming soon</p>
+								<p class="text-xs text-gray-500 mt-1">Organize rooms into projects</p>
+							</div>
 						</div>
-					</div>
-				)}
-				{navSection === 'settings' && (
-					<div class="flex-1 flex flex-col overflow-hidden">
-						{/* Settings navigation list */}
-						<div class="flex-1 overflow-y-auto">
-							<nav class="py-2">
-								{SETTINGS_SECTIONS.map((section) => {
-									const isActive = activeSettingsSection === section.id;
-									return (
-										<button
-											key={section.id}
-											onClick={() => (settingsSectionSignal.value = section.id)}
-											class={cn(
-												'w-full px-4 py-3 flex items-center gap-3 text-left',
-												'transition-colors duration-150',
-												isActive
-													? 'bg-dark-800 text-gray-100'
-													: 'text-gray-400 hover:text-gray-200 hover:bg-dark-800/50'
-											)}
-										>
-											<SectionIcon type={section.icon} />
-											<span class="truncate">{section.label}</span>
-											{isActive && (
-												<svg
-													class="w-4 h-4 ml-auto text-blue-400"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke="currentColor"
-												>
-													<path
-														stroke-linecap="round"
-														stroke-linejoin="round"
-														stroke-width={2}
-														d="M9 5l7 7-7 7"
-													/>
-												</svg>
-											)}
-										</button>
-									);
-								})}
-							</nav>
+					)}
+					{navSection === 'settings' && (
+						<div class="flex-1 flex flex-col overflow-hidden">
+							{/* Settings navigation list */}
+							<div class="flex-1 overflow-y-auto">
+								<nav class="py-2">
+									{SETTINGS_SECTIONS.map((section) => {
+										const isActive = activeSettingsSection === section.id;
+										return (
+											<button
+												key={section.id}
+												onClick={() => (settingsSectionSignal.value = section.id)}
+												class={cn(
+													'w-full px-4 py-3 flex items-center gap-3 text-left',
+													'transition-colors duration-150',
+													isActive
+														? 'bg-dark-800 text-gray-100'
+														: 'text-gray-400 hover:text-gray-200 hover:bg-dark-800/50'
+												)}
+											>
+												<SectionIcon type={section.icon} />
+												<span class="truncate">{section.label}</span>
+												{isActive && (
+													<svg
+														class="w-4 h-4 ml-auto text-blue-400"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke="currentColor"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															stroke-width={2}
+															d="M9 5l7 7-7 7"
+														/>
+													</svg>
+												)}
+											</button>
+										);
+									})}
+								</nav>
+							</div>
 						</div>
-					</div>
-				)}
+					)}
+				</div>
 			</div>
 		</>
 	);

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -406,7 +406,10 @@ export function ContextPanel() {
 				</div>
 
 				{/* Content — key triggers fade-in (animate-fadeIn) on section change */}
-				<div key={navSection + (isRoomDetail ? '-detail' : '')} class="flex-1 overflow-hidden flex flex-col animate-fadeIn">
+				<div
+					key={navSection + (isRoomDetail ? '-detail' : '')}
+					class="flex-1 overflow-hidden flex flex-col animate-fadeIn"
+				>
 					{navSection === 'home' && (
 						<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
 					)}

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -34,66 +34,98 @@ export default function MainContent() {
 	const navSection = navSectionSignal.value;
 	const settingsSection = settingsSectionSignal.value;
 
-	// Space route takes priority
-	if (spaceId) {
-		return <SpaceIsland key={spaceId} spaceId={spaceId} />;
-	}
-
-	// /spaces route: show standalone spaces page (no sidebar)
-	if (navSection === 'spaces') {
-		return <SpacesPage />;
-	}
-
-	// Room route
-	if (roomId) {
-		return (
-			<Room key={roomId} roomId={roomId} sessionViewId={roomSessionId} taskViewId={roomTaskId} />
-		);
-	}
-
 	// Validate that the current session actually exists in the sessions list
 	// (handles case where session is deleted in another tab)
-	const sessionExists = sessionId && sessionsList.some((s) => s.id === sessionId);
+	const sessionExists = !!(sessionId && sessionsList.some((s) => s.id === sessionId));
 
-	// If there's a valid session, show the chat
-	if (sessionId && sessionExists) {
-		return <ChatContainer key={sessionId} sessionId={sessionId} />;
+	// Compute a stable key that changes when the major content view changes.
+	// This drives the animate-fadeIn-200 transition wrapper below.
+	let contentKey: string;
+	if (spaceId) {
+		contentKey = `space-${spaceId}`;
+	} else if (navSection === 'spaces') {
+		contentKey = 'spaces';
+	} else if (roomId) {
+		contentKey = `room-${roomId}`;
+	} else if (sessionExists) {
+		contentKey = `chat-${sessionId}`;
+	} else if (navSection === 'chats') {
+		contentKey = 'chats';
+	} else if (navSection === 'settings') {
+		// Settings sub-section changes don't re-animate — only the major section switch does
+		contentKey = 'settings';
+	} else if (navSection === 'inbox') {
+		contentKey = 'inbox';
+	} else {
+		contentKey = 'home';
 	}
 
-	// /sessions route: show sessions grid
-	if (navSection === 'chats') {
-		return <SessionsPage />;
-	}
+	function renderContent() {
+		// Space route takes priority
+		if (spaceId) {
+			return <SpaceIsland spaceId={spaceId} />;
+		}
 
-	// If Settings is selected in NavRail, show the selected settings section content
-	if (navSection === 'settings') {
-		return (
-			<div class="flex-1 flex flex-col bg-dark-900 overflow-hidden">
-				{/* Settings Header */}
-				<div class="px-6 py-4 border-b border-dark-700 flex items-center gap-3">
-					<MobileMenuButton />
-					<div>
-						<h2 class="text-lg font-semibold text-gray-100">Global Settings</h2>
-						<p class="text-sm text-gray-400">Default configurations for new sessions</p>
+		// /spaces route: show standalone spaces page (no sidebar)
+		if (navSection === 'spaces') {
+			return <SpacesPage />;
+		}
+
+		// Room route
+		if (roomId) {
+			return (
+				<Room key={roomId} roomId={roomId} sessionViewId={roomSessionId} taskViewId={roomTaskId} />
+			);
+		}
+
+		// If there's a valid session, show the chat
+		if (sessionExists && sessionId) {
+			return <ChatContainer key={sessionId} sessionId={sessionId} />;
+		}
+
+		// /sessions route: show sessions grid
+		if (navSection === 'chats') {
+			return <SessionsPage />;
+		}
+
+		// If Settings is selected in NavRail, show the selected settings section content
+		if (navSection === 'settings') {
+			return (
+				<div class="flex-1 flex flex-col bg-dark-900 overflow-hidden">
+					{/* Settings Header */}
+					<div class="px-6 py-4 border-b border-dark-700 flex items-center gap-3">
+						<MobileMenuButton />
+						<div>
+							<h2 class="text-lg font-semibold text-gray-100">Global Settings</h2>
+							<p class="text-sm text-gray-400">Default configurations for new sessions</p>
+						</div>
+					</div>
+					{/* Settings Content */}
+					<div class="flex-1 overflow-y-auto p-6">
+						{settingsSection === 'general' && <GeneralSettings />}
+						{settingsSection === 'providers' && <ProvidersSettings />}
+						{settingsSection === 'mcp-servers' && <McpServersSettings />}
+						{settingsSection === 'usage' && <UsageAnalytics />}
+						{settingsSection === 'about' && <AboutSection />}
 					</div>
 				</div>
-				{/* Settings Content */}
-				<div class="flex-1 overflow-y-auto p-6">
-					{settingsSection === 'general' && <GeneralSettings />}
-					{settingsSection === 'providers' && <ProvidersSettings />}
-					{settingsSection === 'mcp-servers' && <McpServersSettings />}
-					{settingsSection === 'usage' && <UsageAnalytics />}
-					{settingsSection === 'about' && <AboutSection />}
-				</div>
-			</div>
-		);
+			);
+		}
+
+		// Inbox route
+		if (navSection === 'inbox') {
+			return <Inbox />;
+		}
+
+		// Default: Show Lobby (home page)
+		return <Lobby />;
 	}
 
-	// Inbox route
-	if (navSection === 'inbox') {
-		return <Inbox />;
-	}
-
-	// Default: Show Lobby (home page)
-	return <Lobby />;
+	// Wrap content in a keyed div so Preact remounts it (and replays animate-fadeIn-200)
+	// whenever the major content view changes.
+	return (
+		<div key={contentKey} class="flex-1 flex flex-col overflow-hidden animate-fadeIn-200">
+			{renderContent()}
+		</div>
+	);
 }

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -8,6 +8,7 @@ import {
 	navigateToSpaces,
 } from '../lib/router.ts';
 import { NavIconButton } from '../components/ui/NavIconButton.tsx';
+import { InboxBadge } from '../components/ui/InboxBadge.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 import { DaemonStatusIndicator } from '../components/DaemonStatusIndicator.tsx';
 import { MAIN_NAV_ITEMS, SETTINGS_NAV_ITEM } from '../lib/nav-config.tsx';
@@ -69,15 +70,7 @@ export function NavRail() {
 								>
 									{item.icon}
 								</NavIconButton>
-								{badge > 0 && (
-									<div class="w-2 h-2 rounded-full bg-red-500 absolute top-1 right-1 flex items-center justify-center">
-										{badge <= 9 ? (
-											<span class="text-white text-[8px] font-bold leading-none">{badge}</span>
-										) : (
-											<span class="text-white text-[8px] font-bold leading-none">9+</span>
-										)}
-									</div>
-								)}
+								<InboxBadge count={badge} class="absolute top-1 right-1" />
 							</div>
 						);
 					}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -465,6 +465,23 @@ html {
 	animation: scaleIn 200ms ease-out;
 }
 
+@keyframes badgePop {
+	from {
+		transform: scale(0.5);
+	}
+	to {
+		transform: scale(1);
+	}
+}
+
+.animate-badge-pop {
+	animation: badgePop 150ms ease-out;
+}
+
+.animate-fadeIn-200 {
+	animation: fadeIn 200ms ease-in-out;
+}
+
 .animate-pulse-slow {
 	animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }


### PR DESCRIPTION
## Summary

- **InboxBadge component**: Animated badge that scales 0.5→1 (`badgePop`, 150ms) on count increase and fades out (`opacity-0`, 200ms) when count drops to 0 before unmounting. Replaces inline badge divs in `NavRail.tsx` and `BottomTabBar.tsx`.
- **RoomTasks approve animation**: Clicking Approve shows "✓ Approved" for 300ms, fades card to `opacity-40`, and turns border green (`border-l-green-500`); reject form now uses max-height CSS collapse (200ms) instead of conditional render; `toast.rejected()` called on confirm.
- **ContextPanel section fade**: `key` prop on content wrapper triggers `animate-fadeIn` (150ms) on section or detail toggle change.
- **MainContent page fade**: Keyed wrapper div replays `animate-fadeIn-200` (200ms) on major section switches (space/room/chat/settings/inbox/home). Settings sub-section changes do not re-trigger.
- **New CSS utilities**: `animate-badge-pop` (badgePop keyframe, 150ms) and `animate-fadeIn-200` (fadeIn keyframe, 200ms).

## Test plan

- [x] `InboxBadge.test.tsx` — 9 tests: renders/hides by count, badge-pop class, fade-out on count→0, DOM removal after 200ms, re-show after re-increase, class passthrough
- [x] `RoomTasks.test.tsx` — 4 new approve animation tests: "✓ Approved" text + disabled, `opacity-40` class, `border-l-green-500` class, button text revert after 300ms (fake timers); existing reject form tests updated for max-height transition
- [x] `bun run typecheck` — zero errors
- [x] `bun run lint` — zero errors (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)