### PR TITLE
docs: implementation plan for persistent job queue adoption

### DIFF
--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
@@ -113,4 +113,4 @@ Milestones 2, 3, 4, and 5 can proceed in parallel after Milestone 1 is complete.
 
 ## Total Estimated Task Count
 
-19 tasks across 6 milestones.
+18 tasks across 6 milestones (3 + 3 + 3 + 4 + 2 + 3).

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Wire the existing but unused `JobQueueRepository` and `JobQueueProcessor` into the daemon lifecycle, then migrate all `setInterval`-based background tasks to the persistent job queue. This makes background work durable across daemon restarts and centralizes scheduling.
+Wire the existing but unused `JobQueueRepository` and `JobQueueProcessor` into the daemon lifecycle, then migrate the three primary `setInterval`-based background task subsystems to the persistent job queue. This makes background work durable across daemon restarts and centralizes scheduling.
 
 ## Background
 
@@ -16,7 +16,19 @@ PR #203 produced a comprehensive ADR (`docs/adr/0002-job-queue-migration.md`) ov
 The subsystems to migrate:
 1. **Session background tasks** -- fire-and-forget title generation tracked in `pendingBackgroundTasks` Set
 2. **GitHub polling** -- `setInterval` in `GitHubPollingService` (60s cycle)
-3. **Room runtime tick** -- `setInterval` in `RoomRuntime.start()` (30s cycle, 17 `scheduleTick()` call sites)
+3. **Room runtime tick** -- `setInterval` in `RoomRuntime.start()` (30s cycle), with **17 `scheduleTick()` call sites**, **6 `scheduleTickAfterRateLimitReset()` call sites** (lines 617, 696, 732, 985, 1052, 1084), and **2 `queueMicrotask(() => this.tick())` call sites** (lines 2241, 3421) — totaling ~23 scheduling points that need migration
+
+## Out of Scope
+
+The following `setInterval` users are explicitly **out of scope** for this migration and will remain as-is:
+
+- **`WebSocketServerTransport.staleCheckTimer`** (`packages/daemon/src/lib/websocket-server-transport.ts` line 87) — This is a transport-layer health check (30s stale connection cleanup), not a background business task. It operates at a different abstraction layer and does not benefit from persistence.
+- **`SpaceRuntime.tickTimer`** (`packages/daemon/src/lib/space/runtime/space-runtime.ts` line 226) — SpaceRuntime is a newer/parallel runtime implementation. Its tick loop follows the same pattern as RoomRuntime but is a separate subsystem. It should be migrated in a follow-up once RoomRuntime migration is proven stable.
+- **`TaskAgentManager` polling interval** (`packages/daemon/src/lib/space/runtime/task-agent-manager.ts` line 190) — Part of the SpaceRuntime subsystem, out of scope for the same reason.
+- **`JobQueueProcessor` internal poll timer** (`packages/daemon/src/storage/job-queue-processor.ts` line 38) — This is the job queue infrastructure itself; its internal `setInterval` is the mechanism that drives all job processing and is not a migration target.
+- **`app.ts` shutdown readiness check** (`packages/daemon/src/app.ts` line 367) — One-shot `setInterval` for graceful shutdown polling, not a recurring background task.
+
+Task 6.2 must explicitly verify these exclusions and document them in a code comment for future reference.
 
 ## Approach
 
@@ -25,22 +37,65 @@ Continue on the existing PR #203 branch (`plan/persistent-job-queue-adoption`). 
 **Key design decisions:**
 - Handlers self-schedule the next run (no dedicated scheduler service for now)
 - `listJobs` must be extended to accept `status` as an array for deduplication queries
-- Room tick deduplication uses application-level checks (not DB unique index) for simplicity
+- Room tick deduplication uses application-level checks (not DB unique index) for simplicity. **Risk acknowledged:** the check-then-enqueue pattern has a small race window. If this proves problematic in practice, a follow-up can add a unique partial index on `(queue, json_extract(payload, '$.roomId')) WHERE status IN ('pending', 'processing')` as the ADR suggests. For now the application-level approach is acceptable because: (a) SQLite serializes writes, limiting the race window; (b) a rare duplicate tick is harmless (tick is idempotent); (c) the dedup check should use "no pending job exists at all for this roomId" (not just "no future-scheduled job"), see detailed logic in Milestone 4.
 - `stopRuntime()` must call `runtimes.delete(roomId)` to fix the liveness check bug
