### PR TITLE
feat: create job queue constants, wire processor into app lifecycle

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -28,6 +28,7 @@
 		"packages/daemon/src/lib/prompts/index.ts",
 		"packages/shared/src/event-bus.ts",
 		"packages/daemon/src/lib/room/task-message-queue.ts",
+		"packages/daemon/src/lib/job-queue-constants.ts",
 		"packages/daemon/dump-context.ts",
 		".claude/**"
 	],

--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -58,6 +58,16 @@ TEMPERATURE=1.0
 MAX_SESSIONS=10
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Job Queue Configuration
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Maximum number of jobs that can run concurrently across all queues.
+# Increase if you have many background tasks (GitHub polling, room ticks,
+# session title generation) that need to run in parallel.
+# Default: 5
+# NEOKAI_JOB_QUEUE_MAX_CONCURRENT=5
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Test Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -20,6 +20,8 @@ import { SpaceAgentManager } from './lib/space/managers/space-agent-manager';
 import { SpaceManager } from './lib/space/managers/space-manager';
 import type { SpaceRuntimeService } from './lib/space/runtime/space-runtime-service';
 import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
+import { JobQueueRepository } from './storage/repositories/job-queue-repository';
+import { JobQueueProcessor } from './storage/job-queue-processor';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -63,6 +65,10 @@ export interface DaemonAppContext {
 	spaceRuntimeService: SpaceRuntimeService;
 	/** Task Agent Manager — manages Task Agent session lifecycle for space tasks */
 	taskAgentManager: TaskAgentManager;
+	/** Persistent job queue repository */
+	jobQueue: JobQueueRepository;
+	/** Persistent job queue processor */
+	jobProcessor: JobQueueProcessor;
 	/**
 	 * Cleanup function for graceful shutdown.
 	 * Closes all connections, stops sessions, and closes database.
@@ -99,6 +105,18 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	await db.initialize();
 	const reactiveDb = createReactiveDatabase(db);
 	const liveQueries = new LiveQueryEngine(db.getDatabase(), reactiveDb);
+
+	// Initialize job queue
+	const jobQueue = new JobQueueRepository(db.getDatabase());
+	const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
+	const jobProcessor = new JobQueueProcessor(jobQueue, {
+		pollIntervalMs: 1000,
+		maxConcurrent,
+		staleThresholdMs: 5 * 60 * 1000,
+	});
+	jobProcessor.setChangeNotifier((table) => {
+		reactiveDb.notifyChange(table);
+	});
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
@@ -228,6 +246,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		gitHubService: gitHubService ?? undefined,
 		spaceManager,
 		spaceAgentManager,
+		jobQueue,
+		jobProcessor,
 	});
 
 	// Create WebSocket handlers
@@ -342,6 +362,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		logInfo('[Daemon] GitHub service started');
 	}
 
+	// Start job queue processor last (after all handler registrations)
+	jobProcessor.start();
+	logInfo('[Daemon] Job queue processor started');
+
 	// Cleanup function for graceful shutdown
 	let isCleanedUp = false;
 	const cleanup = async () => {
@@ -390,6 +414,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 					clearInterval(checkInterval);
 				}
 			}
+
+			// Stop job queue processor before MessageHub cleanup
+			await jobProcessor.stop();
+			logInfo('[Daemon] Job queue processor stopped');
 
 			// Cleanup MessageHub (rejects remaining calls)
 			messageHub.cleanup();
@@ -451,6 +479,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		spaceManager,
 		spaceRuntimeService,
 		taskAgentManager,
+		jobQueue,
+		jobProcessor,
 		cleanup,
 	};
 }

--- a/packages/daemon/src/lib/job-queue-constants.ts
+++ b/packages/daemon/src/lib/job-queue-constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Job queue name constants.
+ * Use these constants when enqueueing or registering handlers to avoid typos.
+ */
+
+export const SESSION_TITLE_GENERATION = 'session.title_generation';
+export const GITHUB_POLL = 'github.poll';
+export const ROOM_TICK = 'room.tick';
+export const JOB_QUEUE_CLEANUP = 'job_queue.cleanup';

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -80,9 +80,16 @@ export interface RPCHandlerDependencies {
 	/** Space manager instance — shared with DaemonAppContext (single source of truth) */
 	spaceManager: SpaceManager;
 	spaceAgentManager: SpaceAgentManager;
-	/** Persistent job queue repository */
+	/**
+	 * Persistent job queue repository.
+	 * TODO: consumed by Milestones 2–5 handlers (session title generation,
+	 * GitHub polling, room tick, cleanup jobs).
+	 */
 	jobQueue: JobQueueRepository;
-	/** Persistent job queue processor */
+	/**
+	 * Persistent job queue processor.
+	 * TODO: consumed by Milestones 2–5 handlers for registering queue handlers.
+	 */
 	jobProcessor: JobQueueProcessor;
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -58,6 +58,8 @@ import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -78,6 +80,10 @@ export interface RPCHandlerDependencies {
 	/** Space manager instance — shared with DaemonAppContext (single source of truth) */
 	spaceManager: SpaceManager;
 	spaceAgentManager: SpaceAgentManager;
+	/** Persistent job queue repository */
+	jobQueue: JobQueueRepository;
+	/** Persistent job queue processor */
+	jobProcessor: JobQueueProcessor;
 }
 
 const log = new Logger('rpc-handlers');

--- a/packages/daemon/src/storage/job-queue-processor.ts
+++ b/packages/daemon/src/storage/job-queue-processor.ts
@@ -35,6 +35,10 @@ export class JobQueueProcessor {
 
 	start(): void {
 		this.running = true;
+		// Eagerly reclaim stale jobs from a previous crash before the first poll tick,
+		// so crash-recovery is instant rather than delayed by up to STALE_CHECK_INTERVAL.
+		this.repo.reclaimStale(Date.now() - this.staleThresholdMs);
+		this.lastStaleCheck = Date.now();
 		this.pollTimer = setInterval(() => {
 			this.tick();
 		}, this.pollIntervalMs);

--- a/packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts
@@ -3,7 +3,7 @@
  *
  * Verifies:
  * - DaemonAppContext includes jobProcessor and jobQueue
- * - Cleanup stops the processor before messageHub
+ * - Cleanup stops the processor before messageHub (ordering guaranteed by stop() resolving)
  * - maxConcurrent is configurable via NEOKAI_JOB_QUEUE_MAX_CONCURRENT env var
  */
 
@@ -36,8 +36,7 @@ const DB_SCHEMA = `
 
 describe('DaemonAppContext — jobQueue and jobProcessor fields', () => {
 	it('DaemonAppContext interface includes jobQueue and jobProcessor', () => {
-		// Verify the interface has both fields by constructing a shape check.
-		// This is a compile-time guard — if the interface lacks the fields, tsc fails.
+		// Compile-time guard: if the interface lacks these fields, tsc fails.
 		const requiredFields: Array<keyof DaemonAppContext> = ['jobQueue', 'jobProcessor'];
 		expect(requiredFields).toContain('jobQueue');
 		expect(requiredFields).toContain('jobProcessor');
@@ -58,73 +57,93 @@ describe('JobQueueProcessor lifecycle', () => {
 		db.close();
 	});
 
-	it('processor stops before messageHub — stop() resolves and marks as stopped', async () => {
+	it('stop() resolves only after all in-flight jobs finish (cleanup ordering guarantee)', async () => {
+		// Verifies that `await jobProcessor.stop()` always settles before code that follows it —
+		// this is what guarantees stop() happens before messageHub.cleanup() in app.ts.
+		let jobFinished = false;
+		let resolveJob!: () => void;
+
 		const processor = new JobQueueProcessor(repo, { pollIntervalMs: 5000 });
-		const stopOrder: string[] = [];
+		processor.register('lifecycle-queue', async () => {
+			await new Promise<void>((resolve) => {
+				resolveJob = resolve;
+			});
+			jobFinished = true;
+		});
 
-		processor.start();
+		repo.enqueue({ queue: 'lifecycle-queue', payload: {} });
+		await processor.tick();
+		// Job is now in-flight
 
-		// Simulate the cleanup ordering: stop processor first, then messageHub
-		await processor.stop();
-		stopOrder.push('processor');
-		stopOrder.push('messageHub');
+		const stopPromise = processor.stop();
+		expect(jobFinished).toBe(false); // still running
 
-		expect(stopOrder[0]).toBe('processor');
-		expect(stopOrder[1]).toBe('messageHub');
+		resolveJob();
+		await stopPromise;
+		expect(jobFinished).toBe(true); // stop() settled only after job completed
 	});
 
-	it('processor stop() resolves even with no in-flight jobs', async () => {
+	it('stop() resolves immediately when no in-flight jobs', async () => {
 		const processor = new JobQueueProcessor(repo, { pollIntervalMs: 5000 });
 		processor.start();
-
-		// Should resolve immediately when no jobs are in flight
 		await expect(processor.stop()).resolves.toBeUndefined();
 	});
 
-	it('maxConcurrent defaults to 5 when env var is unset', () => {
+	it('maxConcurrent defaults to 5 and is enforced by the processor', async () => {
 		const savedEnv = process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
 		delete process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
 
 		const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
-		expect(maxConcurrent).toBe(5);
+		const resolvers: Array<() => void> = [];
+
+		const processor = new JobQueueProcessor(repo, { maxConcurrent, pollIntervalMs: 5000 });
+		processor.register('default-limit-queue', async () => {
+			await new Promise<void>((resolve) => resolvers.push(resolve));
+		});
+
+		// Enqueue more jobs than the default limit
+		for (let i = 0; i < 8; i++) {
+			repo.enqueue({ queue: 'default-limit-queue', payload: { i } });
+		}
+
+		const claimed = await processor.tick();
+		expect(claimed).toBe(5); // processor enforces the computed maxConcurrent
+
+		for (const r of resolvers) r();
+		await processor.stop();
 
 		if (savedEnv !== undefined) {
 			process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = savedEnv;
 		}
 	});
 
-	it('maxConcurrent reads from NEOKAI_JOB_QUEUE_MAX_CONCURRENT env var', () => {
+	it('maxConcurrent reads from NEOKAI_JOB_QUEUE_MAX_CONCURRENT and is enforced by the processor', async () => {
 		const savedEnv = process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
-		process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = '10';
+		process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = '3';
 
 		const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
-		expect(maxConcurrent).toBe(10);
+		const resolvers: Array<() => void> = [];
+
+		const processor = new JobQueueProcessor(repo, { maxConcurrent, pollIntervalMs: 5000 });
+		processor.register('custom-limit-queue', async () => {
+			await new Promise<void>((resolve) => resolvers.push(resolve));
+		});
+
+		for (let i = 0; i < 5; i++) {
+			repo.enqueue({ queue: 'custom-limit-queue', payload: { i } });
+		}
+
+		const claimed = await processor.tick();
+		expect(claimed).toBe(3); // processor enforces the env-configured limit
+
+		for (const r of resolvers) r();
+		await processor.stop();
 
 		if (savedEnv !== undefined) {
 			process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = savedEnv;
 		} else {
 			delete process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
 		}
-	});
-
-	it('processor with custom maxConcurrent respects the concurrency limit', async () => {
-		const maxConcurrent = 3;
-		const processor = new JobQueueProcessor(repo, { maxConcurrent, pollIntervalMs: 5000 });
-		const resolvers: Array<() => void> = [];
-
-		processor.register('test', async () => {
-			await new Promise<void>((resolve) => resolvers.push(resolve));
-		});
-
-		for (let i = 0; i < 5; i++) {
-			repo.enqueue({ queue: 'test', payload: { i } });
-		}
-
-		const claimed = await processor.tick();
-		expect(claimed).toBe(maxConcurrent);
-
-		for (const r of resolvers) r();
-		await processor.stop();
 	});
 
 	it('JobQueueRepository and JobQueueProcessor can be instantiated together', () => {

--- a/packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/app/job-queue-lifecycle.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Job Queue Lifecycle Tests
+ *
+ * Verifies:
+ * - DaemonAppContext includes jobProcessor and jobQueue
+ * - Cleanup stops the processor before messageHub
+ * - maxConcurrent is configurable via NEOKAI_JOB_QUEUE_MAX_CONCURRENT env var
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { JobQueueProcessor } from '../../../src/storage/job-queue-processor';
+import type { DaemonAppContext } from '../../../src/app';
+
+const DB_SCHEMA = `
+	CREATE TABLE IF NOT EXISTS job_queue (
+		id TEXT PRIMARY KEY,
+		queue TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'pending'
+			CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+		payload TEXT NOT NULL DEFAULT '{}',
+		result TEXT,
+		error TEXT,
+		priority INTEGER NOT NULL DEFAULT 0,
+		max_retries INTEGER NOT NULL DEFAULT 3,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		run_at INTEGER NOT NULL,
+		created_at INTEGER NOT NULL,
+		started_at INTEGER,
+		completed_at INTEGER
+	);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status);
+`;
+
+describe('DaemonAppContext — jobQueue and jobProcessor fields', () => {
+	it('DaemonAppContext interface includes jobQueue and jobProcessor', () => {
+		// Verify the interface has both fields by constructing a shape check.
+		// This is a compile-time guard — if the interface lacks the fields, tsc fails.
+		const requiredFields: Array<keyof DaemonAppContext> = ['jobQueue', 'jobProcessor'];
+		expect(requiredFields).toContain('jobQueue');
+		expect(requiredFields).toContain('jobProcessor');
+	});
+});
+
+describe('JobQueueProcessor lifecycle', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(DB_SCHEMA);
+		repo = new JobQueueRepository(db as any);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('processor stops before messageHub — stop() resolves and marks as stopped', async () => {
+		const processor = new JobQueueProcessor(repo, { pollIntervalMs: 5000 });
+		const stopOrder: string[] = [];
+
+		processor.start();
+
+		// Simulate the cleanup ordering: stop processor first, then messageHub
+		await processor.stop();
+		stopOrder.push('processor');
+		stopOrder.push('messageHub');
+
+		expect(stopOrder[0]).toBe('processor');
+		expect(stopOrder[1]).toBe('messageHub');
+	});
+
+	it('processor stop() resolves even with no in-flight jobs', async () => {
+		const processor = new JobQueueProcessor(repo, { pollIntervalMs: 5000 });
+		processor.start();
+
+		// Should resolve immediately when no jobs are in flight
+		await expect(processor.stop()).resolves.toBeUndefined();
+	});
+
+	it('maxConcurrent defaults to 5 when env var is unset', () => {
+		const savedEnv = process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
+		delete process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
+
+		const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
+		expect(maxConcurrent).toBe(5);
+
+		if (savedEnv !== undefined) {
+			process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = savedEnv;
+		}
+	});
+
+	it('maxConcurrent reads from NEOKAI_JOB_QUEUE_MAX_CONCURRENT env var', () => {
+		const savedEnv = process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
+		process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = '10';
+
+		const maxConcurrent = Number(process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT) || 5;
+		expect(maxConcurrent).toBe(10);
+
+		if (savedEnv !== undefined) {
+			process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT = savedEnv;
+		} else {
+			delete process.env.NEOKAI_JOB_QUEUE_MAX_CONCURRENT;
+		}
+	});
+
+	it('processor with custom maxConcurrent respects the concurrency limit', async () => {
+		const maxConcurrent = 3;
+		const processor = new JobQueueProcessor(repo, { maxConcurrent, pollIntervalMs: 5000 });
+		const resolvers: Array<() => void> = [];
+
+		processor.register('test', async () => {
+			await new Promise<void>((resolve) => resolvers.push(resolve));
+		});
+
+		for (let i = 0; i < 5; i++) {
+			repo.enqueue({ queue: 'test', payload: { i } });
+		}
+
+		const claimed = await processor.tick();
+		expect(claimed).toBe(maxConcurrent);
+
+		for (const r of resolvers) r();
+		await processor.stop();
+	});
+
+	it('JobQueueRepository and JobQueueProcessor can be instantiated together', () => {
+		const processor = new JobQueueProcessor(repo, {
+			pollIntervalMs: 1000,
+			maxConcurrent: 5,
+			staleThresholdMs: 5 * 60 * 1000,
+		});
+		expect(processor).toBeInstanceOf(JobQueueProcessor);
+		expect(repo).toBeInstanceOf(JobQueueRepository);
+	});
+});

--- a/packages/daemon/tests/unit/storage/job-queue-processor.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-processor.test.ts
@@ -313,6 +313,60 @@ describe('JobQueueProcessor', () => {
 		});
 	});
 
+	describe('eager stale reclamation on start()', () => {
+		it('reclaims stale processing jobs immediately when start() is called', async () => {
+			const eagerProcessor = new JobQueueProcessor(repo, {
+				staleThresholdMs: 1000,
+				pollIntervalMs: 5000, // long interval so the interval tick doesn't interfere
+			});
+			eagerProcessor.register('eager-queue', async () => {});
+
+			// Enqueue and dequeue manually to create a "processing" job
+			const job = repo.enqueue({ queue: 'eager-queue', payload: {} });
+			repo.dequeue('eager-queue', 1);
+
+			// Confirm it's processing
+			expect(repo.getJob(job.id)?.status).toBe('processing');
+
+			// Make it stale (started 10s ago, threshold is 1s)
+			db.prepare(`UPDATE job_queue SET started_at = ? WHERE id = ?`).run(
+				Date.now() - 10_000,
+				job.id
+			);
+
+			// start() should eagerly reclaim before the first tick
+			eagerProcessor.start();
+			// Give the immediate tick time to process the reclaimed job
+			await flush();
+			await eagerProcessor.stop();
+
+			const after = repo.getJob(job.id);
+			expect(after?.status).toBe('completed');
+		});
+
+		it('does not wait for STALE_CHECK_INTERVAL before first reclamation', async () => {
+			// Create a spy on reclaimStale to verify it's called during start()
+			let reclaimCallCount = 0;
+			const originalReclaim = repo.reclaimStale.bind(repo);
+			repo.reclaimStale = (staleBefore: number) => {
+				reclaimCallCount++;
+				return originalReclaim(staleBefore);
+			};
+
+			const eagerProcessor = new JobQueueProcessor(repo, {
+				staleThresholdMs: 1000,
+				pollIntervalMs: 5000,
+			});
+			eagerProcessor.register('spy-queue', async () => {});
+
+			eagerProcessor.start();
+			await eagerProcessor.stop();
+
+			// reclaimStale should have been called during start() (before any tick interval)
+			expect(reclaimCallCount).toBeGreaterThanOrEqual(1);
+		});
+	});
+
 	describe('start / stop', () => {
 		it('start() begins polling and processes enqueued jobs', async () => {
 			const shortProcessor = new JobQueueProcessor(repo, { pollIntervalMs: 50 });


### PR DESCRIPTION
- Add job-queue-constants.ts with SESSION_TITLE_GENERATION, GITHUB_POLL,
  ROOM_TICK, and JOB_QUEUE_CLEANUP queue name constants
- Eager reclaimStale() in JobQueueProcessor.start() before first tick for
  instant crash recovery (no 60s STALE_CHECK_INTERVAL delay)
- Instantiate JobQueueRepository and JobQueueProcessor in app.ts with
  maxConcurrent defaulting to 5 (NEOKAI_JOB_QUEUE_MAX_CONCURRENT env var)
- Wire change notifier: reactiveDb.notifyChange on job completion
- jobProcessor.start() placed last (after gitHubService.start())
- jobProcessor.stop() in cleanup() before messageHub.cleanup()
- Expose jobQueue and jobProcessor on DaemonAppContext and RPCHandlerDependencies
- Add eager reclamation and lifecycle unit tests
