### PR TITLE
feat: add room.tick job handler, enqueueRoomTick, and cancelPendingTickJobs

### DIFF
--- a/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
@@ -1,0 +1,72 @@
+import type { Job } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { RoomRuntime } from '../room/runtime/room-runtime';
+import { ROOM_TICK } from '../job-queue-constants';
+
+export const DEFAULT_TICK_INTERVAL_MS = 30_000;
+
+export type GetRuntimeForRoom = (roomId: string) => RoomRuntime | undefined;
+
+/**
+ * Enqueues a room.tick job for a room if no pending tick job already exists for it.
+ * Deduplication is by roomId — only one pending tick per room is allowed.
+ */
+export async function enqueueRoomTick(
+	roomId: string,
+	jobQueue: JobQueueRepository,
+	delayMs: number = DEFAULT_TICK_INTERVAL_MS
+): Promise<void> {
+	const existing = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 100 });
+	const hasPending = existing.some((j) => (j.payload as { roomId?: string }).roomId === roomId);
+	if (hasPending) return;
+
+	jobQueue.enqueue({
+		queue: ROOM_TICK,
+		payload: { roomId },
+		maxRetries: 0,
+		runAt: Date.now() + delayMs,
+	});
+}
+
+/**
+ * Cancels all pending room.tick jobs for a given room.
+ */
+export async function cancelPendingTickJobs(
+	roomId: string,
+	jobQueue: JobQueueRepository
+): Promise<void> {
+	const pending = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 100 });
+	for (const job of pending) {
+		if ((job.payload as { roomId?: string }).roomId === roomId) {
+			jobQueue.deleteJob(job.id);
+		}
+	}
+}
+
+/**
+ * Creates a room.tick job handler bound to a runtime lookup function.
+ */
+export function createRoomTickHandler(
+	getRuntimeForRoom: GetRuntimeForRoom,
+	jobQueue: JobQueueRepository,
+	tickIntervalMs: number = DEFAULT_TICK_INTERVAL_MS
+) {
+	return async function roomTickHandler(job: Job): Promise<Record<string, unknown>> {
+		const { roomId } = job.payload as { roomId: string };
+
+		const runtime = getRuntimeForRoom(roomId);
+		if (!runtime || runtime.getState() !== 'running') {
+			return { skipped: true, reason: 'not running' };
+		}
+
+		try {
+			await runtime.tick();
+		} finally {
+			if (runtime.getState() === 'running') {
+				await enqueueRoomTick(roomId, jobQueue, tickIntervalMs);
+			}
+		}
+
+		return { roomId };
+	};
+}

--- a/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
@@ -1,22 +1,29 @@
-import type { Job } from '../../storage/repositories/job-queue-repository';
-import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { Job, JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { RoomRuntime } from '../room/runtime/room-runtime';
 import { ROOM_TICK } from '../job-queue-constants';
 
 export const DEFAULT_TICK_INTERVAL_MS = 30_000;
 
-export type GetRuntimeForRoom = (roomId: string) => RoomRuntime | undefined;
+/**
+ * Lookup function that returns the RoomRuntime for a given room ID.
+ * Returns null (or undefined) when no runtime exists for the room.
+ * Matches the return type of RoomRuntimeService.getRuntime().
+ */
+export type GetRuntimeForRoom = (roomId: string) => RoomRuntime | null | undefined;
 
 /**
  * Enqueues a room.tick job for a room if no pending tick job already exists for it.
  * Deduplication is by roomId — only one pending tick per room is allowed.
+ *
+ * Uses a high limit (10_000) to safely cover deployments with thousands of rooms
+ * while remaining bounded. At most one pending tick exists per room in steady state.
  */
-export async function enqueueRoomTick(
+export function enqueueRoomTick(
 	roomId: string,
 	jobQueue: JobQueueRepository,
 	delayMs: number = DEFAULT_TICK_INTERVAL_MS
-): Promise<void> {
-	const existing = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 100 });
+): void {
+	const existing = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 10_000 });
 	const hasPending = existing.some((j) => (j.payload as { roomId?: string }).roomId === roomId);
 	if (hasPending) return;
 