+- **Pause/resume must cancel in-flight tick jobs** — see Milestone 4 for detailed design of pause/resume interaction with the job queue
+
+## Handler Registration and Startup Ordering
+
+All handlers **must** be registered before `jobProcessor.start()` is called. If a pending job exists in the DB from a previous run and no handler is registered for its queue, it will fail with "No handler registered" and consume retry attempts.
+
+**Required startup order in `app.ts`:**
+
+```
+1. sessionManager.start()       → registers 'session.title_generation' handler
+2. gitHubService.start()        → registers 'github.poll' handler + enqueues initial poll
+3. roomRuntimeService.start()   → registers 'room.tick' handler
+4. Register cleanup handler     → registers 'job_queue.cleanup' handler + enqueues initial cleanup
+5. jobProcessor.start()         → begins processing (all handlers now registered)
+```
+
+Each milestone's wiring task must respect this ordering. Task 1.2 must initially call `jobProcessor.start()` as the **last** step, and each subsequent milestone inserts its handler registration before that call.
+
+## maxConcurrent Configuration
+
+The initial `maxConcurrent: 3` is conservative. With multiple active rooms, each generating `room.tick` jobs every 30s, plus GitHub polling and title generation, the 3-slot limit may cause contention — a long-running title generation or poll could block room ticks.
+
+**Mitigation strategy:**
+- Start with `maxConcurrent: 5` instead of 3, based on expected workload (typically 1-3 active rooms + 1 GitHub poll + occasional title gen)
+- The processor's `dequeue` already handles priority via FIFO ordering; room ticks are short-lived and will cycle quickly
+- If contention appears in practice, the follow-up is per-queue concurrency limits (the ADR's open question on priority inversion)
+- Task 1.2 should make `maxConcurrent` configurable via environment variable (`NEOKAI_JOB_QUEUE_MAX_CONCURRENT`, default 5)
+
+## Stale Job Reclamation Timing
+
+`JobQueueProcessor.checkStaleJobs()` runs only after `STALE_CHECK_INTERVAL = 60_000ms` has elapsed since the last check. After a daemon restart, jobs stuck in `processing` from the previous run will sit unreclaimed for up to 60 seconds.
+
+**Mitigation:** Task 1.2 must add an eager `reclaimStale()` call in `JobQueueProcessor.start()` — immediately after starting, reclaim any stale jobs before the first poll tick. This ensures crash-recovery is instant rather than delayed by up to 60 seconds.
+
+## Rollback Strategy
+
+Each milestone removes old scheduling code (`setInterval`, `pendingBackgroundTasks`, etc.) and replaces it with job queue calls. If a milestone causes issues:
+
+1. **Revert the merge commit** for that milestone's PR — this restores the old `setInterval` code
+2. Old jobs in the `job_queue` table for the reverted subsystem will go stale and be cleaned up by the cleanup job (or manually via `DELETE FROM job_queue WHERE queue = '...'`)
+3. The job queue infrastructure (Milestone 1) can remain in place even if individual migrations are reverted
+
+For the highest-risk migration (Milestone 4 — room tick), the implementer should ensure the PR is small enough to revert cleanly and should include a feature flag or environment variable (`NEOKAI_USE_JOB_QUEUE_ROOM_TICK=true`) that can disable the migration without a full revert.
 
 ## Milestones
 
-1. **Foundation -- Wire JobQueueProcessor into DaemonApp** -- Instantiate processor in `app.ts`, add constants file, extend `listJobs` to accept status arrays, connect change notifier to ReactiveDatabase, hook into start/stop lifecycle.
+1. **Foundation -- Wire JobQueueProcessor into DaemonApp** -- Instantiate processor in `app.ts`, add constants file, extend `listJobs` to accept status arrays, connect change notifier to ReactiveDatabase, hook into start/stop lifecycle. Add eager stale reclamation on startup.
 
 2. **Migrate Session Background Tasks** -- Replace `pendingBackgroundTasks` Set in `SessionManager` with a `session.title_generation` job queue handler. Add `SessionManager.start()` method.
 
 3. **Migrate GitHub Polling** -- Replace `setInterval` in `GitHubPollingService` with self-scheduling `github.poll` jobs. Expose `triggerPoll()` method, register handler, add dedup logic in finally block.
 
-4. **Migrate Room Runtime Tick** -- Replace `setInterval` + `scheduleTick()` + `queueMicrotask` in `RoomRuntime` with `room.tick` jobs. Fix `stopRuntime()` to delete from runtimes map. Handle 17 `scheduleTick()` call sites.
+4. **Migrate Room Runtime Tick** -- Replace `setInterval` + `scheduleTick()` + `scheduleTickAfterRateLimitReset()` + `queueMicrotask` in `RoomRuntime` with `room.tick` jobs. Fix `stopRuntime()` to delete from runtimes map. Handle all ~23 scheduling call sites. Add pause/resume-aware job cancellation.
 
 5. **Database Cleanup Job and Stale Job Reclamation** -- Add a self-scheduling `job_queue.cleanup` job that runs daily. Remove old completed/dead jobs. Verify stale job reclamation works across restarts.
 
-6. **Integration Tests and E2E Validation** -- Online tests for crash-recovery scenarios across all migrated subsystems. Verify job processing resumes after daemon restart.
+6. **Integration Tests and E2E Validation** -- Online tests for crash-recovery scenarios across all migrated subsystems. Verify job processing resumes after daemon restart. Audit for remaining `setInterval` usage and document out-of-scope exclusions.
 
 ## Cross-Milestone Dependencies
 
@@ -58,4 +113,4 @@ Milestones 2, 3, 4, and 5 can proceed in parallel after Milestone 1 is complete.
 
 ## Total Estimated Task Count
 
-18 tasks across 6 milestones.
+19 tasks across 6 milestones.

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
@@ -1,0 +1,61 @@
+# Complete and Adopt Persistent Job Queue -- Continue from PR #203
+
+## Goal
+
+Wire the existing but unused `JobQueueRepository` and `JobQueueProcessor` into the daemon lifecycle, then migrate all `setInterval`-based background tasks to the persistent job queue. This makes background work durable across daemon restarts and centralizes scheduling.
+
+## Background
+
+PR #203 produced a comprehensive ADR (`docs/adr/0002-job-queue-migration.md`) over 13 review iterations. The plan is well-specified but zero production code has been implemented. The existing infrastructure includes:
+
+- `JobQueueRepository` (complete, 203 lines) -- CRUD, dequeue, retry, cleanup
+- `JobQueueProcessor` (complete, 123 lines) -- poll-based processor with handler registration
+- `job_queue` SQLite table with indexes
+- Comprehensive unit tests for both
+
+The subsystems to migrate:
+1. **Session background tasks** -- fire-and-forget title generation tracked in `pendingBackgroundTasks` Set
+2. **GitHub polling** -- `setInterval` in `GitHubPollingService` (60s cycle)
+3. **Room runtime tick** -- `setInterval` in `RoomRuntime.start()` (30s cycle, 17 `scheduleTick()` call sites)
+
+## Approach
+
+Continue on the existing PR #203 branch (`plan/persistent-job-queue-adoption`). Implement in 6 milestones, each producing a PR-ready commit. All work targets the `dev` branch.
+
+**Key design decisions:**
+- Handlers self-schedule the next run (no dedicated scheduler service for now)
+- `listJobs` must be extended to accept `status` as an array for deduplication queries
+- Room tick deduplication uses application-level checks (not DB unique index) for simplicity
+- `stopRuntime()` must call `runtimes.delete(roomId)` to fix the liveness check bug
+
+## Milestones
+
+1. **Foundation -- Wire JobQueueProcessor into DaemonApp** -- Instantiate processor in `app.ts`, add constants file, extend `listJobs` to accept status arrays, connect change notifier to ReactiveDatabase, hook into start/stop lifecycle.
+
+2. **Migrate Session Background Tasks** -- Replace `pendingBackgroundTasks` Set in `SessionManager` with a `session.title_generation` job queue handler. Add `SessionManager.start()` method.
+
+3. **Migrate GitHub Polling** -- Replace `setInterval` in `GitHubPollingService` with self-scheduling `github.poll` jobs. Expose `triggerPoll()` method, register handler, add dedup logic in finally block.
+
+4. **Migrate Room Runtime Tick** -- Replace `setInterval` + `scheduleTick()` + `queueMicrotask` in `RoomRuntime` with `room.tick` jobs. Fix `stopRuntime()` to delete from runtimes map. Handle 17 `scheduleTick()` call sites.
+
+5. **Database Cleanup Job and Stale Job Reclamation** -- Add a self-scheduling `job_queue.cleanup` job that runs daily. Remove old completed/dead jobs. Verify stale job reclamation works across restarts.
+
+6. **Integration Tests and E2E Validation** -- Online tests for crash-recovery scenarios across all migrated subsystems. Verify job processing resumes after daemon restart.
+
+## Cross-Milestone Dependencies
+
+```
+Milestone 1 (Foundation)
+  +-- Milestone 2 (Session tasks)
+  +-- Milestone 3 (GitHub polling)
+  +-- Milestone 4 (Room tick)
+  +-- Milestone 5 (Cleanup job)
+       |
+       +-- Milestone 6 (Integration tests) -- depends on Milestones 2, 3, 4, 5
+```
+
+Milestones 2, 3, 4, and 5 can proceed in parallel after Milestone 1 is complete. Milestone 6 depends on all prior milestones.
+
+## Total Estimated Task Count
+
+18 tasks across 6 milestones.

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Make the persistent job queue operational by wiring `JobQueueProcessor` into the daemon lifecycle, extending `listJobs` to support status arrays, creating queue name constants, and connecting the change notifier to `ReactiveDatabase`.
+Make the persistent job queue operational by wiring `JobQueueProcessor` into the daemon lifecycle, extending `listJobs` to support status arrays, creating queue name constants, connecting the change notifier to `ReactiveDatabase`, and adding eager stale job reclamation on startup.
 
 ## Scope
 
@@ -13,6 +13,7 @@ Make the persistent job queue operational by wiring `JobQueueProcessor` into the
 - Add `jobProcessor` and `jobQueue` to `DaemonAppContext`
 - Hook `jobProcessor.stop()` into cleanup (before `messageHub.cleanup()`)
 - Pass `jobQueue` and `jobProcessor` through `RPCHandlerDependencies`
+- Add eager `reclaimStale()` call in `JobQueueProcessor.start()` for instant crash recovery
 
 ## Tasks
 
@@ -46,9 +47,9 @@ Make the persistent job queue operational by wiring `JobQueueProcessor` into the
 
 ---
 
-### Task 1.2: Create job queue constants and wire processor into app.ts
+### Task 1.2: Create job queue constants, wire processor into app.ts, and add eager stale reclamation
 
-**Description:** Create the queue name constants file and wire `JobQueueProcessor` into the `DaemonApp` lifecycle. This includes instantiation, ReactiveDatabase change notification, cleanup ordering, and exposing via `DaemonAppContext`.
+**Description:** Create the queue name constants file and wire `JobQueueProcessor` into the `DaemonApp` lifecycle. This includes instantiation, ReactiveDatabase change notification, cleanup ordering, and exposing via `DaemonAppContext`. Also modify `JobQueueProcessor.start()` to eagerly reclaim stale jobs on startup (before the first poll tick) so crash-recovery is instant rather than delayed by up to 60 seconds.
 
 **Agent type:** coder
 
@@ -61,29 +62,35 @@ Make the persistent job queue operational by wiring `JobQueueProcessor` into the
    ROOM_TICK = 'room.tick'
    JOB_QUEUE_CLEANUP = 'job_queue.cleanup'
    ```
-3. In `packages/daemon/src/app.ts`:
+3. In `packages/daemon/src/storage/job-queue-processor.ts`:
+   - In `start()`, add `this.repo.reclaimStale(this.staleThresholdMs)` call **before** the first `this.tick()` call. This ensures any jobs left in `processing` from a previous crash are immediately reclaimed on startup, rather than waiting for the 60s `STALE_CHECK_INTERVAL`
+   - Add a unit test specifically for this eager reclamation behavior
+4. In `packages/daemon/src/app.ts`:
    - Import `JobQueueRepository` from `./storage/repositories/job-queue-repository`
    - Import `JobQueueProcessor` from `./storage/job-queue-processor`
    - After `liveQueries` creation (~line 101), instantiate:
      ```
      const jobQueue = new JobQueueRepository(db.getDatabase());
-     const jobProcessor = new JobQueueProcessor(jobQueue, { pollIntervalMs: 1000, maxConcurrent: 3, staleThresholdMs: 5 * 60 * 1000 });
+     const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
+     const jobProcessor = new JobQueueProcessor(jobQueue, { pollIntervalMs: 1000, maxConcurrent, staleThresholdMs: 5 * 60 * 1000 });
      ```
    - Call `jobProcessor.setChangeNotifier((table) => { reactiveDb.notifyChange(table); });`
-   - Before `gitHubService.start()` (~line 341), call `jobProcessor.start()` with log message
+   - **IMPORTANT startup ordering:** `jobProcessor.start()` must be the **last** startup call, placed AFTER all handler registrations. Initially (before Milestones 2-4 add their handlers), place it after `gitHubService.start()` (~line 341). Each subsequent milestone will insert handler registrations before this call.
    - In `cleanup()`, add `await jobProcessor.stop()` BEFORE `messageHub.cleanup()` (~line 394) with log message
-4. Add `jobProcessor: JobQueueProcessor` and `jobQueue: JobQueueRepository` to `DaemonAppContext` interface and return object
-5. Add `jobProcessor` and `jobQueue` to `RPCHandlerDependencies` in `packages/daemon/src/lib/rpc-handlers/index.ts` (interface only, no handler changes yet)
-6. Pass `jobProcessor` and `jobQueue` from `app.ts` to `setupRPCHandlers()`
-7. Run `bun run check` to verify no lint/type errors
-8. Create unit test `packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts` that verifies:
+5. Add `jobProcessor: JobQueueProcessor` and `jobQueue: JobQueueRepository` to `DaemonAppContext` interface and return object
+6. Add `jobProcessor` and `jobQueue` to `RPCHandlerDependencies` in `packages/daemon/src/lib/rpc-handlers/index.ts` (interface only, no handler changes yet)
+7. Pass `jobProcessor` and `jobQueue` from `app.ts` to `setupRPCHandlers()`
+8. Run `bun run check` to verify no lint/type errors
+9. Create unit test `packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts` that verifies:
    - `DaemonAppContext` includes `jobProcessor` and `jobQueue`
    - Cleanup stops the processor before messageHub
+   - `maxConcurrent` is configurable via env var
 
 **Acceptance criteria:**
-- `JobQueueProcessor` is instantiated in `app.ts` with `maxConcurrent: 3`
+- `JobQueueProcessor` is instantiated in `app.ts` with `maxConcurrent` defaulting to 5 (configurable via `NEOKAI_JOB_QUEUE_MAX_CONCURRENT`)
+- Eager `reclaimStale()` called in `start()` before first poll tick
 - Change notifier wired to `reactiveDb.notifyChange`
-- `jobProcessor.start()` called before server starts serving
+- `jobProcessor.start()` called AFTER all handler registrations
 - `jobProcessor.stop()` called in cleanup BEFORE `messageHub.cleanup()`
 - `jobProcessor` and `jobQueue` available in `DaemonAppContext`
 - `RPCHandlerDependencies` interface includes both fields
@@ -98,24 +105,32 @@ Make the persistent job queue operational by wiring `JobQueueProcessor` into the
 
 ### Task 1.3: Unit tests for processor lifecycle integration
 
-**Description:** Add comprehensive unit tests verifying the processor integrates correctly with the app lifecycle, including start/stop ordering and change notification flow.
+**Description:** Add unit tests verifying the `JobQueueProcessor` contract **in isolation** — specifically the behavioral contracts that the app-level wiring depends on. This focuses on processor internals (polling, dequeue, handler dispatch, stale reclamation, error/retry) and does NOT test app-level wiring (which is covered by Task 1.2's test file).
+
+**Scope clarification vs Task 1.2 tests:**
+- **Task 1.2** (`app/job-queue-lifecycle.test.ts`) tests app-level wiring: context fields, cleanup ordering, env var config
+- **Task 1.3** (`storage/job-queue-processor-lifecycle.test.ts`) tests processor contract: start → poll → dequeue → dispatch → stop, change notification callbacks, error → retry → dead transitions, stale reclamation timing, eager reclaim on start
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Create `packages/daemon/tests/unit/storage/job-queue-processor-lifecycle.test.ts`
-2. Test that `start()` begins polling and processes enqueued jobs
-3. Test that `stop()` waits for in-flight jobs to complete
-4. Test that `setChangeNotifier` is called when jobs complete
-5. Test that processor handles handler errors gracefully (retries, then marks dead)
-6. Test that stale job reclamation works after threshold
-7. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-processor-lifecycle.test.ts`
+2. Test that `start()` calls `reclaimStale()` eagerly before the first poll tick
+3. Test that `start()` begins polling and processes enqueued jobs via registered handlers
+4. Test that `stop()` waits for in-flight jobs to complete before resolving
+5. Test that `setChangeNotifier` callback is invoked when jobs complete (status transitions)
+6. Test that processor handles handler errors gracefully: first failure increments `attempts` and re-queues as `pending`; after `maxRetries` exhausted, marks as `dead`
+7. Test that stale job reclamation works: a job stuck in `processing` beyond `staleThresholdMs` is reset to `pending`
+8. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-processor-lifecycle.test.ts`
 
 **Acceptance criteria:**
-- Tests cover start/stop lifecycle
-- Tests cover change notification callback
-- Tests cover error handling and retry behavior
-- Tests cover stale job reclamation
+- Tests cover eager stale reclamation on start
+- Tests cover start → poll → dequeue → dispatch lifecycle
+- Tests cover stop draining in-flight jobs
+- Tests cover change notification callback invocation
+- Tests cover error → retry → dead transitions
+- Tests cover stale job reclamation timing
+- No overlap with Task 1.2's app-wiring tests
 - All tests pass
 
 **Depends on:** Task 1.2

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
@@ -1,0 +1,123 @@
+# Milestone 1: Foundation -- Wire JobQueueProcessor into DaemonApp
+
+## Goal
+
+Make the persistent job queue operational by wiring `JobQueueProcessor` into the daemon lifecycle, extending `listJobs` to support status arrays, creating queue name constants, and connecting the change notifier to `ReactiveDatabase`.
+
+## Scope
+
+- Extend `JobQueueRepository.listJobs()` to accept `status` as `JobStatus | JobStatus[]`
+- Create `packages/daemon/src/lib/job-queue-constants.ts` with queue name constants
+- Instantiate `JobQueueProcessor` in `app.ts`
+- Connect `setChangeNotifier` to `ReactiveDatabase`
+- Add `jobProcessor` and `jobQueue` to `DaemonAppContext`
+- Hook `jobProcessor.stop()` into cleanup (before `messageHub.cleanup()`)
+- Pass `jobQueue` and `jobProcessor` through `RPCHandlerDependencies`
+
+## Tasks
+
+### Task 1.1: Extend listJobs to accept status arrays
+
+**Description:** Modify `JobQueueRepository.listJobs()` to accept `status` as either a single `JobStatus` string or an array of `JobStatus` values. When an array is provided, generate `IN (?,?,...)` SQL with dynamic placeholders. Empty array returns no rows.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Read `packages/daemon/src/storage/repositories/job-queue-repository.ts` lines 128-147
+2. Change the `status` field type in the filter parameter from `status?: JobStatus` to `status?: JobStatus | JobStatus[]`
+3. Update the SQL generation: if array, build `AND status IN (?,?,...)`; if string, keep existing `AND status = ?`; if empty array, return `[]` early
+4. Update `packages/daemon/tests/unit/storage/job-queue-repository.test.ts` with tests for:
+   - `status: ['pending', 'processing']` returns jobs matching either status
+   - `status: 'pending'` (string) still works as before
+   - `status: []` (empty array) returns empty results
+5. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-repository.test.ts` to verify
+6. Run `bun run check` to verify no lint/type errors
+
+**Acceptance criteria:**
+- `listJobs({ status: ['pending', 'processing'] })` returns jobs with either status
+- `listJobs({ status: 'pending' })` still works (backward compatible)
+- `listJobs({ status: [] })` returns empty array
+- All existing job-queue-repository tests pass
+- New tests cover the array status filter
+
+**Depends on:** none
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 1.2: Create job queue constants and wire processor into app.ts
+
+**Description:** Create the queue name constants file and wire `JobQueueProcessor` into the `DaemonApp` lifecycle. This includes instantiation, ReactiveDatabase change notification, cleanup ordering, and exposing via `DaemonAppContext`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-queue-constants.ts` with constants:
+   ```
+   SESSION_TITLE_GENERATION = 'session.title_generation'
+   GITHUB_POLL = 'github.poll'
+   ROOM_TICK = 'room.tick'
+   JOB_QUEUE_CLEANUP = 'job_queue.cleanup'
+   ```
+3. In `packages/daemon/src/app.ts`:
+   - Import `JobQueueRepository` from `./storage/repositories/job-queue-repository`
+   - Import `JobQueueProcessor` from `./storage/job-queue-processor`
+   - After `liveQueries` creation (~line 101), instantiate:
+     ```
+     const jobQueue = new JobQueueRepository(db.getDatabase());
+     const jobProcessor = new JobQueueProcessor(jobQueue, { pollIntervalMs: 1000, maxConcurrent: 3, staleThresholdMs: 5 * 60 * 1000 });
+     ```
+   - Call `jobProcessor.setChangeNotifier((table) => { reactiveDb.notifyChange(table); });`
+   - Before `gitHubService.start()` (~line 341), call `jobProcessor.start()` with log message
+   - In `cleanup()`, add `await jobProcessor.stop()` BEFORE `messageHub.cleanup()` (~line 394) with log message
+4. Add `jobProcessor: JobQueueProcessor` and `jobQueue: JobQueueRepository` to `DaemonAppContext` interface and return object
+5. Add `jobProcessor` and `jobQueue` to `RPCHandlerDependencies` in `packages/daemon/src/lib/rpc-handlers/index.ts` (interface only, no handler changes yet)
+6. Pass `jobProcessor` and `jobQueue` from `app.ts` to `setupRPCHandlers()`
+7. Run `bun run check` to verify no lint/type errors
+8. Create unit test `packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts` that verifies:
+   - `DaemonAppContext` includes `jobProcessor` and `jobQueue`
+   - Cleanup stops the processor before messageHub
+
+**Acceptance criteria:**
+- `JobQueueProcessor` is instantiated in `app.ts` with `maxConcurrent: 3`
+- Change notifier wired to `reactiveDb.notifyChange`
+- `jobProcessor.start()` called before server starts serving
+- `jobProcessor.stop()` called in cleanup BEFORE `messageHub.cleanup()`
+- `jobProcessor` and `jobQueue` available in `DaemonAppContext`
+- `RPCHandlerDependencies` interface includes both fields
+- Constants file exists with all 4 queue names
+- All existing tests pass
+
+**Depends on:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 1.3: Unit tests for processor lifecycle integration
+
+**Description:** Add comprehensive unit tests verifying the processor integrates correctly with the app lifecycle, including start/stop ordering and change notification flow.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/unit/storage/job-queue-processor-lifecycle.test.ts`
+2. Test that `start()` begins polling and processes enqueued jobs
+3. Test that `stop()` waits for in-flight jobs to complete
+4. Test that `setChangeNotifier` is called when jobs complete
+5. Test that processor handles handler errors gracefully (retries, then marks dead)
+6. Test that stale job reclamation works after threshold
+7. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-processor-lifecycle.test.ts`
+
+**Acceptance criteria:**
+- Tests cover start/stop lifecycle
+- Tests cover change notification callback
+- Tests cover error handling and retry behavior
+- Tests cover stale job reclamation
+- All tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
@@ -1,0 +1,119 @@
+# Milestone 2: Migrate Session Background Tasks
+
+## Goal
+
+Replace the fire-and-forget `pendingBackgroundTasks` Set in `SessionManager` with a persistent `session.title_generation` job. Title generation becomes durable and survives daemon restarts.
+
+## Scope
+
+- Create `session.title_generation` job handler
+- Add `SessionManager.start()` method that registers the handler
+- Remove `pendingBackgroundTasks` from `SessionManager`
+- Replace fire-and-forget title generation with `jobQueue.enqueue()`
+
+## Key Files
+
+- `packages/daemon/src/lib/session/session-manager.ts` -- line 59 (`pendingBackgroundTasks`), lines 150-161 (title gen enqueue), lines 361-376 (cleanup drain)
+- `packages/daemon/src/lib/session/session-lifecycle.ts` -- `generateTitleAndRenameBranch()` method
+- `packages/daemon/src/storage/job-queue-processor.ts` -- handler registration
+- `packages/daemon/src/app.ts` -- call ordering
+
+## Tasks
+
+### Task 2.1: Create session title generation job handler
+
+**Description:** Create a job handler for `session.title_generation` that calls the existing `SessionLifecycle.generateTitleAndRenameBranch()` method. The handler extracts `sessionId` and `userMessageText` from the job payload.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-handlers/session-title.handler.ts`
+3. Define the handler function: accepts a `Job`, extracts `{ sessionId, userMessageText }` from payload, calls `sessionLifecycle.generateTitleAndRenameBranch(sessionId, userMessageText)`
+4. The handler should catch and log errors but not rethrow (title gen is non-fatal) -- actually, let errors propagate so the job queue retries
+5. Return `{ generated: true }` on success
+6. Create unit test `packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts`:
+   - Mock `SessionLifecycle` with a `generateTitleAndRenameBranch` stub
+   - Test successful title generation
+   - Test error propagation for retries
+   - Test missing session handling
+7. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Handler exists at `packages/daemon/src/lib/job-handlers/session-title.handler.ts`
+- Handler calls `generateTitleAndRenameBranch` with correct params from payload
+- Unit tests pass with mocked dependencies
+- Errors propagate for job queue retry logic
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.2: Wire handler into SessionManager and remove pendingBackgroundTasks
+
+**Description:** Add a `start()` method to `SessionManager` that registers the title generation handler with the job processor. Replace `pendingBackgroundTasks` usage with `jobQueue.enqueue()`. Update `app.ts` to call `sessionManager.start()` before `jobProcessor.start()`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/session/session-manager.ts`:
+   - Add `jobQueue: JobQueueRepository` and `jobProcessor: JobQueueProcessor` to constructor dependencies
+   - Add `start()` method that registers the `session.title_generation` handler on `jobProcessor`
+   - Replace lines 150-161 (the `pendingBackgroundTasks` tracking) with:
+     ```
+     this.jobQueue.enqueue({
+       queue: QUEUES.SESSION_TITLE_GENERATION,
+       payload: { sessionId, userMessageText },
+       maxRetries: 2,
+     });
+     ```
+   - Remove `private pendingBackgroundTasks: Set<Promise<unknown>>` field
+   - Update `cleanup()` to remove the pendingBackgroundTasks drain logic (lines 361-376) -- the job processor handles draining
+2. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `SessionManager` constructor
+   - Call `sessionManager.start()` after sessionManager creation but before `jobProcessor.start()`
+3. Update existing `SessionManager` unit tests to account for constructor changes
+4. Add unit test verifying `enqueue` is called instead of direct title generation
+5. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- `pendingBackgroundTasks` field completely removed from `SessionManager`
+- Title generation enqueued as a job instead of fire-and-forget Promise
+- `sessionManager.start()` registers the handler with `jobProcessor`
+- `app.ts` calls `sessionManager.start()` in correct order
+- All existing session-related tests pass
+- Cleanup no longer drains background tasks (processor handles this)
+
+**Depends on:** Task 2.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.3: Online test for session title generation via job queue
+
+**Description:** Create an online test that verifies title generation works end-to-end through the job queue, including retry on failure.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/lifecycle/session-title-job.test.ts`
+2. Use `createDaemonServer()` test helper to spin up a daemon
+3. Create a session, send a message, and verify:
+   - A `session.title_generation` job is enqueued
+   - The job is processed (status transitions: pending -> processing -> completed)
+   - The session title is updated
+4. Test retry behavior: mock title generation to fail on first attempt, succeed on second
+5. Run with `NEOKAI_USE_DEV_PROXY=1` for mocked API calls
+
+**Acceptance criteria:**
+- Online test verifies end-to-end title generation via job queue
+- Job status transitions are verified
+- Retry on failure is tested
+- Test runs successfully with dev proxy
+
+**Depends on:** Task 2.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
@@ -73,7 +73,7 @@ Replace the fire-and-forget `pendingBackgroundTasks` Set in `SessionManager` wit
    - Update `cleanup()` to remove the pendingBackgroundTasks drain logic (lines 361-376) -- the job processor handles draining
 2. In `packages/daemon/src/app.ts`:
    - Pass `jobQueue` and `jobProcessor` to `SessionManager` constructor
-   - Call `sessionManager.start()` after sessionManager creation but before `jobProcessor.start()`
+   - Call `sessionManager.start()` after sessionManager creation but before `jobProcessor.start()`. Per the startup ordering in `00-overview.md`, `sessionManager.start()` is step 1, `jobProcessor.start()` is step 5. Ensure the handler registration happens before the processor starts so that any pending `session.title_generation` jobs from a previous run are processed correctly on restart.
 3. Update existing `SessionManager` unit tests to account for constructor changes
 4. Add unit test verifying `enqueue` is called instead of direct title generation
 5. Run `bun run check` and all daemon tests

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
@@ -66,8 +66,9 @@ Replace the `setInterval`-based polling loop in `GitHubPollingService` with self
 **Subtasks:**
 1. In `packages/daemon/src/lib/github/polling-service.ts`:
    - Remove `setInterval` from `start()` -- `start()` becomes a state flag setter only
-   - Remove `clearInterval` from `stop()` -- `stop()` becomes a state flag setter
-   - Keep the `pollingInterval` field removal or rename to clarify it's no longer used
+   - Remove `clearInterval(this.pollingInterval)` from `stop()` — `stop()` becomes a state flag setter only
+   - Remove the `pollingInterval` field declaration and its type (`ReturnType<typeof setInterval> | null`)
+   - Remove any initialization of `pollingInterval` (e.g., `this.pollingInterval = null` in constructor)
 2. In `packages/daemon/src/lib/github/github-service.ts`:
    - Accept `jobQueue` and `jobProcessor` in `GitHubServiceOptions`
    - In `start()`: register the `github.poll` handler on `jobProcessor`, then enqueue the initial `github.poll` job with `runAt: Date.now()` (immediate first poll)

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
@@ -1,0 +1,118 @@
+# Milestone 3: Migrate GitHub Polling
+
+## Goal
+
+Replace the `setInterval`-based polling loop in `GitHubPollingService` with self-scheduling `github.poll` jobs. Polling becomes durable and recoverable after daemon restarts.
+
+## Scope
+
+- Expose a `triggerPoll()` method on `GitHubPollingService`
+- Create `github.poll` job handler with self-scheduling
+- Add deduplication in the finally block to prevent duplicate poll chains
+- Remove `setInterval` from `GitHubPollingService.start()`
+- Wire handler registration through `GitHubService`
+
+## Key Files
+
+- `packages/daemon/src/lib/github/polling-service.ts` -- line 76 (`setInterval`), `start()/stop()` methods, `pollAllRepositories()` (private)
+- `packages/daemon/src/lib/github/github-service.ts` -- orchestrator, `start()/stop()` lifecycle
+- `packages/daemon/src/app.ts` -- GitHub service creation and startup
+
+## Tasks
+
+### Task 3.1: Expose triggerPoll and create github.poll handler
+
+**Description:** Add a public `triggerPoll()` method to `GitHubPollingService` that calls the existing private `pollAllRepositories()`. Create a `github.poll` job handler that calls `triggerPoll()` and self-schedules the next poll.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. In `packages/daemon/src/lib/github/polling-service.ts`:
+   - Add public `async triggerPoll(): Promise<void>` that calls `this.pollAllRepositories()`
+   - Add a guard: if `this.isPolling` is true, skip (reuse existing mutex)
+3. Create `packages/daemon/src/lib/job-handlers/github-poll.handler.ts`:
+   - Handler calls `pollingService.triggerPoll()`
+   - In a `finally` block, check for existing pending/processing `github.poll` jobs using `jobQueue.listJobs({ queue: QUEUES.GITHUB_POLL, status: ['pending', 'processing'], limit: 1000 })`
+   - Only enqueue next poll job (with `runAt: Date.now() + intervalMs`) if no future-scheduled pending job exists (i.e., no job with `runAt > now`)
+   - Return `{ polled: true, nextRunAt }` on success
+4. Create unit test `packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts`:
+   - Mock `GitHubPollingService.triggerPoll()`
+   - Test handler calls triggerPoll
+   - Test self-scheduling enqueues next job
+   - Test dedup: if pending future job exists, skip enqueue
+   - Test error in triggerPoll still schedules next job (finally block)
+5. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- `GitHubPollingService` has a public `triggerPoll()` method
+- Handler calls triggerPoll and self-schedules
+- Dedup prevents duplicate poll chains
+- Errors in polling do not break the scheduling chain
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 3.2: Remove setInterval and wire handler into GitHubService
+
+**Description:** Remove the `setInterval` from `GitHubPollingService.start()` and wire the `github.poll` handler registration through `GitHubService`. The initial poll job is enqueued when `GitHubService.start()` is called.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/github/polling-service.ts`:
+   - Remove `setInterval` from `start()` -- `start()` becomes a state flag setter only
+   - Remove `clearInterval` from `stop()` -- `stop()` becomes a state flag setter
+   - Keep the `pollingInterval` field removal or rename to clarify it's no longer used
+2. In `packages/daemon/src/lib/github/github-service.ts`:
+   - Accept `jobQueue` and `jobProcessor` in `GitHubServiceOptions`
+   - In `start()`: register the `github.poll` handler on `jobProcessor`, then enqueue the initial `github.poll` job with `runAt: Date.now()` (immediate first poll)
+   - In `stop()`: no need to deregister -- processor stop handles this
+3. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `createGitHubService()`
+4. Update existing GitHub polling tests to account for removal of setInterval
+5. Add integration-style unit test verifying the full flow: GitHubService.start() -> enqueue -> handler -> triggerPoll -> self-schedule
+6. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- No `setInterval` in `GitHubPollingService`
+- `GitHubService.start()` enqueues initial `github.poll` job
+- Handler is registered on `jobProcessor`
+- Existing GitHub tests pass or are updated
+- Full flow unit test passes
+
+**Depends on:** Task 3.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 3.3: Online test for GitHub polling via job queue
+
+**Description:** Create an online test verifying GitHub polling works end-to-end through the job queue, including self-scheduling and recovery after restart.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/features/github-poll-job.test.ts`
+2. Use `createDaemonServer()` with GitHub config enabled
+3. Verify:
+   - `github.poll` job is enqueued on startup
+   - Job transitions through pending -> processing -> completed
+   - Next poll job is automatically scheduled
+   - No duplicate poll jobs exist simultaneously
+4. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- Online test verifies end-to-end GitHub polling via job queue
+- Self-scheduling chain is verified
+- Dedup is verified (no duplicate pending jobs)
+- Test runs with dev proxy
+
+**Depends on:** Task 3.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
@@ -33,8 +33,8 @@ Replace the `setInterval`-based polling loop in `GitHubPollingService` with self
    - Add a guard: if `this.isPolling` is true, skip (reuse existing mutex)
 3. Create `packages/daemon/src/lib/job-handlers/github-poll.handler.ts`:
    - Handler calls `pollingService.triggerPoll()`
-   - In a `finally` block, check for existing pending/processing `github.poll` jobs using `jobQueue.listJobs({ queue: QUEUES.GITHUB_POLL, status: ['pending', 'processing'], limit: 1000 })`
-   - Only enqueue next poll job (with `runAt: Date.now() + intervalMs`) if no future-scheduled pending job exists (i.e., no job with `runAt > now`)
+   - In a `finally` block, check for existing pending `github.poll` jobs using `jobQueue.listJobs({ queue: QUEUES.GITHUB_POLL, status: ['pending'], limit: 10 })`
+   - Only enqueue next poll job (with `runAt: Date.now() + intervalMs`) if **no pending job exists at all** — not just "no future-scheduled job". A pending job with `runAt` in the past means it's ready to run and the chain is alive; enqueuing another would create a duplicate. The check is simply: `if (pendingJobs.length === 0) { enqueue next }`
    - Return `{ polled: true, nextRunAt }` on success
 4. Create unit test `packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts`:
    - Mock `GitHubPollingService.triggerPoll()`
@@ -95,22 +95,26 @@ Replace the `setInterval`-based polling loop in `GitHubPollingService` with self
 
 **Description:** Create an online test verifying GitHub polling works end-to-end through the job queue, including self-scheduling and recovery after restart.
 
+**Note on GitHub API mocking:** The dev proxy (`NEOKAI_USE_DEV_PROXY=1`) only intercepts Anthropic API calls, not GitHub REST API calls. For this test, the focus is on verifying the **job queue mechanics** (enqueue, process, self-schedule, dedup) rather than actual GitHub API responses. The test should mock or stub the `GitHubPollingService.triggerPoll()` method to avoid real GitHub API calls, or configure the GitHub service with a test repository that doesn't require authentication.
+
 **Agent type:** coder
 
 **Subtasks:**
 1. Create `packages/daemon/tests/online/features/github-poll-job.test.ts`
 2. Use `createDaemonServer()` with GitHub config enabled
-3. Verify:
+3. Mock or stub `GitHubPollingService.triggerPoll()` to avoid real GitHub API calls — the test verifies job queue mechanics, not GitHub API integration
+4. Verify:
    - `github.poll` job is enqueued on startup
    - Job transitions through pending -> processing -> completed
    - Next poll job is automatically scheduled
    - No duplicate poll jobs exist simultaneously
-4. Run with `NEOKAI_USE_DEV_PROXY=1`
+5. Run with `NEOKAI_USE_DEV_PROXY=1`
 
 **Acceptance criteria:**
 - Online test verifies end-to-end GitHub polling via job queue
 - Self-scheduling chain is verified
 - Dedup is verified (no duplicate pending jobs)
+- Test does not make real GitHub API calls
 - Test runs with dev proxy
 
 **Depends on:** Task 3.2

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
@@ -1,0 +1,162 @@
+# Milestone 4: Migrate Room Runtime Tick
+
+## Goal
+
+Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `RoomRuntime` with persistent `room.tick` jobs. This is the highest-risk migration because room runtime manages agent sessions and task execution.
+
+## Scope
+
+- Create `room.tick` job handler
+- Replace `setInterval` in `RoomRuntime.start()` with job-based scheduling
+- Replace all 17 `scheduleTick()` call sites with `enqueueRoomTick()`
+- Replace `queueMicrotask` tick drain with job enqueueing
+- Fix `stopRuntime()` to call `runtimes.delete(roomId)`
+- Add `stoppedRooms` tracking for liveness checks
+- Wire handler through `RoomRuntimeService`
+
+## Key Files
+
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- 3474 lines; `tickTimer` at line 157, `setInterval` at line 422, `scheduleTick()` at line 3418, `queueMicrotask` at line 2241, `scheduleTickAfterRateLimitReset()` at line 3428
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` -- `stopRuntime()` at line 124, `startRuntime()` at line 135, `runtimes` Map at line 51
+
+## Tasks
+
+### Task 4.1: Create room.tick handler and enqueueRoomTick helper
+
+**Description:** Create the `room.tick` job handler and a helper function `enqueueRoomTick()` that deduplicates tick jobs per room. The handler calls `runtime.tick()` and re-schedules the next tick.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-handlers/room-tick.handler.ts`:
+   - Handler extracts `{ roomId }` from job payload
+   - Looks up runtime from a `getRuntimeForRoom` callback
+   - If runtime not found or state is not 'running', return `{ skipped: true }`
+   - Call `await runtime.tick()`
+   - In `finally` block: check if room is still active, if so call `enqueueRoomTick(roomId)` with delay
+3. Create `enqueueRoomTick(roomId, jobQueue, delayMs?)` helper function:
+   - Check for existing pending/processing `room.tick` jobs for this room using `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending', 'processing'], limit: 1000 })`
+   - Filter by `payload.roomId === roomId`
+   - Only enqueue if no matching job with `runAt > now` exists
+   - Default delay is 30,000ms (30s tick interval)
+4. Create unit test `packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts`:
+   - Mock RoomRuntime with tick() stub
+   - Test handler calls tick and re-schedules
+   - Test handler skips when runtime not found
+   - Test handler skips when runtime not running
+   - Test enqueueRoomTick dedup logic
+   - Test error in tick() still allows re-scheduling
+5. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Handler exists and correctly calls `runtime.tick()`
+- `enqueueRoomTick` deduplicates by roomId
+- Handler re-schedules next tick after completion
+- Errors in tick do not break the scheduling chain
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.2: Replace setInterval and scheduleTick in RoomRuntime
+
+**Description:** Remove `setInterval` from `RoomRuntime.start()`, remove the `scheduleTick()` method, and replace all 17 call sites with `enqueueRoomTick()`. This is the core migration task for the room runtime.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`:
+   - Add `jobQueue?: JobQueueRepository` to `RoomRuntimeConfig` interface
+   - Store `jobQueue` in the constructor
+   - In `start()` (line 420-424): Remove `this.tickTimer = setInterval(...)`, replace with `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate first tick
+   - In `stop()` (line 435-447): Remove `clearInterval(this.tickTimer)` and `this.tickTimer = null`
+   - Remove the `tickTimer` field (line 157)
+   - Replace `scheduleTick()` method (line 3418-3422) body: instead of `queueMicrotask(() => this.tick())`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate re-tick
+   - Replace `scheduleTickAfterRateLimitReset()` (line 3428-3452): instead of `setTimeout(() => this.scheduleTick(), delayMs)`, call `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)`
+   - Update line 2241 (`queueMicrotask(() => this.tick())`) to use `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
+   - Replace all 17 `this.scheduleTick()` call sites (lines 259, 423, 432, 553, 560, 665, 1024, 1149, 1287, 1315, 1588, 1700, 1815, 3364, 3410, 3432, 3451) -- some become `enqueueRoomTick`, some are in the replaced methods
+2. Ensure `RoomRuntime.tick()` remains the same public method signature -- it is now only called by the job handler
+3. Run existing room runtime tests to check for breakage
+4. Run `bun run check`
+
+**Acceptance criteria:**
+- No `setInterval` in `RoomRuntime`
+- No `tickTimer` field
+- `scheduleTick()` uses job queue instead of `queueMicrotask`
+- `scheduleTickAfterRateLimitReset()` uses job queue with delay instead of `setTimeout`
+- All 17 `scheduleTick()` call sites updated
+- `tick()` method signature unchanged
+- TypeScript compiles without errors
+
+**Depends on:** Task 4.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.3: Wire handler into RoomRuntimeService and fix stopRuntime bug
+
+**Description:** Register the `room.tick` handler in `RoomRuntimeService`, fix `stopRuntime()` to delete from the `runtimes` map, and pass `jobQueue` to `RoomRuntime` instances.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:
+   - Add `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
+   - In `start()`: register the `room.tick` handler on `jobProcessor`
+   - The handler needs access to `this.runtimes` map for runtime lookup
+   - Pass `jobQueue` to all `RoomRuntime` constructor calls (in `createOrGetRuntime`)
+2. Fix `stopRuntime()` (line 124-129): after `runtime.stop()`, add `this.runtimes.delete(roomId)` so that the heartbeat liveness check works correctly
+3. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
+4. Update `packages/daemon/src/lib/rpc-handlers/index.ts` to forward `jobQueue` and `jobProcessor` to `RoomRuntimeService`
+5. Update existing room runtime tests
+6. Add unit test verifying:
+   - Handler is registered on `start()`
+   - `stopRuntime()` removes from runtimes map
+   - `startRuntime()` creates runtime with jobQueue
+7. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- `room.tick` handler registered in `RoomRuntimeService.start()`
+- `stopRuntime()` calls `this.runtimes.delete(roomId)`
+- `jobQueue` passed to all `RoomRuntime` instances
+- Existing room tests pass
+- New tests verify handler registration and stopRuntime fix
+
+**Depends on:** Task 4.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.4: Online test for room tick via job queue
+
+**Description:** Create an online test verifying room ticks work end-to-end through the job queue, including dedup and recovery for stopped rooms.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/room/room-tick-job.test.ts`
+2. Use `createDaemonServer()` and create a room
+3. Verify:
+   - `room.tick` job is enqueued when room runtime starts
+   - Job processes and re-schedules
+   - No duplicate tick jobs for the same room
+   - Stopping a room prevents further tick scheduling
+   - Restarting a room resumes tick scheduling
+4. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- Online test verifies end-to-end room tick via job queue
+- Dedup verified (one pending tick per room)
+- Stop/restart lifecycle verified
+- Test runs with dev proxy
+
+**Depends on:** Task 4.3
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
@@ -2,58 +2,143 @@
 
 ## Goal
 
-Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `RoomRuntime` with persistent `room.tick` jobs. This is the highest-risk migration because room runtime manages agent sessions and task execution.
+Replace the `setInterval` + `scheduleTick()` + `scheduleTickAfterRateLimitReset()` + `queueMicrotask` pattern in `RoomRuntime` with persistent `room.tick` jobs. This is the highest-risk migration because room runtime manages agent sessions and task execution.
 
 ## Scope
 
 - Create `room.tick` job handler
 - Replace `setInterval` in `RoomRuntime.start()` with job-based scheduling
-- Replace all 17 `scheduleTick()` call sites with `enqueueRoomTick()`
-- Replace `queueMicrotask` tick drain with job enqueueing
+- Replace all `scheduleTick()` call sites (~17) with `enqueueRoomTick()`
+- Replace all `scheduleTickAfterRateLimitReset()` call sites (6) with `enqueueRoomTick(roomId, jobQueue, delayMs)`
+- Replace `queueMicrotask(() => this.tick())` call sites (2) with `enqueueRoomTick()`
+- Replace `tickLocked`/`tickQueued` mutex with job-queue-level dedup
+- Add pause/resume-aware job cancellation to prevent double ticks
 - Fix `stopRuntime()` to call `runtimes.delete(roomId)`
 - Add `stoppedRooms` tracking for liveness checks
 - Wire handler through `RoomRuntimeService`
+- Optional: feature flag `NEOKAI_USE_JOB_QUEUE_ROOM_TICK` for rollback safety
+
+## Scheduling Call Sites — Complete Inventory
+
+The implementer **must not rely on hardcoded line numbers** — they will shift after Milestones 1-3 are merged. Instead, search dynamically:
+
+```bash
+grep -n 'this\.scheduleTick()' packages/daemon/src/lib/room/runtime/room-runtime.ts
+grep -n 'this\.scheduleTickAfterRateLimitReset(' packages/daemon/src/lib/room/runtime/room-runtime.ts
+grep -n 'queueMicrotask.*this\.tick' packages/daemon/src/lib/room/runtime/room-runtime.ts
+```
+
+**As of current `dev` branch, the complete inventory is:**
+
+### `this.scheduleTick()` — 17 call sites
+Lines: 259, 423, 432, 553, 560, 665, 1024, 1149, 1287, 1315, 1588, 1700, 1815, 3364, 3410, 3432, 3451
+
+Of these, lines 3432 and 3451 are **inside** `scheduleTickAfterRateLimitReset()` and will be removed when that method is rewritten. So 15 external `scheduleTick()` sites need direct replacement.
+
+### `this.scheduleTickAfterRateLimitReset(groupId)` — 6 call sites
+Lines: 617, 696, 732, 985, 1052, 1084
+
+Each of these must be replaced with `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)` where `delayMs` is computed from `this.groupRepo.getRateLimitRemainingMs(groupId) + 5000` (the same logic currently in `scheduleTickAfterRateLimitReset()`). The delay computation must be **inlined at each call site** or extracted to a helper `getRateLimitDelay(groupId)` — the important thing is preserving the 5-second buffer.
+
+### `queueMicrotask(() => this.tick())` — 2 call sites
+Lines: 2241, 3421 (inside `scheduleTick()` body)
+
+Line 3421 disappears when `scheduleTick()` is rewritten. Line 2241 must be replaced with `enqueueRoomTick(this.roomId, this.jobQueue, 0)`.
+
+**Total: ~23 scheduling points** (15 external `scheduleTick` + 6 `scheduleTickAfterRateLimitReset` + 1 external `queueMicrotask` + the `setInterval` in `start()` = 23 distinct replacements).
+
+## Pause/Resume and Dedup Design
+
+### Current in-memory mutex
+
+The current `RoomRuntime` uses `tickLocked` and `tickQueued` fields as a lightweight mutex:
+- `tickLocked = true` while `tick()` is executing
+- `tickQueued = true` if a tick request arrives while locked — ensures one queued tick
+
+This in-memory state is lost when migrating to the job queue and must be replaced.
+
+### Job-queue-level dedup
+
+The `enqueueRoomTick()` helper handles dedup:
+- Before enqueuing, check `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })` and filter by `payload.roomId`
+- If **any** pending job exists for this roomId, skip enqueuing (regardless of `runAt`)
+- Jobs currently in `processing` status are fine — they're already executing and will self-schedule on completion
+- This replaces the `tickQueued` semantic: at most one pending tick exists per room
+
+### Pause/resume interaction
+
+**Problem:** After migration, `pause()` sets `this.state = 'paused'` but an already-enqueued `room.tick` job remains in the `pending` queue. When the processor picks it up, the handler checks `runtime.state !== 'running'` and skips — but the job still consumed a processing slot and the completed job's `finally` block might re-schedule.
+
+**Solution:**
+1. The `room.tick` handler's **first check** is `if (runtime.state !== 'running') return { skipped: true, reason: 'not running' }` — no re-schedule in finally when skipped
+2. `pause()` must cancel pending tick jobs: call `cancelPendingTickJobs(this.roomId, this.jobQueue)` which finds all pending `room.tick` jobs for this roomId and deletes them (or marks them `dead`)
+3. `resume()` calls `enqueueRoomTick(this.roomId, this.jobQueue, 0)` — a fresh tick is enqueued
+4. The handler's `finally` block **only** re-schedules if the runtime is still in `running` state AND the handler was not skipped
+
+This preserves the invariant: paused rooms have zero pending ticks, resumed rooms get exactly one.
+
+### `cancelPendingTickJobs(roomId, jobQueue)` helper
+
+```
+function cancelPendingTickJobs(roomId: string, jobQueue: JobQueueRepository): void {
+  const jobs = jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 });
+  for (const job of jobs) {
+    if (job.payload?.roomId === roomId) {
+      jobQueue.deleteJob(job.id);  // or mark as 'dead'
+    }
+  }
+}
+```
+
+If `JobQueueRepository` lacks a `deleteJob` method, add one in Task 4.1.
 
 ## Key Files
 
-- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- 3474 lines; `tickTimer` at line 157, `setInterval` at line 422, `scheduleTick()` at line 3418, `queueMicrotask` at line 2241, `scheduleTickAfterRateLimitReset()` at line 3428
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- 3474 lines; `tickTimer` at line 157, `tickLocked`/`tickQueued` at lines 155-156, `setInterval` at line 422, `scheduleTick()` at line 3418, `queueMicrotask` at line 2241, `scheduleTickAfterRateLimitReset()` at line 3428, `pause()` at line 426, `resume()` at line 430
 - `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` -- `stopRuntime()` at line 124, `startRuntime()` at line 135, `runtimes` Map at line 51
 
 ## Tasks
 
-### Task 4.1: Create room.tick handler and enqueueRoomTick helper
+### Task 4.1: Create room.tick handler, enqueueRoomTick, and cancelPendingTickJobs helpers
 
-**Description:** Create the `room.tick` job handler and a helper function `enqueueRoomTick()` that deduplicates tick jobs per room. The handler calls `runtime.tick()` and re-schedules the next tick.
+**Description:** Create the `room.tick` job handler and helper functions for dedup-aware tick enqueuing and pause-aware cancellation. The handler calls `runtime.tick()` and re-schedules the next tick only if the runtime is still running. Add `deleteJob` to `JobQueueRepository` if it doesn't exist.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root
-2. Create `packages/daemon/src/lib/job-handlers/room-tick.handler.ts`:
+2. Check if `JobQueueRepository` has a `deleteJob(id)` method. If not, add one (simple `DELETE FROM job_queue WHERE id = ?`)
+3. Create `packages/daemon/src/lib/job-handlers/room-tick.handler.ts`:
    - Handler extracts `{ roomId }` from job payload
    - Looks up runtime from a `getRuntimeForRoom` callback
-   - If runtime not found or state is not 'running', return `{ skipped: true }`
+   - If runtime not found or state is not 'running', return `{ skipped: true, reason: 'not running' }` — **do not re-schedule**
    - Call `await runtime.tick()`
-   - In `finally` block: check if room is still active, if so call `enqueueRoomTick(roomId)` with delay
-3. Create `enqueueRoomTick(roomId, jobQueue, delayMs?)` helper function:
-   - Check for existing pending/processing `room.tick` jobs for this room using `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending', 'processing'], limit: 1000 })`
+   - In `finally` block: re-check `runtime.state === 'running'`, if still running call `enqueueRoomTick(roomId, jobQueue, tickInterval)`; if not, skip re-schedule
+4. Create `enqueueRoomTick(roomId, jobQueue, delayMs?)` helper function:
+   - Check for existing pending `room.tick` jobs for this room using `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })`
    - Filter by `payload.roomId === roomId`
