### PR TITLE
feat: add resolveTaskTypesForStep for multi-agent per-agent type resolution

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -326,10 +326,13 @@ export class SpaceRuntime {
 			throw new Error(`Start step "${workflow.startStepId}" not found in workflow "${workflowId}"`);
 		}
 
-		const resolved = this.resolveTaskTypeForStep(startStep);
 		const taskManager = this.getOrCreateTaskManager(spaceId);
 		let task: SpaceTask;
 		try {
+			// resolveTaskTypeForStep is inside the try/catch so that an exception from
+			// resolveStepAgents (e.g. a step with neither agentId nor agents) triggers
+			// the same executor/meta cleanup path as a task-creation failure.
+			const resolved = this.resolveTaskTypeForStep(startStep);
 			task = await taskManager.createTask({
 				title: startStep.name,
 				description: startStep.instructions ?? '',

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -355,11 +355,7 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Resolve the appropriate SpaceTaskType (and optional customAgentId) for
-	 * a workflow step, based on the primary agent's role.
-	 *
-	 * For multi-agent steps (agents[] format), the first entry is used as the primary agent
-	 * for task-type resolution. Individual sub-tasks for each agent are created by the executor.
+	 * Resolve the SpaceTaskType (and optional customAgentId) for a single agentId.
 	 *
 	 * Mapping rules:
 	 *   agent.role === 'planner'          → taskType: 'planning',  customAgentId: undefined
@@ -367,17 +363,11 @@ export class SpaceRuntime {
 	 *   any other role (custom)           → taskType: 'coding',    customAgentId: agentId
 	 *   agent not found                   → taskType: 'coding',    customAgentId: agentId
 	 */
-	resolveTaskTypeForStep(step: WorkflowStep): ResolvedTaskType {
-		// Use the first resolved agent as the primary for task-type resolution.
-		const stepAgents = resolveStepAgents(step);
-		const primaryAgentId = stepAgents[0]?.agentId;
-		const agent = primaryAgentId
-			? this.config.spaceAgentManager.getById(primaryAgentId)
-			: undefined;
+	private resolveTaskTypeForAgent(agentId: string | undefined): ResolvedTaskType {
+		const agent = agentId ? this.config.spaceAgentManager.getById(agentId) : undefined;
 
 		if (!agent) {
-			// Unknown agent → treat as custom coding agent
-			return { taskType: 'coding', customAgentId: primaryAgentId };
+			return { taskType: 'coding', customAgentId: agentId };
 		}
 
 		if (agent.role === 'planner') {
@@ -389,7 +379,38 @@ export class SpaceRuntime {
 		}
 
 		// Custom role
-		return { taskType: 'coding', customAgentId: primaryAgentId };
+		return { taskType: 'coding', customAgentId: agentId };
+	}
+
+	/**
+	 * Resolve per-agent task types for a workflow step.
+	 *
+	 * Returns one `ResolvedTaskType` per agent entry in the step (in order).
+	 * For single-agent steps (agentId shorthand), returns a one-element array.
+	 *
+	 * Mapping rules per agent:
+	 *   agent.role === 'planner'          → taskType: 'planning',  customAgentId: undefined
+	 *   agent.role === 'coder'|'general'  → taskType: 'coding',    customAgentId: undefined
+	 *   any other role (custom)           → taskType: 'coding',    customAgentId: agentId
+	 *   agent not found                   → taskType: 'coding',    customAgentId: agentId
+	 */
+	resolveTaskTypesForStep(step: WorkflowStep): ResolvedTaskType[] {
+		const stepAgents = resolveStepAgents(step);
+		return stepAgents.map((sa) => this.resolveTaskTypeForAgent(sa.agentId));
+	}
+
+	/**
+	 * Resolve the appropriate SpaceTaskType (and optional customAgentId) for
+	 * a workflow step, based on the primary agent's role.
+	 *
+	 * For backward compatibility: delegates to `resolveTaskTypesForStep()` and
+	 * returns the first entry (primary agent).
+	 *
+	 * For multi-agent steps (agents[] format), use `resolveTaskTypesForStep()`
+	 * to get per-agent results.
+	 */
+	resolveTaskTypeForStep(step: WorkflowStep): ResolvedTaskType {
+		return this.resolveTaskTypesForStep(step)[0];
 	}
 
 	/**
@@ -904,7 +925,7 @@ export class SpaceRuntime {
 			this.config.workflowRunRepo,
 			workspacePath,
 			undefined, // use default commandRunner
-			(step) => this.resolveTaskTypeForStep(step) // inject TaskTypeResolver
+			(step) => this.resolveTaskTypesForStep(step) // inject TaskTypeResolver (multi-agent)
 		);
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -112,8 +112,8 @@ export interface TaskTypeResolution {
  *
  * May return either a single `TaskTypeResolution` (single-agent / backward-compat)
  * or an array of `TaskTypeResolution` (one per agent in a multi-agent step).
- * When an array is returned, the first entry is used for the primary task created
- * by the executor; individual per-agent sub-tasks use their corresponding entry.
+ * The executor currently uses only the first entry to create the primary task.
+ * Per-agent sub-task creation for the remaining entries is deferred to a later phase.
  */
 export type TaskTypeResolver = (step: WorkflowStep) => TaskTypeResolution | TaskTypeResolution[];
 

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -98,14 +98,24 @@ export type CommandRunner = (
 ) => Promise<{ exitCode: number | null; timedOut?: boolean; stderr?: string }>;
 
 /**
+ * Single-agent resolution result used by TaskTypeResolver.
+ */
+export interface TaskTypeResolution {
+	taskType?: string;
+	customAgentId?: string;
+}
+
+/**
  * Optional resolver injected by SpaceRuntime to set task metadata (taskType,
  * customAgentId) at task-creation time. When provided, the task is created
  * complete in a single DB write — no second update required.
+ *
+ * May return either a single `TaskTypeResolution` (single-agent / backward-compat)
+ * or an array of `TaskTypeResolution` (one per agent in a multi-agent step).
+ * When an array is returned, the first entry is used for the primary task created
+ * by the executor; individual per-agent sub-tasks use their corresponding entry.
  */
-export type TaskTypeResolver = (step: WorkflowStep) => {
-	taskType?: string;
-	customAgentId?: string;
-};
+export type TaskTypeResolver = (step: WorkflowStep) => TaskTypeResolution | TaskTypeResolution[];
 
 // ---------------------------------------------------------------------------
 // Default timeout constants
@@ -426,7 +436,10 @@ export class WorkflowExecutor {
 		// When a taskTypeResolver is provided it fully controls taskType AND customAgentId —
 		// customAgentId: undefined means "no custom agent" for preset roles (planner/coder/general).
 		// Without a resolver (backward-compat), fall back to nextStep.agentId.
-		const resolved = this.taskTypeResolver?.(nextStep);
+		// The resolver may return a single resolution or an array (multi-agent); use the first entry
+		// for the primary task.
+		const rawResolved = this.taskTypeResolver?.(nextStep);
+		const resolved = Array.isArray(rawResolved) ? rawResolved[0] : rawResolved;
 
 		// Create a pending SpaceTask for the new step
 		const task = await this.taskManager.createTask({

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -217,6 +217,69 @@ describe('SpaceRuntime', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// resolveTaskTypesForStep (multi-agent variant)
+	// -------------------------------------------------------------------------
+
+	describe('resolveTaskTypesForStep()', () => {
+		test('single agentId shorthand → one-element array with correct resolution', () => {
+			const step = { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER };
+			const results = runtime.resolveTaskTypesForStep(step);
+			expect(results).toHaveLength(1);
+			expect(results[0].taskType).toBe('planning');
+			expect(results[0].customAgentId).toBeUndefined();
+		});
+
+		test('multi-agent step → one ResolvedTaskType per agent entry', () => {
+			const step = {
+				id: STEP_A,
+				name: 'Multi',
+				agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }, { agentId: AGENT_CUSTOM }],
+			};
+			const results = runtime.resolveTaskTypesForStep(step);
+			expect(results).toHaveLength(3);
+			expect(results[0]).toEqual({ taskType: 'planning', customAgentId: undefined });
+			expect(results[1]).toEqual({ taskType: 'coding', customAgentId: undefined });
+			expect(results[2]).toEqual({ taskType: 'coding', customAgentId: AGENT_CUSTOM });
+		});
+
+		test('multi-agent step with general role → coding, no customAgentId', () => {
+			const step = {
+				id: STEP_A,
+				name: 'Multi',
+				agents: [{ agentId: AGENT_GENERAL }, { agentId: AGENT_CODER }],
+			};
+			const results = runtime.resolveTaskTypesForStep(step);
+			expect(results).toHaveLength(2);
+			expect(results[0]).toEqual({ taskType: 'coding', customAgentId: undefined });
+			expect(results[1]).toEqual({ taskType: 'coding', customAgentId: undefined });
+		});
+
+		test('multi-agent step with unknown agentId → coding + customAgentId preserved', () => {
+			const step = {
+				id: STEP_A,
+				name: 'Multi',
+				agents: [{ agentId: AGENT_CODER }, { agentId: 'unknown-agent-id' }],
+			};
+			const results = runtime.resolveTaskTypesForStep(step);
+			expect(results).toHaveLength(2);
+			expect(results[0]).toEqual({ taskType: 'coding', customAgentId: undefined });
+			expect(results[1]).toEqual({ taskType: 'coding', customAgentId: 'unknown-agent-id' });
+		});
+
+		test('resolveTaskTypeForStep delegates to first entry of resolveTaskTypesForStep', () => {
+			const step = {
+				id: STEP_A,
+				name: 'Multi',
+				agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+			};
+			const single = runtime.resolveTaskTypeForStep(step);
+			const multi = runtime.resolveTaskTypesForStep(step);
+			expect(single).toEqual(multi[0]);
+			expect(single.taskType).toBe('planning');
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// getRulesForStep
 	// -------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -532,6 +532,90 @@ describe('SpaceRuntime', () => {
 			expect(run.goalId).toBeUndefined();
 			expect(tasks[0].goalId).toBeUndefined();
 		});
+
+		test('multi-agent start step: uses first agent taskType for the initial task', async () => {
+			// Workflow with agents[] format: planner first, then coder
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi-Agent Start ${Date.now()}`,
+				description: '',
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Multi Step',
+						agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Multi Run');
+
+			// The primary task uses the first agent's resolution (planner → planning)
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].taskType).toBe('planning');
+			expect(tasks[0].customAgentId).toBeUndefined();
+		});
+
+		test('multi-agent start step with custom-role first agent: sets customAgentId', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi-Agent Custom ${Date.now()}`,
+				description: '',
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Custom Multi Step',
+						agents: [{ agentId: AGENT_CUSTOM }, { agentId: AGENT_CODER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Custom Multi Run');
+
+			expect(tasks[0].taskType).toBe('coding');
+			expect(tasks[0].customAgentId).toBe(AGENT_CUSTOM);
+		});
+
+		test('cancels run and clears executor when start step has no agent configuration', async () => {
+			// Bypass FK + manager validation to insert a step with no agentId/agents
+			db.exec('PRAGMA foreign_keys = OFF');
+			let workflow: SpaceWorkflow;
+			try {
+				const repo = new SpaceWorkflowRepository(db);
+				// Insert step JSON directly with no agentId and no agents[]
+				workflow = repo.createWorkflow({
+					spaceId: SPACE_ID,
+					name: `No Agent Step ${Date.now()}`,
+					description: '',
+					steps: [{ id: STEP_A, name: 'Broken Step' } as never],
+					transitions: [],
+					startStepId: STEP_A,
+					rules: [],
+					tags: [],
+				});
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+
+			const runsBefore = workflowRunRepo.listBySpace(SPACE_ID);
+
+			await expect(runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Broken Run')).rejects.toThrow();
+
+			// Run should be cancelled, executor map should be clean
+			const runsAfter = workflowRunRepo.listBySpace(SPACE_ID);
+			const newRun = runsAfter.find((r) => !runsBefore.some((b) => b.id === r.id));
+			expect(newRun).toBeDefined();
+			expect(newRun!.status).toBe('cancelled');
+			expect(runtime.executorCount).toBe(0);
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
- Extract resolveTaskTypeForAgent() private helper with core role→type mapping
- Add resolveTaskTypesForStep() returning ResolvedTaskType[] (one per agent)
- Keep resolveTaskTypeForStep() delegating to first entry for backward compat
- Update TaskTypeResolver type to accept single resolution or array
- Executor normalises array result to first entry for primary task creation
- Inject resolveTaskTypesForStep into WorkflowExecutor instead of single variant
- 5 new unit tests covering multi-agent steps, mixed roles, and delegate consistency
