### PR TITLE
ci: skip Codex bridge tests + fix multi-agent import test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,8 @@ jobs:
           - git
           - lifecycle
           - mcp
-          - providers-anthropic-to-codex-bridge
+          # Codex bridge tests disabled — requires OPENAI_API_KEY (real API, not mocked)
+          # - providers-anthropic-to-codex-bridge
           - providers-anthropic-copilot
           - rewind
           # Room tests temporarily disabled during refactoring
@@ -189,8 +190,8 @@ jobs:
           - module: mcp
             test_path: tests/online/mcp
             mock_sdk: true
-          - module: providers-anthropic-to-codex-bridge
-            test_path: tests/online/providers/anthropic-to-codex-bridge-provider.test.ts
+          # - module: providers-anthropic-to-codex-bridge
+          #   test_path: tests/online/providers/anthropic-to-codex-bridge-provider.test.ts
           - module: providers-anthropic-copilot
             test_path: tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
             timeout: 15
@@ -280,10 +281,6 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Install Codex CLI (providers-anthropic-to-codex-bridge shard)
-        if: matrix.module == 'providers-anthropic-to-codex-bridge'
-        run: npm install -g @openai/codex
-
       - name: Run daemon online tests (${{ matrix.module }})
         working-directory: packages/daemon
         run: bun test ${{ matrix.test_path }} --coverage --coverage-reporter=lcov --coverage-dir=coverage-online-${{ matrix.module }}
@@ -298,7 +295,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ matrix.mock_sdk == true && 'sk-devproxy-test-key' || ((startsWith(matrix.module, 'features') || startsWith(matrix.module, 'room')) && secrets.ANTHROPIC_API_KEY || '') }}
           ANTHROPIC_AUTH_TOKEN: ""
           CLAUDE_CODE_OAUTH_TOKEN: ${{ matrix.mock_sdk != true && (startsWith(matrix.module, 'features') || startsWith(matrix.module, 'room')) && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
-          OPENAI_API_KEY: ${{ matrix.module == 'providers-anthropic-to-codex-bridge' && secrets.OPENAI_API_KEY || '' }}
+          OPENAI_API_KEY: ""
           # Requires a PAT with the `copilot_requests` scope stored as COPILOT_GITHUB_TOKEN.
           # secrets.GITHUB_TOKEN is a repo-scoped installation token and cannot authenticate Copilot API calls.
           # If the secret is absent the env var is empty and the test FAILS (hard-fail, not skip — by design).

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -1311,7 +1311,7 @@ describe('multi-agent step import', () => {
 			getAgentById(spaceId: string, id: string) {
 				const agent = agentRepo.getById(id);
 				if (!agent || agent.spaceId !== spaceId) return null;
-				return { id: agent.id, name: agent.name };
+				return { id: agent.id, name: agent.name, role: agent.role };
 			},
 		};
 		workflowManager = new SpaceWorkflowManager(workflowRepo, agentLookup);

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -5,8 +5,7 @@
 # features) into shards with explicit file lists. This script catches new test
 # files that were added but not included in any shard.
 #
-# CI SECRET REQUIREMENTS for providers-anthropic-to-codex-bridge shard:
-#   OPENAI_API_KEY      — required for this shard.
+# NOTE: providers-anthropic-to-codex-bridge shard is disabled (requires OPENAI_API_KEY).
 #
 # Usage: bash scripts/validate-online-test-matrix.sh
 
@@ -64,7 +63,7 @@ FEATURES_FILES=(
 
 PROVIDERS_FILES=(
   anthropic-to-copilot-bridge-provider.test.ts
-  anthropic-to-codex-bridge-provider.test.ts
+  anthropic-to-codex-bridge-provider.test.ts  # CI shard disabled — kept here so validator doesn't flag it
 )
 
 check_split_module() {


### PR DESCRIPTION
## Summary
- Disables the `providers-anthropic-to-codex-bridge` CI shard which hits the real OpenAI/Codex API and requires `OPENAI_API_KEY`
- Removes the `codex` CLI install step (only needed by that shard)
- Updates validation script to keep the file tracked but not require a CI shard
- Fixes multi-agent import test: `agentLookup` mock was missing `role` field, causing channel validation to fail with "known roles: none"

## Test plan
- [x] `bash scripts/validate-online-test-matrix.sh` passes
- [x] `bun test tests/unit/rpc-handlers/space-export-import-handlers.test.ts` — 69 tests pass
- [ ] CI runs without the codex bridge shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)