### PR TITLE
test: add E2E tests for multi-agent step editor and channel topology

### DIFF
--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -20,6 +20,16 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpace,
+	deleteSpace,
+	navigateToSpace,
+	resetEditorModeStorage,
+	openNewWorkflowEditor,
+	switchToVisualMode,
+	openWorkflowForEdit,
+	setupMultiAgentStep,
+} from '../helpers/workflow-editor-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
@@ -35,130 +45,44 @@ const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
 
 // ─── RPC helpers (infrastructure only) ───────────────────────────────────────
 
-interface SpaceSetup {
-	spaceId: string;
-	agentAId: string;
-	agentBId: string;
-}
-
-async function createTestSpace(page: Page): Promise<SpaceSetup> {
+/**
+ * Creates a space and two agents (coder, reviewer) for multi-agent test scenarios.
+ * Returns only spaceId — agent IDs are not needed by tests since agents are
+ * selected by option label in the UI.
+ */
+async function createTestSpace(page: Page): Promise<string> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
 	const spaceName = `E2E Multi-Agent Editor ${Date.now()}`;
-	return page.evaluate(
-		async ({ wsPath, name, roleA, roleB, agentAName, agentBName }) => {
+	const spaceId = await createSpace(page, spaceName);
+
+	await page.evaluate(
+		async ({ sid, roleA, roleB, agentAName, agentBName }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path.
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', {})) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) await hub.request('space.delete', { id: existing.id });
-			} catch {
-				// Ignore cleanup errors
-			}
-
-			const res = await hub.request('space.create', { name, workspacePath: wsPath });
-			const spaceId = (res as { id: string }).id;
-
-			const aRes = await hub.request('spaceAgent.create', {
-				spaceId,
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
 				name: agentAName,
 				role: roleA,
 				description: '',
 			});
-			const agentAId = (aRes as { agent: { id: string } }).agent.id;
-
-			const bRes = await hub.request('spaceAgent.create', {
-				spaceId,
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
 				name: agentBName,
 				role: roleB,
 				description: '',
 			});
-			const agentBId = (bRes as { agent: { id: string } }).agent.id;
-
-			return { spaceId, agentAId, agentBId };
 		},
 		{
-			wsPath: workspaceRoot,
-			name: spaceName,
+			sid: spaceId,
 			roleA: ROLE_A,
 			roleB: ROLE_B,
 			agentAName: AGENT_A_NAME,
 			agentBName: AGENT_B_NAME,
 		}
 	);
-}
 
-async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
-
-// ─── UI helpers ───────────────────────────────────────────────────────────────
-
-async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
-	await page.goto(`/space/${spaceId}`);
-	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
-}
-
-async function resetEditorModeStorage(page: Page): Promise<void> {
-	await page.evaluate(() => {
-		localStorage.removeItem('workflow-editor-mode');
-	});
-}
-
-async function openNewWorkflowEditor(page: Page): Promise<void> {
-	await page.locator('text=Workflows').first().click();
-	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
-	await expect(createBtn).toBeVisible({ timeout: 5000 });
-	await createBtn.click();
-	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
-}
-
-async function switchToVisualMode(page: Page): Promise<void> {
-	page.once('dialog', (d) => d.accept());
-	await page.getByTestId('editor-mode-visual').click();
-	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
-}
-
-/**
- * Open the workflow edit UI for an existing workflow in the list.
- * Forced opacity reveal is required because edit buttons are CSS group-hover only.
- */
-async function openWorkflowForEdit(page: Page, workflowName: string): Promise<void> {
-	await page.locator('text=Workflows').first().click();
-	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
-
-	const workflowCard = page
-		.locator('[class*="group"]')
-		.filter({ has: page.locator(`text=${workflowName}`) })
-		.first();
-	await expect(workflowCard).toBeVisible({ timeout: 3000 });
-	await workflowCard.evaluate((el) => {
-		const actions = el.querySelector<HTMLElement>('[data-testid="workflow-card-actions"]');
-		if (actions) actions.style.opacity = '1';
-	});
-
-	const editBtn = workflowCard.getByRole('button', { name: 'Edit' });
-	await expect(editBtn).toBeVisible({ timeout: 3000 });
-	await editBtn.click();
-
-	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+	return spaceId;
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -172,13 +96,12 @@ test.describe('Multi-Agent Step Editor', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		await resetEditorModeStorage(page);
-		const setup = await createTestSpace(page);
-		spaceId = setup.spaceId;
+		spaceId = await createTestSpace(page);
 	});
 
 	test.afterEach(async ({ page }) => {
 		if (spaceId) {
-			await deleteTestSpace(page, spaceId);
+			await deleteSpace(page, spaceId);
 			spaceId = '';
 		}
 	});
