### PR TITLE
test: add online test for GitHub polling via job queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,7 +178,9 @@ jobs:
               tests/online/features/message-delivery-mode-queue.test.ts
             mock_sdk: true
           - module: features-2
-            test_path: tests/online/features/message-persistence.test.ts
+            test_path: >-
+              tests/online/features/github-poll-job.test.ts
+              tests/online/features/message-persistence.test.ts
             mock_sdk: true
           - module: git
             test_path: tests/online/git

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -51,13 +51,16 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 	// completion, not from when the job was dequeued.
 	const nextRunAt = Date.now() + intervalMs;
 
-	// Only enqueue the next job if there is no pending or processing job
-	// already in the chain. Checking 'processing' prevents a duplicate chain
-	// from forming under stale-reclaim or slow-poll scenarios.
+	// Only enqueue the next job if no pending job is already waiting.
+	// We check 'pending' only (not 'processing') because the current job is
+	// itself in 'processing' state while this handler runs — including
+	// 'processing' would always find itself and prevent self-scheduling.
+	// A stale/duplicate 'processing' job is handled by the processor's eager
+	// stale-reclamation on startup, which moves it back to 'pending'.
 	// limit: 1 is sufficient — we only need to know if any job exists.
 	const existingJobs = jobQueue.listJobs({
 		queue: GITHUB_POLL,
-		status: ['pending', 'processing'],
+		status: 'pending',
 		limit: 1,
 	});
 

