### PR TITLE
feat: emit session group events via DaemonHub (Task 2.3)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -188,8 +188,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			maxTokens: config.maxTokens,
 			temperature: config.temperature,
 			workspaceRoot: config.workspaceRoot,
-		}
+		},
+		jobQueue,
+		jobProcessor
 	);
+
+	// Register session title generation handler before jobProcessor starts
+	sessionManager.start();
 
 	// Initialize State Manager (listens to EventBus, clean dependency graph!)
 	const stateManager = new StateManager(

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -23,7 +23,7 @@ import type { TaskAgentManager } from './lib/space/runtime/task-agent-manager';
 import { JobQueueRepository } from './storage/repositories/job-queue-repository';
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
-import { GITHUB_POLL, JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
+import { JOB_QUEUE_CLEANUP } from './lib/job-queue-constants';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -225,6 +225,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				config,
 				apiKey,
 				githubToken: process.env.GITHUB_TOKEN, // Optional GitHub token for polling
+				jobQueue,
+				jobProcessor,
 			});
 
 			logInfo('[Daemon] GitHub integration enabled', {
@@ -366,27 +368,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	});
 
 	// Start GitHub service after server is ready.
-	// Pass useJobQueueScheduler when polling is configured so the pollingService's
-	// built-in setInterval is skipped — the github.poll job-queue chain owns the
-	// schedule instead, preventing a dual-schedule where both mechanisms fire independently.
+	// GitHubService.start() registers the github.poll handler and enqueues the
+	// initial job when jobProcessor/jobQueue are provided.
 	if (gitHubService) {
-		const useJobQueueScheduler = !!config.githubPollingInterval && config.githubPollingInterval > 0;
-		gitHubService.start({ useJobQueueScheduler });
+		gitHubService.start();
 		logInfo('[Daemon] GitHub service started');
-
-		// Seed the initial github.poll job if polling is configured and no job already exists.
-		// The self-scheduling chain in the handler keeps the chain alive after this seed.
-		if (config.githubPollingInterval && config.githubPollingInterval > 0) {
-			const existing = jobQueue.listJobs({
-				queue: GITHUB_POLL,
-				status: ['pending', 'processing'],
-				limit: 1,
-			});
-			if (existing.length === 0) {
-				jobQueue.enqueue({ queue: GITHUB_POLL, payload: {} });
-				logInfo('[Daemon] Seeded initial github.poll job');
-			}
-		}
 	}
 
 	// Register job handlers BEFORE starting the processor so no pending job

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -489,6 +489,29 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		agentId: string;
 	};
 