-   - Only enqueue if no matching job with `runAt > now` exists
+   - Only enqueue if **no pending job exists at all** for this roomId (not just "no future-scheduled job")
    - Default delay is 30,000ms (30s tick interval)
-4. Create unit test `packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts`:
+5. Create `cancelPendingTickJobs(roomId, jobQueue)` helper function:
+   - Find all pending `room.tick` jobs for this roomId
+   - Delete them via `jobQueue.deleteJob(id)`
+6. Create unit test `packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts`:
    - Mock RoomRuntime with tick() stub
-   - Test handler calls tick and re-schedules
-   - Test handler skips when runtime not found
-   - Test handler skips when runtime not running
-   - Test enqueueRoomTick dedup logic
-   - Test error in tick() still allows re-scheduling
-5. Run tests and `bun run check`
+   - Test handler calls tick and re-schedules when runtime is running
+   - Test handler skips and does NOT re-schedule when runtime not found
+   - Test handler skips and does NOT re-schedule when runtime is paused
+   - Test enqueueRoomTick dedup logic: second enqueue with existing pending job is a no-op
+   - Test cancelPendingTickJobs removes all pending jobs for a given roomId
+   - Test error in tick() still allows re-scheduling (if runtime still running)
+7. Run tests and `bun run check`
 
 **Acceptance criteria:**
 - Handler exists and correctly calls `runtime.tick()`