--- a/packages/daemon/tests/online/features/github-poll-job.test.ts
+++ b/packages/daemon/tests/online/features/github-poll-job.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Online test: GitHub polling via job queue
+ *
+ * Verifies end-to-end GitHub polling job queue mechanics without making real
+ * GitHub API calls:
+ * - Initial github.poll job is enqueued on startup
+ * - Job transitions through pending -> processing -> completed
+ * - Self-scheduling: next poll job is automatically enqueued after completion
+ * - Dedup: no duplicate pending poll jobs exist simultaneously
+ *
+ * GitHubPollingService.triggerPoll() is stubbed immediately after daemon
+ * startup to prevent any real GitHub API calls. Even without the stub the
+ * handler is safe (errors are caught internally), but the stub makes intent
+ * explicit and avoids spurious network noise.
+ *
+ * NOTE: dev proxy intercepts Anthropic API calls only. This test does not
+ * send any Claude messages, so no Anthropic calls are made either.
+ *
+ * Run:
+ *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/features/github-poll-job.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+import type { DaemonAppContext } from '../../../src/app';
+import { GITHUB_POLL } from '../../../src/lib/job-queue-constants';
+import type { Job, JobStatus } from '../../../src/storage/repositories/job-queue-repository';
+
+// ---------------------------------------------------------------------------
+// Test configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Environment variables injected into the in-process daemon to enable GitHub
+ * polling without touching real credentials.
+ *
+ * GITHUB_POLLING_INTERVAL=300 (5 min) keeps self-scheduled jobs far in the
+ * future so the test can assert a single pending job without racing against a
+ * second real execution.
+ *
+ * GITHUB_TOKEN is a fake value that satisfies the token-presence guard inside
+ * GitHubService. No repositories are added to the polling service, so
+ * triggerPoll() is a no-op even before the stub is applied.
+ */
+const GITHUB_TEST_ENV: Record<string, string> = {
+	GITHUB_POLLING_INTERVAL: '300',
+	GITHUB_TOKEN: 'ghp_fake_token_for_job_queue_test',
+};
+
+/** Maximum time (ms) to wait for a job to reach a desired status. */
+const JOB_WAIT_TIMEOUT_MS = 8000;
+
+/** Polling cadence for job-status checks. */
+const POLL_INTERVAL_MS = 100;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type InProcessDaemon = DaemonServerContext & { daemonContext?: DaemonAppContext };
+
+/** Extract the DaemonAppContext from an in-process daemon. */
+function getDaemonCtx(daemon: DaemonServerContext): DaemonAppContext {
+	const ctx = daemon as InProcessDaemon;
+	if (!ctx.daemonContext) {
+		throw new Error(
+			'daemonContext not available — did you run in spawned mode (DAEMON_TEST_SPAWN=true)?'
+		);
+	}
+	return ctx.daemonContext;
+}
+
+/**
+ * Poll the job queue until at least one github.poll job exists with one of
+ * the given statuses, or until the timeout expires.
+ *
+ * Returns the first matching job, or undefined on timeout.
+ */
+async function waitForGitHubPollJob(
+	daemonCtx: DaemonAppContext,
+	statuses: JobStatus[],
+	timeoutMs: number = JOB_WAIT_TIMEOUT_MS
+): Promise<Job | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const jobs = daemonCtx.jobQueue.listJobs({ queue: GITHUB_POLL, status: statuses });
+		if (jobs.length > 0) {
+			return jobs[0];
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+	return undefined;
+}
+
+/**
+ * Stub triggerPoll() on the polling service so no real GitHub HTTP requests
+ * are made during the test. Returns true if the stub was applied.
+ */
+function stubTriggerPoll(daemonCtx: DaemonAppContext): boolean {
+	const pollingService = daemonCtx.gitHubService?.getPollingService();
+	if (!pollingService) {
+		return false;
+	}
+	pollingService.triggerPoll = async () => {};
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('GitHub polling via job queue (online)', () => {
+	let daemon: DaemonServerContext;
+
+	beforeEach(async () => {
+		daemon = await createDaemonServer({ env: GITHUB_TEST_ENV });
+
+		// Stub triggerPoll as early as possible.  The job processor polls every
+		// 1 s, so this window is reliable.  Even if the first job fires before
+		// the stub is applied it still completes safely because:
+		//   a) no repositories are registered → pollAllRepositories() is a no-op
+		//   b) any error from triggerPoll() is caught inside handleGitHubPoll()
+		const daemonCtx = getDaemonCtx(daemon);
+		stubTriggerPoll(daemonCtx);
+	}, 30_000);
+
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+
+	test('github.poll job is enqueued on daemon startup', () => {
+		const daemonCtx = getDaemonCtx(daemon);
+
+		// gitHubService.start() enqueues the initial job synchronously before
+		// the daemon returns from createDaemonServer(), so it is visible
+		// immediately — no polling loop needed.
+		expect(daemonCtx.gitHubService).not.toBeNull();
+
+		const jobs = daemonCtx.jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['pending', 'processing', 'completed'],
+		});
+		expect(jobs.length).toBeGreaterThanOrEqual(1);
+		expect(jobs[0].queue).toBe(GITHUB_POLL);
+	});
+
+	test('job transitions through processing and reaches completed', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+
+		const completed = await waitForGitHubPollJob(daemonCtx, ['completed']);
+
+		expect(completed).toBeDefined();
+		expect(completed!.queue).toBe(GITHUB_POLL);
+		expect(completed!.status).toBe('completed');
+		expect(completed!.completedAt).not.toBeNull();
+	}, 15_000);
+
+	test('self-scheduling: next poll job is enqueued after the initial job completes', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+
+		// Wait for the initial job to complete.
+		const firstCompleted = await waitForGitHubPollJob(daemonCtx, ['completed']);
+		expect(firstCompleted).toBeDefined();
+
+		// The handler must have enqueued a new pending job for the next cycle.
+		const next = await waitForGitHubPollJob(daemonCtx, ['pending']);
+		expect(next).toBeDefined();
+		expect(next!.queue).toBe(GITHUB_POLL);
+
+		// The next job should be scheduled ~300 s from now (GITHUB_POLLING_INTERVAL).
+		// We verify it is at least 200 s in the future to allow for minor clock skew.
+		const minExpectedRunAt = Date.now() + 200_000;
+		expect(next!.runAt).toBeGreaterThan(minExpectedRunAt);
+	}, 15_000);
+
+	test('dedup: at most one pending github.poll job exists at any time', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+
+		// Let the initial job run and the next job be enqueued.
+		await waitForGitHubPollJob(daemonCtx, ['completed']);
+		await waitForGitHubPollJob(daemonCtx, ['pending']);
+
+		// Check that the handler did not create multiple pending jobs.
+		const pendingJobs = daemonCtx.jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['pending'],
+		});
+		expect(pendingJobs.length).toBeLessThanOrEqual(1);
+	}, 15_000);
+
+	test('github service polling is active (isPolling returns true)', () => {
+		const daemonCtx = getDaemonCtx(daemon);
+
+		// gitHubService should be initialized because GITHUB_POLLING_INTERVAL > 0
+		// and a GITHUB_TOKEN was provided.
+		expect(daemonCtx.gitHubService).not.toBeNull();
+		expect(daemonCtx.gitHubService!.isPolling()).toBe(true);
+	});
+});

--- a/packages/daemon/tests/online/features/github-poll-job.test.ts
+++ b/packages/daemon/tests/online/features/github-poll-job.test.ts
@@ -6,7 +6,10 @@
  * - Initial github.poll job is enqueued on startup
  * - Job transitions through pending -> processing -> completed
  * - Self-scheduling: next poll job is automatically enqueued after completion
- * - Dedup: no duplicate pending poll jobs exist simultaneously
+ * - Dedup: no duplicate pending poll jobs exist simultaneously (including
+ *   during the processing window)
+ * - Recovery: a stale processing job left by a simulated crash is reclaimed
+ *   by reclaimStale() and eventually completes
  *
  * GitHubPollingService.triggerPoll() is stubbed immediately after daemon
  * startup to prevent any real GitHub API calls. Even without the stub the
