### PR TITLE
task/task 13 update spacesessiongrouprepository for new

### DIFF
--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -179,11 +179,16 @@ export class SpaceSessionGroupRepository {
 			.get(groupId, sessionId) as Record<string, unknown> | undefined;
 
 		if (existing) {
+			const now = Date.now();
 			this.db
 				.prepare(
 					`UPDATE space_session_group_members SET role = ?, order_index = ?, agent_id = ?, status = ? WHERE group_id = ? AND session_id = ?`
 				)
 				.run(role, orderIndex, agentId ?? null, status, groupId, sessionId);
+			// Touch group updated_at so consumers polling on the group see the change
+			this.db
+				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+				.run(now, groupId);
 			return this.getMember(existing.id as string)!;
 		}
 
@@ -265,6 +270,7 @@ export class SpaceSessionGroupRepository {
 	/**
 	 * Update status on an existing member by member ID.
 	 * Returns null if the member record does not exist.
+	 * The member update and group timestamp touch are performed atomically.
 	 */
 	updateMemberStatus(
 		memberId: string,
@@ -276,14 +282,14 @@ export class SpaceSessionGroupRepository {
 
 		if (!row) return null;
 
-		this.db
-			.prepare(`UPDATE space_session_group_members SET status = ? WHERE id = ?`)
-			.run(status, memberId);
-
-		// Touch group updated_at
-		this.db
-			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
-			.run(Date.now(), row.group_id as string);
+		this.db.transaction(() => {
+			this.db
+				.prepare(`UPDATE space_session_group_members SET status = ? WHERE id = ?`)
+				.run(status, memberId);
+			this.db
+				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+				.run(Date.now(), row.group_id as string);
+		})();
 
 		return this.getMember(memberId);
 	}

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -263,6 +263,32 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
+	 * Update status on an existing member by member ID.
+	 * Returns null if the member record does not exist.
+	 */
+	updateMemberStatus(
+		memberId: string,
+		status: 'active' | 'completed' | 'failed'
+	): SpaceSessionGroupMember | null {
+		const row = this.db
+			.prepare(`SELECT * FROM space_session_group_members WHERE id = ?`)
+			.get(memberId) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+
+		this.db
+			.prepare(`UPDATE space_session_group_members SET status = ? WHERE id = ?`)
+			.run(status, memberId);
+
+		// Touch group updated_at
+		this.db
+			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+			.run(Date.now(), row.group_id as string);
+
+		return this.getMember(memberId);
+	}
+
+	/**
 	 * Remove a session from a group
 	 */
 	removeMember(groupId: string, sessionId: string): boolean {

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -15,6 +15,8 @@ export interface CreateSessionGroupParams {
 	workflowRunId?: string;
 	currentStepId?: string;
 	taskId?: string;
+	/** Initial lifecycle status (default: 'active') */
+	status?: 'active' | 'completed' | 'failed';
 }
 
 export interface UpdateSessionGroupParams {
@@ -23,6 +25,7 @@ export interface UpdateSessionGroupParams {
 	workflowRunId?: string | null;
 	currentStepId?: string | null;
 	taskId?: string | null;
+	status?: 'active' | 'completed' | 'failed';
 }
 
 export interface AddMemberParams {
@@ -53,22 +56,23 @@ export class SpaceSessionGroupRepository {
 		const id = generateUUID();
 		const now = Date.now();
 
-		const stmt = this.db.prepare(
-			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, task_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-		);
-
-		stmt.run(
-			id,
-			params.spaceId,
-			params.name,
-			params.description ?? null,
-			params.workflowRunId ?? null,
-			params.currentStepId ?? null,
-			params.taskId ?? null,
-			now,
-			now
-		);
+		this.db
+			.prepare(
+				`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, task_id, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.name,
+				params.description ?? null,
+				params.workflowRunId ?? null,
+				params.currentStepId ?? null,
+				params.taskId ?? null,
+				params.status ?? 'active',
+				now,
+				now
+			);
 
 		return this.getGroup(id)!;
 	}
@@ -144,6 +148,10 @@ export class SpaceSessionGroupRepository {
 			fields.push('task_id = ?');
 			values.push(params.taskId ?? null);
 		}
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -170,6 +178,7 @@ export class SpaceSessionGroupRepository {
 	/**
 	 * Add a session member to a group.
 	 * Idempotent — if the session is already a member, updates all provided fields.
+	 * The member write and group timestamp touch are performed atomically.
 	 */
 	addMember(groupId: string, sessionId: string, params: AddMemberParams): SpaceSessionGroupMember {
 		const { role, orderIndex = 0, agentId, status = 'active' } = params;
@@ -180,32 +189,33 @@ export class SpaceSessionGroupRepository {
 
 		if (existing) {
 			const now = Date.now();
-			this.db
-				.prepare(
-					`UPDATE space_session_group_members SET role = ?, order_index = ?, agent_id = ?, status = ? WHERE group_id = ? AND session_id = ?`
-				)
-				.run(role, orderIndex, agentId ?? null, status, groupId, sessionId);
-			// Touch group updated_at so consumers polling on the group see the change
-			this.db
-				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
-				.run(now, groupId);
+			this.db.transaction(() => {
+				this.db
+					.prepare(
+						`UPDATE space_session_group_members SET role = ?, order_index = ?, agent_id = ?, status = ? WHERE group_id = ? AND session_id = ?`
+					)
+					.run(role, orderIndex, agentId ?? null, status, groupId, sessionId);
+				this.db
+					.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+					.run(now, groupId);
+			})();
 			return this.getMember(existing.id as string)!;
 		}
 
 		const id = generateUUID();
 		const now = Date.now();
 
-		this.db
-			.prepare(
-				`INSERT INTO space_session_group_members (id, group_id, session_id, role, agent_id, status, order_index, created_at)
+		this.db.transaction(() => {
+			this.db
+				.prepare(
+					`INSERT INTO space_session_group_members (id, group_id, session_id, role, agent_id, status, order_index, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-			)
-			.run(id, groupId, sessionId, role, agentId ?? null, status, orderIndex, now);
-
-		// Touch group updated_at
-		this.db
-			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
-			.run(now, groupId);
+				)
+				.run(id, groupId, sessionId, role, agentId ?? null, status, orderIndex, now);
+			this.db
+				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+				.run(now, groupId);
+		})();
 
 		return this.getMember(id)!;
 	}
@@ -213,6 +223,7 @@ export class SpaceSessionGroupRepository {
 	/**
 	 * Update fields on an existing group member (e.g. transition status after session completes).
 	 * Returns null if the member record does not exist.
+	 * The member write and group timestamp touch are performed atomically.
 	 */
 	updateMember(
 		groupId: string,
@@ -248,22 +259,26 @@ export class SpaceSessionGroupRepository {
 		}
 
 		values.push(groupId, sessionId);
-		const result = this.db
-			.prepare(
-				`UPDATE space_session_group_members SET ${fields.join(', ')} WHERE group_id = ? AND session_id = ?`
-			)
-			.run(...values);
+		let updated: Record<string, unknown> | undefined;
 
-		if (result.changes === 0) return null;
+		this.db.transaction(() => {
+			const result = this.db
+				.prepare(
+					`UPDATE space_session_group_members SET ${fields.join(', ')} WHERE group_id = ? AND session_id = ?`
+				)
+				.run(...values);
 
-		// Touch group updated_at
-		this.db
-			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
-			.run(Date.now(), groupId);
+			if (result.changes === 0) return;
 
-		const updated = this.db
-			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
-			.get(groupId, sessionId) as Record<string, unknown> | undefined;
+			this.db
+				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+				.run(Date.now(), groupId);
+
+			updated = this.db
+				.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+				.get(groupId, sessionId) as Record<string, unknown> | undefined;
+		})();
+
 		return updated ? this.rowToMember(updated) : null;
 	}
 
@@ -295,20 +310,26 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
-	 * Remove a session from a group
+	 * Remove a session from a group.
+	 * The delete and group timestamp touch are performed atomically.
 	 */
 	removeMember(groupId: string, sessionId: string): boolean {
-		const result = this.db
-			.prepare(`DELETE FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
-			.run(groupId, sessionId);
+		let changed = false;
 
-		if (result.changes > 0) {
-			this.db
-				.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
-				.run(Date.now(), groupId);
-		}
+		this.db.transaction(() => {
+			const result = this.db
+				.prepare(`DELETE FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+				.run(groupId, sessionId);
 
-		return result.changes > 0;
+			if (result.changes > 0) {
+				changed = true;
+				this.db
+					.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+					.run(Date.now(), groupId);
+			}
+		})();
+
+		return changed;
 	}
 
 	/**
@@ -350,6 +371,7 @@ export class SpaceSessionGroupRepository {
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			currentStepId: (row.current_step_id as string | null) ?? undefined,
 			taskId: (row.task_id as string | null) ?? undefined,
+			status: ((row.status as string | null) ?? 'active') as 'active' | 'completed' | 'failed',
 			members,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -187,6 +187,9 @@ export function createSpaceTables(db: BunDatabase): void {
 	`);
 
 	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
+	);
+	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_session_groups_task_id ON space_session_groups(task_id)`
 	);
 
@@ -205,4 +208,11 @@ export function createSpaceTables(db: BunDatabase): void {
 			UNIQUE(group_id, session_id)
 		)
 	`);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_group_id ON space_session_group_members(group_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_group_members_session_id ON space_session_group_members(session_id)`
+	);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -178,11 +178,17 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_run_id TEXT,
 			current_step_id TEXT,
 			task_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'completed', 'failed')),
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_session_groups_task_id ON space_session_groups(task_id)`
+	);
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_session_group_members (

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -37,6 +37,7 @@ describe('SpaceSessionGroupRepository', () => {
 			expect(group.name).toBe('Group A');
 			expect(group.description).toBeUndefined();
 			expect(group.taskId).toBeUndefined();
+			expect(group.status).toBe('active');
 			expect(group.members).toEqual([]);
 			expect(group.createdAt).toBeGreaterThan(0);
 		});
@@ -49,6 +50,11 @@ describe('SpaceSessionGroupRepository', () => {
 		it('creates a group with taskId', () => {
 			const group = repo.createGroup({ spaceId, name: 'Group C', taskId: 'task-42' });
 			expect(group.taskId).toBe('task-42');
+		});
+
+		it('creates a group with explicit status', () => {
+			const group = repo.createGroup({ spaceId, name: 'Group D', status: 'completed' });
+			expect(group.status).toBe('completed');
 		});
 	});
 
@@ -118,6 +124,14 @@ describe('SpaceSessionGroupRepository', () => {
 			const group = repo.createGroup({ spaceId, name: 'G', taskId: 'task-1' });
 			const updated = repo.updateGroup(group.id, { taskId: null });
 			expect(updated!.taskId).toBeUndefined();
+		});
+
+		it('updates group status', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			expect(group.status).toBe('active');
+
+			const updated = repo.updateGroup(group.id, { status: 'completed' });
+			expect(updated!.status).toBe('completed');
 		});
 
 		it('returns null for unknown ID', () => {
@@ -196,6 +210,18 @@ describe('SpaceSessionGroupRepository', () => {
 			const found = repo.getGroup(group.id);
 			expect(found!.members[0].sessionId).toBe('session-1');
 			expect(found!.members[1].sessionId).toBe('session-2');
+		});
+
+		it('touches group updated_at on idempotent re-add', async () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
+			const before = repo.getGroup(group.id)!.updatedAt;
+
+			await new Promise((r) => setTimeout(r, 5));
+			repo.addMember(group.id, 'session-1', { role: 'reviewer' }); // re-add same session
+
+			const after = repo.getGroup(group.id)!.updatedAt;
+			expect(after).toBeGreaterThan(before);
 		});
 	});
 

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -253,6 +253,42 @@ describe('SpaceSessionGroupRepository', () => {
 		});
 	});
 
+	describe('updateMemberStatus', () => {
+		it('transitions member status by member ID', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', { role: 'coder' });
+
+			const updated = repo.updateMemberStatus(member.id, 'completed');
+			expect(updated).not.toBeNull();
+			expect(updated!.status).toBe('completed');
+			expect(updated!.role).toBe('coder');
+		});
+
+		it('transitions to failed status', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', { role: 'worker' });
+
+			const updated = repo.updateMemberStatus(member.id, 'failed');
+			expect(updated!.status).toBe('failed');
+		});
+
+		it('returns null for non-existent member ID', () => {
+			expect(repo.updateMemberStatus('nonexistent-id', 'completed')).toBeNull();
+		});
+
+		it('touches group updated_at', async () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', { role: 'coder' });
+			const before = repo.getGroup(group.id)!.updatedAt;
+
+			await new Promise((r) => setTimeout(r, 5));
+			repo.updateMemberStatus(member.id, 'completed');
+
+			const after = repo.getGroup(group.id)!.updatedAt;
+			expect(after).toBeGreaterThanOrEqual(before);
+		});
+	});
+
 	describe('removeMember', () => {
 		it('removes a member from a group', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -249,7 +249,7 @@ describe('SpaceSessionGroupRepository', () => {
 			repo.updateMember(group.id, 'session-1', { status: 'completed' });
 
 			const after = repo.getGroup(group.id)!.updatedAt;
-			expect(after).toBeGreaterThanOrEqual(before);
+			expect(after).toBeGreaterThan(before);
 		});
 	});
 
@@ -272,6 +272,21 @@ describe('SpaceSessionGroupRepository', () => {
 			expect(updated!.status).toBe('failed');
 		});
 
+		it('does not modify other fields (role, agentId, orderIndex)', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', {
+				role: 'security-auditor',
+				agentId: 'agent-7',
+				orderIndex: 3,
+			});
+
+			const updated = repo.updateMemberStatus(member.id, 'completed');
+			expect(updated!.status).toBe('completed');
+			expect(updated!.role).toBe('security-auditor');
+			expect(updated!.agentId).toBe('agent-7');
+			expect(updated!.orderIndex).toBe(3);
+		});
+
 		it('returns null for non-existent member ID', () => {
 			expect(repo.updateMemberStatus('nonexistent-id', 'completed')).toBeNull();
 		});
@@ -285,7 +300,7 @@ describe('SpaceSessionGroupRepository', () => {
 			repo.updateMemberStatus(member.id, 'completed');
 
 			const after = repo.getGroup(group.id)!.updatedAt;
-			expect(after).toBeGreaterThanOrEqual(before);
+			expect(after).toBeGreaterThan(before);
 		});
 	});
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -390,6 +390,8 @@ export interface SpaceSessionGroup {
 	currentStepId?: string;
 	/** ID of the SpaceTask this group serves */
 	taskId?: string;
+	/** Lifecycle status of this group */
+	status: 'active' | 'completed' | 'failed';
 	/** Members of this group */
 	members: SpaceSessionGroupMember[];
 	/** Creation timestamp (milliseconds since epoch) */


### PR DESCRIPTION
- **feat(tasks): make failed state non-terminal (allow messages + retry)**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: align needs_attention handling between RPC and agent-tool paths**
- **ci: add setup-devproxy composite action with caching to fix CI install failures**
- **fix(ci): use jq + GITHUB_TOKEN auth to resolve devproxy version in setup action**
- **fix(ci): inject github.token into composite action step env for API auth**
- **fix: resolve leftover conflict markers in human-message-routing tests**
- **ci: simplify CI pipeline by removing intermediate gate jobs and extracting Dev Proxy action**
- **fix: restore runner.os guard on setup-devproxy, add startup timeout failure**
- **fix: always set archivedAt when archiving task without active runtime**
- **fix: correct comment about orphaned worktree cleanup, add review state test**
- **fix(ci): use nc -z TCP check for devproxy readiness instead of curl**
- **feat: add draft message auto-save to task view input**
- **fix: address review feedback on task draft auto-save**
- **feat: persist task input draft to server-side storage**
- **fix: address review feedback on task draft RPC handler**
- **ci: add rpc-task-draft-handlers.test.ts to rpc-1 CI matrix shard**
- **ci: register rpc-task-draft-handlers.test.ts in validate-online-test-matrix script**
- **fix: address review feedback on task draft hook (round 2)**
- **fix: add cancelled flag to loadDraft to prevent cross-task data corruption**
- **fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker**
- **test(dialog-handlers): fix platform-agnostic test and cover error-handling path**
- **fix: address round-7 review feedback on task draft hook**
- **ci: retrigger CI after base branch corrected to dev**
- **ci: retrigger CI (rpc-remove-output flaky timeout)**
- **feat: raise draft/message char limit from 100k to 200k**
- **fix: correct too-long test repeat count and JSDoc after 200k limit raise**
- **chore: bump version to 0.7.1 (#357)**
- **fix: skip max feedback iterations limit when task is in review state (#358)**
- **docs: Goal V2 (Mission System) plan for autonomous agent workflows (#322)**
- **fix: preserve PR data on runtime escalation and show PR in task view header (#360)**
- **chore: update deps to latest minor versions (except claude agent SDK) (#362)**
- **chore: upgrade @anthropic-ai/claude-agent-sdk from 0.2.55 to 0.2.76 (#363)**
- **feat: order tasks by most recently updated within each status (#365)**
- **feat: add GLM-5-Turbo model support (#367)**
- **fix: prevent API error bounce loops for all agents in runtime (#366)**
- **feat: Anthropic-compatible HTTP bridge backed by codex app-server (#339)**
- **feat: GitHub Copilot as transparent AgentSession backend via embedded Anthropic-compatible server (#340)**
- **feat: add mission metadata schema and types for Goal V2 (#369)**
- **docs: Goal V2 Mission System -- Autonomous Agent Workflows plan (#368)**
- **fix: show PR link for all task statuses once created (#372)**
- **Plan: Full first-class anthropic-copilot and anthropic-codex provider support (#370)**
- **feat: tighten leader agent tool permissions to read-only context subset (#371)**
- **feat: define V2 mission types and extend RoomGoal (Task 1.1) (#374)**
- **chore: remove pi-mono approach dead code (#364)**
- **feat: widen Provider type union to include anthropic-copilot and anthropic-codex (#373)**
- **fix: remove unsafe provider casts in daemon, use widened Provider type (#377)**
- **fix: Enter to send in task HumanInputArea, default target to leader (#387)**
- **fix: inject room chat system prompt to prevent premature task creation (#379)**
- **feat: add anthropic-codex Codex entry to PROVIDER_LABELS (#375)**
- **feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs (#376)**
- **fix: parse /context response from assistant messages (new SDK format) (#381)**
- **fix: prevent agent from creating duplicate PRs on re-dispatch (#392)**
- **fix: remove merge method flag from human approval message (#393)**
- **feat: iterate all tool results in codex bridge continuation (#378)**
- **feat: replace copy toast with inline green check mark (#394)**
- **feat: require explicit provider ID for all model resolution (#388)**
- **test: add provider routing tests for copilot/cross-provider model switches (#395)**
- **feat: provider-grouped model picker with availability dots (#398)**
- **feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge (#380)**
- **feat: improve error mapping in copilot bridge (Task 5.1) (#384)**
- **fix: render leader questions as interactive forms in task conversation (#400)**
- **feat: wire thread/tokenUsage/updated into SSE message_delta token counts (#383)**
- **feat: recurring missions — scheduling with execution identity and recovery (Task 3) (#390)**
- **feat: UI terminology — rename Goal to Mission (Task 5) (#397)**
- **feat: implement semi-autonomous mode for coder/general tasks (Task 4) (#396)**
- **feat: measurable missions — structured metrics and adaptive replanning (Task 2) (#382)**
- **fix: call queryObject.close() before clearing transport reference (#403)**
- **fix: scope message locator in persistence e2e test to avoid strict mode violation (#402)**
- **feat: provider-aware session creation (#399) (#401)**
- **feat: add provider badge in session status bar next to model icon (#391)**
- **feat: heuristic token accounting for copilot bridge (#385)**
- **test: unit tests for provider routing and type safety (Task 7.1) (#399)**
- **feat: log warning when tool_choice is provided but not honored in both bridges (#386)**
- **task/task 72 update online provider test shards (#409)**
- **feat: graceful degradation on provider unavailability (#408)**
- **test: add E2E tests for provider model switching UI (#406)**
- **feat: eager leader initialization and fix observer race in TaskGroupManager (#411)**
- **feat: filter unauthenticated providers from model picker (#410)**
- **Fix SQLITE_BUSY retries and closed SSE controller handling (#415)**
- **fix: resolve leader questions routing to dead session instances (#404)**
- **feat: add OpenAI token refresh/login in settings for Codex (#416)**
- **fix: use correct /room/:id route in mission-terminology e2e tests (#419)**
- **fix: restore dead worker sessions before routing leader feedback (#418)**
- **feat: UI — type-specific mission creation and detail views (Task 6) (#405)**
- **fix: capture assistant.message.content when Copilot SDK skips streaming deltas (#421)**
- **fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback (#412)**
- **fix: support Agent tool name for subagent blocks (SDK 0.2.76+ renamed Task to Agent) (#424)**
- **fix(codex-bridge): persist Codex sessions across turns (#420)**
- **docs: add final provider parity report (#413)**
- **docs: plan for Multi-Agent V2 customizable agents and workflows (#359)**
- **task/fix logout button not working for openai and copil (#423)**
- **feat: define Space shared types in @neokai/shared (#425)**
- **feat: add Migration 29 — create all Space system tables (#427)**
- **feat: add SpaceAgent and workflow types to space.ts (Task 3.1) (#426)**
- **feat: custom agent types, repository, and manager (Task 2.1) (#428)**
- **feat: add Space repositories and managers (Task 1.3) (#429)**
- **feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2) (#430)**
- **feat: Space RPC handlers and DaemonEventMap registration (Task 1.4) (#433)**
- **docs: add provider setup documentation for anthropic-copilot and anthropic-codex (#414)**
- **test: integration testing and documentation for Mission System V2 (Task 7) (#422)**
- **feat: add task management tools to leader role (#435)**
- **feat: add spaceAgent RPC handlers and DaemonEventMap entries (Task 2.2) (#431)**
- **feat: simplify multi-agent space — explicit workflowId or AI auto-select only (#434)**
- **feat: add leader progress summary at end of each turn (#436)**
- **feat: custom agent session init factory and SpaceAgent tools (Task 2.3) (#432)**
- **docs: update multi-agent space task docs with simplified workflow selection design (#439)**
- **docs: NeoKai UI/UX 1.0.0 upgrade plan (#442)**
- **docs: add NeoKai UI/UX 1.0.0 upgrade specification (#444)**
- **feat: extend CSS custom properties vocabulary in styles.css (#445)**
- **feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3) (#437)**
- **feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4) (#440)**
- **feat: Space navigation, routing, and signals (Task 5.1) (#438)**
- **feat: add WorkflowExecutor core for Space workflow run progression (Task 4.1) (#443)**
- **feat: define Space export/import JSON format (Task 8.1) (#441)**
- **docs: align Milestone 4 planning docs with transition/condition implementation (#447)**
- **feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2) (#450)**
- **fix: make CreateWorkflowRunParams.currentStepId optional (#449)**
- **feat: add SpaceStore reactive state management (Task 5.2) (#446)**
- **fix: fix failing E2E tests for mission creation routes and persistence (#451)**
- **feat: add Space export/import RPC handlers (Task 8.2) (#452)**
- **feat: workflow selection logic and Space agent tools (Task 7.1) (#453)**
- **fix: sync space_agents columns in space-test-db.ts with migration schema (#448)**
- **feat: Space creation UX and 3-column layout (Task 5.3) (#455)**
- **task/make turn summary card use bigger font and render  (#460)**
- **feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3) (#454)**
- **feat: Task 8.3 — Frontend Export/Import UI for Space agents and workflows**
- **fix: fetch real Copilot model IDs dynamically via client.listModels() (#464)**
- **task/fix agent session crash when switching modelprovid (#459)**
- **task/add support for minimax m27 highspeed model (#458)**
- **feat: Task 6.1 - Custom Agent List and Editor**
- **task/task 72 space agent prompt enhancement (#457)**
- **feat: workflow step builder (Task 6.2) (#463)**
- **fix: handle thinking blocks in SDK title generation (#461)**
- **refactor: remove detectProvider heuristic entirely (#467)**
- **feat: Task 6.3 - Workflow Rules Editor and Space integration (#468)**
- **feat: add structured tokens object to design-tokens module (#469)**
- **test: add tokens unified namespace tests for Task 1.2 (#470)**
- **feat: typography and global prose refinements (Task 1.3) (#471)**
- **fix: ensure onError cleanup runs on subprocess crash in codex bridge (#473)**
- **fix: clear stale sdkSessionId when SDK session file no longer exists (#474)**
- **fix: display Copilot quota errors as UI error blocks and stop retrying (#476)**
- **feat: display API retry errors in UI during SDK retry attempts (#475)**
- **fix: use unique workspace paths and correct delete params in space E2E tests (#477)**
- **feat: Button/IconButton/NavIconButton unification (Task 2.1) (#472)**
- **fix: clean up stale spaces before creating in E2E tests (#478)**
- **fix: correct space.list response shape in E2E stale-space cleanup (#481)**
- **fix: use correct space.create response shape in E2E tests (#482)**
- **ci: skip unstable space E2E tests (export-import, workflow-rules) (#483)**
- **docs: plan for workflow visual editor implementation (#479)**
- **feat: add VisualCanvas component with pan and zoom (Task 1.2) (#484)**
- **feat: add layout column to space_workflows for visual editor (Task 1.1) (#485)**
- **feat: replace hidden dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2) (#480)**
- **feat: add SVG overlay layer for edges in VisualCanvas (Task 1.3) (#488)**
- **feat: add WorkflowNode canvas component (Task 2.1) (#490)**
- **fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors (#486)**
- **feat: DAG auto-layout algorithm for workflow visual editor (Task 5.1) (#487)**
- **feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4) (#489)**
- **feat: add node selection and multi-select to visual editor (Task 2.3) (#491)**
- **feat: implement WorkflowNode with drag-and-drop support (Task 2.2) (#492)**
- **fix: always set provider in createCustomAgentInit for Space custom agents (#495)**
- **feat: create connections by dragging from output to input ports (Task 3.2) (#496)**
- **feat: implement NodeConfigPanel and extract GateConfig (Task 4.1) (#497)**
- **feat: add Spaces UI with global agent and context panel (#493)**
- **task/task 31 render edges as svg bezier curves (#494)**
- **feat: implement EdgeConfigPanel component for transition editing (Task 4.2) (#498)**
- **feat: serialize visual state to SpaceWorkflow data model (Task 5.2) (#499)**
- **Plan: Task Agent session orchestrator for Space tasks (#501)**
- **feat: add VisualWorkflowEditor orchestrator component (Task 6.1) (#500)**
- **feat: add space_task_agent session type and taskAgentSessionId to SpaceTask (#502)**
- **feat: define Task Agent MCP tool schemas (Task 1.3) (#503)**
- **feat: add List/Visual toggle in SpaceIsland workflow editor (Task 6.2) (#505)**
- **feat: add template support to visual workflow editor (Task 5.3) (#506)**
- **test: add performance validation for large workflows (Task 7.3) (#504)**
- **feat: build Task Agent system prompt and initial message builders (#507)**
- **feat: add task_agent_session_id to space_tasks schema and repository (#508)**
- **docs: plan for Space Agent Coordinator reactive event-driven task coordination (Layer 4a) (#512)**
- **feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2) (#510)**
- **feat: implement Task Agent MCP tool handlers (Task 3.1) (#513)**
- **test: add E2E tests for visual workflow editor (Task 7.1) (#509)**
- **feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1) (#515)**
- **feat: add retryTask and reassignTask methods to SpaceTaskManager (#514)**
- **feat: implement SessionNotificationSink for Space Agent event injection (#519)**
- **test: fix pre-existing test failures for compatibility (Task 7.2) (#511)**
- **feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column (#516)**
- **feat: add coordination tools to space-agent-tools (Task 3.2) (#520)**
- **test: add MCP server factory tests for createTaskAgentMcpServer (#517)**
- **feat: update space-chat-agent prompt with coordinator behavior (Task 4.1) (#523)**
- **feat: update SpaceManager and RPC handlers for autonomy level (Task 1.2) (#524)**
- **feat: integrate NotificationSink into SpaceRuntime tick loop (Task 2.2) (#525)**
- **fix: use worktree path for SDK session file lookups (#518)**
- **task/review pr 518 (#527)**
- **feat: update global-spaces-agent prompt with coordination guidance (#522)**
- **test: autonomy level behavior tests for space agent (Task 6.2) (#526)**
- **feat: add needs_attention detection for standalone tasks in SpaceRuntime (#529)**
- **feat: add coordination tools to global-spaces-tools.ts (Task 3.3) (#521)**
- **feat: implement TaskAgentManager core (Task 4.1) (#528)**
- **test: add full pipeline integration tests for concurrent notification events (Task 6.1) (#531)**
- **feat: wire SessionNotificationSink into provisionGlobalSpacesAgent (Task 5.2) (#530)**
- **feat: wire TaskAgentManager into DaemonApp (Task 4.3) (#532)**
- **test: edge case and resilience tests for notification system (Task 6.3) (#537)**
- **feat: add human message routing to Task Agent via space.task.sendMessage/getMessages (#536)**
- **feat: add Task Agent spawning to SpaceRuntime tick loop (Task 5.1) (#538)**
- **test: verify all MCP tools registered in global-spaces provisioning (Task 5.3) (#534)**
- **feat: add send_message_to_task tool to Space Agent (#535)**
- **feat: wire TaskAgentManager into SpaceRuntimeService (Task 5.2) (#540)**
- **feat: add task completion notification to Space Agent (Task 6.2) (#541)**
- **test: online tests with dev proxy for space agent coordination (Task 6.4) (#539)**
- **feat: add toast semantic methods and ConfirmModal enhancements (Task 2.3) (#543)**
- **feat: add Task Agent session rehydration on daemon restart (Task 5.3) (#542)**
- **feat: add semantic status border and inline reject form to RoomTasks (Task 2.4) (#544)**
- **feat: add Inbox navigation infrastructure (Task 3.1) (#545)**
- **feat: add Inbox view (inbox-store + Inbox.tsx + MainContent routing) (Task 3.2) (#546)**
- **test: add end-to-end online test for Task Agent lifecycle (Task 6.3) (#547)**
- **feat: add direct approve/reject to Inbox without TaskView navigation (Task 4.3) (#548)**
- **feat: hide ContextPanel when inbox is active (Task 4.2) (#550)**
- **fix: remove premature task_agent_session_id index from migration 29 (#551)**
- **feat: auto-expand review TaskCards with Approve button and worker summary (Task 4.4) (#553)**
- **docs: plan for workflow iteration loop with agent-driven cyclic transitions (#552)**
- **docs: plan to fix E2E test failures on dev branch CI (#556)**
- **docs: plan for task status lifecycle redesign (#555)**
- **feat: add goalId column to space_tasks and types (Task 3.1) (#561)**
- **fix: replace fixed sleep with Playwright auto-retrying assertion in worktree-isolation E2E test (#557)**
- **fix: rewrite task-actions-dropdown E2E tests to match actual inline button UI (#558)**
- **Plan: Redesign RoomContextPanel goal-centric sidebar (#563)**
- **feat: add iteration tracking columns to DB and types (Task 2.1) (#564)**
- **fix: remove stale sessions from RoomContextPanel on session delete/update (#554)**
- **fix: update space-creation E2E test assertions to match actual tabbed UI (#559)**
- **feat: add ActionBar component and replace inline HeaderReviewBar in TaskView (Task 4.5) (#560)**
- **feat: propagate goalId through workflow task creation (Task 3.2) (#565)**
- **feat: add task_result condition type and isCyclic to workflow transitions (#562)**
- **fix: fix visual-workflow-editor E2E tests — space URL sync + navigateToSpace wait (#567)**
- **feat: add CollapsibleSection component for sidebar sections (#568)**
- **feat: add /room/:roomId/agent route pattern and navigation (#570)**
- **feat: add mobile BottomTabBar with iOS-style navigation (Task 4.6) (#571)**
- **feat: add computed signals for goal-task grouping and orphan tasks (#569)**
- **test: unit tests for goalId propagation (Task 5.3) (#572)**
- **feat: add archived status to TaskStatus and SpaceTaskStatus unions (#566)**
- **feat: add Verify & Test step to Coding Workflow template (#573)**
- **feat: implement task_result evaluation in WorkflowExecutor (#574)**
- **chore: trigger PR creation for task 5.1 (#583)**
- **feat(workflow): implement iteration detection and capping in WorkflowExecutor (#585)**
- **fix: replace crypto.randomUUID with browser-compatible generateUUID (#587)**
- **feat: wire step_result through advance_workflow to executor (Task 1.3) (#586)**
- **feat: rewrite RoomContextPanel with goal-centric sidebar layout (#577)**
- **test: unit tests for archived status transitions and archival filtering (#580)**
- **test: add unit tests for router room agent route (#575)**
- **test: add reactivity and edge case tests for room store computed signals (#576)**
- **fix: stop worktree cleanup on complete and cancel in task-group-manager (#578)**
- **test: add space task manager tests for archival and reactivation lifecycle (#579)**
- **test: add archive and reactivation RPC handler tests for space tasks (#593)**
- **fix: fix flaky online tests in CI (#582)**
- **feat: Phase 4 micro-animations — badge pop, card approve/reject, panel & page fade-in (#590)**
- **test: add missing draft/pending Active tab and sessions count badge tests for RoomContextPanel (#591)**
- **feat: update task tab grouping to Active/Review/Done/Archived (#581)**
- **feat: add model switching in TaskView and auto-fallback on rate/usage limits (#589)**
- **test: add end-to-end cyclic workflow integration test (Task 5.5) (#598)**
- **test: validate Room.tsx integration with room agent routes (#592)**
- **feat: update room-runtime and RPC handlers for new lifecycle (#594)**
- **feat: add reactivate and archive actions to TaskView (#601)**
- **test: add E2E tests for room sidebar sections (goal expand/collapse and task tab filtering) (#602)**
- **feat: allow cancelled → completed status transition (#600)**
- **test: add E2E tests for room sidebar URL navigation and persistence (#603)**
- **fix: update room-agent-tools guards and comments for new task lifecycle (#599)**
- **test: add web unit tests for archived status and reactivate/archive button visibility (#604)**
- **fix: recover rate-limited workers stuck in later iterations (feedbackIteration > 0) (#596)**
- **test: add unit tests for room-runtime lifecycle changes (#605)**
- **test: add online integration tests for task reactivation and archive lifecycle (#608)**
- **test: add edge-case tests for cyclic transition condition evaluation and iterationCount (#609)**
- **test: add E2E tests for task reactivate and archive UI actions (#611)**
- **fix: sync root repo after PR merge via lifecycle gate (#610)**
- **docs: plan for Space Agent Groups flexible multi-agent collaboration (#606)**
- **feat: add migration 40 for flexible session groups (#614)**
- **feat: extend WorkflowStep with agents array and WorkflowChannel topology (#613)**
- **docs: implementation plan for persistent job queue adoption (#612)**
- **feat: update shared types for flexible SpaceSessionGroup model (#615)**
- **feat: add updateMemberStatus method to SpaceSessionGroupRepository**
