### PR TITLE
feat: add ChannelResolver, list_group_members and relay_message tools to Task Agent

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -200,7 +200,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push(
 		`- **request_human_input** — Surface a human gate and block until the human responds. ` +
-			`Pass a \`prompt\` describing what decision or approval is needed. ` +
+			`Pass a \`question\` describing what decision or approval is needed. ` +
 			`Returns the human's response. ` +
 			`Call this when \`advance_workflow\` returns a \`human\` gate condition.`
 	);

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -19,6 +19,8 @@
  *   - advance_workflow      — Evaluate transitions from the current step and move to next
  *   - report_result         — Mark the task complete/failed and record the result summary
  *   - request_human_input   — Surface a human gate and block until the user responds
+ *   - list_group_members    — List all group members with session IDs and permitted channels
+ *   - relay_message         — Inject a user-turn message into any group member (unrestricted)
  *
  * ## Content interpolation
  * All operator-supplied content (space.backgroundContext, space.instructions,
@@ -202,6 +204,19 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`Returns the human's response. ` +
 			`Call this when \`advance_workflow\` returns a \`human\` gate condition.`
 	);
+	sections.push(
+		`- **list_group_members** — List all members of the current task's session group. ` +
+			`Returns each member's \`sessionId\`, \`role\`, \`agentId\`, \`status\`, and ` +
+			`\`permittedTargets\` (which roles they can message per the declared channel topology). ` +
+			`Use this to discover active sub-sessions before calling \`relay_message\`.`
+	);
+	sections.push(
+		`- **relay_message** — Inject a user-turn message into any group member's session. ` +
+			`Pass \`target_session_id\` (from \`list_group_members\`) and the \`message\` string. ` +
+			`You are NOT constrained by channel topology — you can relay to any member. ` +
+			`Cross-group messaging is rejected. Use this to route feedback, questions, or context ` +
+			`between step agents that cannot communicate directly.`
+	);
 
 	// ---- step_result vs report_result status ---------------------------------
 	sections.push(`\n## Result Fields: \`step_result\` vs \`report_result.status\`\n`);
@@ -273,6 +288,34 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	sections.push(
 		`5. **One step at a time.** Do not spawn multiple step agents concurrently unless the ` +
 			`workflow explicitly defines parallel steps. Follow the linear execution loop above.`
+	);
+
+	// ---- Channel topology and relay capabilities ----------------------------
+	sections.push(`\n## Channel Topology and Message Relay\n`);
+	sections.push(
+		`Workflow steps may declare a channel topology that governs which agent roles can communicate ` +
+			`with each other. Use \`list_group_members\` to see the active members and their ` +
+			`\`permittedTargets\` — roles they are allowed to message per the declared topology.\n`
+	);
+	sections.push(
+		`**You are NOT constrained by the channel topology.** As the Task Agent coordinator, ` +
+			`you can relay messages to any group member using \`relay_message\`, regardless of which ` +
+			`channels are declared. This allows you to:\n` +
+			`- Route feedback from a reviewer agent to a coder agent\n` +
+			`- Forward context or questions between parallel sub-sessions\n` +
+			`- Intervene when the declared topology does not cover a needed communication path\n`
+	);
+	sections.push(
+		`**Cross-group messaging is always rejected.** You can only relay to sessions that are ` +
+			`members of the same group as this task. Attempting to relay to a session in a different ` +
+			`group will return an error.\n`
+	);
+	sections.push(
+		`**When to use relay_message:**\n` +
+			`- A step agent produces output that another step agent needs as input\n` +
+			`- A reviewer step identifies issues that should be sent back to the coder step\n` +
+			`- You need to inject context or instructions mid-execution into a running sub-session\n` +
+			`- The channel topology does not permit direct communication between two agents\n`
 	);
 
 	// ---- Task context -------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/channel-resolver.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-resolver.ts
@@ -18,17 +18,40 @@
 
 import type { ResolvedChannel } from '@neokai/shared';
 
