### PR TITLE
feat: allow cancelled → completed status transition

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -30,7 +30,7 @@ export const VALID_STATUS_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
 	review: ['completed', 'needs_attention', 'in_progress'],
 	completed: ['in_progress', 'archived'], // Reactivate or archive
 	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
-	cancelled: ['pending', 'in_progress', 'archived'], // Restart or archive
+	cancelled: ['pending', 'in_progress', 'completed', 'archived'], // Restart, complete, or archive
 	archived: [], // True terminal state — no going back
 };
 

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -27,7 +27,7 @@ export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStat
 	review: ['completed', 'needs_attention', 'in_progress'],
 	completed: ['in_progress', 'archived'], // Reactivate or archive
 	needs_attention: ['pending', 'in_progress', 'review', 'archived'], // Restart allowed + archive
-	cancelled: ['pending', 'in_progress', 'archived'], // Restart or archive
+	cancelled: ['pending', 'in_progress', 'completed', 'archived'], // Restart, complete, or archive
 	archived: [], // True terminal state — no going back
 };
 

--- a/packages/daemon/tests/unit/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/lib/space-task-manager.test.ts
@@ -546,10 +546,11 @@ describe('SpaceTaskManager', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.completed).toEqual(['in_progress', 'archived']);
 		});
 
-		it('cancelled allows restart and archival', () => {
+		it('cancelled allows restart, completion, and archival', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.cancelled).toEqual([
 				'pending',
 				'in_progress',
+				'completed',
 				'archived',
 			]);
 		});
@@ -587,6 +588,14 @@ describe('SpaceTaskManager', () => {
 			await manager.cancelTask(task.id);
 			const archived = await manager.setTaskStatus(task.id, 'archived');
 			expect(archived.status).toBe('archived');
+		});
+
+		it('transitions cancelled -> completed (e.g. PR merged after cancellation)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.setTaskStatus(task.id, 'in_progress');
+			await manager.cancelTask(task.id);
+			const completed = await manager.setTaskStatus(task.id, 'completed');
+			expect(completed.status).toBe('completed');
 		});
 
 		it('transitions needs_attention -> archived', async () => {

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -895,6 +895,15 @@ describe('TaskManager', () => {
 			expect(archived.status).toBe('archived');
 		});
 
+		it('should allow cancelled → completed transition (e.g. PR merged after cancellation)', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: '' });
+			await taskManager.startTask(task.id);
+			await taskManager.cancelTask(task.id);
+
+			const completed = await taskManager.setTaskStatus(task.id, 'completed');
+			expect(completed.status).toBe('completed');
+		});
+
 		it('should allow needs_attention → archived transition', async () => {
 			const task = await taskManager.createTask({ title: 'T', description: '' });
 			await taskManager.startTask(task.id);
@@ -1087,8 +1096,13 @@ describe('TaskManager', () => {
 			expect(VALID_STATUS_TRANSITIONS.completed).toEqual(['in_progress', 'archived']);
 		});
 
-		it('cancelled allows restart and archival', () => {
-			expect(VALID_STATUS_TRANSITIONS.cancelled).toEqual(['pending', 'in_progress', 'archived']);
+		it('cancelled allows restart, completion, and archival', () => {
+			expect(VALID_STATUS_TRANSITIONS.cancelled).toEqual([
+				'pending',
+				'in_progress',
+				'completed',
+				'archived',
+			]);
 		});
 
 		it('needs_attention allows restart, review, and archival', () => {


### PR DESCRIPTION
Adds 'completed' to valid transitions from 'cancelled' status in both
TaskManager and SpaceTaskManager. This supports cases where a task's
work was actually finished (e.g., PR merged) but the task was cancelled
due to session timeout or other reasons.
