### PR TITLE
feat: add session title generation job handler

### DIFF
--- a/packages/daemon/src/lib/job-handlers/session-title.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/session-title.handler.ts
@@ -12,10 +12,14 @@ export async function handleSessionTitleGeneration(
 	job: Job,
 	sessionLifecycle: SessionLifecycle
 ): Promise<{ generated: true }> {
-	const { sessionId, userMessageText } = job.payload as {
-		sessionId: string;
-		userMessageText: string;
-	};
+	const { sessionId, userMessageText } = job.payload;
+
+	if (!sessionId || typeof sessionId !== 'string') {
+		throw new Error('Job payload missing required field: sessionId');
+	}
+	if (typeof userMessageText !== 'string') {
+		throw new Error('Job payload missing required field: userMessageText');
+	}
 
 	await sessionLifecycle.generateTitleAndRenameBranch(sessionId, userMessageText);
 

--- a/packages/daemon/src/lib/job-handlers/session-title.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/session-title.handler.ts
@@ -17,7 +17,7 @@ export async function handleSessionTitleGeneration(
 	if (!sessionId || typeof sessionId !== 'string') {
 		throw new Error('Job payload missing required field: sessionId');
 	}
-	if (typeof userMessageText !== 'string') {
+	if (!userMessageText || typeof userMessageText !== 'string') {
 		throw new Error('Job payload missing required field: userMessageText');
 	}
 

--- a/packages/daemon/src/lib/job-handlers/session-title.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/session-title.handler.ts
@@ -1,0 +1,23 @@
+import type { Job } from '../../storage/repositories/job-queue-repository';
+import type { SessionLifecycle } from '../session/session-lifecycle';
+
+/**
+ * Job handler for session.title_generation queue.
+ *
+ * Calls SessionLifecycle.generateTitleAndRenameBranch() with the sessionId and
+ * userMessageText from the job payload. Errors propagate so the job queue can
+ * retry the job automatically.
+ */
+export async function handleSessionTitleGeneration(
+	job: Job,
+	sessionLifecycle: SessionLifecycle
+): Promise<{ generated: true }> {
+	const { sessionId, userMessageText } = job.payload as {
+		sessionId: string;
+		userMessageText: string;
+	};
+
+	await sessionLifecycle.generateTitleAndRenameBranch(sessionId, userMessageText);
+
+	return { generated: true };
+}

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,6 +62,8 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
+import { SESSION_TITLE_GENERATION } from '../job-queue-constants';
+import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -147,6 +149,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 	setupTestHandlers(deps.messageHub, deps.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
+
+	// Job queue handler registrations
+	deps.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
+		handleSessionTitleGeneration(job, deps.sessionManager.getSessionLifecycle())
+	);
 
 	// Room handlers
 	setupRoomHandlers(

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -219,8 +219,7 @@ export class SessionManager {
 	}
 
 	/**
-	 * Get the session lifecycle manager (exposed for testing)
-	 * @internal
+	 * Get the session lifecycle manager.
 	 */
 	getSessionLifecycle(): SessionLifecycle {
 		return this.sessionLifecycle;

--- a/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
@@ -93,4 +93,13 @@ describe('handleSessionTitleGeneration', () => {
 			'Job payload missing required field: userMessageText'
 		);
 	});
+
+	it('throws when userMessageText is an empty string', async () => {
+		const lifecycle = makeSessionLifecycle();
+		const job = makeJob({ sessionId: 'session-123', userMessageText: '' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
+			'Job payload missing required field: userMessageText'
+		);
+	});
 });

--- a/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { handleSessionTitleGeneration } from '../../../src/lib/job-handlers/session-title.handler';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+import type { SessionLifecycle } from '../../../src/lib/session/session-lifecycle';
+
+function makeJob(payload: Record<string, unknown>): Job {
+	return {
+		id: 'test-job-id',
+		queue: 'session.title_generation',
+		status: 'processing',
+		payload,
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now(),
+		createdAt: Date.now(),
+		startedAt: Date.now(),
+		completedAt: null,
+	};
+}
+
+function makeSessionLifecycle(
+	impl?: Partial<Pick<SessionLifecycle, 'generateTitleAndRenameBranch'>>
+): SessionLifecycle {
+	return {
+		generateTitleAndRenameBranch:
+			impl?.generateTitleAndRenameBranch ??
+			mock(() => Promise.resolve({ title: 'Generated Title', isFallback: false })),
+	} as unknown as SessionLifecycle;
+}
+
+describe('handleSessionTitleGeneration', () => {
+	it('calls generateTitleAndRenameBranch with correct params and returns { generated: true }', async () => {
+		const stub = mock(() => Promise.resolve({ title: 'My Title', isFallback: false }));
+		const lifecycle = makeSessionLifecycle({ generateTitleAndRenameBranch: stub });
+
+		const job = makeJob({ sessionId: 'session-123', userMessageText: 'hello world' });
+		const result = await handleSessionTitleGeneration(job, lifecycle);
+
+		expect(result).toEqual({ generated: true });
+		expect(stub).toHaveBeenCalledTimes(1);
+		expect(stub).toHaveBeenCalledWith('session-123', 'hello world');
+	});
+
+	it('propagates errors from generateTitleAndRenameBranch for job queue retry', async () => {
+		const error = new Error('API failure');
+		const stub = mock(() => Promise.reject(error));
+		const lifecycle = makeSessionLifecycle({ generateTitleAndRenameBranch: stub });
+
+		const job = makeJob({ sessionId: 'session-abc', userMessageText: 'some text' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow('API failure');
+		expect(stub).toHaveBeenCalledTimes(1);
+	});
+
+	it('propagates "session not found" error when session is missing', async () => {
+		const stub = mock(() => Promise.reject(new Error('Session session-missing not found')));
+		const lifecycle = makeSessionLifecycle({ generateTitleAndRenameBranch: stub });
+
+		const job = makeJob({ sessionId: 'session-missing', userMessageText: 'hi' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
+			'Session session-missing not found'
+		);
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/session-title-handler.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, mock } from 'bun:test';
 import { handleSessionTitleGeneration } from '../../../src/lib/job-handlers/session-title.handler';
+import { SESSION_TITLE_GENERATION } from '../../../src/lib/job-queue-constants';
 import type { Job } from '../../../src/storage/repositories/job-queue-repository';
 import type { SessionLifecycle } from '../../../src/lib/session/session-lifecycle';
 
 function makeJob(payload: Record<string, unknown>): Job {
 	return {
 		id: 'test-job-id',
-		queue: 'session.title_generation',
+		queue: SESSION_TITLE_GENERATION,
 		status: 'processing',
 		payload,
 		result: null,
@@ -63,6 +64,33 @@ describe('handleSessionTitleGeneration', () => {
 
 		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
 			'Session session-missing not found'
+		);
+	});
+
+	it('throws when sessionId is missing from payload', async () => {
+		const lifecycle = makeSessionLifecycle();
+		const job = makeJob({ userMessageText: 'hello' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
+			'Job payload missing required field: sessionId'
+		);
+	});
+
+	it('throws when sessionId is not a string', async () => {
+		const lifecycle = makeSessionLifecycle();
+		const job = makeJob({ sessionId: 42, userMessageText: 'hello' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
+			'Job payload missing required field: sessionId'
+		);
+	});
+
+	it('throws when userMessageText is missing from payload', async () => {
+		const lifecycle = makeSessionLifecycle();
+		const job = makeJob({ sessionId: 'session-123' });
+
+		await expect(handleSessionTitleGeneration(job, lifecycle)).rejects.toThrow(
+			'Job payload missing required field: userMessageText'
 		);
 	});
 });


### PR DESCRIPTION
Create job handler for session.title_generation queue that delegates to
SessionLifecycle.generateTitleAndRenameBranch(). Errors propagate so
the job queue can retry. Includes unit tests for success, error
propagation, and missing-session cases.