-- `enqueueRoomTick` deduplicates by roomId
-- Handler re-schedules next tick after completion
-- Errors in tick do not break the scheduling chain
+- Handler does NOT re-schedule when runtime is not running or paused
+- `enqueueRoomTick` deduplicates by roomId using "no pending job at all" check
+- `cancelPendingTickJobs` removes all pending tick jobs for a room
+- `deleteJob` method exists on `JobQueueRepository`
+- Errors in tick do not break the scheduling chain for running runtimes
 - Unit tests pass
 
 **Depends on:** Task 1.2
@@ -62,9 +147,16 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 
 ---
 
-### Task 4.2: Replace setInterval and scheduleTick in RoomRuntime
+### Task 4.2: Replace setInterval, scheduleTick, scheduleTickAfterRateLimitReset, and pause/resume in RoomRuntime
 
-**Description:** Remove `setInterval` from `RoomRuntime.start()`, remove the `scheduleTick()` method, and replace all 17 call sites with `enqueueRoomTick()`. This is the core migration task for the room runtime.
+**Description:** Remove `setInterval` from `RoomRuntime.start()`, rewrite `scheduleTick()` and `scheduleTickAfterRateLimitReset()`, replace all call sites, update `pause()`/`resume()` to interact with the job queue, and remove the in-memory `tickLocked`/`tickQueued` mutex.
+
+**IMPORTANT:** Do NOT rely on the line numbers listed below — they are approximate and will shift after Milestones 1-3. Use grep to find all call sites dynamically:
+```bash
+grep -n 'this\.scheduleTick()' room-runtime.ts
+grep -n 'this\.scheduleTickAfterRateLimitReset(' room-runtime.ts
+grep -n 'queueMicrotask.*this\.tick' room-runtime.ts
+```
 
 **Agent type:** coder
 