@@ -30,12 +37,14 @@ export async function enqueueRoomTick(
 
 /**
  * Cancels all pending room.tick jobs for a given room.
+ *
+ * Note: in-flight (processing) tick jobs are intentionally NOT cancelled here.
+ * If a tick job is mid-flight when pause/stop is called, its finally block will
+ * check runtime.getState() === 'running' before re-scheduling. Since the runtime
+ * is no longer running, it will skip re-enqueuing — the loop self-terminates.
  */
-export async function cancelPendingTickJobs(
-	roomId: string,
-	jobQueue: JobQueueRepository
-): Promise<void> {
-	const pending = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 100 });
+export function cancelPendingTickJobs(roomId: string, jobQueue: JobQueueRepository): void {
+	const pending = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 10_000 });
 	for (const job of pending) {
 		if ((job.payload as { roomId?: string }).roomId === roomId) {
 			jobQueue.deleteJob(job.id);
@@ -63,7 +72,7 @@ export function createRoomTickHandler(
 			await runtime.tick();
 		} finally {
 			if (runtime.getState() === 'running') {
-				await enqueueRoomTick(roomId, jobQueue, tickIntervalMs);
+				enqueueRoomTick(roomId, jobQueue, tickIntervalMs);
 			}
 		}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -48,6 +48,11 @@ export interface RoomRuntimeServiceConfig {
 	getGlobalSettings: () => GlobalSettings;
 	/** Reactive database wrapper for change event emission */
 	reactiveDb: ReactiveDatabase;
+	/**
+	 * When true, the internal setInterval tick in each RoomRuntime is disabled.
+	 * Set this when a job-queue handler drives runtime.tick() to prevent double-firing.
+	 */
+	disableInternalTick?: boolean;
 }
 
 export class RoomRuntimeService {
@@ -423,6 +428,7 @@ export class RoomRuntimeService {
 			getTask: (taskId) => taskManager.getTask(taskId),
 			getGoal: (goalId) => goalManager.getGoal(goalId),
 			getGlobalSettings: this.ctx.getGlobalSettings,
+			disableInternalTick: this.ctx.disableInternalTick,
 		});
 
 		this.runtimes.set(room.id, runtime);

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -123,6 +123,12 @@ export interface RoomRuntimeConfig {
 	/** Tick interval in ms (default: 30000) */
 	tickInterval?: number;
 	/**
+	 * When true, the internal setInterval periodic tick is disabled.
+	 * Use this when an external job-queue drives runtime.tick() to prevent
+	 * double-firing every interval period.
+	 */
+	disableInternalTick?: boolean;
+	/**
 	 * Fetch Worker assistant messages for forwarding to Leader.
 	 * Returns messages after (exclusive) the message with afterMessageId.
 	 * If afterMessageId is null, returns all messages for the session.
@@ -155,6 +161,7 @@ export class RoomRuntime {
 	private tickLocked = false;
 	private tickQueued = false;
 	private tickTimer: ReturnType<typeof setInterval> | null = null;
+	private readonly disableInternalTick: boolean;
 
 	private readonly roomId: string;
 	private room: Room;
@@ -273,6 +280,7 @@ export class RoomRuntime {
 		this.maxConcurrentGroups = config.maxConcurrentGroups ?? DEFAULT_MAX_CONCURRENT_GROUPS;
 		this.maxFeedbackIterations = config.maxFeedbackIterations ?? DEFAULT_MAX_FEEDBACK_ITERATIONS;
 		this.tickInterval = config.tickInterval ?? 30_000;
+		this.disableInternalTick = config.disableInternalTick ?? false;
 		this.getWorkerMessages = config.getWorkerMessages;
 		this.daemonHub = config.daemonHub;
 		this.messageHub = config.messageHub;
@@ -419,7 +427,9 @@ export class RoomRuntime {
 
 	start(): void {
 		this.state = 'running';
-		this.tickTimer = setInterval(() => this.tick(), this.tickInterval);
+		if (!this.disableInternalTick) {
+			this.tickTimer = setInterval(() => this.tick(), this.tickInterval);
+		}
 		this.scheduleTick();
 	}
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -163,7 +163,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomManager,
 		deps.daemonHub,
 		deps.config.workspaceRoot,
-		deps.sessionManager
+		deps.sessionManager,
+		deps.jobQueue
 	);
 
 	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)
@@ -222,7 +223,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomRuntimeService.getAgentSession(sessionId)
 	);
 
-	setupRoomRuntimeHandlers(deps.messageHub, deps.daemonHub, roomRuntimeService);
+	setupRoomRuntimeHandlers(deps.messageHub, deps.daemonHub, roomRuntimeService, deps.jobQueue);
 	setupTaskHandlers(
 		deps.messageHub,
 		roomManager,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,9 +62,10 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { SESSION_TITLE_GENERATION, GITHUB_POLL } from '../job-queue-constants';
+import { SESSION_TITLE_GENERATION, GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
 import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
 import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
+import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -178,9 +179,40 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
 		reactiveDb: deps.reactiveDb,
 	});
-	roomRuntimeService.start().catch((error) => {
-		log.error('Failed to start RoomRuntimeService:', error);
-	});
+	// Register room.tick job handler before starting the service so no tick jobs
+	// fired during recovery are picked up without a handler.
+	deps.jobProcessor.register(
+		ROOM_TICK,
+		createRoomTickHandler(
+			(roomId) => roomRuntimeService.getRuntime(roomId) ?? undefined,
+			deps.jobQueue
+		)
+	);
+
+	// Seed an initial room.tick job for every room after startup, and for each
+	// newly created room. The handler's finally block keeps the loop going; this
+	// is the only bootstrap call needed.
+	const seedRoomTick = (roomId: string) => enqueueRoomTick(roomId, deps.jobQueue);
+
+	roomRuntimeService
+		.start()
+		.then(() => {
+			for (const room of roomManager.listRooms()) {
+				seedRoomTick(room.id);
+			}
+		})
+		.catch((error) => {
+			log.error('Failed to start RoomRuntimeService:', error);
+		});
+
+	// Seed a tick for rooms created after startup.
+	const unsubRoomCreated = deps.daemonHub.on(
+		'room.created',
+		(event) => {
+			seedRoomTick(event.room.id);
+		},
+		{ sessionId: 'global' }
+	);
 
 	// Wire question handlers now that roomRuntimeService is available.
 	// Pass its session lookup so question.respond reaches the correct live AgentSession
@@ -408,6 +440,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Return result with cleanup function and exposed services
 	return {
 		cleanup: () => {
+			unsubRoomCreated();
 			roomRuntimeService.stop();
 			spaceRuntimeService.stop();
 		},

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -179,6 +179,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultModel: deps.config.defaultModel,
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
 		reactiveDb: deps.reactiveDb,
+		// Disable the internal setInterval tick — the job-queue handler drives runtime.tick() instead.
+		disableInternalTick: true,
 	});
 	// Register room.tick job handler before starting the service so no tick jobs
 	// fired during recovery are picked up without a handler.

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -18,9 +18,11 @@ import type { DaemonHub } from '../daemon-hub';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import type { SessionManager } from '../session-manager';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import { getCliAgents, refresh as refreshCliAgents } from '../room/agents/cli-agent-registry';
 import { inferProviderForModel } from '../providers/registry';
 import { Logger } from '../logger';
+import { cancelPendingTickJobs, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 
 const log = new Logger('room-handlers');
 
@@ -29,7 +31,8 @@ export function setupRoomHandlers(
 	roomManager: RoomManager,
 	daemonHub: DaemonHub,
 	workspaceRoot?: string,
-	sessionManager?: SessionManager
+	sessionManager?: SessionManager,
+	jobQueue?: JobQueueRepository
 ): void {
 	// room.create - Create a new room
 	messageHub.onRequest('room.create', async (data) => {
@@ -240,6 +243,12 @@ export function setupRoomHandlers(
 			throw new Error(`Failed to delete room: ${params.roomId}`);
 		}
 
+		// Cancel any pending tick jobs for the deleted room to avoid DB noise.
+		// (In-flight ticks will self-terminate: handler returns {skipped} when no runtime found.)
+		if (jobQueue) {
+			cancelPendingTickJobs(params.roomId, jobQueue);
+		}
+
 		return { success: true };
 	});
 
@@ -277,7 +286,8 @@ export function setupRoomHandlers(
 export function setupRoomRuntimeHandlers(
 	messageHub: MessageHub,
 	daemonHub: DaemonHub,
-	roomRuntimeService: RoomRuntimeService
+	roomRuntimeService: RoomRuntimeService,
+	jobQueue?: JobQueueRepository
 ): void {
 	// room.runtime.state - Get runtime state for a room
 	messageHub.onRequest('room.runtime.state', async (data) => {
@@ -357,6 +367,10 @@ export function setupRoomRuntimeHandlers(
 				state: 'running',
 			})
 			.catch(() => {});
+		// Re-seed the tick loop — it self-terminated when the runtime was stopped.
+		if (jobQueue) {
+			enqueueRoomTick(params.roomId, jobQueue);
+		}
 		return { success: true, state: 'running' };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -335,6 +335,11 @@ export function setupRoomRuntimeHandlers(
 				state: 'running',
 			})
 			.catch(() => {});
+		// Re-seed the tick loop — it self-terminated when the runtime was paused.
+		// enqueueRoomTick dedup ensures this is safe even if a pending tick still exists.
+		if (jobQueue) {
+			enqueueRoomTick(params.roomId, jobQueue);
+		}
 		return { success: true, state: 'running' };
 	});
 

--- a/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/room-handlers.ts
@@ -356,6 +356,10 @@ export function setupRoomRuntimeHandlers(
 				state: 'stopped',
 			})
 			.catch(() => {});
+		// Cancel pending tick jobs to avoid unnecessary DB churn after stop.
+		if (jobQueue) {
+			cancelPendingTickJobs(params.roomId, jobQueue);
+		}
 		return { success: true, state: 'stopped' };
 	});
 

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -188,6 +188,11 @@ export class JobQueueRepository {
 		return result.changes;
 	}
 
+	deleteJob(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM job_queue WHERE id = ?`).run(id);
+		return result.changes > 0;
+	}
+
 	reclaimStale(staleBefore: number): number {
 		const result = this.db
 			.prepare(

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -197,6 +197,49 @@ describe('enqueueRoomTick', () => {
 	});
 });
 
+describe('pause→resume tick loop re-seed', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(CREATE_TABLE_SQL);
+		repo = new JobQueueRepository(db as any);
+	});
+
+	it('tick firing during pause leaves no pending jobs; re-seeding via enqueueRoomTick restores the loop', () => {
+		// Step 1: tick fires while runtime is paused — no re-enqueue happens
+		const pausedRuntime = makeRuntime('paused');
+		const handler = createRoomTickHandler(() => pausedRuntime, repo, 1000);
+		const job = makeJob('room-pause-resume');
+
+		// Fire tick while paused (simulates the pending job firing after pause was called)
+		return handler(job).then((result) => {
+			expect(result).toEqual({ skipped: true, reason: 'not running' });
+			// Loop is dead: no pending tick jobs
+			const afterPause = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+			expect(afterPause).toHaveLength(0);
+
+			// Step 2: resume handler calls enqueueRoomTick to re-seed
+			enqueueRoomTick('room-pause-resume', repo, 1000);
+
+			// Loop is alive again: one pending tick job exists
+			const afterResume = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+			expect(afterResume).toHaveLength(1);
+			expect((afterResume[0].payload as any).roomId).toBe('room-pause-resume');
+		});
+	});
+
+	it('enqueueRoomTick after resume is a no-op when a pending tick already exists (dedup guard)', () => {
+		// Pending tick already exists (e.g., resume called before the pending tick fired)
+		enqueueRoomTick('room-dedup-resume', repo, 1000);
+		// Simulates what room.runtime.resume calls
+		enqueueRoomTick('room-dedup-resume', repo, 1000);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(1);
+	});
+});
+
 describe('cancelPendingTickJobs', () => {
 	let db: Database;
 	let repo: JobQueueRepository;

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -207,27 +207,26 @@ describe('pause→resume tick loop re-seed', () => {
 		repo = new JobQueueRepository(db as any);
 	});
 
-	it('tick firing during pause leaves no pending jobs; re-seeding via enqueueRoomTick restores the loop', () => {
+	it('tick firing during pause leaves no pending jobs; re-seeding via enqueueRoomTick restores the loop', async () => {
 		// Step 1: tick fires while runtime is paused — no re-enqueue happens
 		const pausedRuntime = makeRuntime('paused');
 		const handler = createRoomTickHandler(() => pausedRuntime, repo, 1000);
 		const job = makeJob('room-pause-resume');
 
 		// Fire tick while paused (simulates the pending job firing after pause was called)
-		return handler(job).then((result) => {
-			expect(result).toEqual({ skipped: true, reason: 'not running' });
-			// Loop is dead: no pending tick jobs
-			const afterPause = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
-			expect(afterPause).toHaveLength(0);
+		const result = await handler(job);
+		expect(result).toEqual({ skipped: true, reason: 'not running' });
+		// Loop is dead: no pending tick jobs
+		const afterPause = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(afterPause).toHaveLength(0);
 
-			// Step 2: resume handler calls enqueueRoomTick to re-seed
-			enqueueRoomTick('room-pause-resume', repo, 1000);
+		// Step 2: resume handler calls enqueueRoomTick to re-seed
+		enqueueRoomTick('room-pause-resume', repo, 1000);
 
-			// Loop is alive again: one pending tick job exists
-			const afterResume = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
-			expect(afterResume).toHaveLength(1);
-			expect((afterResume[0].payload as any).roomId).toBe('room-pause-resume');
-		});
+		// Loop is alive again: one pending tick job exists
+		const afterResume = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(afterResume).toHaveLength(1);
+		expect((afterResume[0].payload as any).roomId).toBe('room-pause-resume');
 	});
 
 	it('enqueueRoomTick after resume is a no-op when a pending tick already exists (dedup guard)', () => {

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import {
+	createRoomTickHandler,
+	enqueueRoomTick,
+	cancelPendingTickJobs,
+	DEFAULT_TICK_INTERVAL_MS,
+} from '../../../src/lib/job-handlers/room-tick.handler';
+import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
+
+/** Build a minimal Job object without touching the DB — simulates a dequeued (processing) job */
+function makeJob(roomId: string): Job {
+	return {
+		id: `test-job-${roomId}`,
+		queue: ROOM_TICK,
+		status: 'processing',
+		payload: { roomId },
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 0,
+		retryCount: 0,
+		runAt: Date.now(),
+		createdAt: Date.now(),
+		startedAt: Date.now(),
+		completedAt: null,
+	};
+}
+
+const CREATE_TABLE_SQL = `
+	CREATE TABLE IF NOT EXISTS job_queue (
+		id TEXT PRIMARY KEY,
+		queue TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'pending'
+			CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+		payload TEXT NOT NULL DEFAULT '{}',
+		result TEXT,
+		error TEXT,
+		priority INTEGER NOT NULL DEFAULT 0,
+		max_retries INTEGER NOT NULL DEFAULT 3,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		run_at INTEGER NOT NULL,
+		created_at INTEGER NOT NULL,
+		started_at INTEGER,
+		completed_at INTEGER
+	);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status);
+`;
+
+function makeRuntime(state: 'running' | 'paused' | 'stopped', tickFn?: () => Promise<void>) {
+	return {
+		getState: () => state,
+		tick: tickFn ?? (async () => {}),
+	};
+}
+
+describe('createRoomTickHandler', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(CREATE_TABLE_SQL);
+		repo = new JobQueueRepository(db as any);
+	});
+
+	it('calls tick and re-schedules when runtime is running', async () => {
+		let tickCalled = false;
+		const runtime = makeRuntime('running', async () => {
+			tickCalled = true;
+		});
+		const handler = createRoomTickHandler(() => runtime, repo, 1000);
+
+		const job = makeJob('room-1');
+		await handler(job);
+
+		expect(tickCalled).toBe(true);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending.some((j) => (j.payload as any).roomId === 'room-1')).toBe(true);
+	});
+
+	it('skips and does NOT re-schedule when runtime not found', async () => {
+		const handler = createRoomTickHandler(() => undefined, repo, 1000);
+		const job = makeJob('room-2');
+
+		const result = await handler(job);
+
+		expect(result).toEqual({ skipped: true, reason: 'not running' });
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+
+	it('skips and does NOT re-schedule when runtime is paused', async () => {
+		const runtime = makeRuntime('paused');
+		const handler = createRoomTickHandler(() => runtime, repo, 1000);
+		const job = makeJob('room-3');
+
+		const result = await handler(job);
+
+		expect(result).toEqual({ skipped: true, reason: 'not running' });
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+
+	it('re-schedules after error in tick() if runtime still running', async () => {
+		let callCount = 0;
+		const runtimeState = { state: 'running' as 'running' | 'paused' | 'stopped' };
+		const runtime = {
+			getState: () => runtimeState.state,
+			tick: async () => {
+				callCount++;
+				throw new Error('tick failed');
+			},
+		};
+
+		const handler = createRoomTickHandler(() => runtime, repo, 1000);
+		const job = makeJob('room-4');
+
+		await expect(handler(job)).rejects.toThrow('tick failed');
+		expect(callCount).toBe(1);
+
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending.some((j) => (j.payload as any).roomId === 'room-4')).toBe(true);
+	});
+
+	it('does NOT re-schedule after error in tick() when runtime becomes paused', async () => {
+		const runtimeState = { state: 'running' as 'running' | 'paused' | 'stopped' };
+		const runtime = {
+			getState: () => runtimeState.state,
+			tick: async () => {
+				runtimeState.state = 'paused';
+				throw new Error('tick failed, now paused');
+			},
+		};
+
+		const handler = createRoomTickHandler(() => runtime, repo, 1000);
+		const job = makeJob('room-5');
+
+		await expect(handler(job)).rejects.toThrow();
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+});
+
+describe('enqueueRoomTick', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(CREATE_TABLE_SQL);
+		repo = new JobQueueRepository(db as any);
+	});
+
+	it('enqueues a pending tick job', async () => {
+		await enqueueRoomTick('room-a', repo, 1000);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(1);
+		expect((pending[0].payload as any).roomId).toBe('room-a');
+	});
+
+	it('deduplicates: second enqueue with existing pending job is a no-op', async () => {
+		await enqueueRoomTick('room-a', repo, 1000);
+		await enqueueRoomTick('room-a', repo, 1000);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(1);
+	});
+
+	it('allows enqueueing for different rooms independently', async () => {
+		await enqueueRoomTick('room-a', repo, 1000);
+		await enqueueRoomTick('room-b', repo, 1000);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(2);
+	});
+
+	it('uses default delay when not specified', async () => {
+		const before = Date.now();
+		await enqueueRoomTick('room-x', repo);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(1);
+		expect(pending[0].runAt).toBeGreaterThanOrEqual(before + DEFAULT_TICK_INTERVAL_MS - 100);
+	});
+});
+
+describe('cancelPendingTickJobs', () => {
+	let db: Database;
+	let repo: JobQueueRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		db.exec(CREATE_TABLE_SQL);
+		repo = new JobQueueRepository(db as any);
+	});
+
+	it('removes all pending tick jobs for a room', async () => {
+		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
+		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
+		await cancelPendingTickJobs('room-z', repo);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+
+	it('only removes jobs for the specified room, not others', async () => {
+		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
+		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-other' } });
+		await cancelPendingTickJobs('room-z', repo);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(1);
+		expect((pending[0].payload as any).roomId).toBe('room-other');
+	});
+
+	it('is a no-op when no pending jobs exist', async () => {
+		await cancelPendingTickJobs('room-none', repo);
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -10,25 +10,6 @@ import {
 } from '../../../src/lib/job-handlers/room-tick.handler';
 import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
 
-/** Build a minimal Job object without touching the DB — simulates a dequeued (processing) job */
-function makeJob(roomId: string): Job {
-	return {
-		id: `test-job-${roomId}`,
-		queue: ROOM_TICK,
-		status: 'processing',
-		payload: { roomId },
-		result: null,
-		error: null,
-		priority: 0,
-		maxRetries: 0,
-		retryCount: 0,
-		runAt: Date.now(),
-		createdAt: Date.now(),
-		startedAt: Date.now(),
-		completedAt: null,
-	};
-}
-
 const CREATE_TABLE_SQL = `
 	CREATE TABLE IF NOT EXISTS job_queue (
 		id TEXT PRIMARY KEY,
@@ -54,6 +35,25 @@ function makeRuntime(state: 'running' | 'paused' | 'stopped', tickFn?: () => Pro
 	return {
 		getState: () => state,
 		tick: tickFn ?? (async () => {}),
+	};
+}
+
+/** Build a minimal Job object without touching the DB — simulates a dequeued (processing) job */
+function makeJob(roomId: string): Job {
+	return {
+		id: `test-job-${roomId}`,
+		queue: ROOM_TICK,
+		status: 'processing',
+		payload: { roomId },
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 0,
+		retryCount: 0,
+		runAt: Date.now(),
+		createdAt: Date.now(),
+		startedAt: Date.now(),
+		completedAt: null,
 	};
 }
 
@@ -97,6 +97,18 @@ describe('createRoomTickHandler', () => {
 		const runtime = makeRuntime('paused');
 		const handler = createRoomTickHandler(() => runtime, repo, 1000);
 		const job = makeJob('room-3');
+
+		const result = await handler(job);
+
+		expect(result).toEqual({ skipped: true, reason: 'not running' });
+		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
+	});
+
+	it('skips and does NOT re-schedule when runtime is stopped', async () => {
+		const runtime = makeRuntime('stopped');
+		const handler = createRoomTickHandler(() => runtime, repo, 1000);
+		const job = makeJob('room-stopped');
 
 		const result = await handler(job);
 
@@ -155,30 +167,30 @@ describe('enqueueRoomTick', () => {
 		repo = new JobQueueRepository(db as any);
 	});
 
-	it('enqueues a pending tick job', async () => {
-		await enqueueRoomTick('room-a', repo, 1000);
+	it('enqueues a pending tick job', () => {
+		enqueueRoomTick('room-a', repo, 1000);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(1);
 		expect((pending[0].payload as any).roomId).toBe('room-a');
 	});
 
-	it('deduplicates: second enqueue with existing pending job is a no-op', async () => {
-		await enqueueRoomTick('room-a', repo, 1000);
-		await enqueueRoomTick('room-a', repo, 1000);
+	it('deduplicates: second enqueue with existing pending job is a no-op', () => {
+		enqueueRoomTick('room-a', repo, 1000);
+		enqueueRoomTick('room-a', repo, 1000);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(1);
 	});
 
-	it('allows enqueueing for different rooms independently', async () => {
-		await enqueueRoomTick('room-a', repo, 1000);
-		await enqueueRoomTick('room-b', repo, 1000);
+	it('allows enqueueing for different rooms independently', () => {
+		enqueueRoomTick('room-a', repo, 1000);
+		enqueueRoomTick('room-b', repo, 1000);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(2);
 	});
 
-	it('uses default delay when not specified', async () => {
+	it('uses default delay when not specified', () => {
 		const before = Date.now();
-		await enqueueRoomTick('room-x', repo);
+		enqueueRoomTick('room-x', repo);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(1);
 		expect(pending[0].runAt).toBeGreaterThanOrEqual(before + DEFAULT_TICK_INTERVAL_MS - 100);
@@ -195,26 +207,39 @@ describe('cancelPendingTickJobs', () => {
 		repo = new JobQueueRepository(db as any);
 	});
 
-	it('removes all pending tick jobs for a room', async () => {
+	it('removes all pending tick jobs for a room', () => {
 		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
 		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
-		await cancelPendingTickJobs('room-z', repo);
+		cancelPendingTickJobs('room-z', repo);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(0);
 	});
 
-	it('only removes jobs for the specified room, not others', async () => {
+	it('only removes jobs for the specified room, not others', () => {
 		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-z' } });
 		repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-other' } });
-		await cancelPendingTickJobs('room-z', repo);
+		cancelPendingTickJobs('room-z', repo);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(1);
 		expect((pending[0].payload as any).roomId).toBe('room-other');
 	});
 
-	it('is a no-op when no pending jobs exist', async () => {
-		await cancelPendingTickJobs('room-none', repo);
+	it('is a no-op when no pending jobs exist', () => {
+		cancelPendingTickJobs('room-none', repo);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(0);
+	});
+
+	it('does not cancel in-flight (processing) tick jobs — they self-terminate via finally block', () => {
+		// Simulate an in-flight tick: status is processing, not pending
+		const job = repo.enqueue({ queue: ROOM_TICK, payload: { roomId: 'room-inflight' } });
+		// Move to processing state
+		repo.dequeue(ROOM_TICK, 1);
+
+		cancelPendingTickJobs('room-inflight', repo);
+
+		// The processing job is still there (not cancelled)
+		const processing = repo.listJobs({ queue: ROOM_TICK, status: ['processing'] });
+		expect(processing.some((j) => j.id === job.id)).toBe(true);
 	});
 });

--- a/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
@@ -636,4 +636,30 @@ describe('JobQueueRepository', () => {
 			expect(reclaimed).toBe(4);
 		});
 	});
+
+	describe('deleteJob', () => {
+		it('returns true and removes the job when it exists', () => {
+			const job = repository.enqueue({ queue: 'test', payload: {} });
+			const deleted = repository.deleteJob(job.id);
+			expect(deleted).toBe(true);
+			expect(repository.getJob(job.id)).toBeNull();
+		});
+
+		it('returns false when the job ID does not exist', () => {
+			const deleted = repository.deleteJob('non-existent-id');
+			expect(deleted).toBe(false);
+		});
+
+		it('deletes exactly one row and leaves others untouched', () => {
+			const job1 = repository.enqueue({ queue: 'test', payload: { n: 1 } });
+			const job2 = repository.enqueue({ queue: 'test', payload: { n: 2 } });
+			const job3 = repository.enqueue({ queue: 'test', payload: { n: 3 } });
+
+			repository.deleteJob(job2.id);
+
+			expect(repository.getJob(job1.id)).not.toBeNull();
+			expect(repository.getJob(job2.id)).toBeNull();
+			expect(repository.getJob(job3.id)).not.toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
- Add `deleteJob(id)` to JobQueueRepository (simple DELETE by id)
- Create `packages/daemon/src/lib/job-handlers/room-tick.handler.ts`:
  - `createRoomTickHandler`: calls runtime.tick() and re-schedules in
    finally block only if runtime.state === 'running'; skips entirely
    when runtime not found or not running
  - `enqueueRoomTick`: dedup-aware enqueue — no-ops if any pending
    room.tick job exists for the given roomId
  - `cancelPendingTickJobs`: deletes all pending room.tick jobs for a room
- Add unit tests covering: tick+reschedule, skip-when-not-found,
  skip-when-paused, error-still-reschedules, dedup no-op, cancel
