### PR TITLE
feat: show associated goal on room task list and task view

### DIFF
--- a/packages/e2e/tests/features/task-goal-indicator.e2e.ts
+++ b/packages/e2e/tests/features/task-goal-indicator.e2e.ts
@@ -1,0 +1,218 @@
+/**
+ * Task Goal Indicator E2E Tests
+ *
+ * Tests that tasks linked to a goal show the goal name badge:
+ * - Goal badge appears in task list (RoomDashboard) when task is linked to a goal
+ * - Goal badge appears in TaskView header when task is linked to a goal
+ * - Clicking goal badge in task list switches to Missions tab
+ * - Clicking goal badge in TaskView navigates back to room and switches to Missions tab
+ * - Tasks without a goal do NOT show the badge
+ *
+ * Setup: RPC to create room, task, and goal and link them together (infrastructure).
+ * Test actions and assertions: all through visible UI.
+ * Teardown: RPC room delete.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { deleteRoom } from '../helpers/room-helpers';
+
+// ─── RPC Setup Helpers ────────────────────────────────────────────────────────
+
+async function createRoomWithLinkedGoalAndTask(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<{ roomId: string; taskId: string; goalId: string }> {
+	await waitForWebSocketConnected(page);
+
+	return page.evaluate(async () => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+
+		// Create room
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Goal Indicator Test Room',
+		});
+		const roomId = (roomRes as { room: { id: string } }).room.id;
+
+		// Create task
+		const taskRes = await hub.request('task.create', {
+			roomId,
+			title: 'Goal-Linked Task',
+			description: 'A task linked to a mission',
+		});
+		const taskId = (taskRes as { task: { id: string } }).task.id;
+
+		// Create goal (mission)
+		const goalRes = await hub.request('goal.create', {
+			roomId,
+			title: 'My Test Mission',
+			description: 'A mission for testing goal indicators',
+			priority: 'normal',
+		});
+		const goalId = (goalRes as { goal: { id: string } }).goal.id;
+
+		// Link task to goal
+		await hub.request('goal.linkTask', { roomId, goalId, taskId });
+
+		return { roomId, taskId, goalId };
+	});
+}
+
+async function createRoomWithUnlinkedTask(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<{ roomId: string; taskId: string }> {
+	await waitForWebSocketConnected(page);
+
+	return page.evaluate(async () => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E Goal Indicator Unlinked Test Room',
+		});
+		const roomId = (roomRes as { room: { id: string } }).room.id;
+
+		const taskRes = await hub.request('task.create', {
+			roomId,
+			title: 'Unlinked Task',
+			description: 'A task with no mission',
+		});
+		const taskId = (taskRes as { task: { id: string } }).task.id;
+
+		return { roomId, taskId };
+	});
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Task Goal Indicator — Task List', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('shows goal badge on task linked to a mission', async ({ page }) => {
+		const result = await createRoomWithLinkedGoalAndTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Should see the goal badge with mission title
+		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);
+		await expect(badge).toBeVisible({ timeout: 10000 });
+		await expect(badge).toContainText('My Test Mission');
+	});
+
+	test('does NOT show goal badge on task with no mission', async ({ page }) => {
+		const result = await createRoomWithUnlinkedTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Ensure the task is visible first
+		await expect(page.locator('h4:has-text("Unlinked Task")')).toBeVisible({ timeout: 10000 });
+
+		// No goal badge should be present for this task
+		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);
+		await expect(badge).not.toBeVisible();
+	});
+
+	test('clicking goal badge switches to Missions tab', async ({ page }) => {
+		const result = await createRoomWithLinkedGoalAndTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for and click the goal badge
+		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);
+		await expect(badge).toBeVisible({ timeout: 10000 });
+		await badge.click();
+
+		// Should now be on the Missions tab
+		await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
+	});
+});
+
+test.describe('Task Goal Indicator — TaskView', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('shows goal badge in TaskView header for linked task', async ({ page }) => {
+		const result = await createRoomWithLinkedGoalAndTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}/task/${result.taskId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for task to load
+		await expect(page.locator('[data-testid="task-status-badge"]')).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Goal badge should be visible with mission title
+		const badge = page.locator('[data-testid="task-view-goal-badge"]');
+		await expect(badge).toBeVisible({ timeout: 5000 });
+		await expect(badge).toContainText('My Test Mission');
+	});
+
+	test('does NOT show goal badge in TaskView for unlinked task', async ({ page }) => {
+		const result = await createRoomWithUnlinkedTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}/task/${result.taskId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for task to load
+		await expect(page.locator('[data-testid="task-status-badge"]')).toBeVisible({
+			timeout: 10000,
+		});
+
+		// No goal badge should be visible
+		const badge = page.locator('[data-testid="task-view-goal-badge"]');
+		await expect(badge).not.toBeVisible();
+	});
+
+	test('clicking goal badge in TaskView navigates to room Missions tab', async ({ page }) => {
+		const result = await createRoomWithLinkedGoalAndTask(page);
+		roomId = result.roomId;
+
+		await page.goto(`/room/${roomId}/task/${result.taskId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for task to load and goal badge to appear
+		await expect(page.locator('[data-testid="task-status-badge"]')).toBeVisible({
+			timeout: 10000,
+		});
+		const badge = page.locator('[data-testid="task-view-goal-badge"]');
+		await expect(badge).toBeVisible({ timeout: 5000 });
+
+		// Click the badge — should navigate back to room and show Missions tab
+		await badge.click();
+
+		// Should be back at room overview showing Missions tab
+		await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
+	});
+});

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -15,7 +15,7 @@ import type { TaskSummary, RuntimeState } from '@neokai/shared';
 
 // Define signals for store mock
 let mockTasks: ReturnType<typeof signal<TaskSummary[]>>;
-let mockGoals: ReturnType<typeof signal<{ id: string; title: string; linkedTaskIds: string[] }[]>>;
+let mockGoalByTaskId: ReturnType<typeof signal<Map<string, unknown>>>;
 let mockSessions: ReturnType<typeof signal<{ id: string; title: string; status: string }[]>>;
 let mockRoomId: ReturnType<typeof signal<string | null>>;
 let mockRuntimeState: ReturnType<typeof signal<RuntimeState | null>>;
@@ -31,7 +31,7 @@ vi.mock('../../lib/room-store.ts', () => ({
 	get roomStore() {
 		return {
 			tasks: mockTasks,
-			goals: mockGoals,
+			goalByTaskId: mockGoalByTaskId,
 			sessions: mockSessions,
 			roomId: mockRoomId,
 			runtimeState: mockRuntimeState,
@@ -63,7 +63,7 @@ vi.mock('../../lib/utils.ts', () => ({
 
 // Initialize signals after mocks
 mockTasks = signal<TaskSummary[]>([]);
-mockGoals = signal([]);
+mockGoalByTaskId = signal(new Map());
 mockSessions = signal([]);
 mockRoomId = signal<string | null>('room-1');
 mockRuntimeState = signal<RuntimeState | null>(null);
@@ -78,7 +78,7 @@ describe('RoomDashboard', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
-		mockGoals.value = [];
+		mockGoalByTaskId.value = new Map();
 		mockSessions.value = [];
 		mockRoomId.value = 'room-1';
 		mockRuntimeState.value = null;

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -15,6 +15,7 @@ import type { TaskSummary, RuntimeState } from '@neokai/shared';
 
 // Define signals for store mock
 let mockTasks: ReturnType<typeof signal<TaskSummary[]>>;
+let mockGoals: ReturnType<typeof signal<{ id: string; title: string; linkedTaskIds: string[] }[]>>;
 let mockSessions: ReturnType<typeof signal<{ id: string; title: string; status: string }[]>>;
 let mockRoomId: ReturnType<typeof signal<string | null>>;
 let mockRuntimeState: ReturnType<typeof signal<RuntimeState | null>>;
@@ -30,6 +31,7 @@ vi.mock('../../lib/room-store.ts', () => ({
 	get roomStore() {
 		return {
 			tasks: mockTasks,
+			goals: mockGoals,
 			sessions: mockSessions,
 			roomId: mockRoomId,
 			runtimeState: mockRuntimeState,
@@ -41,6 +43,10 @@ vi.mock('../../lib/room-store.ts', () => ({
 			archiveRoom: vi.fn().mockResolvedValue(undefined),
 		};
 	},
+}));
+
+vi.mock('../../lib/signals.ts', () => ({
+	currentRoomTabSignal: { value: null },
 }));
 
 const mockNavigateToRoomTask = vi.fn();
@@ -57,6 +63,7 @@ vi.mock('../../lib/utils.ts', () => ({
 
 // Initialize signals after mocks
 mockTasks = signal<TaskSummary[]>([]);
+mockGoals = signal([]);
 mockSessions = signal([]);
 mockRoomId = signal<string | null>('room-1');
 mockRuntimeState = signal<RuntimeState | null>(null);
@@ -71,6 +78,7 @@ describe('RoomDashboard', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
+		mockGoals.value = [];
 		mockSessions.value = [];
 		mockRoomId.value = 'room-1';
 		mockRuntimeState.value = null;

--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -35,7 +35,6 @@ function RuntimeStateIndicator({ state }: { state: RuntimeState }) {
 
 export function RoomDashboard() {
 	const tasks = roomStore.tasks.value;
-	const goals = roomStore.goals.value;
 	const sessions = roomStore.sessions.value;
 	const roomId = roomStore.roomId.value;
 	const runtimeState = roomStore.runtimeState.value;
@@ -203,7 +202,7 @@ export function RoomDashboard() {
 				<h2 class="text-sm font-semibold text-gray-300 uppercase tracking-wide">Tasks</h2>
 				<RoomTasks
 					tasks={tasks}
-					goals={goals}
+					goalByTaskId={roomStore.goalByTaskId.value}
 					onTaskClick={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
 					onView={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
 					onGoalClick={() => {

--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -14,6 +14,7 @@ import { useState } from 'preact/hooks';
 import type { RuntimeState } from '@neokai/shared';
 import { roomStore } from '../../lib/room-store';
 import { navigateToRooms, navigateToRoomTask } from '../../lib/router';
+import { currentRoomTabSignal } from '../../lib/signals';
 import { RoomSessions } from './RoomSessions';
 import { RoomTasks } from './RoomTasks';
 import { ConfirmModal } from '../ui/ConfirmModal';
@@ -34,6 +35,7 @@ function RuntimeStateIndicator({ state }: { state: RuntimeState }) {
 
 export function RoomDashboard() {
 	const tasks = roomStore.tasks.value;
+	const goals = roomStore.goals.value;
 	const sessions = roomStore.sessions.value;
 	const roomId = roomStore.roomId.value;
 	const runtimeState = roomStore.runtimeState.value;
@@ -201,8 +203,12 @@ export function RoomDashboard() {
 				<h2 class="text-sm font-semibold text-gray-300 uppercase tracking-wide">Tasks</h2>
 				<RoomTasks
 					tasks={tasks}
+					goals={goals}
 					onTaskClick={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
 					onView={roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined}
+					onGoalClick={() => {
+						currentRoomTabSignal.value = 'goals';
+					}}
 					onReject={async (taskId, feedback) => {
 						try {
 							await roomStore.rejectTask(taskId, feedback);

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, cleanup, act } from '@testing-library/preact';
-import type { TaskSummary } from '@neokai/shared';
+import type { TaskSummary, RoomGoal } from '@neokai/shared';
 import { RoomTasks, selectedTabSignal, getInitialTab } from './RoomTasks';
 
 // Mock toast to prevent side effects from toast.rejected() calls
@@ -1227,6 +1227,129 @@ describe('RoomTasks', () => {
 
 			expect(onReactivate).toHaveBeenCalledWith('task-42');
 			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Goal Badge', () => {
+		beforeEach(() => {
+			selectedTabSignal.value = 'active';
+		});
+
+		const createGoal = (id: string, title: string, linkedTaskIds: string[]): RoomGoal => ({
+			id,
+			roomId: 'room-1',
+			title,
+			description: '',
+			status: 'active',
+			priority: 'normal',
+			progress: 0,
+			linkedTaskIds,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		});
+
+		it('should show goal badge on task linked to a goal', () => {
+			const task = createTask('task-1', 'in_progress');
+			const goal = createGoal('goal-1', 'My Mission', ['task-1']);
+
+			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-1"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toContain('My Mission');
+		});
+
+		it('should NOT show goal badge on task not linked to any goal', () => {
+			const task = createTask('task-2', 'in_progress');
+			const goal = createGoal('goal-1', 'My Mission', ['task-1']); // links to task-1 only
+
+			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-2"]');
+			expect(badge).toBeNull();
+		});
+
+		it('should NOT show goal badge when goals prop is not provided', () => {
+			const task = createTask('task-1', 'in_progress');
+
+			const { container } = render(<RoomTasks tasks={[task]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-1"]');
+			expect(badge).toBeNull();
+		});
+
+		it('should call onGoalClick with goalId when badge is clicked', () => {
+			const task = createTask('task-1', 'in_progress');
+			const goal = createGoal('goal-1', 'My Mission', ['task-1']);
+			const onGoalClick = vi.fn();
+
+			const { container } = render(
+				<RoomTasks tasks={[task]} goals={[goal]} onGoalClick={onGoalClick} />
+			);
+
+			const badge = container.querySelector(
+				'[data-testid="task-goal-badge-task-1"]'
+			) as HTMLButtonElement;
+			fireEvent.click(badge);
+
+			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
+		});
+
+		it('should NOT call onTaskClick when goal badge is clicked (stopPropagation)', () => {
+			const task = createTask('task-1', 'in_progress');
+			const goal = createGoal('goal-1', 'My Mission', ['task-1']);
+			const onGoalClick = vi.fn();
+			const onTaskClick = vi.fn();
+
+			const { container } = render(
+				<RoomTasks
+					tasks={[task]}
+					goals={[goal]}
+					onGoalClick={onGoalClick}
+					onTaskClick={onTaskClick}
+				/>
+			);
+
+			const badge = container.querySelector(
+				'[data-testid="task-goal-badge-task-1"]'
+			) as HTMLButtonElement;
+			fireEvent.click(badge);
+
+			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
+			expect(onTaskClick).not.toHaveBeenCalled();
+		});
+
+		it('should show goal badge on tasks in review tab', () => {
+			selectedTabSignal.value = 'review';
+			const task = createTask('task-r', 'review');
+			const goal = createGoal('goal-1', 'Review Mission', ['task-r']);
+
+			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-r"]');
+			expect(badge).toBeTruthy();
+			expect(badge?.textContent).toContain('Review Mission');
+		});
+
+		it('should show goal badge on tasks in done tab', () => {
+			selectedTabSignal.value = 'done';
+			const task = createTask('task-d', 'completed');
+			const goal = createGoal('goal-1', 'Done Mission', ['task-d']);
+
+			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-d"]');
+			expect(badge).toBeTruthy();
+		});
+
+		it('should show correct goal title as tooltip on badge', () => {
+			const task = createTask('task-1', 'in_progress');
+			const goal = createGoal('goal-1', 'Specific Goal Name', ['task-1']);
+
+			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+
+			const badge = container.querySelector('[data-testid="task-goal-badge-task-1"]');
+			expect(badge?.getAttribute('title')).toBe('Mission: Specific Goal Name');
 		});
 	});
 });

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -1252,7 +1252,9 @@ describe('RoomTasks', () => {
 			const task = createTask('task-1', 'in_progress');
 			const goal = createGoal('goal-1', 'My Mission', ['task-1']);
 
-			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+			const { container } = render(
+				<RoomTasks tasks={[task]} goalByTaskId={new Map([['task-1', goal]])} />
+			);
 
 			const badge = container.querySelector('[data-testid="task-goal-badge-task-1"]');
 			expect(badge).toBeTruthy();
@@ -1263,13 +1265,15 @@ describe('RoomTasks', () => {
 			const task = createTask('task-2', 'in_progress');
 			const goal = createGoal('goal-1', 'My Mission', ['task-1']); // links to task-1 only
 
-			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+			const { container } = render(
+				<RoomTasks tasks={[task]} goalByTaskId={new Map([['task-1', goal]])} />
+			);
 
 			const badge = container.querySelector('[data-testid="task-goal-badge-task-2"]');
 			expect(badge).toBeNull();
 		});
 
-		it('should NOT show goal badge when goals prop is not provided', () => {
+		it('should NOT show goal badge when goalByTaskId prop is not provided', () => {
 			const task = createTask('task-1', 'in_progress');
 
 			const { container } = render(<RoomTasks tasks={[task]} />);
@@ -1278,13 +1282,17 @@ describe('RoomTasks', () => {
 			expect(badge).toBeNull();
 		});
 
-		it('should call onGoalClick with goalId when badge is clicked', () => {
+		it('should call onGoalClick when badge is clicked', () => {
 			const task = createTask('task-1', 'in_progress');
 			const goal = createGoal('goal-1', 'My Mission', ['task-1']);
 			const onGoalClick = vi.fn();
 
 			const { container } = render(
-				<RoomTasks tasks={[task]} goals={[goal]} onGoalClick={onGoalClick} />
+				<RoomTasks
+					tasks={[task]}
+					goalByTaskId={new Map([['task-1', goal]])}
+					onGoalClick={onGoalClick}
+				/>
 			);
 
 			const badge = container.querySelector(
@@ -1292,7 +1300,7 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(badge);
 
-			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
+			expect(onGoalClick).toHaveBeenCalled();
 		});
 
 		it('should NOT call onTaskClick when goal badge is clicked (stopPropagation)', () => {
@@ -1304,7 +1312,7 @@ describe('RoomTasks', () => {
 			const { container } = render(
 				<RoomTasks
 					tasks={[task]}
-					goals={[goal]}
+					goalByTaskId={new Map([['task-1', goal]])}
 					onGoalClick={onGoalClick}
 					onTaskClick={onTaskClick}
 				/>
@@ -1315,7 +1323,7 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(badge);
 
-			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
+			expect(onGoalClick).toHaveBeenCalled();
 			expect(onTaskClick).not.toHaveBeenCalled();
 		});
 
@@ -1324,7 +1332,9 @@ describe('RoomTasks', () => {
 			const task = createTask('task-r', 'review');
 			const goal = createGoal('goal-1', 'Review Mission', ['task-r']);
 
-			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+			const { container } = render(
+				<RoomTasks tasks={[task]} goalByTaskId={new Map([['task-r', goal]])} />
+			);
 
 			const badge = container.querySelector('[data-testid="task-goal-badge-task-r"]');
 			expect(badge).toBeTruthy();
@@ -1336,7 +1346,9 @@ describe('RoomTasks', () => {
 			const task = createTask('task-d', 'completed');
 			const goal = createGoal('goal-1', 'Done Mission', ['task-d']);
 
-			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+			const { container } = render(
+				<RoomTasks tasks={[task]} goalByTaskId={new Map([['task-d', goal]])} />
+			);
 
 			const badge = container.querySelector('[data-testid="task-goal-badge-task-d"]');
 			expect(badge).toBeTruthy();
@@ -1346,7 +1358,9 @@ describe('RoomTasks', () => {
 			const task = createTask('task-1', 'in_progress');
 			const goal = createGoal('goal-1', 'Specific Goal Name', ['task-1']);
 
-			const { container } = render(<RoomTasks tasks={[task]} goals={[goal]} />);
+			const { container } = render(
+				<RoomTasks tasks={[task]} goalByTaskId={new Map([['task-1', goal]])} />
+			);
 
 			const badge = container.querySelector('[data-testid="task-goal-badge-task-1"]');
 			expect(badge?.getAttribute('title')).toBe('Mission: Specific Goal Name');

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -10,7 +10,7 @@
 
 import { useState } from 'preact/hooks';
 import { signal, effect } from '@preact/signals';
-import type { TaskSummary, TaskStatus } from '@neokai/shared';
+import type { TaskSummary, TaskStatus, RoomGoal } from '@neokai/shared';
 import { toast } from '../../lib/toast.ts';
 
 /** Tab filter types */