@@ -72,24 +164,37 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 1. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`:
    - Add `jobQueue?: JobQueueRepository` to `RoomRuntimeConfig` interface
    - Store `jobQueue` in the constructor
-   - In `start()` (line 420-424): Remove `this.tickTimer = setInterval(...)`, replace with `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate first tick
-   - In `stop()` (line 435-447): Remove `clearInterval(this.tickTimer)` and `this.tickTimer = null`
-   - Remove the `tickTimer` field (line 157)
-   - Replace `scheduleTick()` method (line 3418-3422) body: instead of `queueMicrotask(() => this.tick())`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate re-tick
-   - Replace `scheduleTickAfterRateLimitReset()` (line 3428-3452): instead of `setTimeout(() => this.scheduleTick(), delayMs)`, call `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)`
-   - Update line 2241 (`queueMicrotask(() => this.tick())`) to use `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
-   - Replace all 17 `this.scheduleTick()` call sites (lines 259, 423, 432, 553, 560, 665, 1024, 1149, 1287, 1315, 1588, 1700, 1815, 3364, 3410, 3432, 3451) -- some become `enqueueRoomTick`, some are in the replaced methods
-2. Ensure `RoomRuntime.tick()` remains the same public method signature -- it is now only called by the job handler
-3. Run existing room runtime tests to check for breakage
-4. Run `bun run check`
+   - Import `enqueueRoomTick`, `cancelPendingTickJobs` from the handler file
+   - **Optional feature flag:** Check `process.env.NEOKAI_USE_JOB_QUEUE_ROOM_TICK !== 'false'` to allow disabling the migration without a full revert. If `false`, fall back to the old `setInterval` behavior. (This is optional but recommended for rollback safety.)
+2. In `start()`: Remove `this.tickTimer = setInterval(...)`, replace with `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate first tick
+3. In `stop()`: Remove `clearInterval(this.tickTimer)` and `this.tickTimer = null`. Add `cancelPendingTickJobs(this.roomId, this.jobQueue)` to cancel any pending tick jobs.
+4. Remove the `tickTimer` field
+5. Remove `tickLocked` and `tickQueued` fields — dedup is now at the job queue level
+6. Update `tick()` method: remove the `tickLocked`/`tickQueued` mutex logic at entry and exit. The job queue processor's `maxConcurrent` and the handler's structure already prevent concurrent ticks for the same room.
+7. Rewrite `scheduleTick()`: instead of `queueMicrotask(() => this.tick())`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate re-tick
+8. Rewrite `scheduleTickAfterRateLimitReset(groupId)`:
+   - Compute `delayMs = this.groupRepo.getRateLimitRemainingMs(groupId) + 5000` (preserve the 5s buffer)
+   - If `delayMs <= 0`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
+   - Otherwise call `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)` — this replaces the `setTimeout` + `scheduleTick` pattern
+   - Keep the log message for observability
+9. Replace the standalone `queueMicrotask(() => this.tick())` at ~line 2241 with `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
+10. **Update `pause()`:** After setting `this.state = 'paused'`, call `cancelPendingTickJobs(this.roomId, this.jobQueue)` to drain any pending tick jobs
+11. **Update `resume()`:** After setting `this.state = 'running'`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` to start the tick chain fresh
+12. Verify all ~23 scheduling points are addressed by running the grep commands above — there should be zero remaining matches
+13. Run existing room runtime tests to check for breakage
+14. Run `bun run check`
 
 **Acceptance criteria:**
 - No `setInterval` in `RoomRuntime`