+	// Space session group events (channel: 'space:${spaceId}')
+	// sessionId is set to 'space:${spaceId}' for channel routing — only clients subscribed
+	// to that space receive these events.
+	'spaceSessionGroup.created': {
+		sessionId: string; // 'space:${spaceId}'
+		spaceId: string;
+		taskId: string;
+		group: import('@neokai/shared').SpaceSessionGroup;
+	};
+	'spaceSessionGroup.memberAdded': {
+		sessionId: string; // 'space:${spaceId}'
+		spaceId: string;
+		groupId: string;
+		member: import('@neokai/shared').SpaceSessionGroupMember;
+	};
+	'spaceSessionGroup.memberUpdated': {
+		sessionId: string; // 'space:${spaceId}'
+		spaceId: string;
+		groupId: string;
+		memberId: string;
+		member: import('@neokai/shared').SpaceSessionGroupMember;
+	};
+
 	// Space workflow definition events (global events - use 'global' as sessionId)
 	// NOTE: namespace is 'spaceWorkflow.*' (not 'space.workflow.*') — matches SpaceStore subscriptions in M5
 	'spaceWorkflow.created': {

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -13,6 +13,10 @@
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
 import type { Config } from '../../config';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../storage/job-queue-processor';
+import { GITHUB_POLL } from '../job-queue-constants';
+import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
 import type {
 	GitHubEvent,
 	RoutingResult,
@@ -50,6 +54,10 @@ export interface GitHubServiceOptions {
 	apiKey: string;
 	/** Optional GitHub token for polling and permission checks */
 	githubToken?: string;
+	/** Job queue repository — required to enqueue the initial github.poll job */
+	jobQueue?: JobQueueRepository;
+	/** Job queue processor — required to register the github.poll handler */
+	jobProcessor?: JobQueueProcessor;
 }
 
 /**
@@ -78,6 +86,8 @@ export class GitHubService {
 	private routerAgent: RouterAgent;
 	private inboxManager: InboxManager;
 	private webhookHandler?: (req: Request) => Promise<Response>;
+	private jobQueue?: JobQueueRepository;
+	private jobProcessor?: JobQueueProcessor;
 
 	constructor(options: GitHubServiceOptions) {
 		this.db = options.db;
@@ -85,6 +95,8 @@ export class GitHubService {
 		this.config = options.config;
 		this.apiKey = options.apiKey;
 		this.githubToken = options.githubToken;
+		this.jobQueue = options.jobQueue;
+		this.jobProcessor = options.jobProcessor;
 
 		// Initialize filter config manager
 		this.filterConfigManager = createFilterConfigManager(this.db.getDatabase());
@@ -117,16 +129,13 @@ export class GitHubService {
 	}
 
 	/**
-	 * Start the GitHub service
-	 * - Starts polling if configured
-	 * - Creates webhook handler if secret is configured
-	 *
-	 * @param options.useJobQueueScheduler - When true, the polling service is created
-	 *   but its built-in setInterval timer is NOT started. The job-queue handler owns
-	 *   the schedule entirely (via the github.poll queue), which avoids a dual-schedule
-	 *   where both the setInterval and the job-queue chain call triggerPoll independently.
+	 * Start the GitHub service.
+	 * - Creates webhook handler if secret is configured.
+	 * - Creates and starts the polling service if polling is configured.
+	 * - Registers the github.poll job handler and enqueues the initial job when
+	 *   both jobProcessor/jobQueue and polling are configured.
 	 */
-	start(options?: { useJobQueueScheduler?: boolean }): void {
+	start(): void {
 		// Initialize webhook handler if secret is configured
 		if (this.config.githubWebhookSecret) {
 			this.webhookHandler = createWebhookHandler(this.config.githubWebhookSecret, async (event) => {
@@ -141,27 +150,46 @@ export class GitHubService {
 			this.config.githubPollingInterval > 0 &&
 			this.githubToken
 		) {
+			const intervalMs = this.config.githubPollingInterval * 1000;
+
 			this.pollingService = createPollingService(
 				{
 					token: this.githubToken,
-					interval: this.config.githubPollingInterval * 1000, // Convert to ms
+					interval: intervalMs,
 				},
 				async (event) => {
 					await this.processEvent(event);
 				}
 			);
 
-			if (options?.useJobQueueScheduler) {
-				// Job queue owns the schedule — skip the built-in setInterval so only
-				// one scheduling mechanism fires per interval.
-				log.info('Polling service created (job-queue-driven, setInterval skipped)', {
-					intervalMs: this.config.githubPollingInterval * 1000,
-				});
-			} else {
+			// Register the github.poll job handler so the processor can execute it.
+			// pollingService.start() is called inside this guard so that isRunning() is
+			// consistent with whether an actual poll chain is in place — if jobQueue/
+			// jobProcessor are absent no scheduling exists and the service must not
+			// report itself as running.
+			if (this.jobProcessor && this.jobQueue) {
 				this.pollingService.start();
-				log.info('Polling service started', {
-					intervalMs: this.config.githubPollingInterval * 1000,
+				log.info('Polling service started (job-queue-driven)', { intervalMs });
+
+				this.jobProcessor.register(GITHUB_POLL, () =>
+					handleGitHubPoll({
+						pollingService: this.pollingService,
+						jobQueue: this.jobQueue!,
+						intervalMs,
+					})
+				);
+				log.info('github.poll job handler registered');
+
+				// Enqueue the initial poll immediately if no job is already in flight.
+				const existing = this.jobQueue.listJobs({
+					queue: GITHUB_POLL,
+					status: ['pending', 'processing'],
+					limit: 1,
 				});
+				if (existing.length === 0) {
+					this.jobQueue.enqueue({ queue: GITHUB_POLL, payload: {}, runAt: Date.now() });
+					log.info('Enqueued initial github.poll job');
+				}
 			}
 		}
 

--- a/packages/daemon/src/lib/github/polling-service.ts
+++ b/packages/daemon/src/lib/github/polling-service.ts
@@ -14,7 +14,6 @@ const log = new Logger('github-polling');
 
 const DEFAULT_BASE_URL = 'https://api.github.com';
 const DEFAULT_USER_AGENT = 'NeoKai-GitHub-Integration/1.0';
-const DEFAULT_INTERVAL = 60000; // 1 minute
 
 /**
  * State for a single repository being polled
@@ -36,7 +35,7 @@ interface RepoState {
 export class GitHubPollingService {
 	private config: PollingConfig;
 	private repositories: Map<string, RepoState> = new Map();
-	private pollingInterval: Timer | null = null;
+	private running = false;
 	private isPolling = false;
 	private onEvent?: (event: GitHubEvent) => Promise<void> | void;
 
@@ -46,7 +45,7 @@ export class GitHubPollingService {
 	) {
 		this.config = {
 			token: config.token,
-			interval: config.interval ?? DEFAULT_INTERVAL,
+			interval: config.interval ?? 60000,
 			baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
 			userAgent: config.userAgent ?? DEFAULT_USER_AGENT,
 		};
@@ -54,39 +53,26 @@ export class GitHubPollingService {
 	}
 
 	/**
-	 * Start the polling loop
+	 * Start the polling service (state flag only — scheduling is handled by the job queue).
 	 */
 	start(): void {
-		if (this.pollingInterval) {
+		if (this.running) {
 			log.warn('Polling service already running');
 			return;
 		}
 
+		this.running = true;
 		log.info('Starting GitHub polling service', {
-			interval: this.config.interval,
 			repositoryCount: this.repositories.size,
 		});
-
-		// Run initial poll immediately
-		this.pollAllRepositories().catch((error) => {
-			log.error('Initial poll failed', error);
-		});
-
-		// Schedule recurring polls
-		this.pollingInterval = setInterval(() => {
-			this.pollAllRepositories().catch((error) => {
-				log.error('Scheduled poll failed', error);
-			});
-		}, this.config.interval);
 	}
 
 	/**
-	 * Stop the polling loop
+	 * Stop the polling service (state flag only).
 	 */
 	stop(): void {
-		if (this.pollingInterval) {
-			clearInterval(this.pollingInterval);
-			this.pollingInterval = null;
+		if (this.running) {
+			this.running = false;
 			log.info('GitHub polling service stopped');
 		}
 	}
@@ -133,10 +119,10 @@ export class GitHubPollingService {
 	}
 
 	/**
-	 * Check if the service is currently polling
+	 * Check if the service is currently running
 	 */
 	isRunning(): boolean {
-		return this.pollingInterval !== null;
+		return this.running;
 	}
 
 	/**

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -30,11 +30,16 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 	let polled = false;
 
 	try {
-		if (pollingService) {
+		if (!pollingService) {
+			log.warn('github.poll handler called but no polling service is configured');
+		} else if (!pollingService.isRunning()) {
+			// Polling service was stopped (e.g. GitHubService.stop() was called at runtime).
+			// Skip triggerPoll for this cycle; the self-schedule below keeps the chain alive
+			// so that polling resumes automatically if the service is restarted.
+			log.debug('github.poll handler skipping triggerPoll — polling service is stopped');
+		} else {
 			await pollingService.triggerPoll();
 			polled = true;
-		} else {
-			log.warn('github.poll handler called but no polling service is configured');
 		}
 	} catch (error) {
 		log.error('triggerPoll failed', {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,7 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { SESSION_TITLE_GENERATION, GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
-import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
+import { GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
 import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
 import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
@@ -151,11 +150,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 	setupTestHandlers(deps.messageHub, deps.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
-
-	// Job queue handler registrations
-	deps.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
-		handleSessionTitleGeneration(job, deps.sessionManager.getSessionLifecycle())
-	);
 
 	// Room handlers
 	setupRoomHandlers(

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,7 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { GITHUB_POLL, ROOM_TICK } from '../job-queue-constants';
-import { handleGitHubPoll } from '../job-handlers/github-poll.handler';
+import { ROOM_TICK } from '../job-queue-constants';
 import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
@@ -247,27 +246,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		roomManager,
 		deps.gitHubService ?? null
 	);
-
-	// Register github.poll job handler.
-	// pollingService is created inside GitHubService.start(), which runs in app.ts
-	// after setupRPCHandlers returns. Resolving it at call time via getPollingService()
-	// ensures the handler always sees the live instance rather than undefined.
-	// GitHubService.start() is called with useJobQueueScheduler:true so its built-in
-	// setInterval is skipped — the job-queue chain is the sole scheduler.
-	if (
-		deps.gitHubService &&
-		deps.config.githubPollingInterval &&
-		deps.config.githubPollingInterval > 0
-	) {
-		const intervalMs = deps.config.githubPollingInterval * 1000;
-		deps.jobProcessor.register(GITHUB_POLL, () =>
-			handleGitHubPoll({
-				pollingService: deps.gitHubService!.getPollingService(),
-				jobQueue: deps.jobQueue,
-				intervalMs,
-			})
-		);
-	}
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -9,7 +9,6 @@
  *
  * Also manages:
  * - EventBus subscriptions for async message processing
- * - Background task tracking for cleanup
  */
 
 import type { Session, MessageHub, MessageDeliveryMode } from '@neokai/shared';
@@ -21,6 +20,10 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../storage/job-queue-processor';
+import { SESSION_TITLE_GENERATION } from '../job-queue-constants';
+import { handleSessionTitleGeneration } from '../job-handlers/session-title.handler';
 
 // Import extracted modules
 import { SessionCache } from './session-cache';
@@ -35,12 +38,11 @@ import { MessagePersistence } from './message-persistence';
 /**
  * Cleanup state machine for SessionManager
  *
- * Prevents race conditions during cleanup by tracking state and
- * preventing new background tasks from starting during cleanup.
+ * Prevents concurrent or redundant cleanup calls.
  *
  * States:
  * - IDLE: Normal operation, cleanup not started
- * - CLEANING: Cleanup in progress, barrier active for new background tasks
+ * - CLEANING: Cleanup in progress
  * - CLEANED: Cleanup complete, no further operations allowed
  */
 export enum CleanupState {
@@ -53,10 +55,7 @@ export class SessionManager {
 	private logger: Logger;
 	private worktreeManager: WorktreeManager;
 	private eventBusUnsubscribers: Array<() => void> = [];
-
-	// Track pending background tasks (like title generation) for cleanup
-	// These are fire-and-forget operations that must complete before DB closes
-	private pendingBackgroundTasks: Set<Promise<unknown>> = new Set();
+	private started = false;
 
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
@@ -73,7 +72,9 @@ export class SessionManager {
 		private authManager: AuthManager,
 		private settingsManager: SettingsManager,
 		private eventBus: DaemonHub,
-		private config: SessionLifecycleConfig
+		private config: SessionLifecycleConfig,
+		private jobQueue: JobQueueRepository,
+		private jobProcessor: JobQueueProcessor
 	) {
 		this.logger = new Logger('SessionManager');
 		this.worktreeManager = new WorktreeManager();
@@ -113,6 +114,21 @@ export class SessionManager {
 	}
 
 	/**
+	 * Register job handlers and start background processing.
+	 * Must be called after construction but before jobProcessor.start().
+	 * Throws if called more than once to catch accidental double-registration.
+	 */
+	start(): void {
+		if (this.started) {
+			throw new Error('SessionManager.start() called more than once');
+		}
+		this.started = true;
+		this.jobProcessor.register(SESSION_TITLE_GENERATION, (job) =>
+			handleSessionTitleGeneration(job, this.sessionLifecycle)
+		);
+	}
+
+	/**
 	 * Setup EventBus subscriptions for async message processing
 	 * ARCHITECTURE: EventBus-centric pattern - SessionManager handles message persistence
 	 */
@@ -138,29 +154,14 @@ export class SessionManager {
 			const { sessionId, userMessageText, needsWorkspaceInit, hasDraftToClear } = data;
 
 			try {
-				// STEP 1: Generate title and rename branch (if needed)
+				// STEP 1: Enqueue title generation job (if needed)
 				// Only run if workspace initialization is needed (first message)
-				// CRITICAL: Check cleanup barrier to prevent race conditions
 				if (needsWorkspaceInit) {
-					// BARRIER: Skip new background tasks during cleanup
-					// This prevents race conditions where tasks complete during shutdown
-					/* v8 ignore next */
-					if (this.cleanupState !== CleanupState.IDLE) return;
-
-					const titleGenTask = this.sessionLifecycle
-						.generateTitleAndRenameBranch(sessionId, userMessageText)
-						.catch((error) => {
-							// Title generation failure is non-fatal
-							this.logger.error(`[SessionManager] Title generation failed:`, error);
-						});
-
-					// Track task for cleanup barrier
-					this.pendingBackgroundTasks.add(titleGenTask);
-					titleGenTask.finally(() => {
-						this.pendingBackgroundTasks.delete(titleGenTask);
+					this.jobQueue.enqueue({
+						queue: SESSION_TITLE_GENERATION,
+						payload: { sessionId, userMessageText },
+						maxRetries: 2,
 					});
-
-					await titleGenTask;
 				}
 
 				// STEP 2: Clear draft if it matches the sent message content
@@ -324,11 +325,14 @@ export class SessionManager {
 	 * Cleanup all sessions (called during shutdown)
 	 *
 	 * Uses a state machine to prevent race conditions:
-	 * - IDLE → CLEANING: Sets barrier, prevents new background tasks
+	 * - IDLE → CLEANING: Sets barrier
 	 * - CLEANING: Executes cleanup in phases
 	 * - CLEANING → CLEANED: Final state, no more operations allowed
 	 *
 	 * If cleanup fails, state returns to IDLE to allow retry.
+	 *
+	 * Title generation jobs are drained by the job processor (stopped in app.ts
+	 * before sessionManager.cleanup() is called), not here.
 	 */
 	async cleanup(): Promise<void> {
 		// State check: prevent concurrent cleanup
@@ -336,7 +340,7 @@ export class SessionManager {
 			return;
 		}
 
-		// Transition to CLEANING state - sets the barrier for new background tasks
+		// Transition to CLEANING state
 		this.cleanupState = CleanupState.CLEANING;
 
 		try {
@@ -351,31 +355,7 @@ export class SessionManager {
 			}
 			this.eventBusUnsubscribers = [];
 
-			// PHASE 2: Wait for pending background tasks (like title generation) with timeout
-			// These are fire-and-forget operations from EventBus handlers
-			// The cleanup barrier prevents new tasks from starting
-			// Use a timeout to prevent hanging in CI when title generation takes too long
-			const BACKGROUND_TASK_TIMEOUT_MS = 5000; // 5 seconds max wait
-
-			if (this.pendingBackgroundTasks.size > 0) {
-				const timeoutPromise = new Promise<'timeout'>((resolve) =>
-					setTimeout(() => resolve('timeout'), BACKGROUND_TASK_TIMEOUT_MS)
-				);
-
-				await Promise.race([
-					Promise.all(Array.from(this.pendingBackgroundTasks))
-						.then(() => 'completed' as const)
-						.catch((error) => {
-							this.logger.error(`[SessionManager] Error waiting for background tasks:`, error);
-							return 'error' as const;
-						}),
-					timeoutPromise,
-				]);
-
-				this.pendingBackgroundTasks.clear();
-			}
-
-			// PHASE 3: Cleanup all in-memory sessions in parallel
+			// PHASE 2: Cleanup all in-memory sessions in parallel
 			// CRITICAL: Each AgentSession.cleanup() now properly stops SDK queries
 			// with lifecycle manager, ensuring subprocesses exit before we continue
 			const cleanupPromises: Promise<void>[] = [];

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -827,6 +827,10 @@ export class TaskAgentManager {
 										err
 									);
 								});
+						} else {
+							log.warn(
+								`TaskAgentManager: could not resolve spaceId for sub-session ${subSessionId} — spaceSessionGroup.memberUpdated (failed) not emitted`
+							);
 						}
 					}
 				} catch (err) {
@@ -907,6 +911,10 @@ export class TaskAgentManager {
 									err
 								);
 							});
+					} else {
+						log.warn(
+							`TaskAgentManager: could not resolve spaceId for task ${taskId} — spaceSessionGroup.memberUpdated (completed) not emitted`
+						);
 					}
 				}
 			} catch (err) {
@@ -1078,6 +1086,7 @@ export class TaskAgentManager {
 				this.injectSubSessionMessage(subSessionId, message),
 			onSubSessionComplete: (stepId, subSessionId) =>
 				this.handleSubSessionComplete(taskId, stepId, subSessionId),
+			daemonHub: this.config.daemonHub,
 		});
 
 		agentSession.setRuntimeMcpServers({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -268,7 +268,7 @@ export class TaskAgentManager {
 
 			// --- Build and attach MCP server with live runtime dependencies
 			const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
-			const subSessionFactory = this.createSubSessionFactory(taskId);
+			const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
 
 			const mcpServer = createTaskAgentMcpServer({
 				taskId,
@@ -321,6 +321,21 @@ export class TaskAgentManager {
 					});
 					this.taskGroupIds.set(taskId, group.id);
 					log.info(`TaskAgentManager: created session group ${group.id} for task ${taskId}`);
+					// Fetch the group with members populated for the event payload
+					const groupWithMembers = this.config.sessionGroupRepo.getGroup(group.id) ?? group;
+					this.config.daemonHub
+						.emit('spaceSessionGroup.created', {
+							sessionId: `space:${spaceId}`,
+							spaceId,
+							taskId,
+							group: groupWithMembers,
+						})
+						.catch((err) => {
+							log.warn(
+								`TaskAgentManager: failed to emit spaceSessionGroup.created for group ${group.id}:`,
+								err
+							);
+						});
 				} catch (addErr) {
 					// addMember failed — remove the orphaned group row before propagating
 					try {
@@ -636,7 +651,7 @@ export class TaskAgentManager {
 	 * Create a `SubSessionFactory` implementation bound to a specific taskId.
 	 * Passed to `createTaskAgentMcpServer()` for the given Task Agent session.
 	 */
-	private createSubSessionFactory(taskId: string): SubSessionFactory {
+	private createSubSessionFactory(taskId: string, spaceId: string): SubSessionFactory {
 		return {
 			create: async (
 				init: AgentSessionInit,
@@ -659,6 +674,19 @@ export class TaskAgentManager {
 						log.info(
 							`TaskAgentManager: added sub-session ${sessionId} as member ${member.id} to group ${groupId}`
 						);
+						this.config.daemonHub
+							.emit('spaceSessionGroup.memberAdded', {
+								sessionId: `space:${spaceId}`,
+								spaceId,
+								groupId,
+								member,
+							})
+							.catch((err) => {
+								log.warn(
+									`TaskAgentManager: failed to emit spaceSessionGroup.memberAdded for member ${member.id}:`,
+									err
+								);
+							});
 					} catch (err) {
 						log.warn(
 							`TaskAgentManager: failed to add sub-session ${sessionId} to group ${groupId}:`,
@@ -781,7 +809,26 @@ export class TaskAgentManager {
 				const memberId = this.subSessionMemberIds.get(subSessionId);
 				if (!memberId) return;
 				try {
-					this.config.sessionGroupRepo.updateMemberStatus(memberId, 'failed');
+					const updatedMember = this.config.sessionGroupRepo.updateMemberStatus(memberId, 'failed');
+					if (updatedMember) {
+						const spaceId = this.getSpaceIdForSubSession(subSessionId);
+						if (spaceId) {
+							this.config.daemonHub
+								.emit('spaceSessionGroup.memberUpdated', {
+									sessionId: `space:${spaceId}`,
+									spaceId,
+									groupId: updatedMember.groupId,
+									memberId,
+									member: updatedMember,
+								})
+								.catch((err) => {
+									log.warn(
+										`TaskAgentManager: failed to emit spaceSessionGroup.memberUpdated for member ${memberId}:`,
+										err
+									);
+								});
+						}
+					}
 				} catch (err) {
 					log.warn(
 						`TaskAgentManager: failed to mark member ${memberId} as failed for sub-session ${subSessionId}:`,
@@ -839,7 +886,29 @@ export class TaskAgentManager {
 		const memberId = this.subSessionMemberIds.get(subSessionId);
 		if (memberId) {
 			try {
-				this.config.sessionGroupRepo.updateMemberStatus(memberId, 'completed');
+				const updatedMember = this.config.sessionGroupRepo.updateMemberStatus(
+					memberId,
+					'completed'
+				);
+				if (updatedMember) {
+					const spaceId = this.getSpaceIdForTask(taskId);
+					if (spaceId) {
+						this.config.daemonHub
+							.emit('spaceSessionGroup.memberUpdated', {
+								sessionId: `space:${spaceId}`,
+								spaceId,
+								groupId: updatedMember.groupId,
+								memberId,
+								member: updatedMember,
+							})
+							.catch((err) => {
+								log.warn(
+									`TaskAgentManager: failed to emit spaceSessionGroup.memberUpdated for member ${memberId}:`,
+									err
+								);
+							});
+					}
+				}
 			} catch (err) {
 				log.warn(
 					`TaskAgentManager: failed to mark member ${memberId} as completed for sub-session ${subSessionId}:`,
@@ -991,7 +1060,7 @@ export class TaskAgentManager {
 
 		// --- Build and attach MCP server (runtime-only, not persisted)
 		const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
-		const subSessionFactory = this.createSubSessionFactory(taskId);
+		const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
 
 		const mcpServer = createTaskAgentMcpServer({
 			taskId,
@@ -1181,5 +1250,18 @@ export class TaskAgentManager {
 	/** Returns the space ID for a task by reading it from the task repository. */
 	private getSpaceIdForTask(taskId: string): string | null {
 		return this.config.taskRepo.getTask(taskId)?.spaceId ?? null;
+	}
+
+	/**
+	 * Look up the spaceId for a sub-session by searching for the parent taskId.
+	 * Used when emitting events from the error handler where only subSessionId is available.
+	 */
+	private getSpaceIdForSubSession(subSessionId: string): string | null {
+		for (const [taskId, stepMap] of this.subSessions) {
+			if (stepMap.has(subSessionId)) {
+				return this.getSpaceIdForTask(taskId);
+			}
+		}
+		return null;
 	}
 }

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -353,6 +353,25 @@ export class StateManager {
 			});
 		});
 
+		// Space session group events (space-scoped channel: 'space:${spaceId}')
+		this.eventBus.on('spaceSessionGroup.created', (data) => {
+			this.messageHub.event('spaceSessionGroup.created', data, {
+				channel: data.sessionId, // 'space:${spaceId}'
+			});
+		});
+
+		this.eventBus.on('spaceSessionGroup.memberAdded', (data) => {
+			this.messageHub.event('spaceSessionGroup.memberAdded', data, {
+				channel: data.sessionId, // 'space:${spaceId}'
+			});
+		});
+
+		this.eventBus.on('spaceSessionGroup.memberUpdated', (data) => {
+			this.messageHub.event('spaceSessionGroup.memberUpdated', data, {
+				channel: data.sessionId, // 'space:${spaceId}'
+			});
+		});
+
 		// Space workflow definition events (global channel)
 		this.eventBus.on('spaceWorkflow.created', (data) => {
 			this.messageHub.event('spaceWorkflow.created', data, {

--- a/packages/daemon/tests/unit/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/github/github-service-polling.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Integration-style unit tests for GitHubService job-queue-driven polling.
+ *
+ * Verifies the full flow:
+ *   GitHubService.start()
+ *     → registers github.poll handler on jobProcessor
+ *     → enqueues initial github.poll job
+ *   handler invocation
+ *     → calls triggerPoll on the polling service
+ *     → self-schedules next job
+ */
+
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
+import { Database as SqliteDatabase } from 'bun:sqlite';
+import { GitHubService } from '../../../src/lib/github/github-service';
+import { GITHUB_POLL } from '../../../src/lib/job-queue-constants';
+import type { Job } from '../../../src/storage/repositories/job-queue-repository';
+import type { Database } from '../../../src/storage/database';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+	return {
+		id: 'job-1',
+		queue: GITHUB_POLL,
+		status: 'pending',
+		payload: {},
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now() + 60000,
+		createdAt: Date.now(),
+		startedAt: null,
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeDb(): Database {
+	// FilterConfigManager needs a real SQLite db with .prepare()
+	const sqlite = new SqliteDatabase(':memory:');
+	return {
+		getDatabase: () => sqlite,
+		listGitHubMappingsForRepository: mock(() => []),
+		listGitHubMappings: mock(() => []),
+		getGitHubMappingByRoomId: mock(() => null),
+		countInboxItemsByStatus: mock(() => 0),
+		listPendingInboxItems: mock(() => []),
+		getInboxItem: mock(() => null),
+		createInboxItem: mock(() => ({})),
+		updateInboxItem: mock(() => null),
+	} as unknown as Database;
+}
+
+function makeDaemonHub() {
+	return { emit: mock(() => {}) } as never;
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+	return {
+		githubPollingInterval: 60, // seconds
+		githubWebhookSecret: undefined,
+		...overrides,
+	} as never;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('GitHubService — job-queue-driven polling', () => {
+	let registerMock: ReturnType<typeof mock>;
+	let enqueueMock: ReturnType<typeof mock>;
+	let listJobsMock: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		registerMock = mock(() => {});
+		enqueueMock = mock(() => makeJob());
+		listJobsMock = mock(() => []); // no existing jobs → enqueue initial
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	function makeJobProcessor() {
+		return {
+			register: registerMock,
+		} as never;
+	}
+
+	function makeJobQueue(listOverride?: ReturnType<typeof mock>) {
+		return {
+			enqueue: enqueueMock,
+			listJobs: listOverride ?? listJobsMock,
+		} as never;
+	}
+
+	function makeService(configOverrides: Record<string, unknown> = {}) {
+		return new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(configOverrides),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+	}
+
+	it('registers github.poll handler on jobProcessor when start() is called', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(registerMock).toHaveBeenCalledTimes(1);
+		const [queue] = registerMock.mock.calls[0] as [string, unknown];
+		expect(queue).toBe(GITHUB_POLL);
+	});
+
+	it('enqueues initial github.poll job immediately on start()', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const [arg] = enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }];
+		expect(arg.queue).toBe(GITHUB_POLL);
+		// runAt should be approximately now (within 2 seconds)
+		expect(arg.runAt).toBeGreaterThanOrEqual(Date.now() - 100);
+		expect(arg.runAt).toBeLessThanOrEqual(Date.now() + 2000);
+	});
+
+	it('skips initial enqueue when a pending job already exists (dedup)', () => {
+		const listWithExisting = mock(() => [makeJob({ status: 'pending' })]);
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(listWithExisting),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('skips initial enqueue when a processing job already exists (dedup)', () => {
+		const listWithExisting = mock(() => [makeJob({ status: 'processing' })]);
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(listWithExisting),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when jobProcessor is absent', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			// no jobQueue / jobProcessor
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when polling interval is 0', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig({ githubPollingInterval: 0 }),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('does not register handler or enqueue when githubToken is absent', () => {
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			// no githubToken
+			jobQueue: makeJobQueue(),
+			jobProcessor: makeJobProcessor(),
+		});
+
+		svc.start();
+
+		expect(registerMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('registered handler calls triggerPoll and self-schedules next job', async () => {
+		// Capture the registered handler so we can invoke it directly.
+		let capturedHandler: (() => Promise<unknown>) | undefined;
+		const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+			capturedHandler = handler;
+		});
+
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: { register: capturingRegister } as never,
+		});
+
+		svc.start();
+
+		expect(capturedHandler).toBeDefined();
+
+		// Polling service was created by start(); getPollingService() returns it.
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService).toBeDefined();
+
+		// Spy on triggerPoll.
+		const triggerPollMock = mock(async () => {});
+		(pollingService as never as Record<string, unknown>).triggerPoll = triggerPollMock;
+
+		// Reset enqueueMock to count only the self-schedule enqueue from the handler.
+		// The initial enqueue happened during start() already.
+		enqueueMock.mockClear();
+
+		// Point the captured jobQueue to fresh mocks for the handler's dedup check.
+		// (Assigning jobQueueInService.listJobs is what matters — the handler references
+		// the jobQueue object stored on svc, not the outer listJobsMock variable.)
+		const jobQueueInService = (svc as never as Record<string, unknown>).jobQueue as {
+			listJobs: ReturnType<typeof mock>;
+			enqueue: ReturnType<typeof mock>;
+		};
+		jobQueueInService.listJobs = mock(() => []);
+		jobQueueInService.enqueue = enqueueMock;
+
+		const result = await capturedHandler!();
+
+		// triggerPoll was called once
+		expect(triggerPollMock).toHaveBeenCalledTimes(1);
+
+		// Handler returns { polled: true, nextRunAt }
+		expect((result as Record<string, unknown>).polled).toBe(true);
+		expect(typeof (result as Record<string, unknown>).nextRunAt).toBe('number');
+
+		// Self-schedule: one new job was enqueued with a future runAt
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const [enqueueArg] = enqueueMock.mock.calls[0] as [{ queue: string; runAt: number }];
+		expect(enqueueArg.queue).toBe(GITHUB_POLL);
+		expect(enqueueArg.runAt).toBeGreaterThan(Date.now());
+	});
+
+	it('isPolling() returns false after stop(), and isRunning() on pollingService is false', () => {
+		const svc = makeService();
+		svc.start();
+
+		expect(svc.isPolling()).toBe(true);
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService.isRunning()).toBe(true);
+
+		svc.stop();
+
+		// After stop() the state flag is cleared; no job-queue chain is drained
+		// (that requires stopping the JobQueueProcessor itself, done in app.ts shutdown).
+		expect(svc.isPolling()).toBe(false);
+		expect(pollingService.isRunning()).toBe(false);
+	});
+
+	it('handler skips triggerPoll when pollingService.isRunning() is false', async () => {
+		let capturedHandler: (() => Promise<unknown>) | undefined;
+		const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+			capturedHandler = handler;
+		});
+
+		const svc = new GitHubService({
+			db: makeDb(),
+			daemonHub: makeDaemonHub(),
+			config: makeConfig(),
+			apiKey: 'test-api-key',
+			githubToken: 'test-github-token',
+			jobQueue: makeJobQueue(),
+			jobProcessor: { register: capturingRegister } as never,
+		});
+
+		svc.start();
+
+		// Save the pollingService reference before stop() clears it on the service.
+		const pollingService = svc.getPollingService()!;
+		expect(pollingService).toBeDefined();
+
+		// Stop the service — sets pollingService.running = false
+		svc.stop();
+
+		const triggerPollMock = mock(async () => {});
+		(pollingService as never as Record<string, unknown>).triggerPoll = triggerPollMock;
+
+		enqueueMock.mockClear();
+		const jobQueueInService = (svc as never as Record<string, unknown>).jobQueue as {
+			listJobs: ReturnType<typeof mock>;
+			enqueue: ReturnType<typeof mock>;
+		};
+		jobQueueInService.listJobs = mock(() => []);
+		jobQueueInService.enqueue = enqueueMock;
+
+		const result = await capturedHandler!();
+
+		// triggerPoll must NOT be called when the service is stopped
+		expect(triggerPollMock).not.toHaveBeenCalled();
+		expect((result as Record<string, unknown>).polled).toBe(false);
+
+		// But the chain self-schedules so polling resumes automatically when restarted
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -38,13 +38,18 @@ describe('handleGitHubPoll', () => {
 	});
 
 	function makeDeps(
-		overrides: { intervalMs?: number; pollingService?: ReturnType<typeof mock> | undefined } = {}
+		overrides: {
+			intervalMs?: number;
+			pollingService?: ReturnType<typeof mock> | undefined;
+			isRunning?: boolean;
+		} = {}
 	) {
+		const running = overrides.isRunning ?? true;
 		return {
 			pollingService:
 				'pollingService' in overrides
 					? overrides.pollingService
-					: ({ triggerPoll: triggerPollMock } as never),
+					: ({ triggerPoll: triggerPollMock, isRunning: () => running } as never),
 			jobQueue: {
 				enqueue: enqueueMock,
 				listJobs: listJobsMock,
@@ -107,7 +112,7 @@ describe('handleGitHubPoll', () => {
 		listJobsMock = mock(() => []);
 
 		const deps = makeDeps();
-		deps.pollingService = { triggerPoll: triggerPollMock } as never;
+		deps.pollingService = { triggerPoll: triggerPollMock, isRunning: () => true } as never;
 		deps.jobQueue.listJobs = listJobsMock as never;
 		deps.jobQueue.enqueue = enqueueMock as never;
 
@@ -135,6 +140,16 @@ describe('handleGitHubPoll', () => {
 		expect(result.polled).toBe(false);
 		expect(triggerPollMock).not.toHaveBeenCalled();
 		// Still enqueues next job
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips triggerPoll and returns polled: false when pollingService.isRunning() is false', async () => {
+		const deps = makeDeps({ isRunning: false });
+		const result = await handleGitHubPoll(deps);
+
+		expect(triggerPollMock).not.toHaveBeenCalled();
+		expect(result.polled).toBe(false);
+		// Self-schedule still happens so the chain resumes when service is restarted
 		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/daemon/tests/unit/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/session/session-manager.test.ts
@@ -13,6 +13,8 @@ import type { AuthManager } from '../../../src/lib/auth-manager';
 import type { SettingsManager } from '../../../src/lib/settings-manager';
 import type { MessageHub, Session } from '@neokai/shared';
 import { DEFAULT_GLOBAL_SETTINGS } from '@neokai/shared';
+import type { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../../src/storage/job-queue-processor';
 
 describe('SessionManager', () => {
 	let sessionManager: SessionManager;
@@ -21,6 +23,8 @@ describe('SessionManager', () => {
 	let mockAuthManager: AuthManager;
 	let mockSettingsManager: SettingsManager;
 	let mockEventBus: DaemonHub;
+	let mockJobQueue: JobQueueRepository;
+	let mockJobProcessor: JobQueueProcessor;
 	let config: Record<string, unknown>;
 	let eventHandlers: Map<string, (...args: unknown[]) => unknown>;
 
@@ -99,6 +103,19 @@ describe('SessionManager', () => {
 			initialize: mock(async () => {}),
 		} as unknown as DaemonHub;
 
+		// Job queue mocks
+		mockJobQueue = {
+			enqueue: mock(() => ({ id: 'job-id', queue: 'session.title_generation' })),
+			listJobs: mock(() => []),
+		} as unknown as JobQueueRepository;
+
+		// Job processor mocks
+		mockJobProcessor = {
+			register: mock(() => {}),
+			start: mock(() => {}),
+			stop: mock(async () => {}),
+		} as unknown as JobQueueProcessor;
+
 		// Config
 		config = {
 			defaultModel: 'claude-sonnet-4-20250514',
@@ -114,7 +131,9 @@ describe('SessionManager', () => {
 			mockAuthManager,
 			mockSettingsManager,
 			mockEventBus,
-			config as Parameters<typeof SessionManager>[5]
+			config as Parameters<typeof SessionManager>[5],
+			mockJobQueue,
+			mockJobProcessor
 		);
 	});
 
@@ -139,6 +158,26 @@ describe('SessionManager', () => {
 
 		it('should have no active sessions initially', () => {
 			expect(sessionManager.getActiveSessions()).toBe(0);
+		});
+	});
+
+	describe('start', () => {
+		it('should register session.title_generation handler on jobProcessor', () => {
+			expect(mockJobProcessor.register).not.toHaveBeenCalled();
+
+			sessionManager.start();
+
+			expect(mockJobProcessor.register).toHaveBeenCalledTimes(1);
+			expect(mockJobProcessor.register).toHaveBeenCalledWith(
+				'session.title_generation',
+				expect.any(Function)
+			);
+		});
+
+		it('should throw if called more than once', () => {
+			sessionManager.start();
+
+			expect(() => sessionManager.start()).toThrow('SessionManager.start() called more than once');
 		});
 	});
 
@@ -494,11 +533,11 @@ describe('SessionManager', () => {
 			expect(sessionManager.getCleanupState()).toBe(CleanupState.CLEANED);
 		});
 
-		it('should wait for pending background tasks with timeout', async () => {
-			// This tests the timeout behavior for background tasks
+		it('should complete without draining pending tasks (processor handles drain)', async () => {
+			// Background task draining is now handled by the job processor,
+			// not by SessionManager. Cleanup should be immediate.
 			await sessionManager.cleanup();
 
-			// Should complete within reasonable time
 			expect(sessionManager.getCleanupState()).toBe(CleanupState.CLEANED);
 		});
 	});
@@ -561,13 +600,9 @@ describe('SessionManager', () => {
 				);
 			});
 
-			it('should skip background tasks during cleanup', async () => {
-				// Start cleanup to set barrier
-				const cleanupPromise = sessionManager.cleanup();
-
+			it('should enqueue title generation job when needsWorkspaceInit is true', async () => {
 				const handler = eventHandlers.get('message.persisted');
 
-				// This should be skipped due to cleanup barrier
 				await handler?.({
 					sessionId: 'test-id',
 					userMessageText: 'test message',
@@ -575,7 +610,11 @@ describe('SessionManager', () => {
 					hasDraftToClear: false,
 				});
 
-				await cleanupPromise;
+				expect(mockJobQueue.enqueue).toHaveBeenCalledWith({
+					queue: 'session.title_generation',
+					payload: { sessionId: 'test-id', userMessageText: 'test message' },
+					maxRetries: 2,
+				});
 			});
 
 			it('should clear draft when hasDraftToClear is true', async () => {

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -2339,14 +2339,29 @@ describe('TaskAgentManager', () => {
 			expect(payload.member.status).toBe('failed');
 		});
 
+		test('spaceSessionGroup.memberAdded uses space-specific channel', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const factory = getFactory(ctx.manager, task.id);
+			await factory.create(
+				{
+					sessionId: `sub-channel-test-${task.id}`,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			const evt = ctx.daemonHub.emitted.find((e) => e.event === 'spaceSessionGroup.memberAdded');
+			expect(evt?.data.sessionId).toBe(`space:${ctx.spaceId}`);
+		});
+
 		test('no spaceSessionGroup.created event when group creation fails', async () => {
 			// Sabotage sessionGroupRepo.createGroup to throw
-			const origCreate = ctx.sessionGroupRepo.createGroup.bind(ctx.sessionGroupRepo);
 			let callCount = 0;
-			ctx.sessionGroupRepo.createGroup = (...args) => {
+			ctx.sessionGroupRepo.createGroup = (..._args) => {
 				callCount++;
 				throw new Error('forced failure');
-				return origCreate(...args);
 			};
 
 			const task = await makeTask(ctx.taskManager);

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -45,6 +45,8 @@ type EventHandler = (data: Record<string, unknown>) => void;
 
 class TestDaemonHub {
 	private listeners = new Map<string, Map<string, EventHandler>>();
+	/** Tracks all emitted events for assertion in tests */
+	readonly emitted: Array<{ event: string; data: Record<string, unknown> }> = [];
 
 	on(event: string, handler: EventHandler, opts?: { sessionId?: string }): () => void {
 		const key = opts?.sessionId ? `${event}:${opts.sessionId}` : `${event}:*`;
@@ -58,7 +60,8 @@ class TestDaemonHub {
 		};
 	}
 
-	emit(event: string, data: Record<string, unknown>): void {
+	emit(event: string, data: Record<string, unknown>): Promise<void> {
+		this.emitted.push({ event, data });
 		const sessionId = (data as { sessionId?: string }).sessionId;
 		// Emit to session-specific listeners
 		if (sessionId) {
@@ -71,6 +74,7 @@ class TestDaemonHub {
 		for (const handler of this.listeners.get(`${event}:*`)?.values() ?? []) {
 			handler(data);
 		}
+		return Promise.resolve();
 	}
 }
 
@@ -2165,6 +2169,193 @@ describe('TaskAgentManager', () => {
 
 			// Group map should be populated even though the task session was not rehydrated
 			expect(ctx.manager.getTaskGroupId(task.id)).toBe(group.id);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Event emission (Task 2.3)
+	// -----------------------------------------------------------------------
+
+	describe('event emission', () => {
+		/** Helper: get the SubSessionFactory bound to a taskId via the private method */
+		function getFactory(
+			manager: TaskAgentManager,
+			taskId: string
+		): import('../../../src/lib/space/tools/task-agent-tools.ts').SubSessionFactory {
+			return (
+				manager as unknown as {
+					createSubSessionFactory: (
+						taskId: string,
+						spaceId: string
+					) => import('../../../src/lib/space/tools/task-agent-tools.ts').SubSessionFactory;
+				}
+			).createSubSessionFactory(taskId, ctx.spaceId);
+		}
+
+		test('spaceSessionGroup.created emitted after spawnTaskAgent', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const events = ctx.daemonHub.emitted.filter((e) => e.event === 'spaceSessionGroup.created');
+			expect(events.length).toBe(1);
+
+			const payload = events[0].data as {
+				sessionId: string;
+				spaceId: string;
+				taskId: string;
+				group: { id: string; members: unknown[] };
+			};
+			expect(payload.sessionId).toBe(`space:${ctx.spaceId}`);
+			expect(payload.spaceId).toBe(ctx.spaceId);
+			expect(payload.taskId).toBe(task.id);
+			expect(payload.group).toBeDefined();
+			// Group should include the task-agent member
+			expect(Array.isArray(payload.group.members)).toBe(true);
+			expect(payload.group.members.length).toBeGreaterThan(0);
+		});
+
+		test('spaceSessionGroup.created uses space-specific channel', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const evt = ctx.daemonHub.emitted.find((e) => e.event === 'spaceSessionGroup.created');
+			expect(evt?.data.sessionId).toBe(`space:${ctx.spaceId}`);
+		});
+
+		test('spaceSessionGroup.memberAdded emitted when sub-session is created', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-event-test-${task.id}`;
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			const events = ctx.daemonHub.emitted.filter(
+				(e) => e.event === 'spaceSessionGroup.memberAdded'
+			);
+			expect(events.length).toBe(1);
+
+			const payload = events[0].data as {
+				sessionId: string;
+				spaceId: string;
+				groupId: string;
+				member: { sessionId: string; role: string; agentId?: string; status: string };
+			};
+			expect(payload.sessionId).toBe(`space:${ctx.spaceId}`);
+			expect(payload.spaceId).toBe(ctx.spaceId);
+			expect(payload.groupId).toBe(ctx.manager.getTaskGroupId(task.id));
+			expect(payload.member.sessionId).toBe(subSessionId);
+			expect(payload.member.role).toBe('coder');
+			expect(payload.member.agentId).toBe(ctx.agentId);
+			expect(payload.member.status).toBe('active');
+		});
+
+		test('spaceSessionGroup.memberUpdated emitted when sub-session completes', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-complete-event-${task.id}`;
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// Simulate completion via handleSubSessionComplete (private method)
+			const handleComplete = (
+				ctx.manager as unknown as {
+					handleSubSessionComplete: (
+						taskId: string,
+						stepId: string,
+						subSessionId: string
+					) => Promise<void>;
+				}
+			).handleSubSessionComplete;
+			await handleComplete.call(ctx.manager, task.id, 'step-1', subSessionId);
+
+			const events = ctx.daemonHub.emitted.filter(
+				(e) => e.event === 'spaceSessionGroup.memberUpdated'
+			);
+			expect(events.length).toBe(1);
+
+			const payload = events[0].data as {
+				sessionId: string;
+				spaceId: string;
+				groupId: string;
+				memberId: string;
+				member: { status: string };
+			};
+			expect(payload.sessionId).toBe(`space:${ctx.spaceId}`);
+			expect(payload.spaceId).toBe(ctx.spaceId);
+			expect(payload.member.status).toBe('completed');
+		});
+
+		test('spaceSessionGroup.memberUpdated emitted when sub-session errors', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const factory = getFactory(ctx.manager, task.id);
+			const subSessionId = `sub-error-event-${task.id}`;
+			await factory.create(
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, role: 'coder' }
+			);
+
+			// Register a completion callback to activate the session.error listener
+			factory.onComplete(subSessionId, async () => {});
+
+			// Simulate session error via DaemonHub event
+			ctx.daemonHub.emit('session.error', {
+				sessionId: subSessionId,
+				error: 'test error',
+			});
+
+			// Wait a tick for the async handler to fire
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			const events = ctx.daemonHub.emitted.filter(
+				(e) => e.event === 'spaceSessionGroup.memberUpdated'
+			);
+			expect(events.length).toBe(1);
+
+			const payload = events[0].data as {
+				sessionId: string;
+				spaceId: string;
+				member: { status: string };
+			};
+			expect(payload.sessionId).toBe(`space:${ctx.spaceId}`);
+			expect(payload.member.status).toBe('failed');
+		});
+
+		test('no spaceSessionGroup.created event when group creation fails', async () => {
+			// Sabotage sessionGroupRepo.createGroup to throw
+			const origCreate = ctx.sessionGroupRepo.createGroup.bind(ctx.sessionGroupRepo);
+			let callCount = 0;
+			ctx.sessionGroupRepo.createGroup = (...args) => {
+				callCount++;
+				throw new Error('forced failure');
+				return origCreate(...args);
+			};
+
+			const task = await makeTask(ctx.taskManager);
+			// Should not throw — group creation is non-fatal
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			expect(callCount).toBe(1);
+			const events = ctx.daemonHub.emitted.filter((e) => e.event === 'spaceSessionGroup.created');
+			expect(events.length).toBe(0);
 		});
 	});
 });

--- a/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
+++ b/packages/e2e/tests/features/space-multi-agent-editor.e2e.ts
@@ -1,0 +1,393 @@
+/**
+ * Multi-Agent Step Editor E2E Tests
+ *
+ * Tests:
+ * - Add a second agent to a step — verify both agents appear as badges in the canvas node
+ * - Configure a one-way channel (A → B) — verify directed arrow in panel and node
+ * - Configure a bidirectional channel (A ↔ B) — verify bidirectional arrow in panel and node
+ * - Remove one agent — verify only one remains and associated channels are removed
+ * - Save workflow and re-open — verify multi-agent config AND channel topology persists
+ *
+ * Setup: creates a Space with two agents via RPC in beforeEach (infrastructure).
+ * Cleanup: deletes the Space via RPC in afterEach.
+ *
+ * E2E Rules:
+ * - All test actions go through the UI (clicks, inputs, navigation)
+ * - All assertions check visible DOM state
+ * - RPC is only used in beforeEach/afterEach for test infrastructure
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpace,
+	deleteSpace,
+	navigateToSpace,
+	resetEditorModeStorage,
+	openNewWorkflowEditor,
+	switchToVisualMode,
+	openWorkflowForEdit,
+	setupMultiAgentStep,
+} from '../helpers/workflow-editor-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+
+// ─── Roles used across tests ──────────────────────────────────────────────────
+
+const ROLE_A = 'coder';
+const ROLE_B = 'reviewer';
+const AGENT_A_NAME = 'Coder Agent';
+const AGENT_B_NAME = 'Reviewer Agent';
+// Option text as rendered by the agent select: "{name} ({role})"
+const AGENT_A_OPTION = `${AGENT_A_NAME} (${ROLE_A})`;
+const AGENT_B_OPTION = `${AGENT_B_NAME} (${ROLE_B})`;
+
+// ─── RPC helpers (infrastructure only) ───────────────────────────────────────
+
+/**
+ * Creates a space and two agents (coder, reviewer) for multi-agent test scenarios.
+ * Returns only spaceId — agent IDs are not needed by tests since agents are
+ * selected by option label in the UI.
+ */
+async function createTestSpace(page: Page): Promise<string> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+	const spaceName = `E2E Multi-Agent Editor ${Date.now()}`;
+	const spaceId = await createSpace(page, spaceName);
+
+	await page.evaluate(
+		async ({ sid, roleA, roleB, agentAName, agentBName }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
+				name: agentAName,
+				role: roleA,
+				description: '',
+			});
+			await hub.request('spaceAgent.create', {
+				spaceId: sid,
+				name: agentBName,
+				role: roleB,
+				description: '',
+			});
+		},
+		{
+			sid: spaceId,
+			roleA: ROLE_A,
+			roleB: ROLE_B,
+			agentAName: AGENT_A_NAME,
+			agentBName: AGENT_B_NAME,
+		}
+	);
+
+	return spaceId;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Multi-Agent Step Editor', () => {
+	test.describe.configure({ mode: 'serial' });
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let spaceId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await resetEditorModeStorage(page);
+		spaceId = await createTestSpace(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (spaceId) {
+			await deleteSpace(page, spaceId);
+			spaceId = '';
+		}
+	});
+
+	// ─── Test 1: Add second agent — verify both agents appear as badges ───────
+
+	test('Edit step to add second agent — verify both agents appear as badges', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Multi-Agent Badges Test');
+
+		// Add one step
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await expect(nodes).toHaveCount(1, { timeout: 3000 });
+
+		// Open node config panel
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Parallel Step');
+
+		// Switch to multi-agent mode and add both agents
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+
+		// Verify agent names are rendered in the list entries
+		const agentsList = panel.getByTestId('agents-list');
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_B_NAME })
+		).toBeVisible({ timeout: 2000 });
+
+		// Close panel and verify node shows agent badges for both agents
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		const node = nodes.first();
+		const agentBadges = node.getByTestId('agent-badges');
+		await expect(agentBadges).toBeVisible({ timeout: 3000 });
+		// Both agent names should appear as badge spans within the agent-badges container
+		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 2: Configure channels — one-way and bidirectional ──────────────
+
+	test('Add one-way and bidirectional channels — verify directed arrows appear', async ({
+		page,
+	}) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Channel Topology Test');
+
+		// Add step and open config
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Channel Step');
+
+		// Set up two agents (required for channels section to appear)
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+
+		// Channels section should now be visible (multi-agent mode)
+		const channelsSection = panel.getByTestId('channels-section');
+		await expect(channelsSection).toBeVisible({ timeout: 3000 });
+
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		const channelsList = panel.getByTestId('channels-list');
+
+		// ── Add one-way channel: coder → reviewer ────────────────────────────
+
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		// Direction defaults to 'one-way' — no change needed
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+
+		// Channel entry should appear: "coder → reviewer"
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(1, { timeout: 3000 });
+		const firstEntry = channelsList.getByTestId('channel-entry').first();
+		await expect(firstEntry).toContainText(ROLE_A);
+		await expect(firstEntry).toContainText('→');
+		await expect(firstEntry).toContainText(ROLE_B);
+
+		// ── Add bidirectional channel: reviewer ↔ coder ──────────────────────
+
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_B });
+		await addChannelForm
+			.getByTestId('channel-direction-select')
+			.selectOption({ value: 'bidirectional' });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_A);
+		await addChannelForm.getByTestId('add-channel-button').click();
+
+		// Two channel entries should now be present
+		await expect(channelsList.getByTestId('channel-entry')).toHaveCount(2, { timeout: 3000 });
+		const secondEntry = channelsList.getByTestId('channel-entry').nth(1);
+		await expect(secondEntry).toContainText(ROLE_B);
+		await expect(secondEntry).toContainText('↔');
+		await expect(secondEntry).toContainText(ROLE_A);
+
+		// Close panel and verify canvas node renders channel topology via ChannelTopologyBadge
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		const node = nodes.first();
+		// The ChannelTopologyBadge container has data-testid="channel-topology-badge"
+		const topologyBadge = node.getByTestId('channel-topology-badge');
+		await expect(topologyBadge).toBeVisible({ timeout: 3000 });
+
+		// One-way arrow should appear within the topology badge
+		await expect(
+			topologyBadge.locator('[class*="font-mono"]').filter({ hasText: ROLE_A }).first()
+		).toBeVisible({
+			timeout: 2000,
+		});
+		// Bidirectional arrow should also appear within the topology badge
+		await expect(topologyBadge.locator('text=↔').first()).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 3: Remove one agent — verify channels removed ──────────────────
+
+	test('Remove one agent — verify only one remains and channels are removed', async ({ page }) => {
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill('Remove Agent Test');
+
+		// Add step, open config, set up multi-agent with a channel
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Remove Step');
+
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+
+		// Add channel coder → reviewer
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+		await expect(panel.getByTestId('channels-list').getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		// Remove Reviewer Agent (the second entry in the list)
+		const agentsList = panel.getByTestId('agents-list');
+		const secondAgentEntry = agentsList
+			.getByTestId('agent-entry')
+			.filter({ hasText: AGENT_B_NAME });
+		await secondAgentEntry.getByTestId('remove-agent-button').click();
+
+		// Only one agent entry should remain
+		await expect(agentsList.getByTestId('agent-entry')).toHaveCount(1, { timeout: 3000 });
+		await expect(
+			agentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
+
+		// "Switch to single" button (data-testid="switch-to-single-button") appears when
+		// exactly 1 agent remains in multi-agent mode
+		const switchToSingleBtn = panel.getByTestId('switch-to-single-button');
+		await expect(switchToSingleBtn).toBeVisible({ timeout: 3000 });
+
+		// Click "Switch to single" — reverts to single-agent mode and clears channels
+		await switchToSingleBtn.click();
+
+		// Channels section should no longer be visible (single-agent mode, channels cleared)
+		await expect(panel.getByTestId('channels-section')).not.toBeVisible({ timeout: 3000 });
+
+		// Single-agent select dropdown and add-agent button should be visible
+		await expect(panel.getByTestId('agent-select')).toBeVisible({ timeout: 3000 });
+		await expect(panel.getByTestId('add-agent-button')).toBeVisible({ timeout: 2000 });
+	});
+
+	// ─── Test 4: Save and reopen — verify persistence ─────────────────────────
+
+	test('Save workflow and reopen — multi-agent config and channel topology persist', async ({
+		page,
+	}) => {
+		const WORKFLOW_NAME = `Persist Test ${Date.now()}`;
+
+		await navigateToSpace(page, spaceId);
+		await openNewWorkflowEditor(page);
+		await switchToVisualMode(page);
+
+		const editor = page.getByTestId('visual-workflow-editor');
+		await editor.getByTestId('workflow-name-input').fill(WORKFLOW_NAME);
+
+		// Add step, configure multi-agent with one channel
+		await editor.getByTestId('add-step-button').click();
+		const nodes = editor.locator('[data-testid^="workflow-node-"]');
+		await nodes.first().click();
+		const panel = editor.getByTestId('node-config-panel');
+		await expect(panel).toBeVisible({ timeout: 3000 });
+		await panel.getByTestId('step-name-input').fill('Persist Step');
+
+		await setupMultiAgentStep(panel, AGENT_A_OPTION, AGENT_B_OPTION);
+
+		// Add one-way channel coder → reviewer
+		const addChannelForm = panel.getByTestId('add-channel-form');
+		await addChannelForm.getByTestId('channel-from-select').selectOption({ value: ROLE_A });
+		await addChannelForm.getByTestId('channel-to-input').fill(ROLE_B);
+		await addChannelForm.getByTestId('add-channel-button').click();
+		await expect(panel.getByTestId('channels-list').getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		await panel.getByTestId('close-button').click();
+		await expect(panel).not.toBeVisible({ timeout: 2000 });
+
+		// Save the workflow
+		await editor.getByTestId('save-button').click();
+		await expect(page.getByTestId('editor-mode-toggle')).not.toBeVisible({ timeout: 5000 });
+		await expect(page.locator(`text=${WORKFLOW_NAME}`)).toBeVisible({ timeout: 5000 });
+
+		// ── Reopen the workflow ─────────────────────────────────────────────────
+
+		await openWorkflowForEdit(page, WORKFLOW_NAME);
+
+		// switchToVisualMode registers a dialog handler before clicking the toggle.
+		// When re-opening a saved workflow in list mode (no unsaved edits), the app may
+		// or may not show a native confirm() dialog depending on whether it detects edits.
+		// The one-shot handler is harmless if no dialog fires — Playwright discards it.
+		await switchToVisualMode(page);
+
+		const editorReopen = page.getByTestId('visual-workflow-editor');
+		const reopenedNodes = editorReopen.locator('[data-testid^="workflow-node-"]');
+		await expect(reopenedNodes).toHaveCount(1, { timeout: 5000 });
+
+		// ── Verify canvas node shows agent badges for both agents ───────────────
+
+		const node = reopenedNodes.first();
+		const agentBadges = node.getByTestId('agent-badges');
+		await expect(agentBadges).toBeVisible({ timeout: 3000 });
+		await expect(agentBadges.locator(`text=${AGENT_A_NAME}`)).toBeVisible({ timeout: 2000 });
+		await expect(agentBadges.locator(`text=${AGENT_B_NAME}`)).toBeVisible({ timeout: 2000 });
+
+		// ── Verify canvas node shows channel topology arrow ─────────────────────
+
+		// ChannelTopologyBadge renders within data-testid="channel-topology-badge"
+		const topologyBadge = node.getByTestId('channel-topology-badge');
+		await expect(topologyBadge).toBeVisible({ timeout: 3000 });
+		// The one-way arrow → should appear between the role names
+		await expect(topologyBadge.locator('text=→').first()).toBeVisible({ timeout: 2000 });
+
+		// ── Open node config and verify agents list and channel persist ─────────
+
+		await node.click();
+		const reopenedPanel = editorReopen.getByTestId('node-config-panel');
+		await expect(reopenedPanel).toBeVisible({ timeout: 3000 });
+
+		// Agents list should have 2 entries
+		const reopenedAgentsList = reopenedPanel.getByTestId('agents-list');
+		await expect(reopenedAgentsList).toBeVisible({ timeout: 3000 });
+		await expect(reopenedAgentsList.getByTestId('agent-entry')).toHaveCount(2, { timeout: 3000 });
+		await expect(
+			reopenedAgentsList.getByTestId('agent-entry').filter({ hasText: AGENT_A_NAME })
+		).toBeVisible({ timeout: 2000 });
+		await expect(
+			reopenedAgentsList.getByTestId('agent-entry').filter({ hasText: AGENT_B_NAME })
+		).toBeVisible({ timeout: 2000 });
+
+		// Channels section should be visible with the persisted channel
+		const reopenedChannelsSection = reopenedPanel.getByTestId('channels-section');
+		await expect(reopenedChannelsSection).toBeVisible({ timeout: 3000 });
+		const reopenedChannelsList = reopenedPanel.getByTestId('channels-list');
+		await expect(reopenedChannelsList.getByTestId('channel-entry')).toHaveCount(1, {
+			timeout: 3000,
+		});
+
+		// Persisted channel should show "coder → reviewer"
+		const persistedEntry = reopenedChannelsList.getByTestId('channel-entry').first();
+		await expect(persistedEntry).toContainText(ROLE_A);
+		await expect(persistedEntry).toContainText('→');
+		await expect(persistedEntry).toContainText(ROLE_B);
+	});
+});

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -19,95 +19,25 @@
 
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures';
-import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpace,
+	deleteSpace,
+	navigateToSpace,
+	resetEditorModeStorage,
+	openNewWorkflowEditor,
+	switchToVisualMode,
+} from '../helpers/workflow-editor-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
 // ─── RPC helpers (infrastructure only) ────────────────────────────────────────
 
 async function createTestSpace(page: Page): Promise<string> {
-	await waitForWebSocketConnected(page);
-	const workspaceRoot = await getWorkspaceRoot(page);
-	const spaceName = `E2E Visual Editor Test ${Date.now()}`;
-	return page.evaluate(
-		async ({ wsPath, name }) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path.
-			// Normalize paths to handle macOS symlink resolution (/var/ vs /private/var/).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', {})) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
-				if (existing) {
-					await hub.request('space.delete', { id: existing.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
-
-			const res = await hub.request('space.create', { name, workspacePath: wsPath });
-			return (res as { id: string }).id;
-		},
-		{ wsPath: workspaceRoot, name: spaceName }
-	);
+	return createSpace(page, `E2E Visual Editor Test ${Date.now()}`);
 }
 
 async function deleteTestSpace(page: Page, spaceId: string): Promise<void> {
-	if (!spaceId) return;
-	try {
-		await page.evaluate(async (id) => {
-			const hub = window.__messageHub || window.appState?.messageHub;
-			if (!hub?.request) return;
-			await hub.request('space.delete', { id });
-		}, spaceId);
-	} catch {
-		// Best-effort cleanup
-	}
-}
-
-async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
-	await page.goto(`/space/${spaceId}`);
-	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-	// Wait for SpaceIsland to finish loading — the tab bar appears after space.overview resolves
-	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
-}
-
-/**
- * Reset the workflow editor mode stored in localStorage to prevent test-ordering
- * flakiness. SpaceIsland reads 'workflow-editor-mode' on mount; if a prior test
- * left it at 'visual', subsequent tests start in visual mode unexpectedly.
- */
-async function resetEditorModeStorage(page: Page): Promise<void> {
-	await page.evaluate(() => {
-		localStorage.removeItem('workflow-editor-mode');
-	});
-}
-
-/** Navigate to Workflows tab and open the workflow editor for a new workflow. */
-async function openNewWorkflowEditor(page: Page): Promise<void> {
-	// Click Workflows tab
-	await page.locator('text=Workflows').first().click();
-
-	// Wait for the "Create Workflow" button (the only label used in WorkflowList.tsx)
-	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
-	await expect(createBtn).toBeVisible({ timeout: 5000 });
-	await createBtn.click();
-
-	// Wait for editor mode toggle strip to appear
-	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
-}
-
-/** Switch to Visual editor mode, accepting any confirmation dialogs. */
-async function switchToVisualMode(page: Page): Promise<void> {
-	// Register dialog handler before clicking — native confirm() fires synchronously
-	page.once('dialog', (d) => d.accept());
-	await page.getByTestId('editor-mode-visual').click();
-	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
+	return deleteSpace(page, spaceId);
 }
 
 /** Get the default agent ID for the active space (infrastructure only). */

--- a/packages/e2e/tests/helpers/workflow-editor-helpers.ts
+++ b/packages/e2e/tests/helpers/workflow-editor-helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared helpers for visual workflow editor E2E tests.
+ *
+ * Used by:
+ * - tests/features/visual-workflow-editor.e2e.ts
+ * - tests/features/space-multi-agent-editor.e2e.ts
+ */
+
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from './wait-helpers';
+
+// ─── Space lifecycle (RPC — infrastructure only) ───────────────────────────────
+
+export async function createSpace(page: Page, name: string): Promise<string> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+	return page.evaluate(
+		async ({ wsPath, spaceName }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Clean up any leftover space at this workspace path.
+			const norm = (p: string) => p.replace(/^\/private/, '');
+			try {
+				const list = (await hub.request('space.list', {})) as Array<{
+					id: string;
+					workspacePath: string;
+				}>;
+				const existing = list.find((s) => norm(s.workspacePath) === norm(wsPath));
+				if (existing) await hub.request('space.delete', { id: existing.id });
+			} catch {
+				// Ignore cleanup errors
+			}
+
+			const res = await hub.request('space.create', { name: spaceName, workspacePath: wsPath });
+			return (res as { id: string }).id;
+		},
+		{ wsPath: workspaceRoot, spaceName: name }
+	);
+}
+
+export async function deleteSpace(page: Page, spaceId: string): Promise<void> {
+	if (!spaceId) return;
+	try {
+		await page.evaluate(async (id) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('space.delete', { id });
+		}, spaceId);
+	} catch {
+		// Best-effort cleanup
+	}
+}
+
+// ─── Navigation helpers ────────────────────────────────────────────────────────
+
+export async function navigateToSpace(page: Page, spaceId: string): Promise<void> {
+	await page.goto(`/space/${spaceId}`);
+	await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+	await expect(page.locator('text=Dashboard').first()).toBeVisible({ timeout: 15000 });
+}
+
+// ─── Editor mode helpers ───────────────────────────────────────────────────────
+
+/**
+ * Reset the workflow editor mode stored in localStorage to prevent test-ordering
+ * flakiness. SpaceIsland reads 'workflow-editor-mode' on mount; if a prior test
+ * left it at 'visual', subsequent tests start in visual mode unexpectedly.
+ */
+export async function resetEditorModeStorage(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		localStorage.removeItem('workflow-editor-mode');
+	});
+}
+
+/** Navigate to Workflows tab and open the workflow editor for a new workflow. */
+export async function openNewWorkflowEditor(page: Page): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	const createBtn = page.getByRole('button', { name: 'Create Workflow' });
+	await expect(createBtn).toBeVisible({ timeout: 5000 });
+	await createBtn.click();
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+/** Switch to Visual editor mode, accepting any confirmation dialogs. */
+export async function switchToVisualMode(page: Page): Promise<void> {
+	// Register dialog handler before clicking — native confirm() fires synchronously
+	page.once('dialog', (d) => d.accept());
+	await page.getByTestId('editor-mode-visual').click();
+	await expect(page.getByTestId('visual-workflow-editor')).toBeVisible({ timeout: 5000 });
+}
+
+/**
+ * Open the workflow edit UI for an existing workflow in the list.
+ * The edit button is CSS group-hover only, so opacity is forced via JS before clicking.
+ */
+export async function openWorkflowForEdit(page: Page, workflowName: string): Promise<void> {
+	await page.locator('text=Workflows').first().click();
+	await expect(page.locator(`text=${workflowName}`)).toBeVisible({ timeout: 5000 });
+
+	const workflowCard = page
+		.locator('[class*="group"]')
+		.filter({ has: page.locator(`text=${workflowName}`) })
+		.first();
+	await expect(workflowCard).toBeVisible({ timeout: 3000 });
+	await workflowCard.evaluate((el) => {
+		const actions = el.querySelector<HTMLElement>('[data-testid="workflow-card-actions"]');
+		if (actions) actions.style.opacity = '1';
+	});
+
+	const editBtn = workflowCard.getByRole('button', { name: 'Edit' });
+	await expect(editBtn).toBeVisible({ timeout: 3000 });
+	await editBtn.click();
+
+	await expect(page.getByTestId('editor-mode-toggle')).toBeVisible({ timeout: 5000 });
+}
+
+// ─── Multi-agent step helpers ──────────────────────────────────────────────────
+
+/**
+ * Configure a node config panel to have two agents in multi-agent mode.
+ *
+ * Precondition: the NodeConfigPanel is already open (panel locator is visible).
+ * Postcondition: agents-list has 2 agent-entry items and channels-section is visible.
+ *
+ * @param panel - Locator scoped to the `node-config-panel` element
+ * @param agentAOption - Exact option label for the first agent (e.g. "Coder Agent (coder)")
+ * @param agentBOption - Exact option label for the second agent (e.g. "Reviewer Agent (reviewer)")
+ */
+export async function setupMultiAgentStep(
+	panel: Locator,
+	agentAOption: string,
+	agentBOption: string
+): Promise<void> {
+	// Select first agent in single-agent mode
+	await panel.getByTestId('agent-select').selectOption({ label: agentAOption });
+
+	// Switch to multi-agent mode — moves the selected agent into the agents[] array
+	await panel.getByTestId('add-agent-button').click();
+	await expect(panel.getByTestId('agents-list')).toBeVisible({ timeout: 3000 });
+
+	// Add second agent from the dropdown (shows remaining agents)
+	await panel.getByTestId('add-agent-select').selectOption({ label: agentBOption });
+
+	// Verify both entries are present before returning
+	await expect(panel.getByTestId('agents-list').getByTestId('agent-entry')).toHaveCount(2, {
+		timeout: 3000,
+	});
+}

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -147,6 +147,7 @@ function AgentsSection({ step, agents, onUpdate }: AgentsSectionProps) {
 				{stepAgents.length === 1 && (
 					<button
 						type="button"
+						data-testid="switch-to-single-button"
 						onClick={() =>
 							onUpdate({
 								...step,

--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -38,7 +38,7 @@ function ChannelTopologyBadge({ step }: { step: StepDraft }) {
 	};
 
 	return (
-		<div class="mt-1.5 space-y-0.5">
+		<div class="mt-1.5 space-y-0.5" data-testid="channel-topology-badge">
 			{channels.map((ch, i) => (
 				<div key={i} class="flex items-center gap-0.5 text-xs text-gray-500">
 					<span class="font-mono">{roleLabel(ch.from)}</span>


### PR DESCRIPTION
- Add spaceSessionGroup.created/memberAdded/memberUpdated to DaemonEventMap
- Emit spaceSessionGroup.created after group + task-agent member created in spawnTaskAgent
- Emit spaceSessionGroup.memberAdded after sub-session added to group in SubSessionFactory.create
- Emit spaceSessionGroup.memberUpdated after member status updated to 'completed' (handleSubSessionComplete) or 'failed' (session.error handler)
- All events use sessionId: 'space:${spaceId}' for channel-scoped delivery
- Bridge all three events in StateManager to forward them to WebSocket clients
- Add getSpaceIdForSubSession() helper for the error path where only subSessionId is available
- Update TestDaemonHub.emit to return Promise<void> and track emitted events
- Add 6 new unit tests covering event emission at each lifecycle point (88 total)
