### PR TITLE
feat: remove setInterval from GitHubPollingService and wire handler into GitHubService

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -23,7 +23,7 @@ import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
-import { GITHUB_POLL, JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
+import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -225,6 +225,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				config,
 				apiKey,
 				githubToken: process.env.GITHUB_TOKEN, // Optional GitHub token for polling
+				jobQueue,
+				jobProcessor,
 			});
 
 			logInfo('[Daemon] GitHub integration enabled', {
@@ -366,27 +368,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	});
 
 	// Start GitHub service after server is ready.
-	// Pass useJobQueueScheduler when polling is configured so the pollingService's
-	// built-in setInterval is skipped — the github.poll job-queue chain owns the
-	// schedule instead, preventing a dual-schedule where both mechanisms fire independently.
+	// GitHubService.start() registers the github.poll handler and enqueues the
+	// initial job when jobProcessor/jobQueue are provided.
 	if (gitHubService) {
-		const useJobQueueScheduler = !!config.githubPollingInterval && config.githubPollingInterval > 0;
-		gitHubService.start({ useJobQueueScheduler });
+		gitHubService.start();
 		logInfo('[Daemon] GitHub service started');
-
-		// Seed the initial github.poll job if polling is configured and no job already exists.
-		// The self-scheduling chain in the handler keeps the chain alive after this seed.
-		if (config.githubPollingInterval && config.githubPollingInterval > 0) {
-			const existing = jobQueue.listJobs({
-				queue: GITHUB_POLL,
-				status: ['pending', 'processing'],
-				limit: 1,
-			});
-			if (existing.length === 0) {
-				jobQueue.enqueue({ queue: GITHUB_POLL, payload: {} });
-				logInfo('[Daemon] Seeded initial github.poll job');
-			}
-		}
 	}
 
 	// Register job handlers BEFORE starting the processor so no pending job

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -13,6 +13,10 @@
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
 import type { Config } from '../../config';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../storage/job-queue-processor';