-- No `tickTimer` field
-- `scheduleTick()` uses job queue instead of `queueMicrotask`
-- `scheduleTickAfterRateLimitReset()` uses job queue with delay instead of `setTimeout`
-- All 17 `scheduleTick()` call sites updated
-- `tick()` method signature unchanged
+- No `tickTimer`, `tickLocked`, or `tickQueued` fields
+- `scheduleTick()` uses `enqueueRoomTick` instead of `queueMicrotask`
+- `scheduleTickAfterRateLimitReset()` uses `enqueueRoomTick` with computed delay instead of `setTimeout`
+- All 6 `scheduleTickAfterRateLimitReset` call sites preserved (they call the rewritten method)
+- The standalone `queueMicrotask` at ~line 2241 replaced
+- `pause()` cancels pending tick jobs
+- `resume()` enqueues a fresh tick
+- `tick()` method signature unchanged (still `async tick(): Promise<void>`)
+- `grep -c 'setInterval\|queueMicrotask.*tick\|tickTimer\|tickLocked\|tickQueued' room-runtime.ts` returns 0
 - TypeScript compiles without errors
 
 **Depends on:** Task 4.1
@@ -100,19 +205,19 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 
 ### Task 4.3: Wire handler into RoomRuntimeService and fix stopRuntime bug
 
