### PR TITLE
feat: update WorkflowExecutor for multi-agent parallel step execution

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -27,7 +27,7 @@ import type {
 	WorkflowRule,
 	WorkflowStep,
 } from '@neokai/shared';
-import { resolveStepAgents } from '@neokai/shared';
+import { resolveStepAgents, resolveStepChannels } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -327,22 +327,27 @@ export class SpaceRuntime {
 		}
 
 		const taskManager = this.getOrCreateTaskManager(spaceId);
-		let task: SpaceTask;
+		const tasks: SpaceTask[] = [];
 		try {
-			// resolveTaskTypeForStep is inside the try/catch so that an exception from
-			// resolveStepAgents (e.g. a step with neither agentId nor agents) triggers
-			// the same executor/meta cleanup path as a task-creation failure.
-			const resolved = this.resolveTaskTypeForStep(startStep);
-			task = await taskManager.createTask({
-				title: startStep.name,
-				description: startStep.instructions ?? '',
-				workflowRunId: run.id,
-				workflowStepId: startStep.id,
-				taskType: resolved.taskType,
-				customAgentId: resolved.customAgentId,
-				status: 'pending',
-				goalId: run.goalId,
-			});
+			// Multi-agent start steps: create one SpaceTask per agent.
+			// resolveStepAgents() normalises agentId vs agents[] and throws when
+			// neither is present — keeping it inside the try/catch ensures the
+			// executor/run state is cleaned up on configuration errors.
+			const startAgents = resolveStepAgents(startStep);
+			for (const agentEntry of startAgents) {
+				const resolved = this.resolveTaskTypeForAgent(agentEntry.agentId);
+				const task = await taskManager.createTask({
+					title: startStep.name,
+					description: agentEntry.instructions ?? startStep.instructions ?? '',
+					workflowRunId: run.id,
+					workflowStepId: startStep.id,
+					taskType: resolved.taskType,
+					customAgentId: resolved.customAgentId,
+					status: 'pending',
+					goalId: run.goalId,
+				});
+				tasks.push(task);
+			}
 		} catch (err) {
 			// Clean up the executor/meta entries so the run is not orphaned in the map.
 			this.executors.delete(run.id);
@@ -354,11 +359,18 @@ export class SpaceRuntime {
 			throw err;
 		}
 
-		return { run, tasks: [task] };
+		// Resolve channel topology for the start step and store in run config.
+		// TODO Milestone 6: pass resolvedChannels to session group creation in
+		// TaskAgentManager.spawnTaskAgent() rather than storing in run config.
+		this.storeResolvedChannels(run.id, space.id, startStep);
+
+		return { run, tasks };
 	}
 
 	/**
-	 * Resolve the SpaceTaskType (and optional customAgentId) for a single agentId.
+	 * Resolve the appropriate SpaceTaskType (and optional customAgentId) for a specific
+	 * agent ID. This is the canonical per-agent resolver used by the TaskTypeResolver
+	 * callback injected into WorkflowExecutor.
 	 *
 	 * Mapping rules:
 	 *   agent.role === 'planner'          → taskType: 'planning',  customAgentId: undefined
@@ -366,10 +378,11 @@ export class SpaceRuntime {
 	 *   any other role (custom)           → taskType: 'coding',    customAgentId: agentId
 	 *   agent not found                   → taskType: 'coding',    customAgentId: agentId
 	 */
-	private resolveTaskTypeForAgent(agentId: string | undefined): ResolvedTaskType {
-		const agent = agentId ? this.config.spaceAgentManager.getById(agentId) : undefined;
+	resolveTaskTypeForAgent(agentId: string): ResolvedTaskType {
+		const agent = this.config.spaceAgentManager.getById(agentId);
 
 		if (!agent) {
+			// Unknown agent → treat as custom coding agent
 			return { taskType: 'coding', customAgentId: agentId };
 		}
 
@@ -632,6 +645,27 @@ export class SpaceRuntime {
 					});
 				}
 			}
+
+			// Partial failure gate: applies only to multi-agent steps (stepTasks.length > 1).
+			// For single-task steps the existing per-task notification is sufficient —
+			// a human can reset just the task without also needing to reset the run.
+			// For multi-agent parallel steps, wait until ALL sibling tasks reach a
+			// terminal state before escalating the run. This prevents premature
+			// escalation when one task has failed but siblings are still running.
+			if (stepTasks.length > 1) {
+				const { allTerminal } = this.areAllStepTasksTerminal(stepTasks);
+				if (allTerminal) {
+					this.config.workflowRunRepo.updateStatus(runId, 'needs_attention');
+					await this.safeNotify({
+						kind: 'workflow_run_needs_attention',
+						spaceId: meta.spaceId,
+						runId,
+						reason: `One or more parallel tasks on step "${currentStep.name}" require attention`,
+						timestamp: new Date().toISOString(),
+					});
+				}
+			}
+
 			return;
 		}
 
