### PR TITLE
feat: extend listJobs to accept status arrays

### DIFF
--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -125,7 +125,11 @@ export class JobQueueRepository {
 		return this.rowToJob(row);
 	}
 
-	listJobs(filter: { queue?: string; status?: JobStatus; limit?: number }): Job[] {
+	listJobs(filter: { queue?: string; status?: JobStatus | JobStatus[]; limit?: number }): Job[] {
+		if (Array.isArray(filter.status) && filter.status.length === 0) {
+			return [];
+		}
+
 		let query = `SELECT * FROM job_queue WHERE 1=1`;
 		const params: (string | number)[] = [];
 
@@ -134,8 +138,14 @@ export class JobQueueRepository {
 			params.push(filter.queue);
 		}
 		if (filter.status !== undefined) {
-			query += ` AND status = ?`;
-			params.push(filter.status);
+			if (Array.isArray(filter.status)) {
+				const placeholders = filter.status.map(() => '?').join(',');
+				query += ` AND status IN (${placeholders})`;
+				params.push(...filter.status);
+			} else {
+				query += ` AND status = ?`;
+				params.push(filter.status);
+			}
 		}
 
 		query += ` ORDER BY created_at DESC LIMIT ?`;

--- a/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
@@ -416,6 +416,51 @@ describe('JobQueueRepository', () => {
 			expect(jobs.length).toBe(3);
 		});
 
+		it('filters by status array (returns jobs matching any of the statuses)', () => {
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.enqueue({ queue: 'test', payload: {} });
+			const [processing] = repository.dequeue('test', 1);
+			repository.complete(processing.id);
+			// Now we have: 1 pending, 1 completed
+
+			const jobs = repository.listJobs({ status: ['pending', 'completed'] });
+
+			expect(jobs.length).toBe(2);
+			expect(jobs.every((j) => j.status === 'pending' || j.status === 'completed')).toBe(true);
+		});
+
+		it('filters by status array — only matching statuses returned', () => {
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.dequeue('test', 1);
+			// Now: 1 pending, 1 processing
+
+			const jobs = repository.listJobs({ status: ['pending'] });
+
+			expect(jobs.length).toBe(1);
+			expect(jobs[0].status).toBe('pending');
+		});
+
+		it('returns empty array for empty status array', () => {
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.enqueue({ queue: 'test', payload: {} });
+
+			const jobs = repository.listJobs({ status: [] });
+
+			expect(jobs).toEqual([]);
+		});
+
+		it('string status still works (backward compatible)', () => {
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.enqueue({ queue: 'test', payload: {} });
+			repository.dequeue('test', 1);
+
+			const jobs = repository.listJobs({ status: 'pending' });
+
+			expect(jobs.length).toBe(1);
+			expect(jobs[0].status).toBe('pending');
+		});
+
 		it('orders by created_at DESC', async () => {
 			repository.enqueue({ queue: 'test', payload: { order: 1 } });
 			await new Promise((r) => setTimeout(r, 5));


### PR DESCRIPTION
Allow JobQueueRepository.listJobs() status filter to accept either a
single JobStatus string or an array of JobStatus values. Array inputs
generate IN (?,?,...) SQL; empty array returns [] early.
