### PR TITLE
feat: update visual workflow editor for multi-agent steps and channel topology

### DIFF
--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -8,7 +8,7 @@
  * Expanded: name input, agent dropdown, entry/exit gate selectors, instructions
  */
 
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, WorkflowStepAgent, WorkflowChannel } from '@neokai/shared';
 import type { WorkflowConditionType } from '@neokai/shared';
 import { cn } from '../../lib/utils';
 import { GateConfig, CONDITION_LABELS } from './visual-editor/GateConfig';
@@ -24,8 +24,22 @@ export interface StepDraft {
 	/** Existing step ID when editing an existing workflow */
 	id?: string;
 	name: string;
+	/** Single-agent shorthand (backward compat). When agents is provided and non-empty, agents takes precedence. */
 	agentId: string;
+	/** Multiple agents for parallel execution. When non-empty, takes precedence over agentId. */
+	agents?: WorkflowStepAgent[];
+	/** Directed messaging topology between agents. */
+	channels?: WorkflowChannel[];
 	instructions: string;
+}
+
+// ============================================================================
+// Multi-agent helpers
+// ============================================================================
+
+/** Returns true when this step has multiple agents configured. */
+export function isMultiAgentStep(step: StepDraft): boolean {
+	return Array.isArray(step.agents) && step.agents.length > 0;
 }
 
 // Re-export ConditionDraft so existing importers don't break
@@ -102,6 +116,310 @@ function ChevronUp() {
 }
 
 // ============================================================================
+// MultiAgentSection — manages the agents list in expanded view
+// ============================================================================
+
+interface MultiAgentSectionProps {
+	step: StepDraft;
+	agents: SpaceAgent[];
+	onUpdate: (step: StepDraft) => void;
+}
+
+function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
+	const stepAgents = step.agents ?? [];
+
+	function updateAgents(next: WorkflowStepAgent[]) {
+		if (next.length === 0) {
+			// Switch back to single-agent mode
+			onUpdate({ ...step, agents: undefined, agentId: '' });
+		} else if (next.length === 1) {
+			// Keep multi-agent mode with 1 entry so user can add more
+			onUpdate({ ...step, agents: next, agentId: '' });
+		} else {
+			onUpdate({ ...step, agents: next, agentId: '' });
+		}
+	}
+
+	function addAgent(agentId: string) {
+		if (!agentId) return;
+		if (stepAgents.some((a) => a.agentId === agentId)) return;
+		updateAgents([...stepAgents, { agentId }]);
+	}
+
+	function removeAgent(agentId: string) {
+		const next = stepAgents.filter((a) => a.agentId !== agentId);
+		updateAgents(next);
+	}
+
+	function updateAgentInstructions(agentId: string, instructions: string) {
+		updateAgents(
+			stepAgents.map((a) =>
+				a.agentId === agentId ? { ...a, instructions: instructions || undefined } : a
+			)
+		);
+	}
+
+	const usedIds = new Set(stepAgents.map((a) => a.agentId));
+	const availableAgents = agents.filter((a) => !usedIds.has(a.id));
+
+	return (
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<label class="text-xs font-medium text-gray-400">
+					Agents <span class="text-gray-600">({stepAgents.length})</span>
+				</label>
+				{stepAgents.length === 1 && (
+					<button
+						type="button"
+						onClick={() =>
+							onUpdate({ ...step, agents: undefined, agentId: stepAgents[0]?.agentId ?? '' })
+						}
+						class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+					>
+						Switch to single
+					</button>
+				)}
+			</div>
+
+			{/* Agent list */}
+			<div class="space-y-1.5">
+				{stepAgents.map((sa) => {
+					const agentInfo = agents.find((a) => a.id === sa.agentId);
+					return (
+						<div key={sa.agentId} class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1">
+							<div class="flex items-center justify-between">
+								<span class="text-xs font-medium text-gray-200">
+									{agentInfo?.name ?? sa.agentId}
+									{agentInfo && <span class="text-gray-500 ml-1">({agentInfo.role})</span>}
+								</span>
+								<button
+									type="button"
+									onClick={() => removeAgent(sa.agentId)}
+									class="text-gray-600 hover:text-red-400 transition-colors"
+									title="Remove agent"
+								>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M6 18L18 6M6 6l12 12"
+										/>
+									</svg>
+								</button>
+							</div>
+							<input
+								type="text"
+								value={sa.instructions ?? ''}
+								onInput={(e) =>
+									updateAgentInstructions(sa.agentId, (e.currentTarget as HTMLInputElement).value)
+								}
+								placeholder="Per-agent instructions (optional)…"
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+							/>
+						</div>
+					);
+				})}
+			</div>
+
+			{/* Add agent dropdown */}
+			{availableAgents.length > 0 && (
+				<select
+					value=""
+					onChange={(e) => {
+						addAgent((e.currentTarget as HTMLSelectElement).value);
+						(e.currentTarget as HTMLSelectElement).value = '';
+					}}
+					class="w-full text-xs bg-dark-800 border border-dark-600 border-dashed rounded px-2 py-1.5 text-gray-500 focus:outline-none focus:border-blue-500"
+				>
+					<option value="">+ Add agent…</option>
+					{availableAgents.map((a) => (
+						<option key={a.id} value={a.id}>
+							{a.name} ({a.role})
+						</option>
+					))}
+				</select>
+			)}
+
+			{/* Channels section */}
+			<ChannelsSection step={step} agents={agents} onUpdate={onUpdate} />
+		</div>
+	);
+}
+
+// ============================================================================
+// ChannelsSection — manages messaging topology channels
+// ============================================================================
+
+interface ChannelsSectionProps {
+	step: StepDraft;
+	agents: SpaceAgent[];
+	onUpdate: (step: StepDraft) => void;
+}
+
+/** Human-readable label for a channel direction. */
+function channelDirectionLabel(direction: 'one-way' | 'bidirectional'): string {
+	return direction === 'bidirectional' ? '↔' : '→';
+}
+
+/** Format a to value for display. */
+function formatTo(to: string | string[]): string {
+	return Array.isArray(to) ? `[${to.join(', ')}]` : to;
+}
+
+function ChannelsSection({ step, agents, onUpdate }: ChannelsSectionProps) {
+	const channels = step.channels ?? [];
+	const stepAgents = step.agents ?? [];
+
+	// Collect known roles from step agents (+ wildcard)
+	const knownRoles = [
+		'*',
+		...stepAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
+	];
+
+	function updateChannels(next: WorkflowChannel[]) {
+		onUpdate({ ...step, channels: next.length > 0 ? next : undefined });
+	}
+
+	function removeChannel(index: number) {
+		updateChannels(channels.filter((_, i) => i !== index));
+	}
+
+	function addChannel(from: string, to: string, direction: 'one-way' | 'bidirectional') {
+		if (!from || !to) return;
+		// Support comma-separated multi-select for fan-out
+		const toValue: string | string[] = to.includes(',')
+			? to
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: to;
+		updateChannels([...channels, { from, to: toValue, direction }]);
+	}
+
+	return (
+		<div class="space-y-2 pt-2 border-t border-dark-700">
+			<label class="text-xs font-medium text-gray-400">
+				Channels <span class="text-gray-600 font-normal">(messaging topology)</span>
+			</label>
+
+			{channels.length === 0 && (
+				<p class="text-xs text-gray-600">No channels — agents are isolated.</p>
+			)}
+
+			{/* Channel list */}
+			<div class="space-y-1">
+				{channels.map((ch, i) => (
+					<div
+						key={i}
+						class="flex items-center gap-2 bg-dark-800 border border-dark-600 rounded px-2 py-1.5"
+					>
+						<span class="text-xs text-gray-300 font-mono flex-1">
+							{ch.from} {channelDirectionLabel(ch.direction)} {formatTo(ch.to)}
+							{ch.label && <span class="text-gray-500 ml-1">"{ch.label}"</span>}
+						</span>
+						<button
+							type="button"
+							onClick={() => removeChannel(i)}
+							class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
+							title="Remove channel"
+						>
+							<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
+						</button>
+					</div>
+				))}
+			</div>
+
+			{/* Add channel form */}
+			<AddChannelForm knownRoles={knownRoles} onAdd={addChannel} />
+		</div>
+	);
+}
+
+interface AddChannelFormProps {
+	knownRoles: string[];
+	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional') => void;
+}
+
+function AddChannelForm({ knownRoles, onAdd }: AddChannelFormProps) {
+	return (
+		<details class="group">
+			<summary class="text-xs text-blue-400 hover:text-blue-300 cursor-pointer list-none">
+				+ Add channel
+			</summary>
+			<ChannelFormBody knownRoles={knownRoles} onAdd={onAdd} />
+		</details>
+	);
+}
+
+interface ChannelFormBodyProps {
+	knownRoles: string[];
+	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional') => void;
+}
+
+function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
+	// We use a form inside details to avoid useState — just read values on submit
+	function handleSubmit(e: Event) {
+		e.preventDefault();
+		const form = e.currentTarget as HTMLFormElement;
+		const from = (form.elements.namedItem('from') as HTMLSelectElement).value;
+		const to = (form.elements.namedItem('to') as HTMLInputElement).value.trim();
+		const direction = (form.elements.namedItem('direction') as HTMLSelectElement).value as
+			| 'one-way'
+			| 'bidirectional';
+		onAdd(from, to, direction);
+		form.reset();
+	}
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			class="mt-2 space-y-2 bg-dark-800 border border-dark-600 rounded p-2"
+		>
+			<div class="flex gap-2">
+				<select
+					name="from"
+					class="flex-1 text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
+				>
+					<option value="">From…</option>
+					{knownRoles.map((r) => (
+						<option key={r} value={r}>
+							{r}
+						</option>
+					))}
+				</select>
+				<select
+					name="direction"
+					class="text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
+				>
+					<option value="one-way">→ one-way</option>
+					<option value="bidirectional">↔ bidirectional</option>
+				</select>
+			</div>
+			<input
+				name="to"
+				type="text"
+				placeholder="To role(s) — comma-separated for fan-out, * for all"
+				class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
+			/>
+			<button
+				type="submit"
+				class="w-full text-xs py-1 rounded bg-dark-700 hover:bg-dark-600 text-gray-300 transition-colors"
+			>
+				Add
+			</button>
+		</form>
+	);
+}
+
+// ============================================================================
 // Main Component
 // ============================================================================
 