@@ -733,7 +767,7 @@ export class SpaceRuntime {
 		if (!stepTasks.every((t) => t.status === 'completed')) return;
 
 		try {
-			const { tasks: newTasks } = await freshExecutor.advance();
+			const { step: newStep, tasks: newTasks } = await freshExecutor.advance();
 
 			// Tasks are created with taskType already set by the TaskTypeResolver
 			// injected into the executor via buildExecutor(). No second update needed.
@@ -743,6 +777,10 @@ export class SpaceRuntime {
 				// cleanupTerminalExecutors() will emit workflow_run_completed and remove executor.
 				// No cleanup here: executors map is iterated by for..of which captures the
 				// initial key set, so the entry stays until cleanupTerminalExecutors() runs.
+			} else {
+				// Resolve channel topology for the new step.
+				// TODO Milestone 6: pass to session group creation instead of run config.
+				this.storeResolvedChannels(runId, meta.spaceId, newStep);
 			}
 		} catch (err) {
 			if (!(err instanceof WorkflowTransitionError)) {
@@ -911,8 +949,8 @@ export class SpaceRuntime {
 
 	/**
 	 * Builds a WorkflowExecutor for the given run with fresh state.
-	 * Injects the TaskTypeResolver so tasks are created with correct taskType
-	 * in a single atomic DB write.
+	 * Injects a per-agent TaskTypeResolver so each task is created with the correct
+	 * taskType / customAgentId in a single atomic DB write.
 	 */
 	private buildExecutor(
 		workflow: SpaceWorkflow,
@@ -928,7 +966,63 @@ export class SpaceRuntime {
 			this.config.workflowRunRepo,
 			workspacePath,
 			undefined, // use default commandRunner
-			(step) => this.resolveTaskTypesForStep(step) // inject TaskTypeResolver (multi-agent)
+			// Per-agent resolver: called once per agent entry in the step.
+			// This replaces the old step-level resolver so multi-agent steps produce
+			// correctly-typed tasks for each agent independently.
+			(_step, agentEntry) => this.resolveTaskTypeForAgent(agentEntry.agentId)
 		);
+	}
+
+	/**
+	 * Checks whether all tasks in a step have reached a terminal state.
+	 *
+	 * Terminal statuses: completed, needs_attention, cancelled, archived.
+	 * Failed statuses (a subset of terminal): needs_attention, cancelled.
+	 *
+	 * Used to implement the partial-failure gate: for multi-agent steps, the run
+	 * must not be escalated to needs_attention until every sibling task has settled.
+	 *
+	 * @param stepTasks - Pre-fetched tasks for the current step.
+	 */
+	private areAllStepTasksTerminal(stepTasks: SpaceTask[]): {
+		allTerminal: boolean;
+		anyFailed: boolean;
+	} {
+		const TERMINAL = new Set<string>(['completed', 'needs_attention', 'cancelled', 'archived']);
+		const FAILED = new Set<string>(['needs_attention', 'cancelled']);
+
+		const allTerminal = stepTasks.every((t) => TERMINAL.has(t.status));
+		const anyFailed = stepTasks.some((t) => FAILED.has(t.status));
+
+		return { allTerminal, anyFailed };
+	}
+
+	/**
+	 * Resolves the channel topology for a workflow step and stores it in the run's
+	 * config for use by session group creation (Milestone 6).
+	 *
+	 * Calls `resolveStepChannels()` using all Space agents as the lookup table.
+	 * Stores the result under `run.config._resolvedChannels`.
+	 *
+	 * TODO Milestone 6: pass resolvedChannels to session group metadata in
+	 * TaskAgentManager.spawnTaskAgent() instead of storing in run config.
+	 *
+	 * Steps with no `channels` declaration produce an empty array (no-op).
+	 */
+	private storeResolvedChannels(runId: string, spaceId: string, step: WorkflowStep): void {
+		if (!step.channels || step.channels.length === 0) return;
+
+		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
+		const resolved = resolveStepChannels(step, allAgents);
+
+		if (resolved.length === 0) return;
+
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) return;
+
+		const config = (run.config ?? {}) as Record<string, unknown>;
+		this.config.workflowRunRepo.updateRun(runId, {
+			config: { ...config, _resolvedChannels: resolved },
+		});
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -327,12 +327,12 @@ export class SpaceRuntime {
 		}
 
 		const taskManager = this.getOrCreateTaskManager(spaceId);
+		// Multi-agent start steps: create one SpaceTask per agent.
+		// resolveStepAgents() normalises agentId vs agents[] for backward compatibility.
+		// Keep inside the try block so a malformed step (neither agentId nor agents)
+		// triggers the rollback path and does not leave the executor/run orphaned.
 		const tasks: SpaceTask[] = [];
 		try {
-			// Multi-agent start steps: create one SpaceTask per agent.
-			// resolveStepAgents() normalises agentId vs agents[] and throws when
-			// neither is present — keeping it inside the try/catch ensures the
-			// executor/run state is cleaned up on configuration errors.
 			const startAgents = resolveStepAgents(startStep);
 			for (const agentEntry of startAgents) {
 				const resolved = this.resolveTaskTypeForAgent(agentEntry.agentId);
@@ -653,8 +653,7 @@ export class SpaceRuntime {
 			// terminal state before escalating the run. This prevents premature
 			// escalation when one task has failed but siblings are still running.
 			if (stepTasks.length > 1) {
-				const { allTerminal } = this.areAllStepTasksTerminal(stepTasks);
-				if (allTerminal) {
+				if (this.areAllStepTasksTerminal(stepTasks)) {
 					this.config.workflowRunRepo.updateStatus(runId, 'needs_attention');
 					await this.safeNotify({
 						kind: 'workflow_run_needs_attention',
@@ -703,14 +702,18 @@ export class SpaceRuntime {
 
 			// Step 1: Check tasks that already have a Task Agent session (in_progress).
 			// Full loop always completes so that dead-agent resets are applied to ALL
-			// tasks before deciding whether to skip. Early-returning on the first alive
-			// agent would leave dead-agent tasks unrecovered if a step has multiple tasks.
-			let anyAgentAlive = false;
+			// tasks before deciding whether to skip.
+			//
+			// NOTE: we intentionally do NOT return early when alive agents are found.
+			// For multi-agent parallel steps, some tasks may have alive agents while
+			// siblings are still pending (e.g. a spawn failure on a prior tick). An
+			// early return here would permanently skip spawning those unspawned tasks.
+			// Always proceed to Step 2 so pending tasks are always re-examined.
+			// The final `return` at the end of the TAM block still prevents advance().
 			for (const task of stepTasks) {
 				if (!task.taskAgentSessionId) continue;
 
 				if (tam.isTaskAgentAlive(task.id)) {
-					anyAgentAlive = true;
 					continue; // still check remaining tasks for dead agents
 				}
 
@@ -724,9 +727,6 @@ export class SpaceRuntime {
 					status: 'pending',
 				});
 			}
-
-			// If any Task Agent is actively running, skip this tick — it drives the workflow.
-			if (anyAgentAlive) return;
 
 			// Step 2: Spawn Task Agents for pending tasks without an agent session.
 			// Re-read from DB to pick up status resets applied in Step 1.
@@ -974,27 +974,20 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Checks whether all tasks in a step have reached a terminal state.
+	 * Returns true when every task in the step has reached a terminal state.
 	 *
 	 * Terminal statuses: completed, needs_attention, cancelled, archived.
-	 * Failed statuses (a subset of terminal): needs_attention, cancelled.
 	 *
 	 * Used to implement the partial-failure gate: for multi-agent steps, the run
 	 * must not be escalated to needs_attention until every sibling task has settled.
+	 * The caller is already inside `if (stepTasks.some(needs_attention))`, so
+	 * "any failed" is guaranteed true at the call site — no need to return it.
 	 *
 	 * @param stepTasks - Pre-fetched tasks for the current step.
 	 */
-	private areAllStepTasksTerminal(stepTasks: SpaceTask[]): {
-		allTerminal: boolean;
-		anyFailed: boolean;
-	} {
+	private areAllStepTasksTerminal(stepTasks: SpaceTask[]): boolean {
 		const TERMINAL = new Set<string>(['completed', 'needs_attention', 'cancelled', 'archived']);
-		const FAILED = new Set<string>(['needs_attention', 'cancelled']);
-
-		const allTerminal = stepTasks.every((t) => TERMINAL.has(t.status));
-		const anyFailed = stepTasks.some((t) => FAILED.has(t.status));
-
-		return { allTerminal, anyFailed };
+		return stepTasks.every((t) => TERMINAL.has(t.status));
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -525,6 +525,12 @@ export class WorkflowExecutor {
 	/**
 	 * Resolves the task result for the current step from the most recently completed task.
 	 * DB task `result` takes priority; `fallback` is used when the DB result is empty.
+	 *
+	 * For multi-agent steps (agents[] with multiple entries), multiple tasks share the
+	 * same stepId. This method picks the most recently completed one, so `task_result`
+	 * conditions on parallel steps are inherently non-deterministic — the "winning"
+	 * result depends on which agent finishes last. Prefer `condition` or `always`
+	 * transition types for steps that use parallel agent execution.
 	 */
 	private async resolveTaskResult(stepId: string, fallback?: string): Promise<string | undefined> {
 		const allTasks = await this.taskManager.listTasksByWorkflowRun(this.run.id);

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -25,7 +25,9 @@ import type {
 	WorkflowCondition,
 	WorkflowTransition,
 	WorkflowStep,
+	WorkflowStepAgent,
 } from '@neokai/shared';
+import { resolveStepAgents } from '@neokai/shared';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 
@@ -110,12 +112,16 @@ export interface TaskTypeResolution {
  * customAgentId) at task-creation time. When provided, the task is created
  * complete in a single DB write — no second update required.
  *
- * May return either a single `TaskTypeResolution` (single-agent / backward-compat)
- * or an array of `TaskTypeResolution` (one per agent in a multi-agent step).
- * The executor currently uses only the first entry to create the primary task.
- * Per-agent sub-task creation for the remaining entries is deferred to a later phase.
+ * Receives the full step AND the specific agent entry being created, so the
+ * resolver can derive per-agent taskType / customAgentId for multi-agent steps.
  */
-export type TaskTypeResolver = (step: WorkflowStep) => TaskTypeResolution | TaskTypeResolution[];
+export type TaskTypeResolver = (
+	step: WorkflowStep,
+	agentEntry: WorkflowStepAgent
+) => {
+	taskType?: string;
+	customAgentId?: string;
+};
 
 // ---------------------------------------------------------------------------
 // Default timeout constants
@@ -396,7 +402,11 @@ export class WorkflowExecutor {
 		};
 	}
 
-	/** Follows a transition: updates currentStepId and creates a SpaceTask for the target step. */
+	/**
+	 * Follows a transition: updates currentStepId and creates one SpaceTask per agent
+	 * in the target step. Multi-agent steps produce multiple parallel tasks, all sharing
+	 * the same `workflowRunId` and `workflowStepId`. Single-agent steps produce one task.
+	 */
 	private async followTransition(
 		transition: WorkflowTransition
 	): Promise<{ step: WorkflowStep; tasks: SpaceTask[] }> {
@@ -432,28 +442,36 @@ export class WorkflowExecutor {
 		if (!updatedRun) throw new Error('Failed to persist step ID update');
 		this.run = updatedRun;
 
-		// Resolve task metadata so the task is created complete in a single write.
-		// When a taskTypeResolver is provided it fully controls taskType AND customAgentId —
-		// customAgentId: undefined means "no custom agent" for preset roles (planner/coder/general).
-		// Without a resolver (backward-compat), fall back to nextStep.agentId.
-		// The resolver may return a single resolution or an array (multi-agent); use the first entry
-		// for the primary task.
-		const rawResolved = this.taskTypeResolver?.(nextStep);
-		const resolved = Array.isArray(rawResolved) ? rawResolved[0] : rawResolved;
+		// Resolve agents for this step: supports both agentId (single-agent shorthand)
+		// and agents[] (multi-agent parallel execution).
+		const stepAgents = resolveStepAgents(nextStep);
 
-		// Create a pending SpaceTask for the new step
-		const task = await this.taskManager.createTask({
-			title: nextStep.name,
-			description: nextStep.instructions ?? '',
-			workflowRunId: this.run.id,
-			workflowStepId: nextStep.id,
-			taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
-			customAgentId: resolved !== undefined ? resolved.customAgentId : nextStep.agentId,
-			status: 'pending',
-			goalId: this.run.goalId,
-		});
+		// Create one pending SpaceTask per agent. All tasks share the same workflowRunId
+		// and workflowStepId so SpaceRuntime can track them as a group.
+		// Per-agent instructions override step-level instructions when present.
+		const tasks: SpaceTask[] = [];
+		for (const agentEntry of stepAgents) {
+			// Resolve task metadata per agent so each task is created complete in one DB write.
+			// When a taskTypeResolver is provided it fully controls taskType AND customAgentId —
+			// customAgentId: undefined means "no custom agent" for preset roles (planner/coder/general).
+			// Without a resolver (backward-compat), fall back to agentEntry.agentId.
+			const resolved = this.taskTypeResolver?.(nextStep, agentEntry);
 
-		return { step: nextStep, tasks: [task] };
+			const task = await this.taskManager.createTask({
+				title: nextStep.name,
+				description: agentEntry.instructions ?? nextStep.instructions ?? '',
+				workflowRunId: this.run.id,
+				workflowStepId: nextStep.id,
+				taskType: resolved?.taskType as import('@neokai/shared').SpaceTaskType | undefined,
+				customAgentId: resolved !== undefined ? resolved.customAgentId : agentEntry.agentId,
+				status: 'pending',
+				goalId: this.run.goalId,
+			});
+
+			tasks.push(task);
+		}
+
+		return { step: nextStep, tasks };
 	}
 
 	/**

--- a/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-notifications.test.ts
@@ -1308,4 +1308,133 @@ describe('SpaceRuntime — notification events', () => {
 			}
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// Multi-agent partial failure notifications
+	// -------------------------------------------------------------------------
+
+	describe('multi-agent partial failure', () => {
+		const AGENT_PLANNER = 'agent-planner-notif';
+
+		beforeEach(() => {
+			seedAgentRow(db, AGENT_PLANNER, SPACE_ID, 'planner');
+		});
+
+		test('emits task_needs_attention for each failed parallel task when all are terminal', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Parallel Fail Notify ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Step',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// Both tasks fail → all terminal
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Coder failed' });
+			taskRepo.updateTask(tasks[1].id, { status: 'needs_attention', error: 'Planner failed' });
+
+			await runtime.executeTick();
+
+			const naEvents = sink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(naEvents).toHaveLength(2);
+			const runEvents = sink.events.filter((e) => e.kind === 'workflow_run_needs_attention');
+			expect(runEvents).toHaveLength(1);
+		});
+
+		test('does NOT emit workflow_run_needs_attention when sibling tasks are still running', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Partial Terminal Notify ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Partial',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// One task fails, one still running
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Fail' });
+			taskRepo.updateTask(tasks[1].id, { status: 'in_progress' });
+
+			await runtime.executeTick();
+
+			const naEvents = sink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(naEvents).toHaveLength(1); // only the failed task
+
+			const runEvents = sink.events.filter((e) => e.kind === 'workflow_run_needs_attention');
+			expect(runEvents).toHaveLength(0); // sibling still running
+		});
+
+		test('does NOT emit workflow_run_needs_attention for single-task step (backward compat)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Single', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(1);
+
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Failed' });
+
+			await runtime.executeTick();
+
+			// Only task_needs_attention — no run escalation for single-task steps
+			const naEvents = sink.events.filter((e) => e.kind === 'task_needs_attention');
+			expect(naEvents).toHaveLength(1);
+
+			const runEvents = sink.events.filter((e) => e.kind === 'workflow_run_needs_attention');
+			expect(runEvents).toHaveLength(0);
+		});
+
+		test('multi-agent partial failure dedup: does not re-emit run needs_attention on second tick', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Partial Fail Dedup ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Dedup',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			taskRepo.updateTask(tasks[1].id, { status: 'needs_attention', error: 'Fail' });
+
+			// First tick: run escalated
+			await runtime.executeTick();
+			const runEvents1 = sink.events.filter((e) => e.kind === 'workflow_run_needs_attention');
+			expect(runEvents1).toHaveLength(1);
+
+			// Second tick: run is now needs_attention, processRunTick returns early
+			await runtime.executeTick();
+			const runEvents2 = sink.events.filter((e) => e.kind === 'workflow_run_needs_attention');
+			expect(runEvents2).toHaveLength(1); // still 1, not 2
+		});
+	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -533,8 +533,9 @@ describe('SpaceRuntime', () => {
 			expect(tasks[0].goalId).toBeUndefined();
 		});
 
-		test('multi-agent start step: uses first agent taskType for the initial task', async () => {
-			// Workflow with agents[] format: planner first, then coder
+		test('multi-agent start step: creates one task per agent', async () => {
+			// Workflow with agents[] format: planner first, then coder.
+			// startWorkflowRun creates one pending SpaceTask per agent entry.
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Agent Start ${Date.now()}`,
@@ -554,10 +555,14 @@ describe('SpaceRuntime', () => {
 
 			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Multi Run');
 
-			// The primary task uses the first agent's resolution (planner → planning)
-			expect(tasks).toHaveLength(1);
-			expect(tasks[0].taskType).toBe('planning');
-			expect(tasks[0].customAgentId).toBeUndefined();
+			// One task per agent — planner task and coder task created in parallel
+			expect(tasks).toHaveLength(2);
+			const plannerTask = tasks.find((t) => t.taskType === 'planning');
+			const coderTask = tasks.find((t) => t.taskType === 'coding');
+			expect(plannerTask).toBeDefined();
+			expect(plannerTask!.customAgentId).toBeUndefined();
+			expect(coderTask).toBeDefined();
+			expect(coderTask!.customAgentId).toBeUndefined();
 		});
 
 		test('multi-agent start step with custom-role first agent: sets customAgentId', async () => {
@@ -1807,6 +1812,298 @@ describe('SpaceRuntime', () => {
 
 			const workflows = workflowManager.listWorkflows(newSpaceId);
 			expect(workflows).toHaveLength(3); // still 3, not 6
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Multi-agent steps
+	// -------------------------------------------------------------------------
+
+	describe('multi-agent step support', () => {
+		test('startWorkflowRun() creates multiple tasks for multi-agent start step', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi-Agent Start ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Start',
+						agents: [
+							{ agentId: AGENT_CODER, instructions: 'Coder task' },
+							{ agentId: AGENT_PLANNER, instructions: 'Planner task' },
+						],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(tasks).toHaveLength(2);
+			for (const task of tasks) {
+				expect(task.workflowRunId).toBe(run.id);
+				expect(task.workflowStepId).toBe(STEP_A);
+				expect(task.status).toBe('pending');
+			}
+
+			// Descriptions set from per-agent instructions
+			const descriptions = tasks.map((t) => t.description).sort();
+			expect(descriptions).toEqual(['Coder task', 'Planner task'].sort());
+		});
+
+		test('startWorkflowRun() uses agentId shorthand for single-agent start step (backward compat)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Start', agentId: AGENT_CODER },
+			]);
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0].workflowStepId).toBe(STEP_A);
+		});
+
+		test('startWorkflowRun() applies per-agent taskType for multi-agent start step', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi-Agent TaskType ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Mixed Start',
+						agents: [{ agentId: AGENT_PLANNER }, { agentId: AGENT_CODER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			expect(tasks).toHaveLength(2);
+
+			const plannerTask = tasks.find((t) => t.taskType === 'planning');
+			const coderTask = tasks.find((t) => t.taskType === 'coding');
+
+			expect(plannerTask).toBeDefined();
+			expect(plannerTask!.customAgentId).toBeUndefined();
+
+			expect(coderTask).toBeDefined();
+			expect(coderTask!.customAgentId).toBeUndefined();
+		});
+
+		test('executeTick() does NOT advance when only some parallel tasks are completed', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Partial Complete ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel A',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// Only complete one of the two parallel tasks
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			// tasks[1] stays pending
+
+			await runtime.executeTick();
+
+			// No new task for STEP_B should have been created
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			const stepBTasks = allTasks.filter((t) => t.workflowStepId === STEP_B);
+			expect(stepBTasks).toHaveLength(0);
+		});
+
+		test('executeTick() advances when ALL parallel tasks are completed', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `All Complete ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel A',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+					{ id: STEP_B, name: 'Step B', agentId: AGENT_CODER },
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// Complete both parallel tasks
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			taskRepo.updateTask(tasks[1].id, { status: 'completed' });
+
+			await runtime.executeTick();
+
+			// Step B task should now exist
+			const allTasks = taskRepo.listByWorkflowRun(run.id);
+			const stepBTasks = allTasks.filter((t) => t.workflowStepId === STEP_B);
+			expect(stepBTasks).toHaveLength(1);
+		});
+
+		test('executeTick() marks run as needs_attention when all parallel tasks terminal and any failed', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Partial Failure ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Fail',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// One task completes, one fails — both terminal
+			taskRepo.updateTask(tasks[0].id, { status: 'completed' });
+			taskRepo.updateTask(tasks[1].id, { status: 'needs_attention', error: 'Build failed' });
+
+			await runtime.executeTick();
+
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			expect(updatedRun.status).toBe('needs_attention');
+		});
+
+		test('executeTick() does NOT mark run needs_attention when parallel tasks are not all terminal yet', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Partial Terminal ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel Waiting',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_PLANNER }],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(2);
+
+			// One task fails, one is still running
+			taskRepo.updateTask(tasks[0].id, { status: 'needs_attention', error: 'Fail' });
+			taskRepo.updateTask(tasks[1].id, { status: 'in_progress' });
+
+			await runtime.executeTick();
+
+			// Run should still be in_progress — sibling task is still running
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			expect(updatedRun.status).toBe('in_progress');
+		});
+
+		test('resolveTaskTypeForAgent() returns correct mapping for each role', () => {
+			expect(runtime.resolveTaskTypeForAgent(AGENT_PLANNER)).toEqual({
+				taskType: 'planning',
+				customAgentId: undefined,
+			});
+			expect(runtime.resolveTaskTypeForAgent(AGENT_CODER)).toEqual({
+				taskType: 'coding',
+				customAgentId: undefined,
+			});
+			expect(runtime.resolveTaskTypeForAgent(AGENT_GENERAL)).toEqual({
+				taskType: 'coding',
+				customAgentId: undefined,
+			});
+			expect(runtime.resolveTaskTypeForAgent(AGENT_CUSTOM)).toEqual({
+				taskType: 'coding',
+				customAgentId: AGENT_CUSTOM,
+			});
+		});
+
+		test('resolveTaskTypeForAgent() returns custom coding agent for unknown agentId', () => {
+			const result = runtime.resolveTaskTypeForAgent('unknown-agent-id');
+			expect(result.taskType).toBe('coding');
+			expect(result.customAgentId).toBe('unknown-agent-id');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Channel topology resolution
+	// -------------------------------------------------------------------------
+
+	describe('channel topology resolution', () => {
+		test('storeResolvedChannels: step with channels stores resolved channels in run config', async () => {
+			// Need two agents with different roles for channel resolution
+			const AGENT_REVIEWER = 'agent-reviewer';
+			seedAgentRow(db, AGENT_REVIEWER, SPACE_ID, 'Reviewer', 'reviewer');
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Channel Step ${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Code and Review',
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+						channels: [
+							{
+								from: 'coder',
+								to: 'reviewer',
+								direction: 'one-way',
+								label: 'submit',
+							},
+						],
+					},
+				],
+				transitions: [],
+				startStepId: STEP_A,
+				rules: [],
+				tags: [],
+			});
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Run config should contain resolved channels
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			const resolvedChannels = (updatedRun.config as Record<string, unknown>)?._resolvedChannels;
+			expect(Array.isArray(resolvedChannels)).toBe(true);
+			expect((resolvedChannels as unknown[]).length).toBeGreaterThan(0);
+		});
+
+		test('storeResolvedChannels: step without channels does not modify run config', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'No Channels', agentId: AGENT_CODER },
+			]);
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// Run config should NOT have _resolvedChannels
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
+				?._resolvedChannels;
+			expect(resolvedChannels).toBeUndefined();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -1700,9 +1700,11 @@ describe('SpaceRuntime', () => {
 			expect(taskRepo.getTask(tasks[0].id)!.status).toBe('pending');
 		});
 
-		test('liveness loop resets all dead-agent tasks before deciding to skip tick', async () => {
+		test('liveness loop resets dead-agent tasks and immediately re-spawns them in the same tick', async () => {
 			// Two tasks for the same step: task A alive, task B dead.
-			// The dead-agent reset for task B must still happen even though task A is alive.
+			// Step 1 resets task B to pending; Step 2 re-spawns it in the same tick.
+			// The `anyAgentAlive` early return was removed so that dead siblings in
+			// multi-agent steps always get re-spawned without waiting for the next tick.
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
 			]);
@@ -1745,10 +1747,11 @@ describe('SpaceRuntime', () => {
 
 			await rt2.executeTick();
 
-			// Dead task B should have been reset to pending (dead-agent recovery happened)
+			// Dead task B: reset in Step 1 then immediately re-spawned in Step 2 of the
+			// same tick (fresh DB read picks it up as pending with no session).
 			const updatedB = taskRepo.getTask(taskBId)!;
-			expect(updatedB.status).toBe('pending');
-			expect(updatedB.taskAgentSessionId).toBeFalsy(); // cleared (null stored as undefined by repo)
+			expect(updatedB.status).toBe('in_progress');
+			expect(updatedB.taskAgentSessionId).toBe(`session:${taskBId}`); // new session from re-spawn
 
 			// Alive task A should be untouched
 			const updatedA = taskRepo.getTask(aliveId)!;

--- a/packages/daemon/tests/unit/space/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor.test.ts
@@ -2063,4 +2063,243 @@ describe('WorkflowExecutor', () => {
 			expect(runRepo.getRun(run.id)?.iterationCount).toBe(1);
 		});
 	});
+
+	// =========================================================================
+	// Multi-agent steps
+	// =========================================================================
+
+	describe('multi-agent steps', () => {
+		test('advance() creates one task per agent when step uses agents[] array', async () => {
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-multi-agent-${Date.now()}`,
+				steps: [
+					{ id: STEP_A, name: 'Start', agentId: AGENT_A },
+					{
+						id: STEP_B,
+						name: 'Parallel Work',
+						agents: [
+							{ agentId: AGENT_A, instructions: 'Do thing A' },
+							{ agentId: AGENT_B, instructions: 'Do thing B' },
+						],
+					},
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Multi Agent Run',
+				currentStepId: STEP_A,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+
+			// Two agents → two tasks
+			expect(result.tasks).toHaveLength(2);
+			expect(result.step.id).toBe(STEP_B);
+
+			// Both tasks share the same workflowRunId and workflowStepId
+			for (const task of result.tasks) {
+				expect(task.workflowRunId).toBe(run.id);
+				expect(task.workflowStepId).toBe(STEP_B);
+				expect(task.status).toBe('pending');
+			}
+		});
+
+		test('advance() creates tasks with per-agent instructions', async () => {
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-per-agent-instructions-${Date.now()}`,
+				steps: [
+					{ id: STEP_A, name: 'Start', agentId: AGENT_A },
+					{
+						id: STEP_B,
+						name: 'Parallel',
+						instructions: 'Shared instructions',
+						agents: [
+							{ agentId: AGENT_A, instructions: 'Agent A override' },
+							{ agentId: AGENT_B }, // no per-agent instructions → falls back to step
+						],
+					},
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Per-Agent Instructions Run',
+				currentStepId: STEP_A,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+
+			expect(result.tasks).toHaveLength(2);
+
+			// Task for AGENT_A: per-agent instructions override
+			const allTasks = await taskManager.listTasksByWorkflowRun(run.id);
+			const stepBTasks = allTasks.filter((t) => t.workflowStepId === STEP_B);
+
+			// Sort by description to make assertions deterministic
+			stepBTasks.sort((a, b) => a.description.localeCompare(b.description));
+			expect(stepBTasks[0].description).toBe('Agent A override');
+			expect(stepBTasks[1].description).toBe('Shared instructions');
+		});
+
+		test('advance() with agentId shorthand still creates exactly one task (backward compat)', async () => {
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-single-agent-compat-${Date.now()}`,
+				steps: [
+					{ id: STEP_A, name: 'Start', agentId: AGENT_A },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT_B },
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Backward Compat Run',
+				currentStepId: STEP_A,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+
+			// Single agentId → single task
+			expect(result.tasks).toHaveLength(1);
+			expect(result.tasks[0].workflowStepId).toBe(STEP_B);
+		});
+
+		test('advance() uses TaskTypeResolver per-agent for each agent entry', async () => {
+			const resolverCalls: Array<{ agentId: string }> = [];
+
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-resolver-${Date.now()}`,
+				steps: [
+					{ id: STEP_A, name: 'Start', agentId: AGENT_A },
+					{
+						id: STEP_B,
+						name: 'Parallel',
+						agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }],
+					},
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Resolver Run',
+				currentStepId: STEP_A,
+			});
+
+			// Inject a TaskTypeResolver that records calls and assigns custom agent IDs
+			const executor = new WorkflowExecutor(
+				workflow,
+				run,
+				taskManager,
+				runRepo,
+				WORKSPACE,
+				makeOkRunner(),
+				(_step, agentEntry) => {
+					resolverCalls.push({ agentId: agentEntry.agentId });
+					return { taskType: 'coding', customAgentId: agentEntry.agentId };
+				}
+			);
+
+			const result = await executor.advance();
+
+			// Resolver called once per agent
+			expect(resolverCalls).toHaveLength(2);
+			expect(resolverCalls.map((c) => c.agentId).sort()).toEqual([AGENT_A, AGENT_B].sort());
+
+			// Tasks have correct customAgentId set by resolver
+			const agentIds = result.tasks.map((t) => t.customAgentId).sort();
+			expect(agentIds).toEqual([AGENT_A, AGENT_B].sort());
+		});
+
+		test('three-agent step creates three tasks', async () => {
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-three-agents-${Date.now()}`,
+				steps: [
+					{ id: STEP_A, name: 'Start', agentId: AGENT_A },
+					{
+						id: STEP_B,
+						name: 'Triple Parallel',
+						agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }, { agentId: AGENT_C }],
+					},
+				],
+				transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Triple Run',
+				currentStepId: STEP_A,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+
+			expect(result.tasks).toHaveLength(3);
+			for (const task of result.tasks) {
+				expect(task.workflowStepId).toBe(STEP_B);
+				expect(task.workflowRunId).toBe(run.id);
+			}
+		});
+
+		test('advance() on multi-agent step with cyclic transition increments iterationCount once', async () => {
+			const workflow = workflowRepo.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `WF-cyclic-multi-${Date.now()}`,
+				steps: [
+					{
+						id: STEP_A,
+						name: 'Parallel A',
+						agents: [{ agentId: AGENT_A }, { agentId: AGENT_B }],
+					},
+				],
+				transitions: [
+					{
+						from: STEP_A,
+						to: STEP_A,
+						condition: { type: 'always' },
+						isCyclic: true,
+						order: 0,
+					},
+				],
+				startStepId: STEP_A,
+			});
+
+			const run = runRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cyclic Multi Run',
+				currentStepId: STEP_A,
+				maxIterations: 5,
+			});
+
+			const executor = makeExecutor(workflow, run);
+			const result = await executor.advance();
+
+			// Creates two tasks (one per agent) even on cyclic transition
+			expect(result.tasks).toHaveLength(2);
+			// Only one iteration increment per advance() call, not per task
+			expect(runRepo.getRun(run.id)?.iterationCount).toBe(1);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- `WorkflowExecutor.followTransition()` uses `resolveStepAgents()` to create one `SpaceTask` per agent in the target step. All tasks share `workflowRunId` + `workflowStepId`. Per-agent instructions override step-level instructions when set.
- `TaskTypeResolver` type updated to receive `(step, agentEntry)` so each agent gets its own `taskType`/`customAgentId` in a single DB write.
- `SpaceRuntime.startWorkflowRun()` creates multiple tasks for multi-agent start steps using `resolveStepAgents()`.
- `SpaceRuntime.resolveTaskTypeForAgent(agentId)` added; `resolveTaskTypeForStep()` delegates to it for backward compatibility.
- `areAllStepTasksTerminal(stepTasks)` helper returns `{allTerminal, anyFailed}` for a step's task list.
- **Partial failure gate** in `processRunTick()`: for multi-agent steps, the run is escalated to `needs_attention` only after ALL sibling tasks are terminal and any failed. Single-task steps preserve existing behavior (run stays `in_progress`, allowing task-level retry without resetting the run).
- `storeResolvedChannels()` calls `resolveStepChannels()` at step start and stores resolved channels in `run.config._resolvedChannels` as a placeholder for Milestone 6 session group wiring.

## Test plan

- [ ] `bun test packages/daemon/tests/unit/space/workflow-executor.test.ts` — 83 tests pass (6 new multi-agent tests)
- [ ] `bun test packages/daemon/tests/unit/space/space-runtime.test.ts` — 67 tests pass (11 new multi-agent/channel tests)
- [ ] `bun test packages/daemon/tests/unit/space/space-runtime-notifications.test.ts` — 47 tests pass (4 new partial failure notification tests)
- [ ] All existing tests continue to pass (1088 total in `tests/unit/space/`)
- [ ] TypeScript: `bun run typecheck` — no errors
- [ ] Lint: `bun run lint` — 0 warnings, 0 errors