### PR TITLE
feat: thread reactiveDb through dependency interfaces

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -248,6 +248,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		spaceAgentManager,
 		jobQueue,
 		jobProcessor,
+		reactiveDb,
 	});
 
 	// Create WebSocket handlers

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
@@ -45,6 +46,8 @@ export interface RoomRuntimeServiceConfig {
 	defaultModel: string;
 	/** Get current global settings including fallbackModels for auto-fallback on rate limits */
 	getGlobalSettings: () => GlobalSettings;
+	/** Reactive database wrapper for change event emission */
+	reactiveDb: ReactiveDatabase;
 }
 
 export class RoomRuntimeService {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -12,6 +12,7 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import type { Config } from '../../config';
 import type { Database } from '../../storage/database';
+import type { ReactiveDatabase } from '../../storage/reactive-database';
 
 import { setupSessionHandlers } from './session-handlers';
 import { setupMessageHandlers } from './message-handlers';
@@ -91,6 +92,8 @@ export interface RPCHandlerDependencies {
 	 * TODO: consumed by Milestones 2–5 handlers for registering queue handlers.
 	 */
 	jobProcessor: JobQueueProcessor;
+	/** Reactive database wrapper for change event emission */
+	reactiveDb: ReactiveDatabase;
 }
 
 const log = new Logger('rpc-handlers');
@@ -164,6 +167,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultWorkspacePath: deps.config.workspaceRoot,
 		defaultModel: deps.config.defaultModel,
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
+		reactiveDb: deps.reactiveDb,
 	});
 	roomRuntimeService.start().catch((error) => {
 		log.error('Failed to start RoomRuntimeService:', error);

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -41,6 +41,8 @@ describe('RoomRuntimeService', () => {
 			sessionManager: {} as never,
 			defaultWorkspacePath: '/tmp',
 			defaultModel: 'global-default-model',
+			getGlobalSettings: () => ({}) as never,
+			reactiveDb: {} as never,
 		};
 
 		service = new RoomRuntimeService(config);


### PR DESCRIPTION
Add ReactiveDatabase to RPCHandlerDependencies and RoomRuntimeServiceConfig
so downstream classes can receive it for future LiveQuery adoption.

- Add reactiveDb field to RPCHandlerDependencies interface
- Add reactiveDb field to RoomRuntimeServiceConfig interface
- Pass reactiveDb from app.ts → setupRPCHandlers → RoomRuntimeService