@@ -41,7 +41,9 @@ if (typeof window !== 'undefined') {
 
 interface RoomTasksProps {
 	tasks: TaskSummary[];
+	goals?: RoomGoal[];
 	onTaskClick?: (taskId: string) => void;
+	onGoalClick?: (goalId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -102,12 +104,23 @@ function getStatusBorderColor(status: TaskStatus): string {
 
 export function RoomTasks({
 	tasks,
+	goals,
 	onTaskClick,
+	onGoalClick,
 	onView,
 	onReject,
 	onApprove,
 	onReactivate,
 }: RoomTasksProps) {
+	// Build reverse lookup: taskId → RoomGoal
+	const goalByTaskId = new Map<string, RoomGoal>();
+	if (goals) {
+		for (const goal of goals) {
+			for (const taskId of goal.linkedTaskIds) {
+				goalByTaskId.set(taskId, goal);
+			}
+		}
+	}
 	let selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 
@@ -175,7 +188,9 @@ export function RoomTasks({
 					tasks={filteredTasks}
 					allTasks={tasks}
 					tab={selectedTab}
+					goalByTaskId={goalByTaskId}
 					onTaskClick={onTaskClick}
+					onGoalClick={onGoalClick}
 					onView={onView}
 					onReject={onReject}
 					onApprove={onApprove}
@@ -281,7 +296,9 @@ function TaskList({
 	tasks,
 	allTasks,
 	tab,
+	goalByTaskId,
 	onTaskClick,
+	onGoalClick,
 	onView,
 	onReject,
 	onApprove,
@@ -290,7 +307,9 @@ function TaskList({
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
 	tab: TaskFilterTab;
+	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
+	onGoalClick?: (goalId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -317,7 +336,9 @@ function TaskList({
 						variant="yellow"
 						tasks={inProgress}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
@@ -329,7 +350,9 @@ function TaskList({
 						variant="default"
 						tasks={pending}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
@@ -341,7 +364,9 @@ function TaskList({
 						variant="gray"
 						tasks={draft}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
 					/>
@@ -363,7 +388,9 @@ function TaskList({
 						variant="purple"
 						tasks={reviewTasks}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						onView={onView}
 						onReject={onReject}
 						onApprove={onApprove}
@@ -378,7 +405,9 @@ function TaskList({
 						variant="red"
 						tasks={needsAttention}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						showAlert
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
@@ -401,7 +430,9 @@ function TaskList({
 						variant="green"
 						tasks={completed}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						onReactivate={onReactivate}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
@@ -414,7 +445,9 @@ function TaskList({
 						variant="gray"
 						tasks={cancelled}
 						allTasks={allTasks}
+						goalByTaskId={goalByTaskId}
 						onTaskClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						onReactivate={onReactivate}
 						rejectingTaskId={rejectingTaskId}
 						onSetRejectingTaskId={setRejectingTaskId}
@@ -433,7 +466,9 @@ function TaskList({
 				variant="gray"
 				tasks={tasks}
 				allTasks={allTasks}
+				goalByTaskId={goalByTaskId}
 				onTaskClick={onTaskClick}
+				onGoalClick={onGoalClick}
 				rejectingTaskId={rejectingTaskId}
 				onSetRejectingTaskId={setRejectingTaskId}
 			/>
@@ -448,7 +483,9 @@ function TaskGroup({
 	variant,
 	tasks,
 	allTasks,
+	goalByTaskId,
 	onTaskClick,
+	onGoalClick,
 	onView,
 	onReject,
 	onApprove,
@@ -462,7 +499,9 @@ function TaskGroup({
 	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
 	tasks: TaskSummary[];
 	allTasks: TaskSummary[];
+	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
+	onGoalClick?: (goalId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -528,7 +567,9 @@ function TaskGroup({
 						key={task.id}
 						task={task}
 						allTasks={allTasks}
+						goal={goalByTaskId?.get(task.id)}
 						onClick={onTaskClick}
+						onGoalClick={onGoalClick}
 						onView={onView}
 						onReject={onReject}
 						onApprove={onApprove}
@@ -553,7 +594,9 @@ function isBlocked(task: TaskSummary, allTasks: TaskSummary[]): boolean {
 function TaskItem({
 	task,
 	allTasks,
+	goal,
 	onClick,
+	onGoalClick,
 	onView,
 	onReject,
 	onApprove,
@@ -563,7 +606,9 @@ function TaskItem({
 }: {
 	task: TaskSummary;
 	allTasks: TaskSummary[];
+	goal?: RoomGoal;
 	onClick?: (taskId: string) => void;
+	onGoalClick?: (goalId: string) => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -598,7 +643,7 @@ function TaskItem({
 		>
 			<div class="flex items-start justify-between">
 				<div class="flex-1 min-w-0">
-					<div class="flex items-center gap-2">
+					<div class="flex items-center gap-2 flex-wrap">
 						<h4 class="text-sm font-medium text-gray-100 truncate">{task.title}</h4>
 						{isWorking && (
 							<span class="inline-flex items-center gap-1 text-xs font-medium text-blue-400 bg-blue-900/20 border border-blue-700/40 px-1.5 py-0.5 rounded-full flex-shrink-0">
@@ -610,6 +655,27 @@ function TaskItem({
 							<span class="text-xs px-1.5 py-0.5 rounded bg-orange-900/20 text-orange-400 flex-shrink-0">
 								Blocked
 							</span>
+						)}
+						{goal && (
+							<button
+								data-testid={`task-goal-badge-${task.id}`}
+								onClick={(e) => {
+									e.stopPropagation();
+									onGoalClick?.(goal.id);
+								}}
+								class="inline-flex items-center gap-1 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 px-1.5 py-0.5 rounded-full flex-shrink-0 hover:bg-emerald-900/40 transition-colors"
+								title={`Mission: ${goal.title}`}
+							>
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M13 10V3L4 14h7v7l9-11h-7z"
+									/>
+								</svg>
+								<span class="max-w-[120px] truncate">{goal.title}</span>
+							</button>
 						)}
 					</div>
 				</div>

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -41,9 +41,10 @@ if (typeof window !== 'undefined') {
 
 interface RoomTasksProps {
 	tasks: TaskSummary[];
-	goals?: RoomGoal[];
+	/** Pre-built reverse lookup from roomStore.goalByTaskId.value */
+	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: (goalId: string) => void;
+	onGoalClick?: () => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -104,7 +105,7 @@ function getStatusBorderColor(status: TaskStatus): string {
 
 export function RoomTasks({
 	tasks,
-	goals,
+	goalByTaskId,
 	onTaskClick,
 	onGoalClick,
 	onView,
@@ -112,15 +113,6 @@ export function RoomTasks({
 	onApprove,
 	onReactivate,
 }: RoomTasksProps) {
-	// Build reverse lookup: taskId → RoomGoal
-	const goalByTaskId = new Map<string, RoomGoal>();
-	if (goals) {
-		for (const goal of goals) {
-			for (const taskId of goal.linkedTaskIds) {
-				goalByTaskId.set(taskId, goal);
-			}
-		}
-	}
 	let selectedTab = selectedTabSignal.value;
 	const tabCounts = getTabCounts(tasks);
 
@@ -309,7 +301,7 @@ function TaskList({
 	tab: TaskFilterTab;
 	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: (goalId: string) => void;
+	onGoalClick?: () => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -501,7 +493,7 @@ function TaskGroup({
 	allTasks: TaskSummary[];
 	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: (goalId: string) => void;
+	onGoalClick?: () => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -608,7 +600,7 @@ function TaskItem({
 	allTasks: TaskSummary[];
 	goal?: RoomGoal;
 	onClick?: (taskId: string) => void;
-	onGoalClick?: (goalId: string) => void;
+	onGoalClick?: () => void;
 	onView?: (taskId: string) => void;
 	onReject?: (taskId: string, feedback: string) => void;
 	onApprove?: (taskId: string) => void;
@@ -661,7 +653,7 @@ function TaskItem({
 								data-testid={`task-goal-badge-${task.id}`}
 								onClick={(e) => {
 									e.stopPropagation();
-									onGoalClick?.(goal.id);
+									onGoalClick?.();
 								}}
 								class="inline-flex items-center gap-1 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 px-1.5 py-0.5 rounded-full flex-shrink-0 hover:bg-emerald-900/40 transition-colors"
 								title={`Mission: ${goal.title}`}

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2091,3 +2091,149 @@ describe('TaskView — Reactivate and Archive actions', () => {
 		expect(sendButton.disabled).toBe(false);
 	});
 });
+
+// Import roomStore to set up goal associations for goal badge tests
+import { roomStore } from '../../lib/room-store.ts';
+import { currentRoomTabSignal } from '../../lib/signals.ts';
+
+describe('TaskView — goal badge', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+		// Clear goals between tests
+		roomStore.goals.value = [];
+		currentRoomTabSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+		roomStore.goals.value = [];
+		currentRoomTabSignal.value = null;
+	});
+
+	it('shows goal badge when task is linked to a goal', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		roomStore.goals.value = [
+			{
+				id: 'goal-1',
+				roomId: 'room-1',
+				title: 'Test Mission',
+				description: '',
+				status: 'active',
+				priority: 'normal',
+				progress: 0,
+				linkedTaskIds: ['task-1'],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		];
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const badge = container.querySelector('[data-testid="task-view-goal-badge"]');
+		expect(badge).toBeTruthy();
+		expect(badge?.textContent).toContain('Test Mission');
+	});
+
+	it('does NOT show goal badge when task has no linked goal', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		// No goals set - roomStore.goals.value is already []
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		const badge = container.querySelector('[data-testid="task-view-goal-badge"]');
+		expect(badge).toBeNull();
+	});
+
+	it('sets currentRoomTabSignal to "goals" and navigates to room when goal badge clicked', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		roomStore.goals.value = [
+			{
+				id: 'goal-1',
+				roomId: 'room-1',
+				title: 'Clickable Mission',
+				description: '',
+				status: 'active',
+				priority: 'normal',
+				progress: 0,
+				linkedTaskIds: ['task-1'],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		];
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.querySelector('[data-testid="task-view-goal-badge"]')).toBeTruthy();
+		});
+
+		const badge = container.querySelector(
+			'[data-testid="task-view-goal-badge"]'
+		) as HTMLButtonElement;
+		fireEvent.click(badge);
+
+		expect(currentRoomTabSignal.value).toBe('goals');
+		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+	});
+
+	it('shows goal title as tooltip on badge', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		roomStore.goals.value = [
+			{
+				id: 'goal-1',
+				roomId: 'room-1',
+				title: 'Tooltip Mission Title',
+				description: '',
+				status: 'active',
+				priority: 'normal',
+				progress: 0,
+				linkedTaskIds: ['task-1'],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		];
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.querySelector('[data-testid="task-view-goal-badge"]')).toBeTruthy();
+		});
+
+		const badge = container.querySelector('[data-testid="task-view-goal-badge"]');
+		expect(badge?.getAttribute('title')).toBe('Mission: Tooltip Mission Title');
+	});
+});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -963,8 +963,9 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 							<button
 								data-testid="task-view-goal-badge"
 								onClick={() => {
-									currentRoomTabSignal.value = 'goals';
+									// Navigate first so taskViewId is cleared before the signal is consumed
 									navigateToRoom(roomId);
+									currentRoomTabSignal.value = 'goals';
 								}}
 								class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 hover:bg-emerald-900/40 rounded transition-colors"
 								title={`Mission: ${associatedGoal.title}`}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -22,6 +22,8 @@ import { useMessageHub } from '../../hooks/useMessageHub';
 import { useModal } from '../../hooks/useModal';
 import { useTaskInputDraft } from '../../hooks/useTaskInputDraft';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { roomStore } from '../../lib/room-store';
+import { currentRoomTabSignal } from '../../lib/signals';
 import { getModelLabel } from '../../lib/session-utils';
 import { toast } from '../../lib/toast.ts';
 import { copyToClipboard } from '../../lib/utils';
@@ -597,6 +599,9 @@ function ArchiveTaskDialog({ task, isOpen, onClose, onConfirm }: ArchiveTaskDial
 export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const { request, onEvent, joinRoom, leaveRoom } = useMessageHub();
 	const [task, setTask] = useState<NeoTask | null>(null);
+
+	// Look up the goal associated with this task (reverse lookup from roomStore)
+	const associatedGoal = roomStore.goalByTaskId.value.get(taskId) ?? null;
 	const [group, setGroup] = useState<TaskGroupInfo | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
@@ -952,6 +957,28 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 								</svg>
 								<span>PR #{task.prNumber ?? '?'}</span>
 							</a>
+						)}
+						{/* Mission link — shown when task is linked to a goal */}
+						{associatedGoal && (
+							<button
+								data-testid="task-view-goal-badge"
+								onClick={() => {
+									currentRoomTabSignal.value = 'goals';
+									navigateToRoom(roomId);
+								}}
+								class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 hover:bg-emerald-900/40 rounded transition-colors"
+								title={`Mission: ${associatedGoal.title}`}
+							>
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M13 10V3L4 14h7v7l9-11h-7z"
+									/>
+								</svg>
+								<span class="max-w-[160px] truncate">{associatedGoal.title}</span>
+							</button>
 						)}
 					</div>
 					{group && (

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -39,6 +39,8 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 		});
 		return () => {
 			roomStore.select(null);
+			// Clear any pending tab signal when leaving a room to prevent cross-room contamination
+			currentRoomTabSignal.value = null;
 		};
 	}, [roomId]);
 
@@ -52,7 +54,7 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 			}
 			currentRoomTabSignal.value = null;
 		}
-	}, [pendingTab, taskViewId]);
+	}, [pendingTab, taskViewId, roomId]);
 
 	// Update URL when tab changes
 	const handleTabChange = (tab: RoomTab) => {

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { roomStore } from '../lib/room-store';
 import { navigateToHome, navigateToRoomTask, navigateToRoom } from '../lib/router';
+import { currentRoomTabSignal } from '../lib/signals';
 import { RoomDashboard } from '../components/room/RoomDashboard';
 import ChatContainer from './ChatContainer';
 import { GoalsEditor, RoomContext, RoomSettings, RoomAgents } from '../components/room';
@@ -40,6 +41,18 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 			roomStore.select(null);
 		};
 	}, [roomId]);
+
+	// Watch for pending tab navigation from goal badges in task list / task view
+	const pendingTab = currentRoomTabSignal.value;
+	useEffect(() => {
+		if (pendingTab && !taskViewId) {
+			const validTabs: RoomTab[] = ['overview', 'context', 'agents', 'goals', 'settings'];
+			if (validTabs.includes(pendingTab as RoomTab)) {
+				setActiveTab(pendingTab as RoomTab);
+			}
+			currentRoomTabSignal.value = null;
+		}
+	}, [pendingTab, taskViewId]);
 
 	// Update URL when tab changes
 	const handleTabChange = (tab: RoomTab) => {

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -176,6 +176,17 @@ class RoomStore {
 		return result;
 	});
 
+	/** Reverse lookup: taskId → RoomGoal (the goal that owns this task) */
+	readonly goalByTaskId = computed(() => {
+		const result = new Map<string, RoomGoal>();
+		for (const goal of this.goals.value) {
+			for (const taskId of goal.linkedTaskIds) {
+				result.set(taskId, goal);
+			}
+		}
+		return result;
+	});
+
 	/** Tasks not linked to any goal */
 	readonly orphanTasks = computed(() => {
 		const linkedIds = new Set<string>();

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -46,6 +46,10 @@ export const contextPanelOpenSignal = signal<boolean>(false);
 // Create Room modal open state - shared between ContextPanel and Lobby
 export const createRoomModalSignal = signal<boolean>(false);
 
+// Room tab navigation signal - set this to navigate to a specific room tab
+// Room.tsx watches this and switches activeTab accordingly, then clears it
+export const currentRoomTabSignal = signal<string | null>(null);
+
 // Settings section signal - which settings section is active
 export type SettingsSection =
 	| 'general'


### PR DESCRIPTION
- Add `currentRoomTabSignal` to signals.ts for cross-component tab navigation
- Add `goalByTaskId` computed signal to room-store for reverse task→goal lookup
- Show emerald goal badge on tasks in RoomTasks list with goal title and tooltip
- Clicking goal badge in task list switches to Missions tab via signal
- Show goal badge in TaskView header with mission title and navigation
- Clicking goal badge in TaskView navigates back to room and switches to Missions tab
- Room.tsx watches currentRoomTabSignal to switch activeTab when signal changes
- Unit tests: goal badge in RoomTasks (8 tests) and TaskView (4 tests)
- E2E tests: task list badge, task view badge, and tab navigation flows
