### PR TITLE
feat: add reactivate and archive actions to TaskView

### DIFF
--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -217,6 +217,13 @@ export function RoomDashboard() {
 							// Error handled by store
 						}
 					}}
+					onReactivate={async (taskId) => {
+						try {
+							await roomStore.setTaskStatus(taskId, 'in_progress');
+						} catch {
+							// Error handled by store
+						}
+					}}
 				/>
 			</div>
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -45,6 +45,7 @@ interface RoomTasksProps {
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
+	onReactivate?: (taskId: string) => void;
 }
 
 /** Get count of tasks for each filter tab */
@@ -99,7 +100,14 @@ function getStatusBorderColor(status: TaskStatus): string {
 	}
 }
 
-export function RoomTasks({ tasks, onTaskClick, onView, onReject, onApprove }: RoomTasksProps) {
+export function RoomTasks({
+	tasks,
+	onTaskClick,
+	onView,
+	onReject,
+	onApprove,
+	onReactivate,
+}: RoomTasksProps) {
 	let selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 
@@ -171,6 +179,7 @@ export function RoomTasks({ tasks, onTaskClick, onView, onReject, onApprove }: R
 					onView={onView}
 					onReject={onReject}
 					onApprove={onApprove}
+					onReactivate={onReactivate}
 				/>
 			)}
 		</div>
@@ -276,6 +285,7 @@ function TaskList({
 	onView,
 	onReject,
 	onApprove,
+	onReactivate,
 }: {
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
@@ -284,6 +294,7 @@ function TaskList({
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
+	onReactivate?: (taskId: string) => void;
 }) {
 	const [rejectingTaskId, setRejectingTaskId] = useState<string | null>(null);
 
@@ -391,6 +402,7 @@ function TaskList({
 						tasks={completed}
 						allTasks={allTasks}
 						onTaskClick={onTaskClick}
+						onReactivate={onReactivate}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
@@ -403,6 +415,7 @@ function TaskList({
 						tasks={cancelled}
 						allTasks={allTasks}
 						onTaskClick={onTaskClick}
+						onReactivate={onReactivate}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
@@ -439,6 +452,7 @@ function TaskGroup({
 	onView,
 	onReject,
 	onApprove,
+	onReactivate,
 	showAlert = false,
 	rejectingTaskId,
 	onSetRejectingTaskId,
@@ -452,6 +466,7 @@ function TaskGroup({
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
+	onReactivate?: (taskId: string) => void;
 	showAlert?: boolean;
 	rejectingTaskId?: string | null;
 	onSetRejectingTaskId?: (id: string | null) => void;
@@ -517,6 +532,7 @@ function TaskGroup({
 						onView={onView}
 						onReject={onReject}
 						onApprove={onApprove}
+						onReactivate={onReactivate}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={onSetRejectingTaskId}
 					/>
@@ -541,6 +557,7 @@ function TaskItem({
 	onView,
 	onReject,
 	onApprove,
+	onReactivate,
 	rejectingTaskId,
 	onSetRejectingTaskId,
 }: {
@@ -550,6 +567,7 @@ function TaskItem({
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
+	onReactivate?: (taskId: string) => void;
 	rejectingTaskId?: string | null;
 	onSetRejectingTaskId?: (id: string | null) => void;
 }) {
@@ -567,6 +585,8 @@ function TaskItem({
 	const hasDeps = task.dependsOn && task.dependsOn.length > 0;
 	const isWorking = isReview && !!task.activeSession;
 	const isRejecting = rejectingTaskId === task.id;
+	const showReactivate =
+		(task.status === 'completed' || task.status === 'cancelled') && !!onReactivate;
 
 	// Compute border color: when approve animation active, switch to green
 	const borderColor = cardFading ? 'border-l-green-500' : getStatusBorderColor(task.status);
@@ -669,6 +689,21 @@ function TaskItem({
 							)}
 						</div>
 					)}
+				</div>
+			)}
+			{/* Done/Cancelled: reactivate action */}
+			{showReactivate && (
+				<div class="mt-2" onClick={(e) => e.stopPropagation()}>
+					<button
+						onClick={(e) => {
+							e.stopPropagation();
+							onReactivate(task.id);
+						}}
+						class="px-3 py-1.5 text-xs font-medium text-blue-400 border border-blue-700/50 hover:bg-blue-900/20 rounded-lg transition-colors"
+						data-testid={`task-reactivate-${task.id}`}
+					>
+						Reactivate
+					</button>
 				</div>
 			)}
 			{task.status === 'needs_attention' && task.error && (

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1880,4 +1880,77 @@ describe('TaskView — Reactivate and Archive actions', () => {
 			});
 		});
 	});
+
+	it('shows Archive button for needs_attention task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'needs_attention') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-archive-button"]')).not.toBeNull();
+	});
+
+	it('calls task.setStatus with archived when Archive dialog is confirmed', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			if (method === 'task.setStatus') return {};
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open the archive dialog
+		const archiveButton = container.querySelector(
+			'[data-testid="task-archive-button"]'
+		) as HTMLElement;
+		expect(archiveButton).not.toBeNull();
+		fireEvent.click(archiveButton);
+
+		// The Modal renders into body via a portal, so query from document
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="archive-task-confirm"]')).not.toBeNull();
+		});
+
+		await act(async () => {
+			fireEvent.click(
+				document.querySelector('[data-testid="archive-task-confirm"]') as HTMLElement
+			);
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.setStatus', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				status: 'archived',
+			});
+		});
+	});
+
+	it('does NOT show reactivation hint when completed task has an active group', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.textContent).not.toContain('Sending a message will reactivate this task.');
+	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1743,3 +1743,141 @@ describe('TaskView — PR link in header', () => {
 		expect(prLink).not.toBeNull();
 	});
 });
+
+// ─── Reactivate and Archive Action Tests ───
+
+describe('TaskView — Reactivate and Archive actions', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+		_draftContentSignal.value = '';
+		_draftRestoredSignal.value = false;
+		mockSetMessageText.mockClear();
+		mockClearDraft.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('shows Reactivate button for completed task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-reactivate-button"]')).not.toBeNull();
+	});
+
+	it('shows Archive button for completed task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-archive-button"]')).not.toBeNull();
+	});
+
+	it('shows Reactivate button for cancelled task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-reactivate-button"]')).not.toBeNull();
+	});
+
+	it('shows "Sending a message will reactivate this task" hint for completed task without group', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.textContent).toContain('Sending a message will reactivate this task.');
+	});
+
+	it('input is disabled for archived task (no group)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'archived') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.disabled).toBe(true);
+		const sendButton = getByTestId('input-textarea-send') as HTMLButtonElement;
+		expect(sendButton.disabled).toBe(true);
+	});
+
+	it('calls task.setStatus with in_progress when Reactivate button is clicked', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			if (method === 'task.setStatus') return { task: makeTask('task-1', 'in_progress') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const reactivateButton = container.querySelector(
+			'[data-testid="task-reactivate-button"]'
+		) as HTMLElement;
+		expect(reactivateButton).not.toBeNull();
+
+		await act(async () => {
+			fireEvent.click(reactivateButton);
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.setStatus', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				status: 'in_progress',
+			});
+		});
+	});
+});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -104,12 +104,14 @@ const TASK_STATUS_COLORS: Record<string, string> = {
 	review: 'text-purple-400',
 	draft: 'text-gray-500',
 	cancelled: 'text-gray-500',
+	archived: 'text-gray-600',
 };
 
 type HumanMessageTarget = 'worker' | 'leader';
 
 interface HumanInputAreaProps {
 	hasGroup: boolean;
+	taskStatus: string;
 	roomId: string;
 	taskId: string;
 	/** Called after a successful action that requires a full conversation re-fetch */
@@ -123,6 +125,7 @@ const TARGET_LABELS: Record<HumanMessageTarget, string> = {
 
 function HumanInputArea({
 	hasGroup,
+	taskStatus,
 	roomId,
 	taskId,
 	onMessageSentWithReload,
@@ -159,7 +162,9 @@ function HumanInputArea({
 		return () => document.removeEventListener('mousedown', onDocMouseDown);
 	}, [menuOpen]);
 
-	const canSend = hasGroup;
+	const isArchived = taskStatus === 'archived';
+	const canReactivateWithMessage = taskStatus === 'completed' || taskStatus === 'cancelled';
+	const canSend = !isArchived && (hasGroup || canReactivateWithMessage);
 
 	const sendMessage = async () => {
 		if (sending || !messageText.trim() || !canSend) return;
@@ -182,11 +187,15 @@ function HumanInputArea({
 	};
 
 	const targetLabel = target === 'leader' ? 'leader' : 'worker';
-	const placeholder = !hasGroup
-		? 'No active agent group yet — input will activate once a group starts.'
-		: isTouchDeviceRef.current
-			? `Send a message to the ${targetLabel}…`
-			: `Send a message to the ${targetLabel}… (Enter to send, Shift+Enter for newline)`;
+	const placeholder = isArchived
+		? 'Archived tasks cannot receive messages.'
+		: canReactivateWithMessage && !hasGroup
+			? 'Send a message to reactivate this task…'
+			: !hasGroup
+				? 'No active agent group yet — input will activate once a group starts.'
+				: isTouchDeviceRef.current
+					? `Send a message to the ${targetLabel}…`
+					: `Send a message to the ${targetLabel}… (Enter to send, Shift+Enter for newline)`;
 
 	return (
 		<div class="border-t border-dark-700 bg-dark-850 flex-shrink-0 px-4 py-3 space-y-2">
@@ -278,7 +287,16 @@ function HumanInputArea({
 					</div>
 				}
 			/>
-			{!canSend && <p class="text-xs text-gray-500">No active group to receive messages yet.</p>}
+			{canReactivateWithMessage && (
+				<p class="text-xs text-amber-500/80">Sending a message will reactivate this task.</p>
+			)}
+			{!canSend && !canReactivateWithMessage && (
+				<p class="text-xs text-gray-500">
+					{isArchived
+						? 'Archived tasks cannot receive messages.'
+						: 'No active group to receive messages yet.'}
+				</p>
+			)}
 			{inputError && <p class="text-xs text-red-400">{inputError}</p>}
 		</div>
 	);
@@ -333,8 +351,8 @@ function CompleteTaskDialog({ task, isOpen, onClose, onConfirm }: CompleteTaskDi
 						<li>
 							Task status changes to <span class="text-green-400">completed</span>
 						</li>
-						<li>All sessions will be terminated</li>
-						<li>Task slot will be freed</li>
+						<li>Active sessions will be stopped</li>
+						<li>Worktree and branch are preserved — you can reactivate later</li>
 					</ul>
 				</div>
 
@@ -430,14 +448,14 @@ function CancelTaskDialog({ task, isOpen, onClose, onConfirm }: CancelTaskDialog
 					You are about to cancel <strong class="text-gray-100">{task.title}</strong>.
 				</p>
 
-				<div class="bg-red-900/20 border border-red-800/50 rounded-lg p-3 text-xs text-gray-400">
-					<p class="font-medium text-red-400 mb-1.5">This action cannot be undone:</p>
+				<div class="bg-amber-900/20 border border-amber-800/50 rounded-lg p-3 text-xs text-gray-400">
+					<p class="font-medium text-amber-400 mb-1.5">This action is reversible:</p>
 					<ul class="list-disc list-inside space-y-1">
 						<li>
 							Task will be marked as <span class="text-gray-300">cancelled</span>
 						</li>
-						<li>All sessions will be terminated</li>
-						<li>Isolated worktree and branch will be removed</li>
+						<li>Active sessions will be stopped</li>
+						<li>Worktree and branch are preserved — you can reactivate later</li>
 					</ul>
 				</div>
 
@@ -485,6 +503,97 @@ function CancelTaskDialog({ task, isOpen, onClose, onConfirm }: CancelTaskDialog
 	);
 }
 
+interface ArchiveTaskDialogProps {
+	task: NeoTask;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => Promise<void>;
+}
+
+function ArchiveTaskDialog({ task, isOpen, onClose, onConfirm }: ArchiveTaskDialogProps) {
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleClose = () => {
+		setError(null);
+		onClose();
+	};
+
+	const handleConfirm = async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			await onConfirm();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to archive task');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Archive Task?" size="sm" showCloseButton>
+			<div class="space-y-4">
+				<p class="text-sm text-gray-300">
+					You are about to archive <strong class="text-gray-100">{task.title}</strong>.
+				</p>
+
+				<div class="bg-red-900/20 border border-red-800/50 rounded-lg p-3 text-xs text-gray-400">
+					<p class="font-medium text-red-400 mb-1.5">This action is permanent:</p>
+					<ul class="list-disc list-inside space-y-1">
+						<li>
+							Task will be marked as <span class="text-gray-300">archived</span>
+						</li>
+						<li>All sessions will be terminated</li>
+						<li>Isolated worktree and branch will be cleaned up</li>
+						<li>The task cannot be reactivated after archiving</li>
+					</ul>
+				</div>
+
+				{error && (
+					<p class="text-sm text-red-400 bg-red-900/20 border border-red-800/50 rounded px-3 py-2">
+						{error}
+					</p>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<button
+						type="button"
+						onClick={handleClose}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Keep Task
+					</button>
+					<button
+						type="button"
+						onClick={() => void handleConfirm()}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:cursor-not-allowed bg-red-600 hover:bg-red-700 text-white disabled:bg-red-600/50 flex items-center gap-1.5"
+						data-testid="archive-task-confirm"
+					>
+						{loading ? (
+							'Archiving…'
+						) : (
+							<>
+								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8l1 13a2 2 0 002 2h8a2 2 0 002-2L19 8"
+									/>
+								</svg>
+								Archive Task
+							</>
+						)}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}
+
 export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const { request, onEvent, joinRoom, leaveRoom } = useMessageHub();
 	const [task, setTask] = useState<NeoTask | null>(null);
@@ -507,11 +616,13 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const completeModal = useModal();
 	const cancelModal = useModal();
 	const rejectModal = useModal();
+	const archiveModal = useModal();
 
 	// Review state — approve/reject for tasks awaiting human review
 	const [approving, setApproving] = useState(false);
 	const [rejecting, setRejecting] = useState(false);
 	const [reviewError, setReviewError] = useState<string | null>(null);
+	const [reactivating, setReactivating] = useState(false);
 
 	// Tracks whether the conversation pane is showing its first batch of messages.
 	// Starts true, resets to true each time the conversation reloads (conversationKey bumps),
@@ -685,6 +796,11 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	// Pending, in_progress, and review tasks can be cancelled
 	const canCancel =
 		task.status === 'pending' || task.status === 'in_progress' || task.status === 'review';
+	// Completed and cancelled tasks can be reactivated
+	const canReactivate = task.status === 'completed' || task.status === 'cancelled';
+	// Completed, cancelled, and needs_attention tasks can be archived
+	const canArchive =
+		task.status === 'completed' || task.status === 'cancelled' || task.status === 'needs_attention';
 
 	// Complete task handler — throws on error so the dialog can display it
 	const completeTask = async (summary: string) => {
@@ -704,6 +820,28 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		await request('task.cancel', { roomId, taskId });
 		cancelModal.close();
 		toast.info('Task cancelled');
+		navigateToRoom(roomId);
+	};
+
+	// Reactivate task handler — transitions completed/cancelled to in_progress
+	const reactivateTask = async () => {
+		if (reactivating) return;
+		setReactivating(true);
+		try {
+			await request('task.setStatus', { roomId, taskId, status: 'in_progress' });
+			toast.success('Task reactivated');
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to reactivate task');
+		} finally {
+			setReactivating(false);
+		}
+	};
+
+	// Archive task handler — transitions to archived (permanent)
+	const archiveTask = async () => {
+		await request('task.setStatus', { roomId, taskId, status: 'archived' });
+		archiveModal.close();
+		toast.info('Task archived');
 		navigateToRoom(roomId);
 	};
 
@@ -869,6 +1007,42 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 						title="Cancel task"
 					>
 						Cancel
+					</button>
+				)}
+				{canReactivate && (
+					<button
+						class="py-1 px-2.5 rounded-lg text-xs bg-blue-700 hover:bg-blue-600 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1"
+						onClick={() => void reactivateTask()}
+						disabled={reactivating}
+						data-testid="task-reactivate-button"
+						title="Reactivate task"
+					>
+						{reactivating ? (
+							'Reactivating…'
+						) : (
+							<>
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+									/>
+								</svg>
+								Reactivate
+							</>
+						)}
+					</button>
+				)}
+				{canArchive && (
+					<button
+						class="py-1 px-2.5 rounded-lg text-xs border border-dark-600 text-gray-400 hover:text-red-400 hover:border-red-700/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						onClick={archiveModal.open}
+						disabled={reactivating}
+						data-testid="task-archive-button"
+						title="Archive task (permanent)"
+					>
+						Archive
 					</button>
 				)}
 				{canComplete && task.status !== 'review' && (
@@ -1110,6 +1284,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			{/* Human input area (always visible) */}
 			<HumanInputArea
 				hasGroup={group !== null}
+				taskStatus={task.status}
 				roomId={roomId}
 				taskId={taskId}
 				onMessageSentWithReload={() => setConversationKey((k) => k + 1)}
@@ -1127,6 +1302,12 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				isOpen={cancelModal.isOpen}
 				onClose={cancelModal.close}
 				onConfirm={cancelTask}
+			/>
+			<ArchiveTaskDialog
+				task={task}
+				isOpen={archiveModal.isOpen}
+				onClose={archiveModal.close}
+				onConfirm={archiveTask}
 			/>
 			{/* Reject dialog — for tasks awaiting human review */}
 			<RejectModal

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -287,7 +287,7 @@ function HumanInputArea({
 					</div>
 				}
 			/>
-			{canReactivateWithMessage && (
+			{canReactivateWithMessage && !hasGroup && (
 				<p class="text-xs text-amber-500/80">Sending a message will reactivate this task.</p>
 			)}
 			{!canSend && !canReactivateWithMessage && (
@@ -1036,9 +1036,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				)}
 				{canArchive && (
 					<button
-						class="py-1 px-2.5 rounded-lg text-xs border border-dark-600 text-gray-400 hover:text-red-400 hover:border-red-700/60 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						class="py-1 px-2.5 rounded-lg text-xs border border-dark-600 text-gray-400 hover:text-red-400 hover:border-red-700/60 transition-colors"
 						onClick={archiveModal.open}
-						disabled={reactivating}
 						data-testid="task-archive-button"
 						title="Archive task (permanent)"
 					>

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -597,6 +597,29 @@ class RoomStore {
 	}
 
 	/**
+	 * Set task status directly (e.g., reactivate completed/cancelled to in_progress).
+	 */
+	async setTaskStatus(taskId: string, status: string): Promise<void> {
+		const roomId = this.roomId.value;
+		if (!roomId) {
+			throw new Error('No room selected');
+		}
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			throw new Error('Not connected');
+		}
+
+		await hub.request<{ success: boolean }>('task.setStatus', {
+			roomId,
+			taskId,
+			status,
+		});
+
+		// Task state updates arrive via room.task.update events
+	}
+
+	/**
 	 * Reject a task in review status with feedback.
 	 */
 	async rejectTask(taskId: string, feedback: string): Promise<void> {

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -20,6 +20,7 @@ import type {
 	Room,
 	TaskSummary,
 	NeoTask,
+	TaskStatus,
 	SessionSummary,
 	RoomOverview,
 	RoomGoal,
@@ -599,7 +600,7 @@ class RoomStore {
 	/**
 	 * Set task status directly (e.g., reactivate completed/cancelled to in_progress).
 	 */
-	async setTaskStatus(taskId: string, status: string): Promise<void> {
+	async setTaskStatus(taskId: string, status: TaskStatus): Promise<void> {
 		const roomId = this.roomId.value;
 		if (!roomId) {
 			throw new Error('No room selected');


### PR DESCRIPTION
- Add Reactivate button (blue) in TaskView header for completed/cancelled tasks
  — calls task.setStatus with in_progress via RPC
- Add Archive button in TaskView header for completed/cancelled/needs_attention tasks
  — shows ArchiveTaskDialog with permanent-action warning about worktree cleanup
- Update CancelTaskDialog from red "cannot be undone" to amber "reversible" with
  note that worktree is preserved and task can be reactivated later
- Update CompleteTaskDialog to reflect preserved worktree behavior
- Enable message input for completed/cancelled tasks with amber reactivation hint;
  disable for archived tasks
- Add Reactivate button to TaskItem in RoomTasks Done tab (completed/cancelled)
- Add onReactivate prop chain: RoomTasks → TaskList → TaskGroup → TaskItem
- Add roomStore.setTaskStatus() and wire onReactivate in RoomDashboard
- Add 6 new unit tests covering new actions and messaging behavior
