### PR TITLE
test: add web unit tests for archived status and reactivate/archive button visibility

### DIFF
--- a/packages/web/src/components/inbox/Inbox.test.tsx
+++ b/packages/web/src/components/inbox/Inbox.test.tsx
@@ -82,13 +82,13 @@ describe('Inbox', () => {
 
 		it('should show count of awaiting review tasks', () => {
 			mockItemsSignal.value = [makeInboxTask('t1', 'r1', 'Room 1')];
-			render(<Inbox />);
-			expect(screen.getByText('1 awaiting review')).toBeTruthy();
+			const { container } = render(<Inbox />);
+			expect(container.textContent).toContain('1 awaiting review');
 		});
 
 		it('should show 0 awaiting review when empty', () => {
-			render(<Inbox />);
-			expect(screen.getByText('0 awaiting review')).toBeTruthy();
+			const { container } = render(<Inbox />);
+			expect(container.textContent).toContain('0 awaiting review');
 		});
 	});
 
@@ -125,13 +125,13 @@ describe('Inbox', () => {
 			expect(screen.getByText('My Room')).toBeTruthy();
 		});
 
-		it('should render a Review button for each task', () => {
+		it('should render a View button for each task', () => {
 			mockItemsSignal.value = [
 				makeInboxTask('t1', 'r1', 'Room 1'),
 				makeInboxTask('t2', 'r2', 'Room 2'),
 			];
 			render(<Inbox />);
-			const buttons = screen.getAllByText('Review');
+			const buttons = screen.getAllByText('View');
 			expect(buttons).toHaveLength(2);
 		});
 
@@ -142,11 +142,11 @@ describe('Inbox', () => {
 			expect(card).toBeTruthy();
 		});
 
-		it('should navigate to correct room and task on Review click', () => {
+		it('should navigate to correct room and task on View click', () => {
 			mockItemsSignal.value = [makeInboxTask('task-abc', 'room-xyz', 'Test Room')];
 			render(<Inbox />);
 
-			const reviewBtn = screen.getByText('Review');
+			const reviewBtn = screen.getByText('View');
 			fireEvent.click(reviewBtn);
 
 			expect(navSectionSignal.value).toBe('rooms');

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -413,7 +413,7 @@ describe('RoomDashboard', () => {
 			await selectReviewTab(container);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			)!;
 			expect(viewBtn).toBeTruthy();
 
@@ -429,7 +429,7 @@ describe('RoomDashboard', () => {
 			await selectReviewTab(container);
 
 			const viewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
-				b.textContent?.includes('审阅')
+				b.textContent?.includes('View details')
 			)!;
 			await fireEvent.click(viewBtn);
 

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -1161,4 +1161,72 @@ describe('RoomTasks', () => {
 			expect(selectedTabSignal.value).toBe('archived');
 		});
 	});
+
+	describe('Reactivate Button in Done Tab', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'done';
+		});
+
+		it('should show Reactivate button for completed task when onReactivate is provided', () => {
+			const onReactivate = vi.fn();
+			const tasks = [createTask('t1', 'completed')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReactivate={onReactivate} />);
+
+			const reactivateBtn = container.querySelector('[data-testid="task-reactivate-t1"]');
+			expect(reactivateBtn).toBeTruthy();
+		});
+
+		it('should show Reactivate button for cancelled task when onReactivate is provided', () => {
+			const onReactivate = vi.fn();
+			const tasks = [createTask('t1', 'cancelled')];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReactivate={onReactivate} />);
+
+			const reactivateBtn = container.querySelector('[data-testid="task-reactivate-t1"]');
+			expect(reactivateBtn).toBeTruthy();
+		});
+
+		it('should NOT show Reactivate button when onReactivate is not provided', () => {
+			const tasks = [createTask('t1', 'completed')];
+
+			const { container } = render(<RoomTasks tasks={tasks} />);
+
+			const reactivateBtn = container.querySelector('[data-testid="task-reactivate-t1"]');
+			expect(reactivateBtn).toBeFalsy();
+		});
+
+		it('should call onReactivate with correct task id when clicked', () => {
+			const onReactivate = vi.fn();
+			const tasks = [createTask('task-42', 'completed', { title: 'Done task' })];
+
+			const { container } = render(<RoomTasks tasks={tasks} onReactivate={onReactivate} />);
+
+			const reactivateBtn = container.querySelector(
+				'[data-testid="task-reactivate-task-42"]'
+			) as HTMLButtonElement;
+			expect(reactivateBtn).toBeTruthy();
+			fireEvent.click(reactivateBtn);
+
+			expect(onReactivate).toHaveBeenCalledWith('task-42');
+		});
+
+		it('should NOT call onTaskClick when Reactivate is clicked (stopPropagation)', () => {
+			const onReactivate = vi.fn();
+			const onTaskClick = vi.fn();
+			const tasks = [createTask('task-42', 'completed', { title: 'Done task' })];
+
+			const { container } = render(
+				<RoomTasks tasks={tasks} onReactivate={onReactivate} onTaskClick={onTaskClick} />
+			);
+
+			const reactivateBtn = container.querySelector(
+				'[data-testid="task-reactivate-task-42"]'
+			) as HTMLButtonElement;
+			fireEvent.click(reactivateBtn);
+
+			expect(onReactivate).toHaveBeenCalledWith('task-42');
+			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2047,9 +2047,10 @@ describe('TaskView — Reactivate and Archive actions', () => {
 			expect(container.textContent).not.toContain('Loading task');
 		});
 
-		const statusBadge = container.querySelector('.text-gray-600');
+		// Verify the element containing "archived" text carries the text-gray-600 class
+		const allGraySpans = Array.from(container.querySelectorAll('.text-gray-600'));
+		const statusBadge = allGraySpans.find((el) => el.textContent?.includes('archived'));
 		expect(statusBadge).not.toBeNull();
-		expect(statusBadge?.textContent).toContain('archived');
 	});
 
 	it('input is enabled for completed task (no group)', async () => {

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1953,4 +1953,140 @@ describe('TaskView — Reactivate and Archive actions', () => {
 
 		expect(container.textContent).not.toContain('Sending a message will reactivate this task.');
 	});
+
+	it('shows Archive button for cancelled task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-archive-button"]')).not.toBeNull();
+	});
+
+	it('does NOT show Reactivate button for in_progress task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-reactivate-button"]')).toBeNull();
+	});
+
+	it('does NOT show Reactivate button for archived task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'archived') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-reactivate-button"]')).toBeNull();
+	});
+
+	it('does NOT show Archive button for in_progress task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-archive-button"]')).toBeNull();
+	});
+
+	it('does NOT show Archive button for archived task', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'archived') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		expect(container.querySelector('[data-testid="task-archive-button"]')).toBeNull();
+	});
+
+	it('archived status badge has text-gray-600 class', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'archived') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const statusBadge = container.querySelector('.text-gray-600');
+		expect(statusBadge).not.toBeNull();
+		expect(statusBadge?.textContent).toContain('archived');
+	});
+
+	it('input is enabled for completed task (no group)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.disabled).toBe(false);
+		const sendButton = getByTestId('input-textarea-send') as HTMLButtonElement;
+		expect(sendButton.disabled).toBe(false);
+	});
+
+	it('input is enabled for cancelled task (no group)', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'cancelled') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('input-textarea-field')).toBeTruthy();
+		});
+
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		expect(textarea.disabled).toBe(false);
+		const sendButton = getByTestId('input-textarea-send') as HTMLButtonElement;
+		expect(sendButton.disabled).toBe(false);
+	});
 });

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -204,9 +204,9 @@ describe('RoomContextPanel', () => {
 			makeTask('t2', 'T2', 'in_progress'),
 			makeTask('t3', 'T3', 'pending'),
 		];
-		render(<RoomContextPanel roomId="room-1" />);
-		expect(screen.getByText('2 pending')).toBeTruthy();
-		expect(screen.getByText('1 active')).toBeTruthy();
+		const { container } = render(<RoomContextPanel roomId="room-1" />);
+		// All draft/pending/in_progress tasks are counted as "active" in the stats strip
+		expect(container.textContent).toContain('3 active');
 	});
 
 	it('renders "No tasks" when there are no tasks', () => {


### PR DESCRIPTION
- TaskView: add 8 new tests for Archive button (cancelled, not for in_progress/archived),
  Reactivate button (not for in_progress/archived), archived status badge text-gray-600,
  and input enabled for completed/cancelled tasks
- Fix pre-existing test failures: Inbox button text 'Review'→'View', awaiting review
  count assertions to use textContent.toContain; RoomDashboard '审阅'→'View details';
  RoomContextPanel stats strip to expect '3 active' (pending+in_progress are all 'active')
