### PR TITLE
feat: add channel and multi-agent step validation to SpaceWorkflowManager

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -206,7 +206,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		getAgentById(spaceId: string, id: string) {
 			const agent = spaceAgentRepo.getById(id);
 			if (!agent || agent.spaceId !== spaceId) return null;
-			return { id: agent.id, name: agent.name };
+			return { id: agent.id, name: agent.name, role: agent.role };
 		},
 	};
 	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -32,7 +32,7 @@ import type { SpaceWorkflowRepository } from '../../../storage/repositories/spac
  */
 export interface SpaceAgentLookup {
 	/** Returns the SpaceAgent with the given UUID in the given space, or null if not found. */
-	getAgentById(spaceId: string, id: string): { id: string; name: string } | null;
+	getAgentById(spaceId: string, id: string): { id: string; name: string; role: string } | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +187,19 @@ export class SpaceWorkflowManager {
 			);
 		}
 
+		// Format-level validation: always run regardless of agentLookup
+		if (hasAgents) {
+			for (let j = 0; j < step.agents!.length; j++) {
+				const entry = step.agents![j];
+				if (!entry.agentId || !entry.agentId.trim()) {
+					throw new WorkflowValidationError(
+						`step[${index}].agents[${j}]: agentId must be a non-empty SpaceAgent UUID`
+					);
+				}
+			}
+		}
+
+		// Existence validation: only when agentLookup is available
 		if (this.agentLookup) {
 			if (hasAgentId) {
 				const agent = this.agentLookup.getAgentById(spaceId, step.agentId!);
@@ -199,11 +212,6 @@ export class SpaceWorkflowManager {
 			if (hasAgents) {
 				for (let j = 0; j < step.agents!.length; j++) {
 					const entry = step.agents![j];
-					if (!entry.agentId || !entry.agentId.trim()) {
-						throw new WorkflowValidationError(
-							`step[${index}].agents[${j}]: agentId must be a non-empty SpaceAgent UUID`
-						);
-					}
 					const agent = this.agentLookup.getAgentById(spaceId, entry.agentId);
 					if (!agent) {
 						throw new WorkflowValidationError(
@@ -212,6 +220,92 @@ export class SpaceWorkflowManager {
 					}
 				}
 			}
+		}
+
+		// Channel validation (after agent validation so we can collect roles)
+		if (step.channels && step.channels.length > 0) {
+			this.validateStepChannels(spaceId, step, index);
+		}
+	}
+
+	private validateStepChannels(spaceId: string, step: WorkflowStepInput, stepIndex: number): void {
+		const channels = step.channels!;
+
+		// Channels require the multi-agent agents[] format — single-agent steps have no peers
+		if (!step.agents || step.agents.length === 0) {
+			throw new WorkflowValidationError(
+				`step[${stepIndex}]: channels require a multi-agent step (agents[] must be provided)`
+			);
+		}
+
+		// Collect known roles from agents when agentLookup is available
+		let knownRoles: Set<string> | null = null;
+		if (this.agentLookup) {
+			knownRoles = new Set<string>();
+			for (const agentEntry of step.agents) {
+				if (agentEntry.agentId && agentEntry.agentId.trim()) {
+					const agent = this.agentLookup.getAgentById(spaceId, agentEntry.agentId);
+					if (agent) {
+						knownRoles.add(agent.role);
+					}
+				}
+			}
+		}
+
+		const validDirections = new Set(['one-way', 'bidirectional']);
+
+		for (let ci = 0; ci < channels.length; ci++) {
+			const ch = channels[ci];
+			const loc = `step[${stepIndex}].channels[${ci}]`;
+
+			// Validate direction
+			if (!validDirections.has(ch.direction)) {
+				throw new WorkflowValidationError(
+					`${loc}: direction must be 'one-way' or 'bidirectional', got "${ch.direction}"`
+				);
+			}
+
+			// Validate from
+			if (!ch.from || !ch.from.trim()) {
+				throw new WorkflowValidationError(`${loc}: 'from' must be a non-empty role string`);
+			}
+
+			// Validate to
+			if (Array.isArray(ch.to)) {
+				if (ch.to.length === 0) {
+					throw new WorkflowValidationError(
+						`${loc}: 'to' array must contain at least one role string`
+					);
+				}
+				for (let ti = 0; ti < ch.to.length; ti++) {
+					if (!ch.to[ti] || !ch.to[ti].trim()) {
+						throw new WorkflowValidationError(`${loc}.to[${ti}]: must be a non-empty role string`);
+					}
+				}
+			} else {
+				if (!ch.to || !(ch.to as string).trim()) {
+					throw new WorkflowValidationError(`${loc}: 'to' must be a non-empty role string`);
+				}
+			}
+
+			// Role reference validation: only when agentLookup resolved roles
+			if (knownRoles !== null) {
+				this.validateChannelRoleRef(ch.from, knownRoles, `${loc}.from`);
+				const toRoles = Array.isArray(ch.to) ? ch.to : [ch.to as string];
+				for (const toRole of toRoles) {
+					this.validateChannelRoleRef(toRole, knownRoles, `${loc}.to`);
+				}
+			}
+		}
+	}
+
+	private validateChannelRoleRef(role: string, knownRoles: Set<string>, location: string): void {
+		if (role === '*') return; // wildcard matches all agents
+		if (!knownRoles.has(role)) {
+			const known = [...knownRoles].join(', ') || 'none';
+			throw new WorkflowValidationError(
+				`${location}: role "${role}" does not match any agent role in this step (known roles: ${known})`
+			);
 		}
 	}
 

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -115,6 +115,8 @@ export class SpaceWorkflowManager {
 				id: s.id,
 				name: s.name,
 				agentId: s.agentId,
+				agents: s.agents,
+				channels: s.channels,
 				instructions: s.instructions,
 			}));
 			this.validateTransitions(
@@ -199,7 +201,9 @@ export class SpaceWorkflowManager {
 			}
 		}
 
-		// Existence validation: only when agentLookup is available
+		// Existence validation: only when agentLookup is available.
+		// Also collect agent roles here to avoid a second traversal in channel validation.
+		let knownRoles: Set<string> | null = null;
 		if (this.agentLookup) {
 			if (hasAgentId) {
 				const agent = this.agentLookup.getAgentById(spaceId, step.agentId!);
@@ -210,6 +214,7 @@ export class SpaceWorkflowManager {
 				}
 			}
 			if (hasAgents) {
+				knownRoles = new Set<string>();
 				for (let j = 0; j < step.agents!.length; j++) {
 					const entry = step.agents![j];
 					const agent = this.agentLookup.getAgentById(spaceId, entry.agentId);
@@ -218,17 +223,26 @@ export class SpaceWorkflowManager {
 							`step[${index}].agents[${j}]: agentId "${entry.agentId}" does not match any SpaceAgent in this space`
 						);
 					}
+					knownRoles.add(agent.role);
 				}
 			}
 		}
 
