### PR TITLE
test: verify eager stale job reclamation on processor restart

### DIFF
--- a/packages/daemon/tests/unit/storage/job-queue-processor.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-processor.test.ts
@@ -313,60 +313,6 @@ describe('JobQueueProcessor', () => {
 		});
 	});
 
-	describe('eager stale reclamation on start()', () => {
-		it('reclaims stale processing jobs immediately when start() is called', async () => {
-			const eagerProcessor = new JobQueueProcessor(repo, {
-				staleThresholdMs: 1000,
-				pollIntervalMs: 5000, // long interval so the interval tick doesn't interfere
-			});
-			eagerProcessor.register('eager-queue', async () => {});
-
-			// Enqueue and dequeue manually to create a "processing" job
-			const job = repo.enqueue({ queue: 'eager-queue', payload: {} });
-			repo.dequeue('eager-queue', 1);
-
-			// Confirm it's processing
-			expect(repo.getJob(job.id)?.status).toBe('processing');
-
-			// Make it stale (started 10s ago, threshold is 1s)
-			db.prepare(`UPDATE job_queue SET started_at = ? WHERE id = ?`).run(
-				Date.now() - 10_000,
-				job.id
-			);
-
-			// start() should eagerly reclaim before the first tick
-			eagerProcessor.start();
-			// Give the immediate tick time to process the reclaimed job
-			await flush();
-			await eagerProcessor.stop();
-
-			const after = repo.getJob(job.id);
-			expect(after?.status).toBe('completed');
-		});
-
-		it('does not wait for STALE_CHECK_INTERVAL before first reclamation', async () => {
-			// Create a spy on reclaimStale to verify it's called during start()
-			let reclaimCallCount = 0;
-			const originalReclaim = repo.reclaimStale.bind(repo);
-			repo.reclaimStale = (staleBefore: number) => {
-				reclaimCallCount++;
-				return originalReclaim(staleBefore);
-			};
-
-			const eagerProcessor = new JobQueueProcessor(repo, {
-				staleThresholdMs: 1000,
-				pollIntervalMs: 5000,
-			});
-			eagerProcessor.register('spy-queue', async () => {});
-
-			eagerProcessor.start();
-			await eagerProcessor.stop();
-
-			// reclaimStale should have been called during start() (before any tick interval)
-			expect(reclaimCallCount).toBeGreaterThanOrEqual(1);
-		});
-	});
-
 	describe('start / stop', () => {
 		it('start() begins polling and processes enqueued jobs', async () => {
 			const shortProcessor = new JobQueueProcessor(repo, { pollIntervalMs: 50 });

--- a/packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for stale job reclamation on daemon restart.
+ *
+ * Focuses on the eager reclaimStale() call added in Task 1.2 to `JobQueueProcessor.start()`.
+ * This ensures that jobs stuck in `processing` due to a crash are reclaimed IMMEDIATELY
+ * on restart — not after the 60-second STALE_CHECK_INTERVAL delay.
+ *
+ * The "restart" is simulated by:
+ *   1. Using one processor instance to dequeue a job (marking it `processing`).
+ *   2. Abandoning that processor without calling stop() — simulating a crash.
+ *   3. Creating a SECOND processor on the same DB and calling start() on it.
+ *   4. Asserting the stale job is reclaimed and re-processed within the first tick.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { JobQueueProcessor } from '../../../src/storage/job-queue-processor';
+
+const DB_SCHEMA = `
+	CREATE TABLE IF NOT EXISTS job_queue (
+		id TEXT PRIMARY KEY,
+		queue TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'pending'
+			CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+		payload TEXT NOT NULL DEFAULT '{}',
+		result TEXT,
+		error TEXT,
+		priority INTEGER NOT NULL DEFAULT 0,
+		max_retries INTEGER NOT NULL DEFAULT 3,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		run_at INTEGER NOT NULL,
+		created_at INTEGER NOT NULL,
+		started_at INTEGER,
+		completed_at INTEGER
+	);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status);
+`;
+
+/** Wait for async microtasks/macrotasks to settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+describe('Stale job reclamation on restart (eager reclaim)', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	// Processor created in tests — each test is responsible for stopping it.
+	let restartedProcessor: JobQueueProcessor | null = null;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(DB_SCHEMA);
+		repo = new JobQueueRepository(db as any);
+		restartedProcessor = null;
+	});
+
+	afterEach(async () => {
+		if (restartedProcessor !== null) {
+			await restartedProcessor.stop();
+		}
+		db.close();
+	});
+
+	it('reclaims a stale processing job immediately on start() without waiting 60 s', async () => {
+		// --- Phase 1: simulate a "crashed" processor that left a job in processing ---
+		const crashedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 1_000,
+			pollIntervalMs: 60_000, // large — won't tick during test
+		});
+		crashedProcessor.register('work-queue', async () => {});
+
+		const job = repo.enqueue({ queue: 'work-queue', payload: { task: 'doSomething' } });
+		// Dequeue manually to mark it processing (simulates the crashed processor picking it up)
+		repo.dequeue('work-queue', 1);
+		expect(repo.getJob(job.id)?.status).toBe('processing');
+
+		// Backdate started_at so the job is beyond the stale threshold (started 10 s ago)
+		db.prepare('UPDATE job_queue SET started_at = ? WHERE id = ?').run(Date.now() - 10_000, job.id);
+
+		// "Crash" — we simply do NOT call crashedProcessor.stop() and discard it.
+
+		// --- Phase 2: daemon restarts, creates a fresh processor on the same DB ---
+		const processed: string[] = [];
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 1_000,
+			pollIntervalMs: 60_000, // large — ensures reclamation comes only from start(), not interval
+		});
+		restartedProcessor.register('work-queue', async (j) => {
+			processed.push(j.id);
+		});
+
+		// start() must eagerly call reclaimStale() before the first interval tick
+		restartedProcessor.start();
+
+		// Give the immediate first tick time to pick up and process the reclaimed job
+		await flush();
+
+		const after = repo.getJob(job.id);
+		expect(after?.status).toBe('completed');
+		expect(processed).toContain(job.id);
+	});
+
+	it('calls reclaimStale() synchronously during start() before any tick interval fires', async () => {
+		let reclaimCallCount = 0;
+		const originalReclaim = repo.reclaimStale.bind(repo);
+		repo.reclaimStale = (staleBefore: number) => {
+			reclaimCallCount++;
+			return originalReclaim(staleBefore);
+		};
+
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 1_000,
+			pollIntervalMs: 60_000,
+		});
+		restartedProcessor.register('spy-queue', async () => {});
+
+		// reclaimStale must be called synchronously inside start(), before any async work
+		restartedProcessor.start();
+
+		// Immediately after start() — before awaiting — the count must already be 1
+		expect(reclaimCallCount).toBeGreaterThanOrEqual(1);
+
+		await restartedProcessor.stop();
+		restartedProcessor = null;
+	});
+
+	it('reclaimed job is re-processed by the registered handler', async () => {
+		// Simulate crash: leave a stale processing job in the DB
+		const job = repo.enqueue({ queue: 'crash-queue', payload: { value: 42 } });
+		repo.dequeue('crash-queue', 1);
+		db.prepare('UPDATE job_queue SET started_at = ? WHERE id = ?').run(Date.now() - 30_000, job.id);
+		expect(repo.getJob(job.id)?.status).toBe('processing');
+
+		// Restart: new processor registers a handler that records the received job
+		let receivedPayload: Record<string, unknown> | null = null;
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 5_000,
+			pollIntervalMs: 60_000,
+		});
+		restartedProcessor.register('crash-queue', async (j) => {
+			receivedPayload = j.payload;
+		});
+
+		restartedProcessor.start();
+		await flush();
+
+		expect(repo.getJob(job.id)?.status).toBe('completed');
+		expect(receivedPayload).toEqual({ value: 42 });
+	});
+
+	it('does NOT reclaim a recently-started processing job (still within threshold)', async () => {
+		// Enqueue and dequeue to mark as processing — started_at will be ~now
+		const job = repo.enqueue({ queue: 'fresh-queue', payload: {} });
+		repo.dequeue('fresh-queue', 1);
+		expect(repo.getJob(job.id)?.status).toBe('processing');
+
+		// 60-second threshold — a job started moments ago is NOT stale
+		const processed: string[] = [];
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 60_000,
+			pollIntervalMs: 60_000,
+		});
+		restartedProcessor.register('fresh-queue', async (j) => {
+			processed.push(j.id);
+		});
+
+		restartedProcessor.start();
+		await flush();
+
+		// Job should remain processing — it was not reclaimed
+		const after = repo.getJob(job.id);
+		expect(after?.status).toBe('processing');
+		expect(processed).not.toContain(job.id);
+	});
+
+	it('reclaims multiple stale jobs from different queues on startup', async () => {
+		// Simulate crash leaving stale jobs across two queues
+		const jobA = repo.enqueue({ queue: 'queue-a', payload: { seq: 1 } });
+		const jobB = repo.enqueue({ queue: 'queue-b', payload: { seq: 2 } });
+		repo.dequeue('queue-a', 1);
+		repo.dequeue('queue-b', 1);
+
+		const pastTime = Date.now() - 20_000;
+		db.prepare('UPDATE job_queue SET started_at = ? WHERE id IN (?, ?)').run(
+			pastTime,
+			jobA.id,
+			jobB.id
+		);
+
+		const processedQueues: string[] = [];
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 5_000,
+			maxConcurrent: 10,
+			pollIntervalMs: 60_000,
+		});
+		restartedProcessor.register('queue-a', async (j) => {
+			processedQueues.push(j.queue);
+		});
+		restartedProcessor.register('queue-b', async (j) => {
+			processedQueues.push(j.queue);
+		});
+
+		restartedProcessor.start();
+		await flush();
+
+		expect(repo.getJob(jobA.id)?.status).toBe('completed');
+		expect(repo.getJob(jobB.id)?.status).toBe('completed');
+		expect(processedQueues).toContain('queue-a');
+		expect(processedQueues).toContain('queue-b');
+	});
+
+	it('does not interfere with a pending job that was never picked up', async () => {
+		// Enqueue the stale job first so dequeue picks it up (dequeue orders by run_at ASC)
+		const stale = repo.enqueue({ queue: 'mixed-queue', payload: { type: 'stale' } });
+		repo.dequeue('mixed-queue', 1); // marks stale job as processing
+		db.prepare('UPDATE job_queue SET started_at = ? WHERE id = ?').run(
+			Date.now() - 15_000,
+			stale.id
+		);
+		expect(repo.getJob(stale.id)?.status).toBe('processing');
+
+		// Pending job — enqueued after, never dequeued, still pending
+		const pending = repo.enqueue({ queue: 'mixed-queue', payload: { type: 'new' } });
+		expect(repo.getJob(pending.id)?.status).toBe('pending');
+
+		const processedTypes: string[] = [];
+		restartedProcessor = new JobQueueProcessor(repo, {
+			staleThresholdMs: 5_000,
+			maxConcurrent: 10,
+			pollIntervalMs: 60_000,
+		});
+		restartedProcessor.register('mixed-queue', async (j) => {
+			processedTypes.push((j.payload as { type: string }).type);
+		});
+
+		restartedProcessor.start();
+		await flush();
+
+		// Both should be completed — stale reclaimed + pending picked up normally
+		expect(repo.getJob(stale.id)?.status).toBe('completed');
+		expect(repo.getJob(pending.id)?.status).toBe('completed');
+		expect(processedTypes).toContain('stale');
+		expect(processedTypes).toContain('new');
+	});
+});

--- a/packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-stale-reclamation.test.ts
@@ -5,11 +5,10 @@
  * This ensures that jobs stuck in `processing` due to a crash are reclaimed IMMEDIATELY
  * on restart — not after the 60-second STALE_CHECK_INTERVAL delay.
  *
- * The "restart" is simulated by:
- *   1. Using one processor instance to dequeue a job (marking it `processing`).
- *   2. Abandoning that processor without calling stop() — simulating a crash.
- *   3. Creating a SECOND processor on the same DB and calling start() on it.
- *   4. Asserting the stale job is reclaimed and re-processed within the first tick.
+ * The "crash" is simulated by directly manipulating the DB to leave a row in `processing`
+ * state with a backdated `started_at`, then creating a fresh processor and calling start().
+ * This covers the restart scenario more clearly than the general processor tests in
+ * job-queue-processor.test.ts (which test the same processor before and after start()).
  */
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
@@ -62,24 +61,16 @@ describe('Stale job reclamation on restart (eager reclaim)', () => {
 	});
 
 	it('reclaims a stale processing job immediately on start() without waiting 60 s', async () => {
-		// --- Phase 1: simulate a "crashed" processor that left a job in processing ---
-		const crashedProcessor = new JobQueueProcessor(repo, {
-			staleThresholdMs: 1_000,
-			pollIntervalMs: 60_000, // large — won't tick during test
-		});
-		crashedProcessor.register('work-queue', async () => {});
-
+		// Simulate a crash: enqueue a job, dequeue it (marks it processing), then backdate
+		// started_at to beyond the stale threshold — as if the previous process died mid-job.
 		const job = repo.enqueue({ queue: 'work-queue', payload: { task: 'doSomething' } });
-		// Dequeue manually to mark it processing (simulates the crashed processor picking it up)
 		repo.dequeue('work-queue', 1);
 		expect(repo.getJob(job.id)?.status).toBe('processing');
 
 		// Backdate started_at so the job is beyond the stale threshold (started 10 s ago)
 		db.prepare('UPDATE job_queue SET started_at = ? WHERE id = ?').run(Date.now() - 10_000, job.id);
 
-		// "Crash" — we simply do NOT call crashedProcessor.stop() and discard it.
-
-		// --- Phase 2: daemon restarts, creates a fresh processor on the same DB ---
+		// Daemon restarts — creates a fresh processor on the same DB
 		const processed: string[] = [];
 		restartedProcessor = new JobQueueProcessor(repo, {
 			staleThresholdMs: 1_000,


### PR DESCRIPTION
Add dedicated test suite covering the crash-and-restart scenario for
JobQueueProcessor. Tests verify that stale processing jobs (left by a
crashed processor) are reclaimed immediately when a new processor starts
via the eager reclaimStale() call in start(), not after the 60s interval.

Scenarios covered:
- Stale job reclaimed and re-processed immediately on start()
- reclaimStale() called synchronously inside start() before any tick
- Reclaimed job receives correct payload from handler
- Non-stale (recently-started) processing jobs are not reclaimed
- Multiple stale jobs from different queues all reclaimed on restart
- Pending jobs coexist correctly with stale reclamation on restart
