### PR TITLE
feat: update room-runtime and RPC handlers for new lifecycle

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1549,7 +1549,12 @@ export class RoomRuntime {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 
 		if (group) {
-			// Terminate active sessions if group is still active
+			// Terminate active sessions if group is still active.
+			// If terminateGroup() fails (e.g., concurrent version conflict), we log and
+			// continue rather than aborting — archive is destructive and non-reversible,
+			// so the worktree and task must still be cleaned up regardless of group state.
+			// This is a deliberate best-effort approach (distinct from terminateTaskGroup
+			// which returns false on failure and lets the caller decide).
 			const isActiveGroup = group.completedAt === null;
 			if (isActiveGroup) {
 				const terminated = await this.taskGroupManager.terminateGroup(group.id);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1538,21 +1538,35 @@ export class RoomRuntime {
 	}
 
 	/**
-	 * Archive a task group - cleanup worktree regardless of state.
+	 * Archive a task group - terminate active sessions, cleanup worktree, and set archived status.
 	 *
-	 * Called when user archives a task via UI. This cleans up the worktree
-	 * to free disk space even for failed tasks (kept for debugging initially).
-	 * Also sets the archivedAt timestamp on the task.
+	 * Called when user archives a task via UI. This:
+	 * 1. Terminates any active sessions and mirroring (if group is still active).
+	 * 2. Cleans up the worktree to free disk space.
+	 * 3. Sets the task status to 'archived' with archivedAt timestamp.
 	 */
 	async archiveTaskGroup(taskId: string): Promise<boolean> {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 
-		// Cleanup worktree via TaskGroupManager (handles both active and completed groups)
 		if (group) {
+			// Terminate active sessions if group is still active
+			const isActiveGroup = group.completedAt === null;
+			if (isActiveGroup) {
+				const terminated = await this.taskGroupManager.terminateGroup(group.id);
+				if (!terminated) {
+					log.warn(
+						`archiveTaskGroup: failed to terminate active group ${group.id} for task ${taskId}`
+					);
+				}
+			}
+			await this.terminateGroupSessions(group);
+			this.cleanupMirroring(group.id, isActiveGroup ? 'Task archived by user.' : undefined);
+
+			// Cleanup worktree via TaskGroupManager
 			await this.taskGroupManager.archiveGroup(group.id);
 		}
 
-		// Set archivedAt timestamp on task
+		// Set archivedAt timestamp on task (transitions to 'archived' status)
 		await this.taskManager.archiveTask(taskId);
 
 		return true;

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -509,16 +509,17 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: 'Room runtime not found' });
 			}
 
-			// Cancelled tasks cannot be revived via message — the worktree is cleaned
-			// up on cancellation so restoring the session would point to a gone
-			// workspace. Direct the caller to restart the task from scratch instead.
+			// Cancelled tasks are blocked from agent-tool messaging — an agent should not
+			// silently reactivate a task that was explicitly cancelled by a human. The
+			// worktree is still present (only archiveGroup cleans it up), but resuming
+			// without explicit human intent risks restarting undesired work.
+			// Use set_task_status to explicitly restart the task first.
 			if (task.status === 'cancelled') {
 				return jsonResult({
 					success: false,
 					error:
-						`Task ${args.task_id} is cancelled. Cancelled tasks cannot receive messages ` +
-						'because their workspace has been cleaned up. Use set_task_status to restart it ' +
-						'(e.g. status: "pending" or "in_progress").',
+						`Task ${args.task_id} is cancelled. Use set_task_status to restart it ` +
+						'(e.g. status: "pending" or "in_progress") before sending a message.',
 				});
 			}
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -394,10 +394,10 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						task.status === 'needs_attention' &&
 						group.completedAt !== null
 					) {
-						// Lightweight revive (failed → review only): clear completedAt without
-						// resetting metadata. Only supported for failed tasks — cancelled tasks
-						// have their worktree cleaned up so reviving the group would point
-						// sessions at a gone workspace.
+						// Lightweight revive (needs_attention → review only): clear completedAt
+						// without resetting metadata. Only offered on this agent-tool path for
+						// needs_attention tasks — cancelled tasks use resetGroupForRestart above
+						// for a clean-slate restart, not a lightweight revive.
 						const revived = groupRepo.reviveGroup(group.id);
 						if (!revived) {
 							return jsonResult({

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -820,16 +820,22 @@ export function setupTaskHandlers(
 		}
 
 		// needs_attention, completed, and cancelled tasks: auto-reactivate via reviveTaskForMessage.
-		// reviveTaskForMessage is a lightweight revive (preserves conversation history) that
-		// restores sessions and injects the message without wiping the group state.
-		// This mirrors the agent-tool path in room-agent-tools.ts send_message_to_task.
+		// reviveTaskForMessage is a lightweight revive that restores sessions and injects the
+		// message WITHOUT wiping the group metadata or conversation history.
+		//
+		// Note — deliberate asymmetry with task.setStatus:
+		//   task.setStatus(cancelled → in_progress)  → resetGroupForRestart (clean slate)
+		//   task.sendHumanMessage(cancelled task)     → reviveTaskForMessage  (keep history)
+		// Sending a message to a cancelled task is a "continue this conversation" action, so
+		// we preserve context. Explicitly restarting via setStatus is a "start over" action.
 		if (
 			task.status === 'needs_attention' ||
 			task.status === 'completed' ||
 			task.status === 'cancelled'
 		) {
 			// needs_attention transitions through 'review' (its prior working state);
-			// completed/cancelled transition directly to 'in_progress'.
+			// completed/cancelled transition directly to 'in_progress' as the pre-revival
+			// intermediate status before reviveTaskForMessage restores sessions.
 			const intermediateStatus = task.status === 'needs_attention' ? 'review' : 'in_progress';
 			try {
 				await taskManager.setTaskStatus(params.taskId, intermediateStatus);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -396,6 +396,24 @@ export function setupTaskHandlers(
 			);
 		}
 
+		// Archiving: delegate entirely to archiveTaskGroup (terminates sessions + cleans worktree)
+		// or archiveTask (no runtime — sets archivedAt directly). Early return skips generic path.
+		if (params.status === 'archived') {
+			const runtime = runtimeService?.getRuntime(params.roomId);
+			if (runtime) {
+				await runtime.archiveTaskGroup(params.taskId);
+			} else {
+				await taskManager.archiveTask(params.taskId);
+			}
+
+			const archivedTask = await taskManager.getTask(params.taskId);
+			if (archivedTask) {
+				emitTaskUpdate(params.roomId, archivedTask);
+				emitRoomOverview(params.roomId);
+			}
+			return { task: archivedTask };
+		}
+
 		// If there's an active group with runtime, terminate it on terminal transitions.
 		if (runtimeService) {
 			const runtime = runtimeService.getRuntime(params.roomId);
@@ -431,7 +449,8 @@ export function setupTaskHandlers(
 			}
 		}
 
-		// Handle restart: reset needs_attention/cancelled group so runtime picks it up fresh
+		// Handle restart: reset cancelled/needs_attention group so runtime picks it up fresh.
+		// completed → in_progress uses lightweight revival (group preserved, no full wipe).
 		if (task.status === 'needs_attention' || task.status === 'cancelled') {
 			if (params.status === 'pending' || params.status === 'in_progress') {
 				const groupRepo = new SessionGroupRepository(db.getDatabase());
@@ -800,39 +819,35 @@ export function setupTaskHandlers(
 			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
 		}
 
-		// Cancelled tasks have their workspace cleaned up on cancellation.
-		// Restarting via session injection would point at a gone workspace.
-		// Direct the caller to use set_task_status to restart from scratch.
-		if (task.status === 'cancelled') {
-			throw new Error(
-				`Task ${params.taskId} is cancelled. Cancelled tasks cannot receive messages ` +
-					'because their workspace has been cleaned up. Use set_task_status to restart it ' +
-					'(e.g. status: "pending" or "in_progress").'
-			);
-		}
-
-		// needs_attention tasks: revive sessions and inject the message.
-		// Uses reviveTaskForMessage (lightweight revive via reviveGroup) which preserves
-		// metadata, conversation history, and uses the established session-restore path.
+		// needs_attention, completed, and cancelled tasks: auto-reactivate via reviveTaskForMessage.
+		// reviveTaskForMessage is a lightweight revive (preserves conversation history) that
+		// restores sessions and injects the message without wiping the group state.
 		// This mirrors the agent-tool path in room-agent-tools.ts send_message_to_task.
-		if (task.status === 'needs_attention') {
+		if (
+			task.status === 'needs_attention' ||
+			task.status === 'completed' ||
+			task.status === 'cancelled'
+		) {
+			// needs_attention transitions through 'review' (its prior working state);
+			// completed/cancelled transition directly to 'in_progress'.
+			const intermediateStatus = task.status === 'needs_attention' ? 'review' : 'in_progress';
 			try {
-				await taskManager.setTaskStatus(params.taskId, 'review');
+				await taskManager.setTaskStatus(params.taskId, intermediateStatus);
 			} catch (err) {
 				throw new Error(`Failed to revive task ${params.taskId}: ${String(err)}`);
 			}
 
 			const revived = await runtime.reviveTaskForMessage(params.taskId, params.message.trim());
 			if (!revived) {
-				// Rollback: restore task to needs_attention (review → needs_attention is a valid transition)
+				// Rollback: restore task to original status
 				try {
-					await taskManager.setTaskStatus(params.taskId, 'needs_attention');
+					await taskManager.setTaskStatus(params.taskId, task.status);
 				} catch {
 					// Best-effort rollback; swallow to avoid masking the revive error
 				}
 				throw new Error(
 					`Failed to revive task ${params.taskId}: agent sessions could not be restored. ` +
-						'Task status has been reset to needs_attention.'
+						`Task status has been reset to ${task.status}.`
 				);
 			}
 

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -1049,6 +1049,30 @@ describe('task.setStatus RPC Handler', () => {
 			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
 		});
 
+		it('emits task update and room overview after archiving via runtime', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const { service } = makeRuntimeService();
+
+			const mh = createMockMessageHub();
+			const daemonHub = createMockDaemonHub();
+			setupTaskHandlers(
+				mh.hub,
+				mockRoomManager,
+				daemonHub,
+				makeDb(makeGroupRow()),
+				makeSetStatusWithArchiveFactory(completedTask),
+				service
+			);
+
+			const handler = mh.handlers.get('task.setStatus')!;
+			await handler({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'room.task.update',
+				expect.objectContaining({ roomId: 'room-1' })
+			);
+		});
+
 		it('calls taskManager.archiveTask when no runtime is available', async () => {
 			const completedTask = { ...mockTask, status: 'completed' as const };
 			const factory = makeSetStatusWithArchiveFactory(completedTask);

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -326,16 +326,6 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
 			).rejects.toThrow('No active session group');
 		});
-
-		it('throws when task is cancelled (workspace cleaned up)', async () => {
-			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
-			const { service } = makeRuntimeService();
-			setup({ task: cancelledTask, runtimeService: service });
-
-			await expect(
-				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'hello' }, {})
-			).rejects.toThrow('cancelled');
-		});
 	});
 
 	describe('needs_attention task revival', () => {
@@ -389,6 +379,110 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			// Verify rollback: first transitioned to 'review', then rolled back to 'needs_attention'
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'review');
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'needs_attention');
+		});
+	});
+
+	describe('completed task auto-reactivation', () => {
+		it('auto-reactivates a completed task and injects the message', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setup({ task: completedTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'please continue' },
+				{}
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'please continue');
+		});
+
+		it('throws and rolls back when reviveTaskForMessage fails for completed task', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const { service, runtime } = makeRuntimeService(true, true, false);
+
+			const setTaskStatus = mock(async () => completedTask);
+			const factory: TaskManagerFactory = mock(() => ({
+				createTask: mock(async () => completedTask),
+				getTask: mock(async () => completedTask),
+				listTasks: mock(async () => []),
+				failTask: mock(async () => completedTask),
+				cancelTask: mock(async () => ({ ...completedTask, status: 'cancelled' as const })),
+				setTaskStatus,
+			}));
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			setupTaskHandlers(
+				hub,
+				mockRoomManager,
+				createMockDaemonHub(),
+				makeDb(makeGroupRow()),
+				factory,
+				service
+			);
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'continue' }, {})
+			).rejects.toThrow('agent sessions could not be restored');
+
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'continue');
+			// Verify intermediate transition to in_progress, then rollback to completed
+			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
+			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'completed');
+		});
+	});
+
+	describe('cancelled task auto-reactivation', () => {
+		it('auto-reactivates a cancelled task and injects the message', async () => {
+			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setup({ task: cancelledTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', message: 'restart please' },
+				{}
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'restart please');
+		});
+
+		it('throws and rolls back when reviveTaskForMessage fails for cancelled task', async () => {
+			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
+			const { service, runtime } = makeRuntimeService(true, true, false);
+
+			const setTaskStatus = mock(async () => cancelledTask);
+			const factory: TaskManagerFactory = mock(() => ({
+				createTask: mock(async () => cancelledTask),
+				getTask: mock(async () => cancelledTask),
+				listTasks: mock(async () => []),
+				failTask: mock(async () => cancelledTask),
+				cancelTask: mock(async () => cancelledTask),
+				setTaskStatus,
+			}));
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			setupTaskHandlers(
+				hub,
+				mockRoomManager,
+				createMockDaemonHub(),
+				makeDb(makeGroupRow()),
+				factory,
+				service
+			);
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'retry' }, {})
+			).rejects.toThrow('agent sessions could not be restored');
+
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith('task-1', 'retry');
+			// Verify intermediate transition to in_progress, then rollback to cancelled
+			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress');
+			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled');
 		});
 	});
 });