-		// Channel validation (after agent validation so we can collect roles)
+		// Channel validation (after agent validation so roles are already collected)
 		if (step.channels && step.channels.length > 0) {
-			this.validateStepChannels(spaceId, step, index);
+			this.validateStepChannels(step, index, knownRoles);
 		}
 	}
 
-	private validateStepChannels(spaceId: string, step: WorkflowStepInput, stepIndex: number): void {
+	private validateStepChannels(
+		step: WorkflowStepInput,
+		stepIndex: number,
+		/**
+		 * Roles collected from agentLookup during agent existence validation.
+		 * Null when agentLookup is not configured — role-reference checks are skipped.
+		 */
+		knownRoles: Set<string> | null
+	): void {
 		const channels = step.channels!;
 
 		// Channels require the multi-agent agents[] format — single-agent steps have no peers
@@ -236,20 +250,6 @@ export class SpaceWorkflowManager {
 			throw new WorkflowValidationError(
 				`step[${stepIndex}]: channels require a multi-agent step (agents[] must be provided)`
 			);
-		}
-
-		// Collect known roles from agents when agentLookup is available
-		let knownRoles: Set<string> | null = null;
-		if (this.agentLookup) {
-			knownRoles = new Set<string>();
-			for (const agentEntry of step.agents) {
-				if (agentEntry.agentId && agentEntry.agentId.trim()) {
-					const agent = this.agentLookup.getAgentById(spaceId, agentEntry.agentId);
-					if (agent) {
-						knownRoles.add(agent.role);
-					}
-				}
-			}
 		}
 
 		const validDirections = new Set(['one-way', 'bidirectional']);

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -214,7 +214,7 @@ describe('Space Export/Import RPC Handlers', () => {
 			getAgentById(spaceId: string, id: string) {
 				const agent = agentRepo.getById(id);
 				if (!agent || agent.spaceId !== spaceId) return null;
-				return { id: agent.id, name: agent.name };
+				return { id: agent.id, name: agent.name, role: agent.role };
 			},
 		};
 		workflowManager = new SpaceWorkflowManager(workflowRepo, agentLookup);

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -219,7 +219,7 @@ function buildDeps(
 		getAgentById(spaceId: string, id: string) {
 			const agent = agentRepo.getById(id);
 			if (!agent || agent.spaceId !== spaceId) return null;
-			return { id: agent.id, name: agent.name };
+			return { id: agent.id, name: agent.name, role: agent.role };
 		},
 	};
 	const workflowManager = new SpaceWorkflowManager(workflowRepo, agentLookup);

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -814,7 +814,7 @@ describe('SpaceWorkflowManager', () => {
 		seedAgent(db, 'agent-1', 'space-1', 'MyAgent');
 		const lookup: SpaceAgentLookup = {
 			getAgentById: (_spaceId, id) =>
-				id === 'agent-1' ? { id: 'agent-1', name: 'MyAgent' } : null,
+				id === 'agent-1' ? { id: 'agent-1', name: 'MyAgent', role: 'coder' } : null,
 		};
 		const mgr = new SpaceWorkflowManager(repo, lookup);
 		const wf = mgr.createWorkflow({
@@ -1062,5 +1062,416 @@ describe('SpaceWorkflowManager', () => {
 		const refs = manager.getWorkflowsReferencingAgent('agent-1');
 		expect(refs).toHaveLength(1);
 		expect(refs[0].id).toBe(wf.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// agents[] format validation (no agentLookup needed)
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow rejects agents[] entry with empty agentId (no lookup)', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Agents Empty',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: '' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects agents[] entry with whitespace-only agentId (no lookup)', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Agents Whitespace',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: '   ' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow accepts agents[] with non-empty agentIds (no lookup)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Valid Agents',
+			steps: [
+				{
+					name: 'Step',
+					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+				},
+			],
+		});
+		expect(wf.steps[0].agents).toHaveLength(2);
+	});
+
+	test('updateWorkflow rejects agents[] entry with empty agentId (no lookup)', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		expect(() =>
+			manager.updateWorkflow(wf.id, {
+				steps: [{ id: 'step-x', name: 'Step', agents: [{ agentId: '' }] }],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Channel validation — structural (no agentLookup needed)
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow rejects channels with invalid direction', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Direction',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: 'coder', to: 'reviewer', direction: 'invalid' as never }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with empty from', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty From',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: '', to: 'reviewer', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with empty string to', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty To',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: 'coder', to: '', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with empty array to', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty Array To',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: 'coder', to: [], direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels when no agents[] provided', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Channels No Agents',
+				steps: [
+					{
+						name: 'Step',
+						agentId: 'agent-a',
+						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow accepts valid channels with * wildcard (no lookup)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Wildcard Channels',
+			steps: [
+				{
+					name: 'Step',
+					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					channels: [
+						{ from: '*', to: 'reviewer', direction: 'one-way' },
+						{ from: 'coder', to: '*', direction: 'bidirectional' },
+						{ from: '*', to: '*', direction: 'one-way' },
+					],
+				},
+			],
+		});
+		expect(wf.steps[0].channels).toHaveLength(3);
+	});
+
+	test('createWorkflow accepts valid one-way channel with array to (no lookup)', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Array To Channels',
+			steps: [
+				{
+					name: 'Step',
+					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					channels: [{ from: 'hub', to: ['spoke-a', 'spoke-b'], direction: 'bidirectional' }],
+				},
+			],
+		});
+		expect(wf.steps[0].channels).toHaveLength(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// Channel role validation — requires agentLookup
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow validates channel roles against agent roles (with lookup)', () => {
+		seedAgent(db, 'agent-coder-id', 'space-1', 'CoderAgent');
+		seedAgent(db, 'agent-reviewer-id', 'space-1', 'ReviewerAgent');
+		const lookup: SpaceAgentLookup = {
+			getAgentById: (_spaceId, id) => {
+				if (id === 'agent-coder-id') return { id, name: 'CoderAgent', role: 'coder' };
+				if (id === 'agent-reviewer-id') return { id, name: 'ReviewerAgent', role: 'reviewer' };
+				return null;
+			},
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		const wf = mgr.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Valid Role Channels',
+			steps: [
+				{
+					name: 'Step',
+					agents: [{ agentId: 'agent-coder-id' }, { agentId: 'agent-reviewer-id' }],
+					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+				},
+			],
+		});
+		expect(wf.steps[0].channels).toHaveLength(1);
+	});
+
+	test('createWorkflow rejects channel from referencing unknown role (with lookup)', () => {
+		const lookup: SpaceAgentLookup = {
+			getAgentById: (_spaceId, id) => {
+				if (id === 'agent-coder-id') return { id, name: 'CoderAgent', role: 'coder' };
+				return null;
+			},
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		expect(() =>
+			mgr.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Role From',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-coder-id' }],
+						channels: [{ from: 'unknown-role', to: 'coder', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channel to referencing unknown role (with lookup)', () => {
+		const lookup: SpaceAgentLookup = {
+			getAgentById: (_spaceId, id) => {
+				if (id === 'agent-coder-id') return { id, name: 'CoderAgent', role: 'coder' };
+				return null;
+			},
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		expect(() =>
+			mgr.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Bad Role To',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-coder-id' }],
+						channels: [{ from: 'coder', to: 'unknown-role', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow accepts * wildcard in channel roles even with lookup', () => {
+		const lookup: SpaceAgentLookup = {
+			getAgentById: (_spaceId, id) => {
+				if (id === 'agent-coder-id') return { id, name: 'CoderAgent', role: 'coder' };
+				return null;
+			},
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		const wf = mgr.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Wildcard With Lookup',
+			steps: [
+				{
+					name: 'Step',
+					agents: [{ agentId: 'agent-coder-id' }],
+					channels: [{ from: '*', to: 'coder', direction: 'one-way' }],
+				},
+			],
+		});
+		expect(wf.steps[0].channels).toHaveLength(1);
+	});
+
+	test('updateWorkflow validates channel roles in step replacement (with lookup)', () => {
+		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', steps: [coderStep] });
+		const lookup: SpaceAgentLookup = {
+			getAgentById: (_spaceId, id) => {
+				if (id === 'agent-coder-id') return { id, name: 'CoderAgent', role: 'coder' };
+				return null;
+			},
+		};
+		const mgr = new SpaceWorkflowManager(repo, lookup);
+		expect(() =>
+			mgr.updateWorkflow(wf.id, {
+				steps: [
+					{
+						id: 'step-x',
+						name: 'Step',
+						agents: [{ agentId: 'agent-coder-id' }],
+						channels: [{ from: 'coder', to: 'bad-role', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	// -------------------------------------------------------------------------
+	// Multi-agent step CRUD round-trip via manager
+	// -------------------------------------------------------------------------
+
+	test('createWorkflow with multi-agent step and channels persists and reads back correctly', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Multi-Agent CRUD',
+			steps: [
+				{
+					id: 'step-1',
+					name: 'Parallel Review',
+					agents: [
+						{ agentId: 'agent-coder', instructions: 'write code' },
+						{ agentId: 'agent-reviewer' },
+					],
+					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'submit' }],
+					instructions: 'shared context',
+				},
+			],
+		});
+
+		const read = manager.getWorkflow(wf.id)!;
+		const step = read.steps[0];
+		expect(step.agentId).toBeUndefined();
+		expect(step.agents).toHaveLength(2);
+		expect(step.agents![0].agentId).toBe('agent-coder');
+		expect(step.agents![0].instructions).toBe('write code');
+		expect(step.agents![1].agentId).toBe('agent-reviewer');
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0]).toMatchObject({
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+			label: 'submit',
+		});
+		expect(step.instructions).toBe('shared context');
+	});
+
+	test('updateWorkflow replaces multi-agent step with channels correctly', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Update Multi-Agent',
+			steps: [coderStep],
+		});
+
+		const updated = manager.updateWorkflow(wf.id, {
+			steps: [
+				{
+					id: 'step-new',
+					name: 'New Parallel Step',
+					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					channels: [{ from: 'security', to: ['coder', 'reviewer'], direction: 'bidirectional' }],
+				},
+			],
+		})!;
+
+		const step = updated.steps[0];
+		expect(step.agentId).toBeUndefined();
+		expect(step.agents).toHaveLength(2);
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0].direction).toBe('bidirectional');
+		expect(step.channels![0].to).toEqual(['coder', 'reviewer']);
+	});
+
+	test('deleteWorkflow with multi-agent step cleans up correctly', () => {
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Delete Multi-Agent',
+			steps: [
+				{
+					id: 'step-1',
+					name: 'Parallel Step',
+					agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+					channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+				},
+			],
+		});
+
+		expect(manager.deleteWorkflow(wf.id)).toBe(true);
+		expect(manager.getWorkflow(wf.id)).toBeNull();
+	});
+
+	test('legacy single-agent workflow continues to work alongside multi-agent workflows', () => {
+		// Create a mix of single-agent and multi-agent workflows
+		const single = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Single Agent',
+			steps: [coderStep],
+		});
+		const multi = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Multi Agent',
+			steps: [
+				{
+					id: 'step-m',
+					name: 'Parallel',
+					agents: [{ agentId: 'agent-x' }, { agentId: 'agent-y' }],
+					channels: [{ from: 'x', to: 'y', direction: 'bidirectional' }],
+				},
+			],
+		});
+
+		const workflows = manager.listWorkflows('space-1');
+		expect(workflows).toHaveLength(2);
+
+		const readSingle = manager.getWorkflow(single.id)!;
+		expect(readSingle.steps[0].agentId).toBe('agent-coder');
+		expect(readSingle.steps[0].agents).toBeUndefined();
+		expect(readSingle.steps[0].channels).toBeUndefined();
+
+		const readMulti = manager.getWorkflow(multi.id)!;
+		expect(readMulti.steps[0].agents).toHaveLength(2);
+		expect(readMulti.steps[0].channels).toHaveLength(1);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -1189,7 +1189,7 @@ describe('SpaceWorkflowManager', () => {
 		).toThrow(WorkflowValidationError);
 	});
 