@@ -148,6 +466,7 @@ export function WorkflowStepCard({
 	onRemove,
 	disableRemove = false,
 }: WorkflowStepCardProps) {
+	const multi = isMultiAgentStep(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
 
 	return (
@@ -167,12 +486,28 @@ export function WorkflowStepCard({
 
 				{/* Step info */}
 				<div class="flex-1 min-w-0">
-					<div class="flex items-center gap-1.5 min-w-0">
+					<div class="flex items-center gap-1.5 min-w-0 flex-wrap">
 						<span class="text-xs font-medium text-gray-200 truncate">
 							{step.name || 'Unnamed Step'}
 						</span>
 						<span class="text-xs text-gray-600 flex-shrink-0">·</span>
-						<span class="text-xs text-gray-500 truncate flex-shrink-0">{agentName || '—'}</span>
+						{multi ? (
+							<span class="flex items-center gap-1 flex-wrap">
+								{step.agents!.map((a) => {
+									const name = agents.find((ag) => ag.id === a.agentId)?.name ?? a.agentId;
+									return (
+										<span
+											key={a.agentId}
+											class="text-xs bg-dark-700 border border-dark-600 text-gray-300 rounded px-1 py-0.5"
+										>
+											{name}
+										</span>
+									);
+								})}
+							</span>
+						) : (
+							<span class="text-xs text-gray-500 truncate flex-shrink-0">{agentName || '—'}</span>
+						)}
 					</div>
 				</div>
 
@@ -248,25 +583,42 @@ export function WorkflowStepCard({
 						/>
 					</div>
 
-					{/* Agent */}
-					<div class="space-y-1">
-						<label class="text-xs font-medium text-gray-400">Agent</label>
-						<select
-							value={step.agentId}
-							onChange={(e) =>
-								onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
-							}
-							class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
-						>
-							<option value="">— Select agent —</option>
-							{agents.map((a) => (
-								<option key={a.id} value={a.id}>
-									{a.name}
-									{` (${a.role})`}
-								</option>
-							))}
-						</select>
-					</div>
+					{/* Agent(s) */}
+					{multi ? (
+						<MultiAgentSection step={step} agents={agents} onUpdate={onUpdate} />
+					) : (
+						<div class="space-y-1">
+							<div class="flex items-center justify-between">
+								<label class="text-xs font-medium text-gray-400">Agent</label>
+								<button
+									type="button"
+									onClick={() => {
+										const firstId = step.agentId;
+										const existing: WorkflowStepAgent[] = firstId ? [{ agentId: firstId }] : [];
+										onUpdate({ ...step, agents: existing, agentId: '' });
+									}}
+									class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+								>
+									+ Add agent
+								</button>
+							</div>
+							<select
+								value={step.agentId}
+								onChange={(e) =>
+									onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
+								}
+								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+							>
+								<option value="">— Select agent —</option>
+								{agents.map((a) => (
+									<option key={a.id} value={a.id}>
+										{a.name}
+										{` (${a.role})`}
+									</option>
+								))}
+							</select>
+						</div>
+					)}
 
 					{/* Entry Gate */}
 					<GateConfig

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -288,7 +288,12 @@ function ChannelsSection({ step, agents, onUpdate }: ChannelsSectionProps) {
 		updateChannels(channels.filter((_, i) => i !== index));
 	}
 
-	function addChannel(from: string, to: string, direction: 'one-way' | 'bidirectional') {
+	function addChannel(
+		from: string,
+		to: string,
+		direction: 'one-way' | 'bidirectional',
+		label?: string
+	) {
 		if (!from || !to) return;
 		// Support comma-separated multi-select for fan-out
 		const toValue: string | string[] = to.includes(',')
@@ -297,7 +302,7 @@ function ChannelsSection({ step, agents, onUpdate }: ChannelsSectionProps) {
 					.map((s) => s.trim())
 					.filter(Boolean)
 			: to;
-		updateChannels([...channels, { from, to: toValue, direction }]);
+		updateChannels([...channels, { from, to: toValue, direction, label: label || undefined }]);
 	}
 
 	return (
@@ -348,7 +353,7 @@ function ChannelsSection({ step, agents, onUpdate }: ChannelsSectionProps) {
 
 interface AddChannelFormProps {
 	knownRoles: string[];
-	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional') => void;
+	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional', label?: string) => void;
 }
 
 function AddChannelForm({ knownRoles, onAdd }: AddChannelFormProps) {
@@ -364,7 +369,7 @@ function AddChannelForm({ knownRoles, onAdd }: AddChannelFormProps) {
 
 interface ChannelFormBodyProps {
 	knownRoles: string[];
-	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional') => void;
+	onAdd: (from: string, to: string, direction: 'one-way' | 'bidirectional', label?: string) => void;
 }
 
 function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
@@ -377,7 +382,8 @@ function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
 		const direction = (form.elements.namedItem('direction') as HTMLSelectElement).value as
 			| 'one-way'
 			| 'bidirectional';
-		onAdd(from, to, direction);
+		const label = (form.elements.namedItem('label') as HTMLInputElement).value.trim();
+		onAdd(from, to, direction, label || undefined);
 		form.reset();
 	}
 
@@ -410,6 +416,12 @@ function ChannelFormBody({ knownRoles, onAdd }: ChannelFormBodyProps) {
 				name="to"
 				type="text"
 				placeholder="To role(s) — comma-separated for fan-out, * for all"
+				class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
+			/>
+			<input
+				name="label"
+				type="text"
+				placeholder="Label (optional)"
 				class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
 			/>
 			<button

--- a/packages/web/src/components/space/WorkflowStepCard.tsx
+++ b/packages/web/src/components/space/WorkflowStepCard.tsx
@@ -129,15 +129,7 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 	const stepAgents = step.agents ?? [];
 
 	function updateAgents(next: WorkflowStepAgent[]) {
-		if (next.length === 0) {
-			// Switch back to single-agent mode
-			onUpdate({ ...step, agents: undefined, agentId: '' });
-		} else if (next.length === 1) {
-			// Keep multi-agent mode with 1 entry so user can add more
-			onUpdate({ ...step, agents: next, agentId: '' });
-		} else {
-			onUpdate({ ...step, agents: next, agentId: '' });
-		}
+		onUpdate({ ...step, agents: next, agentId: '' });
 	}
 
 	function addAgent(agentId: string) {
@@ -148,7 +140,13 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 
 	function removeAgent(agentId: string) {
 		const next = stepAgents.filter((a) => a.agentId !== agentId);
-		updateAgents(next);
+		if (next.length === 0) {
+			// Switch back to single-agent mode: restore agentId from the removed agent and
+			// clear channels (orphaned channels on a single-agent step are semantically invalid)
+			onUpdate({ ...step, agents: undefined, agentId, channels: undefined });
+		} else {
+			updateAgents(next);
+		}
 	}
 
 	function updateAgentInstructions(agentId: string, instructions: string) {
@@ -172,7 +170,12 @@ function MultiAgentSection({ step, agents, onUpdate }: MultiAgentSectionProps) {
 					<button
 						type="button"
 						onClick={() =>
-							onUpdate({ ...step, agents: undefined, agentId: stepAgents[0]?.agentId ?? '' })
+							onUpdate({
+								...step,
+								agents: undefined,
+								agentId: stepAgents[0]?.agentId ?? '',
+								channels: undefined,
+							})
 						}
 						class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
 					>

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -16,8 +16,9 @@
  */
 
 import { useState, useEffect } from 'preact/hooks';
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, WorkflowStepAgent, WorkflowChannel } from '@neokai/shared';
 import type { StepDraft } from '../WorkflowStepCard';
+import { isMultiAgentStep } from '../WorkflowStepCard';
 import { GateConfig } from './GateConfig';
 import type { ConditionDraft } from './GateConfig';
 
@@ -49,6 +50,342 @@ export interface NodeConfigPanelProps {
 	onClose: () => void;
 	/** Called when the user confirms deletion of this step */
 	onDelete: (stepId: string) => void;
+}
+
+// ============================================================================
+// AgentsSection — manages agents list in the config panel
+// ============================================================================
+
+interface AgentsSectionProps {
+	step: StepDraft;
+	agents: SpaceAgent[];
+	onUpdate: (step: StepDraft) => void;
+}
+
+function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
+	const multi = isMultiAgentStep(step);
+	const stepAgents = step.agents ?? [];
+
+	function updateAgents(next: WorkflowStepAgent[]) {
+		onUpdate({
+			...step,
+			agents: next.length > 0 ? next : undefined,
+			agentId: next.length > 0 ? '' : step.agentId,
+		});
+	}
+
+	function addAgent(agentId: string) {
+		if (!agentId) return;
+		if (stepAgents.some((a) => a.agentId === agentId)) return;
+		updateAgents([...stepAgents, { agentId }]);
+	}
+
+	function removeAgent(agentId: string) {
+		const next = stepAgents.filter((a) => a.agentId !== agentId);
+		if (next.length === 0) {
+			// Switch back to single-agent mode, clearing agents array
+			onUpdate({ ...step, agents: undefined });
+		} else {
+			updateAgents(next);
+		}
+	}
+
+	function updateAgentInstructions(agentId: string, instructions: string) {
+		updateAgents(
+			stepAgents.map((a) =>
+				a.agentId === agentId ? { ...a, instructions: instructions || undefined } : a
+			)
+		);
+	}
+
+	const usedIds = new Set(stepAgents.map((a) => a.agentId));
+	const availableAgents = agents.filter((a) => !usedIds.has(a.id));
+
+	if (!multi) {
+		// Single-agent mode
+		return (
+			<div class="space-y-1.5">
+				<div class="flex items-center justify-between">
+					<label class="text-xs font-medium text-gray-400">Agent</label>
+					<button
+						type="button"
+						data-testid="add-agent-button"
+						onClick={() => {
+							const firstId = step.agentId;
+							const existing: WorkflowStepAgent[] = firstId ? [{ agentId: firstId }] : [];
+							onUpdate({ ...step, agents: existing, agentId: '' });
+						}}
+						class="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+					>
+						+ Add agent
+					</button>
+				</div>
+				<select
+					data-testid="agent-select"
+					value={step.agentId}
+					onChange={(e) =>
+						onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
+					}
+					class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+				>
+					<option value="">— Select agent —</option>
+					{agents.map((a) => (
+						<option key={a.id} value={a.id}>
+							{a.name}
+							{` (${a.role})`}
+						</option>
+					))}
+				</select>
+			</div>
+		);
+	}
+
+	// Multi-agent mode
+	return (
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<label class="text-xs font-medium text-gray-400">
+					Agents <span class="text-gray-600">({stepAgents.length})</span>
+				</label>
+				{stepAgents.length <= 1 && (
+					<button
+						type="button"
+						onClick={() =>
+							onUpdate({ ...step, agents: undefined, agentId: stepAgents[0]?.agentId ?? '' })
+						}
+						class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+					>
+						Switch to single
+					</button>
+				)}
+			</div>
+
+			<div class="space-y-1.5" data-testid="agents-list">
+				{stepAgents.map((sa) => {
+					const agentInfo = agents.find((a) => a.id === sa.agentId);
+					return (
+						<div
+							key={sa.agentId}
+							class="bg-dark-800 border border-dark-600 rounded p-2 space-y-1"
+							data-testid="agent-entry"
+						>
+							<div class="flex items-center justify-between">
+								<span class="text-xs font-medium text-gray-200">
+									{agentInfo?.name ?? sa.agentId}
+									{agentInfo && <span class="text-gray-500 ml-1">({agentInfo.role})</span>}
+								</span>
+								<button
+									type="button"
+									data-testid="remove-agent-button"
+									onClick={() => removeAgent(sa.agentId)}
+									class="text-gray-600 hover:text-red-400 transition-colors"
+									title="Remove agent"
+								>
+									<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M6 18L18 6M6 6l12 12"
+										/>
+									</svg>
+								</button>
+							</div>
+							<input
+								type="text"
+								data-testid="agent-instructions-input"
+								value={sa.instructions ?? ''}
+								onInput={(e) =>
+									updateAgentInstructions(sa.agentId, (e.currentTarget as HTMLInputElement).value)
+								}
+								placeholder="Per-agent instructions (optional)…"
+								class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-700"
+							/>
+						</div>
+					);
+				})}
+			</div>
+
+			{availableAgents.length > 0 && (
+				<select
+					data-testid="add-agent-select"
+					value=""
+					onChange={(e) => {
+						addAgent((e.currentTarget as HTMLSelectElement).value);
+						(e.currentTarget as HTMLSelectElement).value = '';
+					}}
+					class="w-full text-xs bg-dark-800 border border-dark-600 border-dashed rounded px-2 py-1.5 text-gray-500 focus:outline-none focus:border-blue-500"
+				>
+					<option value="">+ Add agent…</option>
+					{availableAgents.map((a) => (
+						<option key={a.id} value={a.id}>
+							{a.name} ({a.role})
+						</option>
+					))}
+				</select>
+			)}
+		</div>
+	);
+}
+
+// ============================================================================
+// ChannelsPanelSection — manages messaging channels in the config panel
+// ============================================================================
+
+interface ChannelsPanelSectionProps {
+	step: StepDraft;
+	agents: SpaceAgent[];
+	onUpdate: (step: StepDraft) => void;
+}
+
+function ChannelsPanelSection({ step, agents, onUpdate }: ChannelsPanelSectionProps) {
+	const channels = step.channels ?? [];
+	const stepAgents = step.agents ?? [];
+
+	// Collect known roles from step agents (+ wildcard)
+	const knownRoles = [
+		'*',
+		...stepAgents.map((sa) => agents.find((a) => a.id === sa.agentId)?.role ?? sa.agentId),
+	];
+
+	const [newFrom, setNewFrom] = useState('');
+	const [newTo, setNewTo] = useState('');
+	const [newDirection, setNewDirection] = useState<'one-way' | 'bidirectional'>('one-way');
+	const [newLabel, setNewLabel] = useState('');
+
+	function updateChannels(next: WorkflowChannel[]) {
+		onUpdate({ ...step, channels: next.length > 0 ? next : undefined });
+	}
+
+	function removeChannel(index: number) {
+		updateChannels(channels.filter((_, i) => i !== index));
+	}
+
+	function addChannel() {
+		if (!newFrom || !newTo) return;
+		const toValue: string | string[] = newTo.includes(',')
+			? newTo
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: newTo.trim();
+		const ch: WorkflowChannel = {
+			from: newFrom,
+			to: toValue,
+			direction: newDirection,
+			label: newLabel.trim() || undefined,
+		};
+		updateChannels([...channels, ch]);
+		setNewFrom('');
+		setNewTo('');
+		setNewDirection('one-way');
+		setNewLabel('');
+	}
+
+	const formatTo = (to: string | string[]) => (Array.isArray(to) ? `[${to.join(', ')}]` : to);
+
+	return (
+		<div class="space-y-2 pt-3 border-t border-dark-700" data-testid="channels-section">
+			<label class="text-xs font-medium text-gray-400">
+				Channels <span class="text-gray-600 font-normal">(messaging topology)</span>
+			</label>
+
+			{channels.length === 0 && (
+				<p class="text-xs text-gray-600">No channels — agents are isolated.</p>
+			)}
+
+			<div class="space-y-1" data-testid="channels-list">
+				{channels.map((ch, i) => (
+					<div
+						key={i}
+						class="flex items-center gap-2 bg-dark-800 border border-dark-600 rounded px-2 py-1.5"
+						data-testid="channel-entry"
+					>
+						<span class="text-xs text-gray-300 font-mono flex-1">
+							{ch.from} {ch.direction === 'bidirectional' ? '↔' : '→'} {formatTo(ch.to)}
+							{ch.label && <span class="text-gray-500 ml-1">"{ch.label}"</span>}
+						</span>
+						<button
+							type="button"
+							data-testid="remove-channel-button"
+							onClick={() => removeChannel(i)}
+							class="text-gray-600 hover:text-red-400 transition-colors flex-shrink-0"
+							title="Remove channel"
+						>
+							<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
+						</button>
+					</div>
+				))}
+			</div>
+
+			{/* Add channel form */}
+			<div
+				class="space-y-2 bg-dark-800 border border-dark-600 rounded p-2"
+				data-testid="add-channel-form"
+			>
+				<div class="flex gap-2">
+					<select
+						data-testid="channel-from-select"
+						value={newFrom}
+						onChange={(e) => setNewFrom((e.currentTarget as HTMLSelectElement).value)}
+						class="flex-1 text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
+					>
+						<option value="">From…</option>
+						{knownRoles.map((r) => (
+							<option key={r} value={r}>
+								{r}
+							</option>
+						))}
+					</select>
+					<select
+						data-testid="channel-direction-select"
+						value={newDirection}
+						onChange={(e) =>
+							setNewDirection(
+								(e.currentTarget as HTMLSelectElement).value as 'one-way' | 'bidirectional'
+							)
+						}
+						class="text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500"
+					>
+						<option value="one-way">→ one-way</option>
+						<option value="bidirectional">↔ bidirectional</option>
+					</select>
+				</div>
+				<input
+					data-testid="channel-to-input"
+					type="text"
+					value={newTo}
+					onInput={(e) => setNewTo((e.currentTarget as HTMLInputElement).value)}
+					placeholder="To role(s) — comma-separated, * for all"
+					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
+				/>
+				<input
+					data-testid="channel-label-input"
+					type="text"
+					value={newLabel}
+					onInput={(e) => setNewLabel((e.currentTarget as HTMLInputElement).value)}
+					placeholder="Label (optional)"
+					class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2 py-1 text-gray-300 focus:outline-none focus:border-blue-500 placeholder-gray-600"
+				/>
+				<button
+					type="button"
+					data-testid="add-channel-button"
+					onClick={addChannel}
+					disabled={!newFrom || !newTo}
+					class="w-full text-xs py-1 rounded bg-dark-700 hover:bg-dark-600 disabled:opacity-40 disabled:cursor-not-allowed text-gray-300 transition-colors"
+				>
+					Add channel
+				</button>
+			</div>
+		</div>
+	);
 }
 
 // ============================================================================
@@ -167,26 +504,13 @@ export function NodeConfigPanel({
 					</button>
 				)}
 
-				{/* Agent */}
-				<div class="space-y-1.5">
-					<label class="text-xs font-medium text-gray-400">Agent</label>
-					<select
-						data-testid="agent-select"
-						value={step.agentId}
-						onChange={(e) =>
-							onUpdate({ ...step, agentId: (e.currentTarget as HTMLSelectElement).value })
-						}
-						class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
-					>
-						<option value="">— Select agent —</option>
-						{agents.map((a) => (
-							<option key={a.id} value={a.id}>
-								{a.name}
-								{` (${a.role})`}
-							</option>
-						))}
-					</select>
-				</div>
+				{/* Agent(s) */}
+				<AgentsSection step={step} agents={agents} onUpdate={onUpdate} />
+
+				{/* Channels (shown only in multi-agent mode) */}
+				{isMultiAgentStep(step) && (
+					<ChannelsPanelSection step={step} agents={agents} onUpdate={onUpdate} />
+				)}
 
 				{/* Entry Gate */}
 				<GateConfig

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -67,11 +67,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	const stepAgents = step.agents ?? [];
 
 	function updateAgents(next: WorkflowStepAgent[]) {
-		onUpdate({
-			...step,
-			agents: next.length > 0 ? next : undefined,
-			agentId: next.length > 0 ? '' : step.agentId,
-		});
+		onUpdate({ ...step, agents: next, agentId: '' });
 	}
 
 	function addAgent(agentId: string) {
@@ -83,8 +79,9 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 	function removeAgent(agentId: string) {
 		const next = stepAgents.filter((a) => a.agentId !== agentId);
 		if (next.length === 0) {
-			// Switch back to single-agent mode, clearing agents array
-			onUpdate({ ...step, agents: undefined });
+			// Switch back to single-agent mode: restore agentId from the removed agent and
+			// clear channels (orphaned channels on a single-agent step are semantically invalid)
+			onUpdate({ ...step, agents: undefined, agentId, channels: undefined });
 		} else {
 			updateAgents(next);
 		}
@@ -147,11 +144,16 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 				<label class="text-xs font-medium text-gray-400">
 					Agents <span class="text-gray-600">({stepAgents.length})</span>
 				</label>
-				{stepAgents.length <= 1 && (
+				{stepAgents.length === 1 && (
 					<button
 						type="button"
 						onClick={() =>
-							onUpdate({ ...step, agents: undefined, agentId: stepAgents[0]?.agentId ?? '' })
+							onUpdate({
+								...step,
+								agents: undefined,
+								agentId: stepAgents[0]?.agentId ?? '',
+								channels: undefined,
+							})
 						}
 						class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
 					>
@@ -252,6 +254,15 @@ function ChannelsPanelSection({ step, agents, onUpdate }: ChannelsPanelSectionPr
 	const [newTo, setNewTo] = useState('');
 	const [newDirection, setNewDirection] = useState<'one-way' | 'bidirectional'>('one-way');
 	const [newLabel, setNewLabel] = useState('');
+
+	// Reset add-channel form fields when the selected node changes, so stale values
+	// from one node don't bleed into the form for the next selected node.
+	useEffect(() => {
+		setNewFrom('');
+		setNewTo('');
+		setNewDirection('one-way');
+		setNewLabel('');
+	}, [step.localId]);
 
 	function updateChannels(next: WorkflowChannel[]) {
 		onUpdate({ ...step, channels: next.length > 0 ? next : undefined });

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -515,9 +515,11 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			return;
 		}
 
-		// Validate each step has an agent assigned
+		// Validate each step has an agent assigned (single or multi-agent)
 		for (let i = 0; i < nodes.length; i++) {
-			if (!nodes[i].step.agentId) {
+			const step = nodes[i].step;
+			const hasMultiAgent = Array.isArray(step.agents) && step.agents.length > 0;
+			if (!hasMultiAgent && !step.agentId) {
 				setError(`Step ${i + 1} requires an agent.`);
 				return;
 			}

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -25,24 +25,12 @@ import type { Point } from './types';
 // ============================================================================
 
 /** Renders a compact text representation of channel topology. */
-function ChannelTopologyBadge({ step, agents }: { step: StepDraft; agents: SpaceAgent[] }) {
+function ChannelTopologyBadge({ step }: { step: StepDraft; agents: SpaceAgent[] }) {
 	const channels = step.channels;
 	if (!channels || channels.length === 0) return null;
 
-	/** Resolve a role to a display label (first 8 chars to keep compact). */
-	const roleLabel = (role: string) => {
-		if (role === '*') return '*';
-		// Try to find a matching agent name
-		const sa = (step.agents ?? []).find((a) => {
-			const agentInfo = agents.find((ag) => ag.id === a.agentId);
-			return agentInfo?.role === role;
-		});
-		if (sa) {
-			const name = agents.find((ag) => ag.id === sa.agentId)?.name ?? role;
-			return name.length > 6 ? name.slice(0, 6) + '…' : name;
-		}
-		return role.length > 6 ? role.slice(0, 6) + '…' : role;
-	};
+	/** Truncate a role string for compact display. Channels already use role strings as identifiers. */
+	const roleLabel = (role: string) => (role.length > 8 ? role.slice(0, 8) + '…' : role);
 
 	const formatTo = (to: string | string[]) => {
 		if (Array.isArray(to)) return `[${to.map(roleLabel).join(',')}]`;

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -17,7 +17,51 @@
 import { useEffect, useCallback, useRef } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 import type { StepDraft } from '../WorkflowStepCard';
+import { isMultiAgentStep } from '../WorkflowStepCard';
 import type { Point } from './types';
+
+// ============================================================================
+// Channel topology visualization helpers
+// ============================================================================
+
+/** Renders a compact text representation of channel topology. */
+function ChannelTopologyBadge({ step, agents }: { step: StepDraft; agents: SpaceAgent[] }) {
+	const channels = step.channels;
+	if (!channels || channels.length === 0) return null;
+
+	/** Resolve a role to a display label (first 8 chars to keep compact). */
+	const roleLabel = (role: string) => {
+		if (role === '*') return '*';
+		// Try to find a matching agent name
+		const sa = (step.agents ?? []).find((a) => {
+			const agentInfo = agents.find((ag) => ag.id === a.agentId);
+			return agentInfo?.role === role;
+		});
+		if (sa) {
+			const name = agents.find((ag) => ag.id === sa.agentId)?.name ?? role;
+			return name.length > 6 ? name.slice(0, 6) + '…' : name;
+		}
+		return role.length > 6 ? role.slice(0, 6) + '…' : role;
+	};
+
+	const formatTo = (to: string | string[]) => {
+		if (Array.isArray(to)) return `[${to.map(roleLabel).join(',')}]`;
+		return roleLabel(to);
+	};
+
+	return (
+		<div class="mt-1.5 space-y-0.5">
+			{channels.map((ch, i) => (
+				<div key={i} class="flex items-center gap-0.5 text-xs text-gray-500">
+					<span class="font-mono">{roleLabel(ch.from)}</span>
+					<span class="text-gray-600">{ch.direction === 'bidirectional' ? '↔' : '→'}</span>
+					<span class="font-mono">{formatTo(ch.to)}</span>
+					{ch.label && <span class="text-gray-700 ml-0.5">"{ch.label}"</span>}
+				</div>
+			))}
+		</div>
+	);
+}
 
 // ============================================================================
 // Props
@@ -73,6 +117,7 @@ export function WorkflowNode({
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
 
+	const multi = isMultiAgentStep(step);
 	const agentName = agents.find((a) => a.id === step.agentId)?.name ?? step.agentId;
 
 	// ---- Drag state ----
@@ -223,7 +268,7 @@ export function WorkflowNode({
 				position: 'absolute',
 				left: position.x,
 				top: position.y,
-				minWidth: 160,
+				minWidth: multi ? 200 : 160,
 				cursor: 'grab',
 				userSelect: 'none',
 			}}
@@ -280,15 +325,34 @@ export function WorkflowNode({
 				<p
 					data-testid="step-name"
 					class="text-sm font-medium text-white truncate"
-					style={{ maxWidth: 160 }}
+					style={{ maxWidth: 180 }}
 				>
 					{step.name || '(unnamed)'}
 				</p>
 
-				{/* Agent name */}
-				<p data-testid="agent-name" class="text-xs text-gray-400 truncate mt-0.5">
-					{agentName}
-				</p>
+				{/* Agent(s) */}
+				{multi ? (
+					<div data-testid="agent-badges" class="flex flex-wrap gap-1 mt-1">
+						{step.agents!.map((sa) => {
+							const name = agents.find((a) => a.id === sa.agentId)?.name ?? sa.agentId;
+							return (
+								<span
+									key={sa.agentId}
+									class="text-xs bg-gray-700 text-gray-300 rounded px-1.5 py-0.5"
+								>
+									{name}
+								</span>
+							);
+						})}
+					</div>
+				) : (
+					<p data-testid="agent-name" class="text-xs text-gray-400 truncate mt-0.5">
+						{agentName}
+					</p>
+				)}
+
+				{/* Channel topology */}
+				<ChannelTopologyBadge step={step} agents={agents} />
 			</div>
 
 			{/* Bottom port */}

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -25,7 +25,7 @@ import type { Point } from './types';
 // ============================================================================
 
 /** Renders a compact text representation of channel topology. */
-function ChannelTopologyBadge({ step }: { step: StepDraft; agents: SpaceAgent[] }) {
+function ChannelTopologyBadge({ step }: { step: StepDraft }) {
 	const channels = step.channels;
 	if (!channels || channels.length === 0) return null;
 
@@ -340,7 +340,7 @@ export function WorkflowNode({
 				)}
 
 				{/* Channel topology */}
-				<ChannelTopologyBadge step={step} agents={agents} />
+				<ChannelTopologyBadge step={step} />
 			</div>
 
 			{/* Bottom port */}

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -357,4 +357,179 @@ describe('NodeConfigPanel', () => {
 			expect(container.textContent).not.toContain('Workflow ends here');
 		});
 	});
+
+	// ============================================================================
+	// Multi-agent: AgentsSection
+	// ============================================================================
+
+	describe('multi-agent mode', () => {
+		it('shows single agent dropdown in single-agent mode', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			// Single agent mode shows the agent-select dropdown
+			expect(getByTestId('agent-select')).toBeTruthy();
+		});
+
+		it('shows "Add agent" button in single-agent mode', () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(getByTestId('add-agent-button')).toBeTruthy();
+		});
+
+		it('clicking "Add agent" switches to multi-agent mode with existing agent', () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			fireEvent.click(getByTestId('add-agent-button'));
+			expect(onUpdate).toHaveBeenCalledOnce();
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.agents).toHaveLength(1);
+			expect(updatedStep.agents[0].agentId).toBe('agent-1'); // existing agentId preserved
+		});
+
+		it('shows agents list in multi-agent mode', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getByTestId, queryByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getByTestId('agents-list')).toBeTruthy();
+			// Single agent dropdown should not be present
+			expect(queryByTestId('agent-select')).toBeNull();
+		});
+
+		it('renders one entry per agent in multi-agent mode', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getAllByTestId('agent-entry')).toHaveLength(2);
+		});
+
+		it('shows agent name and role in each agent entry', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			const entry = getByTestId('agents-list');
+			expect(entry.textContent).toContain('Planner');
+			expect(entry.textContent).toContain('planner');
+		});
+
+		it('remove agent button calls onUpdate without that agent', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.click(getAllByTestId('remove-agent-button')[0]);
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.agents).toHaveLength(1);
+			expect(updatedStep.agents[0].agentId).toBe('agent-2');
+		});
+
+		it('removing last agent switches back to single-agent mode', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.click(getByTestId('remove-agent-button'));
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.agents).toBeUndefined();
+		});
+
+		it('shows add-agent-select dropdown for agents not yet in step', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			// agent-2 is not in step yet, should appear in dropdown
+			const select = getByTestId('add-agent-select');
+			expect(select.textContent).toContain('Coder');
+		});
+
+		it('shows channels section in multi-agent mode', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getByTestId('channels-section')).toBeTruthy();
+		});
+
+		it('does not show channels section in single-agent mode', () => {
+			const { queryByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			expect(queryByTestId('channels-section')).toBeNull();
+		});
+
+		it('renders existing channels in channels list', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				channels: [
+					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
+					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
+				],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			expect(getAllByTestId('channel-entry')).toHaveLength(2);
+		});
+
+		it('remove channel button calls onUpdate without that channel', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+				channels: [
+					{ from: 'coder', to: 'reviewer', direction: 'one-way' },
+					{ from: 'reviewer', to: 'coder', direction: 'bidirectional' },
+				],
+			});
+			const { getAllByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			fireEvent.click(getAllByTestId('remove-channel-button')[0]);
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.channels).toHaveLength(1);
+			expect(updatedStep.channels[0].from).toBe('reviewer');
+		});
+
+		it('add channel button is disabled when from or to is empty', () => {
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step })} />);
+			const addBtn = getByTestId('add-channel-button');
+			expect(addBtn.hasAttribute('disabled')).toBe(true);
+		});
+
+		it('add channel adds a new channel entry', () => {
+			const onUpdate = vi.fn();
+			const step = makeStep({
+				agentId: '',
+				agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+			});
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
+			// Set from
+			act(() => {
+				fireEvent.change(getByTestId('channel-from-select'), { target: { value: 'coder' } });
+			});
+			// Set to
+			act(() => {
+				fireEvent.input(getByTestId('channel-to-input'), { target: { value: 'reviewer' } });
+			});
+			// Click add
+			act(() => {
+				fireEvent.click(getByTestId('add-channel-button'));
+			});
+			expect(onUpdate).toHaveBeenCalled();
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.channels).toHaveLength(1);
+			expect(updatedStep.channels[0].from).toBe('coder');
+			expect(updatedStep.channels[0].to).toBe('reviewer');
+			expect(updatedStep.channels[0].direction).toBe('one-way');
+		});
+	});
 });

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -428,16 +428,22 @@ describe('NodeConfigPanel', () => {
 			expect(updatedStep.agents[0].agentId).toBe('agent-2');
 		});
 
-		it('removing last agent switches back to single-agent mode', () => {
+		it('removing last agent switches back to single-agent mode, restores agentId and clears channels', () => {
 			const onUpdate = vi.fn();
 			const step = makeStep({
 				agentId: '',
 				agents: [{ agentId: 'agent-1' }],
+				channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' as const }],
 			});
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ step, onUpdate })} />);
 			fireEvent.click(getByTestId('remove-agent-button'));
 			const updatedStep = onUpdate.mock.calls[0][0];
+			// agents cleared
 			expect(updatedStep.agents).toBeUndefined();
+			// agentId restored from the removed agent
+			expect(updatedStep.agentId).toBe('agent-1');
+			// channels cleared (orphaned channels on single-agent step are invalid)
+			expect(updatedStep.channels).toBeUndefined();
 		});
 
 		it('shows add-agent-select dropdown for agents not yet in step', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -252,6 +252,69 @@ describe('WorkflowNode click', () => {
 });
 
 // ============================================================================
+// Multi-agent rendering tests
+// ============================================================================
+
+describe('WorkflowNode multi-agent rendering', () => {
+	it('renders agent badges when step has agents array', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+		};
+		const { getByTestId, queryByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		const badges = getByTestId('agent-badges');
+		expect(badges).toBeTruthy();
+		// agent-name element should not be present in multi-agent mode
+		expect(queryByTestId('agent-name')).toBeNull();
+		// Both agent names should appear
+		expect(badges.textContent).toContain('Alpha Agent');
+		expect(badges.textContent).toContain('Beta Agent');
+	});
+
+	it('renders single agent name when agents array is absent', () => {
+		const { getByTestId, queryByTestId } = render(<WorkflowNode {...makeProps()} />);
+		expect(getByTestId('agent-name')).toBeTruthy();
+		expect(queryByTestId('agent-badges')).toBeNull();
+	});
+
+	it('renders single agent name when agents array is empty', () => {
+		const step = { ...STEP_DRAFT, agents: [] as { agentId: string }[] };
+		const { getByTestId, queryByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		// Empty agents array = single-agent mode
+		expect(getByTestId('agent-name')).toBeTruthy();
+		expect(queryByTestId('agent-badges')).toBeNull();
+	});
+
+	it('falls back to agentId as badge label when agent not found', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'unknown-agent-id' }],
+		};
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		expect(getByTestId('agent-badges').textContent).toContain('unknown-agent-id');
+	});
+
+	it('uses wider minWidth for multi-agent steps', () => {
+		const step = {
+			...STEP_DRAFT,
+			agentId: '',
+			agents: [{ agentId: 'agent-1' }, { agentId: 'agent-2' }],
+		};
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step })} />);
+		const node = getByTestId('workflow-node-step-local-1');
+		expect(node.style.minWidth).toBe('200px');
+	});
+
+	it('uses default minWidth for single-agent steps', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps()} />);
+		const node = getByTestId('workflow-node-step-local-1');
+		expect(node.style.minWidth).toBe('160px');
+	});
+});
+
+// ============================================================================
 // Drag-and-drop tests
 // ============================================================================
 

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -779,3 +779,129 @@ describe('visualStateToUpdateParams', () => {
 		expect(params.rules![0].id).toBeTruthy();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Multi-agent step serialization
+// ---------------------------------------------------------------------------
+
+describe('multi-agent step serialization', () => {
+	it('workflowToVisualState preserves agents array from WorkflowStep', () => {
+		const workflow = makeWorkflow({
+			steps: [
+				{
+					id: 's1',
+					name: 'Parallel Step',
+					agents: [{ agentId: 'a1' }, { agentId: 'a2', instructions: 'focus on security' }],
+				},
+			],
+		});
+		const state = workflowToVisualState(workflow);
+		const step = state.nodes[0].step;
+		expect(step.agents).toHaveLength(2);
+		expect(step.agents![0].agentId).toBe('a1');
+		expect(step.agents![1].agentId).toBe('a2');
+		expect(step.agents![1].instructions).toBe('focus on security');
+		// agentId should be empty (multi-agent step)
+		expect(step.agentId).toBe('');
+	});
+
+	it('workflowToVisualState preserves channels array from WorkflowStep', () => {
+		const workflow = makeWorkflow({
+			steps: [
+				{
+					id: 's1',
+					name: 'Parallel Step',
+					agents: [{ agentId: 'a1' }, { agentId: 'a2' }],
+					channels: [
+						{ from: 'coder', to: 'reviewer', direction: 'one-way', label: 'PR' },
+						{ from: 'reviewer', to: ['coder', 'qa'], direction: 'bidirectional' },
+					],
+				},
+			],
+		});
+		const state = workflowToVisualState(workflow);
+		const step = state.nodes[0].step;
+		expect(step.channels).toHaveLength(2);
+		expect(step.channels![0]).toEqual({
+			from: 'coder',
+			to: 'reviewer',
+			direction: 'one-way',
+			label: 'PR',
+		});
+		expect(step.channels![1]).toEqual({
+			from: 'reviewer',
+			to: ['coder', 'qa'],
+			direction: 'bidirectional',
+		});
+	});
+
+	it('visualStateToCreateParams outputs agents array for multi-agent steps', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: {
+						localId: 'local-1',
+						id: 's1',
+						name: 'Parallel Step',
+						agentId: '',
+						agents: [{ agentId: 'a1' }, { agentId: 'a2', instructions: 'custom' }],
+						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+						instructions: '',
+					},
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		const step = params.steps![0];
+		expect(step.agents).toHaveLength(2);
+		expect(step.agents![0].agentId).toBe('a1');
+		expect(step.agents![1].instructions).toBe('custom');
+		expect(step.channels).toHaveLength(1);
+		expect(step.channels![0].from).toBe('coder');
+		// agentId should be absent (undefined) when agents is set
+		expect(step.agentId).toBeUndefined();
+	});
+
+	it('visualStateToCreateParams omits empty channels array', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: {
+						localId: 'local-1',
+						id: 's1',
+						name: 'Step',
+						agentId: '',
+						agents: [{ agentId: 'a1' }],
+						channels: [],
+						instructions: '',
+					},
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startStepId: 's1',
+			rules: [],
+			tags: [],
+		};
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.steps![0].channels).toBeUndefined();
+	});
+
+	it('single-agent step round-trip: agentId preserved, no agents array', () => {
+		const workflow = makeWorkflow({
+			steps: [makeStep('s1', 'Code', 'agent-coder')],
+		});
+		const state = workflowToVisualState(workflow);
+		expect(state.nodes[0].step.agentId).toBe('agent-coder');
+		expect(state.nodes[0].step.agents).toBeUndefined();
+
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.steps![0].agentId).toBe('agent-coder');
+		expect(params.steps![0].agents).toBeUndefined();
+	});
+});

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -904,4 +904,41 @@ describe('multi-agent step serialization', () => {
 		expect(params.steps![0].agentId).toBe('agent-coder');
 		expect(params.steps![0].agents).toBeUndefined();
 	});