@@ -87,6 +90,28 @@ async function waitForGitHubPollJob(
 		const jobs = daemonCtx.jobQueue.listJobs({ queue: GITHUB_POLL, status: statuses });
 		if (jobs.length > 0) {
 			return jobs[0];
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+	return undefined;
+}
+
+/**
+ * Poll the job queue until a specific job (by id) reaches one of the given
+ * statuses, or until the timeout expires.
+ */
+async function waitForJobById(
+	daemonCtx: DaemonAppContext,
+	jobId: string,
+	statuses: JobStatus[],
+	timeoutMs: number = JOB_WAIT_TIMEOUT_MS
+): Promise<Job | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const jobs = daemonCtx.jobQueue.listJobs({ queue: GITHUB_POLL, status: statuses });
+		const match = jobs.find((j) => j.id === jobId);
+		if (match) {
+			return match;
 		}
 		await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
 	}
@@ -182,11 +207,20 @@ describe('GitHub polling via job queue (online)', () => {
 	test('dedup: at most one pending github.poll job exists at any time', async () => {
 		const daemonCtx = getDaemonCtx(daemon);
 
+		// Assert immediately after startup: exactly 1 job exists (the initial
+		// pending job) and 0 duplicates.  The processor has not picked it up yet
+		// because it polls every 1 s and we are measuring right after startup.
+		const atStartup = daemonCtx.jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['pending', 'processing'],
+		});
+		expect(atStartup.length).toBe(1);
+
 		// Let the initial job run and the next job be enqueued.
 		await waitForGitHubPollJob(daemonCtx, ['completed']);
 		await waitForGitHubPollJob(daemonCtx, ['pending']);
 
-		// Check that the handler did not create multiple pending jobs.
+		// After self-scheduling: still exactly 1 pending job, never more.
 		const pendingJobs = daemonCtx.jobQueue.listJobs({
 			queue: GITHUB_POLL,
 			status: ['pending'],
@@ -202,4 +236,50 @@ describe('GitHub polling via job queue (online)', () => {
 		expect(daemonCtx.gitHubService).not.toBeNull();
 		expect(daemonCtx.gitHubService!.isPolling()).toBe(true);
 	});
+
+	test('recovery: stale processing job from a simulated crash is reclaimed and completes', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		stubTriggerPoll(daemonCtx);
+
+		// Wait for the initial job to finish so no real processing jobs exist.
+		await waitForGitHubPollJob(daemonCtx, ['completed']);
+
+		// Simulate a daemon crash: insert a github.poll job directly into the
+		// database with status='processing' and a started_at that is 6 minutes
+		// old (exceeding the processor's 5-minute stale threshold).
+		const crashedStartedAt = Date.now() - 6 * 60 * 1000;
+		const rawDb = daemonCtx.db.getDatabase();
+		const staleJobId = crypto.randomUUID();
+		rawDb
+			.prepare(
+				`INSERT INTO job_queue
+				(id, queue, status, payload, result, error, priority, max_retries, retry_count, run_at, created_at, started_at, completed_at)
+				VALUES (?, ?, 'processing', '{}', NULL, NULL, 0, 3, 0, ?, ?, ?, NULL)`
+			)
+			.run(staleJobId, GITHUB_POLL, crashedStartedAt, crashedStartedAt, crashedStartedAt);
+
+		// Verify the stale job is visible as 'processing' before reclamation.
+		const beforeReclaim = daemonCtx.jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['processing'],
+		});
+		expect(beforeReclaim.some((j) => j.id === staleJobId)).toBe(true);
+
+		// Trigger stale reclamation with a 5-minute cutoff — exactly what
+		// JobQueueProcessor.start() does eagerly on daemon restart.
+		const reclaimed = daemonCtx.jobQueue.reclaimStale(Date.now() - 5 * 60 * 1000);
+		expect(reclaimed).toBeGreaterThanOrEqual(1);
+
+		// The reclaimed job is now 'pending' and ready to be picked up.
+		const afterReclaim = daemonCtx.jobQueue.listJobs({
+			queue: GITHUB_POLL,
+			status: ['pending'],
+		});
+		expect(afterReclaim.some((j) => j.id === staleJobId)).toBe(true);
+
+		// The running job processor picks it up and completes it.
+		const completed = await waitForJobById(daemonCtx, staleJobId, ['completed']);
+		expect(completed).toBeDefined();
+		expect(completed!.status).toBe('completed');
+	}, 15_000);
 });

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -94,19 +94,21 @@ describe('handleGitHubPoll', () => {
 		expect(enqueueMock).not.toHaveBeenCalled();
 	});
 
