### PR TITLE
feat: add notifyChange to GoalRepository and wire through GoalManager

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -104,8 +104,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize database
 	const db = new Database(config.dbPath);
-	await db.initialize();
+	// Create reactiveDb before initialize() so GoalRepository can receive it
 	const reactiveDb = createReactiveDatabase(db);
+	await db.initialize(reactiveDb);
 	const liveQueries = new LiveQueryEngine(db.getDatabase(), reactiveDb);
 
 	// Initialize job queue

--- a/packages/daemon/src/lib/room/managers/goal-manager.ts
+++ b/packages/daemon/src/lib/room/managers/goal-manager.ts
@@ -16,6 +16,7 @@ import {
 	type UpdateGoalParams,
 } from '../../../storage/repositories/goal-repository';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
+import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type {
 	RoomGoal,
 	GoalStatus,
@@ -43,9 +44,10 @@ export class GoalManager {
 
 	constructor(
 		private db: BunDatabase,
-		private roomId: string
+		private roomId: string,
+		reactiveDb: ReactiveDatabase
 	) {
-		this.goalRepo = new GoalRepository(db);
+		this.goalRepo = new GoalRepository(db, reactiveDb);
 		this.taskRepo = new TaskRepository(db);
 	}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -371,7 +371,7 @@ export class RoomRuntimeService {
 		const rawDb = this.ctx.db.getDatabase();
 		const groupRepo = new SessionGroupRepository(rawDb);
 		const taskManager = new TaskManager(rawDb, room.id, this.ctx.reactiveDb);
-		const goalManager = new GoalManager(rawDb, room.id);
+		const goalManager = new GoalManager(rawDb, room.id, this.ctx.reactiveDb);
 		const sdkMessageRepo = new SDKMessageRepository(rawDb);
 		const observer = new SessionObserver(this.ctx.daemonHub);
 		const sessionFactory = this.createSessionFactory();

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -127,7 +127,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Create factory function for per-room goal managers
 	const goalManagerFactory: GoalManagerFactory = (roomId: string) => {
-		return new GoalManager(deps.db.getDatabase(), roomId);
+		return new GoalManager(deps.db.getDatabase(), roomId, deps.reactiveDb);
 	};
 
 	// Create factory function for per-room task managers (used by goal review handlers)

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -31,6 +31,7 @@ import {
 	type UpdateGoalParams,
 } from './repositories/goal-repository';
 import { JobQueueRepository } from './repositories/job-queue-repository';
+import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
 export type { SQLiteValue } from './types';
@@ -71,7 +72,7 @@ export class Database {
 		this.core = new DatabaseCore(dbPath);
 	}
 
-	async initialize(): Promise<void> {
+	async initialize(reactiveDb: ReactiveDatabase): Promise<void> {
 		await this.core.initialize();
 
 		// Initialize repositories with the raw BunDatabase instance
@@ -81,7 +82,7 @@ export class Database {
 		this.settingsRepo = new SettingsRepository(db);
 		this.githubMappingRepo = new GitHubMappingRepository(db);
 		this.inboxItemRepo = new InboxItemRepository(db);
-		this.goalRepo = new GoalRepository(db);
+		this.goalRepo = new GoalRepository(db, reactiveDb);
 		this.jobQueueRepo = new JobQueueRepository(db);
 	}
 

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -71,12 +71,6 @@ const METHOD_TABLE_MAP: Record<string, string> = {
 	blockInboxItem: 'inbox_items',
 	deleteInboxItem: 'inbox_items',
 	deleteInboxItemsForRepository: 'inbox_items',
-	// Goal operations
-	createGoal: 'goals',
-	updateGoal: 'goals',
-	deleteGoal: 'goals',
-	linkTaskToGoal: 'goals',
-	unlinkTaskFromGoal: 'goals',
 };
 
 export function createReactiveDatabase(db: Database): ReactiveDatabase {

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -359,6 +359,9 @@ export class GoalRepository {
 
 	/**
 	 * Insert a metric history data point for a goal
+	 *
+	 * TODO(LiveQuery): call notifyChange('mission_metric_history') here once a
+	 * LiveQuery subscription on that table is wired up (deferred from Task 1.4).
 	 */
 	insertMetricHistory(
 		goalId: string,
@@ -482,6 +485,9 @@ export class GoalRepository {
 
 	/**
 	 * Insert a new mission execution record
+	 *
+	 * TODO(LiveQuery): call notifyChange('mission_executions') here once a
+	 * LiveQuery subscription on that table is wired up (deferred from Task 1.4).
 	 */
 	insertExecution(params: CreateExecutionParams): MissionExecution {
 		const id = generateUUID();
@@ -531,6 +537,9 @@ export class GoalRepository {
 
 	/**
 	 * Update a mission execution (status, completedAt, resultSummary, taskIds, planningAttempts)
+	 *
+	 * TODO(LiveQuery): call notifyChange('mission_executions') here once a
+	 * LiveQuery subscription on that table is wired up (deferred from Task 1.4).
 	 */
 	updateExecution(id: string, params: UpdateExecutionParams): MissionExecution | null {
 		const fields: string[] = [];

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -20,6 +20,7 @@ import type {
 	MissionExecutionStatus,
 } from '@neokai/shared';
 import type { SQLiteValue } from '../types';
+import type { ReactiveDatabase } from '../reactive-database';
 
 export interface CreateGoalParams {
 	roomId: string;
@@ -75,7 +76,10 @@ export interface UpdateExecutionParams {
 }
 
 export class GoalRepository {
-	constructor(private db: BunDatabase) {}
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
 
 	/**
 	 * Create a new goal
@@ -119,6 +123,7 @@ export class GoalRepository {
 			params.replanCount ?? 0
 		);
 
+		this.reactiveDb.notifyChange('goals');
 		return this.getGoal(id)!;
 	}
 
@@ -253,6 +258,7 @@ export class GoalRepository {
 		const stmt = this.db.prepare(`UPDATE goals SET ${fields.join(', ')} WHERE id = ?`);
 		stmt.run(...values);
 
+		this.reactiveDb.notifyChange('goals');
 		return this.getGoal(id);
 	}
 
@@ -262,7 +268,11 @@ export class GoalRepository {
 	deleteGoal(id: string): boolean {
 		const stmt = this.db.prepare(`DELETE FROM goals WHERE id = ?`);
 		const result = stmt.run(id);
-		return result.changes > 0;
+		if (result.changes > 0) {
+			this.reactiveDb.notifyChange('goals');
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/packages/daemon/tests/helpers/database.ts
+++ b/packages/daemon/tests/helpers/database.ts
@@ -5,6 +5,7 @@
 import type { Session } from '@neokai/shared';
 import { mock } from 'bun:test';
 import { Database } from '../../src/storage/database';
+import { createReactiveDatabase } from '../../src/storage/reactive-database';
 import { createDaemonHub, type DaemonHub } from '../../src/lib/daemon-hub';
 
 /**
@@ -12,7 +13,8 @@ import { createDaemonHub, type DaemonHub } from '../../src/lib/daemon-hub';
  */
 export async function createTestDb(): Promise<Database> {
 	const db = new Database(':memory:');
-	await db.initialize();
+	const reactiveDb = createReactiveDatabase(db);
+	await db.initialize(reactiveDb);
 	return db;
 }
 

--- a/packages/daemon/tests/helpers/reactive-database.ts
+++ b/packages/daemon/tests/helpers/reactive-database.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared test helper: no-op ReactiveDatabase stub.
+ *
+ * Use this in unit tests that construct GoalRepository, GoalManager, or other
+ * classes that require a ReactiveDatabase but don't need real change notifications.
+ */
+
+import type { ReactiveDatabase } from '../../src/storage/reactive-database';
+
+export const noOpReactiveDb: ReactiveDatabase = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+};

--- a/packages/daemon/tests/unit/room/goal-manager-measurable.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager-measurable.test.ts
@@ -16,18 +16,7 @@ import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { MissionMetric } from '@neokai/shared';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 // Inline goals table DDL matching the V2 schema (mirrors what migration 28 adds)
 const GOALS_TABLE_DDL = `

--- a/packages/daemon/tests/unit/room/goal-manager-measurable.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager-measurable.test.ts
@@ -16,6 +16,18 @@ import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { MissionMetric } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 
 // Inline goals table DDL matching the V2 schema (mirrors what migration 28 adds)
 const GOALS_TABLE_DDL = `
@@ -106,8 +118,8 @@ describe('GoalManager — Measurable Missions', () => {
 		});
 		roomId = room.id;
 
-		goalManager = new GoalManager(db, roomId);
-		goalRepo = new GoalRepository(db);
+		goalManager = new GoalManager(db, roomId, noOpReactiveDb);
+		goalRepo = new GoalRepository(db, noOpReactiveDb);
 	});
 
 	afterEach(() => {
@@ -653,7 +665,7 @@ describe('GoalManager — Measurable Missions', () => {
 	describe('room isolation', () => {
 		it('should not allow recording metric for goal in another room', async () => {
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const goalManager2 = new GoalManager(db, room2.id);
+			const goalManager2 = new GoalManager(db, room2.id, noOpReactiveDb);
 
 			const goal = await goalManager.createGoal({
 				title: 'Room 1 Goal',

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -16,18 +16,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { NeoTask } from '@neokai/shared';

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -16,6 +16,18 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { NeoTask } from '@neokai/shared';
@@ -70,7 +82,7 @@ describe('GoalManager', () => {
 		roomId = room.id;
 
 		// Create goal manager
-		goalManager = new GoalManager(db, roomId);
+		goalManager = new GoalManager(db, roomId, noOpReactiveDb);
 
 		// Create task manager for testing task linking
 		taskManager = new TaskManager(db, roomId, { notifyChange: () => {} } as never);
@@ -175,7 +187,7 @@ describe('GoalManager', () => {
 
 			// Create another room and goal manager
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const goalManager2 = new GoalManager(db, room2.id);
+			const goalManager2 = new GoalManager(db, room2.id, noOpReactiveDb);
 
 			// Should not be able to access room 1's goal from room 2's manager
 			const retrieved = await goalManager2.getGoal(created.id);
@@ -217,7 +229,7 @@ describe('GoalManager', () => {
 			await goalManager.createGoal({ title: 'Room 1 Goal', description: '' });
 
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const goalManager2 = new GoalManager(db, room2.id);
+			const goalManager2 = new GoalManager(db, room2.id, noOpReactiveDb);
 			await goalManager2.createGoal({ title: 'Room 2 Goal', description: '' });
 
 			const goals1 = await goalManager.listGoals();
@@ -485,7 +497,7 @@ describe('GoalManager', () => {
 			// Manually add a non-existent task ID to linkedTaskIds
 			const goalRepo = new (
 				await import('../../../src/storage/repositories/goal-repository')
-			).GoalRepository(db);
+			).GoalRepository(db, noOpReactiveDb);
 			goalRepo.updateGoal(goal.id, { linkedTaskIds: [task1.id, 'non-existent-task'] });
 
 			const updatedGoal = await goalManager.getGoal(goal.id);
@@ -670,7 +682,7 @@ describe('GoalManager', () => {
 			const goal = await goalManager.createGoal({ title: 'Room 1 Goal', description: '' });
 
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const goalManager2 = new GoalManager(db, room2.id);
+			const goalManager2 = new GoalManager(db, room2.id, noOpReactiveDb);
 
 			const result = await goalManager2.deleteGoal(goal.id);
 
@@ -692,7 +704,7 @@ describe('GoalManager', () => {
 			// Link tasks manually via repo to avoid auto-recalculation
 			const goalRepo = new (
 				await import('../../../src/storage/repositories/goal-repository')
-			).GoalRepository(db);
+			).GoalRepository(db, noOpReactiveDb);
 			goalRepo.updateGoal(goal.id, { linkedTaskIds: [task1.id, task2.id] });
 
 			const progress = await goalManager.recalculateProgress(goal.id);
@@ -714,7 +726,7 @@ describe('GoalManager', () => {
 		it('should isolate goals between rooms', async () => {
 			// Create another room
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const goalManager2 = new GoalManager(db, room2.id);
+			const goalManager2 = new GoalManager(db, room2.id, noOpReactiveDb);
 
 			// Add goals to both rooms
 			await goalManager.createGoal({ title: 'Room 1 Goal', description: '' });

--- a/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
+++ b/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
@@ -12,6 +12,18 @@ import { createTables } from '../../../src/storage/schema';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { MissionMetric, CronSchedule } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 
 describe('GoalRepository — V2 Mission fields', () => {
 	let db: Database;
@@ -30,7 +42,7 @@ describe('GoalRepository — V2 Mission fields', () => {
 			defaultPath: '/workspace/test',
 		});
 		roomId = room.id;
-		repo = new GoalRepository(db);
+		repo = new GoalRepository(db, noOpReactiveDb);
 	});
 
 	afterEach(() => {

--- a/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
+++ b/packages/daemon/tests/unit/room/goal-repository-v2.test.ts
@@ -12,18 +12,7 @@ import { createTables } from '../../../src/storage/schema';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { MissionMetric, CronSchedule } from '@neokai/shared';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 describe('GoalRepository — V2 Mission fields', () => {
 	let db: Database;

--- a/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
@@ -19,18 +19,7 @@ import {
 } from './room-runtime-test-helpers';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 // ─── Schema helper ────────────────────────────────────────────────────────────
 

--- a/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/room/mission-system-edge-cases.test.ts
@@ -19,6 +19,18 @@ import {
 } from './room-runtime-test-helpers';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 
 // ─── Schema helper ────────────────────────────────────────────────────────────
 
@@ -222,7 +234,7 @@ describe('Metrics: dual-write derivation', () => {
 		db.exec(
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test', ${now}, ${now})`
 		);
-		goalManager = new GoalManager(db as never, roomId);
+		goalManager = new GoalManager(db as never, roomId, noOpReactiveDb);
 	});
 
 	afterEach(() => {
@@ -509,7 +521,7 @@ describe('Migration: legacy goals default to one_shot / supervised', () => {
 		db.exec(
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Legacy Room', ${now}, ${now})`
 		);
-		goalRepo = new GoalRepository(db as never);
+		goalRepo = new GoalRepository(db as never, noOpReactiveDb);
 	});
 
 	afterEach(() => {

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -17,6 +17,18 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 
 // ============================================================
 // Tests
@@ -236,7 +248,7 @@ describe('Recurring Missions: tickRecurringMissions triggers execution', () => {
 			description: 'From previous execution',
 			status: 'completed',
 		});
-		const goalRepo = new GoalRepository(ctx.db as never);
+		const goalRepo = new GoalRepository(ctx.db as never, noOpReactiveDb);
 		goalRepo.linkTaskToGoal(goal.id, oldTask.id);
 
 		ctx.runtime.start();

--- a/packages/daemon/tests/unit/room/recurring-missions.test.ts
+++ b/packages/daemon/tests/unit/room/recurring-missions.test.ts
@@ -17,18 +17,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
 import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 
 // ============================================================
 // Tests

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1,18 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
 import {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
 import {
@@ -116,8 +128,8 @@ describe('Room Agent Tools', () => {
 			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test', ${Date.now()}, ${Date.now()});
 		`);
 
-		goalManager = new GoalManager(db as never, roomId);
-		taskManager = new TaskManager(db as never, roomId, { notifyChange: () => {} } as never);
+		goalManager = new GoalManager(db as never, roomId, noOpReactiveDb);
+		taskManager = new TaskManager(db as never, roomId, noOpReactiveDb);
 		groupRepo = new SessionGroupRepository(db as never);
 		handlers = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
 	});

--- a/packages/daemon/tests/unit/room/room-manager.test.ts
+++ b/packages/daemon/tests/unit/room/room-manager.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from '../../../src/storage/database';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
 import { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { CreateRoomParams, WorkspacePath } from '@neokai/shared';
 
@@ -23,7 +24,8 @@ describe('RoomManager', () => {
 		// Use an anonymous in-memory database for each test
 		// This ensures complete isolation between tests
 		db = new Database(':memory:');
-		await db.initialize();
+		const reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
 		roomManager = new RoomManager(db.getDatabase());
 	});
 

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -5,18 +5,7 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room, GlobalSettings } from '@neokai/shared';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { HookOptions } from '../../../src/lib/room/runtime/lifecycle-hooks';

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -5,6 +5,18 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room, GlobalSettings } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { HookOptions } from '../../../src/lib/room/runtime/lifecycle-hooks';
@@ -242,8 +254,8 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 	const mockHub = createMockDaemonHub();
 	const groupRepo = new SessionGroupRepository(db as never);
 	const observer = new SessionObserver(mockHub as unknown as DaemonHub);
-	const taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
-	const goalManager = new GoalManager(db as never, 'room-1');
+	const taskManager = new TaskManager(db as never, 'room-1', noOpReactiveDb);
+	const goalManager = new GoalManager(db as never, 'room-1', noOpReactiveDb);
 	const sessionFactory = createMockSessionFactory();
 	const room = makeRoom(opts?.room);
 

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -10,18 +10,7 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room } from '@neokai/shared';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -10,6 +10,18 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 
@@ -166,8 +178,8 @@ describe('Runtime Recovery', () => {
 		const mockHub = createMockDaemonHub();
 		groupRepo = new SessionGroupRepository(db as never);
 		observer = new SessionObserver(mockHub as unknown as DaemonHub);
-		taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
-		goalManager = new GoalManager(db as never, 'room-1');
+		taskManager = new TaskManager(db as never, 'room-1', noOpReactiveDb);
+		goalManager = new GoalManager(db as never, 'room-1', noOpReactiveDb);
 		sessionFactory = createMockSessionFactory();
 
 		runtime = new RoomRuntime({

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -10,18 +10,7 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
-import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import type { LeaderToolCallbacks } from '../../../src/lib/room/agents/leader-agent';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -10,6 +10,18 @@ import { SessionObserver } from '../../../src/lib/room/state/session-observer';
 import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import { TaskManager } from '../../../src/lib/room/managers/task-manager';
 import type { Room, RoomGoal, NeoTask } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 import type { LeaderToolCallbacks } from '../../../src/lib/room/agents/leader-agent';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 
@@ -266,8 +278,8 @@ describe('TaskGroupManager', () => {
 		const mockHub = createMockDaemonHub();
 		groupRepo = new SessionGroupRepository(db as never);
 		observer = new SessionObserver(mockHub as unknown as DaemonHub);
-		taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
-		goalManager = new GoalManager(db as never, 'room-1');
+		taskManager = new TaskManager(db as never, 'room-1', noOpReactiveDb);
+		goalManager = new GoalManager(db as never, 'room-1', noOpReactiveDb);
 		sessionFactory = createMockSessionFactory();
 
 		const room = makeRoom();

--- a/packages/daemon/tests/unit/storage/database-facade.test.ts
+++ b/packages/daemon/tests/unit/storage/database-facade.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from '../../../src/storage';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
 import type { Session } from '@neokai/shared';
 
 // Factory function to create a test session
@@ -47,7 +48,8 @@ describe('Database Facade', () => {
 		const tmpBase = (process.env.TMPDIR || '/tmp').replace(/\/$/, '');
 		dbPath = `${tmpBase}/test-db-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
 		db = new Database(dbPath);
-		await db.initialize();
+		const reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
 	});
 
 	afterEach(() => {

--- a/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
+++ b/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
@@ -11,9 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { rmSync } from 'node:fs';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { createTables } from '../../../src/storage/schema';
 import { createReactiveDatabase } from '../../../src/storage/reactive-database';
@@ -25,10 +22,6 @@ import type { QueryDiff } from '../../../src/storage/live-query';
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function makeTempDbPath(): string {
-	return join(tmpdir(), `goal-repo-lq-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
-}
 
 const GOALS_SQL = `SELECT id, title, status FROM goals ORDER BY created_at ASC`;
 
@@ -43,7 +36,6 @@ interface GoalRow {
 // ---------------------------------------------------------------------------
 
 describe('GoalRepository → LiveQueryEngine subscription on goals', () => {
-	let dbPath: string;
 	let bunDb: BunDatabase;
 	let reactiveDb: ReactiveDatabase;
 	let engine: LiveQueryEngine;
@@ -51,8 +43,7 @@ describe('GoalRepository → LiveQueryEngine subscription on goals', () => {
 	let roomId: string;
 
 	beforeEach(() => {
-		dbPath = makeTempDbPath();
-		bunDb = new BunDatabase(dbPath);
+		bunDb = new BunDatabase(':memory:');
 		createTables(bunDb);
 
 		// Insert a minimal room row so FK constraints are satisfied
@@ -73,18 +64,7 @@ describe('GoalRepository → LiveQueryEngine subscription on goals', () => {
 
 	afterEach(() => {
 		engine.dispose();
-		try {
-			bunDb.close();
-		} catch {
-			/* already closed */
-		}
-		try {
-			rmSync(dbPath, { force: true });
-			rmSync(dbPath + '-wal', { force: true });
-			rmSync(dbPath + '-shm', { force: true });
-		} catch {
-			/* ok */
-		}
+		bunDb.close();
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
+++ b/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
@@ -1,0 +1,247 @@
+/**
+ * GoalRepository LiveQuery Integration Tests
+ *
+ * Unit test: LiveQueryEngine subscriptions on `goals` fire after every
+ * write through GoalRepository (create, update, delete, link, unlink).
+ *
+ * Design: GoalRepository calls reactiveDb.notifyChange('goals') after each
+ * mutating operation. LiveQueryEngine listens on the reactive change event and
+ * re-evaluates registered queries in a microtask, then calls subscribers with
+ * a diff. All assertions await a microtask flush before checking diffs.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../src/storage/live-query';
+import { GoalRepository } from '../../../src/storage/repositories/goal-repository';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { QueryDiff } from '../../../src/storage/live-query';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDbPath(): string {
+	return join(
+		tmpdir(),
+		`goal-repo-lq-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+	);
+}
+
+const GOALS_SQL = `SELECT id, title, status FROM goals ORDER BY created_at ASC`;
+
+interface GoalRow {
+	id: string;
+	title: string;
+	status: string;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('GoalRepository → LiveQueryEngine subscription on goals', () => {
+	let dbPath: string;
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let engine: LiveQueryEngine;
+	let repo: GoalRepository;
+	let roomId: string;
+
+	beforeEach(() => {
+		dbPath = makeTempDbPath();
+		bunDb = new BunDatabase(dbPath);
+		createTables(bunDb);
+
+		// Insert a minimal room row so FK constraints are satisfied
+		roomId = 'room-lq-test';
+		bunDb.exec(
+			`INSERT OR IGNORE INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test Room', ${Date.now()}, ${Date.now()})`
+		);
+
+		// Wire up reactive layer
+		// Note: createReactiveDatabase wraps a Database facade; here we pass the
+		// BunDatabase directly for a lightweight setup.  notifyChange() is called
+		// manually by GoalRepository, so the proxy is not needed.
+		// We build a minimal reactiveDb backed directly by the BunDatabase.
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		engine = new LiveQueryEngine(bunDb, reactiveDb);
+		repo = new GoalRepository(bunDb, reactiveDb);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		try {
+			bunDb.close();
+		} catch {
+			/* already closed */
+		}
+		try {
+			rmSync(dbPath, { force: true });
+			rmSync(dbPath + '-wal', { force: true });
+			rmSync(dbPath + '-shm', { force: true });
+		} catch {
+			/* ok */
+		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// createGoal
+	// ---------------------------------------------------------------------------
+
+	test('createGoal fires a LiveQuery delta', async () => {
+		const diffs: QueryDiff<GoalRow>[] = [];
+		engine.subscribe(GOALS_SQL, [], (diff) => diffs.push(diff));
+
+		// snapshot fires synchronously
+		expect(diffs.length).toBe(1);
+		expect(diffs[0].type).toBe('snapshot');
+		expect(diffs[0].rows).toHaveLength(0);
+
+		repo.createGoal({ roomId, title: 'First Goal' });
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].added).toHaveLength(1);
+		expect(diffs[1].added?.[0].title).toBe('First Goal');
+	});
+
+	// ---------------------------------------------------------------------------
+	// updateGoal
+	// ---------------------------------------------------------------------------
+
+	test('updateGoal fires a LiveQuery delta', async () => {
+		const goal = repo.createGoal({ roomId, title: 'To Update' });
+
+		const diffs: QueryDiff<GoalRow>[] = [];
+		engine.subscribe(GOALS_SQL, [], (diff) => diffs.push(diff));
+		expect(diffs[0].rows).toHaveLength(1);
+
+		repo.updateGoal(goal.id, { status: 'completed' });
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].updated?.[0].status).toBe('completed');
+	});
+
+	// ---------------------------------------------------------------------------
+	// deleteGoal
+	// ---------------------------------------------------------------------------
+
+	test('deleteGoal fires a LiveQuery delta', async () => {
+		const goal = repo.createGoal({ roomId, title: 'To Delete' });
+
+		const diffs: QueryDiff<GoalRow>[] = [];
+		engine.subscribe(GOALS_SQL, [], (diff) => diffs.push(diff));
+		expect(diffs[0].rows).toHaveLength(1);
+
+		repo.deleteGoal(goal.id);
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].removed).toHaveLength(1);
+		expect(diffs[1].removed?.[0].id).toBe(goal.id);
+	});
+
+	// ---------------------------------------------------------------------------
+	// linkTaskToGoal (calls updateGoal internally)
+	// ---------------------------------------------------------------------------
+
+	test('linkTaskToGoal fires a LiveQuery delta', async () => {
+		const goal = repo.createGoal({ roomId, title: 'Link Test' });
+
+		// Insert a minimal task so we have a valid task ID to link
+		const taskId = 'task-lq-link';
+		bunDb.exec(
+			`INSERT OR IGNORE INTO tasks
+			 (id, room_id, title, description, status, priority, created_at)
+			 VALUES ('${taskId}', '${roomId}', 'Task', '', 'pending', 'normal', ${Date.now()})`
+		);
+
+		// Subscribe to linked_task_ids column
+		const LINKED_SQL = `SELECT id, linked_task_ids FROM goals WHERE id = ?`;
+		const diffs: QueryDiff<{ id: string; linked_task_ids: string }>[] = [];
+		engine.subscribe(LINKED_SQL, [goal.id], (diff) => diffs.push(diff));
+		expect(JSON.parse(diffs[0].rows[0].linked_task_ids)).toHaveLength(0);
+
+		repo.linkTaskToGoal(goal.id, taskId);
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		const linkedIds = JSON.parse(diffs[1].updated?.[0].linked_task_ids ?? '[]');
+		expect(linkedIds).toContain(taskId);
+	});
+
+	// ---------------------------------------------------------------------------
+	// unlinkTaskFromGoal (calls updateGoal internally)
+	// ---------------------------------------------------------------------------
+
+	test('unlinkTaskFromGoal fires a LiveQuery delta', async () => {
+		const taskId = 'task-lq-unlink';
+		bunDb.exec(
+			`INSERT OR IGNORE INTO tasks
+			 (id, room_id, title, description, status, priority, created_at)
+			 VALUES ('${taskId}', '${roomId}', 'Task', '', 'pending', 'normal', ${Date.now()})`
+		);
+
+		const goal = repo.createGoal({ roomId, title: 'Unlink Test' });
+		repo.linkTaskToGoal(goal.id, taskId);
+
+		const LINKED_SQL = `SELECT id, linked_task_ids FROM goals WHERE id = ?`;
+		const diffs: QueryDiff<{ id: string; linked_task_ids: string }>[] = [];
+		engine.subscribe(LINKED_SQL, [goal.id], (diff) => diffs.push(diff));
+
+		const initialIds = JSON.parse(diffs[0].rows[0].linked_task_ids);
+		expect(initialIds).toContain(taskId);
+
+		repo.unlinkTaskFromGoal(goal.id, taskId);
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		const afterIds = JSON.parse(diffs[1].updated?.[0].linked_task_ids ?? '[]');
+		expect(afterIds).not.toContain(taskId);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Multiple writes coalesce
+	// ---------------------------------------------------------------------------
+
+	test('multiple rapid createGoal calls coalesce into one delta', async () => {
+		const diffs: QueryDiff<GoalRow>[] = [];
+		engine.subscribe(GOALS_SQL, [], (diff) => diffs.push(diff));
+		expect(diffs[0].rows).toHaveLength(0);
+
+		// Three back-to-back writes without yielding
+		repo.createGoal({ roomId, title: 'Goal A' });
+		repo.createGoal({ roomId, title: 'Goal B' });
+		repo.createGoal({ roomId, title: 'Goal C' });
+
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// Should coalesce into one delta (snapshot + 1 delta)
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].added).toHaveLength(3);
+	});
+});

--- a/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
+++ b/packages/daemon/tests/unit/storage/goal-repository-live-query.test.ts
@@ -27,10 +27,7 @@ import type { QueryDiff } from '../../../src/storage/live-query';
 // ---------------------------------------------------------------------------
 
 function makeTempDbPath(): string {
-	return join(
-		tmpdir(),
-		`goal-repo-lq-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
-	);
+	return join(tmpdir(), `goal-repo-lq-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
 }
 
 const GOALS_SQL = `SELECT id, title, status FROM goals ORDER BY created_at ASC`;

--- a/packages/daemon/tests/unit/storage/live-query-integration.test.ts
+++ b/packages/daemon/tests/unit/storage/live-query-integration.test.ts
@@ -98,11 +98,11 @@ describe('LiveQuery Integration (Database + ReactiveDatabase + LiveQueryEngine)'
 	beforeEach(async () => {
 		dbPath = makeTempDbPath();
 		db = new Database(dbPath);
-		await db.initialize();
+		reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
 
 		// Access the underlying BunDatabase that LiveQueryEngine needs
 		bunDb = db.getDatabase();
-		reactiveDb = createReactiveDatabase(db);
 		engine = new LiveQueryEngine(bunDb, reactiveDb);
 	});
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
@@ -25,6 +25,18 @@ import {
 	GoalRepository,
 	getEffectiveMaxPlanningAttempts,
 } from '../../../../src/storage/repositories/goal-repository.ts';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database.ts';
+
+const noOpReactiveDb = {
+	notifyChange: () => {},
+	on: () => {},
+	off: () => {},
+	getTableVersion: () => 0,
+	beginTransaction: () => {},
+	commitTransaction: () => {},
+	abortTransaction: () => {},
+	db: null as never,
+} as ReactiveDatabase;
 
 // ---------------------------------------------------------------------------
 // Shared test database setup helpers
@@ -262,7 +274,7 @@ describe('GoalRepository: mission metadata CRUD', () => {
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
 		);
 		roomId = 'room-1';
-		repo = new GoalRepository(db);
+		repo = new GoalRepository(db, noOpReactiveDb);
 	});
 
 	test('createGoal defaults to one_shot / supervised', () => {
@@ -348,7 +360,7 @@ describe('GoalRepository: mission_metric_history', () => {
 		db.exec(
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
 		);
-		repo = new GoalRepository(db);
+		repo = new GoalRepository(db, noOpReactiveDb);
 		const goal = repo.createGoal({ roomId: 'room-1', title: 'Metric Goal' });
 		goalId = goal.id;
 	});
@@ -425,7 +437,7 @@ describe('GoalRepository: mission_executions', () => {
 		db.exec(
 			`INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'R', ${now}, ${now})`
 		);
-		repo = new GoalRepository(db);
+		repo = new GoalRepository(db, noOpReactiveDb);
 		const goal = repo.createGoal({ roomId: 'room-1', title: 'Exec Goal' });
 		goalId = goal.id;
 	});

--- a/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
@@ -25,18 +25,7 @@ import {
 	GoalRepository,
 	getEffectiveMaxPlanningAttempts,
 } from '../../../../src/storage/repositories/goal-repository.ts';
-import type { ReactiveDatabase } from '../../../../src/storage/reactive-database.ts';
-
-const noOpReactiveDb = {
-	notifyChange: () => {},
-	on: () => {},
-	off: () => {},
-	getTableVersion: () => 0,
-	beginTransaction: () => {},
-	commitTransaction: () => {},
-	abortTransaction: () => {},
-	db: null as never,
-} as ReactiveDatabase;
+import { noOpReactiveDb } from '../../../helpers/reactive-database';
 
 // ---------------------------------------------------------------------------
 // Shared test database setup helpers

--- a/packages/daemon/tests/unit/storage/reactive-database.test.ts
+++ b/packages/daemon/tests/unit/storage/reactive-database.test.ts
@@ -62,8 +62,8 @@ describe('ReactiveDatabase', () => {
 	beforeEach(async () => {
 		dbPath = makeTempDbPath();
 		db = new Database(dbPath);
-		await db.initialize();
 		reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
- Inject ReactiveDatabase as required constructor param in GoalRepository
- Call reactiveDb.notifyChange('goals') after every write: createGoal,
  updateGoal (covers link/unlink/atomicStart), deleteGoal
- Inject ReactiveDatabase into GoalManager constructor; pass through to
  GoalRepository (GoalManager itself never calls notifyChange)
- Update Database.initialize() to accept ReactiveDatabase so GoalRepository
  inside the facade receives it; reorder app.ts to create reactiveDb before
  db.initialize()
- Update all GoalManager/GoalRepository construction sites:
  rpc-handlers/index.ts, room-runtime-service.ts, storage/index.ts, all tests
- Add unit test: LiveQueryEngine subscription on goals fires after every
  GoalRepository write (create, update, delete, link, unlink, coalescing)
