### PR TITLE
feat: update shared types for flexible SpaceSessionGroup model

### DIFF
--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -25,6 +25,24 @@ export interface UpdateSessionGroupParams {
 	taskId?: string | null;
 }
 
+export interface AddMemberParams {
+	/** Freeform role string matching SpaceAgent.role (e.g. 'coder', 'reviewer', 'security-auditor') */
+	role: string;
+	/** Display order within the group (default: 0) */
+	orderIndex?: number;
+	/** ID of the SpaceAgent config this session uses (nullable for system agents) */
+	agentId?: string;
+	/** Initial lifecycle state (default: 'active') */
+	status?: 'active' | 'completed' | 'failed';
+}
+
+export interface UpdateMemberParams {
+	role?: string;
+	orderIndex?: number;
+	agentId?: string | null;
+	status?: 'active' | 'completed' | 'failed';
+}
+
 export class SpaceSessionGroupRepository {
 	constructor(private db: BunDatabase) {}
 
@@ -84,16 +102,14 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
-	 * Get all session groups that contain a specific task's associated sessions.
-	 * Returns groups matching by spaceId and name pattern (groups for a given task).
+	 * Get all session groups associated with a specific task.
+	 * Queries by the `task_id` column set at group creation time.
 	 */
 	getGroupsByTask(spaceId: string, taskId: string): SpaceSessionGroup[] {
-		// Groups are associated to tasks by their name convention (e.g. "task:{taskId}")
-		// or by querying members. We query groups that are named for a task.
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_session_groups WHERE space_id = ? AND name = ? ORDER BY created_at ASC`
+			`SELECT * FROM space_session_groups WHERE space_id = ? AND task_id = ? ORDER BY created_at ASC`
 		);
-		const rows = stmt.all(spaceId, `task:${taskId}`) as Record<string, unknown>[];
+		const rows = stmt.all(spaceId, taskId) as Record<string, unknown>[];
 
 		return rows.map((row) => {
 			const members = this.getGroupMembers(row.id as string);
@@ -152,17 +168,12 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
-	 * Add a session member to a group
-	 * Idempotent — updates role/orderIndex if the session is already a member
+	 * Add a session member to a group.
+	 * Idempotent — if the session is already a member, updates all provided fields.
 	 */
-	addMember(
-		groupId: string,
-		sessionId: string,
-		role: string,
-		orderIndex = 0,
-		agentId?: string,
-		status: 'active' | 'completed' | 'failed' = 'active'
-	): SpaceSessionGroupMember {
+	addMember(groupId: string, sessionId: string, params: AddMemberParams): SpaceSessionGroupMember {
+		const { role, orderIndex = 0, agentId, status = 'active' } = params;
+
 		const existing = this.db
 			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
 			.get(groupId, sessionId) as Record<string, unknown> | undefined;
@@ -192,6 +203,63 @@ export class SpaceSessionGroupRepository {
 			.run(now, groupId);
 
 		return this.getMember(id)!;
+	}
+
+	/**
+	 * Update fields on an existing group member (e.g. transition status after session completes).
+	 * Returns null if the member record does not exist.
+	 */
+	updateMember(
+		groupId: string,
+		sessionId: string,
+		params: UpdateMemberParams
+	): SpaceSessionGroupMember | null {
+		const fields: string[] = [];
+		const values: (string | number | null)[] = [];
+
+		if (params.role !== undefined) {
+			fields.push('role = ?');
+			values.push(params.role);
+		}
+		if (params.orderIndex !== undefined) {
+			fields.push('order_index = ?');
+			values.push(params.orderIndex);
+		}
+		if (params.agentId !== undefined) {
+			fields.push('agent_id = ?');
+			values.push(params.agentId ?? null);
+		}
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+		}
+
+		if (fields.length === 0) {
+			// Nothing to update — return current state
+			const row = this.db
+				.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+				.get(groupId, sessionId) as Record<string, unknown> | undefined;
+			return row ? this.rowToMember(row) : null;
+		}
+
+		values.push(groupId, sessionId);
+		const result = this.db
+			.prepare(
+				`UPDATE space_session_group_members SET ${fields.join(', ')} WHERE group_id = ? AND session_id = ?`
+			)
+			.run(...values);
+
+		if (result.changes === 0) return null;
+
+		// Touch group updated_at
+		this.db
+			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+			.run(Date.now(), groupId);
+
+		const updated = this.db
+			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+			.get(groupId, sessionId) as Record<string, unknown> | undefined;
+		return updated ? this.rowToMember(updated) : null;
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -14,6 +14,7 @@ export interface CreateSessionGroupParams {
 	description?: string;
 	workflowRunId?: string;
 	currentStepId?: string;
+	taskId?: string;
 }
 
 export interface UpdateSessionGroupParams {
@@ -21,6 +22,7 @@ export interface UpdateSessionGroupParams {
 	description?: string;
 	workflowRunId?: string | null;
 	currentStepId?: string | null;
+	taskId?: string | null;
 }
 
 export class SpaceSessionGroupRepository {
@@ -34,8 +36,8 @@ export class SpaceSessionGroupRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, task_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -45,6 +47,7 @@ export class SpaceSessionGroupRepository {
 			params.description ?? null,
 			params.workflowRunId ?? null,
 			params.currentStepId ?? null,
+			params.taskId ?? null,
 			now,
 			now
 		);
@@ -121,6 +124,10 @@ export class SpaceSessionGroupRepository {
 			fields.push('current_step_id = ?');
 			values.push(params.currentStepId ?? null);
 		}
+		if (params.taskId !== undefined) {
+			fields.push('task_id = ?');
+			values.push(params.taskId ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -151,8 +158,10 @@ export class SpaceSessionGroupRepository {
 	addMember(
 		groupId: string,
 		sessionId: string,
-		role: 'worker' | 'leader',
-		orderIndex = 0
+		role: string,
+		orderIndex = 0,
+		agentId?: string,
+		status: 'active' | 'completed' | 'failed' = 'active'
 	): SpaceSessionGroupMember {
 		const existing = this.db
 			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
@@ -161,9 +170,9 @@ export class SpaceSessionGroupRepository {
 		if (existing) {
 			this.db
 				.prepare(
-					`UPDATE space_session_group_members SET role = ?, order_index = ? WHERE group_id = ? AND session_id = ?`
+					`UPDATE space_session_group_members SET role = ?, order_index = ?, agent_id = ?, status = ? WHERE group_id = ? AND session_id = ?`
 				)
-				.run(role, orderIndex, groupId, sessionId);
+				.run(role, orderIndex, agentId ?? null, status, groupId, sessionId);
 			return this.getMember(existing.id as string)!;
 		}
 
@@ -172,10 +181,10 @@ export class SpaceSessionGroupRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, agent_id, status, order_index, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 			)
-			.run(id, groupId, sessionId, role, orderIndex, now);
+			.run(id, groupId, sessionId, role, agentId ?? null, status, orderIndex, now);
 
 		// Touch group updated_at
 		this.db
@@ -240,6 +249,7 @@ export class SpaceSessionGroupRepository {
 			description: (row.description as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			currentStepId: (row.current_step_id as string | null) ?? undefined,
+			taskId: (row.task_id as string | null) ?? undefined,
 			members,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
@@ -254,7 +264,9 @@ export class SpaceSessionGroupRepository {
 			id: row.id as string,
 			groupId: row.group_id as string,
 			sessionId: row.session_id as string,
-			role: row.role as 'worker' | 'leader',
+			role: row.role as string,
+			agentId: (row.agent_id as string | null) ?? undefined,
+			status: ((row.status as string | null) ?? 'active') as 'active' | 'completed' | 'failed',
 			orderIndex: row.order_index as number,
 			createdAt: row.created_at as number,
 		};

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1488,8 +1488,8 @@ function runMigration28(db: BunDatabase): void {
  * - space_workflow_transitions: directed edges between steps (graph navigation)
  * - space_workflow_runs: active/historical workflow executions (includes current_step_id)
  * - space_tasks: tasks with built-in custom_agent_id, workflow_run_id, workflow_step_id
- * - space_session_groups: named groups of related sessions (includes workflow_run_id, current_step_id)
- * - space_session_group_members: membership records for session groups
+ * - space_session_groups: named groups of related sessions (includes workflow_run_id, current_step_id, task_id)
+ * - space_session_group_members: membership records with freeform role, agent_id, and status
  *
  * All tables are created with IF NOT EXISTS so the migration is idempotent.
  * CASCADE deletes propagate from spaces → all child tables.
@@ -1711,6 +1711,7 @@ function runMigration29(db: BunDatabase): void {
 			description TEXT,
 			workflow_run_id TEXT,
 			current_step_id TEXT,
+			task_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -1728,8 +1729,10 @@ function runMigration29(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			group_id TEXT NOT NULL,
 			session_id TEXT NOT NULL,
-			role TEXT NOT NULL
-				CHECK(role IN ('worker', 'leader')),
+			role TEXT NOT NULL,
+			agent_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'completed', 'failed')),
 			order_index INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -173,6 +173,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			description TEXT,
 			workflow_run_id TEXT,
 			current_step_id TEXT,
+			task_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -184,8 +185,10 @@ export function createSpaceTables(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			group_id TEXT NOT NULL,
 			session_id TEXT NOT NULL,
-			role TEXT NOT NULL
-				CHECK(role IN ('worker', 'leader')),
+			role TEXT NOT NULL,
+			agent_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'completed', 'failed')),
 			order_index INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,8 +4,12 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration37 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration40 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
+ *
+ * IMPORTANT: The schema defined here must exactly match the fully-migrated production
+ * schema (i.e. after all migrations have run). Never add columns or constraints here
+ * that do not yet exist in a production migration — that masks schema divergence.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -437,25 +437,58 @@ describe('Migration 29: Space system tables', () => {
 			 VALUES ('sg-5', 'sp-5', 'Group 5', ${now}, ${now})`
 		);
 
-		// Former enum values still work
-		for (const role of ['worker', 'leader']) {
+		// All role strings are valid — no CHECK constraint on role
+		for (const role of [
+			'worker',
+			'leader',
+			'coder',
+			'reviewer',
+			'security-auditor',
+			'any-custom-role',
+		]) {
 			expect(() => {
 				db.exec(
 					`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
 					 VALUES ('sgm-${role}', 'sg-5', 'sess-${role}', '${role}', 0, ${now})`
+				);
+			}).not.toThrow();
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// space_session_group_members status CHECK
+	// -------------------------------------------------------------------------
+
+	test('space_session_group_members status CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-status', '/workspace/status', 'Status Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_session_groups (id, space_id, name, created_at, updated_at)
+			 VALUES ('sg-status', 'sp-status', 'Status Group', ${now}, ${now})`
+		);
+
+		// Valid statuses
+		for (const status of ['active', 'completed', 'failed']) {
+			expect(() => {
+				db.exec(
+					`INSERT INTO space_session_group_members (id, group_id, session_id, role, status, order_index, created_at)
+					 VALUES ('sgm-${status}', 'sg-status', 'sess-${status}', 'coder', '${status}', 0, ${now})`
 				);
 			}).not.toThrow();
 		}
 
-		// Arbitrary freeform roles now accepted (migration 40 dropped the CHECK)
-		for (const role of ['observer', 'security-auditor', 'coder', 'reviewer']) {
-			expect(() => {
-				db.exec(
-					`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
-					 VALUES ('sgm-${role}', 'sg-5', 'sess-${role}', '${role}', 0, ${now})`
-				);
-			}).not.toThrow();
-		}
+		// Invalid status
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, status, order_index, created_at)
+				 VALUES ('sgm-bad', 'sg-status', 'sess-bad', 'coder', 'pending', 0, ${now})`
+			);
+		}).toThrow();
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -36,6 +36,7 @@ describe('SpaceSessionGroupRepository', () => {
 			expect(group.spaceId).toBe(spaceId);
 			expect(group.name).toBe('Group A');
 			expect(group.description).toBeUndefined();
+			expect(group.taskId).toBeUndefined();
 			expect(group.members).toEqual([]);
 			expect(group.createdAt).toBeGreaterThan(0);
 		});
@@ -43,6 +44,11 @@ describe('SpaceSessionGroupRepository', () => {
 		it('creates a group with description', () => {
 			const group = repo.createGroup({ spaceId, name: 'Group B', description: 'Desc' });
 			expect(group.description).toBe('Desc');
+		});
+
+		it('creates a group with taskId', () => {
+			const group = repo.createGroup({ spaceId, name: 'Group C', taskId: 'task-42' });
+			expect(group.taskId).toBe('task-42');
 		});
 	});
 
@@ -97,6 +103,18 @@ describe('SpaceSessionGroupRepository', () => {
 			expect(updated!.description).toBe('Updated');
 		});
 
+		it('updates taskId', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const updated = repo.updateGroup(group.id, { taskId: 'task-99' });
+			expect(updated!.taskId).toBe('task-99');
+		});
+
+		it('clears taskId with null', () => {
+			const group = repo.createGroup({ spaceId, name: 'G', taskId: 'task-1' });
+			const updated = repo.updateGroup(group.id, { taskId: null });
+			expect(updated!.taskId).toBeUndefined();
+		});
+
 		it('returns null for unknown ID', () => {
 			expect(repo.updateGroup('nonexistent', { name: 'X' })).toBeNull();
 		});