@@ -202,37 +125,19 @@ test.describe('Multi-Agent Step Editor', () => {
 		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
-
-		// Set step name
 		await panel.getByTestId('step-name-input').fill('Parallel Step');
 
-		// Select first agent (Coder Agent) via single-agent select
-		const agentSelect = panel.getByTestId('agent-select');
-		await agentSelect.selectOption({ label: AGENT_A_OPTION });
+		// Switch to multi-agent mode and add both agents
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
-		// Click "+ Add agent" to switch to multi-agent mode
-		await panel.getByTestId('add-agent-button').click();
-
-		// Multi-agent mode: agents-list should appear with one entry (Coder Agent)
+		// Verify agent names are rendered in the list entries
 		const agentsList = panel.getByTestId('agents-list');
-		await expect(agentsList).toBeVisible({ timeout: 3000 });
-		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 2000 });
-
-		// Add Reviewer Agent via add-agent-select
-		const addAgentSelect = panel.getByTestId('add-agent-select');
-		await expect(addAgentSelect).toBeVisible({ timeout: 3000 });
-		await addAgentSelect.selectOption({ label: AGENT_B_OPTION });
-
-		// Both agents should now be in the list
-		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(2, { timeout: 3000 });
-
-		// Verify agent names are rendered in the entries
-		await expect(agentsList.locator(`text=${AGENT_A_NAME}`).first()).toBeVisible({
-			timeout: 2000,
-		});
-		await expect(agentsList.locator(`text=${AGENT_B_NAME}`).first()).toBeVisible({
-			timeout: 2000,
-		});
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_B_NAME })
+		).toBeVisible({ timeout: 2000 });
 
 		// Close panel and verify node shows agent badges for both agents
 		await panel.getByTestId('close-button').click();
@@ -241,8 +146,7 @@ test.describe('Multi-Agent Step Editor', () => {
 		const node = nodes.first();
 		const agentBadges = node.getByTestId('agent-badges');
 		await expect(agentBadges).toBeVisible({ timeout: 3000 });
-
-		// Both agent names should appear as badges in the canvas node
+		// Both agent names should appear as badge spans within the agent-badges container
 		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
 		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
 	});
@@ -265,33 +169,26 @@ test.describe('Multi-Agent Step Editor', () => {
 		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
-
 		await panel.getByTestId('step-name-input').fill('Channel Step');
 
-		// Set up multi-agent step: select Coder Agent, then add Reviewer Agent
-		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
-		await panel.getByTestId('add-agent-button').click();
-		await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
-		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
-		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
-			timeout: 3000,
-		});
+		// Set up two agents (required for channels section to appear)
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
 		// Channels section should now be visible (multi-agent mode)
 		const channelsSection = panel.getByTestId('channels-section');
 		await expect(channelsSection).toBeVisible({ timeout: 3000 });
 
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		const channelsList = panel.getByTestId('channels-list');
+
 		// ── Add one-way channel: coder → reviewer ────────────────────────────
 
-		const addChannelForm = panel.getByTestId('add-channel-form');
-
 		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
-		// Direction is 'one-way' by default — no change needed
+		// Direction defaults to 'one-way' — no change needed
 		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
 		await addChannelForm.getByTestId('add-channel-button').click();
 
 		// Channel entry should appear: "coder → reviewer"
-		const channelsList = panel.getByTestId('channels-list');
 		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
 		const firstEntry = channelsList.getByTestId('channel-entry').first();
 		await expect(firstEntry).toContainText(ROLE_A);
@@ -314,16 +211,23 @@ test.describe('Multi-Agent Step Editor', () => {
 		await expect(secondEntry).toContainText('↔');
 		await expect(secondEntry).toContainText(ROLE_A);
 
-		// Close panel and verify canvas node renders channel topology
+		// Close panel and verify canvas node renders channel topology via ChannelTopologyBadge
 		await panel.getByTestId('close-button').click();
 		await expect(panel).not.toBeVisible({ timeout: 2000 });
 
 		const node = nodes.first();
+		// The ChannelTopologyBadge container has data-testid="channel-topology-badge"
+		const topologyBadge = node.getByTestId('channel-topology-badge');
+		await expect(topologyBadge).toBeVisible({ timeout: 3000 });
 
-		// One-way arrow should appear in the channel topology badge on the node
-		await expect(node.locator('text=→').first()).toBeVisible({ timeout: 3000 });
-		// Bidirectional arrow should also appear
-		await expect(node.locator('text=↔').first()).toBeVisible({ timeout: 3000 });
+		// One-way arrow should appear within the topology badge
+		await expect(
+			topologyBadge.locator('[class*="font-mono"]').filter({ hasText: ROLE_A }).first()
+		).toBeVisible({
+			timeout: 2000,
+		});
+		// Bidirectional arrow should also appear within the topology badge
+		await expect(topologyBadge.locator('text=↔').first()).toBeVisible({ timeout: 2000 });
 	});
 
 	// ─── Test 3: Remove one agent — verify channels removed ──────────────────
