### PR TITLE
feat: add sub-session members to groups (Task 2.2)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -642,8 +642,7 @@ export class TaskAgentManager {
 				const groupId = this.taskGroupIds.get(taskId);
 				if (groupId) {
 					try {
-						const group = this.config.sessionGroupRepo.getGroup(groupId);
-						const orderIndex = group?.members.length ?? 0;
+						const orderIndex = this.config.sessionGroupRepo.getMemberCount(groupId);
 						const member = this.config.sessionGroupRepo.addMember(groupId, sessionId, {
 							role: memberInfo?.role ?? 'agent',
 							agentId: memberInfo?.agentId,
@@ -759,11 +758,20 @@ export class TaskAgentManager {
 		);
 
 		// Subscribe to session.error to mark the group member as 'failed' when a
-		// fatal error occurs. This is independent of the completion callback.
+		// fatal error occurs. Sets `fired = true` so that a subsequent idle transition
+		// (session keeps going after an error) does not overwrite 'failed' with 'completed'.
+		// Also self-unsubscribes both listeners to prevent multiple invocations.
 		const unsubscribeError = this.config.daemonHub.on(
 			'session.error',
 			(_event) => {
 				if (fired) return; // Already handled by completion path
+				fired = true;
+				// Tear down both listeners now that the error terminal state is handled.
+				const unsub = this.sessionListeners.get(subSessionId);
+				if (unsub) {
+					unsub();
+					this.sessionListeners.delete(subSessionId);
+				}
 				const memberId = this.subSessionMemberIds.get(subSessionId);
 				if (!memberId) return;
 				try {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -60,7 +60,11 @@ import type { SpaceRuntimeService } from './space-runtime-service';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
-import type { SubSessionFactory, SubSessionState } from '../tools/task-agent-tools';
+import type {
+	SubSessionFactory,
+	SubSessionMemberInfo,
+	SubSessionState,
+} from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
@@ -137,6 +141,12 @@ export class TaskAgentManager {
 	 * Allows fast lookup when adding sub-session members to an existing group.
 	 */
 	private taskGroupIds = new Map<string, string>();
+
+	/**
+	 * Maps sub-session ID → SpaceSessionGroupMember.id for sessions that were
+	 * successfully added to a group. Used to update member status on completion.
+	 */
+	private subSessionMemberIds = new Map<string, string>();
 
 	/**
 	 * Completion callbacks registered via onComplete().
@@ -581,11 +591,12 @@ export class TaskAgentManager {
 			this.taskAgentSessions.delete(taskId);
 		}
 
-		// 3. Remove any dangling completion callbacks for known session IDs.
+		// 3. Remove any dangling completion callbacks and member ID entries for known session IDs.
 		// We use the exact session IDs collected above (sub-sessions + task agent)
 		// rather than a substring match to avoid false positives.
 		for (const sessionId of sessionIdsToClean) {
 			this.completionCallbacks.delete(sessionId);
+			this.subSessionMemberIds.delete(sessionId);
 		}
 
 		// 4. Remove session listeners for known session IDs
@@ -621,8 +632,37 @@ export class TaskAgentManager {
 	 */
 	private createSubSessionFactory(taskId: string): SubSessionFactory {
 		return {
-			create: async (init: AgentSessionInit): Promise<string> => {
-				return this.createSubSession(taskId, init.sessionId, init);
+			create: async (
+				init: AgentSessionInit,
+				memberInfo?: SubSessionMemberInfo
+			): Promise<string> => {
+				const sessionId = await this.createSubSession(taskId, init.sessionId, init);
+
+				// Add the sub-session as a member of the task's group (non-fatal).
+				const groupId = this.taskGroupIds.get(taskId);
+				if (groupId) {
+					try {
+						const group = this.config.sessionGroupRepo.getGroup(groupId);
+						const orderIndex = group?.members.length ?? 0;
+						const member = this.config.sessionGroupRepo.addMember(groupId, sessionId, {
+							role: memberInfo?.role ?? 'agent',
+							agentId: memberInfo?.agentId,
+							status: 'active',
+							orderIndex,
+						});
+						this.subSessionMemberIds.set(sessionId, member.id);
+						log.info(
+							`TaskAgentManager: added sub-session ${sessionId} as member ${member.id} to group ${groupId}`
+						);
+					} catch (err) {
+						log.warn(
+							`TaskAgentManager: failed to add sub-session ${sessionId} to group ${groupId}:`,
+							err
+						);
+					}
+				}
+
+				return sessionId;
 			},
 
 			getProcessingState: (subSessionId: string): SubSessionState | null => {
@@ -663,6 +703,7 @@ export class TaskAgentManager {
 	 * Register a completion callback for a sub-session.
 	 * Subscribes to DaemonHub session.updated events for the session.
 	 * The callback is called at most once when the session first goes idle.
+	 * Also subscribes to session.error to mark the group member as 'failed'.
 	 */
 	private registerCompletionCallback(subSessionId: string, callback: () => Promise<void>): void {
 		// Add to callback list
@@ -677,7 +718,7 @@ export class TaskAgentManager {
 		// Track whether we've fired (to make callback fire exactly once)
 		let fired = false;
 
-		const unsubscribe = this.config.daemonHub.on(
+		const unsubscribeUpdated = this.config.daemonHub.on(
 			'session.updated',
 			(event) => {
 				if (fired) return;
@@ -717,7 +758,31 @@ export class TaskAgentManager {
 			{ sessionId: subSessionId }
 		);
 
-		this.sessionListeners.set(subSessionId, unsubscribe);
+		// Subscribe to session.error to mark the group member as 'failed' when a
+		// fatal error occurs. This is independent of the completion callback.
+		const unsubscribeError = this.config.daemonHub.on(
+			'session.error',
+			(_event) => {
+				if (fired) return; // Already handled by completion path
+				const memberId = this.subSessionMemberIds.get(subSessionId);
+				if (!memberId) return;
+				try {
+					this.config.sessionGroupRepo.updateMemberStatus(memberId, 'failed');
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager: failed to mark member ${memberId} as failed for sub-session ${subSessionId}:`,
+						err
+					);
+				}
+			},
+			{ sessionId: subSessionId }
+		);
+
+		// Store a combined unsubscribe that tears down both listeners at once.
+		this.sessionListeners.set(subSessionId, () => {
+			unsubscribeUpdated();
+			unsubscribeError();
+		});
 	}
 
 	/**
@@ -753,6 +818,19 @@ export class TaskAgentManager {
 				}
 			} catch (err) {
 				log.warn(`TaskAgentManager: failed to mark step task ${stepTask.id} as completed:`, err);
+			}
+		}
+
+		// Update the group member status to 'completed'.
+		const memberId = this.subSessionMemberIds.get(subSessionId);
+		if (memberId) {
+			try {
+				this.config.sessionGroupRepo.updateMemberStatus(memberId, 'completed');
+			} catch (err) {
+				log.warn(
+					`TaskAgentManager: failed to mark member ${memberId} as completed for sub-session ${subSessionId}:`,
+					err
+				);
 			}
 		}
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -77,6 +77,17 @@ export interface SubSessionState {
 // ---------------------------------------------------------------------------
 
 /**
+ * Agent identity metadata passed to SubSessionFactory.create() so the manager
+ * can record the sub-session as a group member without re-fetching the agent.
+ */
+export interface SubSessionMemberInfo {
+	/** ID of the SpaceAgent config this sub-session uses */
+	agentId?: string;
+	/** Freeform role string from SpaceAgent.role (e.g. 'coder', 'reviewer') */
+	role?: string;
+}
+
+/**
  * Abstraction for creating and querying sub-sessions.
  * Injected into the config so tests can mock session behaviour without a real daemon.
  */
@@ -84,8 +95,10 @@ export interface SubSessionFactory {
 	/**
 	 * Creates and starts a new agent sub-session.
 	 * Returns the session ID of the created session.
+	 * The optional `memberInfo` carries agent identity metadata so the factory
+	 * can register the session as a group member.
 	 */
-	create(init: AgentSessionInit): Promise<string>;
+	create(init: AgentSessionInit, memberInfo?: SubSessionMemberInfo): Promise<string>;
 
 	/**
 	 * Returns the current processing state of a session, or null if the session
@@ -286,10 +299,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Failed to resolve agent init: ${message}` });
 			}
 
+			// Resolve agent identity for group membership tracking.
+			// resolveAgentInit() already validated the agent exists, so this lookup
+			// should always succeed — null here would be a data inconsistency.
+			const agentForMember = agentManager.getById(effectiveTask.customAgentId!);
+
 			// Create and start the sub-session
 			let actualSessionId: string;
 			try {
-				actualSessionId = await sessionFactory.create(init);
+				actualSessionId = await sessionFactory.create(init, {
+					agentId: effectiveTask.customAgentId ?? undefined,
+					role: agentForMember?.role ?? 'agent',
+				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: `Failed to create sub-session: ${message}` });

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -333,6 +333,17 @@ export class SpaceSessionGroupRepository {
 	}
 
 	/**
+	 * Return the current number of members in a group using a COUNT query.
+	 * Used to assign the next orderIndex without fetching all member rows.
+	 */
+	getMemberCount(groupId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as cnt FROM space_session_group_members WHERE group_id = ?`)
+			.get(groupId) as { cnt: number } | undefined;
+		return row?.cnt ?? 0;
+	}
+
+	/**
 	 * Get a single member record by ID
 	 */
 	getMember(id: string): SpaceSessionGroupMember | null {

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1032,6 +1032,182 @@ describe('TaskAgentManager', () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// Sub-session group membership
+	// -----------------------------------------------------------------------
+
+	describe('sub-session group membership', () => {
+		/** Helper: get the SubSessionFactory bound to a taskId via the private method */
+		function getFactory(
+			manager: TaskAgentManager,
+			taskId: string
+		): import('../../../src/lib/space/tools/task-agent-tools.ts').SubSessionFactory {
+			return (
+				manager as unknown as {
+					createSubSessionFactory: (
+						taskId: string
+					) => import('../../../src/lib/space/tools/task-agent-tools.ts').SubSessionFactory;
+				}
+			).createSubSessionFactory(taskId);
+		}
+
+		test('sub-session is added as group member with correct role and agentId', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			expect(groupId).toBeDefined();
+
+			const subSessionId = `sub-session-member-test-${task.id}`;
+			const factory = getFactory(ctx.manager, task.id);
+			const actualId = await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// The factory returns the session ID unchanged
+			expect(actualId).toBe(subSessionId);
+
+			// The group should now contain the sub-session as a member
+			const group = ctx.sessionGroupRepo.getGroup(groupId!);
+			const member = group?.members.find((m) => m.sessionId === subSessionId);
+			expect(member).toBeDefined();
+			expect(member?.agentId).toBe(ctx.agentId);
+			expect(member?.role).toBe('coder');
+			expect(member?.status).toBe('active');
+		});
+
+		test('multiple sub-sessions for same task all appear in the same group', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			expect(groupId).toBeDefined();
+
+			const factory = getFactory(ctx.manager, task.id);
+			const subId1 = `sub-multi-1-${task.id}`;
+			const subId2 = `sub-multi-2-${task.id}`;
+
+			await factory.create(
+				{
+					sessionId: subId1,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+			await factory.create(
+				{
+					sessionId: subId2,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'reviewer' }
+			);
+
+			const group = ctx.sessionGroupRepo.getGroup(groupId!);
+			const subMembers = group?.members.filter((m) => [subId1, subId2].includes(m.sessionId));
+			expect(subMembers?.length).toBe(2);
+
+			// orderIndex should be incremental
+			const indices = subMembers!.map((m) => m.orderIndex).sort((a, b) => a - b);
+			expect(indices[0]).toBeLessThan(indices[1]);
+		});
+
+		test('member status transitions to completed when handleSubSessionComplete fires', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-complete-test-${task.id}`;
+
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// Verify initial status is 'active'
+			const beforeGroup = ctx.sessionGroupRepo.getGroup(groupId!);
+			const memberBefore = beforeGroup?.members.find((m) => m.sessionId === subSessionId);
+			expect(memberBefore?.status).toBe('active');
+
+			// Call handleSubSessionComplete to trigger the status update
+			await (
+				ctx.manager as unknown as {
+					handleSubSessionComplete: (
+						taskId: string,
+						stepId: string,
+						subSessionId: string
+					) => Promise<void>;
+				}
+			).handleSubSessionComplete(task.id, 'step-1', subSessionId);
+
+			// Member status should now be 'completed'
+			const afterGroup = ctx.sessionGroupRepo.getGroup(groupId!);
+			const memberAfter = afterGroup?.members.find((m) => m.sessionId === subSessionId);
+			expect(memberAfter?.status).toBe('completed');
+		});
+
+		test('member status transitions to failed on session.error event', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-error-test-${task.id}`;
+
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// Register a completion callback so the error listener is set up
+			factory.onComplete(subSessionId, async () => {});
+
+			// Emit a session.error event
+			ctx.daemonHub.emit('session.error', {
+				sessionId: subSessionId,
+				error: 'Fatal API error',
+			});
+
+			await new Promise((r) => setTimeout(r, 0));
+
+			// Member status should now be 'failed'
+			const group = ctx.sessionGroupRepo.getGroup(groupId!);
+			const member = group?.members.find((m) => m.sessionId === subSessionId);
+			expect(member?.status).toBe('failed');
+		});
+
+		test('addMember is non-fatal — sub-session is still created when group not found', async () => {
+			// Create a task but do NOT spawn its Task Agent (so no group is created).
+			const task = await makeTask(ctx.taskManager);
+
+			// The factory is created directly without spawning the task agent,
+			// meaning taskGroupIds will not have an entry for this task.
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-no-group-${task.id}`;
+
+			// Should succeed without throwing even though there is no group
+			await expect(
+				factory.create(
+					{
+						sessionId: subSessionId,
+						workspacePath: '/tmp/ws',
+					} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+					{ agentId: ctx.agentId, role: 'coder' }
+				)
+			).resolves.toBe(subSessionId);
+		});
+	});
+
+	// -----------------------------------------------------------------------
 	// Message injection
 	// -----------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1185,6 +1185,62 @@ describe('TaskAgentManager', () => {
 			expect(member?.status).toBe('failed');
 		});
 
+		test('idle event after session.error does not overwrite failed status with completed', async () => {
+			// If session.error fires first (setting fired=true), a subsequent
+			// session.updated → idle must NOT call handleSubSessionComplete.
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const groupId = ctx.manager.getTaskGroupId(task.id);
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-error-then-idle-${task.id}`;
+
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// Simulate that the sub-session has processed messages
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			subSession._sdkMessageCount = 2;
+
+			// Register a completion callback so listeners are set up
+			let completionCallbackFired = false;
+			factory.onComplete(subSessionId, async () => {
+				completionCallbackFired = true;
+			});
+
+			// Emit session.error — sets fired=true and marks member as 'failed'
+			ctx.daemonHub.emit('session.error', {
+				sessionId: subSessionId,
+				error: 'Fatal API error',
+			});
+			await new Promise((r) => setTimeout(r, 0));
+
+			// Member should be 'failed'
+			const groupAfterError = ctx.sessionGroupRepo.getGroup(groupId!);
+			const memberAfterError = groupAfterError?.members.find((m) => m.sessionId === subSessionId);
+			expect(memberAfterError?.status).toBe('failed');
+
+			// Now emit idle — should NOT fire the completion callback or change the status
+			ctx.daemonHub.emit('session.updated', {
+				sessionId: subSessionId,
+				processingState: { status: 'idle' },
+			});
+			await new Promise((r) => setTimeout(r, 0));
+
+			// Completion callback must not have fired (fired guard blocked it)
+			expect(completionCallbackFired).toBe(false);
+
+			// Status must remain 'failed', not overwritten with 'completed'
+			const groupAfterIdle = ctx.sessionGroupRepo.getGroup(groupId!);
+			const memberAfterIdle = groupAfterIdle?.members.find((m) => m.sessionId === subSessionId);
+			expect(memberAfterIdle?.status).toBe('failed');
+		});
+
 		test('addMember is non-fatal — sub-session is still created when group not found', async () => {
 			// Create a task but do NOT spawn its Task Agent (so no group is created).
 			const task = await makeTask(ctx.taskManager);

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -30,6 +30,7 @@ import {
 	createTaskAgentToolHandlers,
 	createTaskAgentMcpServer,
 	type SubSessionFactory,
+	type SubSessionMemberInfo,
 	type SubSessionState,
 	type TaskAgentToolsConfig,
 } from '../../../src/lib/space/tools/task-agent-tools.ts';
@@ -187,20 +188,26 @@ function buildTaskResultWorkflow(
 // ---------------------------------------------------------------------------
 
 function makeMockSessionFactory(overrides?: {
-	create?: (init: unknown) => Promise<string>;
+	create?: (init: unknown, memberInfo?: SubSessionMemberInfo) => Promise<string>;
 	getProcessingState?: (sessionId: string) => SubSessionState | null;
 	onComplete?: (sessionId: string, callback: () => Promise<void>) => void;
-}): SubSessionFactory & { _completionCallbacks: Map<string, () => Promise<void>> } {
+}): SubSessionFactory & {
+	_completionCallbacks: Map<string, () => Promise<void>>;
+	_capturedMemberInfos: Map<string, SubSessionMemberInfo | undefined>;
+} {
 	const completionCallbacks = new Map<string, () => Promise<void>>();
 	const sessionStates = new Map<string, SubSessionState>();
+	const capturedMemberInfos = new Map<string, SubSessionMemberInfo | undefined>();
 
 	return {
 		_completionCallbacks: completionCallbacks,
+		_capturedMemberInfos: capturedMemberInfos,
 
-		async create(init: unknown): Promise<string> {
-			if (overrides?.create) return overrides.create(init);
+		async create(init: unknown, memberInfo?: SubSessionMemberInfo): Promise<string> {
+			if (overrides?.create) return overrides.create(init, memberInfo);
 			const id = `sub-session-${Math.random().toString(36).slice(2)}`;
 			sessionStates.set(id, { isProcessing: true, isComplete: false });
+			capturedMemberInfos.set(id, memberInfo);
 			return id;
 		},
 
@@ -225,6 +232,7 @@ function makeMockSessionFactory(overrides?: {
 		},
 	} as SubSessionFactory & {
 		_completionCallbacks: Map<string, () => Promise<void>>;
+		_capturedMemberInfos: Map<string, SubSessionMemberInfo | undefined>;
 		_triggerComplete: (sessionId: string) => Promise<void>;
 	};
 }
@@ -615,6 +623,26 @@ describe('createTaskAgentToolHandlers — spawn_step_agent', () => {
 		expect(secondParsed.success).toBe(true);
 		// The returned sessionId should be the same as the first (no duplicate sessions)
 		expect(secondParsed.sessionId).toBe(firstSessionId);
+	});
+
+	test('passes agentId and role as memberInfo to sessionFactory.create()', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.spawn_step_agent({ step_id: wf.startStepId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		const sessionId = parsed.sessionId;
+		const memberInfo = factory._capturedMemberInfos.get(sessionId);
+
+		// memberInfo must carry the agent's ID and role
+		expect(memberInfo).toBeDefined();
+		expect(memberInfo?.agentId).toBe(ctx.agentId);
+		// The seed agent has role 'coder' (see seedAgentRow in test context)
+		expect(memberInfo?.role).toBe('coder');
 	});
 });
 


### PR DESCRIPTION
## Summary

- Extends `SubSessionFactory.create()` with optional `SubSessionMemberInfo` (agentId, role) so `spawn_step_agent` can pass agent identity metadata to the manager
- In `createSubSessionFactory()`, after creating a sub-session, looks up the task's group via `taskGroupIds` and calls `sessionGroupRepo.addMember()` with the agent's role/agentId and `status:'active'`; `orderIndex` is set to current member count
- Tracks sub-session member IDs in new `subSessionMemberIds` map (sessionId → memberId)
- In `handleSubSessionComplete()`, calls `updateMemberStatus(memberId, 'completed')`
- In `registerCompletionCallback()`, subscribes to `session.error` to set `status:'failed'`
- Cleans up `subSessionMemberIds` entries in `cleanup()`

## Test plan

- [x] 5 new unit tests in `task-agent-manager.test.ts`:
  - Sub-session added with correct agentId, role, and status:'active'
  - Multiple sub-sessions for same task appear in same group with incremental orderIndex
  - Status transitions to 'completed' after handleSubSessionComplete fires
  - Status transitions to 'failed' on session.error event
  - addMember failure is non-fatal — sub-session is still created
- [x] 1 new test in `task-agent-tools.test.ts`: spawn_step_agent passes correct memberInfo to factory
- [x] All 75 task-agent-manager tests pass, all 61 task-agent-tools tests pass
- [x] Full daemon suite: 7071 pass (8 pre-existing failures in dev-proxy/copilot tests unrelated to this change)