-	it('enqueues next job even when a processing job exists (self-scheduling case)', async () => {
-		// The handler only checks 'pending' — not 'processing' — because it is
-		// itself in 'processing' state while running. A processing job returned
-		// by listJobs would be a concurrent duplicate, but that scenario is
-		// prevented at startup by the dedup check in GitHubService.start().
-		listJobsMock = mock(() => []); // listJobs(status: 'pending') returns nothing
-		const deps = makeDeps();
-		deps.jobQueue.listJobs = listJobsMock as never;
-		deps.jobQueue.enqueue = enqueueMock as never;
+	it('does NOT check processing status in dedup — only pending — so self-scheduling always works', async () => {
+		// The handler must NOT include 'processing' in its dedup query, because the
+		// current job is itself in 'processing' state while executing. Verifying
+		// that listJobs is called with 'pending' (not ['pending','processing']) is
+		// the only way to confirm self-scheduling is not blocked by the handler's own
+		// processing status.
+		await handleGitHubPoll(makeDeps());
 
-		await handleGitHubPoll(deps);
-
-		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const listArg = (
+			listJobsMock.mock.calls[0] as [{ queue: string; status: string; limit: number }]
+		)[0];
+		// Must be a string (single status), not an array that includes 'processing'.
+		expect(typeof listArg.status).toBe('string');
+		expect(listArg.status).toBe('pending');
+		expect(listArg.status).not.toContain('processing');
 	});
 
 	it('still schedules next poll when triggerPoll throws (error is caught internally)', async () => {

--- a/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/github-poll-handler.test.ts
@@ -94,15 +94,19 @@ describe('handleGitHubPoll', () => {
 		expect(enqueueMock).not.toHaveBeenCalled();
 	});
 
-	it('skips enqueueing when a processing job already exists (dedup)', async () => {
-		listJobsMock = mock(() => [makeJob({ status: 'processing' })]);
+	it('enqueues next job even when a processing job exists (self-scheduling case)', async () => {
+		// The handler only checks 'pending' — not 'processing' — because it is
+		// itself in 'processing' state while running. A processing job returned
+		// by listJobs would be a concurrent duplicate, but that scenario is
+		// prevented at startup by the dedup check in GitHubService.start().
+		listJobsMock = mock(() => []); // listJobs(status: 'pending') returns nothing
 		const deps = makeDeps();
 		deps.jobQueue.listJobs = listJobsMock as never;
 		deps.jobQueue.enqueue = enqueueMock as never;
 
 		await handleGitHubPoll(deps);
 
-		expect(enqueueMock).not.toHaveBeenCalled();
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('still schedules next poll when triggerPoll throws (error is caught internally)', async () => {
@@ -122,15 +126,18 @@ describe('handleGitHubPoll', () => {
 		expect(enqueueMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('queries listJobs with pending+processing statuses and GITHUB_POLL queue', async () => {
+	it('queries listJobs with pending status only and GITHUB_POLL queue', async () => {
 		await handleGitHubPoll(makeDeps());
 
 		expect(listJobsMock).toHaveBeenCalledTimes(1);
 		const listArg = (
-			listJobsMock.mock.calls[0] as [{ queue: string; status: string[]; limit: number }]
+			listJobsMock.mock.calls[0] as [{ queue: string; status: string; limit: number }]
 		)[0];
 		expect(listArg.queue).toBe(GITHUB_POLL);
-		expect(listArg.status).toEqual(['pending', 'processing']);
+		// Only 'pending' — not 'processing' — because the current job is itself
+		// in 'processing' state while the handler runs; checking 'processing'
+		// would always find itself and prevent self-scheduling.
+		expect(listArg.status).toBe('pending');
 		expect(listArg.limit).toBe(1);
 	});
 

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -58,6 +58,7 @@ ROOM_FILES=(
 
 FEATURES_FILES=(
   auto-title.test.ts
+  github-poll-job.test.ts
   message-delivery-mode-queue.test.ts
   message-persistence.test.ts
 )


### PR DESCRIPTION
- Create packages/daemon/tests/online/features/github-poll-job.test.ts with
  5 tests verifying end-to-end job queue mechanics for github.poll:
  initial enqueue on startup, pending→processing→completed transition,
  self-scheduling after completion, dedup (≤1 pending at a time), and
  isPolling() state.

- Fix bug in github-poll.handler.ts: the dedup check was including
  'processing' in the status filter, which caused the handler to always
  find itself (it runs while in 'processing' state) and never self-schedule
  the next poll job. Changed to check only 'pending' status.

- Update github-poll-handler.test.ts to match the corrected dedup
  behavior: the "processing job exists" case now correctly documents that
  the handler enqueues the next job (since 'processing' is no longer
  in the filter).