+import { GITHUB_POLL } from '../job-queue-constants';
+import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
 import type {
 	GitHubEvent,
 	RoutingResult,
@@ -50,6 +54,10 @@ export interface GitHubServiceOptions {
 	apiKey: string;
 	/** Optional GitHub token for polling and permission checks */
 	githubToken?: string;
+	/** Job queue repository — required to enqueue the initial github.poll job */
+	jobQueue?: JobQueueRepository;
+	/** Job queue processor — required to register the github.poll handler */
+	jobProcessor?: JobQueueProcessor;
 }
 
 /**
@@ -78,6 +86,8 @@ export class GitHubService {
 	private routerAgent: RouterAgent;
 	private inboxManager: InboxManager;
 	private webhookHandler?: (req: Request) => Promise<Response>;
+	private jobQueue?: JobQueueRepository;
+	private jobProcessor?: JobQueueProcessor;
 
 	constructor(options: GitHubServiceOptions) {
 		this.db = options.db;
@@ -85,6 +95,8 @@ export class GitHubService {
 		this.config = options.config;
 		this.apiKey = options.apiKey;
 		this.githubToken = options.githubToken;
+		this.jobQueue = options.jobQueue;
+		this.jobProcessor = options.jobProcessor;
 
 		// Initialize filter config manager
 		this.filterConfigManager = createFilterConfigManager(this.db.getDatabase());
@@ -117,16 +129,13 @@ export class GitHubService {
 	}
 
 	/**
-	 * Start the GitHub service
-	 * - Starts polling if configured
-	 * - Creates webhook handler if secret is configured
-	 *
-	 * @param options.useJobQueueScheduler - When true, the polling service is created
-	 *   but its built-in setInterval timer is NOT started. The job-queue handler owns
-	 *   the schedule entirely (via the github.poll queue), which avoids a dual-schedule
-	 *   where both the setInterval and the job-queue chain call triggerPoll independently.
+	 * Start the GitHub service.
+	 * - Creates webhook handler if secret is configured.
+	 * - Creates and starts the polling service if polling is configured.
+	 * - Registers the github.poll job handler and enqueues the initial job when
+	 *   both jobProcessor/jobQueue and polling are configured.
 	 */
-	start(options?: { useJobQueueScheduler?: boolean }): void {
+	start(): void {
 		// Initialize webhook handler if secret is configured
 		if (this.config.githubWebhookSecret) {
 			this.webhookHandler = createWebhookHandler(this.config.githubWebhookSecret, async (event) => {
@@ -141,27 +150,42 @@ export class GitHubService {
 			this.config.githubPollingInterval > 0 &&
 			this.githubToken
 		) {
+			const intervalMs = this.config.githubPollingInterval * 1000;
+
 			this.pollingService = createPollingService(
 				{
 					token: this.githubToken,
-					interval: this.config.githubPollingInterval * 1000, // Convert to ms
+					interval: intervalMs,
 				},
 				async (event) => {
 					await this.processEvent(event);
 				}
 			);
 
-			if (options?.useJobQueueScheduler) {
-				// Job queue owns the schedule — skip the built-in setInterval so only
-				// one scheduling mechanism fires per interval.
-				log.info('Polling service created (job-queue-driven, setInterval skipped)', {
-					intervalMs: this.config.githubPollingInterval * 1000,
+			this.pollingService.start();
+			log.info('Polling service started (job-queue-driven)', { intervalMs });
+
+			// Register the github.poll job handler so the processor can execute it.
+			if (this.jobProcessor && this.jobQueue) {
+				this.jobProcessor.register(GITHUB_POLL, () =>
+					handleGitHubPoll({
+						pollingService: this.pollingService,
+						jobQueue: this.jobQueue!,
+						intervalMs,
+					})
+				);
+				log.info('github.poll job handler registered');
+
+				// Enqueue the initial poll immediately if no job is already in flight.
+				const existing = this.jobQueue.listJobs({
+					queue: GITHUB_POLL,
+					status: ['pending', 'processing'],
+					limit: 1,
 				});
-			} else {
-				this.pollingService.start();
-				log.info('Polling service started', {
-					intervalMs: this.config.githubPollingInterval * 1000,
-				});
+				if (existing.length === 0) {
+					this.jobQueue.enqueue({ queue: GITHUB_POLL, payload: {}, runAt: Date.now() });
+					log.info('Enqueued initial github.poll job');
+				}
 			}
 		}
 

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -162,11 +162,15 @@ export class GitHubService {
 				}
 			);
 
-			this.pollingService.start();
-			log.info('Polling service started (job-queue-driven)', { intervalMs });
-
 			// Register the github.poll job handler so the processor can execute it.
+			// pollingService.start() is called inside this guard so that isRunning() is
+			// consistent with whether an actual poll chain is in place — if jobQueue/
+			// jobProcessor are absent no scheduling exists and the service must not
+			// report itself as running.
 			if (this.jobProcessor && this.jobQueue) {
+				this.pollingService.start();
+				log.info('Polling service started (job-queue-driven)', { intervalMs });
+
 				this.jobProcessor.register(GITHUB_POLL, () =>
 					handleGitHubPoll({
 						pollingService: this.pollingService,

--- a/packages/daemon/src/lib/github/polling-service.ts
+++ b/packages/daemon/src/lib/github/polling-service.ts
@@ -14,7 +14,6 @@ const log = new Logger('github-polling');
 
 const DEFAULT_BASE_URL = 'https://api.github.com';
 const DEFAULT_USER_AGENT = 'NeoKai-GitHub-Integration/1.0';
-const DEFAULT_INTERVAL = 60000; // 1 minute
 
 /**
  * State for a single repository being polled
@@ -36,7 +35,7 @@ interface RepoState {
 export class GitHubPollingService {
 	private config: PollingConfig;
 	private repositories: Map<string, RepoState> = new Map();
-	private pollingInterval: Timer | null = null;
+	private running = false;
 	private isPolling = false;
 	private onEvent?: (event: GitHubEvent) => Promise<void> | void;
 
@@ -46,7 +45,7 @@ export class GitHubPollingService {
 	) {
 		this.config = {
 			token: config.token,
-			interval: config.interval ?? DEFAULT_INTERVAL,
+			interval: config.interval ?? 60000,
 			baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
 			userAgent: config.userAgent ?? DEFAULT_USER_AGENT,
 		};
@@ -54,39 +53,26 @@ export class GitHubPollingService {
 	}
 
 	/**
-	 * Start the polling loop
+	 * Start the polling service (state flag only — scheduling is handled by the job queue).
 	 */
 	start(): void {
-		if (this.pollingInterval) {
+		if (this.running) {
 			log.warn('Polling service already running');
 			return;
 		}
 
+		this.running = true;
 		log.info('Starting GitHub polling service', {
-			interval: this.config.interval,
 			repositoryCount: this.repositories.size,
 		});
-
-		// Run initial poll immediately
-		this.pollAllRepositories().catch((error) => {
-			log.error('Initial poll failed', error);
-		});
-
-		// Schedule recurring polls
-		this.pollingInterval = setInterval(() => {
-			this.pollAllRepositories().catch((error) => {
-				log.error('Scheduled poll failed', error);
-			});
-		}, this.config.interval);
 	}
 
 	/**
-	 * Stop the polling loop
+	 * Stop the polling service (state flag only).
 	 */
 	stop(): void {
-		if (this.pollingInterval) {
-			clearInterval(this.pollingInterval);
-			this.pollingInterval = null;
+		if (this.running) {
+			this.running = false;
 			log.info('GitHub polling service stopped');
 		}
 	}
@@ -133,10 +119,10 @@ export class GitHubPollingService {
 	}
 
 	/**
-	 * Check if the service is currently polling
+	 * Check if the service is currently running
 	 */
 	isRunning(): boolean {
-		return this.pollingInterval !== null;
+		return this.running;
 	}
 
 	/**

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -30,11 +30,16 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 	let polled = false;
 
 	try {
-		if (pollingService) {
+		if (!pollingService) {
+			log.warn('github.poll handler called but no polling service is configured');
+		} else if (!pollingService.isRunning()) {
+			// Polling service was stopped (e.g. GitHubService.stop() was called at runtime).
+			// Skip triggerPoll for this cycle; the self-schedule below keeps the chain alive
+			// so that polling resumes automatically if the service is restarted.
+			log.debug('github.poll handler skipping triggerPoll — polling service is stopped');
+		} else {
 			await pollingService.triggerPoll();
 			polled = true;
-		} else {
-			log.warn('github.poll handler called but no polling service is configured');
 		}
 	} catch (error) {
 		log.error('triggerPoll failed', {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,7 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
-import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
+import { ROOM_TICK } from '../job-queue-constants';
 import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
@@ -247,27 +246,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomManager,
 		deps.gitHubService ?? null
 	);
-
-	// Register github.poll job handler.
-	// pollingService is created inside GitHubService.start(), which runs in app.ts
-	// after setupRPCHandlers returns. Resolving it at call time via getPollingService()
-	// ensures the handler always sees the live instance rather than undefined.
-	// GitHubService.start() is called with useJobQueueScheduler:true so its built-in
-	// setInterval is skipped — the job-queue chain is the sole scheduler.
-	if (
-		deps.gitHubService &&
-		deps.config.githubPollingInterval &&
-		deps.config.githubPollingInterval > 0
-	) {
-		const intervalMs = deps.config.githubPollingInterval * 1000;
-		deps.jobProcessor.register(GITHUB_POLL, () =>
-			handleGitHubPoll({
-				pollingService: deps.gitHubService!.getPollingService(),
-				jobQueue: deps.jobQueue,
-				intervalMs,
-			})
-		);
-	}
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);

--- a/packages/daemon/tests/unit/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/github/github-service-polling.test.ts
@@ -245,14 +245,15 @@ describe('GitHubService — job-queue-driven polling', () => {
 		// Reset enqueueMock to count only the self-schedule enqueue from the handler.
 		// The initial enqueue happened during start() already.
 		enqueueMock.mockClear();
-		listJobsMock = mock(() => []); // no existing jobs after this run
 
-		// Point the captured jobQueue to the fresh mocks for the handler's dedup check.
+		// Point the captured jobQueue to fresh mocks for the handler's dedup check.
+		// (Assigning jobQueueInService.listJobs is what matters — the handler references
+		// the jobQueue object stored on svc, not the outer listJobsMock variable.)
 		const jobQueueInService = (svc as never as Record<string, unknown>).jobQueue as {
 			listJobs: ReturnType<typeof mock>;
 			enqueue: ReturnType<typeof mock>;
 		};
-		jobQueueInService.listJobs = listJobsMock;
+		jobQueueInService.listJobs = mock(() => []);
 		jobQueueInService.enqueue = enqueueMock;
 
 		const result = await capturedHandler!();
@@ -269,5 +270,67 @@ describe('GitHubService — job-queue-driven polling', () => {
 		const [enqueueArg] = enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }];
 		expect(enqueueArg.queue).toBe(GITHUB_POLL);
 		expect(enqueueArg.runAt).toBeGreaterThan(Date.now());
+	});
+
+	it('isPolling() returns false after stop(), and isRunning() on pollingService is false', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(svc.isPolling()).toBe(true);
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService.isRunning()).toBe(true);
+
+		svc.stop();
+
+		// After stop() the state flag is cleared; no job-queue chain is drained
+		// (that requires stopping the JobQueueProcessor itself, done in app.ts shutdown).
+		expect(svc.isPolling()).toBe(false);
+		expect(pollingService.isRunning()).toBe(false);
+	});
+
+	it('handler skips triggerPoll when pollingService.isRunning() is false', async () => {
+		let capturedHandler: (() => Promise<unknown>) | undefined;
+		const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+			capturedHandler = handler;
+		});
+
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: { register: capturingRegister } as never,
+		});
+
+		svc.start();
+
+		// Save the pollingService reference before stop() clears it on the service.
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService).toBeDefined();
+
+		// Stop the service — sets pollingService.running = false
+		svc.stop();
+
+		const triggerPollMock = mock(async () => {});
+		(pollingService as never as Record<string, unknown>).triggerPoll = triggerPollMock;
+
+		enqueueMock.mockClear();
+		const jobQueueInService = (svc as never as Record<string, unknown>).jobQueue as {
+			listJobs: ReturnType<typeof mock>;
+			enqueue: ReturnType<typeof mock>;
+		};
+		jobQueueInService.listJobs = mock(() => []);
+		jobQueueInService.enqueue = enqueueMock;
+
+		const result = await capturedHandler!();
+
+		// triggerPoll must NOT be called when the service is stopped
+		expect(triggerPollMock).not.toHaveBeenCalled();
+		expect((result as Record<string, unknown>).polled).toBe(false);
+
+		// But the chain self-schedules so polling resumes automatically when restarted
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/daemon/tests/unit/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/github/github-service-polling.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Integration-style unit tests for GitHubService job-queue-driven polling.
+ *
+ * Verifies the full flow:
+ *   GitHubService.start()
+ *     → registers github.poll handler on jobProcessor
+ *     → enqueues initial github.poll job
+ *   handler invocation
+ *     → calls triggerPoll on the polling service
+ *     → self-schedules next job
+ */
+
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
+import { Database as SqliteDatabase } from 'bun:sqlite';
+import { GitHubService } from '../../../src/lib/github/github-service';
+import { GITHUB_POLL } from '../../../src/lib/job-queue-constants';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+import type { Database } from '../../../src/storage/database';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+	return {
+		id: 'job-1',
+		queue: GITHUB_POLL,
+		status: 'pending',
+		payload: {},
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now() + 60000,
+		createdAt: Date.now(),
+		startedAt: null,
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeDb(): Database {
+	// FilterConfigManager needs a real SQLite db with .prepare()
+	const sqlite = new SqliteDatabase(':memory:');
+	return {
+		getDatabase: () => sqlite,
+		listGitHubMappingsForRepository: mock(() => []),
+		listGitHubMappings: mock(() => []),
+		getGitHubMappingByRoomId: mock(() => null),
+		countInboxItemsByStatus: mock(() => 0),
+		listPendingInboxItems: mock(() => []),
+		getInboxItem: mock(() => null),
+		createInboxItem: mock(() => ({})),
+		updateInboxItem: mock(() => null),
+	} as unknown as Database;
+}
+
+function makeDaemonHub() {
+	return { emit: mock(() => {}) } as never;
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+	return {
+		githubPollingInterval: 60, // seconds
+		githubWebhookSecret: undefined,
+		...overrides,
+	} as never;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('GitHubService — job-queue-driven polling', () => {
+	let registerMock: ReturnType<typeof mock>;
+	let enqueueMock: ReturnType<typeof mock>;
+	let listJobsMock: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		registerMock = mock(() => {});
+		enqueueMock = mock(() => makeJob());
+		listJobsMock = mock(() => []); // no existing jobs → enqueue initial
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	function makeJobProcessor() {
+		return {
+			register: registerMock,
+		} as never;
+	}
+
+	function makeJobQueue(listOverride?: ReturnType<typeof mock>) {
+		return {
+			enqueue: enqueueMock,
+			listJobs: listOverride ?? listJobsMock,
+		} as never;
+	}
+
+	function makeService(configOverrides: Record<string, unknown> = {}) {
+		return new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(configOverrides),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+	}
+
+	it('registers github.poll handler on jobProcessor when start() is called', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(registerMock).toHaveBeenCalledTimes(1);
+		const [queue] = registerMock.mock.calls[0] as [string, unknown];
+		expect(queue).toBe(GITHUB_POLL);
+	});
+
+	it('enqueues initial github.poll job immediately on start()', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const [arg] = enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }];
+		expect(arg.queue).toBe(GITHUB_POLL);
+		// runAt should be approximately now (within 2 seconds)
+		expect(arg.runAt).toBeGreaterThanOrEqual(Date.now() - 100);
+		expect(arg.runAt).toBeLessThanOrEqual(Date.now() + 2000);
+	});
+
+	it('skips initial enqueue when a pending job already exists (dedup)', () => {
+		const listWithExisting = mock(() => [makeJob({ status: 'pending' })]);
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(listWithExisting),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('skips initial enqueue when a processing job already exists (dedup)', () => {
+		const listWithExisting = mock(() => [makeJob({ status: 'processing' })]);
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(listWithExisting),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when jobProcessor is absent', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			// no jobQueue / jobProcessor
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when polling interval is 0', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig({ githubPollingInterval: 0 }),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when githubToken is absent', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			// no githubToken
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('registered handler calls triggerPoll and self-schedules next job', async () => {
+		// Capture the registered handler so we can invoke it directly.
+		let capturedHandler: (() => Promise<unknown>) | undefined;
+		const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+			capturedHandler = handler;
+		});
+
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: { register: capturingRegister } as never,
+		});
+
+		svc.start();
+
+		expect(capturedHandler).toBeDefined();
+
+		// Polling service was created by start(); getPollingService() returns it.
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService).toBeDefined();
+
+		// Spy on triggerPoll.
+		const triggerPollMock = mock(async () => {});
+		(pollingService as never as Record<string, unknown>).triggerPoll = triggerPollMock;
+
+		// Reset enqueueMock to count only the self-schedule enqueue from the handler.
+		// The initial enqueue happened during start() already.
+		enqueueMock.mockClear();
+		listJobsMock = mock(() => []); // no existing jobs after this run
+
+		// Point the captured jobQueue to the fresh mocks for the handler's dedup check.
+		const jobQueueInService = (svc as never as Record<string, unknown>).jobQueue as {
+			listJobs: ReturnType<typeof mock>;
+			enqueue: ReturnType<typeof mock>;
+		};
+		jobQueueInService.listJobs = listJobsMock;
+		jobQueueInService.enqueue = enqueueMock;
+
+		const result = await capturedHandler!();
+
+		// triggerPoll was called once
+		expect(triggerPollMock).toHaveBeenCalledTimes(1);
+
+		// Handler returns { polled: true, nextRunAt }
+		expect((result as Record<string, unknown>).polled).toBe(true);
+		expect(typeof (result as Record<string, unknown>).nextRunAt).toBe('number');
+
+		// Self-schedule: one new job was enqueued with a future runAt
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const [enqueueArg] = enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }];
+		expect(enqueueArg.queue).toBe(GITHUB_POLL);
+		expect(enqueueArg.runAt).toBeGreaterThan(Date.now());
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -38,13 +38,18 @@ describe('handleGitHubPoll', () => {
 	});
 
 	function makeDeps(
-		overrides: { intervalMs?: number; pollingService?: ReturnType<typeof mock> | undefined } = {}
+		overrides: {
+			intervalMs?: number;
+			pollingService?: ReturnType<typeof mock> | undefined;
+			isRunning?: boolean;
+		} = {}
 	) {
+		const running = overrides.isRunning ?? true;
 		return {
 			pollingService:
 				'pollingService' in overrides
 					? overrides.pollingService
-					: ({ triggerPoll: triggerPollMock } as never),
+					: ({ triggerPoll: triggerPollMock, isRunning: () => running } as never),
 			jobQueue: {
 				enqueue: enqueueMock,
 				listJobs: listJobsMock,
@@ -107,7 +112,7 @@ describe('handleGitHubPoll', () => {
 		listJobsMock = mock(() => []);
 
 		const deps = makeDeps();
-		deps.pollingService = { triggerPoll: triggerPollMock } as never;
+		deps.pollingService = { triggerPoll: triggerPollMock, isRunning: () => true } as never;
 		deps.jobQueue.listJobs = listJobsMock as never;
 		deps.jobQueue.enqueue = enqueueMock as never;
 
@@ -135,6 +140,16 @@ describe('handleGitHubPoll', () => {
 		expect(result.polled).toBe(false);
 		expect(triggerPollMock).not.toHaveBeenCalled();
 		// Still enqueues next job
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips triggerPoll and returns polled: false when pollingService.isRunning() is false', async () => {
+		const deps = makeDeps({ isRunning: false });
+		const result = await handleGitHubPoll(deps);
+
+		expect(triggerPollMock).not.toHaveBeenCalled();
+		expect(result.polled).toBe(false);
+		// Self-schedule still happens so the chain resumes when service is restarted
 		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
- Remove setInterval/clearInterval and pollingInterval field from GitHubPollingService;
  start()/stop() become state-flag setters backed by a `running` boolean
- Accept jobQueue and jobProcessor in GitHubServiceOptions; GitHubService.start()
  registers the github.poll handler on jobProcessor and enqueues the initial job
  (with dedup check) — replacing the old dual-mechanism where app.ts seeded the job
  and rpc-handlers/index.ts registered the handler
- app.ts: pass jobQueue/jobProcessor to createGitHubService(), simplify start() call,
  remove seed-job block, remove GITHUB_POLL import
- rpc-handlers/index.ts: remove GITHUB_POLL handler registration (now in GitHubService)
- Add 8 integration-style unit tests in github-service-polling.test.ts covering the
  full flow: start() → register → enqueue → handler → triggerPoll → self-schedule