+
+	it('full round-trip workflowToVisualState → visualStateToUpdateParams preserves multi-agent data', () => {
+		const workflow = makeWorkflow({
+			steps: [
+				{
+					id: 's1',
+					name: 'Parallel',
+					agents: [{ agentId: 'a1', instructions: 'focus on tests' }, { agentId: 'a2' }],
+					channels: [
+						{ from: 'coder', to: 'reviewer', direction: 'one-way' as const },
+						{ from: 'reviewer', to: ['coder', 'qa'], direction: 'bidirectional' as const },
+					],
+				},
+			],
+			layout: { s1: { x: 0, y: 0 } },
+		});
+		const state = workflowToVisualState(workflow);
+		const params = visualStateToUpdateParams(state);
+
+		const step = params.steps![0];
+		// agents array preserved through update round-trip
+		expect(step.agents).toHaveLength(2);
+		expect(step.agents![0].agentId).toBe('a1');
+		expect(step.agents![0].instructions).toBe('focus on tests');
+		expect(step.agents![1].agentId).toBe('a2');
+		expect(step.agents![1].instructions).toBeUndefined();
+		// agentId should be absent for multi-agent steps
+		expect(step.agentId).toBeUndefined();
+		// channels preserved
+		expect(step.channels).toHaveLength(2);
+		expect(step.channels![0]).toEqual({ from: 'coder', to: 'reviewer', direction: 'one-way' });
+		expect(step.channels![1]).toEqual({
+			from: 'reviewer',
+			to: ['coder', 'qa'],
+			direction: 'bidirectional',
+		});
+	});
 });

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -31,6 +31,8 @@ import type {
 	CreateSpaceWorkflowParams,
 	UpdateSpaceWorkflowParams,
 	WorkflowCondition,
+	WorkflowStepAgent,
+	WorkflowChannel,
 } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { StepDraft } from '../WorkflowStepCard';
