### PR TITLE
feat: inject ReactiveDatabase into TaskManager and fire notifyChange after writes

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -10,6 +10,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { TaskRepository } from '../../../storage/repositories/task-repository';
+import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type {
 	NeoTask,
 	TaskStatus,
@@ -55,7 +56,8 @@ export class TaskManager {
 
 	constructor(
 		private db: BunDatabase,
-		private roomId: string
+		private roomId: string,
+		private reactiveDb: ReactiveDatabase
 	) {
 		this.taskRepo = new TaskRepository(db);
 	}
@@ -86,6 +88,7 @@ export class TaskManager {
 			createdByTaskId: params.createdByTaskId,
 		});
 
+		this.reactiveDb.notifyChange('tasks');
 		return task;
 	}
 
@@ -129,6 +132,7 @@ export class TaskManager {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}
 
+		this.reactiveDb.notifyChange('tasks');
 		return updatedTask;
 	}
 
@@ -154,6 +158,7 @@ export class TaskManager {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}
 
+		this.reactiveDb.notifyChange('tasks');
 		return updatedTask;
 	}
 
@@ -297,7 +302,11 @@ export class TaskManager {
 	 * Called when a planning task completes so its children enter the execution queue.
 	 */
 	async promoteDraftTasks(creatorTaskId: string): Promise<number> {
-		return this.taskRepo.promoteDraftTasksByCreator(creatorTaskId);
+		const count = this.taskRepo.promoteDraftTasksByCreator(creatorTaskId);
+		if (count > 0) {
+			this.reactiveDb.notifyChange('tasks');
+		}
+		return count;
 	}
 
 	/**
@@ -338,9 +347,11 @@ export class TaskManager {
 			this.db
 				.prepare(`UPDATE tasks SET assigned_agent = ? WHERE id = ?`)
 				.run(updates.assignedAgent, taskId);
+			this.reactiveDb.notifyChange('tasks');
 			return (await this.getTask(taskId))!;
 		}
 
+		this.reactiveDb.notifyChange('tasks');
 		return updatedTask;
 	}
 
@@ -360,6 +371,7 @@ export class TaskManager {
 		}
 
 		this.taskRepo.deleteTask(taskId);
+		this.reactiveDb.notifyChange('tasks');
 		return true;
 	}
 
@@ -406,6 +418,7 @@ export class TaskManager {
 		}
 
 		this.taskRepo.deleteTask(taskId);
+		this.reactiveDb.notifyChange('tasks');
 		return true;
 	}
 
@@ -431,6 +444,7 @@ export class TaskManager {
 			throw new Error(`Failed to archive task: ${taskId}`);
 		}
 
+		this.reactiveDb.notifyChange('tasks');
 		return updatedTask;
 	}
 
@@ -467,6 +481,7 @@ export class TaskManager {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}
 
+		this.reactiveDb.notifyChange('tasks');
 		return updatedTask;
 	}
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -370,7 +370,7 @@ export class RoomRuntimeService {
 
 		const rawDb = this.ctx.db.getDatabase();
 		const groupRepo = new SessionGroupRepository(rawDb);
-		const taskManager = new TaskManager(rawDb, room.id);
+		const taskManager = new TaskManager(rawDb, room.id, this.ctx.reactiveDb);
 		const goalManager = new GoalManager(rawDb, room.id);
 		const sdkMessageRepo = new SDKMessageRepository(rawDb);
 		const observer = new SessionObserver(this.ctx.daemonHub);
@@ -586,7 +586,7 @@ export class RoomRuntimeService {
 	): Promise<void> {
 		const rawDb = this.ctx.db.getDatabase();
 		const groupRepo = new SessionGroupRepository(rawDb);
-		const taskManager = new TaskManager(rawDb, roomId);
+		const taskManager = new TaskManager(rawDb, roomId, this.ctx.reactiveDb);
 		const sessionFactory = this.createSessionFactory();
 
 		const checker: SessionStateChecker = {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -128,7 +128,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Create factory function for per-room task managers (used by goal review handlers)
 	const goalTaskManagerFactory: GoalTaskManagerFactory = (roomId: string) => {
-		return new TaskManager(deps.db.getDatabase(), roomId);
+		return new TaskManager(deps.db.getDatabase(), roomId, deps.reactiveDb);
 	};
 
 	setupSessionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub, roomManager);
@@ -187,6 +187,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomManager,
 		deps.daemonHub,
 		deps.db,
+		deps.reactiveDb,
 		undefined,
 		roomRuntimeService
 	);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -194,6 +194,7 @@ export function setupTaskHandlers(
 		// Update input_draft directly via repository (lightweight, no status side effects)
 		const taskRepo = new TaskRepository(db.getDatabase());
 		taskRepo.updateTask(params.taskId, { inputDraft: draft });
+		reactiveDb.notifyChange('tasks');
 
 		return { success: true };
 	});

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -19,6 +19,7 @@
 import type { MessageHub, NeoTask, TaskPriority, TaskStatus } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
+import type { ReactiveDatabase } from '../../storage/reactive-database';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
@@ -44,20 +45,14 @@ export type TaskManagerLike = Pick<
 
 export type TaskManagerFactory = (db: Database, roomId: string) => TaskManagerLike;
 
-/**
- * Create a TaskManager instance for a room
- */
-function createTaskManager(db: Database, roomId: string): TaskManagerLike {
-	const rawDb = db.getDatabase();
-	return new TaskManager(rawDb, roomId);
-}
-
 export function setupTaskHandlers(
 	messageHub: MessageHub,
 	roomManager: RoomManager,
 	daemonHub: DaemonHub,
 	db: Database,
-	taskManagerFactory: TaskManagerFactory = createTaskManager,
+	reactiveDb: ReactiveDatabase,
+	taskManagerFactory: TaskManagerFactory = (d, roomId) =>
+		new TaskManager(d.getDatabase(), roomId, reactiveDb),
 	runtimeService?: RoomRuntimeService
 ): void {
 	/**

--- a/packages/daemon/tests/unit/room/goal-manager.test.ts
+++ b/packages/daemon/tests/unit/room/goal-manager.test.ts
@@ -73,7 +73,7 @@ describe('GoalManager', () => {
 		goalManager = new GoalManager(db, roomId);
 
 		// Create task manager for testing task linking
-		taskManager = new TaskManager(db, roomId);
+		taskManager = new TaskManager(db, roomId, { notifyChange: () => {} } as never);
 	});
 
 	afterEach(() => {
@@ -391,7 +391,7 @@ describe('GoalManager', () => {
 			const goal = await goalManager.createGoal({ title: 'Test Goal', description: '' });
 
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const taskManager2 = new TaskManager(db, room2.id);
+			const taskManager2 = new TaskManager(db, room2.id, { notifyChange: () => {} } as never);
 			const task = await taskManager2.createTask({ title: 'Room 2 Task', description: '' });
 
 			await expect(goalManager.linkTaskToGoal(goal.id, task.id)).rejects.toThrow(

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -117,7 +117,7 @@ describe('Room Agent Tools', () => {
 		`);
 
 		goalManager = new GoalManager(db as never, roomId);
-		taskManager = new TaskManager(db as never, roomId);
+		taskManager = new TaskManager(db as never, roomId, { notifyChange: () => {} } as never);
 		groupRepo = new SessionGroupRepository(db as never);
 		handlers = createRoomAgentToolHandlers({ roomId, goalManager, taskManager, groupRepo });
 	});

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -242,7 +242,7 @@ export function createRuntimeTestContext(opts?: RuntimeTestContextOptions): Runt
 	const mockHub = createMockDaemonHub();
 	const groupRepo = new SessionGroupRepository(db as never);
 	const observer = new SessionObserver(mockHub as unknown as DaemonHub);
-	const taskManager = new TaskManager(db as never, 'room-1');
+	const taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
 	const goalManager = new GoalManager(db as never, 'room-1');
 	const sessionFactory = createMockSessionFactory();
 	const room = makeRoom(opts?.room);

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -166,7 +166,7 @@ describe('Runtime Recovery', () => {
 		const mockHub = createMockDaemonHub();
 		groupRepo = new SessionGroupRepository(db as never);
 		observer = new SessionObserver(mockHub as unknown as DaemonHub);
-		taskManager = new TaskManager(db as never, 'room-1');
+		taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
 		goalManager = new GoalManager(db as never, 'room-1');
 		sessionFactory = createMockSessionFactory();
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -266,7 +266,7 @@ describe('TaskGroupManager', () => {
 		const mockHub = createMockDaemonHub();
 		groupRepo = new SessionGroupRepository(db as never);
 		observer = new SessionObserver(mockHub as unknown as DaemonHub);
-		taskManager = new TaskManager(db as never, 'room-1');
+		taskManager = new TaskManager(db as never, 'room-1', { notifyChange: () => {} } as never);
 		goalManager = new GoalManager(db as never, 'room-1');
 		sessionFactory = createMockSessionFactory();
 

--- a/packages/daemon/tests/unit/room/task-manager-live-query.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager-live-query.test.ts
@@ -1,0 +1,295 @@
+/**
+ * TaskManager + LiveQuery Integration Tests
+ *
+ * Verifies that LiveQueryEngine subscriptions on the `tasks` table fire
+ * after every write method in TaskManager. TaskManager writes directly to
+ * the raw BunDatabase (not through the ReactiveDatabase proxy) and manually
+ * calls reactiveDb.notifyChange('tasks') after each durable commit.
+ *
+ * Test setup:
+ *   - In-memory BunDatabase with full schema via createTables()
+ *   - Real ReactiveDatabase wrapping a minimal Database facade
+ *   - Real LiveQueryEngine subscribing to the tasks table
+ *   - Real TaskManager injected with reactiveDb
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../src/storage/live-query';
+import { TaskManager } from '../../../src/lib/room/managers/task-manager';
+import { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import type { QueryDiff } from '../../../src/storage/live-query';
+import type { Database } from '../../../src/storage/index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TaskRow {
+	id: string;
+	title: string;
+	status: string;
+}
+
+const TASKS_SQL = 'SELECT id, title, status FROM tasks WHERE room_id = ? ORDER BY created_at';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+describe('TaskManager + LiveQueryEngine integration', () => {
+	let bunDb: BunDatabase;
+	let engine: LiveQueryEngine;
+	let taskManager: TaskManager;
+	let roomId: string;
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		createTables(bunDb);
+
+		// Create a minimal Database facade so createReactiveDatabase is happy.
+		// TaskManager writes directly to bunDb (not through the proxy), so the
+		// facade only needs to expose getDatabase().
+		const dbFacade = { getDatabase: () => bunDb } as unknown as Database;
+
+		const reactiveDb = createReactiveDatabase(dbFacade);
+		engine = new LiveQueryEngine(bunDb, reactiveDb);
+		taskManager = new TaskManager(bunDb, 'room-test', reactiveDb);
+
+		// Create the room so FK constraints pass
+		const roomManager = new RoomManager(bunDb);
+		const room = roomManager.createRoom({
+			name: 'Test Room',
+			allowedPaths: [{ path: '/workspace' }],
+			defaultPath: '/workspace',
+		});
+		roomId = room.id;
+
+		// Recreate taskManager with the real room id
+		const reactiveDb2 = createReactiveDatabase(dbFacade);
+		engine.dispose();
+		engine = new LiveQueryEngine(bunDb, reactiveDb2);
+		taskManager = new TaskManager(bunDb, roomId, reactiveDb2);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		bunDb.close();
+	});
+
+	// -----------------------------------------------------------------------
+	// createTask fires notification
+	// -----------------------------------------------------------------------
+
+	test('createTask fires a tasks subscription delta', async () => {
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.createTask({ title: 'New Task', description: 'desc' });
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		const delta = diffs[1];
+		expect(delta.type).toBe('delta');
+		expect(delta.added?.length).toBe(1);
+		expect(delta.added?.[0].title).toBe('New Task');
+	});
+
+	// -----------------------------------------------------------------------
+	// updateTaskStatus fires notification
+	// -----------------------------------------------------------------------
+
+	test('updateTaskStatus fires a tasks subscription delta', async () => {
+		const task = await taskManager.createTask({ title: 'Status Task', description: '' });
+		await Promise.resolve(); // flush insert delta
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+		// snapshot is diffs[0]
+
+		await taskManager.updateTaskStatus(task.id, 'in_progress');
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		const delta = diffs[1];
+		expect(delta.type).toBe('delta');
+		expect(delta.updated?.length).toBe(1);
+		expect(delta.updated?.[0].status).toBe('in_progress');
+	});
+
+	// -----------------------------------------------------------------------
+	// updateTaskProgress fires notification
+	// -----------------------------------------------------------------------
+
+	test('updateTaskProgress fires a tasks subscription delta', async () => {
+		const task = await taskManager.createTask({ title: 'Progress Task', description: '' });
+		await taskManager.updateTaskStatus(task.id, 'in_progress');
+		await Promise.resolve();
+
+		// Use a query that includes `progress` so we detect the update
+		const diffs: QueryDiff<{ id: string; progress: number | null }>[] = [];
+		engine.subscribe(
+			'SELECT id, progress FROM tasks WHERE room_id = ? ORDER BY created_at',
+			[roomId],
+			(diff) => diffs.push(diff)
+		);
+
+		await taskManager.updateTaskProgress(task.id, 50, 'halfway');
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].updated?.[0].progress).toBe(50);
+	});
+
+	// -----------------------------------------------------------------------
+	// promoteDraftTasks fires notification
+	// -----------------------------------------------------------------------
+
+	test('promoteDraftTasks fires a tasks subscription delta when tasks are promoted', async () => {
+		// Create a draft task via createTask with status='draft'
+		const plannerTask = await taskManager.createTask({
+			title: 'Planner Task',
+			description: '',
+			status: 'pending',
+		});
+		await taskManager.createTask({
+			title: 'Draft Child',
+			description: '',
+			status: 'draft',
+			createdByTaskId: plannerTask.id,
+		});
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		const count = await taskManager.promoteDraftTasks(plannerTask.id);
+		await Promise.resolve();
+
+		expect(count).toBeGreaterThan(0);
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+	});
+
+	// -----------------------------------------------------------------------
+	// updateDraftTask fires notification
+	// -----------------------------------------------------------------------
+
+	test('updateDraftTask fires a tasks subscription delta', async () => {
+		const draft = await taskManager.createTask({
+			title: 'Draft Task',
+			description: '',
+			status: 'draft',
+		});
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.updateDraftTask(draft.id, { title: 'Updated Draft' });
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].updated?.[0].title).toBe('Updated Draft');
+	});
+
+	// -----------------------------------------------------------------------
+	// removeDraftTask fires notification
+	// -----------------------------------------------------------------------
+
+	test('removeDraftTask fires a tasks subscription delta', async () => {
+		const draft = await taskManager.createTask({
+			title: 'To Remove',
+			description: '',
+			status: 'draft',
+		});
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.removeDraftTask(draft.id);
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		const delta = diffs[1];
+		expect(delta.type).toBe('delta');
+		expect(delta.removed?.length).toBe(1);
+	});
+
+	// -----------------------------------------------------------------------
+	// deleteTask fires notification
+	// -----------------------------------------------------------------------
+
+	test('deleteTask fires a tasks subscription delta', async () => {
+		const task = await taskManager.createTask({ title: 'Delete Me', description: '' });
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.deleteTask(task.id);
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		const delta = diffs[1];
+		expect(delta.type).toBe('delta');
+		expect(delta.removed?.length).toBe(1);
+	});
+
+	// -----------------------------------------------------------------------
+	// archiveTask fires notification
+	// -----------------------------------------------------------------------
+
+	test('archiveTask fires a tasks subscription delta', async () => {
+		const task = await taskManager.createTask({ title: 'Archive Me', description: '' });
+		// pending -> cancelled -> archived (cancelled is a valid archivable state)
+		await taskManager.cancelTask(task.id);
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.archiveTask(task.id);
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+	});
+
+	// -----------------------------------------------------------------------
+	// updateTaskFields fires notification
+	// -----------------------------------------------------------------------
+
+	test('updateTaskFields fires a tasks subscription delta', async () => {
+		const task = await taskManager.createTask({ title: 'Fields Task', description: '' });
+		await Promise.resolve();
+
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		await taskManager.updateTaskFields(task.id, { title: 'Updated Fields' });
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].updated?.[0].title).toBe('Updated Fields');
+	});
+
+	// -----------------------------------------------------------------------
+	// notifyChange is only called after durable commit
+	// -----------------------------------------------------------------------
+
+	test('subscription does not fire before any write', () => {
+		const diffs: QueryDiff<TaskRow>[] = [];
+		engine.subscribe(TASKS_SQL, [roomId], (diff) => diffs.push(diff));
+
+		// Only the initial snapshot — no write has been made
+		expect(diffs.length).toBe(1);
+		expect(diffs[0].type).toBe('snapshot');
+	});
+});

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -45,7 +45,7 @@ describe('TaskManager', () => {
 		roomId = room.id;
 
 		// Create task manager
-		taskManager = new TaskManager(db, roomId);
+		taskManager = new TaskManager(db, roomId, { notifyChange: () => {} } as never);
 	});
 
 	afterEach(() => {
@@ -150,7 +150,7 @@ describe('TaskManager', () => {
 
 			// Create another room and task manager
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const taskManager2 = new TaskManager(db, room2.id);
+			const taskManager2 = new TaskManager(db, room2.id, { notifyChange: () => {} } as never);
 
 			// Should not be able to access room 1's task from room 2's manager
 			const retrieved = await taskManager2.getTask(created.id);
@@ -202,7 +202,7 @@ describe('TaskManager', () => {
 			await taskManager.createTask({ title: 'Room 1 Task', description: '' });
 
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const taskManager2 = new TaskManager(db, room2.id);
+			const taskManager2 = new TaskManager(db, room2.id, { notifyChange: () => {} } as never);
 			await taskManager2.createTask({ title: 'Room 2 Task', description: '' });
 
 			const tasks1 = await taskManager.listTasks();
@@ -533,7 +533,7 @@ describe('TaskManager', () => {
 			const task = await taskManager.createTask({ title: 'Room 1 Task', description: '' });
 
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const taskManager2 = new TaskManager(db, room2.id);
+			const taskManager2 = new TaskManager(db, room2.id, { notifyChange: () => {} } as never);
 
 			const result = await taskManager2.deleteTask(task.id);
 
@@ -755,7 +755,7 @@ describe('TaskManager', () => {
 		it('should isolate tasks between rooms', async () => {
 			// Create another room
 			const room2 = roomManager.createRoom({ name: 'Room 2' });
-			const taskManager2 = new TaskManager(db, room2.id);
+			const taskManager2 = new TaskManager(db, room2.id, { notifyChange: () => {} } as never);
 
 			// Add tasks to both rooms
 			await taskManager.createTask({ title: 'Room 1 Task', description: '' });

--- a/packages/daemon/tests/unit/rpc-handlers/task-get-group-messages.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-get-group-messages.test.ts
@@ -134,7 +134,9 @@ const mockRoomManager = { getRoomOverview: mock(() => null) } as unknown as Room
 describe('task.getGroupMessages RPC handler', () => {
 	it('returns empty result when group does not exist', async () => {
 		const { hub, handlers } = createMockMessageHub();
-		setupTaskHandlers(hub, mockRoomManager, createMockDaemonHub(), makeDb({ groupRow: null }));
+		setupTaskHandlers(hub, mockRoomManager, createMockDaemonHub(), makeDb({ groupRow: null }), {
+			notifyChange: () => {},
+		} as never);
 
 		const handler = handlers.get('task.getGroupMessages');
 		expect(handler).toBeDefined();
@@ -192,7 +194,8 @@ describe('task.getGroupMessages RPC handler', () => {
 						created_at: 2000,
 					},
 				],
-			})
+			}),
+			{ notifyChange: () => {} } as never
 		);
 
 		const handler = handlers.get('task.getGroupMessages');
@@ -244,7 +247,8 @@ describe('task.getGroupMessages RPC handler', () => {
 					})),
 					'leader-session': [],
 				},
-			})
+			}),
+			{ notifyChange: () => {} } as never
 		);
 
 		const handler = handlers.get('task.getGroupMessages');
@@ -293,7 +297,8 @@ describe('task.getGroupMessages RPC handler', () => {
 					})),
 					'leader-session': [],
 				},
-			})
+			}),
+			{ notifyChange: () => {} } as never
 		);
 
 		const handler = handlers.get('task.getGroupMessages');
@@ -359,7 +364,8 @@ describe('task.getGroupMessages RPC handler', () => {
 						},
 					],
 				},
-			})
+			}),
+			{ notifyChange: () => {} } as never
 		);
 
 		const handler = handlers.get('task.getGroupMessages');

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -201,6 +201,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow(submittedForReview)),
+			{ notifyChange: () => {} } as never,
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -318,6 +319,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				mockRoomManager,
 				createMockDaemonHub(),
 				makeDb(null), // no group row
+				{ notifyChange: () => {} } as never,
 				makeTaskManagerFactory(mockTask),
 				service
 			);
@@ -367,6 +369,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				mockRoomManager,
 				createMockDaemonHub(),
 				makeDb(makeGroupRow()),
+				{ notifyChange: () => {} } as never,
 				factory,
 				service
 			);
@@ -419,6 +422,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				mockRoomManager,
 				createMockDaemonHub(),
 				makeDb(makeGroupRow()),
+				{ notifyChange: () => {} } as never,
 				factory,
 				service
 			);
@@ -471,6 +475,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 				mockRoomManager,
 				createMockDaemonHub(),
 				makeDb(makeGroupRow()),
+				{ notifyChange: () => {} } as never,
 				factory,
 				service
 			);
@@ -530,6 +535,7 @@ describe('task.cancel RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow(submittedForReview)),
+			{ notifyChange: () => {} } as never,
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -644,6 +650,7 @@ describe('task.reject RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow(submittedForReview)),
+			{ notifyChange: () => {} } as never,
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -743,6 +750,7 @@ describe('task.reject RPC Handler', () => {
 				mockRoomManager,
 				createMockDaemonHub(),
 				makeDb(null), // no group row
+				{ notifyChange: () => {} } as never,
 				makeTaskManagerFactory(reviewTask),
 				service
 			);
@@ -846,6 +854,7 @@ describe('task.setStatus RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow(submittedForReview)),
+			{ notifyChange: () => {} } as never,
 			taskManagerFactory ?? makeSetStatusTaskManagerFactory(task),
 			runtimeService
 		);
@@ -1099,6 +1108,7 @@ describe('task.setStatus RPC Handler', () => {
 				mockRoomManager,
 				daemonHub,
 				makeDb(makeGroupRow()),
+				{ notifyChange: () => {} } as never,
 				makeSetStatusWithArchiveFactory(completedTask),
 				service
 			);
@@ -1167,6 +1177,7 @@ describe('task.interruptSession RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow()),
+			{ notifyChange: () => {} } as never,
 			makeTaskManagerFactory(task),
 			runtimeService
 		);
@@ -1299,6 +1310,7 @@ describe('task.archive RPC Handler', () => {
 			mockRoomManager,
 			createMockDaemonHub(),
 			makeDb(makeGroupRow()),
+			{ notifyChange: () => {} } as never,
 			opts.taskManagerFactory ?? makeTaskManagerFactory(task),
 			runtimeService
 		);

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -247,6 +247,7 @@ describe('Task RPC Handlers', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager
 		);
 	});
@@ -465,6 +466,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -490,6 +492,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -509,6 +512,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -528,6 +532,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -547,6 +552,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -566,6 +572,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -584,6 +591,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager
 			// no runtimeService
 		);
@@ -604,6 +612,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -623,6 +632,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -646,6 +656,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -669,6 +680,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);
@@ -689,6 +701,7 @@ describe('task.sendHumanMessage handler', () => {
 			roomManagerData.roomManager,
 			daemonHubData.daemonHub,
 			db,
+			{ notifyChange: () => {} } as never,
 			createMockTaskManager,
 			runtimeService
 		);


### PR DESCRIPTION
## Summary

- **Required injection**: Add `reactiveDb: ReactiveDatabase` as required 3rd constructor parameter to `TaskManager`
- **notifyChange calls**: Emit `reactiveDb.notifyChange('tasks')` after every write method (`createTask`, `updateTaskStatus`, `updateTaskProgress`, `promoteDraftTasks`, `updateDraftTask` both code paths, `removeDraftTask`, `deleteTask`, `archiveTask`, `updateTaskFields`)
- **Production sites updated**: `task-handlers.ts` default factory, `index.ts` goalTaskManagerFactory, `room-runtime-service.ts` (createOrGetRuntime + recoverRoomRuntime)
- **Test sites updated**: All `new TaskManager(db, roomId)` calls and all `setupTaskHandlers(...)` calls updated with minimal mock reactiveDb
- **New test file**: `task-manager-live-query.test.ts` — 10 tests verifying LiveQueryEngine subscriptions on `tasks` fire after every write method

Closes Milestone 1, Task 1.2 of the SQL LiveQuery adoption plan.

## Test plan
- [x] All existing TaskManager tests pass (111 tests)
- [x] All RPC task handler tests pass (112 tests)
- [x] New LiveQuery integration tests pass (10 tests)
- [x] TypeCheck clean
- [x] Lint clean
- [x] Pre-commit hooks pass