-	test('createWorkflow rejects channels when no agents[] provided', () => {
+	test('createWorkflow rejects channels when no agents[] provided (agentId-only step)', () => {
 		expect(() =>
 			manager.createWorkflow({
 				spaceId: 'space-1',
@@ -1199,6 +1199,72 @@ describe('SpaceWorkflowManager', () => {
 						name: 'Step',
 						agentId: 'agent-a',
 						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels when agents[] is explicitly empty', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Channels Empty Agents Array',
+				steps: [
+					{
+						id: 'step-x',
+						name: 'Step',
+						agentId: 'agent-a',
+						agents: [],
+						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with whitespace-only from', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Whitespace From',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: '   ', to: 'reviewer', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with whitespace-only string to', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Whitespace To',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: 'coder', to: '   ', direction: 'one-way' }],
+					},
+				],
+			})
+		).toThrow(WorkflowValidationError);
+	});
+
+	test('createWorkflow rejects channels with whitespace-only element in array to', () => {
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Whitespace Array To Element',
+				steps: [
+					{
+						name: 'Step',
+						agents: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+						channels: [{ from: 'coder', to: ['reviewer', '   '], direction: 'one-way' }],
 					},
 				],
 			})


### PR DESCRIPTION
- Extend SpaceAgentLookup to include `role` field so channel role
  validation can resolve agent IDs to their SpaceAgent.role values
- Move agents[].agentId format validation (non-empty string check)
  outside the agentLookup block so it always runs regardless of lookup
- Add validateStepChannels: structural checks (direction enum, non-empty
  from/to) always run; role-reference checks run when agentLookup is set
  and validates from/to against known roles or '*' wildcard
- Channels on a single-agent step (no agents[]) are rejected
- Update agentLookup implementations in index.ts and test helpers to
  include role field in returned object
- Add 20 new tests covering: agents[] format validation, channel
  structural validation, channel role validation with/without lookup,
  and multi-agent step CRUD round-trips via the manager