-**Description:** Register the `room.tick` handler in `RoomRuntimeService`, fix `stopRuntime()` to delete from the `runtimes` map, and pass `jobQueue` to `RoomRuntime` instances.
+**Description:** Register the `room.tick` handler in `RoomRuntimeService`, fix `stopRuntime()` to delete from the `runtimes` map, and pass `jobQueue` to `RoomRuntime` instances. Ensure handler registration happens before `jobProcessor.start()` per the startup ordering in `00-overview.md`.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. In `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:
    - Add `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
-   - In `start()`: register the `room.tick` handler on `jobProcessor`
-   - The handler needs access to `this.runtimes` map for runtime lookup
+   - In `start()`: register the `room.tick` handler on `jobProcessor`. The handler needs access to `this.runtimes` map for runtime lookup by roomId.
    - Pass `jobQueue` to all `RoomRuntime` constructor calls (in `createOrGetRuntime`)
 2. Fix `stopRuntime()` (line 124-129): after `runtime.stop()`, add `this.runtimes.delete(roomId)` so that the heartbeat liveness check works correctly
 3. In `packages/daemon/src/app.ts`:
    - Pass `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
+   - Ensure `roomRuntimeService.start()` is called BEFORE `jobProcessor.start()` (per startup ordering: step 3 before step 5)
 4. Update `packages/daemon/src/lib/rpc-handlers/index.ts` to forward `jobQueue` and `jobProcessor` to `RoomRuntimeService`
 5. Update existing room runtime tests
 6. Add unit test verifying:
@@ -125,6 +230,7 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 - `room.tick` handler registered in `RoomRuntimeService.start()`
 - `stopRuntime()` calls `this.runtimes.delete(roomId)`
 - `jobQueue` passed to all `RoomRuntime` instances
+- Handler registration happens BEFORE `jobProcessor.start()` in `app.ts`
 - Existing room tests pass
 - New tests verify handler registration and stopRuntime fix
 
@@ -136,7 +242,7 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 
 ### Task 4.4: Online test for room tick via job queue
 
-**Description:** Create an online test verifying room ticks work end-to-end through the job queue, including dedup and recovery for stopped rooms.
+**Description:** Create an online test verifying room ticks work end-to-end through the job queue, including dedup, pause/resume job cancellation, and recovery for stopped rooms.
 
 **Agent type:** coder
 
@@ -146,14 +252,17 @@ Replace the `setInterval` + `scheduleTick()` + `queueMicrotask` pattern in `Room
 3. Verify:
    - `room.tick` job is enqueued when room runtime starts
    - Job processes and re-schedules
-   - No duplicate tick jobs for the same room
-   - Stopping a room prevents further tick scheduling
+   - No duplicate tick jobs for the same room (at most one pending)
+   - **Pause cancels pending ticks:** pause the runtime, verify no pending `room.tick` jobs for that room
+   - **Resume enqueues fresh tick:** resume the runtime, verify a new tick job is enqueued
+   - Stopping a room prevents further tick scheduling and cancels pending jobs
    - Restarting a room resumes tick scheduling
 4. Run with `NEOKAI_USE_DEV_PROXY=1`
 
 **Acceptance criteria:**
 - Online test verifies end-to-end room tick via job queue
-- Dedup verified (one pending tick per room)
+- Dedup verified (at most one pending tick per room)
+- Pause/resume lifecycle verified (pause cancels, resume enqueues)
 - Stop/restart lifecycle verified
 - Test runs with dev proxy
 

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
@@ -60,9 +60,9 @@ This in-memory state is lost when migrating to the job queue and must be replace
 ### Job-queue-level dedup
 
 The `enqueueRoomTick()` helper handles dedup:
-- Before enqueuing, check `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })` and filter by `payload.roomId`
+- Before enqueuing, check `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })` and filter by `payload.roomId`. The limit of 100 is sufficient because this is a per-room dedup check (at most one pending tick per room), not a global scan.
 - If **any** pending job exists for this roomId, skip enqueuing (regardless of `runAt`)
-- Jobs currently in `processing` status are fine — they're already executing and will self-schedule on completion
+- Only `pending` status is checked, not `processing`. This is safe because: (a) a `processing` job is already executing and its handler's `finally` block will either re-schedule (if runtime is still `running`) or not (if `paused`/`stopped`); (b) if `pause()` is called while a job is `processing`, the handler detects the paused state and skips without re-scheduling — leaving zero pending ticks, which is correct; (c) checking `processing` would cause `enqueueRoomTick` to skip when a tick is actively running, but the running tick's `finally` block handles the successor.
 - This replaces the `tickQueued` semantic: at most one pending tick exists per room
 
 ### Pause/resume interaction

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
@@ -25,8 +25,9 @@ Add a self-scheduling `job_queue.cleanup` job that runs daily to remove old comp
    - In `finally` block: dedup-check then enqueue next cleanup job with `runAt: Date.now() + 24 * 60 * 60 * 1000` (24 hours)
    - Return `{ deletedJobs, nextRunAt }`
 3. In `packages/daemon/src/app.ts` (or a new init function):
-   - After `jobProcessor.start()`, register the cleanup handler
-   - Check if a pending `job_queue.cleanup` job already exists; if not, enqueue one with `runAt: Date.now()` (run immediately on first boot, then daily)
+   - **BEFORE `jobProcessor.start()`** (step 4 in the startup ordering table — see `00-overview.md`), register the `job_queue.cleanup` handler on `jobProcessor`
+   - Then check if a pending `job_queue.cleanup` job already exists; if not, enqueue one with `runAt: Date.now()` (run immediately on first boot, then daily)
+   - This ordering is critical: if a cleanup job is pending from a previous run and the processor starts before the handler is registered, the job will fail with "No handler registered" and consume retry attempts
 4. Create unit test `packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts`:
    - Test cleanup deletes old jobs
    - Test self-scheduling

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
@@ -46,26 +46,30 @@ Add a self-scheduling `job_queue.cleanup` job that runs daily to remove old comp
 
 ---
 
-### Task 5.2: Verify stale job reclamation on restart
+### Task 5.2: Verify stale job reclamation on restart (with eager reclaim)
 
-**Description:** Add tests verifying that jobs stuck in `processing` status are reclaimed after daemon restart, ensuring no jobs are permanently lost.
+**Description:** Add tests verifying that jobs stuck in `processing` status are reclaimed **immediately** on daemon restart (via the eager `reclaimStale()` added in Task 1.2), ensuring no 60-second delay for crash recovery.
+
+**Note on timing:** `JobQueueProcessor.checkStaleJobs()` has a `STALE_CHECK_INTERVAL = 60_000ms` that normally delays reclamation. However, Task 1.2 added an eager `reclaimStale()` call in `start()` — this test must verify that eager reclamation works correctly, not just the periodic check.
 
 **Agent type:** coder
 
 **Subtasks:**
 1. Create `packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts`
 2. Test scenarios:
-   - Enqueue a job, mark it as processing (simulate mid-execution crash)
+   - Enqueue a job, mark it as processing with a `startedAt` older than `staleThresholdMs` (simulate mid-execution crash)
    - Create a new `JobQueueProcessor`, start it
-   - Verify the stale job is reclaimed after `staleThresholdMs`
+   - Verify the stale job is reclaimed **immediately on startup** (within the first poll tick, not after 60s)
    - Verify reclaimed job is re-processed by its handler
 3. Test that non-stale processing jobs are NOT reclaimed (within threshold)
-4. Run tests
+4. Test that the eager reclaim on startup does not interfere with jobs that are genuinely still processing (started recently)
+5. Run tests
 
 **Acceptance criteria:**
-- Stale jobs (processing for longer than threshold) are reclaimed
+- Stale jobs are reclaimed **immediately on startup** (not after 60s delay)
 - Reclaimed jobs are re-processed
 - Non-stale processing jobs left alone
