### PR TITLE
feat: add job_queue.cleanup handler and wire into daemon startup

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -22,6 +22,8 @@ import type { SpaceRuntimeService } from './lib/space/runtime/space-runtime-serv
 import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
+import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
+import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -360,6 +362,21 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	if (gitHubService) {
 		gitHubService.start();
 		logInfo('[Daemon] GitHub service started');
+	}
+
+	// Register job handlers BEFORE starting the processor so no pending job
+	// from a previous run is dequeued without a handler available.
+	jobProcessor.register(JOB_QUEUE_CLEANUP, createCleanupHandler(jobQueue));
+
+	// Enqueue the initial cleanup job if none is already pending.
+	const pendingCleanup = jobQueue.listJobs({
+		queue: JOB_QUEUE_CLEANUP,
+		status: 'pending',
+		limit: 1,
+	});
+	if (pendingCleanup.length === 0) {
+		jobQueue.enqueue({ queue: JOB_QUEUE_CLEANUP, payload: {}, runAt: Date.now() });
+		logInfo('[Daemon] Enqueued initial job_queue.cleanup job');
 	}
 
 	// Start job queue processor last (after all handler registrations)

--- a/packages/daemon/src/lib/job-handlers/cleanup.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/cleanup.handler.ts
@@ -1,0 +1,21 @@
+import type { Job, JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import { JOB_QUEUE_CLEANUP } from '../job-queue-constants';
+
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const NEXT_RUN_DELAY_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export function createCleanupHandler(jobQueue: JobQueueRepository) {
+	return async (_job: Job): Promise<{ deletedJobs: number; nextRunAt: number }> => {
+		const deletedJobs = jobQueue.cleanup(Date.now() - DEFAULT_MAX_AGE_MS);
+
+		const nextRunAt = Date.now() + NEXT_RUN_DELAY_MS;
+
+		// Self-schedule: only enqueue next cleanup if none is already pending
+		const pending = jobQueue.listJobs({ queue: JOB_QUEUE_CLEANUP, status: 'pending', limit: 1 });
+		if (pending.length === 0) {
+			jobQueue.enqueue({ queue: JOB_QUEUE_CLEANUP, payload: {}, runAt: nextRunAt });
+		}
+
+		return { deletedJobs, nextRunAt };
+	};
+}

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -177,8 +177,13 @@ export class JobQueueRepository {
 	}
 
 	cleanup(beforeMs: number): number {
+		// 'failed' is included defensively: the processor never writes it (retries go back to
+		// 'pending' and exhausted retries become 'dead'), but the type contract allows it and
+		// future code could produce it. Including it prevents indefinite accumulation.
 		const result = this.db
-			.prepare(`DELETE FROM job_queue WHERE status IN ('completed', 'dead') AND completed_at < ?`)
+			.prepare(
+				`DELETE FROM job_queue WHERE status IN ('completed', 'dead', 'failed') AND completed_at < ?`
+			)
 			.run(beforeMs);
 		return result.changes;
 	}

--- a/packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { createCleanupHandler } from '../../../src/lib/job-handlers/cleanup.handler';
+import { JOB_QUEUE_CLEANUP } from '../../../src/lib/job-queue-constants';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+
+function createTestDb(): Database {
+	const db = new Database(':memory:');
+	db.exec(`
+		CREATE TABLE job_queue (
+			id TEXT PRIMARY KEY,
+			queue TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+			payload TEXT NOT NULL DEFAULT '{}',
+			result TEXT,
+			error TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
+			max_retries INTEGER NOT NULL DEFAULT 3,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			run_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER
+		);
+
+		CREATE INDEX idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+		CREATE INDEX idx_job_queue_status ON job_queue(status);
+	`);
+	return db;
+}
+
+/** Fake job fixture used as the argument to the handler */
+const fakeJob: Job = {
+	id: 'fake-job-id',
+	queue: JOB_QUEUE_CLEANUP,
+	status: 'processing',
+	payload: {},
+	result: null,
+	error: null,
+	priority: 0,
+	maxRetries: 3,
+	retryCount: 0,
+	runAt: Date.now(),
+	createdAt: Date.now(),
+	startedAt: Date.now(),
+	completedAt: null,
+};
+
+describe('createCleanupHandler', () => {
+	let db: Database;
+	let jobQueue: JobQueueRepository;
+
+	beforeEach(() => {
+		db = createTestDb();
+		jobQueue = new JobQueueRepository(db as any);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('deletes completed jobs older than 7 days and returns count', async () => {
+		const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+		// Insert an old completed job directly via SQL
+		db.exec(`
+			INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+			VALUES ('old-completed', 'some.queue', 'completed', '{}', 0, 3, 0, ${eightDaysAgo}, ${eightDaysAgo}, ${eightDaysAgo})
+		`);
+
+		// Insert a recent completed job (should NOT be deleted)
+		const recentTime = Date.now() - 60_000; // 1 minute ago
+		db.exec(`
+			INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+			VALUES ('recent-completed', 'some.queue', 'completed', '{}', 0, 3, 0, ${recentTime}, ${recentTime}, ${recentTime})
+		`);
+
+		const handler = createCleanupHandler(jobQueue);
+		const result = await handler(fakeJob);
+
+		expect(result.deletedJobs).toBe(1);
+
+		// Verify only the old job is gone
+		const remaining = jobQueue.listJobs({ limit: 100 });
+		expect(remaining.some((j) => j.id === 'old-completed')).toBe(false);
+		expect(remaining.some((j) => j.id === 'recent-completed')).toBe(true);
+	});
+
+	it('deletes dead jobs older than 7 days', async () => {
+		const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+		db.exec(`
+			INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+			VALUES ('old-dead', 'some.queue', 'dead', '{}', 0, 3, 3, ${eightDaysAgo}, ${eightDaysAgo}, ${eightDaysAgo})
+		`);
+
+		const handler = createCleanupHandler(jobQueue);
+		const result = await handler(fakeJob);
+
+		expect(result.deletedJobs).toBe(1);
+		// Only the next-scheduled pending cleanup job should remain
+		const remaining = jobQueue.listJobs({ limit: 100 });
+		expect(remaining.every((j) => j.status === 'pending' && j.queue === JOB_QUEUE_CLEANUP)).toBe(
+			true
+		);
+	});
+
+	it('self-schedules the next cleanup job ~24 hours from now', async () => {
+		const handler = createCleanupHandler(jobQueue);
+		const before = Date.now();
+		const result = await handler(fakeJob);
+		const after = Date.now();
+
+		const pending = jobQueue.listJobs({ queue: JOB_QUEUE_CLEANUP, status: 'pending', limit: 10 });
+		expect(pending.length).toBe(1);
+
+		const expectedMin = before + 24 * 60 * 60 * 1000;
+		const expectedMax = after + 24 * 60 * 60 * 1000;
+		expect(pending[0].runAt).toBeGreaterThanOrEqual(expectedMin);
+		expect(pending[0].runAt).toBeLessThanOrEqual(expectedMax);
+		expect(result.nextRunAt).toBeGreaterThanOrEqual(expectedMin);
+		expect(result.nextRunAt).toBeLessThanOrEqual(expectedMax);
+	});
+
+	it('does not create duplicate pending cleanup jobs (dedup)', async () => {
+		// Pre-enqueue a pending cleanup job
+		jobQueue.enqueue({ queue: JOB_QUEUE_CLEANUP, payload: {}, runAt: Date.now() + 1000 });
+
+		const handler = createCleanupHandler(jobQueue);
+		await handler(fakeJob);
+
+		const pending = jobQueue.listJobs({ queue: JOB_QUEUE_CLEANUP, status: 'pending', limit: 10 });
+		expect(pending.length).toBe(1); // Still only one — dedup worked
+	});
+
+	it('returns 0 deletedJobs when nothing is old enough', async () => {
+		// Only a recent completed job
+		const recentTime = Date.now() - 60_000;
+		db.exec(`
+			INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+			VALUES ('recent', 'some.queue', 'completed', '{}', 0, 3, 0, ${recentTime}, ${recentTime}, ${recentTime})
+		`);
+
+		const handler = createCleanupHandler(jobQueue);
+		const result = await handler(fakeJob);
+
+		expect(result.deletedJobs).toBe(0);
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/cleanup-handler.test.ts
@@ -135,6 +135,23 @@ describe('createCleanupHandler', () => {
 		expect(pending.length).toBe(1); // Still only one — dedup worked
 	});
 
+	it('deletes failed jobs older than 7 days', async () => {
+		const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+		// 'failed' is a legal status in the type contract; cleanup must prune it
+		// to prevent indefinite accumulation if any code path ever writes it.
+		db.exec(`
+			INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+			VALUES ('old-failed', 'some.queue', 'failed', '{}', 0, 3, 1, ${eightDaysAgo}, ${eightDaysAgo}, ${eightDaysAgo})
+		`);
+
+		const handler = createCleanupHandler(jobQueue);
+		const result = await handler(fakeJob);
+
+		expect(result.deletedJobs).toBe(1);
+		expect(jobQueue.getJob('old-failed')).toBeNull();
+	});
+
 	it('returns 0 deletedJobs when nothing is old enough', async () => {
 		// Only a recent completed job
 		const recentTime = Date.now() - 60_000;

--- a/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/job-queue-repository.test.ts
@@ -539,6 +539,24 @@ describe('JobQueueRepository', () => {
 			expect(repository.getJob(job.id)).toBeNull();
 		});
 
+		it('deletes failed jobs older than threshold', () => {
+			// Insert a 'failed' job directly — the processor never writes this status
+			// (it uses 'dead' for exhausted retries) but the type contract allows it,
+			// so cleanup must handle it to prevent indefinite accumulation.
+			const now = Date.now();
+			const db = (repository as any).db;
+			db.exec(`
+				INSERT INTO job_queue (id, queue, status, payload, priority, max_retries, retry_count, run_at, created_at, completed_at)
+				VALUES ('failed-job', 'test', 'failed', '{}', 0, 3, 1, ${now}, ${now}, ${now})
+			`);
+
+			const threshold = now + 1000;
+			const deleted = repository.cleanup(threshold);
+
+			expect(deleted).toBe(1);
+			expect(repository.getJob('failed-job')).toBeNull();
+		});
+
 		it('does NOT delete pending or processing jobs', () => {
 			const pending = repository.enqueue({ queue: 'test', payload: {} });
 			const enqueued2 = repository.enqueue({ queue: 'test', payload: {} });


### PR DESCRIPTION
- Create cleanup.handler.ts: removes completed/dead jobs older than 7 days,
  self-schedules next run in 24h, deduplicates pending cleanup jobs
- Register handler in app.ts BEFORE jobProcessor.start() to avoid
  "No handler registered" errors for jobs pending from previous runs
- Enqueue initial cleanup job on first boot if none is already pending
- Add unit tests covering: old job deletion, dead job deletion,
  self-scheduling, dedup, and no-op when nothing is stale
