### PR TITLE
fix: recover rate-limited workers stuck in later iterations (feedbackIteration > 0)

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2205,28 +2205,43 @@ export class RoomRuntime {
 	 * 1. Observer callback fired but the routing threw an error (now logged, but still need recovery)
 	 * 2. Observer callback was missed due to a race condition (extremely rare)
 	 * 3. Any other silent failure in the worker→leader routing path
+	 * 4. Worker paused by rate limit — when the backoff expires the timer fires scheduleTick()
+	 *    which calls this function; the group is re-triggered regardless of feedbackIteration.
 	 *
 	 * Conditions for a "stuck worker":
-	 * - feedbackIteration == 0: no review rounds have completed (worker → leader routing never happened)
+	 * - feedbackIteration == 0: no review rounds have completed (worker → leader routing never
+	 *   happened), OR the group has an expired rate limit that was set during a later iteration —
+	 *   in that case the leader was never triggered (onWorkerTerminalState returned early after
+	 *   detecting the rate limit) so recovery is still needed.
 	 * - Worker session IS in the session factory (not a zombie)
 	 * - Worker session processing state is terminal (idle or interrupted)
 	 * - Leader session may or may not exist (with eager init, it always exists; with old lazy
 	 *   init, it may not exist yet — both cases are handled by routeWorkerToLeader)
 	 * - Group is NOT awaiting human review
-	 * - Group is NOT rate-limited
+	 * - Group is NOT actively rate-limited (resetsAt still in the future)
 	 * - Group is NOT paused waiting for a question answer (waiting_for_input is intentional pause)
 	 * - A recovery for this group is NOT already in-flight from a previous tick
 	 */
 	private recoverStuckWorkers(): void {
 		if (!this.sessionFactory.getProcessingState) return; // getProcessingState is optional
 
+		const now = Date.now();
 		const activeGroups = this.groupRepo.getActiveGroups(this.roomId);
 		for (const group of activeGroups) {
-			// Only recover groups that haven't routed to leader yet
-			if (group.feedbackIteration > 0) continue;
+			// An expired rate limit means the worker was paused mid-iteration (feedbackIteration may
+			// be > 0) and the leader was never triggered. Allow recovery in that case.
+			// isRateLimited() already returns false for expired limits, so we check the raw field.
+			const hasExpiredRateLimit = group.rateLimit !== null && now >= group.rateLimit.resetsAt;
+
+			// Skip groups where the leader is actively working (feedbackIteration > 0 means the
+			// worker→leader routing already happened at least once and the leader may still be
+			// reviewing). The exception is an expired rate limit: in that case onWorkerTerminalState
+			// returned early (before routing to the leader) so feedbackIteration was NOT incremented
+			// for this iteration — the leader is idle and recovery is safe.
+			if (group.feedbackIteration > 0 && !hasExpiredRateLimit) continue;
 			// Skip groups awaiting human
 			if (group.submittedForReview) continue;
-			// Skip rate-limited groups
+			// Skip actively rate-limited groups (backoff not yet expired)
 			if (this.groupRepo.isRateLimited(group.id)) continue;
 			// Skip groups paused waiting for a question answer — waiting_for_input is an
 			// intentional pause, not a stuck state; the task resumes when the user answers
@@ -2245,6 +2260,9 @@ export class RoomRuntime {
 			// resumeLeaderFromHuman (or resumeWorkerFromHuman) but the worker has not
 			// produced any new output yet — re-routing would inject a sentinel string
 			// into the leader while it is already processing the human's message.
+			// For the expired-rate-limit case this also acts as a safety net: if the LEADER
+			// hit the rate limit (rateLimit.sessionRole === 'leader'), the worker messages were
+			// already forwarded (lastForwardedMessageId updated) and this check skips re-routing.
 			// When getWorkerMessages is absent (some test contexts), fall through to
 			// preserve the original safety-net behavior.
 			if (this.getWorkerMessages) {
@@ -2264,9 +2282,12 @@ export class RoomRuntime {
 				continue;
 			}
 
+			const reason = hasExpiredRateLimit
+				? `rate limit expired (feedbackIteration=${group.feedbackIteration})`
+				: `feedbackIteration=0, waitingForQuestion=false`;
 			log.warn(
 				`[StuckWorker] Group ${group.id}: worker is '${workerState}' but routing to leader not yet ` +
-					`completed (feedbackIteration=0, waitingForQuestion=false). Re-triggering worker→leader routing.`
+					`completed (${reason}). Re-triggering worker→leader routing.`
 			);
 			this.appendGroupEvent(group.id, 'status', {
 				text: `Worker found in ${workerState} state with routing not yet complete — re-triggering routing to Leader.`,

--- a/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-recovery-safety.test.ts
@@ -591,10 +591,11 @@ describe('Stuck worker detection and recovery', () => {
 		expect(leaderCalls).toHaveLength(1);
 	});
 
-	it('should skip stuck-worker recovery for groups with feedbackIteration > 0', async () => {
+	it('should skip stuck-worker recovery for groups with feedbackIteration > 0 and no expired rate limit', async () => {
 		const group = await spawnGroup();
 
 		// Manually increment feedbackIteration to simulate a group past its first review
+		// with no rate limit — leader may be actively working, skip recovery.
 		ctx.groupRepo.incrementFeedbackIteration(group.id, group.version);
 		const updatedGroup = ctx.groupRepo.getGroup(group.id)!;
 		expect(updatedGroup.feedbackIteration).toBe(1);
@@ -608,11 +609,132 @@ describe('Stuck worker detection and recovery', () => {
 		await ctx.runtime.tick();
 		await new Promise((r) => setTimeout(r, 5));
 
-		// Should NOT re-trigger routing because feedbackIteration > 0
+		// Should NOT re-trigger routing because feedbackIteration > 0 and no expired rate limit
 		const leaderCalls = ctx.sessionFactory.calls.filter(
 			(c) => c.method === 'createAndStartSession' && c.args[1] === 'leader'
 		);
 		expect(leaderCalls).toHaveLength(1);
+	});
+
+	it('should re-trigger routing for feedbackIteration > 0 groups with an expired rate limit', async () => {
+		// Scenario: worker ran a second iteration (after leader feedback), hit a rate limit,
+		// and the rate limit timer fired. feedbackIteration > 0 but the leader was never
+		// triggered for this iteration — recovery must still happen.
+		const localCtx = createRuntimeTestContext({
+			getWorkerMessages: (_sessionId: string, _afterId: string | null) => [
+				// Return a fake rate-limit message so recoverStuckWorkers sees new output.
+				// group.rateLimit is non-null (expired), so the !group.rateLimit guard is false
+				// and the error class falls through to the worktree/exit-gate path.
+				{ id: 'msg-rl-1', text: 'API Error: 429 — rate limit reached', toolCallNames: [] },
+			],
+		});
+
+		const group = await (async () => {
+			await createGoalAndTask(localCtx);
+			localCtx.runtime.start();
+			await localCtx.runtime.tick();
+			const groups = localCtx.groupRepo.getActiveGroups('room-1');
+			return groups[0];
+		})();
+
+		// Advance feedbackIteration to 1 to simulate a post-review state
+		localCtx.groupRepo.incrementFeedbackIteration(group.id, group.version);
+		const afterIncrement = localCtx.groupRepo.getGroup(group.id)!;
+		expect(afterIncrement.feedbackIteration).toBe(1);
+
+		// Set an EXPIRED rate limit (resetsAt in the past) — simulates timer firing after expiry
+		const expiredRateLimit = {
+			detectedAt: Date.now() - 120_000, // detected 2 min ago
+			resetsAt: Date.now() - 10_000, // expired 10 s ago
+			sessionRole: 'worker' as const,
+		};
+		localCtx.groupRepo.setRateLimit(group.id, expiredRateLimit);
+
+		// Worker is in idle state (hit rate limit and stopped)
+		localCtx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
+
+		// With eager init, the leader already exists — routeWorkerToLeader injects a message
+		// rather than creating a new leader session. Wait for injectMessage on the leader.
+		const leaderReceived = new Promise<void>((resolve) => {
+			const orig = localCtx.sessionFactory.injectMessage.bind(localCtx.sessionFactory);
+			localCtx.sessionFactory.injectMessage = async (
+				sessionId: string,
+				message: string,
+				opts?: unknown
+			) => {
+				await orig(sessionId, message, opts as never);
+				if (sessionId === group.leaderSessionId) {
+					localCtx.sessionFactory.injectMessage = orig;
+					resolve();
+				}
+			};
+		});
+
+		await localCtx.runtime.tick();
+
+		// Wait for the fire-and-forget routing triggered by recoverStuckWorkers,
+		// then give a brief drain for incrementFeedbackIteration (runs after injectMessage).
+		await leaderReceived;
+		await new Promise((r) => setTimeout(r, 10));
+
+		// Leader session should have received an injected message from the recovery routing
+		const injectCalls = localCtx.sessionFactory.calls.filter(
+			(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
+		);
+		expect(injectCalls.length).toBeGreaterThanOrEqual(1);
+
+		// feedbackIteration should now be 2 (incremented by routeWorkerToLeader)
+		const updatedGroup = localCtx.groupRepo.getGroup(group.id)!;
+		expect(updatedGroup.feedbackIteration).toBe(2);
+
+		localCtx.runtime.stop();
+		localCtx.db.close();
+	});
+
+	it('should NOT re-trigger routing for feedbackIteration > 0 with leader-side expired rate limit (no new worker messages)', async () => {
+		// Scenario: LEADER hit the rate limit (not worker). Worker messages were already
+		// forwarded to leader before it hit 429. After expiry, recoverStuckWorkers must
+		// NOT re-route because getWorkerMessages returns [] (no new worker output).
+		const localCtx = createRuntimeTestContext({
+			getWorkerMessages: (_sessionId: string, _afterId: string | null) => [],
+			// Empty: all worker messages already forwarded in routeWorkerToLeader
+		});
+
+		const group = await (async () => {
+			await createGoalAndTask(localCtx);
+			localCtx.runtime.start();
+			await localCtx.runtime.tick();
+			const groups = localCtx.groupRepo.getActiveGroups('room-1');
+			return groups[0];
+		})();
+
+		// Advance feedbackIteration to 1 (worker was routed to leader)
+		localCtx.groupRepo.incrementFeedbackIteration(group.id, group.version);
+
+		// Set an expired LEADER rate limit
+		const expiredLeaderRateLimit = {
+			detectedAt: Date.now() - 120_000,
+			resetsAt: Date.now() - 10_000,
+			sessionRole: 'leader' as const,
+		};
+		localCtx.groupRepo.setRateLimit(group.id, expiredLeaderRateLimit);
+
+		localCtx.sessionFactory.processingStates.set(group.workerSessionId, 'idle');
+
+		const callsBefore = localCtx.sessionFactory.calls.length;
+
+		await localCtx.runtime.tick();
+		await new Promise((r) => setTimeout(r, 10));
+
+		// No new injectMessage or leader creation — no new worker messages to route
+		const newCalls = localCtx.sessionFactory.calls.slice(callsBefore);
+		const routingCalls = newCalls.filter(
+			(c) => c.method === 'injectMessage' || c.method === 'createAndStartSession'
+		);
+		expect(routingCalls).toHaveLength(0);
+
+		localCtx.runtime.stop();
+		localCtx.db.close();
 	});
 
 	it('should skip stuck-worker recovery for groups awaiting human review', async () => {


### PR DESCRIPTION
recoverStuckWorkers() had a feedbackIteration > 0 guard that prevented
recovery for workers paused by rate limit during a second (or later)
iteration. When the rate-limit timer fired and called scheduleTick(),
executeTick() ran recoverStuckWorkers() which skipped all groups with
feedbackIteration > 0 — leaving them permanently stuck with an expired
backoff.

The fix: allow recoverStuckWorkers() to re-trigger onWorkerTerminalState
when a group has an expired rate limit (non-null rateLimit where
Date.now() >= resetsAt), regardless of feedbackIteration. The existing
newMessages.length === 0 check acts as a safety guard for the leader-side
rate-limit case (worker messages already forwarded, nothing new to route).