+- Tests verify the eager reclaim path specifically
 - Tests pass
 
 **Depends on:** Task 1.2

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
@@ -1,0 +1,73 @@
+# Milestone 5: Database Cleanup Job and Stale Job Reclamation
+
+## Goal
+
+Add a self-scheduling `job_queue.cleanup` job that runs daily to remove old completed/dead jobs. Verify stale job reclamation works correctly on restart.
+
+## Scope
+
+- Create `job_queue.cleanup` handler
+- Schedule initial cleanup job on daemon start
+- Verify `reclaimStale()` reclaims stuck processing jobs on restart
+
+## Tasks
+
+### Task 5.1: Create cleanup handler and wire into app lifecycle
+
+**Description:** Create the `job_queue.cleanup` handler that removes old completed/dead jobs and self-schedules for the next day. Wire it into the daemon startup.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-handlers/cleanup.handler.ts`:
+   - Handler calls `jobQueue.cleanup(Date.now() - maxAge)` where `maxAge` defaults to 7 days
+   - In `finally` block: dedup-check then enqueue next cleanup job with `runAt: Date.now() + 24 * 60 * 60 * 1000` (24 hours)
+   - Return `{ deletedJobs, nextRunAt }`
+3. In `packages/daemon/src/app.ts` (or a new init function):
+   - After `jobProcessor.start()`, register the cleanup handler
+   - Check if a pending `job_queue.cleanup` job already exists; if not, enqueue one with `runAt: Date.now()` (run immediately on first boot, then daily)
+4. Create unit test `packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts`:
+   - Test cleanup deletes old jobs
+   - Test self-scheduling
+   - Test dedup (does not create duplicate cleanup jobs)
+5. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Cleanup handler removes completed/dead jobs older than 7 days
+- Self-schedules next run in 24 hours
+- Dedup prevents multiple pending cleanup jobs
+- Registered and initial job enqueued on daemon start
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 5.2: Verify stale job reclamation on restart
+
+**Description:** Add tests verifying that jobs stuck in `processing` status are reclaimed after daemon restart, ensuring no jobs are permanently lost.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts`
+2. Test scenarios:
+   - Enqueue a job, mark it as processing (simulate mid-execution crash)
+   - Create a new `JobQueueProcessor`, start it
+   - Verify the stale job is reclaimed after `staleThresholdMs`
+   - Verify reclaimed job is re-processed by its handler
+3. Test that non-stale processing jobs are NOT reclaimed (within threshold)
+4. Run tests
+
+**Acceptance criteria:**
+- Stale jobs (processing for longer than threshold) are reclaimed
+- Reclaimed jobs are re-processed
+- Non-stale processing jobs left alone
+- Tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
@@ -1,0 +1,95 @@
+# Milestone 6: Integration Tests and E2E Validation
+
+## Goal
+
+Comprehensive integration tests verifying crash-recovery, job resumption after restart, and end-to-end validation that all migrated subsystems work together through the job queue.
+
+## Scope
+
+- Online integration tests for crash-recovery across all migrated subsystems
+- Verify job processing resumes correctly after daemon restart
+- Verify no regressions in existing functionality
+- Clean up any remaining stale in-memory patterns
+
+## Tasks
+
+### Task 6.1: Integration test -- job queue crash recovery
+
+**Description:** Create integration tests that simulate daemon crash/restart scenarios and verify all job types resume correctly.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/tests/online/features/job-queue-crash-recovery.test.ts`
+3. Test scenarios:
+   - **Session title gen recovery:** Enqueue a title gen job, stop daemon before completion, restart daemon, verify job is reclaimed and processed
+   - **GitHub poll chain recovery:** Start daemon with GitHub polling, stop daemon mid-poll, restart, verify poll chain resumes without manual intervention
+   - **Room tick recovery:** Create a room, start ticking, stop daemon, restart, verify room ticks resume
+   - **Cleanup job recovery:** Enqueue cleanup job, stop daemon before it runs, restart, verify cleanup runs
+4. Each test uses `createDaemonServer()`, enqueues jobs, then creates a fresh daemon against the same database
+5. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- All four crash-recovery scenarios pass
+- Jobs transition correctly through status changes
+- No lost jobs after restart
+- Self-scheduling chains resume correctly
+
+**Depends on:** Task 2.2, Task 3.2, Task 4.3, Task 5.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 6.2: Cleanup stale in-memory patterns and final verification
+
+**Description:** Remove any remaining dead code from the pre-migration patterns. Run the full test suite to verify no regressions.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Search for remaining `setInterval` patterns in daemon code that should now use job queue:
+   - Confirm `GitHubPollingService` has no `setInterval`
+   - Confirm `RoomRuntime` has no `setInterval` or `tickTimer`
+   - Confirm `SessionManager` has no `pendingBackgroundTasks`
+2. Run `bun run check` (lint + typecheck + knip) to catch dead exports
+3. Run `make test-daemon` for full daemon test suite
+4. Run `make test-web` for full web test suite
+5. Fix any failures found
+6. Create a summary of all changes made across the milestone
+
+**Acceptance criteria:**
+- No `setInterval` for background tasks in migrated subsystems
+- No `pendingBackgroundTasks` in SessionManager
+- `bun run check` passes (no lint, type, or dead export errors)
+- All daemon tests pass
+- All web tests pass
+
+**Depends on:** Task 6.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 6.3: E2E test for job queue health indicator (optional)
+
+**Description:** If time permits, add a minimal E2E test that verifies background tasks continue working from the user's perspective -- sessions get titles, rooms tick, etc.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/e2e/tests/features/job-queue-background-tasks.e2e.ts`
+2. Test via UI:
+   - Create a session, send a message, verify the session title updates (title gen job worked)
+   - If room UI is available: create a room, verify it shows activity (ticks are happening)
+3. All assertions through visible DOM state per E2E rules
+
+**Acceptance criteria:**
+- E2E test verifies background tasks work from user perspective
+- Session title generation visible in UI
+- All assertions via DOM state
+
+**Depends on:** Task 6.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
@@ -10,6 +10,7 @@ Comprehensive integration tests verifying crash-recovery, job resumption after r
 - Verify job processing resumes correctly after daemon restart
 - Verify no regressions in existing functionality
 - Clean up any remaining stale in-memory patterns
+- Audit and document out-of-scope `setInterval` usage
 
 ## Tasks
 
@@ -17,24 +18,30 @@ Comprehensive integration tests verifying crash-recovery, job resumption after r
 
 **Description:** Create integration tests that simulate daemon crash/restart scenarios and verify all job types resume correctly.
 
+**Important implementation note:** `createDaemonServer()` typically creates a fresh database. For crash-recovery tests, you must explicitly configure a **file-backed SQLite database** that persists across daemon instances. Pass the same database path to both the first and second daemon instances so that jobs from the first run survive into the second run.
+
 **Agent type:** coder
 
 **Subtasks:**
 1. Run `bun install` at the worktree root
 2. Create `packages/daemon/tests/online/features/job-queue-crash-recovery.test.ts`
-3. Test scenarios:
-   - **Session title gen recovery:** Enqueue a title gen job, stop daemon before completion, restart daemon, verify job is reclaimed and processed
+3. Configure tests to use a **file-backed SQLite database** (e.g., `tmp/test-crash-recovery.db`) that persists across daemon restarts
+4. Test scenarios:
+   - **Session title gen recovery:** Enqueue a title gen job, stop daemon before completion, restart daemon with same DB, verify job is reclaimed and processed (should happen immediately due to eager `reclaimStale()`)
    - **GitHub poll chain recovery:** Start daemon with GitHub polling, stop daemon mid-poll, restart, verify poll chain resumes without manual intervention
    - **Room tick recovery:** Create a room, start ticking, stop daemon, restart, verify room ticks resume
    - **Cleanup job recovery:** Enqueue cleanup job, stop daemon before it runs, restart, verify cleanup runs
-4. Each test uses `createDaemonServer()`, enqueues jobs, then creates a fresh daemon against the same database
-5. Run with `NEOKAI_USE_DEV_PROXY=1`
+5. Each test uses `createDaemonServer()` with explicit DB path, enqueues jobs, stops daemon, then creates a fresh daemon against the same database file
+6. Clean up temporary database files in `afterEach`/`afterAll`
+7. Run with `NEOKAI_USE_DEV_PROXY=1`
 
 **Acceptance criteria:**
 - All four crash-recovery scenarios pass
 - Jobs transition correctly through status changes
 - No lost jobs after restart
 - Self-scheduling chains resume correctly
+- Eager stale reclamation verified (jobs reclaimed immediately, not after 60s)
+- File-backed DB used (not in-memory)
 
 **Depends on:** Task 2.2, Task 3.2, Task 4.3, Task 5.1
 
@@ -42,26 +49,42 @@ Comprehensive integration tests verifying crash-recovery, job resumption after r
 
 ---
 
-### Task 6.2: Cleanup stale in-memory patterns and final verification
+### Task 6.2: Cleanup stale in-memory patterns, audit setInterval usage, and final verification
 
-**Description:** Remove any remaining dead code from the pre-migration patterns. Run the full test suite to verify no regressions.
+**Description:** Remove any remaining dead code from the pre-migration patterns. Audit all `setInterval` usage in the daemon codebase and document which are in-scope (migrated) and which are out-of-scope (with reasons). Run the full test suite to verify no regressions.
 
 **Agent type:** coder
 
 **Subtasks:**
-1. Search for remaining `setInterval` patterns in daemon code that should now use job queue:
+1. Search for remaining `setInterval` patterns in daemon code:
    - Confirm `GitHubPollingService` has no `setInterval`
-   - Confirm `RoomRuntime` has no `setInterval` or `tickTimer`
+   - Confirm `RoomRuntime` has no `setInterval`, `tickTimer`, `tickLocked`, or `tickQueued`
    - Confirm `SessionManager` has no `pendingBackgroundTasks`
-2. Run `bun run check` (lint + typecheck + knip) to catch dead exports
-3. Run `make test-daemon` for full daemon test suite
-4. Run `make test-web` for full web test suite
-5. Fix any failures found
-6. Create a summary of all changes made across the milestone
+2. **Audit all remaining `setInterval` usage** and verify they are out-of-scope:
+   - `WebSocketServerTransport.staleCheckTimer` — transport-layer health check, not a business task → out of scope
+   - `SpaceRuntime.tickTimer` — separate runtime subsystem, migrate in follow-up → out of scope
+   - `TaskAgentManager` polling interval — part of SpaceRuntime subsystem → out of scope
+   - `JobQueueProcessor` internal poll timer — this IS the job queue infrastructure → out of scope
+   - `app.ts` shutdown readiness check — one-shot shutdown polling → out of scope
+3. Add a code comment in `app.ts` (near the job queue setup) documenting the out-of-scope `setInterval` users for future reference, e.g.:
+   ```
+   // Out-of-scope setInterval users (not migrated to job queue):
+   // - WebSocketServerTransport.staleCheckTimer (transport-layer health check)
+   // - SpaceRuntime.tickTimer (separate runtime, migrate in follow-up)
+   // - TaskAgentManager polling (part of SpaceRuntime)
+   // - JobQueueProcessor internal poll (job queue infrastructure itself)
+   // - app.ts shutdown readiness check (one-shot)
+   ```
+4. Run `bun run check` (lint + typecheck + knip) to catch dead exports
+5. Run `make test-daemon` for full daemon test suite
+6. Run `make test-web` for full web test suite
+7. Fix any failures found
+8. Create a summary of all changes made across the milestone
 
 **Acceptance criteria:**
 - No `setInterval` for background tasks in migrated subsystems
 - No `pendingBackgroundTasks` in SessionManager
+- All remaining `setInterval` usage documented as out-of-scope with reasons
 - `bun run check` passes (no lint, type, or dead export errors)
 - All daemon tests pass
 - All web tests pass


### PR DESCRIPTION
## Summary

Implementation plan for completing and adopting the persistent job queue, continuing from the ADR in PR #203.

- 6 milestones, 18 tasks covering the full migration
- Foundation: wire JobQueueProcessor into DaemonApp, extend listJobs for status arrays
- Migrate session background tasks (pendingBackgroundTasks -> job queue)
- Migrate GitHub polling (setInterval -> self-scheduling jobs)
- Migrate room runtime tick (setInterval + scheduleTick -> job queue)
- Add cleanup job and stale reclamation verification
- Integration tests and E2E validation

## Test plan

- [ ] Review plan files for completeness and accuracy
- [ ] Verify task dependencies are correctly ordered
- [ ] Confirm all affected files are identified