### PR TITLE
test: add unit tests for room-runtime lifecycle changes

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -819,6 +819,13 @@ export function setupTaskHandlers(
 			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
 		}
 
+		// Archived tasks are truly terminal — no messaging allowed.
+		if (task.status === 'archived') {
+			throw new Error(
+				`Task ${params.taskId} is archived and cannot receive messages. Archive is a terminal state.`
+			);
+		}
+
 		// needs_attention, completed, and cancelled tasks: auto-reactivate via reviveTaskForMessage.
 		// reviveTaskForMessage is a lightweight revive that restores sessions and injects the
 		// message WITHOUT wiping the group metadata or conversation history.

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -802,15 +802,6 @@ export function setupTaskHandlers(
 		if (target !== 'worker' && target !== 'leader') {
 			throw new Error(`Invalid target: ${target}`);
 		}
-		if (!runtimeService) {
-			throw new Error('Runtime service is required for task.sendHumanMessage');
-		}
-
-		const runtime = runtimeService.getRuntime(params.roomId);
-		if (!runtime) {
-			throw new Error(`No runtime found for room: ${params.roomId}`);
-		}
-
 		// Cross-room ownership check: verify the task belongs to this room.
 		// TaskManager is room-scoped, so getTask() returns null for tasks in other rooms.
 		const taskManager = taskManagerFactory(db, params.roomId);
@@ -819,11 +810,21 @@ export function setupTaskHandlers(
 			throw new Error(`Task ${params.taskId} not found in room ${params.roomId}`);
 		}
 
-		// Archived tasks are truly terminal — no messaging allowed.
+		// Archived tasks are truly terminal — no messaging allowed. Check this before the runtime
+		// lookup so the error is consistent regardless of whether a runtime is active.
 		if (task.status === 'archived') {
 			throw new Error(
 				`Task ${params.taskId} is archived and cannot receive messages. Archive is a terminal state.`
 			);
+		}
+
+		if (!runtimeService) {
+			throw new Error('Runtime service is required for task.sendHumanMessage');
+		}
+
+		const runtime = runtimeService.getRuntime(params.roomId);
+		if (!runtime) {
+			throw new Error(`No runtime found for room: ${params.roomId}`);
 		}
 
 		// needs_attention, completed, and cancelled tasks: auto-reactivate via reviveTaskForMessage.

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -487,14 +487,23 @@ describe('task.sendHumanMessage RPC Handler', () => {
 	});
 
 	describe('archived task messaging — archived is truly terminal', () => {
-		it('throws when task is archived — messaging is not allowed', async () => {
+		it('throws when task is archived — messaging is not allowed (with runtime)', async () => {
 			const archivedTask = { ...mockTask, status: 'archived' as const };
 			const { service } = makeRuntimeService(true, true, true);
 			setup({ task: archivedTask, runtimeService: service });
 
 			await expect(
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'can you still work?' }, {})
-			).rejects.toThrow('archived');
+			).rejects.toThrow('is archived and cannot receive messages');
+		});
+
+		it('throws when task is archived — messaging is not allowed (without runtime)', async () => {
+			const archivedTask = { ...mockTask, status: 'archived' as const };
+			setup({ task: archivedTask, runtimeService: makeNullRuntimeService() });
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'can you still work?' }, {})
+			).rejects.toThrow('is archived and cannot receive messages');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -485,6 +485,18 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			expect(setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled');
 		});
 	});
+
+	describe('archived task messaging — archived is truly terminal', () => {
+		it('throws when task is archived — messaging is not allowed', async () => {
+			const archivedTask = { ...mockTask, status: 'archived' as const };
+			const { service } = makeRuntimeService(true, true, true);
+			setup({ task: archivedTask, runtimeService: service });
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', message: 'can you still work?' }, {})
+			).rejects.toThrow('archived');
+		});
+	});
 });
 
 // ─── task.cancel Tests ───
@@ -884,6 +896,24 @@ describe('task.setStatus RPC Handler', () => {
 			await expect(
 				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'pending' }, {})
 			).rejects.toThrow('Invalid status transition');
+		});
+
+		it('throws for any transition from archived — archived is truly terminal', async () => {
+			const archivedTask = { ...mockTask, status: 'archived' as const };
+			setup({ task: archivedTask, runtimeService: makeNullRuntimeService() });
+			// Try every possible target status — all must be rejected
+			for (const targetStatus of [
+				'pending',
+				'in_progress',
+				'review',
+				'completed',
+				'cancelled',
+				'needs_attention',
+			] as const) {
+				await expect(
+					getHandler()({ roomId: 'room-1', taskId: 'task-1', status: targetStatus }, {})
+				).rejects.toThrow('Invalid status transition');
+			}
 		});
 	});
 


### PR DESCRIPTION
Add two missing test cases to task-handlers.test.ts:
- task.setStatus from archived to any status throws (archived is terminal)
- task.sendHumanMessage to an archived task throws

Also add explicit archived guard in sendHumanMessage handler so that
messaging an archived task fails with a clear error rather than falling
through to the group-lookup path.

82 tests pass (was 80).
