### PR TITLE
feat: wire SpaceSessionGroupRepository into TaskAgentManager

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -61,6 +61,7 @@ import { SpaceWorkflowRepository } from '../../storage/repositories/space-workfl
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
+import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -270,6 +271,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 	});
 
+	// SpaceSessionGroupRepository — persists session groups for Task Agents and sub-sessions.
+	// Constructed once here and injected into TaskAgentManager.
+	const spaceSessionGroupRepo = new SpaceSessionGroupRepository(deps.db.getDatabase());
+
 	// Task Agent Manager — manages Task Agent session lifecycle and message injection.
 	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
 	// spaceRuntimeService.createOrGetRuntime(spaceId).
@@ -286,6 +291,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		messageHub: deps.messageHub,
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
+		sessionGroupRepo: spaceSessionGroupRepo,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -58,6 +58,7 @@ import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceRuntimeService } from './space-runtime-service';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
 import type { SubSessionFactory, SubSessionState } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
@@ -95,6 +96,8 @@ export interface TaskAgentManagerConfig {
 	getApiKey: () => Promise<string | null>;
 	/** Default model ID for sessions that don't specify one */
 	defaultModel: string;
+	/** Session group repository — used to persist SpaceSessionGroup records per task */
+	sessionGroupRepo: SpaceSessionGroupRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -127,6 +130,12 @@ export class TaskAgentManager {
 	 * spawnTaskAgent() calls from creating duplicate Task Agent sessions.
 	 */
 	private spawningTasks = new Set<string>();
+
+	/**
+	 * Maps taskId → groupId for SpaceSessionGroups created when spawning Task Agents.
+	 * Allows fast lookup when adding sub-session members to an existing group.
+	 */
+	private taskGroupIds = new Map<string, string>();
 
 	/**
 	 * Completion callbacks registered via onComplete().
@@ -284,6 +293,24 @@ export class TaskAgentManager {
 			// --- Store in map before streaming start to allow getTaskAgent() calls
 			this.taskAgentSessions.set(taskId, agentSession);
 
+			// --- Create a SpaceSessionGroup for this task and add the Task Agent as member
+			try {
+				const group = this.config.sessionGroupRepo.createGroup({
+					spaceId,
+					name: `task:${taskId}`,
+					taskId,
+				});
+				this.config.sessionGroupRepo.addMember(group.id, sessionId, {
+					role: 'task-agent',
+					status: 'active',
+				});
+				this.taskGroupIds.set(taskId, group.id);
+				log.info(`TaskAgentManager: created session group ${group.id} for task ${taskId}`);
+			} catch (err) {
+				// Group creation failure is non-fatal — task agent still runs; log and continue
+				log.warn(`TaskAgentManager: failed to create session group for task ${taskId}:`, err);
+			}
+
 			// --- Register in SessionManager cache so getSessionAsync() returns the live
 			// instance with MCP tools attached rather than creating a duplicate from DB.
 			// Without this, RPC handlers (message.send, message.sdkMessages, etc.) would
@@ -423,6 +450,11 @@ export class TaskAgentManager {
 		return this.taskAgentSessions.get(taskId);
 	}
 
+	/** Returns the session group ID for a task, or undefined if no group was created. */
+	getTaskGroupId(taskId: string): string | undefined {
+		return this.taskGroupIds.get(taskId);
+	}
+
 	/** Returns a sub-session by its session ID, or undefined if not found. */
 	getSubSession(subSessionId: string): AgentSession | undefined {
 		for (const [, stepMap] of this.subSessions) {
@@ -550,6 +582,9 @@ export class TaskAgentManager {
 				this.sessionListeners.delete(sessionId);
 			}
 		}
+
+		// 5. Remove group ID lookup
+		this.taskGroupIds.delete(taskId);
 
 		log.info(`TaskAgentManager: cleaned up all sessions for task ${taskId}`);
 	}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -18,6 +18,7 @@
  * - `taskAgentSessions`  — taskId → Task Agent AgentSession
  * - `subSessions`        — taskId → (stepId → AgentSession)
  * - `spawningTasks`      — set of taskIds currently being spawned (concurrency guard)
+ * - `taskGroupIds`       — taskId → SpaceSessionGroup.id (fast lookup for sub-session wiring)
  *
  * The maps are fast-lookup caches; session data is the source of truth in the DB.
  * On daemon restart, maps must be rebuilt via rehydration (Task 5.3).
@@ -293,19 +294,32 @@ export class TaskAgentManager {
 			// --- Store in map before streaming start to allow getTaskAgent() calls
 			this.taskAgentSessions.set(taskId, agentSession);
 
-			// --- Create a SpaceSessionGroup for this task and add the Task Agent as member
+			// --- Create a SpaceSessionGroup for this task and add the Task Agent as member.
+			// Group creation is non-fatal: if either step fails, the task agent still runs.
+			// When createGroup succeeds but addMember throws, delete the orphaned group row
+			// before falling through to the warn log, preventing stale memberless records.
 			try {
 				const group = this.config.sessionGroupRepo.createGroup({
 					spaceId,
 					name: `task:${taskId}`,
 					taskId,
 				});
-				this.config.sessionGroupRepo.addMember(group.id, sessionId, {
-					role: 'task-agent',
-					status: 'active',
-				});
-				this.taskGroupIds.set(taskId, group.id);
-				log.info(`TaskAgentManager: created session group ${group.id} for task ${taskId}`);
+				try {
+					this.config.sessionGroupRepo.addMember(group.id, sessionId, {
+						role: 'task-agent',
+						status: 'active',
+					});
+					this.taskGroupIds.set(taskId, group.id);
+					log.info(`TaskAgentManager: created session group ${group.id} for task ${taskId}`);
+				} catch (addErr) {
+					// addMember failed — remove the orphaned group row before propagating
+					try {
+						this.config.sessionGroupRepo.deleteGroup(group.id);
+					} catch {
+						// best-effort cleanup; ignore secondary failure
+					}
+					throw addErr;
+				}
 			} catch (err) {
 				// Group creation failure is non-fatal — task agent still runs; log and continue
 				log.warn(`TaskAgentManager: failed to create session group for task ${taskId}:`, err);
@@ -583,7 +597,15 @@ export class TaskAgentManager {
 			}
 		}
 
-		// 5. Remove group ID lookup
+		// 5. Mark the session group as completed in the DB, then remove from in-memory map
+		const groupId = this.taskGroupIds.get(taskId);
+		if (groupId) {
+			try {
+				this.config.sessionGroupRepo.updateGroup(groupId, { status: 'completed' });
+			} catch (err) {
+				log.warn(`TaskAgentManager: failed to mark session group ${groupId} as completed:`, err);
+			}
+		}
 		this.taskGroupIds.delete(taskId);
 
 		log.info(`TaskAgentManager: cleaned up all sessions for task ${taskId}`);
@@ -927,6 +949,12 @@ export class TaskAgentManager {
 				}
 				this.subSessions.get(taskId)!.set(subSessionId, subSession);
 			}
+		}
+
+		// --- Restore taskGroupIds from DB so getTaskGroupId() works after restart
+		const existingGroups = this.config.sessionGroupRepo.getGroupsByTask(spaceId, taskId);
+		if (existingGroups.length > 0) {
+			this.taskGroupIds.set(taskId, existingGroups[0].id);
 		}
 
 		log.info(

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -454,13 +454,66 @@ describe('TaskAgentManager', () => {
 			expect(group!.taskId).toBe(task.id);
 		});
 
-		test('cleanup removes taskGroupId from in-memory map', async () => {
+		test('cleanup removes taskGroupId from in-memory map and marks group completed', async () => {
 			const task = await makeTask(ctx.taskManager);
 			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 
-			expect(ctx.manager.getTaskGroupId(task.id)).toBeDefined();
+			const groupId = ctx.manager.getTaskGroupId(task.id)!;
+			expect(groupId).toBeDefined();
+
 			await ctx.manager.cleanup(task.id);
+
+			// In-memory map cleared
 			expect(ctx.manager.getTaskGroupId(task.id)).toBeUndefined();
+
+			// DB group marked completed
+			const group = ctx.sessionGroupRepo.getGroup(groupId);
+			expect(group?.status).toBe('completed');
+		});
+
+		test('spawn still succeeds when createGroup throws (non-fatal)', async () => {
+			// Patch createGroup to throw
+			const origCreate = ctx.sessionGroupRepo.createGroup.bind(ctx.sessionGroupRepo);
+			let callCount = 0;
+			ctx.sessionGroupRepo.createGroup = () => {
+				callCount++;
+				throw new Error('DB error');
+			};
+
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			// Task agent session created normally
+			expect(sessionId).toBe(`space:${ctx.spaceId}:task:${task.id}`);
+			expect(ctx.createdSessions.has(sessionId)).toBe(true);
+			// Group not recorded since createGroup threw
+			expect(ctx.manager.getTaskGroupId(task.id)).toBeUndefined();
+			// createGroup was called
+			expect(callCount).toBe(1);
+
+			// Restore
+			ctx.sessionGroupRepo.createGroup = origCreate;
+		});
+
+		test('no orphaned group when addMember throws after createGroup succeeds', async () => {
+			// Patch addMember to throw
+			const origAdd = ctx.sessionGroupRepo.addMember.bind(ctx.sessionGroupRepo);
+			ctx.sessionGroupRepo.addMember = () => {
+				throw new Error('addMember error');
+			};
+
+			const task = await makeTask(ctx.taskManager);
+			// Spawn still succeeds (non-fatal)
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+			expect(sessionId).toBeDefined();
+
+			// No group persisted (orphan was deleted)
+			const groups = ctx.sessionGroupRepo.getGroupsByTask(ctx.spaceId, task.id);
+			expect(groups).toHaveLength(0);
+			expect(ctx.manager.getTaskGroupId(task.id)).toBeUndefined();
+
+			// Restore
+			ctx.sessionGroupRepo.addMember = origAdd;
 		});
 	});
 
@@ -1688,6 +1741,22 @@ describe('TaskAgentManager', () => {
 			}
 
 			restoreSpy.mockRestore();
+		});
+
+		test('taskGroupIds is restored from DB after rehydration', async () => {
+			const { task } = await seedInProgressTask(ctx);
+
+			// Seed a session group in the DB as if it was created during the original spawn
+			const group = ctx.sessionGroupRepo.createGroup({
+				spaceId: ctx.spaceId,
+				name: `task:${task.id}`,
+				taskId: task.id,
+			});
+
+			await ctx.manager.rehydrate();
+
+			// getTaskGroupId should return the persisted group ID
+			expect(ctx.manager.getTaskGroupId(task.id)).toBe(group.id);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -26,6 +26,7 @@ import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
 import { SpaceAgentManager } from '../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
@@ -228,6 +229,7 @@ interface TestCtx {
 		updateSession: () => void;
 		getDatabase: () => BunDatabase;
 	};
+	sessionGroupRepo: SpaceSessionGroupRepository;
 	manager: TaskAgentManager;
 	createdSessions: Map<string, MockAgentSession>;
 	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
@@ -245,6 +247,7 @@ function makeCtx(): TestCtx {
 
 	const agentRepo = new SpaceAgentRepository(bunDb);
 	const agentManager = new SpaceAgentManager(agentRepo);
+	const sessionGroupRepo = new SpaceSessionGroupRepository(bunDb);
 	const workflowRepo = new SpaceWorkflowRepository(bunDb);
 	const workflowManager = new SpaceWorkflowManager(workflowRepo);
 	const workflowRunRepo = new SpaceWorkflowRunRepository(bunDb);
@@ -329,6 +332,7 @@ function makeCtx(): TestCtx {
 		messageHub: {} as unknown as import('@neokai/shared').MessageHub,
 		getApiKey: async () => 'test-key',
 		defaultModel: 'claude-sonnet-4-5-20250929',
+		sessionGroupRepo,
 	});
 
 	return {
@@ -347,6 +351,7 @@ function makeCtx(): TestCtx {
 		daemonHub,
 		sessionManagerDeleteCalls,
 		mockDb,
+		sessionGroupRepo,
 		manager,
 		createdSessions,
 		fromInitSpy,
@@ -417,6 +422,45 @@ describe('TaskAgentManager', () => {
 			const session = ctx.createdSessions.get(sessionId)!;
 			// Session should have had a message enqueued
 			expect(session._enqueuedMessages.length).toBeGreaterThan(0);
+		});
+
+		test('creates a SpaceSessionGroup in DB with taskId set', async () => {
+			const task = await makeTask(ctx.taskManager);
+			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groups = ctx.sessionGroupRepo.getGroupsByTask(ctx.spaceId, task.id);
+			expect(groups).toHaveLength(1);
+			expect(groups[0].name).toBe(`task:${task.id}`);
+			expect(groups[0].taskId).toBe(task.id);
+			expect(groups[0].spaceId).toBe(ctx.spaceId);
+			expect(groups[0].status).toBe('active');
+
+			// The Task Agent session should be a member with role 'task-agent'
+			expect(groups[0].members).toHaveLength(1);
+			expect(groups[0].members[0].sessionId).toBe(sessionId);
+			expect(groups[0].members[0].role).toBe('task-agent');
+			expect(groups[0].members[0].status).toBe('active');
+		});
+
+		test('getTaskGroupId returns the group ID after spawn', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			expect(groupId).toBeDefined();
+
+			const group = ctx.sessionGroupRepo.getGroup(groupId!);
+			expect(group).not.toBeNull();
+			expect(group!.taskId).toBe(task.id);
+		});
+
+		test('cleanup removes taskGroupId from in-memory map', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			expect(ctx.manager.getTaskGroupId(task.id)).toBeDefined();
+			await ctx.manager.cleanup(task.id);
+			expect(ctx.manager.getTaskGroupId(task.id)).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
- Add sessionGroupRepo field to TaskAgentManagerConfig
- In spawnTaskAgent(), create a SpaceSessionGroup named task:<taskId>
  with taskId set and add the Task Agent session as a member with
  role 'task-agent' and status 'active'
- Store groupId in taskGroupIds map (taskId → groupId) for fast lookup
- Expose getTaskGroupId() for future sub-session wiring
- Clean up taskGroupIds entry in cleanup()
- Construct SpaceSessionGroupRepository once in rpc-handlers/index.ts
  and inject it into TaskAgentManager
- Add 4 new unit tests covering group creation, getTaskGroupId, and
  cleanup behavior (67 → 102 tests passing across 2 files)