@@ -905,6 +999,91 @@ describe('task.setStatus RPC Handler', () => {
 				{}
 			);
 			expect(result).toEqual({ task: { ...cancelledTask, status: 'in_progress' } });
+		});
+
+		it('allows valid transition from completed to in_progress (lightweight revival, no group wipe)', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const { service, cancelTask, terminateTaskGroup } = makeRuntimeServiceWithRuntimeCleanup();
+			setup({ task: completedTask, runtimeService: service });
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'in_progress' },
+				{}
+			);
+			// completed → in_progress: group is NOT reset/terminated — lightweight revival
+			expect(cancelTask).not.toHaveBeenCalled();
+			expect(terminateTaskGroup).not.toHaveBeenCalled();
+			expect(result).toEqual({ task: { ...completedTask, status: 'in_progress' } });
+		});
+	});
+
+	describe('archived transition', () => {
+		function makeSetStatusWithArchiveFactory(task: NeoTask | null): TaskManagerFactory {
+			const archivedTask = task ? { ...task, status: 'archived' as const } : null;
+			const archiveTask = mock(async () => archivedTask!);
+			const manager = {
+				createTask: mock(async () => task!),
+				getTask: mock(async () => task),
+				listTasks: mock(async () => []),
+				failTask: mock(async () => task!),
+				cancelTask: mock(async () => task!),
+				setTaskStatus: mock(async (_id: string, status: string) => ({
+					...task!,
+					status: status as NeoTask['status'],
+				})),
+				archiveTask,
+			};
+			return Object.assign(
+				mock(() => manager),
+				{ _archiveTask: archiveTask }
+			);
+		}
+
+		it('delegates to runtime.archiveTaskGroup when runtime is available', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const { service, runtime } = makeRuntimeService();
+			setup({ task: completedTask, runtimeService: service });
+
+			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
+		});
+
+		it('calls taskManager.archiveTask when no runtime is available', async () => {
+			const completedTask = { ...mockTask, status: 'completed' as const };
+			const factory = makeSetStatusWithArchiveFactory(completedTask);
+			setup({ task: completedTask, runtimeService: undefined, taskManagerFactory: factory });
+
+			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+
+			expect(
+				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
+			).toHaveBeenCalledWith('task-1');
+		});
+
+		it('calls taskManager.archiveTask when runtime has no runtime for room', async () => {
+			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
+			const factory = makeSetStatusWithArchiveFactory(cancelledTask);
+			setup({
+				task: cancelledTask,
+				runtimeService: makeNullRuntimeService(),
+				taskManagerFactory: factory,
+			});
+
+			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
+
+			expect(
+				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
+			).toHaveBeenCalledWith('task-1');
+		});
+
+		it('throws for invalid transition from in_progress to archived', async () => {
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			setup({ task: inProgressTask, runtimeService: makeNullRuntimeService() });
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {})
+			).rejects.toThrow('Invalid status transition');
 		});
 	});
 });


### PR DESCRIPTION
- archiveTaskGroup(): terminate active sessions and mirroring before
  calling archiveGroup (worktree cleanup), ensuring no dangling sessions
  after archiving a still-active task group
- task.setStatus: intercept 'archived' transitions to delegate to
  archiveTaskGroup (with runtime) or archiveTask (without), so archived_at
  is always written and worktrees are cleaned up correctly
- task.setStatus: completed→in_progress now documents the lightweight
  revival path (group preserved, no resetGroupForRestart wipe)
- task.sendHumanMessage: remove the error guard for cancelled tasks and
  merge it with needs_attention into a unified auto-reactivation path
  for completed/cancelled/needs_attention via reviveTaskForMessage
- Tests: update existing cancelled-task test, add tests for completed
  and cancelled auto-reactivation (success + rollback), and add tests
  for the task.setStatus archived transition with/without runtime
