### PR TITLE
feat: expose triggerPoll and create github.poll job handler

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -23,7 +23,7 @@ import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
-import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
+import { GITHUB_POLL, JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -363,6 +363,20 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	if (gitHubService) {
 		gitHubService.start();
 		logInfo('[Daemon] GitHub service started');
+
+		// Seed the initial github.poll job if polling is configured and no job already exists.
+		// The self-scheduling chain in the handler keeps the chain alive after this seed.
+		if (config.githubPollingInterval && config.githubPollingInterval > 0) {
+			const existing = jobQueue.listJobs({
+				queue: GITHUB_POLL,
+				status: ['pending', 'processing'],
+				limit: 1,
+			});
+			if (existing.length === 0) {
+				jobQueue.enqueue({ queue: GITHUB_POLL, payload: {} });
+				logInfo('[Daemon] Seeded initial github.poll job');
+			}
+		}
 	}
 
 	// Register job handlers BEFORE starting the processor so no pending job

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -359,9 +359,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		},
 	});
 
-	// Start GitHub service after server is ready
+	// Start GitHub service after server is ready.
+	// Pass useJobQueueScheduler when polling is configured so the pollingService's
+	// built-in setInterval is skipped — the github.poll job-queue chain owns the
+	// schedule instead, preventing a dual-schedule where both mechanisms fire independently.
 	if (gitHubService) {
-		gitHubService.start();
+		const useJobQueueScheduler = !!config.githubPollingInterval && config.githubPollingInterval > 0;
+		gitHubService.start({ useJobQueueScheduler });
 		logInfo('[Daemon] GitHub service started');
 
 		// Seed the initial github.poll job if polling is configured and no job already exists.

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -120,8 +120,13 @@ export class GitHubService {
 	 * Start the GitHub service
 	 * - Starts polling if configured
 	 * - Creates webhook handler if secret is configured
+	 *
+	 * @param options.useJobQueueScheduler - When true, the polling service is created
+	 *   but its built-in setInterval timer is NOT started. The job-queue handler owns
+	 *   the schedule entirely (via the github.poll queue), which avoids a dual-schedule
+	 *   where both the setInterval and the job-queue chain call triggerPoll independently.
 	 */
-	start(): void {
+	start(options?: { useJobQueueScheduler?: boolean }): void {
 		// Initialize webhook handler if secret is configured
 		if (this.config.githubWebhookSecret) {
 			this.webhookHandler = createWebhookHandler(this.config.githubWebhookSecret, async (event) => {
@@ -130,7 +135,7 @@ export class GitHubService {
 			log.info('Webhook handler initialized');
 		}
 
-		// Start polling if interval is configured and token is available
+		// Create polling service if interval is configured and token is available
 		if (
 			this.config.githubPollingInterval &&
 			this.config.githubPollingInterval > 0 &&
@@ -145,10 +150,19 @@ export class GitHubService {
 					await this.processEvent(event);
 				}
 			);
-			this.pollingService.start();
-			log.info('Polling service started', {
-				intervalMs: this.config.githubPollingInterval * 1000,
-			});
+
+			if (options?.useJobQueueScheduler) {
+				// Job queue owns the schedule — skip the built-in setInterval so only
+				// one scheduling mechanism fires per interval.
+				log.info('Polling service created (job-queue-driven, setInterval skipped)', {
+					intervalMs: this.config.githubPollingInterval * 1000,
+				});
+			} else {
+				this.pollingService.start();
+				log.info('Polling service started', {
+					intervalMs: this.config.githubPollingInterval * 1000,
+				});
+			}
 		}
 
 		log.info('GitHub service started');

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -593,6 +593,13 @@ export class GitHubService {
 	isPolling(): boolean {
 		return this.pollingService?.isRunning() ?? false;
 	}
+
+	/**
+	 * Return the underlying polling service instance, or undefined if not configured.
+	 */
+	getPollingService(): GitHubPollingService | undefined {
+		return this.pollingService;
+	}
 }
 
 /**

--- a/packages/daemon/src/lib/github/polling-service.ts
+++ b/packages/daemon/src/lib/github/polling-service.ts
@@ -140,6 +140,17 @@ export class GitHubPollingService {
 	}
 
 	/**
+	 * Trigger a poll immediately. No-op if a poll is already in progress.
+	 */
+	async triggerPoll(): Promise<void> {
+		if (this.isPolling) {
+			log.debug('Poll already in progress, skipping triggerPoll');
+			return;
+		}
+		await this.pollAllRepositories();
+	}
+
+	/**
 	 * Poll all configured repositories
 	 */
 	private async pollAllRepositories(): Promise<void> {

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -49,10 +49,11 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 	// Only enqueue the next job if there is no pending or processing job
 	// already in the chain. Checking 'processing' prevents a duplicate chain
 	// from forming under stale-reclaim or slow-poll scenarios.
+	// limit: 1 is sufficient — we only need to know if any job exists.
 	const existingJobs = jobQueue.listJobs({
 		queue: GITHUB_POLL,
 		status: ['pending', 'processing'],
-		limit: 10,
+		limit: 1,
 	});
 
 	if (existingJobs.length === 0) {

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -1,0 +1,46 @@
+/**
+ * Job handler for github.poll queue.
+ *
+ * Triggers a poll of all GitHub repositories and self-schedules the next poll
+ * job, with deduplication to prevent multiple concurrent poll chains.
+ */
+
+import { GITHUB_POLL } from '../job-queue-constants';
+import type { GitHubPollingService } from '../github/polling-service';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+
+export interface GitHubPollHandlerDeps {
+	pollingService: GitHubPollingService;
+	jobQueue: JobQueueRepository;
+	intervalMs: number;
+}
+
+export interface GitHubPollResult {
+	polled: boolean;
+	nextRunAt: number;
+}
+
+export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<GitHubPollResult> {
+	const { pollingService, jobQueue, intervalMs } = deps;
+	const nextRunAt = Date.now() + intervalMs;
+
+	try {
+		await pollingService.triggerPoll();
+	} finally {
+		const pendingJobs = jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['pending'],
+			limit: 10,
+		});
+
+		if (pendingJobs.length === 0) {
+			jobQueue.enqueue({
+				queue: GITHUB_POLL,
+				payload: {},
+				runAt: nextRunAt,
+			});
+		}
+	}
+
+	return { polled: true, nextRunAt };
+}

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -6,41 +6,62 @@
  */
 
 import { GITHUB_POLL } from '../job-queue-constants';
+import { Logger } from '../logger';
 import type { GitHubPollingService } from '../github/polling-service';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 
+const log = new Logger('github-poll-handler');
+
 export interface GitHubPollHandlerDeps {
-	pollingService: GitHubPollingService;
+	pollingService: GitHubPollingService | undefined;
 	jobQueue: JobQueueRepository;
 	intervalMs: number;
 }
 
-export interface GitHubPollResult {
+// Extends Record<string, unknown> so the result satisfies JobHandler's return type.
+export interface GitHubPollResult extends Record<string, unknown> {
 	polled: boolean;
 	nextRunAt: number;
 }
 
 export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<GitHubPollResult> {
 	const { pollingService, jobQueue, intervalMs } = deps;
-	const nextRunAt = Date.now() + intervalMs;
+
+	let polled = false;
 
 	try {
-		await pollingService.triggerPoll();
-	} finally {
-		const pendingJobs = jobQueue.listJobs({
-			queue: GITHUB_POLL,
-			status: ['pending'],
-			limit: 10,
-		});
-
-		if (pendingJobs.length === 0) {
-			jobQueue.enqueue({
-				queue: GITHUB_POLL,
-				payload: {},
-				runAt: nextRunAt,
-			});
+		if (pollingService) {
+			await pollingService.triggerPoll();
+			polled = true;
+		} else {
+			log.warn('github.poll handler called but no polling service is configured');
 		}
+	} catch (error) {
+		log.error('triggerPoll failed', {
+			error: error instanceof Error ? error.message : error,
+		});
 	}
 
-	return { polled: true, nextRunAt };
+	// Compute nextRunAt after the poll so the interval is measured from
+	// completion, not from when the job was dequeued.
+	const nextRunAt = Date.now() + intervalMs;
+
+	// Only enqueue the next job if there is no pending or processing job
+	// already in the chain. Checking 'processing' prevents a duplicate chain
+	// from forming under stale-reclaim or slow-poll scenarios.
+	const existingJobs = jobQueue.listJobs({
+		queue: GITHUB_POLL,
+		status: ['pending', 'processing'],
+		limit: 10,
+	});
+
+	if (existingJobs.length === 0) {
+		jobQueue.enqueue({
+			queue: GITHUB_POLL,
+			payload: {},
+			runAt: nextRunAt,
+		});
+	}
+
+	return { polled, nextRunAt };
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,9 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { SESSION_TITLE_GENERATION } from '../job-queue-constants';
+import { SESSION_TITLE_GENERATION, GITHUB_POLL } from '../job-queue-constants';
 import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
+import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -216,6 +217,26 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomManager,
 		deps.gitHubService ?? null
 	);
+
+	// Register github.poll job handler.
+	// The pollingService is lazily resolved at call time — it is created inside
+	// GitHubService.start() which runs after setupRPCHandlers returns, so we
+	// must not capture it here. Reading it via getPollingService() at call time
+	// ensures the handler always sees the live instance.
+	if (
+		deps.gitHubService &&
+		deps.config.githubPollingInterval &&
+		deps.config.githubPollingInterval > 0
+	) {
+		const intervalMs = deps.config.githubPollingInterval * 1000;
+		deps.jobProcessor.register(GITHUB_POLL, () =>
+			handleGitHubPoll({
+				pollingService: deps.gitHubService!.getPollingService(),
+				jobQueue: deps.jobQueue,
+				intervalMs,
+			})
+		);
+	}
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -219,10 +219,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	);
 
 	// Register github.poll job handler.
-	// The pollingService is lazily resolved at call time — it is created inside
-	// GitHubService.start() which runs after setupRPCHandlers returns, so we
-	// must not capture it here. Reading it via getPollingService() at call time
-	// ensures the handler always sees the live instance.
+	// pollingService is created inside GitHubService.start(), which runs in app.ts
+	// after setupRPCHandlers returns. Resolving it at call time via getPollingService()
+	// ensures the handler always sees the live instance rather than undefined.
+	// GitHubService.start() is called with useJobQueueScheduler:true so its built-in
+	// setInterval is skipped — the job-queue chain is the sole scheduler.
 	if (
 		deps.gitHubService &&
 		deps.config.githubPollingInterval &&

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -126,7 +126,7 @@ describe('handleGitHubPoll', () => {
 		)[0];
 		expect(listArg.queue).toBe(GITHUB_POLL);
 		expect(listArg.status).toEqual(['pending', 'processing']);
-		expect(listArg.limit).toBe(10);
+		expect(listArg.limit).toBe(1);
 	});
 
 	it('returns polled: false when pollingService is undefined', async () => {

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for github.poll job handler
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { handleGitHubPoll } from '../../../src/lib/job-handlers/github-poll.handler';
+import { GITHUB_POLL } from '../../../src/lib/job-queue-constants';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+	return {
+		id: 'job-1',
+		queue: GITHUB_POLL,
+		status: 'pending',
+		payload: {},
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now() + 60000,
+		createdAt: Date.now(),
+		startedAt: null,
+		completedAt: null,
+		...overrides,
+	};
+}
+
+describe('handleGitHubPoll', () => {
+	let triggerPollMock: ReturnType<typeof mock>;
+	let enqueueMock: ReturnType<typeof mock>;
+	let listJobsMock: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		triggerPollMock = mock(async () => {});
+		enqueueMock = mock(() => makeJob());
+		listJobsMock = mock(() => []);
+	});
+
+	function makeDeps(overrides: { intervalMs?: number } = {}) {
+		return {
+			pollingService: {
+				triggerPoll: triggerPollMock,
+			} as never,
+			jobQueue: {
+				enqueue: enqueueMock,
+				listJobs: listJobsMock,
+			} as never,
+			intervalMs: overrides.intervalMs ?? 60000,
+		};
+	}
+
+	it('calls triggerPoll on the polling service', async () => {
+		await handleGitHubPoll(makeDeps());
+		expect(triggerPollMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns polled: true and a future nextRunAt', async () => {
+		const before = Date.now();
+		const result = await handleGitHubPoll(makeDeps({ intervalMs: 60000 }));
+		expect(result.polled).toBe(true);
+		expect(result.nextRunAt).toBeGreaterThanOrEqual(before + 60000);
+	});
+
+	it('enqueues next job when no pending job exists', async () => {
+		listJobsMock = mock(() => []);
+		const deps = makeDeps();
+		deps.jobQueue.listJobs = listJobsMock as never;
+
+		await handleGitHubPoll(deps);
+
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const enqueueArg = (enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }])[0];
+		expect(enqueueArg.queue).toBe(GITHUB_POLL);
+		expect(enqueueArg.runAt).toBeGreaterThan(Date.now());
+	});
+
+	it('skips enqueueing when a pending job already exists (dedup)', async () => {
+		listJobsMock = mock(() => [makeJob()]);
+		const deps = makeDeps();
+		deps.jobQueue.listJobs = listJobsMock as never;
+		deps.jobQueue.enqueue = enqueueMock as never;
+
+		await handleGitHubPoll(deps);
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('still schedules next poll even when triggerPoll throws (finally block)', async () => {
+		triggerPollMock = mock(async () => {
+			throw new Error('poll failed');
+		});
+		listJobsMock = mock(() => []);
+
+		const deps = makeDeps();
+		deps.pollingService.triggerPoll = triggerPollMock as never;
+		deps.jobQueue.listJobs = listJobsMock as never;
+		deps.jobQueue.enqueue = enqueueMock as never;
+
+		await expect(handleGitHubPoll(deps)).rejects.toThrow('poll failed');
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('queries listJobs with pending status and GITHUB_POLL queue', async () => {
+		await handleGitHubPoll(makeDeps());
+
+		expect(listJobsMock).toHaveBeenCalledTimes(1);
+		const listArg = (
+			listJobsMock.mock.calls[0] as [{ queue: string; status: string[]; limit: number }]
+		)[0];
+		expect(listArg.queue).toBe(GITHUB_POLL);
+		expect(listArg.status).toEqual(['pending']);
+		expect(listArg.limit).toBe(10);
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -37,11 +37,14 @@ describe('handleGitHubPoll', () => {
 		listJobsMock = mock(() => []);
 	});
 
-	function makeDeps(overrides: { intervalMs?: number } = {}) {
+	function makeDeps(
+		overrides: { intervalMs?: number; pollingService?: ReturnType<typeof mock> | undefined } = {}
+	) {
 		return {
-			pollingService: {
-				triggerPoll: triggerPollMock,
-			} as never,
+			pollingService:
+				'pollingService' in overrides
+					? overrides.pollingService
+					: ({ triggerPoll: triggerPollMock } as never),
 			jobQueue: {
 				enqueue: enqueueMock,
 				listJobs: listJobsMock,
@@ -55,19 +58,19 @@ describe('handleGitHubPoll', () => {
 		expect(triggerPollMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('returns polled: true and a future nextRunAt', async () => {
+	it('returns polled: true when triggerPoll succeeds', async () => {
+		const result = await handleGitHubPoll(makeDeps());
+		expect(result.polled).toBe(true);
+	});
+
+	it('returns a nextRunAt at least intervalMs from now', async () => {
 		const before = Date.now();
 		const result = await handleGitHubPoll(makeDeps({ intervalMs: 60000 }));
-		expect(result.polled).toBe(true);
 		expect(result.nextRunAt).toBeGreaterThanOrEqual(before + 60000);
 	});
 
-	it('enqueues next job when no pending job exists', async () => {
-		listJobsMock = mock(() => []);
-		const deps = makeDeps();
-		deps.jobQueue.listJobs = listJobsMock as never;
-
-		await handleGitHubPoll(deps);
+	it('enqueues next job when no pending or processing job exists', async () => {
+		await handleGitHubPoll(makeDeps());
 
 		expect(enqueueMock).toHaveBeenCalledTimes(1);
 		const enqueueArg = (enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }])[0];
@@ -76,7 +79,7 @@ describe('handleGitHubPoll', () => {
 	});
 
 	it('skips enqueueing when a pending job already exists (dedup)', async () => {
-		listJobsMock = mock(() => [makeJob()]);
+		listJobsMock = mock(() => [makeJob({ status: 'pending' })]);
 		const deps = makeDeps();
 		deps.jobQueue.listJobs = listJobsMock as never;
 		deps.jobQueue.enqueue = enqueueMock as never;
@@ -86,22 +89,35 @@ describe('handleGitHubPoll', () => {
 		expect(enqueueMock).not.toHaveBeenCalled();
 	});
 
-	it('still schedules next poll even when triggerPoll throws (finally block)', async () => {
+	it('skips enqueueing when a processing job already exists (dedup)', async () => {
+		listJobsMock = mock(() => [makeJob({ status: 'processing' })]);
+		const deps = makeDeps();
+		deps.jobQueue.listJobs = listJobsMock as never;
+		deps.jobQueue.enqueue = enqueueMock as never;
+
+		await handleGitHubPoll(deps);
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('still schedules next poll when triggerPoll throws (error is caught internally)', async () => {
 		triggerPollMock = mock(async () => {
 			throw new Error('poll failed');
 		});
 		listJobsMock = mock(() => []);
 
 		const deps = makeDeps();
-		deps.pollingService.triggerPoll = triggerPollMock as never;
+		deps.pollingService = { triggerPoll: triggerPollMock } as never;
 		deps.jobQueue.listJobs = listJobsMock as never;
 		deps.jobQueue.enqueue = enqueueMock as never;
 
-		await expect(handleGitHubPoll(deps)).rejects.toThrow('poll failed');
+		// Error is caught internally — handler resolves successfully
+		const result = await handleGitHubPoll(deps);
+		expect(result.polled).toBe(false);
 		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('queries listJobs with pending status and GITHUB_POLL queue', async () => {
+	it('queries listJobs with pending+processing statuses and GITHUB_POLL queue', async () => {
 		await handleGitHubPoll(makeDeps());
 
 		expect(listJobsMock).toHaveBeenCalledTimes(1);
@@ -109,7 +125,16 @@ describe('handleGitHubPoll', () => {
 			listJobsMock.mock.calls[0] as [{ queue: string; status: string[]; limit: number }]
 		)[0];
 		expect(listArg.queue).toBe(GITHUB_POLL);
-		expect(listArg.status).toEqual(['pending']);
+		expect(listArg.status).toEqual(['pending', 'processing']);
 		expect(listArg.limit).toBe(10);
+	});
+
+	it('returns polled: false when pollingService is undefined', async () => {
+		const deps = makeDeps({ pollingService: undefined });
+		const result = await handleGitHubPoll(deps);
+		expect(result.polled).toBe(false);
+		expect(triggerPollMock).not.toHaveBeenCalled();
+		// Still enqueues next job
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
- Add public `triggerPoll()` to GitHubPollingService (no-op if isPolling)
- Create github-poll.handler.ts with self-scheduling and dedup logic
- Enqueue next poll only when no pending github.poll job exists
- Finally block ensures scheduling chain survives triggerPoll errors
- Unit tests cover: triggerPoll call, self-scheduling, dedup, error recovery