@@ -121,6 +123,8 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 			id: s.id,
 			name: s.name,
 			agentId: s.agentId ?? '',
+			agents: s.agents,
+			channels: s.channels,
 			instructions: s.instructions ?? '',
 		};
 		return { step, position };
@@ -155,7 +159,14 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
  * Shared structure returned by both create and update serialisation.
  */
 interface BuiltWorkflowFields {
-	steps: Array<{ id: string; name: string; agentId: string; instructions?: string }>;
+	steps: Array<{
+		id: string;
+		name: string;
+		agentId?: string;
+		agents?: WorkflowStepAgent[];
+		channels?: WorkflowChannel[];
+		instructions?: string;
+	}>;
 	transitions: Array<{
 		from: string;
 		to: string;
@@ -225,10 +236,16 @@ function buildWorkflowFields(state: VisualEditorState): {
 	const steps = state.nodes.map((node, i) => {
 		const key = node.step.id ?? node.step.localId;
 		const persistedId = nodeMap.get(key)!.persistedId;
+		const hasMultiAgent = Array.isArray(node.step.agents) && node.step.agents.length > 0;
 		return {
 			id: persistedId,
 			name: node.step.name || `Step ${i + 1}`,
-			agentId: node.step.agentId,
+			// When agents array is provided and non-empty, omit agentId (agents takes precedence).
+			// Otherwise use the single agentId (may be empty string, serialized as undefined).
+			agentId: hasMultiAgent ? undefined : node.step.agentId || undefined,
+			agents: hasMultiAgent ? node.step.agents : undefined,
+			channels:
+				node.step.channels && node.step.channels.length > 0 ? node.step.channels : undefined,
 			instructions: node.step.instructions || undefined,
 		};
 	});


### PR DESCRIPTION
- Extended StepDraft type with agents?: WorkflowStepAgent[] and channels?: WorkflowChannel[]
- WorkflowNode renders multiple agent badges (chips) when step.agents is non-empty, with
  wider min-width (200px vs 160px) to accommodate multi-agent layout
- WorkflowNode shows channel topology as directed text arrows (→/↔) between role names
  below the agent badges
- NodeConfigPanel replaced single Agent dropdown with AgentsSection: handles both
  single-agent mode (dropdown + Add agent button to switch) and multi-agent mode
  (list of agents with per-agent instructions, remove buttons, add-from-dropdown)
- NodeConfigPanel adds ChannelsPanelSection (shown in multi-agent mode only): lists
  existing channels with remove buttons, add-channel form with from/direction/to/label
  fields and fan-out support (comma-separated to values)
- WorkflowStepCard (list editor) updated similarly: multi-agent badges in collapsed
  header, MultiAgentSection + ChannelsSection in expanded body
- Serialization updated to preserve agents/channels round-trip (workflowToVisualState
  restores both fields; buildWorkflowFields outputs agents+channels and omits agentId
  when agents array is non-empty)
- VisualWorkflowEditor validation updated to accept multi-agent steps (agents.length > 0
  satisfies the at-least-one-agent requirement without requiring agentId)
- Added 5 serialization tests, 6 WorkflowNode multi-agent rendering tests, and
  19 NodeConfigPanel multi-agent tests (agents list, remove, channels CRUD)
- All 4820 web tests pass; typecheck and lint clean