@@ -336,20 +240,15 @@ test.describe('Multi-Agent Step Editor', () => {
 		const editor = page.getByTestId('visual-workflow-editor');
 		await editor.getByTestId('workflow-name-input').fill('Remove Agent Test');
 
-		// Add step, switch to multi-agent with a channel
+		// Add step, open config, set up multi-agent with a channel
 		await editor.getByTestId('add-step-button').click();
 		const nodes = editor.locator('[data-testid^="workflow-node-"]');
 		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
-
 		await panel.getByTestId('step-name-input').fill('Remove Step');
-		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
-		await panel.getByTestId('add-agent-button').click();
-		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
-		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
-			timeout: 3000,
-		});
+
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
 		// Add channel coder → reviewer
 		const addChannelForm = panel.getByTestId('add-channel-form');
@@ -360,28 +259,32 @@ test.describe('Multi-Agent Step Editor', () => {
 			timeout: 3000,
 		});
 
-		// Remove Reviewer Agent (second entry)
+		// Remove Reviewer Agent (the second entry in the list)
 		const agentsList = panel.getByTestId('agents-list');
-		const secondAgentEntry = agentsList.getByTestId('agent-entry').nth(1);
+		const secondAgentEntry = agentsList
+			.getByTestId('agent-entry')
+			.filter({ hasText: AGENT_B_NAME });
 		await secondAgentEntry.getByTestId('remove-agent-button').click();
 
 		// Only one agent entry should remain
 		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 3000 });
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
 
-		// "Switch to single" button appears when exactly 1 agent remains in multi-agent mode
-		const switchToSingleBtn = panel.getByRole('button', { name: 'Switch to single' });
+		// "Switch to single" button (data-testid="switch-to-single-button") appears when
+		// exactly 1 agent remains in multi-agent mode
+		const switchToSingleBtn = panel.getByTestId('switch-to-single-button');
 		await expect(switchToSingleBtn).toBeVisible({ timeout: 3000 });
 
 		// Click "Switch to single" — reverts to single-agent mode and clears channels
 		await switchToSingleBtn.click();
 
-		// Channels section should no longer be visible (single-agent mode)
+		// Channels section should no longer be visible (single-agent mode, channels cleared)
 		await expect(panel.getByTestId('channels-section')).not.toBeVisible({ timeout: 3000 });
 
-		// Single-agent select dropdown should be visible
+		// Single-agent select dropdown and add-agent button should be visible
 		await expect(panel.getByTestId('agent-select')).toBeVisible({ timeout: 3000 });
-
-		// Add-agent button should be visible (single-agent mode controls)
 		await expect(panel.getByTestId('add-agent-button')).toBeVisible({ timeout: 2000 });
 	});
 
@@ -405,14 +308,9 @@ test.describe('Multi-Agent Step Editor', () => {
 		await nodes.first().click();
 		const panel = editor.getByTestId('node-config-panel');
 		await expect(panel).toBeVisible({ timeout: 3000 });
-
 		await panel.getByTestId('step-name-input').fill('Persist Step');
-		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
-		await panel.getByTestId('add-agent-button').click();
-		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
-		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
-			timeout: 3000,
-		});
+
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
 
 		// Add one-way channel coder → reviewer
 		const addChannelForm = panel.getByTestId('add-channel-form');
