### PR TITLE
fix: update room-agent-tools guards and comments for new task lifecycle

### DIFF
--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -7,8 +7,8 @@
  *
  * Callers are responsible for pre-processing terminated tasks before calling this
  * function. For example:
- * - needs_attention → caller should use runtime.reviveTaskForMessage()
- * - cancelled/completed → caller should block with a user-facing error
+ * - needs_attention/cancelled → caller should use runtime.reviveTaskForMessage()
+ * - completed → caller should use runtime.reviveTaskForMessage() or block with an error
  */
 
 import type { TaskStatus } from '@neokai/shared';

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -376,8 +376,12 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}
 			}
 
-			// Handle restart/revive: update group state for needs_attention/cancelled tasks
-			if (task.status === 'needs_attention' || task.status === 'cancelled') {
+			// Handle restart/revive: update group state for needs_attention, completed, and cancelled tasks
+			if (
+				task.status === 'needs_attention' ||
+				task.status === 'cancelled' ||
+				task.status === 'completed'
+			) {
 				const group = groupRepo.getGroupByTaskId(args.task_id);
 				if (group) {
 					if (args.status === 'pending' || args.status === 'in_progress') {
@@ -394,10 +398,9 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						task.status === 'needs_attention' &&
 						group.completedAt !== null
 					) {
-						// Lightweight revive (needs_attention → review only): clear completedAt
-						// without resetting metadata. Only offered on this agent-tool path for
-						// needs_attention tasks — cancelled tasks use resetGroupForRestart above
-						// for a clean-slate restart, not a lightweight revive.
+						// Lightweight revive: clear completedAt without resetting metadata.
+						// Supported for needs_attention → review only. Cancelled and completed
+						// tasks use resetGroupForRestart() above for a clean slate.
 						const revived = groupRepo.reviveGroup(group.id);
 						if (!revived) {
 							return jsonResult({
@@ -513,13 +516,11 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			// silently reactivate a task that was explicitly cancelled by a human. The
 			// worktree is still present (only archiveGroup cleans it up), but resuming
 			// without explicit human intent risks restarting undesired work.
-			// Use set_task_status to explicitly restart the task first.
+			// Use set_task_status to explicitly reactivate the task first.
 			if (task.status === 'cancelled') {
 				return jsonResult({
 					success: false,
-					error:
-						`Task ${args.task_id} is cancelled. Use set_task_status to restart it ` +
-						'(e.g. status: "pending" or "in_progress") before sending a message.',
+					error: `Task ${args.task_id} is cancelled. Use set_task_status to reactivate it first (e.g. status: "in_progress").`,
 				});
 			}
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -399,8 +399,8 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						group.completedAt !== null
 					) {
 						// Lightweight revive: clear completedAt without resetting metadata.
-						// Supported for needs_attention → review only. Cancelled and completed
-						// tasks use resetGroupForRestart() above for a clean slate.
+						// Supported for needs_attention (failed) → review only. Cancelled and
+						// completed tasks use resetGroupForRestart() above for a clean slate.
 						const revived = groupRepo.reviveGroup(group.id);
 						if (!revived) {
 							return jsonResult({

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -512,57 +512,20 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: 'Room runtime not found' });
 			}
 
-			// Auto-reactivate: if the task is cancelled, reset the group and transition to
-			// in_progress so the message can be delivered without manual intervention.
-			// Worktrees are preserved on cancel (only archiveGroup cleans them up), so
-			// session restoration is safe.
-			if (task.status === 'cancelled') {
-				const group = groupRepo.getGroupByTaskId(args.task_id);
-				if (group) {
-					const reset = groupRepo.resetGroupForRestart(group.id);
-					if (!reset) {
-						return jsonResult({
-							success: false,
-							error: `Failed to reactivate task ${args.task_id} — group may have been modified concurrently`,
-						});
-					}
-				}
+			// Auto-revive: needs_attention and cancelled tasks auto-reactivate so the message
+			// can be delivered without manual intervention. Worktrees are preserved for both
+			// statuses (only archiveGroup cleans them up), so session restoration is safe.
+			//
+			// Deliberate asymmetry with set_task_status:
+			//   set_task_status(cancelled → in_progress) → resetGroupForRestart (clean slate)
+			//   send_message_to_task(cancelled task)    → reviveTaskForMessage  (keep history)
+			// Sending a message is a "continue this conversation" action; history is preserved.
+			if (task.status === 'needs_attention' || task.status === 'cancelled') {
+				// needs_attention transitions through 'review' (its prior working state);
+				// cancelled transitions directly to 'in_progress'.
+				const intermediateStatus = task.status === 'needs_attention' ? 'review' : 'in_progress';
 				try {
-					await taskManager.setTaskStatus(args.task_id, 'in_progress');
-				} catch (err) {
-					return jsonResult({
-						success: false,
-						error: `Failed to reactivate task ${args.task_id}: ${String(err)}`,
-					});
-				}
-
-				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
-				if (!revived) {
-					// Roll back the task status; in_progress → cancelled is a valid transition.
-					try {
-						await taskManager.setTaskStatus(args.task_id, 'cancelled');
-					} catch {
-						// Rollback is best-effort; swallow to avoid masking the original error
-					}
-					return jsonResult({
-						success: false,
-						error:
-							`Failed to reactivate task ${args.task_id}: agent sessions could not be restored. ` +
-							'Task status has been reset to cancelled.',
-					});
-				}
-				return jsonResult({
-					success: true,
-					message: `Task ${args.task_id} reactivated from cancelled to in_progress and message delivered to agent`,
-				});
-			}
-
-			// Auto-revive: if the task needs attention, transition it to 'review' and
-			// restore the agent sessions so the message can be delivered. Needs_attention
-			// tasks preserve their worktree, so session restoration is safe.
-			if (task.status === 'needs_attention') {
-				try {
-					await taskManager.setTaskStatus(args.task_id, 'review');
+					await taskManager.setTaskStatus(args.task_id, intermediateStatus);
 				} catch (err) {
 					return jsonResult({
 						success: false,
@@ -572,9 +535,9 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
 				if (!revived) {
-					// Roll back the task status; review → needs_attention is a valid transition.
+					// Roll back the task status to its original state.
 					try {
-						await taskManager.setTaskStatus(args.task_id, 'needs_attention');
+						await taskManager.setTaskStatus(args.task_id, task.status);
 					} catch {
 						// Rollback is best-effort; swallow to avoid masking the original error
 					}
@@ -582,12 +545,13 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 						success: false,
 						error:
 							`Failed to revive task ${args.task_id}: agent sessions could not be restored. ` +
-							'Task status has been reset to needs_attention.',
+							`Task status has been reset to ${task.status}.`,
 					});
 				}
+				const fromTo = `${task.status} to ${intermediateStatus}`;
 				return jsonResult({
 					success: true,
-					message: `Task ${args.task_id} revived from needs_attention to review and message delivered to agent`,
+					message: `Task ${args.task_id} revived from ${fromTo} and message delivered to agent`,
 				});
 			}
 

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -512,15 +512,48 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				return jsonResult({ success: false, error: 'Room runtime not found' });
 			}
 
-			// Cancelled tasks are blocked from agent-tool messaging — an agent should not
-			// silently reactivate a task that was explicitly cancelled by a human. The
-			// worktree is still present (only archiveGroup cleans it up), but resuming
-			// without explicit human intent risks restarting undesired work.
-			// Use set_task_status to explicitly reactivate the task first.
+			// Auto-reactivate: if the task is cancelled, reset the group and transition to
+			// in_progress so the message can be delivered without manual intervention.
+			// Worktrees are preserved on cancel (only archiveGroup cleans them up), so
+			// session restoration is safe.
 			if (task.status === 'cancelled') {
+				const group = groupRepo.getGroupByTaskId(args.task_id);
+				if (group) {
+					const reset = groupRepo.resetGroupForRestart(group.id);
+					if (!reset) {
+						return jsonResult({
+							success: false,
+							error: `Failed to reactivate task ${args.task_id} — group may have been modified concurrently`,
+						});
+					}
+				}
+				try {
+					await taskManager.setTaskStatus(args.task_id, 'in_progress');
+				} catch (err) {
+					return jsonResult({
+						success: false,
+						error: `Failed to reactivate task ${args.task_id}: ${String(err)}`,
+					});
+				}
+
+				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
+				if (!revived) {
+					// Roll back the task status; in_progress → cancelled is a valid transition.
+					try {
+						await taskManager.setTaskStatus(args.task_id, 'cancelled');
+					} catch {
+						// Rollback is best-effort; swallow to avoid masking the original error
+					}
+					return jsonResult({
+						success: false,
+						error:
+							`Failed to reactivate task ${args.task_id}: agent sessions could not be restored. ` +
+							'Task status has been reset to cancelled.',
+					});
+				}
 				return jsonResult({
-					success: false,
-					error: `Task ${args.task_id} is cancelled. Use set_task_status to reactivate it first (e.g. status: "in_progress").`,
+					success: true,
+					message: `Task ${args.task_id} reactivated from cancelled to in_progress and message delivered to agent`,
 				});
 			}
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1278,15 +1278,19 @@ describe('Room Agent Tools', () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
-			// Move to in_progress and complete the task
+			// Move to in_progress, insert a group, and mark it completed via the repo
+			// so that completedAt is non-null before reactivation
 			await taskManager.startTask(taskId);
 			const groupId = insertGroup(taskId, 'awaiting_human');
+			const groupInserted = groupRepo.getGroup(groupId);
+			expect(groupInserted).not.toBeNull();
+			groupRepo.completeGroup(groupId, groupInserted!.version);
 			await taskManager.completeTask(taskId, 'Done');
 
-			// Verify the group exists
+			// Verify the group has a non-null completedAt before reactivation
 			const groupBefore = groupRepo.getGroup(groupId);
 			expect(groupBefore).not.toBeNull();
-			expect(groupBefore!.taskId).toBe(taskId);
+			expect(groupBefore!.completedAt).not.toBeNull();
 
 			// Reactivate the completed task
 			const result = parseResult(
@@ -1295,7 +1299,7 @@ describe('Room Agent Tools', () => {
 			expect(result.success).toBe(true);
 			expect(result.task.status).toBe('in_progress');
 
-			// The old completed group should be reset and active again
+			// resetGroupForRestart should have cleared completedAt and reset metadata
 			const groupAfter = groupRepo.getGroup(groupId);
 			expect(groupAfter).not.toBeNull();
 			expect(groupAfter!.completedAt).toBeNull();

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1023,7 +1023,7 @@ describe('Room Agent Tools', () => {
 			expect(reviveCalledWith[1]).toBe('please retry');
 		});
 
-		it('should return error for cancelled task (worktree is preserved, explicit reactivation required)', async () => {
+		it('should auto-reactivate cancelled task and deliver message', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => true,
 				injectMessageToWorker: async () => true,
@@ -1039,19 +1039,60 @@ describe('Room Agent Tools', () => {
 			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
-			// Move to cancelled state
+			// Move to cancelled state with a group
+			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_human');
+			const groupInserted = groupRepo.getGroup(groupId);
+			groupRepo.completeGroup(groupId, groupInserted!.version);
+			await taskManager.cancelTask(taskId);
+
+			// Verify the group has a non-null completedAt before reactivation
+			const groupBefore = groupRepo.getGroup(groupId);
+			expect(groupBefore!.completedAt).not.toBeNull();
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'resume please' })
+			);
+			// Cancelled task should be auto-reactivated and message delivered
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('reactivated');
+			expect(result.message).toContain('in_progress');
+
+			// Task should now be in_progress
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('in_progress');
+
+			// Group should have been reset (completedAt cleared)
+			const groupAfter = groupRepo.getGroup(groupId);
+			expect(groupAfter!.completedAt).toBeNull();
+		});
+
+		it('should roll back cancelled task when reviveTaskForMessage fails', async () => {
+			const mockRuntime = {
+				reviveTaskForMessage: async () => false,
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
 			await taskManager.startTask(taskId);
 			await taskManager.cancelTask(taskId);
 
 			const result = parseResult(
 				await h.send_message_to_task({ task_id: taskId, message: 'resume please' })
 			);
-			// Cancelled tasks cannot receive agent-tool messages — explicit reactivation required
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('cancelled');
-			expect(result.error).toContain('set_task_status');
 
-			// Task should remain cancelled (no revive attempted)
+			// Task status should be rolled back to cancelled
 			const task = await taskManager.getTask(taskId);
 			expect(task!.status).toBe('cancelled');
 		});

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1023,7 +1023,7 @@ describe('Room Agent Tools', () => {
 			expect(reviveCalledWith[1]).toBe('please retry');
 		});
 
-		it('should auto-reactivate cancelled task and deliver message', async () => {
+		it('should auto-reactivate cancelled task and deliver message (preserving group history)', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => true,
 				injectMessageToWorker: async () => true,
@@ -1039,7 +1039,7 @@ describe('Room Agent Tools', () => {
 			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
-			// Move to cancelled state with a group
+			// Move to cancelled state with a group that has completedAt set
 			await taskManager.startTask(taskId);
 			const groupId = insertGroup(taskId, 'awaiting_human');
 			const groupInserted = groupRepo.getGroup(groupId);
@@ -1055,19 +1055,19 @@ describe('Room Agent Tools', () => {
 			);
 			// Cancelled task should be auto-reactivated and message delivered
 			expect(result.success).toBe(true);
-			expect(result.message).toContain('reactivated');
+			expect(result.message).toContain('cancelled');
 			expect(result.message).toContain('in_progress');
 
 			// Task should now be in_progress
 			const task = await taskManager.getTask(taskId);
 			expect(task!.status).toBe('in_progress');
 
-			// Group should have been reset (completedAt cleared)
+			// Group history is PRESERVED — no resetGroupForRestart, reviveTaskForMessage keeps context
 			const groupAfter = groupRepo.getGroup(groupId);
-			expect(groupAfter!.completedAt).toBeNull();
+			expect(groupAfter!.completedAt).not.toBeNull();
 		});
 
-		it('should roll back cancelled task when reviveTaskForMessage fails', async () => {
+		it('should roll back cancelled task when reviveTaskForMessage fails (group state preserved)', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => false,
 				injectMessageToWorker: async () => true,
@@ -1083,7 +1083,11 @@ describe('Room Agent Tools', () => {
 			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
+			// Move to cancelled state with a group that has completedAt set
 			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_human');
+			const groupInserted = groupRepo.getGroup(groupId);
+			groupRepo.completeGroup(groupId, groupInserted!.version);
 			await taskManager.cancelTask(taskId);
 
 			const result = parseResult(
@@ -1095,6 +1099,10 @@ describe('Room Agent Tools', () => {
 			// Task status should be rolled back to cancelled
 			const task = await taskManager.getTask(taskId);
 			expect(task!.status).toBe('cancelled');
+
+			// Group state should be untouched — no metadata was wiped during the failed attempt
+			const groupAfter = groupRepo.getGroup(groupId);
+			expect(groupAfter!.completedAt).not.toBeNull();
 		});
 
 		it('should roll back task to needs_attention when reviveTaskForMessage returns false', async () => {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1023,7 +1023,7 @@ describe('Room Agent Tools', () => {
 			expect(reviveCalledWith[1]).toBe('please retry');
 		});
 
-		it('should return error for cancelled task (worktree is gone, restart required)', async () => {
+		it('should return error for cancelled task (worktree is preserved, explicit reactivation required)', async () => {
 			const mockRuntime = {
 				reviveTaskForMessage: async () => true,
 				injectMessageToWorker: async () => true,
@@ -1046,7 +1046,7 @@ describe('Room Agent Tools', () => {
 			const result = parseResult(
 				await h.send_message_to_task({ task_id: taskId, message: 'resume please' })
 			);
-			// Cancelled tasks cannot receive messages — workspace is cleaned up
+			// Cancelled tasks cannot receive agent-tool messages — explicit reactivation required
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('cancelled');
 			expect(result.error).toContain('set_task_status');
@@ -1272,6 +1272,35 @@ describe('Room Agent Tools', () => {
 			expect(groupAfter).not.toBeNull();
 			expect(groupAfter!.completedAt).toBeNull();
 			expect(groupAfter!.submittedForReview).toBe(false);
+		});
+
+		it('should reset old completed group when restarting task', async () => {
+			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Move to in_progress and complete the task
+			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_human');
+			await taskManager.completeTask(taskId, 'Done');
+
+			// Verify the group exists
+			const groupBefore = groupRepo.getGroup(groupId);
+			expect(groupBefore).not.toBeNull();
+			expect(groupBefore!.taskId).toBe(taskId);
+
+			// Reactivate the completed task
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: taskId, status: 'in_progress' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.task.status).toBe('in_progress');
+
+			// The old completed group should be reset and active again
+			const groupAfter = groupRepo.getGroup(groupId);
+			expect(groupAfter).not.toBeNull();
+			expect(groupAfter!.completedAt).toBeNull();
+			expect(groupAfter!.submittedForReview).toBe(false);
+			expect(groupAfter!.feedbackIteration).toBe(0);
 		});
 
 		it('should succeed when group is already gone', async () => {

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -855,7 +855,7 @@ describe('TaskManager', () => {
 			expect(revived.error).toBeUndefined();
 		});
 
-		it('should reject cancelled → review transition (worktree is cleaned up on cancel)', async () => {
+		it('should reject cancelled → review transition (not a valid reactivation path)', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);
 			await taskManager.cancelTask(task.id);


### PR DESCRIPTION
- Update send_message_to_task cancelled guard: change "restart" to
  "reactivate" in error message, reflecting that worktrees are kept
- Extend set_task_status restart/revive block to include completed tasks
  so completed→in_progress triggers resetGroupForRestart (same as
  cancelled tasks), enabling proper agent group reset on reactivation
- Update reviveGroup comment to clarify scope: lightweight revive is
  needs_attention→review only; cancelled and completed use resetGroupForRestart
