### PR TITLE
feat: wire session title handler into SessionManager and remove pendingBackgroundTasks

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -188,8 +188,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			maxTokens: config.maxTokens,
 			temperature: config.temperature,
 			workspaceRoot: config.workspaceRoot,
-		}
+		},
+		jobQueue,
+		jobProcessor
 	);
+
+	// Register session title generation handler before jobProcessor starts
+	sessionManager.start();
 
 	// Initialize State Manager (listens to EventBus, clean dependency graph!)
 	const stateManager = new StateManager(

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,7 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { SESSION_TITLE_GENERATION, GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
-import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
+import { GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
 import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
 import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
@@ -151,11 +150,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 	setupTestHandlers(deps.messageHub, deps.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
-
-	// Job queue handler registrations
-	deps.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
-		handleSessionTitleGeneration(job, deps.sessionManager.getSessionLifecycle())
-	);
 
 	// Room handlers
 	setupRoomHandlers(

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -38,12 +38,11 @@ import { MessagePersistence } from './message-persistence';
 /**
  * Cleanup state machine for SessionManager
  *
- * Prevents race conditions during cleanup by tracking state and
- * preventing new background tasks from starting during cleanup.
+ * Prevents concurrent or redundant cleanup calls.
  *
  * States:
  * - IDLE: Normal operation, cleanup not started
- * - CLEANING: Cleanup in progress, barrier active for new background tasks
+ * - CLEANING: Cleanup in progress
  * - CLEANED: Cleanup complete, no further operations allowed
  */
 export enum CleanupState {
@@ -56,6 +55,7 @@ export class SessionManager {
 	private logger: Logger;
 	private worktreeManager: WorktreeManager;
 	private eventBusUnsubscribers: Array<() => void> = [];
+	private started = false;
 
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
@@ -116,8 +116,13 @@ export class SessionManager {
 	/**
 	 * Register job handlers and start background processing.
 	 * Must be called after construction but before jobProcessor.start().
+	 * Throws if called more than once to catch accidental double-registration.
 	 */
 	start(): void {
+		if (this.started) {
+			throw new Error('SessionManager.start() called more than once');
+		}
+		this.started = true;
 		this.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
 			handleSessionTitleGeneration(job, this.sessionLifecycle)
 		);

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -9,7 +9,6 @@
  *
  * Also manages:
  * - EventBus subscriptions for async message processing
- * - Background task tracking for cleanup
  */
 
 import type { Session, MessageHub, MessageDeliveryMode } from '@neokai/shared';
@@ -21,6 +20,10 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../storage/job-queue-processor';
+import { SESSION_TITLE_GENERATION } from '../job-queue-constants';
+import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
 
 // Import extracted modules
 import { SessionCache } from './session-cache';
@@ -54,10 +57,6 @@ export class SessionManager {
 	private worktreeManager: WorktreeManager;
 	private eventBusUnsubscribers: Array<() => void> = [];
 
-	// Track pending background tasks (like title generation) for cleanup
-	// These are fire-and-forget operations that must complete before DB closes
-	private pendingBackgroundTasks: Set<Promise<unknown>> = new Set();
-
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
 
@@ -73,7 +72,9 @@ export class SessionManager {
 		private authManager: AuthManager,
 		private settingsManager: SettingsManager,
 		private eventBus: DaemonHub,
-		private config: SessionLifecycleConfig
+		private config: SessionLifecycleConfig,
+		private jobQueue: JobQueueRepository,
+		private jobProcessor: JobQueueProcessor
 	) {
 		this.logger = new Logger('SessionManager');
 		this.worktreeManager = new WorktreeManager();
@@ -113,6 +114,16 @@ export class SessionManager {
 	}
 
 	/**
+	 * Register job handlers and start background processing.
+	 * Must be called after construction but before jobProcessor.start().
+	 */
+	start(): void {
+		this.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
+			handleSessionTitleGeneration(job, this.sessionLifecycle)
+		);
+	}
+
+	/**
 	 * Setup EventBus subscriptions for async message processing
 	 * ARCHITECTURE: EventBus-centric pattern - SessionManager handles message persistence
 	 */
@@ -138,29 +149,14 @@ export class SessionManager {
 			const { sessionId, userMessageText, needsWorkspaceInit, hasDraftToClear } = data;
 
 			try {
-				// STEP 1: Generate title and rename branch (if needed)
+				// STEP 1: Enqueue title generation job (if needed)
 				// Only run if workspace initialization is needed (first message)
-				// CRITICAL: Check cleanup barrier to prevent race conditions
 				if (needsWorkspaceInit) {
-					// BARRIER: Skip new background tasks during cleanup
-					// This prevents race conditions where tasks complete during shutdown
-					/* v8 ignore next */
-					if (this.cleanupState !== CleanupState.IDLE) return;
-
-					const titleGenTask = this.sessionLifecycle
-						.generateTitleAndRenameBranch(sessionId, userMessageText)
-						.catch((error) => {
-							// Title generation failure is non-fatal
-							this.logger.error(`[SessionManager] Title generation failed:`, error);
-						});
-
-					// Track task for cleanup barrier
-					this.pendingBackgroundTasks.add(titleGenTask);
-					titleGenTask.finally(() => {
-						this.pendingBackgroundTasks.delete(titleGenTask);
+					this.jobQueue.enqueue({
+						queue: SESSION_TITLE_GENERATION,
+						payload: { sessionId, userMessageText },
+						maxRetries: 2,
 					});
-
-					await titleGenTask;
 				}
 
 				// STEP 2: Clear draft if it matches the sent message content
@@ -324,11 +320,14 @@ export class SessionManager {
 	 * Cleanup all sessions (called during shutdown)
 	 *
 	 * Uses a state machine to prevent race conditions:
-	 * - IDLE → CLEANING: Sets barrier, prevents new background tasks
+	 * - IDLE → CLEANING: Sets barrier
 	 * - CLEANING: Executes cleanup in phases
 	 * - CLEANING → CLEANED: Final state, no more operations allowed
 	 *
 	 * If cleanup fails, state returns to IDLE to allow retry.
+	 *
+	 * Title generation jobs are drained by the job processor (stopped in app.ts
+	 * before sessionManager.cleanup() is called), not here.
 	 */
 	async cleanup(): Promise<void> {
 		// State check: prevent concurrent cleanup
@@ -336,7 +335,7 @@ export class SessionManager {
 			return;
 		}
 
-		// Transition to CLEANING state - sets the barrier for new background tasks
+		// Transition to CLEANING state
 		this.cleanupState = CleanupState.CLEANING;
 
 		try {
@@ -351,31 +350,7 @@ export class SessionManager {
 			}
 			this.eventBusUnsubscribers = [];
 
-			// PHASE 2: Wait for pending background tasks (like title generation) with timeout
-			// These are fire-and-forget operations from EventBus handlers
-			// The cleanup barrier prevents new tasks from starting
-			// Use a timeout to prevent hanging in CI when title generation takes too long
-			const BACKGROUND_TASK_TIMEOUT_MS = 5000; // 5 seconds max wait
-
-			if (this.pendingBackgroundTasks.size > 0) {
-				const timeoutPromise = new Promise<'timeout'>((resolve) =>
-					setTimeout(() => resolve('timeout'), BACKGROUND_TASK_TIMEOUT_MS)
-				);
-
-				await Promise.race([
-					Promise.all(Array.from(this.pendingBackgroundTasks))
-						.then(() => 'completed' as const)
-						.catch((error) => {
-							this.logger.error(`[SessionManager] Error waiting for background tasks:`, error);
-							return 'error' as const;
-						}),
-					timeoutPromise,
-				]);
-
-				this.pendingBackgroundTasks.clear();
-			}
-
-			// PHASE 3: Cleanup all in-memory sessions in parallel
+			// PHASE 2: Cleanup all in-memory sessions in parallel
 			// CRITICAL: Each AgentSession.cleanup() now properly stops SDK queries
 			// with lifecycle manager, ensuring subprocesses exit before we continue
 			const cleanupPromises: Promise<void>[] = [];

--- a/packages/daemon/tests/unit/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/session/session-manager.test.ts
@@ -163,25 +163,21 @@ describe('SessionManager', () => {
 
 	describe('start', () => {
 		it('should register session.title_generation handler on jobProcessor', () => {
+			expect(mockJobProcessor.register).not.toHaveBeenCalled();
+
 			sessionManager.start();
 
+			expect(mockJobProcessor.register).toHaveBeenCalledTimes(1);
 			expect(mockJobProcessor.register).toHaveBeenCalledWith(
 				'session.title_generation',
 				expect.any(Function)
 			);
 		});
 
-		it('should not enqueue a job before start is called', async () => {
-			const handler = eventHandlers.get('message.persisted');
+		it('should throw if called more than once', () => {
+			sessionManager.start();
 
-			await handler?.({
-				sessionId: 'test-id',
-				userMessageText: 'test message',
-				needsWorkspaceInit: false,
-				hasDraftToClear: false,
-			});
-
-			expect(mockJobQueue.enqueue).not.toHaveBeenCalled();
+			expect(() => sessionManager.start()).toThrow('SessionManager.start() called more than once');
 		});
 	});
 

--- a/packages/daemon/tests/unit/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/session/session-manager.test.ts
@@ -13,6 +13,8 @@ import type { AuthManager } from '../../../src/lib/auth-manager';
 import type { SettingsManager } from '../../../src/lib/settings-manager';
 import type { MessageHub, Session } from '@neokai/shared';
 import { DEFAULT_GLOBAL_SETTINGS } from '@neokai/shared';
+import type { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../../src/storage/job-queue-processor';
 
 describe('SessionManager', () => {
 	let sessionManager: SessionManager;
@@ -21,6 +23,8 @@ describe('SessionManager', () => {
 	let mockAuthManager: AuthManager;
 	let mockSettingsManager: SettingsManager;
 	let mockEventBus: DaemonHub;
+	let mockJobQueue: JobQueueRepository;
+	let mockJobProcessor: JobQueueProcessor;
 	let config: Record<string, unknown>;
 	let eventHandlers: Map<string, (...args: unknown[]) => unknown>;
 
@@ -99,6 +103,19 @@ describe('SessionManager', () => {
 			initialize: mock(async () => {}),
 		} as unknown as DaemonHub;
 
+		// Job queue mocks
+		mockJobQueue = {
+			enqueue: mock(() => ({ id: 'job-id', queue: 'session.title_generation' })),
+			listJobs: mock(() => []),
+		} as unknown as JobQueueRepository;
+
+		// Job processor mocks
+		mockJobProcessor = {
+			register: mock(() => {}),
+			start: mock(() => {}),
+			stop: mock(async () => {}),
+		} as unknown as JobQueueProcessor;
+
 		// Config
 		config = {
 			defaultModel: 'claude-sonnet-4-20250514',
@@ -114,7 +131,9 @@ describe('SessionManager', () => {
 			mockAuthManager,
 			mockSettingsManager,
 			mockEventBus,
-			config as Parameters<typeof SessionManager>[5]
+			config as Parameters<typeof SessionManager>[5],
+			mockJobQueue,
+			mockJobProcessor
 		);
 	});
 
@@ -139,6 +158,30 @@ describe('SessionManager', () => {
 
 		it('should have no active sessions initially', () => {
 			expect(sessionManager.getActiveSessions()).toBe(0);
+		});
+	});
+
+	describe('start', () => {
+		it('should register session.title_generation handler on jobProcessor', () => {
+			sessionManager.start();
+
+			expect(mockJobProcessor.register).toHaveBeenCalledWith(
+				'session.title_generation',
+				expect.any(Function)
+			);
+		});
+
+		it('should not enqueue a job before start is called', async () => {
+			const handler = eventHandlers.get('message.persisted');
+
+			await handler?.({
+				sessionId: 'test-id',
+				userMessageText: 'test message',
+				needsWorkspaceInit: false,
+				hasDraftToClear: false,
+			});
+
+			expect(mockJobQueue.enqueue).not.toHaveBeenCalled();
 		});
 	});
 
@@ -494,11 +537,11 @@ describe('SessionManager', () => {
 			expect(sessionManager.getCleanupState()).toBe(CleanupState.CLEANED);
 		});
 
-		it('should wait for pending background tasks with timeout', async () => {
-			// This tests the timeout behavior for background tasks
+		it('should complete without draining pending tasks (processor handles drain)', async () => {
+			// Background task draining is now handled by the job processor,
+			// not by SessionManager. Cleanup should be immediate.
 			await sessionManager.cleanup();
 
-			// Should complete within reasonable time
 			expect(sessionManager.getCleanupState()).toBe(CleanupState.CLEANED);
 		});
 	});
@@ -561,13 +604,9 @@ describe('SessionManager', () => {
 				);
 			});
 
-			it('should skip background tasks during cleanup', async () => {
-				// Start cleanup to set barrier
-				const cleanupPromise = sessionManager.cleanup();
-
+			it('should enqueue title generation job when needsWorkspaceInit is true', async () => {
 				const handler = eventHandlers.get('message.persisted');
 
-				// This should be skipped due to cleanup barrier
 				await handler?.({
 					sessionId: 'test-id',
 					userMessageText: 'test message',
@@ -575,7 +614,11 @@ describe('SessionManager', () => {
 					hasDraftToClear: false,
 				});
 
-				await cleanupPromise;
+				expect(mockJobQueue.enqueue).toHaveBeenCalledWith({
+					queue: 'session.title_generation',
+					payload: { sessionId: 'test-id', userMessageText: 'test message' },
+					maxRetries: 2,
+				});
 			});
 
 			it('should clear draft when hasDraftToClear is true', async () => {


### PR DESCRIPTION
- Add jobQueue and jobProcessor dependencies to SessionManager constructor
- Add start() method that registers session.title_generation handler
- Replace fire-and-forget pendingBackgroundTasks with jobQueue.enqueue()
- Remove pendingBackgroundTasks field and cleanup drain logic
- Call sessionManager.start() in app.ts before jobProcessor.start()
- Move handler registration from rpc-handlers/index.ts to SessionManager.start()
- Update and expand unit tests to cover new enqueue behavior
