### PR TITLE
feat: extend export/import format for multi-agent steps and channels

### DIFF
--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/00-overview.md
@@ -1,0 +1,116 @@
+# Complete and Adopt Persistent Job Queue -- Continue from PR #203
+
+## Goal
+
+Wire the existing but unused `JobQueueRepository` and `JobQueueProcessor` into the daemon lifecycle, then migrate the three primary `setInterval`-based background task subsystems to the persistent job queue. This makes background work durable across daemon restarts and centralizes scheduling.
+
+## Background
+
+PR #203 produced a comprehensive ADR (`docs/adr/0002-job-queue-migration.md`) over 13 review iterations. The plan is well-specified but zero production code has been implemented. The existing infrastructure includes:
+
+- `JobQueueRepository` (complete, 203 lines) -- CRUD, dequeue, retry, cleanup
+- `JobQueueProcessor` (complete, 123 lines) -- poll-based processor with handler registration
+- `job_queue` SQLite table with indexes
+- Comprehensive unit tests for both
+
+The subsystems to migrate:
+1. **Session background tasks** -- fire-and-forget title generation tracked in `pendingBackgroundTasks` Set
+2. **GitHub polling** -- `setInterval` in `GitHubPollingService` (60s cycle)
+3. **Room runtime tick** -- `setInterval` in `RoomRuntime.start()` (30s cycle), with **17 `scheduleTick()` call sites**, **6 `scheduleTickAfterRateLimitReset()` call sites** (lines 617, 696, 732, 985, 1052, 1084), and **2 `queueMicrotask(() => this.tick())` call sites** (lines 2241, 3421) — totaling ~23 scheduling points that need migration
+
+## Out of Scope
+
+The following `setInterval` users are explicitly **out of scope** for this migration and will remain as-is:
+
+- **`WebSocketServerTransport.staleCheckTimer`** (`packages/daemon/src/lib/websocket-server-transport.ts` line 87) — This is a transport-layer health check (30s stale connection cleanup), not a background business task. It operates at a different abstraction layer and does not benefit from persistence.
+- **`SpaceRuntime.tickTimer`** (`packages/daemon/src/lib/space/runtime/space-runtime.ts` line 226) — SpaceRuntime is a newer/parallel runtime implementation. Its tick loop follows the same pattern as RoomRuntime but is a separate subsystem. It should be migrated in a follow-up once RoomRuntime migration is proven stable.
+- **`TaskAgentManager` polling interval** (`packages/daemon/src/lib/space/runtime/task-agent-manager.ts` line 190) — Part of the SpaceRuntime subsystem, out of scope for the same reason.
+- **`JobQueueProcessor` internal poll timer** (`packages/daemon/src/storage/job-queue-processor.ts` line 38) — This is the job queue infrastructure itself; its internal `setInterval` is the mechanism that drives all job processing and is not a migration target.
+- **`app.ts` shutdown readiness check** (`packages/daemon/src/app.ts` line 367) — One-shot `setInterval` for graceful shutdown polling, not a recurring background task.
+
+Task 6.2 must explicitly verify these exclusions and document them in a code comment for future reference.
+
+## Approach
+
+Continue on the existing PR #203 branch (`plan/persistent-job-queue-adoption`). Implement in 6 milestones, each producing a PR-ready commit. All work targets the `dev` branch.
+
+**Key design decisions:**
+- Handlers self-schedule the next run (no dedicated scheduler service for now)
+- `listJobs` must be extended to accept `status` as an array for deduplication queries
+- Room tick deduplication uses application-level checks (not DB unique index) for simplicity. **Risk acknowledged:** the check-then-enqueue pattern has a small race window. If this proves problematic in practice, a follow-up can add a unique partial index on `(queue, json_extract(payload, '$.roomId')) WHERE status IN ('pending', 'processing')` as the ADR suggests. For now the application-level approach is acceptable because: (a) SQLite serializes writes, limiting the race window; (b) a rare duplicate tick is harmless (tick is idempotent); (c) the dedup check should use "no pending job exists at all for this roomId" (not just "no future-scheduled job"), see detailed logic in Milestone 4.
+- `stopRuntime()` must call `runtimes.delete(roomId)` to fix the liveness check bug
+- **Pause/resume must cancel in-flight tick jobs** — see Milestone 4 for detailed design of pause/resume interaction with the job queue
+
+## Handler Registration and Startup Ordering
+
+All handlers **must** be registered before `jobProcessor.start()` is called. If a pending job exists in the DB from a previous run and no handler is registered for its queue, it will fail with "No handler registered" and consume retry attempts.
+
+**Required startup order in `app.ts`:**
+
+```
+1. sessionManager.start()       → registers 'session.title_generation' handler
+2. gitHubService.start()        → registers 'github.poll' handler + enqueues initial poll
+3. roomRuntimeService.start()   → registers 'room.tick' handler
+4. Register cleanup handler     → registers 'job_queue.cleanup' handler + enqueues initial cleanup
+5. jobProcessor.start()         → begins processing (all handlers now registered)
+```
+
+Each milestone's wiring task must respect this ordering. Task 1.2 must initially call `jobProcessor.start()` as the **last** step, and each subsequent milestone inserts its handler registration before that call.
+
+## maxConcurrent Configuration
+
+The initial `maxConcurrent: 3` is conservative. With multiple active rooms, each generating `room.tick` jobs every 30s, plus GitHub polling and title generation, the 3-slot limit may cause contention — a long-running title generation or poll could block room ticks.
+
+**Mitigation strategy:**
+- Start with `maxConcurrent: 5` instead of 3, based on expected workload (typically 1-3 active rooms + 1 GitHub poll + occasional title gen)
+- The processor's `dequeue` already handles priority via FIFO ordering; room ticks are short-lived and will cycle quickly
+- If contention appears in practice, the follow-up is per-queue concurrency limits (the ADR's open question on priority inversion)
+- Task 1.2 should make `maxConcurrent` configurable via environment variable (`NEOKAI_JOB_QUEUE_MAX_CONCURRENT`, default 5)
+
+## Stale Job Reclamation Timing
+
+`JobQueueProcessor.checkStaleJobs()` runs only after `STALE_CHECK_INTERVAL = 60_000ms` has elapsed since the last check. After a daemon restart, jobs stuck in `processing` from the previous run will sit unreclaimed for up to 60 seconds.
+
+**Mitigation:** Task 1.2 must add an eager `reclaimStale()` call in `JobQueueProcessor.start()` — immediately after starting, reclaim any stale jobs before the first poll tick. This ensures crash-recovery is instant rather than delayed by up to 60 seconds.
+
+## Rollback Strategy
+
+Each milestone removes old scheduling code (`setInterval`, `pendingBackgroundTasks`, etc.) and replaces it with job queue calls. If a milestone causes issues:
+
+1. **Revert the merge commit** for that milestone's PR — this restores the old `setInterval` code
+2. Old jobs in the `job_queue` table for the reverted subsystem will go stale and be cleaned up by the cleanup job (or manually via `DELETE FROM job_queue WHERE queue = '...'`)
+3. The job queue infrastructure (Milestone 1) can remain in place even if individual migrations are reverted
+
+For the highest-risk migration (Milestone 4 — room tick), the implementer should ensure the PR is small enough to revert cleanly and should include a feature flag or environment variable (`NEOKAI_USE_JOB_QUEUE_ROOM_TICK=true`) that can disable the migration without a full revert.
+
+## Milestones
+
+1. **Foundation -- Wire JobQueueProcessor into DaemonApp** -- Instantiate processor in `app.ts`, add constants file, extend `listJobs` to accept status arrays, connect change notifier to ReactiveDatabase, hook into start/stop lifecycle. Add eager stale reclamation on startup.
+
+2. **Migrate Session Background Tasks** -- Replace `pendingBackgroundTasks` Set in `SessionManager` with a `session.title_generation` job queue handler. Add `SessionManager.start()` method.
+
+3. **Migrate GitHub Polling** -- Replace `setInterval` in `GitHubPollingService` with self-scheduling `github.poll` jobs. Expose `triggerPoll()` method, register handler, add dedup logic in finally block.
+
+4. **Migrate Room Runtime Tick** -- Replace `setInterval` + `scheduleTick()` + `scheduleTickAfterRateLimitReset()` + `queueMicrotask` in `RoomRuntime` with `room.tick` jobs. Fix `stopRuntime()` to delete from runtimes map. Handle all ~23 scheduling call sites. Add pause/resume-aware job cancellation.
+
+5. **Database Cleanup Job and Stale Job Reclamation** -- Add a self-scheduling `job_queue.cleanup` job that runs daily. Remove old completed/dead jobs. Verify stale job reclamation works across restarts.
+
+6. **Integration Tests and E2E Validation** -- Online tests for crash-recovery scenarios across all migrated subsystems. Verify job processing resumes after daemon restart. Audit for remaining `setInterval` usage and document out-of-scope exclusions.
+
+## Cross-Milestone Dependencies
+
+```
+Milestone 1 (Foundation)
+  +-- Milestone 2 (Session tasks)
+  +-- Milestone 3 (GitHub polling)
+  +-- Milestone 4 (Room tick)
+  +-- Milestone 5 (Cleanup job)
+       |
+       +-- Milestone 6 (Integration tests) -- depends on Milestones 2, 3, 4, 5
+```
+
+Milestones 2, 3, 4, and 5 can proceed in parallel after Milestone 1 is complete. Milestone 6 depends on all prior milestones.
+
+## Total Estimated Task Count
+
+18 tasks across 6 milestones (3 + 3 + 3 + 4 + 2 + 3).

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/01-foundation.md
@@ -1,0 +1,138 @@
+# Milestone 1: Foundation -- Wire JobQueueProcessor into DaemonApp
+
+## Goal
+
+Make the persistent job queue operational by wiring `JobQueueProcessor` into the daemon lifecycle, extending `listJobs` to support status arrays, creating queue name constants, connecting the change notifier to `ReactiveDatabase`, and adding eager stale job reclamation on startup.
+
+## Scope
+
+- Extend `JobQueueRepository.listJobs()` to accept `status` as `JobStatus | JobStatus[]`
+- Create `packages/daemon/src/lib/job-queue-constants.ts` with queue name constants
+- Instantiate `JobQueueProcessor` in `app.ts`
+- Connect `setChangeNotifier` to `ReactiveDatabase`
+- Add `jobProcessor` and `jobQueue` to `DaemonAppContext`
+- Hook `jobProcessor.stop()` into cleanup (before `messageHub.cleanup()`)
+- Pass `jobQueue` and `jobProcessor` through `RPCHandlerDependencies`
+- Add eager `reclaimStale()` call in `JobQueueProcessor.start()` for instant crash recovery
+
+## Tasks
+
+### Task 1.1: Extend listJobs to accept status arrays
+
+**Description:** Modify `JobQueueRepository.listJobs()` to accept `status` as either a single `JobStatus` string or an array of `JobStatus` values. When an array is provided, generate `IN (?,?,...)` SQL with dynamic placeholders. Empty array returns no rows.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Read `packages/daemon/src/storage/repositories/job-queue-repository.ts` lines 128-147
+2. Change the `status` field type in the filter parameter from `status?: JobStatus` to `status?: JobStatus | JobStatus[]`
+3. Update the SQL generation: if array, build `AND status IN (?,?,...)`; if string, keep existing `AND status = ?`; if empty array, return `[]` early
+4. Update `packages/daemon/tests/unit/storage/job-queue-repository.test.ts` with tests for:
+   - `status: ['pending', 'processing']` returns jobs matching either status
+   - `status: 'pending'` (string) still works as before
+   - `status: []` (empty array) returns empty results
+5. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-repository.test.ts` to verify
+6. Run `bun run check` to verify no lint/type errors
+
+**Acceptance criteria:**
+- `listJobs({ status: ['pending', 'processing'] })` returns jobs with either status
+- `listJobs({ status: 'pending' })` still works (backward compatible)
+- `listJobs({ status: [] })` returns empty array
+- All existing job-queue-repository tests pass
+- New tests cover the array status filter
+
+**Depends on:** none
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 1.2: Create job queue constants, wire processor into app.ts, and add eager stale reclamation
+
+**Description:** Create the queue name constants file and wire `JobQueueProcessor` into the `DaemonApp` lifecycle. This includes instantiation, ReactiveDatabase change notification, cleanup ordering, and exposing via `DaemonAppContext`. Also modify `JobQueueProcessor.start()` to eagerly reclaim stale jobs on startup (before the first poll tick) so crash-recovery is instant rather than delayed by up to 60 seconds.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-queue-constants.ts` with constants:
+   ```
+   SESSION_TITLE_GENERATION = 'session.title_generation'
+   GITHUB_POLL = 'github.poll'
+   ROOM_TICK = 'room.tick'
+   JOB_QUEUE_CLEANUP = 'job_queue.cleanup'
+   ```
+3. In `packages/daemon/src/storage/job-queue-processor.ts`:
+   - In `start()`, add `this.repo.reclaimStale(this.staleThresholdMs)` call **before** the first `this.tick()` call. This ensures any jobs left in `processing` from a previous crash are immediately reclaimed on startup, rather than waiting for the 60s `STALE_CHECK_INTERVAL`
+   - Add a unit test specifically for this eager reclamation behavior
+4. In `packages/daemon/src/app.ts`:
+   - Import `JobQueueRepository` from `./storage/repositories/job-queue-repository`
+   - Import `JobQueueProcessor` from `./storage/job-queue-processor`
+   - After `liveQueries` creation (~line 101), instantiate:
+     ```
+     const jobQueue = new JobQueueRepository(db.getDatabase());
+     const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
+     const jobProcessor = new JobQueueProcessor(jobQueue, { pollIntervalMs: 1000, maxConcurrent, staleThresholdMs: 5 * 60 * 1000 });
+     ```
+   - Call `jobProcessor.setChangeNotifier((table) => { reactiveDb.notifyChange(table); });`
+   - **IMPORTANT startup ordering:** `jobProcessor.start()` must be the **last** startup call, placed AFTER all handler registrations. Initially (before Milestones 2-4 add their handlers), place it after `gitHubService.start()` (~line 341). Each subsequent milestone will insert handler registrations before this call.
+   - In `cleanup()`, add `await jobProcessor.stop()` BEFORE `messageHub.cleanup()` (~line 394) with log message
+5. Add `jobProcessor: JobQueueProcessor` and `jobQueue: JobQueueRepository` to `DaemonAppContext` interface and return object
+6. Add `jobProcessor` and `jobQueue` to `RPCHandlerDependencies` in `packages/daemon/src/lib/rpc-handlers/index.ts` (interface only, no handler changes yet)
+7. Pass `jobProcessor` and `jobQueue` from `app.ts` to `setupRPCHandlers()`
+8. Run `bun run check` to verify no lint/type errors
+9. Create unit test `packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts` that verifies:
+   - `DaemonAppContext` includes `jobProcessor` and `jobQueue`
+   - Cleanup stops the processor before messageHub
+   - `maxConcurrent` is configurable via env var
+
+**Acceptance criteria:**
+- `JobQueueProcessor` is instantiated in `app.ts` with `maxConcurrent` defaulting to 5 (configurable via `NEOKAI_JOB_QUEUE_MAX_CONCURRENT`)
+- Eager `reclaimStale()` called in `start()` before first poll tick
+- Change notifier wired to `reactiveDb.notifyChange`
+- `jobProcessor.start()` called AFTER all handler registrations
+- `jobProcessor.stop()` called in cleanup BEFORE `messageHub.cleanup()`
+- `jobProcessor` and `jobQueue` available in `DaemonAppContext`
+- `RPCHandlerDependencies` interface includes both fields
+- Constants file exists with all 4 queue names
+- All existing tests pass
+
+**Depends on:** Task 1.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 1.3: Unit tests for processor lifecycle integration
+
+**Description:** Add unit tests verifying the `JobQueueProcessor` contract **in isolation** — specifically the behavioral contracts that the app-level wiring depends on. This focuses on processor internals (polling, dequeue, handler dispatch, stale reclamation, error/retry) and does NOT test app-level wiring (which is covered by Task 1.2's test file).
+
+**Scope clarification vs Task 1.2 tests:**
+- **Task 1.2** (`app/job-queue-lifecycle.test.ts`) tests app-level wiring: context fields, cleanup ordering, env var config
+- **Task 1.3** (`storage/job-queue-processor-lifecycle.test.ts`) tests processor contract: start → poll → dequeue → dispatch → stop, change notification callbacks, error → retry → dead transitions, stale reclamation timing, eager reclaim on start
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/unit/storage/job-queue-processor-lifecycle.test.ts`
+2. Test that `start()` calls `reclaimStale()` eagerly before the first poll tick
+3. Test that `start()` begins polling and processes enqueued jobs via registered handlers
+4. Test that `stop()` waits for in-flight jobs to complete before resolving
+5. Test that `setChangeNotifier` callback is invoked when jobs complete (status transitions)
+6. Test that processor handles handler errors gracefully: first failure increments `attempts` and re-queues as `pending`; after `maxRetries` exhausted, marks as `dead`
+7. Test that stale job reclamation works: a job stuck in `processing` beyond `staleThresholdMs` is reset to `pending`
+8. Run `cd packages/daemon && bun test tests/unit/storage/job-queue-processor-lifecycle.test.ts`
+
+**Acceptance criteria:**
+- Tests cover eager stale reclamation on start
+- Tests cover start → poll → dequeue → dispatch lifecycle
+- Tests cover stop draining in-flight jobs
+- Tests cover change notification callback invocation
+- Tests cover error → retry → dead transitions
+- Tests cover stale job reclamation timing
+- No overlap with Task 1.2's app-wiring tests
+- All tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/02-session-background-tasks.md
@@ -1,0 +1,119 @@
+# Milestone 2: Migrate Session Background Tasks
+
+## Goal
+
+Replace the fire-and-forget `pendingBackgroundTasks` Set in `SessionManager` with a persistent `session.title_generation` job. Title generation becomes durable and survives daemon restarts.
+
+## Scope
+
+- Create `session.title_generation` job handler
+- Add `SessionManager.start()` method that registers the handler
+- Remove `pendingBackgroundTasks` from `SessionManager`
+- Replace fire-and-forget title generation with `jobQueue.enqueue()`
+
+## Key Files
+
+- `packages/daemon/src/lib/session/session-manager.ts` -- line 59 (`pendingBackgroundTasks`), lines 150-161 (title gen enqueue), lines 361-376 (cleanup drain)
+- `packages/daemon/src/lib/session/session-lifecycle.ts` -- `generateTitleAndRenameBranch()` method
+- `packages/daemon/src/storage/job-queue-processor.ts` -- handler registration
+- `packages/daemon/src/app.ts` -- call ordering
+
+## Tasks
+
+### Task 2.1: Create session title generation job handler
+
+**Description:** Create a job handler for `session.title_generation` that calls the existing `SessionLifecycle.generateTitleAndRenameBranch()` method. The handler extracts `sessionId` and `userMessageText` from the job payload.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-handlers/session-title.handler.ts`
+3. Define the handler function: accepts a `Job`, extracts `{ sessionId, userMessageText }` from payload, calls `sessionLifecycle.generateTitleAndRenameBranch(sessionId, userMessageText)`
+4. The handler should catch and log errors but not rethrow (title gen is non-fatal) -- actually, let errors propagate so the job queue retries
+5. Return `{ generated: true }` on success
+6. Create unit test `packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts`:
+   - Mock `SessionLifecycle` with a `generateTitleAndRenameBranch` stub
+   - Test successful title generation
+   - Test error propagation for retries
+   - Test missing session handling
+7. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Handler exists at `packages/daemon/src/lib/job-handlers/session-title.handler.ts`
+- Handler calls `generateTitleAndRenameBranch` with correct params from payload
+- Unit tests pass with mocked dependencies
+- Errors propagate for job queue retry logic
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.2: Wire handler into SessionManager and remove pendingBackgroundTasks
+
+**Description:** Add a `start()` method to `SessionManager` that registers the title generation handler with the job processor. Replace `pendingBackgroundTasks` usage with `jobQueue.enqueue()`. Update `app.ts` to call `sessionManager.start()` before `jobProcessor.start()`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/session/session-manager.ts`:
+   - Add `jobQueue: JobQueueRepository` and `jobProcessor: JobQueueProcessor` to constructor dependencies
+   - Add `start()` method that registers the `session.title_generation` handler on `jobProcessor`
+   - Replace lines 150-161 (the `pendingBackgroundTasks` tracking) with:
+     ```
+     this.jobQueue.enqueue({
+       queue: QUEUES.SESSION_TITLE_GENERATION,
+       payload: { sessionId, userMessageText },
+       maxRetries: 2,
+     });
+     ```
+   - Remove `private pendingBackgroundTasks: Set<Promise<unknown>>` field
+   - Update `cleanup()` to remove the pendingBackgroundTasks drain logic (lines 361-376) -- the job processor handles draining
+2. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `SessionManager` constructor
+   - Call `sessionManager.start()` after sessionManager creation but before `jobProcessor.start()`. Per the startup ordering in `00-overview.md`, `sessionManager.start()` is step 1, `jobProcessor.start()` is step 5. Ensure the handler registration happens before the processor starts so that any pending `session.title_generation` jobs from a previous run are processed correctly on restart.
+3. Update existing `SessionManager` unit tests to account for constructor changes
+4. Add unit test verifying `enqueue` is called instead of direct title generation
+5. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- `pendingBackgroundTasks` field completely removed from `SessionManager`
+- Title generation enqueued as a job instead of fire-and-forget Promise
+- `sessionManager.start()` registers the handler with `jobProcessor`
+- `app.ts` calls `sessionManager.start()` in correct order
+- All existing session-related tests pass
+- Cleanup no longer drains background tasks (processor handles this)
+
+**Depends on:** Task 2.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 2.3: Online test for session title generation via job queue
+
+**Description:** Create an online test that verifies title generation works end-to-end through the job queue, including retry on failure.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/lifecycle/session-title-job.test.ts`
+2. Use `createDaemonServer()` test helper to spin up a daemon
+3. Create a session, send a message, and verify:
+   - A `session.title_generation` job is enqueued
+   - The job is processed (status transitions: pending -> processing -> completed)
+   - The session title is updated
+4. Test retry behavior: mock title generation to fail on first attempt, succeed on second
+5. Run with `NEOKAI_USE_DEV_PROXY=1` for mocked API calls
+
+**Acceptance criteria:**
+- Online test verifies end-to-end title generation via job queue
+- Job status transitions are verified
+- Retry on failure is tested
+- Test runs successfully with dev proxy
+
+**Depends on:** Task 2.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/03-github-polling.md
@@ -1,0 +1,123 @@
+# Milestone 3: Migrate GitHub Polling
+
+## Goal
+
+Replace the `setInterval`-based polling loop in `GitHubPollingService` with self-scheduling `github.poll` jobs. Polling becomes durable and recoverable after daemon restarts.
+
+## Scope
+
+- Expose a `triggerPoll()` method on `GitHubPollingService`
+- Create `github.poll` job handler with self-scheduling
+- Add deduplication in the finally block to prevent duplicate poll chains
+- Remove `setInterval` from `GitHubPollingService.start()`
+- Wire handler registration through `GitHubService`
+
+## Key Files
+
+- `packages/daemon/src/lib/github/polling-service.ts` -- line 76 (`setInterval`), `start()/stop()` methods, `pollAllRepositories()` (private)
+- `packages/daemon/src/lib/github/github-service.ts` -- orchestrator, `start()/stop()` lifecycle
+- `packages/daemon/src/app.ts` -- GitHub service creation and startup
+
+## Tasks
+
+### Task 3.1: Expose triggerPoll and create github.poll handler
+
+**Description:** Add a public `triggerPoll()` method to `GitHubPollingService` that calls the existing private `pollAllRepositories()`. Create a `github.poll` job handler that calls `triggerPoll()` and self-schedules the next poll.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. In `packages/daemon/src/lib/github/polling-service.ts`:
+   - Add public `async triggerPoll(): Promise<void>` that calls `this.pollAllRepositories()`
+   - Add a guard: if `this.isPolling` is true, skip (reuse existing mutex)
+3. Create `packages/daemon/src/lib/job-handlers/github-poll.handler.ts`:
+   - Handler calls `pollingService.triggerPoll()`
+   - In a `finally` block, check for existing pending `github.poll` jobs using `jobQueue.listJobs({ queue: QUEUES.GITHUB_POLL, status: ['pending'], limit: 10 })`
+   - Only enqueue next poll job (with `runAt: Date.now() + intervalMs`) if **no pending job exists at all** — not just "no future-scheduled job". A pending job with `runAt` in the past means it's ready to run and the chain is alive; enqueuing another would create a duplicate. The check is simply: `if (pendingJobs.length === 0) { enqueue next }`
+   - Return `{ polled: true, nextRunAt }` on success
+4. Create unit test `packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts`:
+   - Mock `GitHubPollingService.triggerPoll()`
+   - Test handler calls triggerPoll
+   - Test self-scheduling enqueues next job
+   - Test dedup: if pending future job exists, skip enqueue
+   - Test error in triggerPoll still schedules next job (finally block)
+5. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- `GitHubPollingService` has a public `triggerPoll()` method
+- Handler calls triggerPoll and self-schedules
+- Dedup prevents duplicate poll chains
+- Errors in polling do not break the scheduling chain
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 3.2: Remove setInterval and wire handler into GitHubService
+
+**Description:** Remove the `setInterval` from `GitHubPollingService.start()` and wire the `github.poll` handler registration through `GitHubService`. The initial poll job is enqueued when `GitHubService.start()` is called.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/github/polling-service.ts`:
+   - Remove `setInterval` from `start()` -- `start()` becomes a state flag setter only
+   - Remove `clearInterval(this.pollingInterval)` from `stop()` — `stop()` becomes a state flag setter only
+   - Remove the `pollingInterval` field declaration and its type (`ReturnType<typeof setInterval> | null`)
+   - Remove any initialization of `pollingInterval` (e.g., `this.pollingInterval = null` in constructor)
+2. In `packages/daemon/src/lib/github/github-service.ts`:
+   - Accept `jobQueue` and `jobProcessor` in `GitHubServiceOptions`
+   - In `start()`: register the `github.poll` handler on `jobProcessor`, then enqueue the initial `github.poll` job with `runAt: Date.now()` (immediate first poll)
+   - In `stop()`: no need to deregister -- processor stop handles this
+3. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `createGitHubService()`
+4. Update existing GitHub polling tests to account for removal of setInterval
+5. Add integration-style unit test verifying the full flow: GitHubService.start() -> enqueue -> handler -> triggerPoll -> self-schedule
+6. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- No `setInterval` in `GitHubPollingService`
+- `GitHubService.start()` enqueues initial `github.poll` job
+- Handler is registered on `jobProcessor`
+- Existing GitHub tests pass or are updated
+- Full flow unit test passes
+
+**Depends on:** Task 3.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 3.3: Online test for GitHub polling via job queue
+
+**Description:** Create an online test verifying GitHub polling works end-to-end through the job queue, including self-scheduling and recovery after restart.
+
+**Note on GitHub API mocking:** The dev proxy (`NEOKAI_USE_DEV_PROXY=1`) only intercepts Anthropic API calls, not GitHub REST API calls. For this test, the focus is on verifying the **job queue mechanics** (enqueue, process, self-schedule, dedup) rather than actual GitHub API responses. The test should mock or stub the `GitHubPollingService.triggerPoll()` method to avoid real GitHub API calls, or configure the GitHub service with a test repository that doesn't require authentication.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/features/github-poll-job.test.ts`
+2. Use `createDaemonServer()` with GitHub config enabled
+3. Mock or stub `GitHubPollingService.triggerPoll()` to avoid real GitHub API calls — the test verifies job queue mechanics, not GitHub API integration
+4. Verify:
+   - `github.poll` job is enqueued on startup
+   - Job transitions through pending -> processing -> completed
+   - Next poll job is automatically scheduled
+   - No duplicate poll jobs exist simultaneously
+5. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- Online test verifies end-to-end GitHub polling via job queue
+- Self-scheduling chain is verified
+- Dedup is verified (no duplicate pending jobs)
+- Test does not make real GitHub API calls
+- Test runs with dev proxy
+
+**Depends on:** Task 3.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/04-room-runtime-tick.md
@@ -1,0 +1,271 @@
+# Milestone 4: Migrate Room Runtime Tick
+
+## Goal
+
+Replace the `setInterval` + `scheduleTick()` + `scheduleTickAfterRateLimitReset()` + `queueMicrotask` pattern in `RoomRuntime` with persistent `room.tick` jobs. This is the highest-risk migration because room runtime manages agent sessions and task execution.
+
+## Scope
+
+- Create `room.tick` job handler
+- Replace `setInterval` in `RoomRuntime.start()` with job-based scheduling
+- Replace all `scheduleTick()` call sites (~17) with `enqueueRoomTick()`
+- Replace all `scheduleTickAfterRateLimitReset()` call sites (6) with `enqueueRoomTick(roomId, jobQueue, delayMs)`
+- Replace `queueMicrotask(() => this.tick())` call sites (2) with `enqueueRoomTick()`
+- Replace `tickLocked`/`tickQueued` mutex with job-queue-level dedup
+- Add pause/resume-aware job cancellation to prevent double ticks
+- Fix `stopRuntime()` to call `runtimes.delete(roomId)`
+- Add `stoppedRooms` tracking for liveness checks
+- Wire handler through `RoomRuntimeService`
+- Optional: feature flag `NEOKAI_USE_JOB_QUEUE_ROOM_TICK` for rollback safety
+
+## Scheduling Call Sites — Complete Inventory
+
+The implementer **must not rely on hardcoded line numbers** — they will shift after Milestones 1-3 are merged. Instead, search dynamically:
+
+```bash
+grep -n 'this\.scheduleTick()' packages/daemon/src/lib/room/runtime/room-runtime.ts
+grep -n 'this\.scheduleTickAfterRateLimitReset(' packages/daemon/src/lib/room/runtime/room-runtime.ts
+grep -n 'queueMicrotask.*this\.tick' packages/daemon/src/lib/room/runtime/room-runtime.ts
+```
+
+**As of current `dev` branch, the complete inventory is:**
+
+### `this.scheduleTick()` — 17 call sites
+Lines: 259, 423, 432, 553, 560, 665, 1024, 1149, 1287, 1315, 1588, 1700, 1815, 3364, 3410, 3432, 3451
+
+Of these, lines 3432 and 3451 are **inside** `scheduleTickAfterRateLimitReset()` and will be removed when that method is rewritten. So 15 external `scheduleTick()` sites need direct replacement.
+
+### `this.scheduleTickAfterRateLimitReset(groupId)` — 6 call sites
+Lines: 617, 696, 732, 985, 1052, 1084
+
+Each of these must be replaced with `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)` where `delayMs` is computed from `this.groupRepo.getRateLimitRemainingMs(groupId) + 5000` (the same logic currently in `scheduleTickAfterRateLimitReset()`). The delay computation must be **inlined at each call site** or extracted to a helper `getRateLimitDelay(groupId)` — the important thing is preserving the 5-second buffer.
+
+### `queueMicrotask(() => this.tick())` — 2 call sites
+Lines: 2241, 3421 (inside `scheduleTick()` body)
+
+Line 3421 disappears when `scheduleTick()` is rewritten. Line 2241 must be replaced with `enqueueRoomTick(this.roomId, this.jobQueue, 0)`.
+
+**Total: ~23 scheduling points** (15 external `scheduleTick` + 6 `scheduleTickAfterRateLimitReset` + 1 external `queueMicrotask` + the `setInterval` in `start()` = 23 distinct replacements).
+
+## Pause/Resume and Dedup Design
+
+### Current in-memory mutex
+
+The current `RoomRuntime` uses `tickLocked` and `tickQueued` fields as a lightweight mutex:
+- `tickLocked = true` while `tick()` is executing
+- `tickQueued = true` if a tick request arrives while locked — ensures one queued tick
+
+This in-memory state is lost when migrating to the job queue and must be replaced.
+
+### Job-queue-level dedup
+
+The `enqueueRoomTick()` helper handles dedup:
+- Before enqueuing, check `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })` and filter by `payload.roomId`. The limit of 100 is sufficient because this is a per-room dedup check (at most one pending tick per room), not a global scan.
+- If **any** pending job exists for this roomId, skip enqueuing (regardless of `runAt`)
+- Only `pending` status is checked, not `processing`. This is safe because: (a) a `processing` job is already executing and its handler's `finally` block will either re-schedule (if runtime is still `running`) or not (if `paused`/`stopped`); (b) if `pause()` is called while a job is `processing`, the handler detects the paused state and skips without re-scheduling — leaving zero pending ticks, which is correct; (c) checking `processing` would cause `enqueueRoomTick` to skip when a tick is actively running, but the running tick's `finally` block handles the successor.
+- This replaces the `tickQueued` semantic: at most one pending tick exists per room
+
+### Pause/resume interaction
+
+**Problem:** After migration, `pause()` sets `this.state = 'paused'` but an already-enqueued `room.tick` job remains in the `pending` queue. When the processor picks it up, the handler checks `runtime.state !== 'running'` and skips — but the job still consumed a processing slot and the completed job's `finally` block might re-schedule.
+
+**Solution:**
+1. The `room.tick` handler's **first check** is `if (runtime.state !== 'running') return { skipped: true, reason: 'not running' }` — no re-schedule in finally when skipped
+2. `pause()` must cancel pending tick jobs: call `cancelPendingTickJobs(this.roomId, this.jobQueue)` which finds all pending `room.tick` jobs for this roomId and deletes them (or marks them `dead`)
+3. `resume()` calls `enqueueRoomTick(this.roomId, this.jobQueue, 0)` — a fresh tick is enqueued
+4. The handler's `finally` block **only** re-schedules if the runtime is still in `running` state AND the handler was not skipped
+
+This preserves the invariant: paused rooms have zero pending ticks, resumed rooms get exactly one.
+
+### `cancelPendingTickJobs(roomId, jobQueue)` helper
+
+```
+function cancelPendingTickJobs(roomId: string, jobQueue: JobQueueRepository): void {
+  const jobs = jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 });
+  for (const job of jobs) {
+    if (job.payload?.roomId === roomId) {
+      jobQueue.deleteJob(job.id);  // or mark as 'dead'
+    }
+  }
+}
+```
+
+If `JobQueueRepository` lacks a `deleteJob` method, add one in Task 4.1.
+
+## Key Files
+
+- `packages/daemon/src/lib/room/runtime/room-runtime.ts` -- 3474 lines; `tickTimer` at line 157, `tickLocked`/`tickQueued` at lines 155-156, `setInterval` at line 422, `scheduleTick()` at line 3418, `queueMicrotask` at line 2241, `scheduleTickAfterRateLimitReset()` at line 3428, `pause()` at line 426, `resume()` at line 430
+- `packages/daemon/src/lib/room/runtime/room-runtime-service.ts` -- `stopRuntime()` at line 124, `startRuntime()` at line 135, `runtimes` Map at line 51
+
+## Tasks
+
+### Task 4.1: Create room.tick handler, enqueueRoomTick, and cancelPendingTickJobs helpers
+
+**Description:** Create the `room.tick` job handler and helper functions for dedup-aware tick enqueuing and pause-aware cancellation. The handler calls `runtime.tick()` and re-schedules the next tick only if the runtime is still running. Add `deleteJob` to `JobQueueRepository` if it doesn't exist.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Check if `JobQueueRepository` has a `deleteJob(id)` method. If not, add one (simple `DELETE FROM job_queue WHERE id = ?`)
+3. Create `packages/daemon/src/lib/job-handlers/room-tick.handler.ts`:
+   - Handler extracts `{ roomId }` from job payload
+   - Looks up runtime from a `getRuntimeForRoom` callback
+   - If runtime not found or state is not 'running', return `{ skipped: true, reason: 'not running' }` — **do not re-schedule**
+   - Call `await runtime.tick()`
+   - In `finally` block: re-check `runtime.state === 'running'`, if still running call `enqueueRoomTick(roomId, jobQueue, tickInterval)`; if not, skip re-schedule
+4. Create `enqueueRoomTick(roomId, jobQueue, delayMs?)` helper function:
+   - Check for existing pending `room.tick` jobs for this room using `jobQueue.listJobs({ queue: QUEUES.ROOM_TICK, status: ['pending'], limit: 100 })`
+   - Filter by `payload.roomId === roomId`
+   - Only enqueue if **no pending job exists at all** for this roomId (not just "no future-scheduled job")
+   - Default delay is 30,000ms (30s tick interval)
+5. Create `cancelPendingTickJobs(roomId, jobQueue)` helper function:
+   - Find all pending `room.tick` jobs for this roomId
+   - Delete them via `jobQueue.deleteJob(id)`
+6. Create unit test `packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts`:
+   - Mock RoomRuntime with tick() stub
+   - Test handler calls tick and re-schedules when runtime is running
+   - Test handler skips and does NOT re-schedule when runtime not found
+   - Test handler skips and does NOT re-schedule when runtime is paused
+   - Test enqueueRoomTick dedup logic: second enqueue with existing pending job is a no-op
+   - Test cancelPendingTickJobs removes all pending jobs for a given roomId
+   - Test error in tick() still allows re-scheduling (if runtime still running)
+7. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Handler exists and correctly calls `runtime.tick()`
+- Handler does NOT re-schedule when runtime is not running or paused
+- `enqueueRoomTick` deduplicates by roomId using "no pending job at all" check
+- `cancelPendingTickJobs` removes all pending tick jobs for a room
+- `deleteJob` method exists on `JobQueueRepository`
+- Errors in tick do not break the scheduling chain for running runtimes
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.2: Replace setInterval, scheduleTick, scheduleTickAfterRateLimitReset, and pause/resume in RoomRuntime
+
+**Description:** Remove `setInterval` from `RoomRuntime.start()`, rewrite `scheduleTick()` and `scheduleTickAfterRateLimitReset()`, replace all call sites, update `pause()`/`resume()` to interact with the job queue, and remove the in-memory `tickLocked`/`tickQueued` mutex.
+
+**IMPORTANT:** Do NOT rely on the line numbers listed below — they are approximate and will shift after Milestones 1-3. Use grep to find all call sites dynamically:
+```bash
+grep -n 'this\.scheduleTick()' room-runtime.ts
+grep -n 'this\.scheduleTickAfterRateLimitReset(' room-runtime.ts
+grep -n 'queueMicrotask.*this\.tick' room-runtime.ts
+```
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/room/runtime/room-runtime.ts`:
+   - Add `jobQueue?: JobQueueRepository` to `RoomRuntimeConfig` interface
+   - Store `jobQueue` in the constructor
+   - Import `enqueueRoomTick`, `cancelPendingTickJobs` from the handler file
+   - **Optional feature flag:** Check `process.env.NEOKAI_USE_JOB_QUEUE_ROOM_TICK !== 'false'` to allow disabling the migration without a full revert. If `false`, fall back to the old `setInterval` behavior. (This is optional but recommended for rollback safety.)
+2. In `start()`: Remove `this.tickTimer = setInterval(...)`, replace with `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate first tick
+3. In `stop()`: Remove `clearInterval(this.tickTimer)` and `this.tickTimer = null`. Add `cancelPendingTickJobs(this.roomId, this.jobQueue)` to cancel any pending tick jobs.
+4. Remove the `tickTimer` field
+5. Remove `tickLocked` and `tickQueued` fields — dedup is now at the job queue level
+6. Update `tick()` method: remove the `tickLocked`/`tickQueued` mutex logic at entry and exit. The job queue processor's `maxConcurrent` and the handler's structure already prevent concurrent ticks for the same room.
+7. Rewrite `scheduleTick()`: instead of `queueMicrotask(() => this.tick())`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` for immediate re-tick
+8. Rewrite `scheduleTickAfterRateLimitReset(groupId)`:
+   - Compute `delayMs = this.groupRepo.getRateLimitRemainingMs(groupId) + 5000` (preserve the 5s buffer)
+   - If `delayMs <= 0`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
+   - Otherwise call `enqueueRoomTick(this.roomId, this.jobQueue, delayMs)` — this replaces the `setTimeout` + `scheduleTick` pattern
+   - Keep the log message for observability
+9. Replace the standalone `queueMicrotask(() => this.tick())` at ~line 2241 with `enqueueRoomTick(this.roomId, this.jobQueue, 0)`
+10. **Update `pause()`:** After setting `this.state = 'paused'`, call `cancelPendingTickJobs(this.roomId, this.jobQueue)` to drain any pending tick jobs
+11. **Update `resume()`:** After setting `this.state = 'running'`, call `enqueueRoomTick(this.roomId, this.jobQueue, 0)` to start the tick chain fresh
+12. Verify all ~23 scheduling points are addressed by running the grep commands above — there should be zero remaining matches
+13. Run existing room runtime tests to check for breakage
+14. Run `bun run check`
+
+**Acceptance criteria:**
+- No `setInterval` in `RoomRuntime`
+- No `tickTimer`, `tickLocked`, or `tickQueued` fields
+- `scheduleTick()` uses `enqueueRoomTick` instead of `queueMicrotask`
+- `scheduleTickAfterRateLimitReset()` uses `enqueueRoomTick` with computed delay instead of `setTimeout`
+- All 6 `scheduleTickAfterRateLimitReset` call sites preserved (they call the rewritten method)
+- The standalone `queueMicrotask` at ~line 2241 replaced
+- `pause()` cancels pending tick jobs
+- `resume()` enqueues a fresh tick
+- `tick()` method signature unchanged (still `async tick(): Promise<void>`)
+- `grep -c 'setInterval\|queueMicrotask.*tick\|tickTimer\|tickLocked\|tickQueued' room-runtime.ts` returns 0
+- TypeScript compiles without errors
+
+**Depends on:** Task 4.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.3: Wire handler into RoomRuntimeService and fix stopRuntime bug
+
+**Description:** Register the `room.tick` handler in `RoomRuntimeService`, fix `stopRuntime()` to delete from the `runtimes` map, and pass `jobQueue` to `RoomRuntime` instances. Ensure handler registration happens before `jobProcessor.start()` per the startup ordering in `00-overview.md`.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. In `packages/daemon/src/lib/room/runtime/room-runtime-service.ts`:
+   - Add `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
+   - In `start()`: register the `room.tick` handler on `jobProcessor`. The handler needs access to `this.runtimes` map for runtime lookup by roomId.
+   - Pass `jobQueue` to all `RoomRuntime` constructor calls (in `createOrGetRuntime`)
+2. Fix `stopRuntime()` (line 124-129): after `runtime.stop()`, add `this.runtimes.delete(roomId)` so that the heartbeat liveness check works correctly
+3. In `packages/daemon/src/app.ts`:
+   - Pass `jobQueue` and `jobProcessor` to `RoomRuntimeServiceConfig`
+   - Ensure `roomRuntimeService.start()` is called BEFORE `jobProcessor.start()` (per startup ordering: step 3 before step 5)
+4. Update `packages/daemon/src/lib/rpc-handlers/index.ts` to forward `jobQueue` and `jobProcessor` to `RoomRuntimeService`
+5. Update existing room runtime tests
+6. Add unit test verifying:
+   - Handler is registered on `start()`
+   - `stopRuntime()` removes from runtimes map
+   - `startRuntime()` creates runtime with jobQueue
+7. Run `bun run check` and all daemon tests
+
+**Acceptance criteria:**
+- `room.tick` handler registered in `RoomRuntimeService.start()`
+- `stopRuntime()` calls `this.runtimes.delete(roomId)`
+- `jobQueue` passed to all `RoomRuntime` instances
+- Handler registration happens BEFORE `jobProcessor.start()` in `app.ts`
+- Existing room tests pass
+- New tests verify handler registration and stopRuntime fix
+
+**Depends on:** Task 4.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 4.4: Online test for room tick via job queue
+
+**Description:** Create an online test verifying room ticks work end-to-end through the job queue, including dedup, pause/resume job cancellation, and recovery for stopped rooms.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/online/room/room-tick-job.test.ts`
+2. Use `createDaemonServer()` and create a room
+3. Verify:
+   - `room.tick` job is enqueued when room runtime starts
+   - Job processes and re-schedules
+   - No duplicate tick jobs for the same room (at most one pending)
+   - **Pause cancels pending ticks:** pause the runtime, verify no pending `room.tick` jobs for that room
+   - **Resume enqueues fresh tick:** resume the runtime, verify a new tick job is enqueued
+   - Stopping a room prevents further tick scheduling and cancels pending jobs
+   - Restarting a room resumes tick scheduling
+4. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- Online test verifies end-to-end room tick via job queue
+- Dedup verified (at most one pending tick per room)
+- Pause/resume lifecycle verified (pause cancels, resume enqueues)
+- Stop/restart lifecycle verified
+- Test runs with dev proxy
+
+**Depends on:** Task 4.3
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/05-cleanup-job.md
@@ -1,0 +1,78 @@
+# Milestone 5: Database Cleanup Job and Stale Job Reclamation
+
+## Goal
+
+Add a self-scheduling `job_queue.cleanup` job that runs daily to remove old completed/dead jobs. Verify stale job reclamation works correctly on restart.
+
+## Scope
+
+- Create `job_queue.cleanup` handler
+- Schedule initial cleanup job on daemon start
+- Verify `reclaimStale()` reclaims stuck processing jobs on restart
+
+## Tasks
+
+### Task 5.1: Create cleanup handler and wire into app lifecycle
+
+**Description:** Create the `job_queue.cleanup` handler that removes old completed/dead jobs and self-schedules for the next day. Wire it into the daemon startup.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/src/lib/job-handlers/cleanup.handler.ts`:
+   - Handler calls `jobQueue.cleanup(Date.now() - maxAge)` where `maxAge` defaults to 7 days
+   - In `finally` block: dedup-check then enqueue next cleanup job with `runAt: Date.now() + 24 * 60 * 60 * 1000` (24 hours)
+   - Return `{ deletedJobs, nextRunAt }`
+3. In `packages/daemon/src/app.ts` (or a new init function):
+   - **BEFORE `jobProcessor.start()`** (step 4 in the startup ordering table — see `00-overview.md`), register the `job_queue.cleanup` handler on `jobProcessor`
+   - Then check if a pending `job_queue.cleanup` job already exists; if not, enqueue one with `runAt: Date.now()` (run immediately on first boot, then daily)
+   - This ordering is critical: if a cleanup job is pending from a previous run and the processor starts before the handler is registered, the job will fail with "No handler registered" and consume retry attempts
+4. Create unit test `packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts`:
+   - Test cleanup deletes old jobs
+   - Test self-scheduling
+   - Test dedup (does not create duplicate cleanup jobs)
+5. Run tests and `bun run check`
+
+**Acceptance criteria:**
+- Cleanup handler removes completed/dead jobs older than 7 days
+- Self-schedules next run in 24 hours
+- Dedup prevents multiple pending cleanup jobs
+- Registered and initial job enqueued on daemon start
+- Unit tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 5.2: Verify stale job reclamation on restart (with eager reclaim)
+
+**Description:** Add tests verifying that jobs stuck in `processing` status are reclaimed **immediately** on daemon restart (via the eager `reclaimStale()` added in Task 1.2), ensuring no 60-second delay for crash recovery.
+
+**Note on timing:** `JobQueueProcessor.checkStaleJobs()` has a `STALE_CHECK_INTERVAL = 60_000ms` that normally delays reclamation. However, Task 1.2 added an eager `reclaimStale()` call in `start()` — this test must verify that eager reclamation works correctly, not just the periodic check.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts`
+2. Test scenarios:
+   - Enqueue a job, mark it as processing with a `startedAt` older than `staleThresholdMs` (simulate mid-execution crash)
+   - Create a new `JobQueueProcessor`, start it
+   - Verify the stale job is reclaimed **immediately on startup** (within the first poll tick, not after 60s)
+   - Verify reclaimed job is re-processed by its handler
+3. Test that non-stale processing jobs are NOT reclaimed (within threshold)
+4. Test that the eager reclaim on startup does not interfere with jobs that are genuinely still processing (started recently)
+5. Run tests
+
+**Acceptance criteria:**
+- Stale jobs are reclaimed **immediately on startup** (not after 60s delay)
+- Reclaimed jobs are re-processed
+- Non-stale processing jobs left alone
+- Tests verify the eager reclaim path specifically
+- Tests pass
+
+**Depends on:** Task 1.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
+++ b/docs/plans/complete-and-adopt-persistent-job-queue-continue-from-pr-203/06-integration-tests.md
@@ -1,0 +1,118 @@
+# Milestone 6: Integration Tests and E2E Validation
+
+## Goal
+
+Comprehensive integration tests verifying crash-recovery, job resumption after restart, and end-to-end validation that all migrated subsystems work together through the job queue.
+
+## Scope
+
+- Online integration tests for crash-recovery across all migrated subsystems
+- Verify job processing resumes correctly after daemon restart
+- Verify no regressions in existing functionality
+- Clean up any remaining stale in-memory patterns
+- Audit and document out-of-scope `setInterval` usage
+
+## Tasks
+
+### Task 6.1: Integration test -- job queue crash recovery
+
+**Description:** Create integration tests that simulate daemon crash/restart scenarios and verify all job types resume correctly.
+
+**Important implementation note:** `createDaemonServer()` typically creates a fresh database. For crash-recovery tests, you must explicitly configure a **file-backed SQLite database** that persists across daemon instances. Pass the same database path to both the first and second daemon instances so that jobs from the first run survive into the second run.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Run `bun install` at the worktree root
+2. Create `packages/daemon/tests/online/features/job-queue-crash-recovery.test.ts`
+3. Configure tests to use a **file-backed SQLite database** (e.g., `tmp/test-crash-recovery.db`) that persists across daemon restarts
+4. Test scenarios:
+   - **Session title gen recovery:** Enqueue a title gen job, stop daemon before completion, restart daemon with same DB, verify job is reclaimed and processed (should happen immediately due to eager `reclaimStale()`)
+   - **GitHub poll chain recovery:** Start daemon with GitHub polling, stop daemon mid-poll, restart, verify poll chain resumes without manual intervention
+   - **Room tick recovery:** Create a room, start ticking, stop daemon, restart, verify room ticks resume
+   - **Cleanup job recovery:** Enqueue cleanup job, stop daemon before it runs, restart, verify cleanup runs
+5. Each test uses `createDaemonServer()` with explicit DB path, enqueues jobs, stops daemon, then creates a fresh daemon against the same database file
+6. Clean up temporary database files in `afterEach`/`afterAll`
+7. Run with `NEOKAI_USE_DEV_PROXY=1`
+
+**Acceptance criteria:**
+- All four crash-recovery scenarios pass
+- Jobs transition correctly through status changes
+- No lost jobs after restart
+- Self-scheduling chains resume correctly
+- Eager stale reclamation verified (jobs reclaimed immediately, not after 60s)
+- File-backed DB used (not in-memory)
+
+**Depends on:** Task 2.2, Task 3.2, Task 4.3, Task 5.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 6.2: Cleanup stale in-memory patterns, audit setInterval usage, and final verification
+
+**Description:** Remove any remaining dead code from the pre-migration patterns. Audit all `setInterval` usage in the daemon codebase and document which are in-scope (migrated) and which are out-of-scope (with reasons). Run the full test suite to verify no regressions.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Search for remaining `setInterval` patterns in daemon code:
+   - Confirm `GitHubPollingService` has no `setInterval`
+   - Confirm `RoomRuntime` has no `setInterval`, `tickTimer`, `tickLocked`, or `tickQueued`
+   - Confirm `SessionManager` has no `pendingBackgroundTasks`
+2. **Audit all remaining `setInterval` usage** and verify they are out-of-scope:
+   - `WebSocketServerTransport.staleCheckTimer` — transport-layer health check, not a business task → out of scope
+   - `SpaceRuntime.tickTimer` — separate runtime subsystem, migrate in follow-up → out of scope
+   - `TaskAgentManager` polling interval — part of SpaceRuntime subsystem → out of scope
+   - `JobQueueProcessor` internal poll timer — this IS the job queue infrastructure → out of scope
+   - `app.ts` shutdown readiness check — one-shot shutdown polling → out of scope
+3. Add a code comment in `app.ts` (near the job queue setup) documenting the out-of-scope `setInterval` users for future reference, e.g.:
+   ```
+   // Out-of-scope setInterval users (not migrated to job queue):
+   // - WebSocketServerTransport.staleCheckTimer (transport-layer health check)
+   // - SpaceRuntime.tickTimer (separate runtime, migrate in follow-up)
+   // - TaskAgentManager polling (part of SpaceRuntime)
+   // - JobQueueProcessor internal poll (job queue infrastructure itself)
+   // - app.ts shutdown readiness check (one-shot)
+   ```
+4. Run `bun run check` (lint + typecheck + knip) to catch dead exports
+5. Run `make test-daemon` for full daemon test suite
+6. Run `make test-web` for full web test suite
+7. Fix any failures found
+8. Create a summary of all changes made across the milestone
+
+**Acceptance criteria:**
+- No `setInterval` for background tasks in migrated subsystems
+- No `pendingBackgroundTasks` in SessionManager
+- All remaining `setInterval` usage documented as out-of-scope with reasons
+- `bun run check` passes (no lint, type, or dead export errors)
+- All daemon tests pass
+- All web tests pass
+
+**Depends on:** Task 6.1
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**
+
+---
+
+### Task 6.3: E2E test for job queue health indicator (optional)
+
+**Description:** If time permits, add a minimal E2E test that verifies background tasks continue working from the user's perspective -- sessions get titles, rooms tick, etc.
+
+**Agent type:** coder
+
+**Subtasks:**
+1. Create `packages/e2e/tests/features/job-queue-background-tasks.e2e.ts`
+2. Test via UI:
+   - Create a session, send a message, verify the session title updates (title gen job worked)
+   - If room UI is available: create a room, verify it shows activity (ticks are happening)
+3. All assertions through visible DOM state per E2E rules
+
+**Acceptance criteria:**
+- E2E test verifies background tasks work from user perspective
+- Session title generation visible in UI
+- All assertions via DOM state
+
+**Depends on:** Task 6.2
+
+**Changes must be on a feature branch with a GitHub PR created via `gh pr create`.**

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -172,23 +172,37 @@ function buildWorkflowCreateParams(
 
 	// Build WorkflowStepInput list — resolve agentRef names → UUIDs
 	const steps: WorkflowStepInput[] = exported.steps.map((exportedStep) => {
-		const agentId =
-			importedAgentNameToId.get(exportedStep.agentRef) ??
-			existingAgentNameToId.get(exportedStep.agentRef) ??
-			null;
-
-		if (!agentId) {
-			warnings.push(
-				`step "${exportedStep.name}" references unknown agent "${exportedStep.agentRef}"`
-			);
-		}
-
 		const step: WorkflowStepInput = {
 			id: stepNameToId.get(exportedStep.name)!,
 			name: exportedStep.name,
-			agentId: agentId ?? '',
 		};
+
+		if (exportedStep.agents && exportedStep.agents.length > 0) {
+			// Multi-agent step: resolve each agentRef name → UUID
+			step.agents = exportedStep.agents.map((a) => {
+				const agentId =
+					importedAgentNameToId.get(a.agentRef) ?? existingAgentNameToId.get(a.agentRef) ?? null;
+				if (!agentId) {
+					warnings.push(`step "${exportedStep.name}" references unknown agent "${a.agentRef}"`);
+				}
+				const entry: { agentId: string; instructions?: string } = { agentId: agentId ?? '' };
+				if (a.instructions !== undefined) entry.instructions = a.instructions;
+				return entry;
+			});
+		} else {
+			// Single-agent step (backward compat): resolve scalar agentRef → agentId
+			const agentRef = exportedStep.agentRef ?? '';
+			const agentId =
+				importedAgentNameToId.get(agentRef) ?? existingAgentNameToId.get(agentRef) ?? null;
+			if (!agentId && agentRef) {
+				warnings.push(`step "${exportedStep.name}" references unknown agent "${agentRef}"`);
+			}
+			step.agentId = agentId ?? '';
+		}
+
 		if (exportedStep.instructions !== undefined) step.instructions = exportedStep.instructions;
+		if (exportedStep.channels && exportedStep.channels.length > 0)
+			step.channels = exportedStep.channels;
 		return step;
 	});
 
@@ -252,10 +266,23 @@ function validateWorkflowForPreview(
 	const errors: string[] = [];
 
 	for (const step of exported.steps) {
-		if (!importedAgentNames.has(step.agentRef) && !existingAgentNameToId.has(step.agentRef)) {
-			errors.push(
-				`step "${step.name}" references unknown agent "${step.agentRef}" — not found in bundle or target space`
-			);
+		if (step.agents && step.agents.length > 0) {
+			// Multi-agent step: validate each agent ref
+			for (const a of step.agents) {
+				if (!importedAgentNames.has(a.agentRef) && !existingAgentNameToId.has(a.agentRef)) {
+					errors.push(
+						`step "${step.name}" references unknown agent "${a.agentRef}" — not found in bundle or target space`
+					);
+				}
+			}
+		} else {
+			// Single-agent step: validate scalar agentRef
+			const agentRef = step.agentRef ?? '';
+			if (agentRef && !importedAgentNames.has(agentRef) && !existingAgentNameToId.has(agentRef)) {
+				errors.push(
+					`step "${step.name}" references unknown agent "${agentRef}" — not found in bundle or target space`
+				);
+			}
 		}
 	}
 
@@ -314,7 +341,13 @@ export function setupSpaceExportImportHandlers(
 
 		const referencedNames = new Set<string>();
 		for (const wf of full.workflows) {
-			for (const step of wf.steps) referencedNames.add(step.agentRef);
+			for (const step of wf.steps) {
+				if (step.agents && step.agents.length > 0) {
+					for (const a of step.agents) referencedNames.add(a.agentRef);
+				} else if (step.agentRef) {
+					referencedNames.add(step.agentRef);
+				}
+			}
 		}
 
 		const bundle: SpaceExportBundle = {

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -185,6 +185,8 @@ function buildWorkflowCreateParams(
 				if (!agentId) {
 					warnings.push(`step "${exportedStep.name}" references unknown agent "${a.agentRef}"`);
 				}
+				// agentId ?? '' is a placeholder for unresolved refs — warnings.length > 0 will
+				// cause a throw before createWorkflow is called, so '' never reaches the DB.
 				const entry: { agentId: string; instructions?: string } = { agentId: agentId ?? '' };
 				if (a.instructions !== undefined) entry.instructions = a.instructions;
 				return entry;
@@ -251,21 +253,30 @@ function buildWorkflowCreateParams(
  * Validate cross-references in an exported workflow against the current import context.
  * Returns a list of human-readable error strings (empty = valid).
  *
+ * Validates:
+ * 1. Agent refs in steps: each agentRef must resolve to a known agent name.
+ * 2. Channel role refs: roles referenced in channel `from`/`to` must match the roles
+ *    of agents assigned to the step (`'*'` wildcard is always valid).
+ *
  * Note: condition expression validation is intentionally omitted here — it is
  * already enforced by the Zod schema in validateExportBundle(), so any bundle
  * that reaches this function has already had its conditions validated.
  *
  * @param importedAgentNames - Set of agent names being imported in the same bundle
  * @param existingAgentNameToId - Map of existing agent names → UUIDs in target space
+ * @param agentNameToRole - Map of agent name → role (from bundle + space agents combined)
  */
 function validateWorkflowForPreview(
 	exported: ExportedSpaceWorkflow,
 	importedAgentNames: Set<string>,
-	existingAgentNameToId: Map<string, string>
+	existingAgentNameToId: Map<string, string>,
+	agentNameToRole: Map<string, string>
 ): string[] {
 	const errors: string[] = [];
 
 	for (const step of exported.steps) {
+		// ── 1. Agent ref validation ───────────────────────────────────────────
+		const stepAgentRefs: string[] = [];
 		if (step.agents && step.agents.length > 0) {
 			// Multi-agent step: validate each agent ref
 			for (const a of step.agents) {
@@ -274,6 +285,7 @@ function validateWorkflowForPreview(
 						`step "${step.name}" references unknown agent "${a.agentRef}" — not found in bundle or target space`
 					);
 				}
+				stepAgentRefs.push(a.agentRef);
 			}
 		} else {
 			// Single-agent step: validate scalar agentRef
@@ -282,6 +294,29 @@ function validateWorkflowForPreview(
 				errors.push(
 					`step "${step.name}" references unknown agent "${agentRef}" — not found in bundle or target space`
 				);
+			}
+			if (agentRef) stepAgentRefs.push(agentRef);
+		}
+
+		// ── 2. Channel role validation ────────────────────────────────────────
+		if (step.channels && step.channels.length > 0) {
+			// Collect the set of roles for agents assigned to this step
+			const stepRoles = new Set<string>();
+			for (const agentRef of stepAgentRefs) {
+				const role = agentNameToRole.get(agentRef);
+				if (role) stepRoles.add(role);
+			}
+
+			for (const channel of step.channels) {
+				const toRoles = Array.isArray(channel.to) ? channel.to : [channel.to];
+				const rolesToCheck = [channel.from, ...toRoles];
+				for (const role of rolesToCheck) {
+					if (role !== '*' && !stepRoles.has(role)) {
+						errors.push(
+							`step "${step.name}" channel references role "${role}" which is not matched by any agent in the step`
+						);
+					}
+				}
 			}
 		}
 	}
@@ -406,6 +441,11 @@ export function setupSpaceExportImportHandlers(
 		const existingWorkflowByName = new Map(existingWorkflows.map((w) => [w.name, w]));
 		const existingAgentNameToId = new Map(existingAgents.map((a) => [a.name, a.id]));
 
+		// Build name → role map for channel role validation.
+		// Bundle agent roles override existing agent roles (bundle wins on same name).
+		const agentNameToRole = new Map<string, string>(existingAgents.map((a) => [a.name, a.role]));
+		for (const a of bundle.agents) agentNameToRole.set(a.name, a.role);
+
 		// Agent previews
 		const agentPreviews: ImportPreview[] = bundle.agents.map((a) => {
 			const existing = existingAgentByName.get(a.name);
@@ -427,8 +467,13 @@ export function setupSpaceExportImportHandlers(
 				workflowPreviews.push({ name: wf.name, action: 'create' });
 			}
 
-			// Cross-reference validation (unresolved agent refs)
-			const errors = validateWorkflowForPreview(wf, importedAgentNames, existingAgentNameToId);
+			// Cross-reference validation (unresolved agent refs + channel role refs)
+			const errors = validateWorkflowForPreview(
+				wf,
+				importedAgentNames,
+				existingAgentNameToId,
+				agentNameToRole
+			);
 			for (const err of errors) {
 				validationErrors.push(`Workflow "${wf.name}": ${err}`);
 			}

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -232,9 +232,15 @@ export function exportWorkflow(
 			});
 			exported.agents = exportedAgents;
 		} else {
-			// Single-agent step: export as scalar agentRef
-			const primaryAgentId = step.agentId ?? '';
-			exported.agentRef = agentIdToName.get(primaryAgentId) ?? primaryAgentId;
+			// Single-agent step: export as scalar agentRef.
+			// Only set agentRef when agentId is present — a step with neither agentId
+			// nor agents is invalid; leaving agentRef unset produces a clear Zod error
+			// ("step must have either agentRef or agents") rather than a confusing
+			// min-length failure on an empty string.
+			const primaryAgentId = step.agentId;
+			if (primaryAgentId) {
+				exported.agentRef = agentIdToName.get(primaryAgentId) ?? primaryAgentId;
+			}
 		}
 
 		if (step.instructions !== undefined) exported.instructions = step.instructions;

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -24,6 +24,7 @@ import type {
 	ExportedSpaceAgent,
 	ExportedSpaceWorkflow,
 	ExportedWorkflowStep,
+	ExportedWorkflowStepAgent,
 	ExportedWorkflowTransition,
 	ExportedWorkflowRule,
 	SpaceExportBundle,
@@ -58,11 +59,36 @@ const workflowConditionSchema = z
 		}
 	});
 
-const exportedWorkflowStepSchema = z.object({
+const exportedWorkflowStepAgentSchema = z.object({
 	agentRef: z.string().min(1),
-	name: z.string().min(1),
 	instructions: z.string().optional(),
 });
+
+const workflowChannelSchema = z.object({
+	from: z.string().min(1),
+	to: z.union([z.string().min(1), z.array(z.string().min(1))]),
+	direction: z.enum(['one-way', 'bidirectional']),
+	label: z.string().optional(),
+});
+
+const exportedWorkflowStepSchema = z
+	.object({
+		agentRef: z.string().min(1).optional(),
+		agents: z.array(exportedWorkflowStepAgentSchema).optional(),
+		channels: z.array(workflowChannelSchema).optional(),
+		name: z.string().min(1),
+		instructions: z.string().optional(),
+	})
+	.superRefine((val, ctx) => {
+		const hasAgentRef = val.agentRef !== undefined && val.agentRef.length > 0;
+		const hasAgents = val.agents !== undefined && val.agents.length > 0;
+		if (!hasAgentRef && !hasAgents) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'step must have either agentRef or agents (non-empty)',
+			});
+		}
+	});
 
 const exportedWorkflowTransitionSchema = z.object({
 	fromStep: z.string().min(1),
@@ -188,15 +214,32 @@ export function exportWorkflow(
 		agentIdToName.set(agent.id, agent.name);
 	}
 
-	// Export steps — strip `id`, remap agentId UUID → agent name.
-	// NOTE: Multi-agent steps (agents[] format) are exported using the primary agentId for
-	// backward compatibility. Full multi-agent export/import support is deferred to Milestone 5.
+	// Export steps — strip `id`, remap agentId UUIDs → agent names.
+	// Multi-agent steps (agents[] non-empty) export an `agents` array.
+	// Single-agent steps export a scalar `agentRef` (backward-compatible shorthand).
+	// Channels are exported as-is (they already use role strings, not UUIDs).
 	const exportedSteps: ExportedWorkflowStep[] = workflow.steps.map((step) => {
-		// Prefer agentId; for multi-agent steps fall back to the first agents[] entry.
-		const primaryAgentId = step.agentId ?? step.agents?.[0]?.agentId ?? '';
-		const agentRef = agentIdToName.get(primaryAgentId) ?? primaryAgentId;
-		const exported: ExportedWorkflowStep = { agentRef, name: step.name };
+		const exported: ExportedWorkflowStep = { name: step.name };
+
+		if (step.agents && step.agents.length > 0) {
+			// Multi-agent step: export agents array with agentRef names
+			const exportedAgents: ExportedWorkflowStepAgent[] = step.agents.map((a) => {
+				const entry: ExportedWorkflowStepAgent = {
+					agentRef: agentIdToName.get(a.agentId) ?? a.agentId,
+				};
+				if (a.instructions !== undefined) entry.instructions = a.instructions;
+				return entry;
+			});
+			exported.agents = exportedAgents;
+		} else {
+			// Single-agent step: export as scalar agentRef
+			const primaryAgentId = step.agentId ?? '';
+			exported.agentRef = agentIdToName.get(primaryAgentId) ?? primaryAgentId;
+		}
+
 		if (step.instructions !== undefined) exported.instructions = step.instructions;
+		if (step.channels && step.channels.length > 0) exported.channels = step.channels;
+
 		return exported;
 	});
 

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -14,6 +14,7 @@ export interface CreateSessionGroupParams {
 	description?: string;
 	workflowRunId?: string;
 	currentStepId?: string;
+	taskId?: string;
 }
 
 export interface UpdateSessionGroupParams {
@@ -21,6 +22,25 @@ export interface UpdateSessionGroupParams {
 	description?: string;
 	workflowRunId?: string | null;
 	currentStepId?: string | null;
+	taskId?: string | null;
+}
+
+export interface AddMemberParams {
+	/** Freeform role string matching SpaceAgent.role (e.g. 'coder', 'reviewer', 'security-auditor') */
+	role: string;
+	/** Display order within the group (default: 0) */
+	orderIndex?: number;
+	/** ID of the SpaceAgent config this session uses (nullable for system agents) */
+	agentId?: string;
+	/** Initial lifecycle state (default: 'active') */
+	status?: 'active' | 'completed' | 'failed';
+}
+
+export interface UpdateMemberParams {
+	role?: string;
+	orderIndex?: number;
+	agentId?: string | null;
+	status?: 'active' | 'completed' | 'failed';
 }
 
 export class SpaceSessionGroupRepository {
@@ -34,8 +54,8 @@ export class SpaceSessionGroupRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, task_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -45,6 +65,7 @@ export class SpaceSessionGroupRepository {
 			params.description ?? null,
 			params.workflowRunId ?? null,
 			params.currentStepId ?? null,
+			params.taskId ?? null,
 			now,
 			now
 		);
@@ -81,16 +102,14 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
-	 * Get all session groups that contain a specific task's associated sessions.
-	 * Returns groups matching by spaceId and name pattern (groups for a given task).
+	 * Get all session groups associated with a specific task.
+	 * Queries by the `task_id` column set at group creation time.
 	 */
 	getGroupsByTask(spaceId: string, taskId: string): SpaceSessionGroup[] {
-		// Groups are associated to tasks by their name convention (e.g. "task:{taskId}")
-		// or by querying members. We query groups that are named for a task.
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_session_groups WHERE space_id = ? AND name = ? ORDER BY created_at ASC`
+			`SELECT * FROM space_session_groups WHERE space_id = ? AND task_id = ? ORDER BY created_at ASC`
 		);
-		const rows = stmt.all(spaceId, `task:${taskId}`) as Record<string, unknown>[];
+		const rows = stmt.all(spaceId, taskId) as Record<string, unknown>[];
 
 		return rows.map((row) => {
 			const members = this.getGroupMembers(row.id as string);
@@ -121,6 +140,10 @@ export class SpaceSessionGroupRepository {
 			fields.push('current_step_id = ?');
 			values.push(params.currentStepId ?? null);
 		}
+		if (params.taskId !== undefined) {
+			fields.push('task_id = ?');
+			values.push(params.taskId ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -145,15 +168,12 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
-	 * Add a session member to a group
-	 * Idempotent — updates role/orderIndex if the session is already a member
+	 * Add a session member to a group.
+	 * Idempotent — if the session is already a member, updates all provided fields.
 	 */
-	addMember(
-		groupId: string,
-		sessionId: string,
-		role: 'worker' | 'leader',
-		orderIndex = 0
-	): SpaceSessionGroupMember {
+	addMember(groupId: string, sessionId: string, params: AddMemberParams): SpaceSessionGroupMember {
+		const { role, orderIndex = 0, agentId, status = 'active' } = params;
+
 		const existing = this.db
 			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
 			.get(groupId, sessionId) as Record<string, unknown> | undefined;
@@ -161,9 +181,9 @@ export class SpaceSessionGroupRepository {
 		if (existing) {
 			this.db
 				.prepare(
-					`UPDATE space_session_group_members SET role = ?, order_index = ? WHERE group_id = ? AND session_id = ?`
+					`UPDATE space_session_group_members SET role = ?, order_index = ?, agent_id = ?, status = ? WHERE group_id = ? AND session_id = ?`
 				)
-				.run(role, orderIndex, groupId, sessionId);
+				.run(role, orderIndex, agentId ?? null, status, groupId, sessionId);
 			return this.getMember(existing.id as string)!;
 		}
 
@@ -172,10 +192,10 @@ export class SpaceSessionGroupRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, agent_id, status, order_index, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 			)
-			.run(id, groupId, sessionId, role, orderIndex, now);
+			.run(id, groupId, sessionId, role, agentId ?? null, status, orderIndex, now);
 
 		// Touch group updated_at
 		this.db
@@ -183,6 +203,63 @@ export class SpaceSessionGroupRepository {
 			.run(now, groupId);
 
 		return this.getMember(id)!;
+	}
+
+	/**
+	 * Update fields on an existing group member (e.g. transition status after session completes).
+	 * Returns null if the member record does not exist.
+	 */
+	updateMember(
+		groupId: string,
+		sessionId: string,
+		params: UpdateMemberParams
+	): SpaceSessionGroupMember | null {
+		const fields: string[] = [];
+		const values: (string | number | null)[] = [];
+
+		if (params.role !== undefined) {
+			fields.push('role = ?');
+			values.push(params.role);
+		}
+		if (params.orderIndex !== undefined) {
+			fields.push('order_index = ?');
+			values.push(params.orderIndex);
+		}
+		if (params.agentId !== undefined) {
+			fields.push('agent_id = ?');
+			values.push(params.agentId ?? null);
+		}
+		if (params.status !== undefined) {
+			fields.push('status = ?');
+			values.push(params.status);
+		}
+
+		if (fields.length === 0) {
+			// Nothing to update — return current state
+			const row = this.db
+				.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+				.get(groupId, sessionId) as Record<string, unknown> | undefined;
+			return row ? this.rowToMember(row) : null;
+		}
+
+		values.push(groupId, sessionId);
+		const result = this.db
+			.prepare(
+				`UPDATE space_session_group_members SET ${fields.join(', ')} WHERE group_id = ? AND session_id = ?`
+			)
+			.run(...values);
+
+		if (result.changes === 0) return null;
+
+		// Touch group updated_at
+		this.db
+			.prepare(`UPDATE space_session_groups SET updated_at = ? WHERE id = ?`)
+			.run(Date.now(), groupId);
+
+		const updated = this.db
+			.prepare(`SELECT * FROM space_session_group_members WHERE group_id = ? AND session_id = ?`)
+			.get(groupId, sessionId) as Record<string, unknown> | undefined;
+		return updated ? this.rowToMember(updated) : null;
 	}
 
 	/**
@@ -240,6 +317,7 @@ export class SpaceSessionGroupRepository {
 			description: (row.description as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			currentStepId: (row.current_step_id as string | null) ?? undefined,
+			taskId: (row.task_id as string | null) ?? undefined,
 			members,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
@@ -254,7 +332,9 @@ export class SpaceSessionGroupRepository {
 			id: row.id as string,
 			groupId: row.group_id as string,
 			sessionId: row.session_id as string,
-			role: row.role as 'worker' | 'leader',
+			role: row.role as string,
+			agentId: (row.agent_id as string | null) ?? undefined,
+			status: ((row.status as string | null) ?? 'active') as 'active' | 'completed' | 'failed',
 			orderIndex: row.order_index as number,
 			createdAt: row.created_at as number,
 		};

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1488,8 +1488,8 @@ function runMigration28(db: BunDatabase): void {
  * - space_workflow_transitions: directed edges between steps (graph navigation)
  * - space_workflow_runs: active/historical workflow executions (includes current_step_id)
  * - space_tasks: tasks with built-in custom_agent_id, workflow_run_id, workflow_step_id
- * - space_session_groups: named groups of related sessions (includes workflow_run_id, current_step_id)
- * - space_session_group_members: membership records for session groups
+ * - space_session_groups: named groups of related sessions (includes workflow_run_id, current_step_id, task_id)
+ * - space_session_group_members: membership records with freeform role, agent_id, and status
  *
  * All tables are created with IF NOT EXISTS so the migration is idempotent.
  * CASCADE deletes propagate from spaces → all child tables.
@@ -1711,6 +1711,7 @@ function runMigration29(db: BunDatabase): void {
 			description TEXT,
 			workflow_run_id TEXT,
 			current_step_id TEXT,
+			task_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -1728,8 +1729,10 @@ function runMigration29(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			group_id TEXT NOT NULL,
 			session_id TEXT NOT NULL,
-			role TEXT NOT NULL
-				CHECK(role IN ('worker', 'leader')),
+			role TEXT NOT NULL,
+			agent_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'completed', 'failed')),
 			order_index INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,8 +4,12 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with runMigration37 in packages/daemon/src/storage/schema/migrations.ts
+ * Keep in sync with runMigration40 in packages/daemon/src/storage/schema/migrations.ts
  * and space-agent-schema.ts.
+ *
+ * IMPORTANT: The schema defined here must exactly match the fully-migrated production
+ * schema (i.e. after all migrations have run). Never add columns or constraints here
+ * that do not yet exist in a production migration — that masks schema divergence.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -173,6 +177,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			description TEXT,
 			workflow_run_id TEXT,
 			current_step_id TEXT,
+			task_id TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -184,8 +189,10 @@ export function createSpaceTables(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			group_id TEXT NOT NULL,
 			session_id TEXT NOT NULL,
-			role TEXT NOT NULL
-				CHECK(role IN ('worker', 'leader')),
+			role TEXT NOT NULL,
+			agent_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'completed', 'failed')),
 			order_index INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE,

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -1522,6 +1522,100 @@ describe('multi-agent step import', () => {
 		expect(step.agents).toBeUndefined();
 	});
 
+	it('preview: flags invalid channel role that does not match any step agent', async () => {
+		const bundle = makeMultiAgentBundle(
+			[
+				{ name: 'Coder', role: 'coder' },
+				{ name: 'Reviewer', role: 'reviewer' },
+			],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+								channels: [
+									// 'typo-role' is not matched by coder or reviewer
+									{ from: 'typo-role', to: 'reviewer', direction: 'one-way' as const },
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		expect(result.validationErrors.some((e) => e.includes('typo-role'))).toBe(true);
+	});
+
+	it('preview: wildcard channel role is always valid', async () => {
+		const bundle = makeMultiAgentBundle(
+			[{ name: 'Coder', role: 'coder' }],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Solo',
+								agents: [{ agentRef: 'Coder' }],
+								channels: [{ from: '*', to: '*', direction: 'bidirectional' as const }],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		// '*' wildcard should not produce a channel role validation error
+		expect(result.validationErrors.filter((e) => e.includes('channel'))).toHaveLength(0);
+	});
+
+	it('preview: validates channel roles from existing space agents', async () => {
+		agentRepo.create({ spaceId: SPACE_ID, name: 'LocalCoder', role: 'coder' });
+
+		// Bundle has no agents — refs resolve from existing space agents
+		const bundle = makeMultiAgentBundle(
+			[],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Step',
+								agents: [{ agentRef: 'LocalCoder' }],
+								channels: [
+									// 'bad-role' is not matched by LocalCoder (role='coder')
+									{ from: 'bad-role', to: 'coder', direction: 'one-way' as const },
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		expect(result.validationErrors.some((e) => e.includes('bad-role'))).toBe(true);
+	});
+
 	it('resolves multi-agent step refs from existing space agents', async () => {
 		const existing1 = agentRepo.create({ spaceId: SPACE_ID, name: 'LocalCoder', role: 'coder' });
 		const existing2 = agentRepo.create({

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -1288,6 +1288,278 @@ describe('Space Export/Import RPC Handlers', () => {
 	});
 });
 
+// ─── Multi-agent step import tests ────────────────────────────────────────────
+
+describe('multi-agent step import', () => {
+	let db: Database;
+	let agentRepo: SpaceAgentRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSchema(db);
+		insertSpace(db, SPACE_ID, 'My Space');
+
+		agentRepo = new SpaceAgentRepository(db as any);
+		workflowRepo = new SpaceWorkflowRepository(db as any);
+
+		const agentLookup: SpaceAgentLookup = {
+			getAgentById(spaceId: string, id: string) {
+				const agent = agentRepo.getById(id);
+				if (!agent || agent.spaceId !== spaceId) return null;
+				return { id: agent.id, name: agent.name };
+			},
+		};
+		workflowManager = new SpaceWorkflowManager(workflowRepo, agentLookup);
+		spaceManager = createMockSpaceManager(SPACE_ID);
+		const mockHub = createMockHub();
+		handlers = mockHub.handlers;
+		const mockDaemonHub = createMockDaemonHub();
+		daemonHub = mockDaemonHub.hub;
+
+		setupSpaceExportImportHandlers(
+			mockHub.hub,
+			spaceManager,
+			agentRepo,
+			workflowRepo,
+			workflowManager,
+			db as any,
+			daemonHub
+		);
+	});
+
+	it('imports multi-agent step and resolves each agentRef → agentId', async () => {
+		const bundle = makeMultiAgentBundle(
+			[
+				{ name: 'Coder', role: 'coder' },
+				{ name: 'Reviewer', role: 'reviewer' },
+			],
+			[
+				{
+					name: 'Collab Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [
+									{ agentRef: 'Coder', instructions: 'Write code' },
+									{ agentRef: 'Reviewer' },
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		expect(result.agents).toHaveLength(2);
+		const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		const step = wf.steps[0];
+
+		// Multi-agent step should have agents array, not single agentId
+		expect(step.agents).toHaveLength(2);
+		expect(step.agentId).toBeUndefined();
+
+		// Each agent should be resolved to its UUID
+		const coderAgent = agentRepo.getById(result.agents.find((a) => a.name === 'Coder')!.id)!;
+		const reviewerAgent = agentRepo.getById(result.agents.find((a) => a.name === 'Reviewer')!.id)!;
+		const agentIds = step.agents!.map((a) => a.agentId);
+		expect(agentIds).toContain(coderAgent.id);
+		expect(agentIds).toContain(reviewerAgent.id);
+	});
+
+	it('preserves per-agent instructions in imported multi-agent step', async () => {
+		const bundle = makeMultiAgentBundle(
+			[
+				{ name: 'Coder', role: 'coder' },
+				{ name: 'Reviewer', role: 'reviewer' },
+			],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [
+									{ agentRef: 'Coder', instructions: 'Implement the feature' },
+									{ agentRef: 'Reviewer', instructions: 'Review thoroughly' },
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		const agentEntries = wf.steps[0].agents!;
+		const byAgentId = new Map(agentEntries.map((a) => [a.agentId, a]));
+
+		const coderId = result.agents.find((a) => a.name === 'Coder')!.id;
+		const reviewerId = result.agents.find((a) => a.name === 'Reviewer')!.id;
+		expect(byAgentId.get(coderId)?.instructions).toBe('Implement the feature');
+		expect(byAgentId.get(reviewerId)?.instructions).toBe('Review thoroughly');
+	});
+
+	it('imports channels as-is in multi-agent step', async () => {
+		const bundle = makeMultiAgentBundle(
+			[
+				{ name: 'Coder', role: 'coder' },
+				{ name: 'Reviewer', role: 'reviewer' },
+			],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+								channels: [
+									{ from: 'coder', to: 'reviewer', direction: 'bidirectional', label: 'feedback' },
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		const step = wf.steps[0];
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0].from).toBe('coder');
+		expect(step.channels![0].to).toBe('reviewer');
+		expect(step.channels![0].direction).toBe('bidirectional');
+		expect(step.channels![0].label).toBe('feedback');
+	});
+
+	it('throws when multi-agent step has unresolved agent ref', async () => {
+		const bundle = makeMultiAgentBundle(
+			[{ name: 'Coder', role: 'coder' }],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [
+									{ agentRef: 'Coder' },
+									{ agentRef: 'GhostAgent' }, // not in bundle or space
+								],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		await expect(
+			call(handlers, 'spaceImport.execute', { spaceId: SPACE_ID, bundle })
+		).rejects.toThrow('unresolved agent reference');
+	});
+
+	it('preview: flags unresolved agent ref in multi-agent step', async () => {
+		const bundle = makeMultiAgentBundle(
+			[{ name: 'Coder', role: 'coder' }],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [{ agentRef: 'Coder' }, { agentRef: 'Missing' }],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportPreviewResult>(handlers, 'spaceImport.preview', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		expect(result.validationErrors.some((e) => e.includes('Missing'))).toBe(true);
+	});
+
+	it('backward compat: single agentRef step still imports as agentId', async () => {
+		const bundle = makeSingleAgentBundle('Coder', 'coder', 'Legacy Step');
+
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		const step = wf.steps[0];
+		// Single-agent step uses agentId field, not agents[]
+		const coderId = result.agents[0].id;
+		expect(step.agentId).toBe(coderId);
+		expect(step.agents).toBeUndefined();
+	});
+
+	it('resolves multi-agent step refs from existing space agents', async () => {
+		const existing1 = agentRepo.create({ spaceId: SPACE_ID, name: 'LocalCoder', role: 'coder' });
+		const existing2 = agentRepo.create({
+			spaceId: SPACE_ID,
+			name: 'LocalReviewer',
+			role: 'reviewer',
+		});
+
+		// Bundle has no agents — refs resolve from existing space agents
+		const bundle = makeMultiAgentBundle(
+			[],
+			[
+				{
+					name: 'Pipeline',
+					steps: [
+						{
+							multiAgentStep: {
+								name: 'Parallel',
+								agents: [{ agentRef: 'LocalCoder' }, { agentRef: 'LocalReviewer' }],
+							},
+						},
+					],
+				},
+			]
+		);
+
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		const wf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		const agentIds = wf.steps[0].agents!.map((a) => a.agentId);
+		expect(agentIds).toContain(existing1.id);
+		expect(agentIds).toContain(existing2.id);
+	});
+});
+
 // ─── Bundle builder helpers ───────────────────────────────────────────────────
 
 type BundleAgent = { name: string; role: string; systemPrompt?: string; model?: string };
@@ -1406,6 +1678,97 @@ function makeTwoStepBundle(): object {
 				],
 				transitions: [{ fromStep: 'Code', toStep: 'Review' }],
 				startStep: 'Code',
+				rules: [],
+				tags: [],
+			},
+		],
+		exportedAt: Date.now(),
+	};
+}
+
+// ─── Multi-agent bundle builder helpers ──────────────────────────────────────
+
+type MultiAgentStepEntry =
+	| { agentRef: string; name: string; instructions?: string }
+	| {
+			multiAgentStep: {
+				name: string;
+				agents: Array<{ agentRef: string; instructions?: string }>;
+				channels?: Array<{
+					from: string;
+					to: string | string[];
+					direction: 'one-way' | 'bidirectional';
+					label?: string;
+				}>;
+				instructions?: string;
+			};
+	  };
+
+function makeMultiAgentBundle(
+	agents: BundleAgent[],
+	workflows: Array<{
+		name: string;
+		steps: MultiAgentStepEntry[];
+	}>
+): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Multi-Agent Bundle',
+		agents: agents.map((a) => ({
+			version: 1,
+			type: 'agent',
+			name: a.name,
+			role: a.role,
+		})),
+		workflows: workflows.map((w) => ({
+			version: 1,
+			type: 'workflow',
+			name: w.name,
+			steps: w.steps.map((s) => {
+				if ('multiAgentStep' in s) {
+					const ms = s.multiAgentStep;
+					const step: Record<string, unknown> = {
+						name: ms.name,
+						agents: ms.agents,
+					};
+					if (ms.channels) step.channels = ms.channels;
+					if (ms.instructions) step.instructions = ms.instructions;
+					return step;
+				}
+				return {
+					agentRef: s.agentRef,
+					name: s.name,
+					...(s.instructions ? { instructions: s.instructions } : {}),
+				};
+			}),
+			transitions: [],
+			startStep: w.steps[0]
+				? 'multiAgentStep' in w.steps[0]
+					? w.steps[0].multiAgentStep.name
+					: w.steps[0].name
+				: '',
+			rules: [],
+			tags: [],
+		})),
+		exportedAt: Date.now(),
+	};
+}
+
+function makeSingleAgentBundle(agentName: string, agentRole: string, stepName: string): object {
+	return {
+		version: 1,
+		type: 'bundle',
+		name: 'Single Agent Bundle',
+		agents: [{ version: 1, type: 'agent', name: agentName, role: agentRole }],
+		workflows: [
+			{
+				version: 1,
+				type: 'workflow',
+				name: 'Legacy Workflow',
+				steps: [{ agentRef: agentName, name: stepName }],
+				transitions: [],
+				startStep: stepName,
 				rules: [],
 				tags: [],
 			},

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1202,3 +1202,353 @@ describe('rule appliesTo round-trip', () => {
 		expect(json).toContain('Simple Agent');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Multi-agent step export tests
+// ---------------------------------------------------------------------------
+
+describe('exportWorkflow — multi-agent steps', () => {
+	function makeMultiAgentWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+		return {
+			id: 'workflow-uuid-ma',
+			spaceId: 'space-uuid-1',
+			name: 'Multi-Agent Workflow',
+			description: 'Tests multi-agent steps',
+			steps: [
+				{
+					id: 'step-uuid-1',
+					name: 'Parallel code+review',
+					agents: [
+						{ agentId: 'agent-uuid-1', instructions: 'Write the feature' },
+						{ agentId: 'agent-uuid-3' },
+					],
+					channels: [
+						{
+							from: 'coder',
+							to: 'reviewer',
+							direction: 'bidirectional',
+						},
+					],
+				},
+				{
+					id: 'step-uuid-2',
+					name: 'Single plan step',
+					agentId: 'agent-uuid-2',
+				},
+			],
+			transitions: [{ id: 'trans-1', from: 'step-uuid-1', to: 'step-uuid-2' }],
+			startStepId: 'step-uuid-1',
+			rules: [],
+			tags: [],
+			createdAt: 1000,
+			updatedAt: 2000,
+			...overrides,
+		};
+	}
+
+	test('exports multi-agent step as agents array (not agentRef)', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		const step = exported.steps[0];
+		// Multi-agent step uses agents array, not agentRef
+		expect(step.agents).toHaveLength(2);
+		expect(step.agentRef).toBeUndefined();
+	});
+
+	test('resolves agentId UUIDs to agent names in agents array', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		const step = exported.steps[0];
+		expect(step.agents![0].agentRef).toBe('My Coder');
+		expect(step.agents![1].agentRef).toBe('Reviewer');
+	});
+
+	test('preserves per-agent instructions in agents array', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		expect(exported.steps[0].agents![0].instructions).toBe('Write the feature');
+		expect(exported.steps[0].agents![1].instructions).toBeUndefined();
+	});
+
+	test('falls back to UUID for unresolved agent in multi-agent step', () => {
+		const workflow = makeMultiAgentWorkflow();
+		// Pass no agents — all refs fall back to UUID
+		const exported = exportWorkflow(workflow, []);
+
+		expect(exported.steps[0].agents![0].agentRef).toBe('agent-uuid-1');
+		expect(exported.steps[0].agents![1].agentRef).toBe('agent-uuid-3');
+	});
+
+	test('exports channels as-is (role strings, not UUIDs)', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		const step = exported.steps[0];
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0].from).toBe('coder');
+		expect(step.channels![0].to).toBe('reviewer');
+		expect(step.channels![0].direction).toBe('bidirectional');
+	});
+
+	test('omits channels when step has no channels', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// Single-agent step (step 1) has no channels
+		expect(exported.steps[1].channels).toBeUndefined();
+	});
+
+	test('single-agent step still exports as agentRef shorthand', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		// Step 1 uses agentId shorthand (not agents[])
+		const step = exported.steps[1];
+		expect(step.agentRef).toBe('Simple Agent');
+		expect(step.agents).toBeUndefined();
+	});
+
+	test('agent UUIDs do not appear in multi-agent exported JSON', () => {
+		const workflow = makeMultiAgentWorkflow();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+
+		expect(json).not.toContain('agent-uuid-1');
+		expect(json).not.toContain('agent-uuid-3');
+		expect(json).toContain('My Coder');
+		expect(json).toContain('Reviewer');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateExportedWorkflow — multi-agent + channels
+// ---------------------------------------------------------------------------
+
+describe('validateExportedWorkflow — multi-agent and channels', () => {
+	test('accepts step with agents array', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{
+					agents: [{ agentRef: 'My Coder', instructions: 'Code it' }, { agentRef: 'Reviewer' }],
+					name: 'Parallel Step',
+				},
+			],
+			transitions: [],
+			startStep: 'Parallel Step',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.steps[0].agents).toHaveLength(2);
+			expect(result.value.steps[0].agents![0].agentRef).toBe('My Coder');
+			expect(result.value.steps[0].agents![0].instructions).toBe('Code it');
+			expect(result.value.steps[0].agentRef).toBeUndefined();
+		}
+	});
+
+	test('accepts step with channels', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{
+					agents: [{ agentRef: 'Coder' }, { agentRef: 'Reviewer' }],
+					channels: [{ from: 'coder', to: 'reviewer', direction: 'bidirectional' }],
+					name: 'Step',
+				},
+			],
+			transitions: [],
+			startStep: 'Step',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.steps[0].channels).toHaveLength(1);
+			expect(result.value.steps[0].channels![0].from).toBe('coder');
+			expect(result.value.steps[0].channels![0].direction).toBe('bidirectional');
+		}
+	});
+
+	test('accepts channel with array `to` field (fan-out topology)', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'W',
+			steps: [
+				{
+					agents: [{ agentRef: 'Hub' }, { agentRef: 'Spoke1' }, { agentRef: 'Spoke2' }],
+					channels: [{ from: 'hub', to: ['spoke1', 'spoke2'], direction: 'one-way' }],
+					name: 'Fan-out',
+				},
+			],
+			transitions: [],
+			startStep: 'Fan-out',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.steps[0].channels![0].to).toEqual(['spoke1', 'spoke2']);
+		}
+	});
+
+	test('rejects step with empty agents array and no agentRef', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [{ agents: [], name: 'Empty agents step' }],
+			transitions: [],
+			startStep: 'Empty agents step',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('step must have either agentRef or agents');
+		}
+	});
+
+	test('rejects agent entry with empty agentRef in agents array', () => {
+		const data = {
+			version: 1,
+			type: 'workflow',
+			name: 'Bad',
+			steps: [
+				{
+					agents: [{ agentRef: '' }],
+					name: 'Step',
+				},
+			],
+			transitions: [],
+			startStep: 'Step',
+			rules: [],
+			tags: [],
+		};
+		const result = validateExportedWorkflow(data);
+		expect(result.ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Multi-agent round-trip: export → JSON → validate
+// ---------------------------------------------------------------------------
+
+describe('round-trip: multi-agent + channels', () => {
+	function makeMultiAgentWorkflowForRoundTrip(): SpaceWorkflow {
+		return {
+			id: 'wf-1',
+			spaceId: 'space-1',
+			name: 'Collab Workflow',
+			description: 'Coder and reviewer in parallel',
+			steps: [
+				{
+					id: 'step-1',
+					name: 'Code and Review',
+					agents: [
+						{ agentId: 'agent-uuid-1', instructions: 'Implement the feature' },
+						{ agentId: 'agent-uuid-3', instructions: 'Review the code' },
+					],
+					channels: [
+						{ from: 'coder', to: 'reviewer', direction: 'bidirectional', label: 'feedback' },
+					],
+					instructions: 'Collaborate on the feature',
+				},
+				{
+					id: 'step-2',
+					name: 'Final Plan',
+					agentId: 'agent-uuid-2',
+				},
+			],
+			transitions: [{ id: 't-1', from: 'step-1', to: 'step-2' }],
+			startStepId: 'step-1',
+			rules: [],
+			tags: ['collab'],
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+	}
+
+	test('multi-agent step round-trip preserves agents array and channels', () => {
+		const workflow = makeMultiAgentWorkflowForRoundTrip();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const step = result.value.steps[0];
+			// Multi-agent step preserved
+			expect(step.agents).toHaveLength(2);
+			expect(step.agents![0].agentRef).toBe('My Coder');
+			expect(step.agents![0].instructions).toBe('Implement the feature');
+			expect(step.agents![1].agentRef).toBe('Reviewer');
+			expect(step.agents![1].instructions).toBe('Review the code');
+			// agentRef shorthand absent for multi-agent step
+			expect(step.agentRef).toBeUndefined();
+			// Channels preserved
+			expect(step.channels).toHaveLength(1);
+			expect(step.channels![0].from).toBe('coder');
+			expect(step.channels![0].to).toBe('reviewer');
+			expect(step.channels![0].direction).toBe('bidirectional');
+			expect(step.channels![0].label).toBe('feedback');
+			// Shared instructions preserved
+			expect(step.instructions).toBe('Collaborate on the feature');
+		}
+	});
+
+	test('single-agent step in mixed workflow round-trips as agentRef', () => {
+		const workflow = makeMultiAgentWorkflowForRoundTrip();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+		const parsed = JSON.parse(json) as unknown;
+		const result = validateExportedWorkflow(parsed);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const step = result.value.steps[1];
+			expect(step.agentRef).toBe('Simple Agent');
+			expect(step.agents).toBeUndefined();
+			expect(step.channels).toBeUndefined();
+		}
+	});
+
+	test('no UUIDs in multi-agent exported JSON', () => {
+		const workflow = makeMultiAgentWorkflowForRoundTrip();
+		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];
+		const exported = exportWorkflow(workflow, agents);
+		const json = JSON.stringify(exported);
+
+		expect(json).not.toContain('agent-uuid-1');
+		expect(json).not.toContain('agent-uuid-2');
+		expect(json).not.toContain('agent-uuid-3');
+		expect(json).not.toContain('step-1');
+		expect(json).not.toContain('step-2');
+		expect(json).toContain('My Coder');
+		expect(json).toContain('Reviewer');
+		expect(json).toContain('Simple Agent');
+	});
+});

--- a/packages/daemon/tests/unit/space/export-format.test.ts
+++ b/packages/daemon/tests/unit/space/export-format.test.ts
@@ -1306,6 +1306,47 @@ describe('exportWorkflow — multi-agent steps', () => {
 		expect(exported.steps[1].channels).toBeUndefined();
 	});
 
+	test('single-agent step with channels exports channels', () => {
+		const workflow = makeMultiAgentWorkflow({
+			steps: [
+				{
+					id: 'step-uuid-1',
+					name: 'Solo with channel',
+					agentId: 'agent-uuid-1',
+					channels: [{ from: 'coder', to: '*', direction: 'one-way' }],
+				},
+			],
+			startStepId: 'step-uuid-1',
+			transitions: [],
+		});
+		const agents = [makeAgent()];
+		const exported = exportWorkflow(workflow, agents);
+
+		const step = exported.steps[0];
+		// Should still use scalar agentRef (single-agent)
+		expect(step.agentRef).toBe('My Coder');
+		expect(step.agents).toBeUndefined();
+		// Channels should be exported as-is
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0].from).toBe('coder');
+		expect(step.channels![0].to).toBe('*');
+		expect(step.channels![0].direction).toBe('one-way');
+	});
+
+	test('export produces no agentRef when step has neither agentId nor agents', () => {
+		const workflow = makeMultiAgentWorkflow({
+			steps: [{ id: 'step-uuid-1', name: 'Broken step' } as any],
+			startStepId: 'step-uuid-1',
+			transitions: [],
+		});
+		const exported = exportWorkflow(workflow, []);
+
+		const step = exported.steps[0];
+		// Neither agentRef nor agents should be set
+		expect(step.agentRef).toBeUndefined();
+		expect(step.agents).toBeUndefined();
+	});
+
 	test('single-agent step still exports as agentRef shorthand', () => {
 		const workflow = makeMultiAgentWorkflow();
 		const agents = [makeAgent(), makeMinimalAgent(), makeReviewerAgent()];

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -437,25 +437,58 @@ describe('Migration 29: Space system tables', () => {
 			 VALUES ('sg-5', 'sp-5', 'Group 5', ${now}, ${now})`
 		);
 
-		// Former enum values still work
-		for (const role of ['worker', 'leader']) {
+		// All role strings are valid — no CHECK constraint on role
+		for (const role of [
+			'worker',
+			'leader',
+			'coder',
+			'reviewer',
+			'security-auditor',
+			'any-custom-role',
+		]) {
 			expect(() => {
 				db.exec(
 					`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
 					 VALUES ('sgm-${role}', 'sg-5', 'sess-${role}', '${role}', 0, ${now})`
+				);
+			}).not.toThrow();
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// space_session_group_members status CHECK
+	// -------------------------------------------------------------------------
+
+	test('space_session_group_members status CHECK constraint is enforced', () => {
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at)
+			 VALUES ('sp-status', '/workspace/status', 'Status Space', ${now}, ${now})`
+		);
+		db.exec(
+			`INSERT INTO space_session_groups (id, space_id, name, created_at, updated_at)
+			 VALUES ('sg-status', 'sp-status', 'Status Group', ${now}, ${now})`
+		);
+
+		// Valid statuses
+		for (const status of ['active', 'completed', 'failed']) {
+			expect(() => {
+				db.exec(
+					`INSERT INTO space_session_group_members (id, group_id, session_id, role, status, order_index, created_at)
+					 VALUES ('sgm-${status}', 'sg-status', 'sess-${status}', 'coder', '${status}', 0, ${now})`
 				);
 			}).not.toThrow();
 		}
 
-		// Arbitrary freeform roles now accepted (migration 40 dropped the CHECK)
-		for (const role of ['observer', 'security-auditor', 'coder', 'reviewer']) {
-			expect(() => {
-				db.exec(
-					`INSERT INTO space_session_group_members (id, group_id, session_id, role, order_index, created_at)
-					 VALUES ('sgm-${role}', 'sg-5', 'sess-${role}', '${role}', 0, ${now})`
-				);
-			}).not.toThrow();
-		}
+		// Invalid status
+		expect(() => {
+			db.exec(
+				`INSERT INTO space_session_group_members (id, group_id, session_id, role, status, order_index, created_at)
+				 VALUES ('sgm-bad', 'sg-status', 'sess-bad', 'coder', 'pending', 0, ${now})`
+			);
+		}).toThrow();
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-session-group-repository.test.ts
@@ -36,6 +36,7 @@ describe('SpaceSessionGroupRepository', () => {
 			expect(group.spaceId).toBe(spaceId);
 			expect(group.name).toBe('Group A');
 			expect(group.description).toBeUndefined();
+			expect(group.taskId).toBeUndefined();
 			expect(group.members).toEqual([]);
 			expect(group.createdAt).toBeGreaterThan(0);
 		});
@@ -44,12 +45,17 @@ describe('SpaceSessionGroupRepository', () => {
 			const group = repo.createGroup({ spaceId, name: 'Group B', description: 'Desc' });
 			expect(group.description).toBe('Desc');
 		});
+
+		it('creates a group with taskId', () => {
+			const group = repo.createGroup({ spaceId, name: 'Group C', taskId: 'task-42' });
+			expect(group.taskId).toBe('task-42');
+		});
 	});
 
 	describe('getGroup', () => {
 		it('returns group with members', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
 
 			const found = repo.getGroup(group.id);
 			expect(found).not.toBeNull();
@@ -78,14 +84,19 @@ describe('SpaceSessionGroupRepository', () => {
 	});
 
 	describe('getGroupsByTask', () => {
-		it('returns groups named task:{taskId}', () => {
-			repo.createGroup({ spaceId, name: 'task:task-1' });
-			repo.createGroup({ spaceId, name: 'task:task-2' });
+		it('returns groups by task_id column', () => {
+			repo.createGroup({ spaceId, name: 'Group for task-1', taskId: 'task-1' });
+			repo.createGroup({ spaceId, name: 'Group for task-2', taskId: 'task-2' });
 			repo.createGroup({ spaceId, name: 'other-group' });
 
 			const groups = repo.getGroupsByTask(spaceId, 'task-1');
 			expect(groups).toHaveLength(1);
-			expect(groups[0].name).toBe('task:task-1');
+			expect(groups[0].taskId).toBe('task-1');
+		});
+
+		it('returns empty array when no groups have matching task_id', () => {
+			repo.createGroup({ spaceId, name: 'some-group' });
+			expect(repo.getGroupsByTask(spaceId, 'task-99')).toHaveLength(0);
 		});
 	});
 
@@ -95,6 +106,18 @@ describe('SpaceSessionGroupRepository', () => {
 			const updated = repo.updateGroup(group.id, { name: 'New', description: 'Updated' });
 			expect(updated!.name).toBe('New');
 			expect(updated!.description).toBe('Updated');
+		});
+
+		it('updates taskId', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const updated = repo.updateGroup(group.id, { taskId: 'task-99' });
+			expect(updated!.taskId).toBe('task-99');
+		});
+
+		it('clears taskId with null', () => {
+			const group = repo.createGroup({ spaceId, name: 'G', taskId: 'task-1' });
+			const updated = repo.updateGroup(group.id, { taskId: null });
+			expect(updated!.taskId).toBeUndefined();
 		});
 
 		it('returns null for unknown ID', () => {
@@ -115,23 +138,51 @@ describe('SpaceSessionGroupRepository', () => {
 	});
 
 	describe('addMember', () => {
-		it('adds a member to a group', () => {
+		it('adds a member with default status', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			const member = repo.addMember(group.id, 'session-1', 'leader', 0);
+			const member = repo.addMember(group.id, 'session-1', { role: 'leader' });
 
 			expect(member.groupId).toBe(group.id);
 			expect(member.sessionId).toBe('session-1');
 			expect(member.role).toBe('leader');
+			expect(member.status).toBe('active');
+			expect(member.agentId).toBeUndefined();
 			expect(member.orderIndex).toBe(0);
+		});
+
+		it('adds a member with agentId and custom status', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', {
+				role: 'coder',
+				agentId: 'agent-42',
+				status: 'completed',
+			});
+
+			expect(member.role).toBe('coder');
+			expect(member.agentId).toBe('agent-42');
+			expect(member.status).toBe('completed');
+		});
+
+		it('accepts freeform role strings', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			const member = repo.addMember(group.id, 'session-1', { role: 'security-auditor' });
+			expect(member.role).toBe('security-auditor');
 		});
 
 		it('is idempotent — updates existing member', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
-			const updated = repo.addMember(group.id, 'session-1', 'leader', 1);
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
+			const updated = repo.addMember(group.id, 'session-1', {
+				role: 'reviewer',
+				orderIndex: 1,
+				agentId: 'agent-5',
+				status: 'completed',
+			});
 
-			expect(updated.role).toBe('leader');
+			expect(updated.role).toBe('reviewer');
 			expect(updated.orderIndex).toBe(1);
+			expect(updated.agentId).toBe('agent-5');
+			expect(updated.status).toBe('completed');
 
 			const found = repo.getGroup(group.id);
 			expect(found!.members).toHaveLength(1);
@@ -139,8 +190,8 @@ describe('SpaceSessionGroupRepository', () => {
 
 		it('multiple members are ordered by order_index', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-2', 'worker', 1);
-			repo.addMember(group.id, 'session-1', 'leader', 0);
+			repo.addMember(group.id, 'session-2', { role: 'worker', orderIndex: 1 });
+			repo.addMember(group.id, 'session-1', { role: 'coder', orderIndex: 0 });
 
 			const found = repo.getGroup(group.id);
 			expect(found!.members[0].sessionId).toBe('session-1');
@@ -148,10 +199,64 @@ describe('SpaceSessionGroupRepository', () => {
 		});
 	});
 
+	describe('updateMember', () => {
+		it('updates status without touching other fields', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder', agentId: 'agent-1' });
+
+			const updated = repo.updateMember(group.id, 'session-1', { status: 'completed' });
+			expect(updated).not.toBeNull();
+			expect(updated!.status).toBe('completed');
+			expect(updated!.role).toBe('coder');
+			expect(updated!.agentId).toBe('agent-1');
+		});
+
+		it('updates multiple fields at once', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
+
+			const updated = repo.updateMember(group.id, 'session-1', {
+				role: 'reviewer',
+				status: 'failed',
+				agentId: 'agent-99',
+			});
+			expect(updated!.role).toBe('reviewer');
+			expect(updated!.status).toBe('failed');
+			expect(updated!.agentId).toBe('agent-99');
+		});
+
+		it('clears agentId with null', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder', agentId: 'agent-1' });
+
+			const updated = repo.updateMember(group.id, 'session-1', { agentId: null });
+			expect(updated!.agentId).toBeUndefined();
+		});
+
+		it('returns null for non-existent member', () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			expect(
+				repo.updateMember(group.id, 'nonexistent-session', { status: 'completed' })
+			).toBeNull();
+		});
+
+		it('touches group updated_at', async () => {
+			const group = repo.createGroup({ spaceId, name: 'G' });
+			repo.addMember(group.id, 'session-1', { role: 'coder' });
+			const before = repo.getGroup(group.id)!.updatedAt;
+
+			await new Promise((r) => setTimeout(r, 5));
+			repo.updateMember(group.id, 'session-1', { status: 'completed' });
+
+			const after = repo.getGroup(group.id)!.updatedAt;
+			expect(after).toBeGreaterThanOrEqual(before);
+		});
+	});
+
 	describe('removeMember', () => {
 		it('removes a member from a group', () => {
 			const group = repo.createGroup({ spaceId, name: 'G' });
-			repo.addMember(group.id, 'session-1', 'worker');
+			repo.addMember(group.id, 'session-1', { role: 'worker' });
 
 			const removed = repo.removeMember(group.id, 'session-1');
 			expect(removed).toBe(true);

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -827,27 +827,53 @@ export interface UpdateSpaceWorkflowParams {
 // ============================================================================
 
 /**
+ * A single agent entry within a multi-agent exported workflow step.
+ * Mirrors `WorkflowStepAgent` but uses a portable `agentRef` name instead of a UUID.
+ */
+export interface ExportedWorkflowStepAgent {
+	/** Name of the SpaceAgent (portable, not a UUID) */
+	agentRef: string;
+	/** Per-agent instructions override */
+	instructions?: string;
+}
+
+/**
  * A single workflow step (graph node) in the exported format.
  *
  * Differences from `WorkflowStep`:
  * - `id` is stripped (space-specific, regenerated on import)
  * - `agentId` UUID is replaced by `agentRef` (the agent's **name**), making the
  *   reference portable across Space instances that may have different UUIDs.
+ * - `agents[]` entries have their `agentId` UUIDs replaced by `agentRef` names.
+ * - `channels[]` are exported as-is — they already use role strings, not UUIDs.
  *
  * Step names are used as cross-references throughout the exported format
  * (in `ExportedWorkflowTransition.fromStep`/`toStep`,
  * `ExportedSpaceWorkflow.startStep`, and `ExportedWorkflowRule.appliesTo`).
  * Step names must therefore be unique within an exported workflow.
  *
- * **Multi-agent limitation (Milestone 5):** The export format currently only supports
- * single-agent steps via `agentRef`. Multi-agent steps (`agents[]`) and channel topology
- * (`channels[]`) are not yet represented here. When exporting a multi-agent step, the
- * primary agent's name is used as `agentRef` and the remaining agents are dropped.
- * Full multi-agent export/import support is planned for Milestone 5.
+ * Exactly one of `agentRef` or `agents` must be present:
+ * - Single-agent steps use `agentRef` (shorthand, backward-compatible).
+ * - Multi-agent steps use `agents` (array of `ExportedWorkflowStepAgent` entries).
  */
 export interface ExportedWorkflowStep {
-	/** Name of the SpaceAgent assigned to this step (portable, not a UUID) */
-	agentRef: string;
+	/**
+	 * Name of the SpaceAgent assigned to this step (portable, not a UUID).
+	 * Used for single-agent steps. Mutually exclusive with `agents`.
+	 */
+	agentRef?: string;
+	/**
+	 * Multiple agents for parallel execution.
+	 * Used for multi-agent steps. Mutually exclusive with `agentRef`.
+	 * When present (non-empty), `agentRef` must be absent.
+	 */
+	agents?: ExportedWorkflowStepAgent[];
+	/**
+	 * Directed messaging topology between agents in this step.
+	 * Uses role strings (portable — not UUIDs). Exported and imported as-is.
+	 * Absent or empty means agents are fully isolated (no messaging).
+	 */
+	channels?: WorkflowChannel[];
 	/** Human-readable step name — used as the stable cross-reference key in the export */
 	name: string;
 	/** Step-specific instructions appended to the agent's system prompt */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -355,8 +355,15 @@ export interface SpaceSessionGroupMember {
 	groupId: string;
 	/** ID of the session */
 	sessionId: string;
-	/** Role of this session within the group */
-	role: 'worker' | 'leader';
+	/**
+	 * Role of this session within the group — freeform string matching SpaceAgent.role
+	 * (e.g. 'coder', 'reviewer', 'security-auditor', or any user-defined role).
+	 */
+	role: string;
+	/** ID of the SpaceAgent config this session uses (nullable for system agents) */
+	agentId?: string;
+	/** Current state of this member's session */
+	status: 'active' | 'completed' | 'failed';
 	/** Display order within the group */
 	orderIndex: number;
 	/** Creation timestamp (milliseconds since epoch) */
@@ -366,7 +373,7 @@ export interface SpaceSessionGroupMember {
 /**
  * A named group of sessions within a Space.
  * Session groups allow organizing related sessions (e.g., a workflow run's
- * leader + workers) under a single logical unit for display and management.
+ * agents) under a single logical unit for display and management.
  */
 export interface SpaceSessionGroup {
 	/** Unique identifier */
@@ -381,6 +388,8 @@ export interface SpaceSessionGroup {
 	workflowRunId?: string;
 	/** ID of the current workflow step being executed by this group */
 	currentStepId?: string;
+	/** ID of the SpaceTask this group serves */
+	taskId?: string;
 	/** Members of this group */
 	members: SpaceSessionGroupMember[];
 	/** Creation timestamp (milliseconds since epoch) */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -861,9 +861,12 @@ export interface ExportedWorkflowStepAgent {
  * `ExportedSpaceWorkflow.startStep`, and `ExportedWorkflowRule.appliesTo`).
  * Step names must therefore be unique within an exported workflow.
  *
- * Exactly one of `agentRef` or `agents` must be present:
+ * At least one of `agentRef` or `agents` (non-empty) must be present:
  * - Single-agent steps use `agentRef` (shorthand, backward-compatible).
  * - Multi-agent steps use `agents` (array of `ExportedWorkflowStepAgent` entries).
+ * - The export function never sets both simultaneously, but the type and Zod schema
+ *   do not enforce mutual exclusivity — if both are present, `agents` takes precedence
+ *   on import (consistent with `WorkflowStep` resolution semantics).
  */
 export interface ExportedWorkflowStep {
 	/**


### PR DESCRIPTION
- Add ExportedWorkflowStepAgent type and update ExportedWorkflowStep to
  support optional agents[] array and channels[] alongside agentRef
- Make agentRef optional on ExportedWorkflowStep (single-agent shorthand)
- Update exportWorkflow(): multi-agent steps export as agents[] with
  agentRef names; single-agent steps use scalar agentRef (backward compat);
  channels exported as-is (role strings, already portable)
- Update Zod schema for step validation: either agentRef or non-empty agents
  required; add workflowChannelSchema and exportedWorkflowStepAgentSchema
- Update buildWorkflowCreateParams(): resolve each agentRef→agentId for
  multi-agent steps; import channels as-is; backward compat for agentRef
- Update validateWorkflowForPreview(): validate all agent refs in
  multi-agent steps
- Update spaceExport.workflows referencedNames to collect refs from agents[]
- Add 22 new unit tests covering export, validation, round-trip, and import
  of multi-agent + channels steps; backward compat tests for single-agent
