### PR TITLE
feat: add MessageHub.onClientDisconnect forwarding method

### DIFF
--- a/packages/shared/src/message-hub/message-hub.ts
+++ b/packages/shared/src/message-hub/message-hub.ts
@@ -190,6 +190,12 @@ export class MessageHub {
 	 * Register a handler for client disconnect events (server-side only)
 	 * Forwards to the primary transport's onClientDisconnect if supported.
 	 * Returns a no-op unsubscribe function if the transport doesn't support it.
+	 *
+	 * NOTE: The transport is resolved at the time this method is called, not when
+	 * a disconnect fires. If the primary transport changes after registration (e.g.
+	 * a new transport is registered with isPrimary:true), this handler stays bound
+	 * to the original transport. In practice this is not an issue because disconnect
+	 * handlers are registered once at server startup before any transport changes.
 	 */
 	onClientDisconnect(handler: (clientId: string) => void): UnsubscribeFn {
 		const transport = this.primaryTransportName

--- a/packages/shared/src/message-hub/message-hub.ts
+++ b/packages/shared/src/message-hub/message-hub.ts
@@ -186,6 +186,22 @@ export class MessageHub {
 		};
 	}
 
+	/**
+	 * Register a handler for client disconnect events (server-side only)
+	 * Forwards to the primary transport's onClientDisconnect if supported.
+	 * Returns a no-op unsubscribe function if the transport doesn't support it.
+	 */
+	onClientDisconnect(handler: (clientId: string) => void): UnsubscribeFn {
+		const transport = this.primaryTransportName
+			? this.transports.get(this.primaryTransportName)
+			: null;
+		if (transport?.onClientDisconnect) {
+			return transport.onClientDisconnect(handler);
+		}
+		// No-op: transport doesn't support disconnect events
+		return () => {};
+	}
+
 	// ========================================
 	// Router Management (Server-side)
 	// ========================================

--- a/packages/shared/tests/message-hub.test.ts
+++ b/packages/shared/tests/message-hub.test.ts
@@ -1117,64 +1117,59 @@ describe('Multi-Transport Support', () => {
 // onClientDisconnect forwarding
 // ========================================
 
+/**
+ * Creates a mock transport with onClientDisconnect support.
+ * Returns both the transport and a simulate function to trigger disconnects.
+ */
+function createMockTransportWithDisconnect(): {
+	transport: IMessageTransport;
+	simulateDisconnect: (clientId: string) => void;
+} {
+	const handlers: Set<(clientId: string) => void> = new Set();
+	const transport: IMessageTransport = {
+		name: 'mock-with-disconnect',
+		initialize: async () => {},
+		close: async () => {},
+		send: async () => {},
+		isReady: () => true,
+		getState: () => 'connected' as ConnectionState,
+		onMessage: () => () => {},
+		onConnectionChange: () => () => {},
+		onClientDisconnect(handler) {
+			handlers.add(handler);
+			return () => {
+				handlers.delete(handler);
+			};
+		},
+	};
+	return {
+		transport,
+		simulateDisconnect: (clientId) => {
+			for (const h of handlers) h(clientId);
+		},
+	};
+}
+
 describe('MessageHub.onClientDisconnect', () => {
 	test('forwards handler to primary transport and fires on disconnect', () => {
 		const hub = new MessageHub();
-
-		// Mock transport that supports onClientDisconnect
-		const disconnectHandlers: Set<(clientId: string) => void> = new Set();
-		const mockTransport: IMessageTransport = {
-			name: 'mock-with-disconnect',
-			initialize: async () => {},
-			close: async () => {},
-			send: async () => {},
-			isReady: () => true,
-			getState: () => 'connected' as ConnectionState,
-			onMessage: () => () => {},
-			onConnectionChange: () => () => {},
-			onClientDisconnect(handler) {
-				disconnectHandlers.add(handler);
-				return () => {
-					disconnectHandlers.delete(handler);
-				};
-			},
-		};
-
-		hub.registerTransport(mockTransport);
+		const { transport, simulateDisconnect } = createMockTransportWithDisconnect();
+		hub.registerTransport(transport);
 
 		const received: string[] = [];
 		hub.onClientDisconnect((clientId) => {
 			received.push(clientId);
 		});
 
-		// Simulate a client disconnect from the transport side
-		for (const h of disconnectHandlers) h('client-abc');
+		simulateDisconnect('client-abc');
 
 		expect(received).toEqual(['client-abc']);
 	});
 
 	test('unsubscribe prevents further callbacks', () => {
 		const hub = new MessageHub();
-
-		const disconnectHandlers: Set<(clientId: string) => void> = new Set();
-		const mockTransport: IMessageTransport = {
-			name: 'mock-with-disconnect',
-			initialize: async () => {},
-			close: async () => {},
-			send: async () => {},
-			isReady: () => true,
-			getState: () => 'connected' as ConnectionState,
-			onMessage: () => () => {},
-			onConnectionChange: () => () => {},
-			onClientDisconnect(handler) {
-				disconnectHandlers.add(handler);
-				return () => {
-					disconnectHandlers.delete(handler);
-				};
-			},
-		};
-
-		hub.registerTransport(mockTransport);
+		const { transport, simulateDisconnect } = createMockTransportWithDisconnect();
+		hub.registerTransport(transport);
 
 		const received: string[] = [];
 		const unsubscribe = hub.onClientDisconnect((clientId) => {
@@ -1182,12 +1177,12 @@ describe('MessageHub.onClientDisconnect', () => {
 		});
 
 		// First disconnect fires
-		for (const h of disconnectHandlers) h('client-1');
+		simulateDisconnect('client-1');
 		expect(received).toEqual(['client-1']);
 
 		// Unsubscribe and fire again — handler should not be called
 		unsubscribe();
-		for (const h of disconnectHandlers) h('client-2');
+		simulateDisconnect('client-2');
 		expect(received).toEqual(['client-1']);
 	});
 

--- a/packages/shared/tests/message-hub.test.ts
+++ b/packages/shared/tests/message-hub.test.ts
@@ -1112,3 +1112,112 @@ describe('Multi-Transport Support', () => {
 		await neoServer.close();
 	});
 });
+
+// ========================================
+// onClientDisconnect forwarding
+// ========================================
+
+describe('MessageHub.onClientDisconnect', () => {
+	test('forwards handler to primary transport and fires on disconnect', () => {
+		const hub = new MessageHub();
+
+		// Mock transport that supports onClientDisconnect
+		const disconnectHandlers: Set<(clientId: string) => void> = new Set();
+		const mockTransport: IMessageTransport = {
+			name: 'mock-with-disconnect',
+			initialize: async () => {},
+			close: async () => {},
+			send: async () => {},
+			isReady: () => true,
+			getState: () => 'connected' as ConnectionState,
+			onMessage: () => () => {},
+			onConnectionChange: () => () => {},
+			onClientDisconnect(handler) {
+				disconnectHandlers.add(handler);
+				return () => {
+					disconnectHandlers.delete(handler);
+				};
+			},
+		};
+
+		hub.registerTransport(mockTransport);
+
+		const received: string[] = [];
+		hub.onClientDisconnect((clientId) => {
+			received.push(clientId);
+		});
+
+		// Simulate a client disconnect from the transport side
+		for (const h of disconnectHandlers) h('client-abc');
+
+		expect(received).toEqual(['client-abc']);
+	});
+
+	test('unsubscribe prevents further callbacks', () => {
+		const hub = new MessageHub();
+
+		const disconnectHandlers: Set<(clientId: string) => void> = new Set();
+		const mockTransport: IMessageTransport = {
+			name: 'mock-with-disconnect',
+			initialize: async () => {},
+			close: async () => {},
+			send: async () => {},
+			isReady: () => true,
+			getState: () => 'connected' as ConnectionState,
+			onMessage: () => () => {},
+			onConnectionChange: () => () => {},
+			onClientDisconnect(handler) {
+				disconnectHandlers.add(handler);
+				return () => {
+					disconnectHandlers.delete(handler);
+				};
+			},
+		};
+
+		hub.registerTransport(mockTransport);
+
+		const received: string[] = [];
+		const unsubscribe = hub.onClientDisconnect((clientId) => {
+			received.push(clientId);
+		});
+
+		// First disconnect fires
+		for (const h of disconnectHandlers) h('client-1');
+		expect(received).toEqual(['client-1']);
+
+		// Unsubscribe and fire again — handler should not be called
+		unsubscribe();
+		for (const h of disconnectHandlers) h('client-2');
+		expect(received).toEqual(['client-1']);
+	});
+
+	test('returns no-op unsubscribe when transport has no onClientDisconnect', () => {
+		const hub = new MessageHub();
+
+		// Transport without onClientDisconnect
+		const mockTransport: IMessageTransport = {
+			name: 'mock-no-disconnect',
+			initialize: async () => {},
+			close: async () => {},
+			send: async () => {},
+			isReady: () => true,
+			getState: () => 'connected' as ConnectionState,
+			onMessage: () => () => {},
+			onConnectionChange: () => () => {},
+			// onClientDisconnect is intentionally omitted
+		};
+
+		hub.registerTransport(mockTransport);
+
+		// Should not throw; returns a no-op function
+		const unsubscribe = hub.onClientDisconnect(() => {});
+		expect(() => unsubscribe()).not.toThrow();
+	});
+
+	test('returns no-op unsubscribe when no transport is registered', () => {
+		const hub = new MessageHub();
+
+		const unsubscribe = hub.onClientDisconnect(() => {});
+		expect(() => unsubscribe()).not.toThrow();
+	});
+});


### PR DESCRIPTION
Adds onClientDisconnect(handler) to MessageHub that delegates to the
primary transport's onClientDisconnect if the transport supports it.
Returns a no-op unsubscribe when the transport omits the optional method.

Four unit tests cover: handler fires on disconnect, unsubscribe stops
callbacks, no-op when transport lacks support, no-op with no transport.