@@ -115,23 +133,42 @@ describe('SpaceSessionGroupRepository', () => {
 	});
 
 	describe('addMember', () => {
-		it('adds a member to a group', () => {
+		it('adds a member to a group with default status', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
 			const member = repo.addMember(group.id, 'session-1', 'leader', 0);
 
 			expect(member.groupId).toBe(group.id);
 			expect(member.sessionId).toBe('session-1');
 			expect(member.role).toBe('leader');
+			expect(member.status).toBe('active');
+			expect(member.agentId).toBeUndefined();
 			expect(member.orderIndex).toBe(0);
+		});
+
+		it('adds a member with agentId and custom status', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', 'coder', 0, 'agent-42', 'completed');
+
+			expect(member.role).toBe('coder');
+			expect(member.agentId).toBe('agent-42');
+			expect(member.status).toBe('completed');
+		});
+
+		it('accepts freeform role strings', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', 'security-auditor');
+			expect(member.role).toBe('security-auditor');
 		});
 
 		it('is idempotent — updates existing member', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
 			repo.addMember(group.id, 'session-1', 'worker');
-			const updated = repo.addMember(group.id, 'session-1', 'leader', 1);
+			const updated = repo.addMember(group.id, 'session-1', 'reviewer', 1, 'agent-5', 'completed');
 
-			expect(updated.role).toBe('leader');
+			expect(updated.role).toBe('reviewer');
 			expect(updated.orderIndex).toBe(1);
+			expect(updated.agentId).toBe('agent-5');
+			expect(updated.status).toBe('completed');
 
 			const found = repo.getGroup(group.id);
 			expect(found!.members).toHaveLength(1);
@@ -140,7 +177,7 @@ describe('SpaceSessionGroupRepository', () => {
 		it('multiple members are ordered by order_index', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
 			repo.addMember(group.id, 'session-2', 'worker', 1);
-			repo.addMember(group.id, 'session-1', 'leader', 0);
+			repo.addMember(group.id, 'session-1', 'coder', 0);
 
 			const found = repo.getGroup(group.id);
 			expect(found!.members[0].sessionId).toBe('session-1');

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -55,7 +55,7 @@ describe('SpaceSessionGroupRepository', () => {
 	describe('getGroup', () => {
 		it('returns group with members', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
 
 			const found = repo.getGroup(group.id);
 			expect(found).not.toBeNull();
@@ -84,14 +84,19 @@ describe('SpaceSessionGroupRepository', () => {
 	});
 
 	describe('getGroupsByTask', () => {
-		it('returns groups named task:{taskId}', () => {
-			repo.createGroup({ spaceId, name: 'task:task-1' });
-			repo.createGroup({ spaceId, name: 'task:task-2' });
+		it('returns groups by task_id column', () => {
+			repo.createGroup({ spaceId, name: 'Group for task-1', taskId: 'task-1' });
+			repo.createGroup({ spaceId, name: 'Group for task-2', taskId: 'task-2' });
 			repo.createGroup({ spaceId, name: 'other-group' });
 
 			const groups = repo.getGroupsByTask(spaceId, 'task-1');
 			expect(groups).toHaveLength(1);
-			expect(groups[0].name).toBe('task:task-1');
+			expect(groups[0].taskId).toBe('task-1');
+		});
+
+		it('returns empty array when no groups have matching task_id', () => {
+			repo.createGroup({ spaceId, name: 'some-group' });
+			expect(repo.getGroupsByTask(spaceId, 'task-99')).toHaveLength(0);
 		});
 	});
 
@@ -133,9 +138,9 @@ describe('SpaceSessionGroupRepository', () => {
 	});
 
 	describe('addMember', () => {
-		it('adds a member to a group with default status', () => {
+		it('adds a member with default status', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			const member = repo.addMember(group.id, 'session-1', 'leader', 0);
+			const member = repo.addMember(group.id, 'session-1', { role: 'leader' });
 
 			expect(member.groupId).toBe(group.id);
 			expect(member.sessionId).toBe('session-1');
@@ -147,7 +152,11 @@ describe('SpaceSessionGroupRepository', () => {
 
 		it('adds a member with agentId and custom status', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			const member = repo.addMember(group.id, 'session-1', 'coder', 0, 'agent-42', 'completed');
+			const member = repo.addMember(group.id, 'session-1', {
+				role: 'coder',
+				agentId: 'agent-42',
+				status: 'completed',
+			});
 
 			expect(member.role).toBe('coder');
 			expect(member.agentId).toBe('agent-42');
@@ -156,14 +165,19 @@ describe('SpaceSessionGroupRepository', () => {
 
 		it('accepts freeform role strings', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			const member = repo.addMember(group.id, 'session-1', 'security-auditor');
+			const member = repo.addMember(group.id, 'session-1', { role: 'security-auditor' });
 			expect(member.role).toBe('security-auditor');
 		});
 
 		it('is idempotent — updates existing member', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
-			const updated = repo.addMember(group.id, 'session-1', 'reviewer', 1, 'agent-5', 'completed');
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
+			const updated = repo.addMember(group.id, 'session-1', {
+				role: 'reviewer',
+				orderIndex: 1,
+				agentId: 'agent-5',
+				status: 'completed',
+			});
 
 			expect(updated.role).toBe('reviewer');
 			expect(updated.orderIndex).toBe(1);
@@ -176,8 +190,8 @@ describe('SpaceSessionGroupRepository', () => {
 
 		it('multiple members are ordered by order_index', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-2', 'worker', 1);
-			repo.addMember(group.id, 'session-1', 'coder', 0);
+			repo.addMember(group.id, 'session-2', { role: 'worker', orderIndex: 1 });
+			repo.addMember(group.id, 'session-1', { role: 'coder', orderIndex: 0 });
 
 			const found = repo.getGroup(group.id);
 			expect(found!.members[0].sessionId).toBe('session-1');
@@ -185,10 +199,64 @@ describe('SpaceSessionGroupRepository', () => {
 		});
 	});
 
+	describe('updateMember', () => {
+		it('updates status without touching other fields', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder', agentId: 'agent-1' });
+
+			const updated = repo.updateMember(group.id, 'session-1', { status: 'completed' });
+			expect(updated).not.toBeNull();
+			expect(updated!.status).toBe('completed');
+			expect(updated!.role).toBe('coder');
+			expect(updated!.agentId).toBe('agent-1');
+		});
+
+		it('updates multiple fields at once', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
+
+			const updated = repo.updateMember(group.id, 'session-1', {
+				role: 'reviewer',
+				status: 'failed',
+				agentId: 'agent-99',
+			});
+			expect(updated!.role).toBe('reviewer');
+			expect(updated!.status).toBe('failed');
+			expect(updated!.agentId).toBe('agent-99');
+		});
+
+		it('clears agentId with null', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder', agentId: 'agent-1' });
+
+			const updated = repo.updateMember(group.id, 'session-1', { agentId: null });
+			expect(updated!.agentId).toBeUndefined();
+		});
+
+		it('returns null for non-existent member', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			expect(
+				repo.updateMember(group.id, 'nonexistent-session', { status: 'completed' })
+			).toBeNull();
+		});
+
+		it('touches group updated_at', async () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder' });
+			const before = repo.getGroup(group.id)!.updatedAt;
+
+			await new Promise((r) => setTimeout(r, 5));
+			repo.updateMember(group.id, 'session-1', { status: 'completed' });
+
+			const after = repo.getGroup(group.id)!.updatedAt;
+			expect(after).toBeGreaterThanOrEqual(before);
+		});
+	});
+
 	describe('removeMember', () => {
 		it('removes a member from a group', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
 
 			const removed = repo.removeMember(group.id, 'session-1');
 			expect(removed).toBe(true);

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -355,8 +355,15 @@ export interface SpaceSessionGroupMember {
 	groupId: string;
 	/** ID of the session */
 	sessionId: string;
-	/** Role of this session within the group */
-	role: 'worker' | 'leader';
+	/**
+	 * Role of this session within the group — freeform string matching SpaceAgent.role
+	 * (e.g. 'coder', 'reviewer', 'security-auditor', or any user-defined role).
+	 */
+	role: string;
+	/** ID of the SpaceAgent config this session uses (nullable for system agents) */
+	agentId?: string;
+	/** Current state of this member's session */
+	status: 'active' | 'completed' | 'failed';
 	/** Display order within the group */
 	orderIndex: number;
 	/** Creation timestamp (milliseconds since epoch) */
@@ -366,7 +373,7 @@ export interface SpaceSessionGroupMember {
 /**
  * A named group of sessions within a Space.
  * Session groups allow organizing related sessions (e.g., a workflow run's
- * leader + workers) under a single logical unit for display and management.
+ * agents) under a single logical unit for display and management.
  */
 export interface SpaceSessionGroup {
 	/** Unique identifier */
@@ -381,6 +388,8 @@ export interface SpaceSessionGroup {
 	workflowRunId?: string;
 	/** ID of the current workflow step being executed by this group */
 	currentStepId?: string;
+	/** ID of the SpaceTask this group serves */
+	taskId?: string;
 	/** Members of this group */
 	members: SpaceSessionGroupMember[];
 	/** Creation timestamp (milliseconds since epoch) */


### PR DESCRIPTION
- Change SpaceSessionGroupMember.role from 'worker' | 'leader' to freeform string
- Add agentId? and status fields to SpaceSessionGroupMember
- Add taskId? to SpaceSessionGroup
- Update repository params, rowToGroup, rowToMember, and addMember signature
- Update test DB schema and add tests covering new fields