+/**
+ * Returns true when `entry` is a structurally valid `ResolvedChannel`.
+ * Filters out malformed DB values (partial serialization, migration bugs, manual edits)
+ * rather than casting them blindly, which would produce undefined behaviour in
+ * `canSend()` / `getPermittedTargets()` (e.g. `ch.fromRole === undefined` always false).
+ */
+function isValidResolvedChannel(entry: unknown): entry is ResolvedChannel {
+	if (!entry || typeof entry !== 'object') return false;
+	const e = entry as Record<string, unknown>;
+	return (
+		typeof e.fromRole === 'string' &&
+		e.fromRole.length > 0 &&
+		typeof e.toRole === 'string' &&
+		e.toRole.length > 0 &&
+		typeof e.fromAgentId === 'string' &&
+		typeof e.toAgentId === 'string' &&
+		e.direction === 'one-way' &&
+		typeof e.isHubSpoke === 'boolean'
+	);
+}
+
 export class ChannelResolver {
 	constructor(private readonly channels: ResolvedChannel[]) {}
 
 	/**
 	 * Build a ChannelResolver from a workflow run's config object.
 	 * Reads `config._resolvedChannels` — stored by `storeResolvedChannels()` in SpaceRuntime.
-	 * Returns an empty resolver if the field is absent or not an array.
+	 * Returns an empty resolver if the field is absent, not an array, or contains only
+	 * invalid entries. Invalid entries are silently filtered rather than casting blindly.
 	 */
 	static fromRunConfig(config: Record<string, unknown> | undefined): ChannelResolver {
 		const raw = config?._resolvedChannels;
-		const channels = Array.isArray(raw) ? (raw as ResolvedChannel[]) : [];
+		if (!Array.isArray(raw)) return new ChannelResolver([]);
+		const channels = raw.filter(isValidResolvedChannel);
 		return new ChannelResolver(channels);
 	}
 
@@ -44,19 +67,22 @@ export class ChannelResolver {
 
 	/**
 	 * Returns all target roles that the given sender role is permitted to message
-	 * according to the declared channel topology.
+	 * according to the declared channel topology. Duplicate role names are deduplicated
+	 * (can occur when multiple agent IDs share the same role and both appear as targets).
 	 * Returns an empty array when no channels are declared or none match.
 	 */
 	getPermittedTargets(fromRole: string): string[] {
-		return this.channels.filter((ch) => ch.fromRole === fromRole).map((ch) => ch.toRole);
+		const targets = this.channels.filter((ch) => ch.fromRole === fromRole).map((ch) => ch.toRole);
+		return [...new Set(targets)];
 	}
 
 	/**
-	 * Returns the full resolved channel topology.
+	 * Returns a shallow copy of the full resolved channel topology.
+	 * Returns a copy so callers cannot mutate the internal array.
 	 * Each entry is a concrete one-way routing rule (bidirectional already split).
 	 */
 	getResolvedChannels(): ResolvedChannel[] {
-		return this.channels;
+		return [...this.channels];
 	}
 
 	/** True when no channels are declared (open topology — no routing constraints). */

--- a/packages/daemon/src/lib/space/runtime/channel-resolver.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-resolver.ts
@@ -1,0 +1,66 @@
+/**
+ * ChannelResolver — validates messaging permissions based on declared channel topology.
+ *
+ * Reads `ResolvedChannel[]` from a workflow run's config (`run.config._resolvedChannels`)
+ * and exposes a simple validation API for checking whether a given agent role is
+ * permitted to send messages to another role.
+ *
+ * Resolved channels are stored by `SpaceRuntime.storeResolvedChannels()` at step-start
+ * (see `space-runtime.ts`). Each entry is a concrete directional routing rule already
+ * expanded from the declarative `WorkflowChannel` declarations:
+ *   - Bidirectional channels are split into two one-way entries
+ *   - Wildcard (`*`) and array `to` declarations are expanded per pair
+ *
+ * When no channels are declared for a step (empty array), all `canSend()` calls
+ * return `false` (open/unrestricted mode is not assumed — Task Agent override handles
+ * cross-member messaging outside the topology).
+ */
+
+import type { ResolvedChannel } from '@neokai/shared';
+
+export class ChannelResolver {
+	constructor(private readonly channels: ResolvedChannel[]) {}
+
+	/**
+	 * Build a ChannelResolver from a workflow run's config object.
+	 * Reads `config._resolvedChannels` — stored by `storeResolvedChannels()` in SpaceRuntime.
+	 * Returns an empty resolver if the field is absent or not an array.
+	 */
+	static fromRunConfig(config: Record<string, unknown> | undefined): ChannelResolver {
+		const raw = config?._resolvedChannels;
+		const channels = Array.isArray(raw) ? (raw as ResolvedChannel[]) : [];
+		return new ChannelResolver(channels);
+	}
+
+	/**
+	 * Returns true if the declared channel topology permits the sender to message the target.
+	 *
+	 * Matches by role string. When no channels are declared, always returns false —
+	 * the Task Agent can override this using `relay_message` (unrestricted).
+	 */
+	canSend(fromRole: string, toRole: string): boolean {
+		return this.channels.some((ch) => ch.fromRole === fromRole && ch.toRole === toRole);
+	}
+
+	/**
+	 * Returns all target roles that the given sender role is permitted to message
+	 * according to the declared channel topology.
+	 * Returns an empty array when no channels are declared or none match.
+	 */
+	getPermittedTargets(fromRole: string): string[] {
+		return this.channels.filter((ch) => ch.fromRole === fromRole).map((ch) => ch.toRole);
+	}
+
+	/**
+	 * Returns the full resolved channel topology.
+	 * Each entry is a concrete one-way routing rule (bidirectional already split).
+	 */
+	getResolvedChannels(): ResolvedChannel[] {
+		return this.channels;
+	}
+
+	/** True when no channels are declared (open topology — no routing constraints). */
+	isEmpty(): boolean {
+		return this.channels.length === 0;
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -360,7 +360,7 @@ export class SpaceRuntime {
 		}
 
 		// Resolve channel topology for the start step and store in run config.
-		// TODO Milestone 6: pass resolvedChannels to session group creation in
+		// TODO: Milestone 6: pass resolvedChannels to session group creation in
 		// TaskAgentManager.spawnTaskAgent() rather than storing in run config.
 		this.storeResolvedChannels(run.id, space.id, startStep);
 
@@ -779,7 +779,7 @@ export class SpaceRuntime {
 				// initial key set, so the entry stays until cleanupTerminalExecutors() runs.
 			} else {
 				// Resolve channel topology for the new step.
-				// TODO Milestone 6: pass to session group creation instead of run config.
+				// TODO: Milestone 6: pass to session group creation instead of run config.
 				this.storeResolvedChannels(runId, meta.spaceId, newStep);
 			}
 		} catch (err) {
@@ -1000,20 +1000,30 @@ export class SpaceRuntime {
 	 * TODO Milestone 6: pass resolvedChannels to session group metadata in
 	 * TaskAgentManager.spawnTaskAgent() instead of storing in run config.
 	 *
-	 * Steps with no `channels` declaration produce an empty array (no-op).
+	 * Steps with no `channels` declaration store an empty array, clearing any
+	 * previously stored topology from prior steps. This prevents stale topology
+	 * from a channel-declaring step from leaking into subsequent steps that have
+	 * no channels — which would cause list_group_members to report incorrect
+	 * permittedTargets and channelTopologyDeclared=true for the wrong step.
 	 */
 	private storeResolvedChannels(runId: string, spaceId: string, step: WorkflowStep): void {
-		if (!step.channels || step.channels.length === 0) return;
-
-		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
-		const resolved = resolveStepChannels(step, allAgents);
-
-		if (resolved.length === 0) return;
-
 		const run = this.config.workflowRunRepo.getRun(runId);
 		if (!run) return;
 
 		const config = (run.config ?? {}) as Record<string, unknown>;
+
+		// No channels declared: clear any previously stored topology so list_group_members
+		// does not return stale topology from a prior step.
+		if (!step.channels || step.channels.length === 0) {
+			this.config.workflowRunRepo.updateRun(runId, {
+				config: { ...config, _resolvedChannels: [] },
+			});
+			return;
+		}
+
+		const allAgents = this.config.spaceAgentManager.listBySpaceId(spaceId);
+		const resolved = resolveStepChannels(step, allAgents);
+
 		this.config.workflowRunRepo.updateRun(runId, {
 			config: { ...config, _resolvedChannels: resolved },
 		});

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -286,6 +286,8 @@ export class TaskAgentManager {
 					this.injectSubSessionMessage(subSessionId, message),
 				onSubSessionComplete: (stepId, subSessionId) =>
 					this.handleSubSessionComplete(taskId, stepId, subSessionId),
+				sessionGroupRepo: this.config.sessionGroupRepo,
+				getGroupId: () => this.taskGroupIds.get(taskId),
 				daemonHub: this.config.daemonHub,
 			});
 
@@ -926,13 +928,19 @@ export class TaskAgentManager {
 		}
 
 		// Notify the Task Agent that a sub-session has completed.
+		// Include the agent's result summary so the Task Agent has immediate context.
 		// This sends a next_turn message so the Task Agent can call advance_workflow.
 		const taskAgentSession = this.taskAgentSessions.get(taskId);
 		if (taskAgentSession) {
 			try {
+				// Fetch the completed step task's result summary from the DB for context.
+				const completedStepTask = stepTasks.length > 0 ? stepTasks[stepTasks.length - 1] : null;
+				const resultSummary = completedStepTask?.result
+					? `\nAgent result summary: ${completedStepTask.result}`
+					: '';
 				await this.injectMessageIntoSession(
 					taskAgentSession,
-					`[STEP_COMPLETE] Step "${stepId}" has completed. Call check_step_status to verify, then call advance_workflow to proceed.`,
+					`[STEP_COMPLETE] Step "${stepId}" sub-session (${subSessionId}) has completed.${resultSummary}\nCall check_step_status to verify, then call advance_workflow to proceed.`,
 					'next_turn'
 				);
 			} catch (err) {
@@ -1087,6 +1095,8 @@ export class TaskAgentManager {
 			onSubSessionComplete: (stepId, subSessionId) =>
 				this.handleSubSessionComplete(taskId, stepId, subSessionId),
 			daemonHub: this.config.daemonHub,
+			sessionGroupRepo: this.config.sessionGroupRepo,
+			getGroupId: () => this.taskGroupIds.get(taskId),
 		});
 
 		agentSession.setRuntimeMcpServers({

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -139,6 +139,39 @@ export const RequestHumanInputSchema = z.object({
 export type RequestHumanInputInput = z.infer<typeof RequestHumanInputSchema>;
 
 // ---------------------------------------------------------------------------
+// list_group_members
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_group_members` input.
+ * Lists all members of the current task's session group with their permitted channels.
+ * No arguments — the group is inferred from the task context.
+ */
+export const ListGroupMembersSchema = z.object({});
+
+export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
+
+// ---------------------------------------------------------------------------
+// relay_message
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `relay_message` input.
+ * Injects a user-turn message into a target sub-session in the same group.
+ * The Task Agent is not constrained by channel topology — it can relay to any member.
+ */
+export const RelayMessageSchema = z.object({
+	/** Session ID of the target sub-session to relay the message to. */
+	target_session_id: z
+		.string()
+		.describe('Session ID of the target sub-session to send the message to'),
+	/** The message to inject as a user turn in the target session. */
+	message: z.string().describe('The message content to inject into the target session'),
+});
+
+export type RelayMessageInput = z.infer<typeof RelayMessageSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export for MCP server factory (Milestone 3)
 // ---------------------------------------------------------------------------
 
@@ -152,6 +185,8 @@ export const TASK_AGENT_TOOL_SCHEMAS = {
 	advance_workflow: AdvanceWorkflowSchema,
 	report_result: ReportResultSchema,
 	request_human_input: RequestHumanInputSchema,
+	list_group_members: ListGroupMembersSchema,
+	relay_message: RelayMessageSchema,
 } as const;
 
 export type TaskAgentToolName = keyof typeof TASK_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -32,7 +32,9 @@ import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
+import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
 import { resolveAgentInit, buildCustomAgentTaskMessage } from '../agents/custom-agent';
+import { ChannelResolver } from '../runtime/channel-resolver';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
@@ -41,6 +43,8 @@ import {
 	AdvanceWorkflowSchema,
 	ReportResultSchema,
 	RequestHumanInputSchema,
+	ListGroupMembersSchema,
+	RelayMessageSchema,
 } from './task-agent-tool-schemas';
 import { resolveStepAgents } from '@neokai/shared';
 import type {
@@ -49,6 +53,8 @@ import type {
 	AdvanceWorkflowInput,
 	ReportResultInput,
 	RequestHumanInputInput,
+	ListGroupMembersInput,
+	RelayMessageInput,
 } from './task-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
@@ -150,6 +156,7 @@ export interface TaskAgentToolsConfig {
 	/**
 	 * Injects a message into an existing sub-session as a user turn.
 	 * Called after spawn to deliver the step's task context message.
+	 * Also used by relay_message to forward messages between group members.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
 	/**
@@ -158,6 +165,18 @@ export interface TaskAgentToolsConfig {
 	 * The Task Agent handler registers this as the session completion callback.
 	 */
 	onSubSessionComplete: (stepId: string, sessionId: string) => Promise<void>;
+	/**
+	 * Session group repository for looking up group members.
+	 * Required by list_group_members and relay_message tools.
+	 * The fast in-memory taskGroupIds map in TaskAgentManager is used to find the group ID,
+	 * then the repo provides the member list.
+	 */
+	sessionGroupRepo: SpaceSessionGroupRepository;
+	/**
+	 * Returns the group ID for this task from the in-memory map.
+	 * Provided by TaskAgentManager so tools can locate the group without a DB scan.
+	 */
+	getGroupId: () => string | undefined;
 	/**
 	 * DaemonHub instance for emitting task completion/failure events.
 	 * Optional — if omitted, no events are emitted (e.g. in unit tests that don't need them).
@@ -188,6 +207,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		sessionFactory,
 		messageInjector,
 		onSubSessionComplete,
+		sessionGroupRepo,
+		getGroupId,
 		daemonHub,
 	} = config;
 
@@ -698,6 +719,133 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
+		 * List all members of the current task's session group.
+		 *
+		 * Returns every member (including the Task Agent itself) with:
+		 *   - sessionId, role, agentId, status
+		 *   - permittedTargets: roles this member can send to per channel topology
+		 *
+		 * The channel topology is read from the active workflow run's config
+		 * (`run.config._resolvedChannels` — stored by SpaceRuntime at step-start).
+		 * If no channels are declared, `permittedTargets` is empty for all members.
+		 *
+		 * The Task Agent itself is listed as a member (role: 'task-agent').
+		 * Use `relay_message` to send messages to any member regardless of topology.
+		 */
+		async list_group_members(_args: ListGroupMembersInput): Promise<ToolResult> {
+			const groupId = getGroupId();
+			if (!groupId) {
+				return jsonResult({
+					success: false,
+					error:
+						`No session group found for task ${taskId}. ` +
+						`The group may not have been created yet — try after spawn_step_agent.`,
+				});
+			}
+
+			const group = sessionGroupRepo.getGroup(groupId);
+			if (!group) {
+				return jsonResult({
+					success: false,
+					error: `Session group ${groupId} not found in the database.`,
+				});
+			}
+
+			// Build ChannelResolver from the active workflow run's config
+			const run = workflowRunRepo.getRun(workflowRunId);
+			const resolver = ChannelResolver.fromRunConfig(
+				run?.config as Record<string, unknown> | undefined
+			);
+
+			const members = group.members.map((m) => ({
+				sessionId: m.sessionId,
+				role: m.role,
+				agentId: m.agentId ?? null,
+				status: m.status,
+				permittedTargets: resolver.getPermittedTargets(m.role),
+			}));
+
+			return jsonResult({
+				success: true,
+				groupId,
+				members,
+				channelTopologyDeclared: !resolver.isEmpty(),
+				message:
+					`Group has ${members.length} member(s). ` +
+					(resolver.isEmpty()
+						? 'No channel topology declared — use relay_message to communicate freely.'
+						: `Channel topology is active. Task Agent can still relay to any member via relay_message.`),
+			});
+		},
+
+		/**
+		 * Relay a message to a target sub-session as a user turn.
+		 *
+		 * The Task Agent is NOT constrained by channel topology — it can relay to
+		 * any member in the same group. This enables routing, arbitration, and
+		 * feedback delivery that step agents cannot do directly.
+		 *
+		 * Cross-group messaging is rejected: the target session must belong to
+		 * the same session group as this Task Agent (verified via DB lookup).
+		 *
+		 * The message is injected via messageInjector, which serializes writes
+		 * per-session so concurrent injections are safely queued.
+		 */
+		async relay_message(args: RelayMessageInput): Promise<ToolResult> {
+			const { target_session_id, message } = args;
+
+			// Validate that the target belongs to this group (DB lookup for restart safety).
+			const groupId = getGroupId();
+			if (!groupId) {
+				return jsonResult({
+					success: false,
+					error:
+						`No session group found for task ${taskId}. ` +
+						`Cannot validate relay target without a group.`,
+				});
+			}
+
+			const group = sessionGroupRepo.getGroup(groupId);
+			if (!group) {
+				return jsonResult({
+					success: false,
+					error: `Session group ${groupId} not found.`,
+				});
+			}
+
+			// Check that the target session is a member of this group
+			const targetMember = group.members.find((m) => m.sessionId === target_session_id);
+			if (!targetMember) {
+				return jsonResult({
+					success: false,
+					error:
+						`Target session ${target_session_id} is not a member of group ${groupId}. ` +
+						`Cross-group messaging is not permitted. ` +
+						`Use list_group_members to see valid targets.`,
+				});
+			}
+
+			// Inject the message into the target session.
+			// messageInjector serializes writes per-session; concurrent calls queue safely.
+			try {
+				await messageInjector(target_session_id, message);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				return jsonResult({
+					success: false,
+					error: `Failed to inject message into session ${target_session_id}: ${msg}`,
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				targetSessionId: target_session_id,
+				targetRole: targetMember.role,
+				message: `Message relayed to ${targetMember.role} (session ${target_session_id}).`,
+			});
+		},
+
+		/**
 		 * Pause workflow execution and surface a question to the human user.
 		 *
 		 * Updates the main task status to `needs_attention` and stores the question
@@ -814,6 +962,21 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'When the human responds, their message will appear in this conversation.',
 			RequestHumanInputSchema.shape,
 			(args) => handlers.request_human_input(args)
+		),
+		tool(
+			'list_group_members',
+			'List all members of the current task session group with their session IDs, roles, and permitted channels. ' +
+				'Use this to discover which sub-sessions are active and what messaging channels are declared.',
+			ListGroupMembersSchema.shape,
+			(args) => handlers.list_group_members(args)
+		),
+		tool(
+			'relay_message',
+			'Relay a message to a target sub-session as a user turn. ' +
+				'The Task Agent is not constrained by channel topology and can relay to any group member. ' +
+				'Cross-group messaging is rejected. Use list_group_members to find valid target session IDs.',
+			RelayMessageSchema.shape,
+			(args) => handlers.relay_message(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -825,6 +825,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				});
 			}
 
+			// Reject self-relay (Task Agent → its own session). The Task Agent is a group
+			// member with role 'task-agent'. Injecting a user-turn into its own session would
+			// produce a spurious conversation turn in the running Task Agent conversation.
+			if (targetMember.role === 'task-agent') {
+				return jsonResult({
+					success: false,
+					error:
+						`Cannot relay a message to the Task Agent's own session (role: 'task-agent'). ` +
+						`relay_message is for communicating with step agent sub-sessions only.`,
+				});
+			}
+
 			// Inject the message into the target session.
 			// messageInjector serializes writes per-session; concurrent calls queue safely.
 			try {

--- a/packages/daemon/tests/unit/space/channel-resolver.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolver.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for ChannelResolver
+ *
+ * Covers:
+ *   - Static factory fromRunConfig()
+ *   - canSend() validation
+ *   - getPermittedTargets() results
+ *   - getResolvedChannels() accessor
+ *   - isEmpty() for empty/non-empty topology
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { ChannelResolver } from '../../../src/lib/space/runtime/channel-resolver.ts';
+import type { ResolvedChannel } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function oneWayChannel(fromRole: string, toRole: string): ResolvedChannel {
+	return {
+		fromRole,
+		toRole,
+		fromAgentId: `agent-${fromRole}`,
+		toAgentId: `agent-${toRole}`,
+		direction: 'one-way',
+		isHubSpoke: false,
+	};
+}
+
+function hubSpokeChannel(fromRole: string, toRole: string): ResolvedChannel {
+	return {
+		fromRole,
+		toRole,
+		fromAgentId: `agent-${fromRole}`,
+		toAgentId: `agent-${toRole}`,
+		direction: 'one-way',
+		isHubSpoke: true,
+	};
+}
+
+// ===========================================================================
+// fromRunConfig()
+// ===========================================================================
+
+describe('ChannelResolver.fromRunConfig', () => {
+	test('returns empty resolver when config is undefined', () => {
+		const resolver = ChannelResolver.fromRunConfig(undefined);
+		expect(resolver.isEmpty()).toBe(true);
+		expect(resolver.getResolvedChannels()).toEqual([]);
+	});
+
+	test('returns empty resolver when config has no _resolvedChannels field', () => {
+		const resolver = ChannelResolver.fromRunConfig({ someOtherField: 'value' });
+		expect(resolver.isEmpty()).toBe(true);
+	});
+
+	test('returns empty resolver when _resolvedChannels is not an array', () => {
+		const resolver = ChannelResolver.fromRunConfig({
+			_resolvedChannels: 'not-an-array',
+		});
+		expect(resolver.isEmpty()).toBe(true);
+	});
+
+	test('returns empty resolver when _resolvedChannels is an empty array', () => {
+		const resolver = ChannelResolver.fromRunConfig({ _resolvedChannels: [] });
+		expect(resolver.isEmpty()).toBe(true);
+	});
+
+	test('returns populated resolver from valid _resolvedChannels', () => {
+		const channels = [oneWayChannel('coder', 'reviewer')];
+		const resolver = ChannelResolver.fromRunConfig({ _resolvedChannels: channels });
+		expect(resolver.isEmpty()).toBe(false);
+		expect(resolver.getResolvedChannels()).toHaveLength(1);
+	});
+});
+
+// ===========================================================================
+// canSend()
+// ===========================================================================
+
+describe('ChannelResolver.canSend', () => {
+	test('returns true for declared one-way channel', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.canSend('coder', 'reviewer')).toBe(true);
+	});
+
+	test('returns false for reverse direction when only one-way declared', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.canSend('reviewer', 'coder')).toBe(false);
+	});
+
+	test('returns true for both directions when bidirectional (two one-way entries)', () => {
+		const resolver = new ChannelResolver([
+			oneWayChannel('coder', 'reviewer'),
+			oneWayChannel('reviewer', 'coder'),
+		]);
+		expect(resolver.canSend('coder', 'reviewer')).toBe(true);
+		expect(resolver.canSend('reviewer', 'coder')).toBe(true);
+	});
+
+	test('returns false for self-loop', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.canSend('coder', 'coder')).toBe(false);
+	});
+
+	test('returns false for unknown roles', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.canSend('security', 'coder')).toBe(false);
+	});
+
+	test('returns false when resolver is empty', () => {
+		const resolver = new ChannelResolver([]);
+		expect(resolver.canSend('coder', 'reviewer')).toBe(false);
+	});
+
+	test('handles hub-spoke channels correctly', () => {
+		// Hub: coder (hub) ↔ reviewer, qa (spokes) — expanded to 4 entries
+		const resolver = new ChannelResolver([
+			hubSpokeChannel('coder', 'reviewer'),
+			hubSpokeChannel('reviewer', 'coder'),
+			hubSpokeChannel('coder', 'qa'),
+			hubSpokeChannel('qa', 'coder'),
+		]);
+		expect(resolver.canSend('coder', 'reviewer')).toBe(true);
+		expect(resolver.canSend('coder', 'qa')).toBe(true);
+		expect(resolver.canSend('reviewer', 'coder')).toBe(true);
+		expect(resolver.canSend('qa', 'coder')).toBe(true);
+		// Spoke-to-spoke is NOT declared in hub-spoke topology
+		expect(resolver.canSend('reviewer', 'qa')).toBe(false);
+		expect(resolver.canSend('qa', 'reviewer')).toBe(false);
+	});
+
+	test('matches by exact role string', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		// Case sensitive
+		expect(resolver.canSend('Coder', 'reviewer')).toBe(false);
+		expect(resolver.canSend('coder', 'Reviewer')).toBe(false);
+	});
+});
+
+// ===========================================================================
+// getPermittedTargets()
+// ===========================================================================
+
+describe('ChannelResolver.getPermittedTargets', () => {
+	test('returns empty array for unknown sender', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.getPermittedTargets('unknown-role')).toEqual([]);
+	});
+
+	test('returns empty array when resolver is empty', () => {
+		const resolver = new ChannelResolver([]);
+		expect(resolver.getPermittedTargets('coder')).toEqual([]);
+	});
+
+	test('returns all targets for a sender with multiple channels', () => {
+		const resolver = new ChannelResolver([
+			oneWayChannel('coder', 'reviewer'),
+			oneWayChannel('coder', 'qa'),
+			oneWayChannel('reviewer', 'coder'),
+		]);
+		const targets = resolver.getPermittedTargets('coder').sort();
+		expect(targets).toEqual(['qa', 'reviewer']);
+	});
+
+	test('returns only targets for the specified sender', () => {
+		const resolver = new ChannelResolver([
+			oneWayChannel('coder', 'reviewer'),
+			oneWayChannel('reviewer', 'coder'),
+		]);
+		expect(resolver.getPermittedTargets('coder')).toEqual(['reviewer']);
+		expect(resolver.getPermittedTargets('reviewer')).toEqual(['coder']);
+	});
+
+	test('returns single target for one-way channel', () => {
+		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.getPermittedTargets('coder')).toEqual(['reviewer']);
+	});
+});
+
+// ===========================================================================
+// getResolvedChannels()
+// ===========================================================================
+
+describe('ChannelResolver.getResolvedChannels', () => {
+	test('returns empty array when no channels', () => {
+		const resolver = new ChannelResolver([]);
+		expect(resolver.getResolvedChannels()).toEqual([]);
+	});
+
+	test('returns all channels in original order', () => {
+		const ch1 = oneWayChannel('coder', 'reviewer');
+		const ch2 = oneWayChannel('reviewer', 'coder');
+		const resolver = new ChannelResolver([ch1, ch2]);
+		expect(resolver.getResolvedChannels()).toEqual([ch1, ch2]);
+	});
+
+	test('preserves isHubSpoke field', () => {
+		const ch = hubSpokeChannel('hub', 'spoke');
+		const resolver = new ChannelResolver([ch]);
+		expect(resolver.getResolvedChannels()[0].isHubSpoke).toBe(true);
+	});
+});
+
+// ===========================================================================
+// isEmpty()
+// ===========================================================================
+
+describe('ChannelResolver.isEmpty', () => {
+	test('true when no channels', () => {
+		expect(new ChannelResolver([]).isEmpty()).toBe(true);
+	});
+
+	test('false when at least one channel', () => {
+		expect(new ChannelResolver([oneWayChannel('a', 'b')]).isEmpty()).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/space/channel-resolver.test.ts
+++ b/packages/daemon/tests/unit/space/channel-resolver.test.ts
@@ -73,6 +73,44 @@ describe('ChannelResolver.fromRunConfig', () => {
 		expect(resolver.isEmpty()).toBe(false);
 		expect(resolver.getResolvedChannels()).toHaveLength(1);
 	});
+
+	test('filters out structurally invalid entries instead of casting blindly', () => {
+		// Mix of valid and invalid entries
+		const raw = [
+			oneWayChannel('coder', 'reviewer'), // valid
+			{ fromRole: 'coder', toRole: 'reviewer' }, // missing direction + isHubSpoke
+			null, // null
+			{
+				fromRole: '',
+				toRole: 'reviewer',
+				fromAgentId: 'a',
+				toAgentId: 'b',
+				direction: 'one-way',
+				isHubSpoke: false,
+			}, // empty fromRole
+			'string-entry', // wrong type
+			{
+				fromRole: 'qa',
+				toRole: 'coder',
+				fromAgentId: 'a',
+				toAgentId: 'b',
+				direction: 'one-way',
+				isHubSpoke: false,
+			}, // valid
+		];
+		const resolver = ChannelResolver.fromRunConfig({ _resolvedChannels: raw });
+		// Only the 2 fully valid entries pass the structural filter
+		expect(resolver.getResolvedChannels()).toHaveLength(2);
+	});
+
+	test('getResolvedChannels returns a copy (mutations do not affect internal state)', () => {
+		const channels = [oneWayChannel('coder', 'reviewer')];
+		const resolver = ChannelResolver.fromRunConfig({ _resolvedChannels: channels });
+		const first = resolver.getResolvedChannels();
+		first.push(oneWayChannel('qa', 'coder')); // mutate returned array
+		// Internal state must be unaffected
+		expect(resolver.getResolvedChannels()).toHaveLength(1);
+	});
 });
 
 // ===========================================================================
@@ -175,6 +213,29 @@ describe('ChannelResolver.getPermittedTargets', () => {
 
 	test('returns single target for one-way channel', () => {
 		const resolver = new ChannelResolver([oneWayChannel('coder', 'reviewer')]);
+		expect(resolver.getPermittedTargets('coder')).toEqual(['reviewer']);
+	});
+
+	test('deduplicates target roles when multiple agent IDs share the same role', () => {
+		// Two different agent IDs both map to the 'reviewer' role
+		const ch1: ResolvedChannel = {
+			fromRole: 'coder',
+			toRole: 'reviewer',
+			fromAgentId: 'agent-coder',
+			toAgentId: 'agent-reviewer-1',
+			direction: 'one-way',
+			isHubSpoke: false,
+		};
+		const ch2: ResolvedChannel = {
+			fromRole: 'coder',
+			toRole: 'reviewer',
+			fromAgentId: 'agent-coder',
+			toAgentId: 'agent-reviewer-2',
+			direction: 'one-way',
+			isHubSpoke: false,
+		};
+		const resolver = new ChannelResolver([ch1, ch2]);
+		// 'reviewer' should appear only once despite two channel entries
 		expect(resolver.getPermittedTargets('coder')).toEqual(['reviewer']);
 	});
 });

--- a/packages/daemon/tests/unit/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime.test.ts
@@ -2095,18 +2095,72 @@ describe('SpaceRuntime', () => {
 			expect((resolvedChannels as unknown[]).length).toBeGreaterThan(0);
 		});
 
-		test('storeResolvedChannels: step without channels does not modify run config', async () => {
+		test('storeResolvedChannels: step without channels stores an empty array (clears stale topology)', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'No Channels', agentId: AGENT_CODER },
 			]);
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Run config should NOT have _resolvedChannels
+			// Run config should have _resolvedChannels set to [] — this prevents stale
+			// topology from a prior step from leaking into the current step.
 			const updatedRun = workflowRunRepo.getRun(run.id)!;
 			const resolvedChannels = (updatedRun.config as Record<string, unknown> | undefined)
 				?._resolvedChannels;
-			expect(resolvedChannels).toBeUndefined();
+			expect(resolvedChannels).toEqual([]);
+		});
+
+		test('storeResolvedChannels: advancing from channel step to no-channel step clears topology', async () => {
+			// Step A has channels; Step B does not. After advancing, topology should be cleared.
+			const AGENT_REVIEWER = 'agent-reviewer-topo';
+			seedAgentRow(db, AGENT_REVIEWER, SPACE_ID, 'Reviewer', 'reviewer');
+
+			const stepA = STEP_A;
+			const stepB = `step-b-${Math.random().toString(36).slice(2)}`;
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: 'Channel then No-Channel',
+				steps: [
+					{
+						id: stepA,
+						name: 'With Channels',
+						agentId: AGENT_CODER,
+						channels: [{ from: 'coder', to: 'reviewer', direction: 'one-way' }],
+						agents: [{ agentId: AGENT_CODER }, { agentId: AGENT_REVIEWER }],
+					},
+					{ id: stepB, name: 'Without Channels', agentId: AGENT_CODER },
+				],
+				transitions: [{ from: stepA, to: stepB, condition: { type: 'always' } }],
+				startStepId: stepA,
+				rules: [],
+			});
+
+			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+			// After start, Step A's channels should be stored
+			const runAfterStart = workflowRunRepo.getRun(run.id)!;
+			const channelsAfterStart = (runAfterStart.config as Record<string, unknown>)
+				?._resolvedChannels as unknown[];
+			expect(channelsAfterStart.length).toBeGreaterThan(0);
+
+			// Mark step A tasks as completed so we can advance
+			const stepATasks = taskRepo
+				.listByWorkflowRun(run.id)
+				.filter((t) => t.workflowStepId === stepA);
+			for (const t of stepATasks) {
+				taskRepo.updateTask(t.id, { status: 'completed' });
+			}
+
+			// Advance to Step B (no channels) via the runtime tick, which is the
+			// path that calls storeResolvedChannels() after a successful advance.
+			await runtime.executeTick();
+
+			// After advancing, topology should be cleared to []
+			const runAfterAdvance = workflowRunRepo.getRun(run.id)!;
+			const channelsAfterAdvance = (runAfterAdvance.config as Record<string, unknown>)
+				?._resolvedChannels;
+			expect(channelsAfterAdvance).toEqual([]);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -15,6 +15,8 @@ import {
 	RequestHumanInputSchema,
 	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
+	ListGroupMembersSchema,
+	RelayMessageSchema,
 } from '../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------