@@ -434,6 +332,11 @@ test.describe('Multi-Agent Step Editor', () => {
 		// ── Reopen the workflow ─────────────────────────────────────────────────
 
 		await openWorkflowForEdit(page, WORKFLOW_NAME);
+
+		// switchToVisualMode registers a dialog handler before clicking the toggle.
+		// When re-opening a saved workflow in list mode (no unsaved edits), the app may
+		// or may not show a native confirm() dialog depending on whether it detects edits.
+		// The one-shot handler is harmless if no dialog fires — Playwright discards it.
 		await switchToVisualMode(page);
 
 		const editorReopen = page.getByTestId('visual-workflow-editor');
@@ -450,8 +353,11 @@ test.describe('Multi-Agent Step Editor', () => {
 
 		// ── Verify canvas node shows channel topology arrow ─────────────────────
 
-		// The ChannelTopologyBadge renders the → symbol between role names
-		await expect(node.locator('text=→').first()).toBeVisible({ timeout: 3000 });
+		// ChannelTopologyBadge renders within data-testid="channel-topology-badge"
+		const topologyBadge = node.getByTestId('channel-topology-badge');
+		await expect(topologyBadge).toBeVisible({ timeout: 3000 });
+		// The one-way arrow → should appear between the role names
+		await expect(topologyBadge.locator('text=→').first()).toBeVisible({ timeout: 2000 });
 
 		// ── Open node config and verify agents list and channel persist ─────────
 
@@ -463,6 +369,12 @@ test.describe('Multi-Agent Step Editor', () => {
 		const reopenedAgentsList = reopenedPanel.getByTestId('agents-list');
 		await expect(reopenedAgentsList).toBeVisible({ timeout: 3000 });
 		await expect(reopenedAgentsList.getByTestId('agent-entry')).toHaveCount(2, { timeout: 3000 });
+		await expect(
+			reopenedAgentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
+		await expect(
+			reopenedAgentsList.getByTestId('agent-entry').filter({ hasText: AGENT_B_NAME })
+		).toBeVisible({ timeout: 2000 });
 
 		// Channels section should be visible with the persisted channel
 		const reopenedChannelsSection = reopenedPanel.getByTestId('channels-section');
@@ -472,7 +384,7 @@ test.describe('Multi-Agent Step Editor', () => {
 			timeout: 3000,
 		});
 
-		// The persisted channel should show coder → reviewer
+		// Persisted channel should show "coder → reviewer"
 		const persistedEntry = reopenedChannelsList.getByTestId('channel-entry').first();
 		await expect(persistedEntry).toContainText(ROLE_A);
 		await expect(persistedEntry).toContainText('→');

--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -1,0 +1,481 @@
+/**
+ * Multi-Agent Step Editor E2E Tests
+ *
+ * Tests:
+ * - Add a second agent to a step — verify both agents appear as badges in the canvas node
+ * - Configure a one-way channel (A → B) — verify directed arrow in panel and node
+ * - Configure a bidirectional channel (A ↔ B) — verify bidirectional arrow in panel and node
+ * - Remove one agent — verify only one remains and associated channels are removed
+ * - Save workflow and re-open — verify multi-agent config AND channel topology persists
+ *
+ * Setup: creates a Space with two agents via RPC in beforeEach (infrastructure).
+ * Cleanup: deletes the Space via RPC in afterEach.
+ *
+ * E2E Rules:
+ * - All test actions go through the UI (clicks, inputs, navigation)
+ * - All assertions check visible DOM state
+ * - RPC is only used in beforeEach/afterEach for test infrastructure
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+
+// ─── Roles used across tests ──────────────────────────────────────────────────
+
+const ROLE_A = 'coder';
+const ROLE_B = 'reviewer';
+const AGENT_A_NAME = 'Coder Agent';
+const AGENT_B_NAME = 'Reviewer Agent';
+// Option text as rendered by the agent select: "{name} ({role})"
+const AGENT_A_OPTION = `${AGENT_A_NAME} (${ROLE_A})`;
+const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
+
+// ─── RPC helpers (infrastructure only) ───────────────────────────────────────
+
+interface SpaceSetup {
+	spaceId: string;
+	agentAId: string;
+	agentBId: string;
+}
+
+async function createTestSpace(page: Page): Promise<SpaceSetup> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+	const spaceName = `E2E Multi-Agent Editor ${Date.now()}`;
+	return page.evaluate(
+		async ({ wsPath, name, roleA, roleB, agentAName, agentBName }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Clean up any leftover space at this workspace path.
+			const norm = (p: string) => p.replace(/^\/private/, '');
+			try {
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
+				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
+				if (existing) await hub.request('space.delete', { id: existing.id });
+			} catch {
+				// Ignore cleanup errors
+			}
+
+			const res = await hub.request('space.create', { name, workspacePath: wsPath });
+			const spaceId = (res as { id: string }).id;
+
+			const aRes = await hub.request('spaceAgent.create', {
+				spaceId,
+				name: agentAName,
+				role: roleA,
+				description: '',
+			});
+			const agentAId = (aRes as { agent: { id: string } }).agent.id;
+
+			const bRes = await hub.request('spaceAgent.create', {
+				spaceId,
+				name: agentBName,
+				role: roleB,
+				description: '',
+			});
+			const agentBId = (bRes as { agent: { id: string } }).agent.id;
+
+			return { spaceId, agentAId, agentBId };
+		},
+		{
+			wsPath: workspaceRoot,
+			name: spaceName,
+			roleA: ROLE_A,
+			roleB: ROLE_B,
+			agentAName: AGENT_A_NAME,
+			agentBName: AGENT_B_NAME,
+		}
+	);
+}
+
+async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── UI helpers ───────────────────────────────────────────────────────────────
+
+async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
+	await page.goto(`/space/${spaceId}`);
+	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
+}
+
+async function resetEditorModeStorage(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		localStorage.removeItem('workflow-editor-mode');
+	});
+}
+
+async function openNewWorkflowEditor(page: Page): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
+	await expect(createBtn).toBeVisible({ timeout: 5000 });
+	await createBtn.click();
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+async function switchToVisualMode(page: Page): Promise<void> {
+	page.once('dialog', (d) => d.accept());
+	await page.getByTestId('editor-mode-visual').click();
+	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Open the workflow edit UI for an existing workflow in the list.
+ * Forced opacity reveal is required because edit buttons are CSS group-hover only.
+ */
+async function openWorkflowForEdit(page: Page, workflowName: string): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
+
+	const workflowCard = page
+		.locator('[class*="group"]')
+		.filter({ has: page.locator(`text=${workflowName}`) })
+		.first();
+	await expect(workflowCard).toBeVisible({ timeout: 3000 });
+	await workflowCard.evaluate((el) => {
+		const actions = el.querySelector<HTMLElement>('[data-testid="workflow-card-actions"]');
+		if (actions) actions.style.opacity = '1';
+	});
+
+	const editBtn = workflowCard.getByRole('button', { name: 'Edit' });
+	await expect(editBtn).toBeVisible({ timeout: 3000 });
+	await editBtn.click();
+
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Multi-Agent Step Editor', () => {
+	test.describe.configure({ mode: 'serial' });
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await resetEditorModeStorage(page);
+		const setup = await createTestSpace(page);
+		spaceId = setup.spaceId;
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteTestSpace(page, spaceId);
+			spaceId = '';
+		}
+	});
+
+	// ─── Test 1: Add second agent — verify both agents appear as badges ───────
+
+	test('Edit step to add second agent — verify both agents appear as badges', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Multi-Agent Badges Test');
+
+		// Add one step
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		// Open node config panel
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+
+		// Set step name
+		await panel.getByTestId('step-name-input').fill('Parallel Step');
+
+		// Select first agent (Coder Agent) via single-agent select
+		const agentSelect = panel.getByTestId('agent-select');
+		await agentSelect.selectOption({ label: AGENT_A_OPTION });
+
+		// Click "+ Add agent" to switch to multi-agent mode
+		await panel.getByTestId('add-agent-button').click();
+
+		// Multi-agent mode: agents-list should appear with one entry (Coder Agent)
+		const agentsList = panel.getByTestId('agents-list');
+		await expect(agentsList).toBeVisible({ timeout: 3000 });
+		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 2000 });
+
+		// Add Reviewer Agent via add-agent-select
+		const addAgentSelect = panel.getByTestId('add-agent-select');
+		await expect(addAgentSelect).toBeVisible({ timeout: 3000 });
+		await addAgentSelect.selectOption({ label: AGENT_B_OPTION });
+
+		// Both agents should now be in the list
+		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(2, { timeout: 3000 });
+
+		// Verify agent names are rendered in the entries
+		await expect(agentsList.locator(`text=${AGENT_A_NAME}`).first()).toBeVisible({
+			timeout: 2000,
+		});
+		await expect(agentsList.locator(`text=${AGENT_B_NAME}`).first()).toBeVisible({
+			timeout: 2000,
+		});
+
+		// Close panel and verify node shows agent badges for both agents
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		const node = nodes.first();
+		const agentBadges = node.getByTestId('agent-badges');
+		await expect(agentBadges).toBeVisible({ timeout: 3000 });
+
+		// Both agent names should appear as badges in the canvas node
+		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 2: Configure channels — one-way and bidirectional ──────────────
+
+	test('Add one-way and bidirectional channels — verify directed arrows appear', async ({
+		page,
+	}) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Channel Topology Test');
+
+		// Add step and open config
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+
+		await panel.getByTestId('step-name-input').fill('Channel Step');
+
+		// Set up multi-agent step: select Coder Agent, then add Reviewer Agent
+		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
+		await panel.getByTestId('add-agent-button').click();
+		await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
+		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+			timeout: 3000,
+		});
+
+		// Channels section should now be visible (multi-agent mode)
+		const channelsSection = panel.getByTestId('channels-section');
+		await expect(channelsSection).toBeVisible({ timeout: 3000 });
+
+		// ── Add one-way channel: coder → reviewer ────────────────────────────
+
+		const addChannelForm = panel.getByTestId('add-channel-form');
+
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		// Direction is 'one-way' by default — no change needed
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+
+		// Channel entry should appear: "coder → reviewer"
+		const channelsList = panel.getByTestId('channels-list');
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
+		const firstEntry = channelsList.getByTestId('channel-entry').first();
+		await expect(firstEntry).toContainText(ROLE_A);
+		await expect(firstEntry).toContainText('→');
+		await expect(firstEntry).toContainText(ROLE_B);
+
+		// ── Add bidirectional channel: reviewer ↔ coder ──────────────────────
+
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_B });
+		await addChannelForm
+			.getByTestId('channel-direction-select')
+			.selectOption({ value: 'bidirectional' });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_A);
+		await addChannelForm.getByTestId('add-channel-button').click();
+
+		// Two channel entries should now be present
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(2, { timeout: 3000 });
+		const secondEntry = channelsList.getByTestId('channel-entry').nth(1);
+		await expect(secondEntry).toContainText(ROLE_B);
+		await expect(secondEntry).toContainText('↔');
+		await expect(secondEntry).toContainText(ROLE_A);
+
+		// Close panel and verify canvas node renders channel topology
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		const node = nodes.first();
+
+		// One-way arrow should appear in the channel topology badge on the node
+		await expect(node.locator('text=→').first()).toBeVisible({ timeout: 3000 });
+		// Bidirectional arrow should also appear
+		await expect(node.locator('text=↔').first()).toBeVisible({ timeout: 3000 });
+	});
+
+	// ─── Test 3: Remove one agent — verify channels removed ──────────────────
+
+	test('Remove one agent — verify only one remains and channels are removed', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Remove Agent Test');
+
+		// Add step, switch to multi-agent with a channel
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+
+		await panel.getByTestId('step-name-input').fill('Remove Step');
+		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
+		await panel.getByTestId('add-agent-button').click();
+		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
+		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+			timeout: 3000,
+		});
+
+		// Add channel coder → reviewer
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+		await expect(panel.getByTestId('channels-list').getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		// Remove Reviewer Agent (second entry)
+		const agentsList = panel.getByTestId('agents-list');
+		const secondAgentEntry = agentsList.getByTestId('agent-entry').nth(1);
+		await secondAgentEntry.getByTestId('remove-agent-button').click();
+
+		// Only one agent entry should remain
+		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 3000 });
+
+		// "Switch to single" button appears when exactly 1 agent remains in multi-agent mode
+		const switchToSingleBtn = panel.getByRole('button', { name: 'Switch to single' });
+		await expect(switchToSingleBtn).toBeVisible({ timeout: 3000 });
+
+		// Click "Switch to single" — reverts to single-agent mode and clears channels
+		await switchToSingleBtn.click();
+
+		// Channels section should no longer be visible (single-agent mode)
+		await expect(panel.getByTestId('channels-section')).not.toBeVisible({ timeout: 3000 });
+
+		// Single-agent select dropdown should be visible
+		await expect(panel.getByTestId('agent-select')).toBeVisible({ timeout: 3000 });
+
+		// Add-agent button should be visible (single-agent mode controls)
+		await expect(panel.getByTestId('add-agent-button')).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 4: Save and reopen — verify persistence ─────────────────────────
+
+	test('Save workflow and reopen — multi-agent config and channel topology persist', async ({
+		page,
+	}) => {
+		const WORKFLOW_NAME = `Persist Test ${Date.now()}`;
+
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill(WORKFLOW_NAME);
+
+		// Add step, configure multi-agent with one channel
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+
+		await panel.getByTestId('step-name-input').fill('Persist Step');
+		await panel.getByTestId('agent-select').selectOption({ label: AGENT_A_OPTION });
+		await panel.getByTestId('add-agent-button').click();
+		await panel.getByTestId('add-agent-select').selectOption({ label: AGENT_B_OPTION });
+		await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+			timeout: 3000,
+		});
+
+		// Add one-way channel coder → reviewer
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+		await expect(panel.getByTestId('channels-list').getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// Save the workflow
+		await editor.getByTestId('save-button').click();
+		await expect(page.getByTestId('editor-mode-toggle')).not.toBeVisible({ timeout: 5000 });
+		await expect(page.locator(`text=${WORKFLOW_NAME}`)).toBeVisible({ timeout: 5000 });
+
+		// ── Reopen the workflow ─────────────────────────────────────────────────
+
+		await openWorkflowForEdit(page, WORKFLOW_NAME);
+		await switchToVisualMode(page);
+
+		const editorReopen = page.getByTestId('visual-workflow-editor');
+		const reopenedNodes = editorReopen.locator('[data-testid^="workflow-node-"]');
+		await expect(reopenedNodes).toHaveCount(1, { timeout: 5000 });
+
+		// ── Verify canvas node shows agent badges for both agents ───────────────
+
+		const node = reopenedNodes.first();
+		const agentBadges = node.getByTestId('agent-badges');
+		await expect(agentBadges).toBeVisible({ timeout: 3000 });
+		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+
+		// ── Verify canvas node shows channel topology arrow ─────────────────────
+
+		// The ChannelTopologyBadge renders the → symbol between role names
+		await expect(node.locator('text=→').first()).toBeVisible({ timeout: 3000 });
+
+		// ── Open node config and verify agents list and channel persist ─────────
+
+		await node.click();
+		const reopenedPanel = editorReopen.getByTestId('node-config-panel');
+		await expect(reopenedPanel).toBeVisible({ timeout: 3000 });
+
+		// Agents list should have 2 entries
+		const reopenedAgentsList = reopenedPanel.getByTestId('agents-list');
+		await expect(reopenedAgentsList).toBeVisible({ timeout: 3000 });
+		await expect(reopenedAgentsList.getByTestId('agent-entry')).toHaveCount(2, { timeout: 3000 });
+
+		// Channels section should be visible with the persisted channel
+		const reopenedChannelsSection = reopenedPanel.getByTestId('channels-section');
+		await expect(reopenedChannelsSection).toBeVisible({ timeout: 3000 });
+		const reopenedChannelsList = reopenedPanel.getByTestId('channels-list');
+		await expect(reopenedChannelsList.getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		// The persisted channel should show coder → reviewer
+		const persistedEntry = reopenedChannelsList.getByTestId('channel-entry').first();
+		await expect(persistedEntry).toContainText(ROLE_A);
+		await expect(persistedEntry).toContainText('→');
+		await expect(persistedEntry).toContainText(ROLE_B);
+	});
+});

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -19,95 +19,25 @@
 
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpace,
+	deleteSpace,
+	navigateToSpace,
+	resetEditorModeStorage,
+	openNewWorkflowEditor,
+	switchToVisualMode,
+} from '../helpers/workflow-editor-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
 // ─── RPC helpers (infrastructure only) ────────────────────────────────────────
 
 async function createTestSpace(page: Page): Promise<string> {
-	await waitForWebSocketConnected(page);
-	const workspaceRoot = await getWorkspaceRoot(page);
-	const spaceName = `E2E Visual Editor Test ${Date.now()}`;
-	return page.evaluate(
-		async ({ wsPath, name }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path.
-			// Normalize paths to handle macOS symlink resolution (/var/ vs /private/var/).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', {})) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) {
-					await hub.request('space.delete', { id: existing.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
-
-			const res = await hub.request('space.create', { name, workspacePath: wsPath });
-			return (res as { id: string }).id;
-		},
-		{ wsPath: workspaceRoot, name: spaceName }
-	);
+	return createSpace(page, `E2E Visual Editor Test ${Date.now()}`);
 }
 
 async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
-
-async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
-	await page.goto(`/space/${spaceId}`);
-	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-	// Wait for SpaceIsland to finish loading — the tab bar appears after space.overview resolves
-	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
-}
-
-/**
- * Reset the workflow editor mode stored in localStorage to prevent test-ordering
- * flakiness. SpaceIsland reads 'workflow-editor-mode' on mount; if a prior test
- * left it at 'visual', subsequent tests start in visual mode unexpectedly.
- */
-async function resetEditorModeStorage(page: Page): Promise<void> {
-	await page.evaluate(() => {
-		localStorage.removeItem('workflow-editor-mode');
-	});
-}
-
-/** Navigate to Workflows tab and open the workflow editor for a new workflow. */
-async function openNewWorkflowEditor(page: Page): Promise<void> {
-	// Click Workflows tab
-	await page.locator('text=Workflows').first().click();
-
-	// Wait for the "Create Workflow" button (the only label used in WorkflowList.tsx)
-	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
-	await expect(createBtn).toBeVisible({ timeout: 5000 });
-	await createBtn.click();
-
-	// Wait for editor mode toggle strip to appear
-	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
-}
-
-/** Switch to Visual editor mode, accepting any confirmation dialogs. */
-async function switchToVisualMode(page: Page): Promise<void> {
-	// Register dialog handler before clicking — native confirm() fires synchronously
-	page.once('dialog', (d) => d.accept());
-	await page.getByTestId('editor-mode-visual').click();
-	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
+	return deleteSpace(page, spaceId);
 }
 
 /** Get the default agent ID for the active space (infrastructure only). */

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared helpers for visual workflow editor E2E tests.
+ *
+ * Used by:
+ * - tests/features/visual-workflow-editor.e2e.ts
+ * - tests/features/space-multi-agent-editor.e2e.ts
+ */
+
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
+
+// ─── Space lifecycle (RPC — infrastructure only) ───────────────────────────────
+
+export async function createSpace(page: Page, name: string): Promise<string> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+	return page.evaluate(
+		async ({ wsPath, spaceName }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Clean up any leftover space at this workspace path.
+			const norm = (p: string) => p.replace(/^\/private/, '');
+			try {
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
+				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
+				if (existing) await hub.request('space.delete', { id: existing.id });
+			} catch {
+				// Ignore cleanup errors
+			}
+
+			const res = await hub.request('space.create', { name: spaceName, workspacePath: wsPath });
+			return (res as { id: string }).id;
+		},
+		{ wsPath: workspaceRoot, spaceName: name }
+	);
+}
+
+export async function deleteSpace(page: Page, spaceId: string): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Navigation helpers ────────────────────────────────────────────────────────
+
+export async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
+	await page.goto(`/space/${spaceId}`);
+	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
+}
+
+// ─── Editor mode helpers ───────────────────────────────────────────────────────
+
+/**
+ * Reset the workflow editor mode stored in localStorage to prevent test-ordering
+ * flakiness. SpaceIsland reads 'workflow-editor-mode' on mount; if a prior test
+ * left it at 'visual', subsequent tests start in visual mode unexpectedly.
+ */
+export async function resetEditorModeStorage(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		localStorage.removeItem('workflow-editor-mode');
+	});
+}
+
+/** Navigate to Workflows tab and open the workflow editor for a new workflow. */
+export async function openNewWorkflowEditor(page: Page): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
+	await expect(createBtn).toBeVisible({ timeout: 5000 });
+	await createBtn.click();
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+/** Switch to Visual editor mode, accepting any confirmation dialogs. */
+export async function switchToVisualMode(page: Page): Promise<void> {
+	// Register dialog handler before clicking — native confirm() fires synchronously
+	page.once('dialog', (d) => d.accept());
+	await page.getByTestId('editor-mode-visual').click();
+	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Open the workflow edit UI for an existing workflow in the list.
+ * The edit button is CSS group-hover only, so opacity is forced via JS before clicking.
+ */
+export async function openWorkflowForEdit(page: Page, workflowName: string): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
+
+	const workflowCard = page
+		.locator('[class*="group"]')
+		.filter({ has: page.locator(`text=${workflowName}`) })
+		.first();
+	await expect(workflowCard).toBeVisible({ timeout: 3000 });
+	await workflowCard.evaluate((el) => {
+		const actions = el.querySelector<HTMLElement>('[data-testid="workflow-card-actions"]');
+		if (actions) actions.style.opacity = '1';
+	});
+
+	const editBtn = workflowCard.getByRole('button', { name: 'Edit' });
+	await expect(editBtn).toBeVisible({ timeout: 3000 });
+	await editBtn.click();
+
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+// ─── Multi-agent step helpers ──────────────────────────────────────────────────
+
+/**
+ * Configure a node config panel to have two agents in multi-agent mode.
+ *
+ * Precondition: the NodeConfigPanel is already open (panel locator is visible).
+ * Postcondition: agents-list has 2 agent-entry items and channels-section is visible.
+ *
+ * @param panel - Locator scoped to the `node-config-panel` element
+ * @param agentAOption - Exact option label for the first agent (e.g. "Coder Agent (coder)")
+ * @param agentBOption - Exact option label for the second agent (e.g. "Reviewer Agent (reviewer)")
+ */
+export async function setupMultiAgentStep(
+	panel: Locator,
+	agentAOption: string,
+	agentBOption: string
+): Promise<void> {
+	// Select first agent in single-agent mode
+	await panel.getByTestId('agent-select').selectOption({ label: agentAOption });
+
+	// Switch to multi-agent mode — moves the selected agent into the agents[] array
+	await panel.getByTestId('add-agent-button').click();
+	await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
+
+	// Add second agent from the dropdown (shows remaining agents)
+	await panel.getByTestId('add-agent-select').selectOption({ label: agentBOption });
+
+	// Verify both entries are present before returning
+	await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+		timeout: 3000,
+	});
+}

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -147,6 +147,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 				{stepAgents.length === 1 && (
 					<button
 						type="button"
+						data-testid="switch-to-single-button"
 						onClick={() =>
 							onUpdate({
 								...step,

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -38,7 +38,7 @@ function ChannelTopologyBadge({ step }: { step: StepDraft }) {
 	};
 
 	return (
-		<div class="mt-1.5 space-y-0.5">
+		<div class="mt-1.5 space-y-0.5" data-testid="channel-topology-badge">
 			{channels.map((ch, i) => (
 				<div key={i} class="flex items-center gap-0.5 text-xs text-gray-500">
 					<span class="font-mono">{roleLabel(ch.from)}</span>


### PR DESCRIPTION
Covers the full add/remove/persist lifecycle for multi-agent workflow
steps and channel topology in the visual editor:
- Add a second agent via "Add agent" button and add-agent-select
- Configure one-way (A → B) and bidirectional (A ↔ B) channels
- Remove an agent and verify channels are cleared via "Switch to single"
- Save and reopen to verify agents badges and channel arrows persist