@@ -274,19 +276,84 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 5 tool schemas', () => {
+	test('contains all 7 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('spawn_step_agent');
 		expect(keys).toContain('check_step_status');
 		expect(keys).toContain('advance_workflow');
 		expect(keys).toContain('report_result');
 		expect(keys).toContain('request_human_input');
-		expect(keys).toHaveLength(5);
+		expect(keys).toContain('list_group_members');
+		expect(keys).toContain('relay_message');
+		expect(keys).toHaveLength(7);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {
 		for (const schema of Object.values(TASK_AGENT_TOOL_SCHEMAS)) {
 			expect(typeof schema.safeParse).toBe('function');
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// list_group_members
+// ---------------------------------------------------------------------------
+
+describe('ListGroupMembersSchema', () => {
+	test('accepts empty object', () => {
+		const result = ListGroupMembersSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts object with extra fields (passthrough)', () => {
+		// Zod strips extra fields by default — just verify it does not throw
+		const result = ListGroupMembersSchema.safeParse({ extra: 'ignored' });
+		expect(result.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// relay_message
+// ---------------------------------------------------------------------------
+
+describe('RelayMessageSchema', () => {
+	test('accepts valid input with target_session_id and message', () => {
+		const result = RelayMessageSchema.safeParse({
+			target_session_id: 'session-abc',
+			message: 'Hello, please review this PR.',
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.target_session_id).toBe('session-abc');
+			expect(result.data.message).toBe('Hello, please review this PR.');
+		}
+	});
+
+	test('rejects missing target_session_id', () => {
+		const result = RelayMessageSchema.safeParse({ message: 'hello' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects missing message', () => {
+		const result = RelayMessageSchema.safeParse({ target_session_id: 'session-abc' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string target_session_id', () => {
+		const result = RelayMessageSchema.safeParse({ target_session_id: 123, message: 'hello' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-string message', () => {
+		const result = RelayMessageSchema.safeParse({
+			target_session_id: 'session-abc',
+			message: { text: 'object' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects empty object', () => {
+		const result = RelayMessageSchema.safeParse({});
+		expect(result.success).toBe(false);
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -2026,6 +2026,78 @@ describe('createTaskAgentToolHandlers — relay_message', () => {
 		expect(parsed.error).toContain('Session is not available');
 	});
 
+	test('rejects self-relay when target is the task-agent member', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		// Add Task Agent itself as a group member (matching production setup)
+		ctx.sessionGroupRepo.addMember(group.id, 'task-agent-session-self', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
+		);
+
+		// Attempt to relay to its own session — should be rejected
+		const result = await handlers.relay_message({
+			target_session_id: 'task-agent-session-self',
+			message: 'This would create a spurious turn.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-agent');
+	});
+
+	test('relay to a completed group member calls injector (failure handled by injector)', async () => {
+		// By design, relay_message does not pre-check member status — the messageInjector
+		// handles failures (e.g., session no longer active). This test documents the behavior:
+		// if the injector throws, relay_message returns success: false with the error.
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'completed-session', {
+			role: 'coder',
+			status: 'completed', // already done
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				groupId: group.id,
+				// Simulate injector throwing because session is gone
+				messageInjector: async () => {
+					throw new Error('Sub-session not found: completed-session');
+				},
+			})
+		);
+
+		const result = await handlers.relay_message({
+			target_session_id: 'completed-session',
+			message: 'Are you still there?',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		// Injector threw → relay_message returns failure
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Sub-session not found');
+	});
+
 	test('relay is not constrained by channel topology', async () => {
 		// Even with one-way channels only coder→reviewer, Task Agent can relay reviewer→coder
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1,12 +1,14 @@
 /**
  * Unit tests for createTaskAgentToolHandlers()
  *
- * Covers all 5 Task Agent tools:
+ * Covers all 7 Task Agent tools:
  *   spawn_step_agent    — creates sub-session, registers callback, injects message
  *   check_step_status   — polling detection of sub-session completion
  *   advance_workflow    — delegates to WorkflowExecutor.advance(), handles gate errors
  *   report_result       — transitions main task to final status
  *   request_human_input — pauses execution, marks task needs_attention
+ *   list_group_members  — lists group members with session IDs and channel info
+ *   relay_message       — injects a message into a target group member's session
  *
  * Tests use a real SQLite database (via runMigrations) and mock SubSessionFactory
  * so no real agent sessions are created.
@@ -26,6 +28,7 @@ import { SpaceWorkflowManager } from '../../../src/lib/space/managers/space-work
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceManager } from '../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
+import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
 import {
 	createTaskAgentToolHandlers,
 	createTaskAgentMcpServer,
@@ -253,6 +256,7 @@ interface TestCtx {
 	taskManager: SpaceTaskManager;
 	agentManager: SpaceAgentManager;
 	runtime: SpaceRuntime;
+	sessionGroupRepo: SpaceSessionGroupRepository;
 }
 
 function makeCtx(): TestCtx {
@@ -275,6 +279,7 @@ function makeCtx(): TestCtx {
 	const taskRepo = new SpaceTaskRepository(db);
 	const spaceManager = new SpaceManager(db);
 	const taskManager = new SpaceTaskManager(db, spaceId);
+	const sessionGroupRepo = new SpaceSessionGroupRepository(db);
 
 	const runtime = new SpaceRuntime({
 		db,
@@ -299,6 +304,7 @@ function makeCtx(): TestCtx {
 		taskManager,
 		agentManager,
 		runtime,
+		sessionGroupRepo,
 	};
 }
 
@@ -310,6 +316,8 @@ function makeConfig(
 	options?: {
 		messageInjector?: (sessionId: string, message: string) => Promise<void>;
 		onSubSessionComplete?: (stepId: string, sessionId: string) => Promise<void>;
+		/** Optional group ID — if provided, getGroupId() returns it */
+		groupId?: string;
 	}
 ): TaskAgentToolsConfig {
 	return {
@@ -326,6 +334,8 @@ function makeConfig(
 		sessionFactory,
 		messageInjector: options?.messageInjector ?? (async () => {}),
 		onSubSessionComplete: options?.onSubSessionComplete ?? (async () => {}),
+		sessionGroupRepo: ctx.sessionGroupRepo,
+		getGroupId: () => options?.groupId,
 	};
 }
 
@@ -1595,12 +1605,14 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers all 5 expected tools', async () => {
+	test('registers all 7 expected tools', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
 			'advance_workflow',
 			'check_step_status',
+			'list_group_members',
+			'relay_message',
 			'report_result',
 			'request_human_input',
 			'spawn_step_agent',
@@ -1713,8 +1725,361 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register all 5 tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(5);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(5);
+		// Both register all 7 tools
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(7);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(7);
+	});
+});
+
+// ===========================================================================
+// list_group_members tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — list_group_members', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when no group ID is available', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		// No groupId in options — getGroupId returns undefined
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.list_group_members({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('No session group found');
+	});
+
+	test('returns error when group does not exist in DB', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: 'nonexistent-group-id' })
+		);
+
+		const result = await handlers.list_group_members({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('nonexistent-group-id');
+	});
+
+	test('returns members for a real group', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Create a group with two members
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'task-agent-session', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session-123', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
+		);
+
+		const result = await handlers.list_group_members({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.groupId).toBe(group.id);
+		expect(parsed.members).toHaveLength(2);
+
+		const taskAgentMember = parsed.members.find((m: { role: string }) => m.role === 'task-agent');
+		expect(taskAgentMember).toBeDefined();
+		expect(taskAgentMember.sessionId).toBe('task-agent-session');
+		expect(taskAgentMember.status).toBe('active');
+		expect(Array.isArray(taskAgentMember.permittedTargets)).toBe(true);
+
+		const coderMember = parsed.members.find((m: { role: string }) => m.role === 'coder');
+		expect(coderMember).toBeDefined();
+		expect(coderMember.sessionId).toBe('coder-session-123');
+		expect(coderMember.agentId).toBe(ctx.agentId);
+	});
+
+	test('channelTopologyDeclared is false when no channels in run config', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'session-a', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
+		);
+
+		const result = await handlers.list_group_members({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.channelTopologyDeclared).toBe(false);
+		// permittedTargets should be empty when no channels declared
+		expect(parsed.members[0].permittedTargets).toEqual([]);
+	});
+
+	test('returns permitted targets based on resolved channels in run config', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Store resolved channels in the run config
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [
+					{
+						fromRole: 'coder',
+						toRole: 'reviewer',
+						fromAgentId: ctx.agentId,
+						toAgentId: 'agent-reviewer-1',
+						direction: 'one-way',
+						isHubSpoke: false,
+					},
+				],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			agentId: ctx.agentId,
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			agentId: 'agent-reviewer-1',
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
+		);
+
+		const result = await handlers.list_group_members({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.channelTopologyDeclared).toBe(true);
+
+		const coderMember = parsed.members.find((m: { role: string }) => m.role === 'coder');
+		expect(coderMember.permittedTargets).toEqual(['reviewer']);
+
+		const reviewerMember = parsed.members.find((m: { role: string }) => m.role === 'reviewer');
+		expect(reviewerMember.permittedTargets).toEqual([]); // reviewer cannot send to coder (one-way)
+	});
+});
+
+// ===========================================================================
+// relay_message tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — relay_message', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when no group ID is available', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
+
+		const result = await handlers.relay_message({
+			target_session_id: 'any-session',
+			message: 'hello',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('No session group found');
+	});
+
+	test('returns error when target session is not in group', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'known-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
+		);
+
+		const result = await handlers.relay_message({
+			target_session_id: 'unknown-session-from-another-group',
+			message: 'hello',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not a member of group');
+	});
+
+	test('successfully relays a message to a group member', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session-relay', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				groupId: group.id,
+				messageInjector: async (sessionId, message) => {
+					injectedMessages.push({ sessionId, message });
+				},
+			})
+		);
+
+		const result = await handlers.relay_message({
+			target_session_id: 'coder-session-relay',
+			message: 'Please fix the tests.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.targetSessionId).toBe('coder-session-relay');
+		expect(parsed.targetRole).toBe('coder');
+
+		// Verify the injector was called with correct args
+		expect(injectedMessages).toHaveLength(1);
+		expect(injectedMessages[0].sessionId).toBe('coder-session-relay');
+		expect(injectedMessages[0].message).toBe('Please fix the tests.');
+	});
+
+	test('returns error when message injection fails', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'failing-session', {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const factory = makeMockSessionFactory();
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				groupId: group.id,
+				messageInjector: async () => {
+					throw new Error('Session is not available');
+				},
+			})
+		);
+
+		const result = await handlers.relay_message({
+			target_session_id: 'failing-session',
+			message: 'hello',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Session is not available');
+	});
+
+	test('relay is not constrained by channel topology', async () => {
+		// Even with one-way channels only coder→reviewer, Task Agent can relay reviewer→coder
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Channels: only coder → reviewer (one-way)
+		ctx.workflowRunRepo.updateRun(run.id, {
+			config: {
+				_resolvedChannels: [
+					{
+						fromRole: 'coder',
+						toRole: 'reviewer',
+						fromAgentId: ctx.agentId,
+						toAgentId: 'agent-reviewer',
+						direction: 'one-way',
+						isHubSpoke: false,
+					},
+				],
+			},
+		});
+
+		const group = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: `task:${mainTask.id}`,
+			taskId: mainTask.id,
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
+			role: 'coder',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
+			role: 'reviewer',
+			status: 'active',
+		});
+
+		const injectedMessages: string[] = [];
+		const factory = makeMockSessionFactory();
+		// Task Agent relays from reviewer back to coder (not in declared topology)
+		const handlers = createTaskAgentToolHandlers(
+			makeConfig(ctx, mainTask.id, run.id, factory, {
+				groupId: group.id,
+				messageInjector: async (_sid, msg) => {
+					injectedMessages.push(msg);
+				},
+			})
+		);
+
+		// This should succeed — Task Agent is unrestricted
+		const result = await handlers.relay_message({
+			target_session_id: 'coder-session',
+			message: 'Feedback from reviewer: please update the API docs.',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(injectedMessages[0]).toBe('Feedback from reviewer: please update the API docs.');
 	});
 });

--- a/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/space/workflow-executor-multi-agent.test.ts
@@ -1336,10 +1336,11 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 
 		const { run, tasks: startTasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-		// Step A has no channels — no _resolvedChannels yet
+		// Step A has no channels — _resolvedChannels is cleared to [] (not undefined)
+		// because storeResolvedChannels always writes the field to prevent stale topology.
 		const runAfterStart = workflowRunRepo.getRun(run.id)!;
 		const configAfterStart = (runAfterStart.config ?? {}) as Record<string, unknown>;
-		expect(configAfterStart._resolvedChannels).toBeUndefined();
+		expect(configAfterStart._resolvedChannels).toEqual([]);
 
 		// Advance to Step B (which has channels)
 		taskRepo.updateTask(startTasks[0].id, { status: 'completed' });


### PR DESCRIPTION
- Create ChannelResolver utility that reads resolved channels from workflow run config
  (`run.config._resolvedChannels`) and provides canSend/getPermittedTargets/getResolvedChannels API
- Add list_group_members tool to Task Agent MCP server: lists all group members with
  sessionId, role, agentId, status, and permittedTargets from channel topology
- Add relay_message tool: Task Agent can inject messages into any group member session
  (unrestricted by channel topology); cross-group messaging rejected via DB lookup
- Add sessionGroupRepo and getGroupId to TaskAgentToolsConfig for group validation
- Update handleSubSessionComplete to include completed agent result summary in STEP_COMPLETE msg
- Update Task Agent system prompt to document new tools and channel topology override capability
- Add 23 ChannelResolver unit tests, 10 new relay/list tool tests, 9 new schema tests
