### PR TITLE
feat: plumb clientId into CallContext

### DIFF
--- a/packages/shared/src/message-hub/message-hub.ts
+++ b/packages/shared/src/message-hub/message-hub.ts
@@ -520,6 +520,7 @@ export class MessageHub {
 				sessionId: message.sessionId,
 				method: message.method,
 				timestamp: message.timestamp,
+				...(clientId !== undefined ? { clientId } : {}),
 			};
 			const result = await Promise.resolve(handler(message.data, context));
 

--- a/packages/shared/src/message-hub/types.ts
+++ b/packages/shared/src/message-hub/types.ts
@@ -74,6 +74,11 @@ export interface CallContext {
 	 * Timestamp
 	 */
 	timestamp: string;
+
+	/**
+	 * Client ID — present for WebSocket-originated requests, undefined for in-process calls
+	 */
+	clientId?: string;
 }
 
 /**

--- a/packages/shared/tests/call-context-clientid.test.ts
+++ b/packages/shared/tests/call-context-clientid.test.ts
@@ -9,7 +9,7 @@ import { describe, test, expect } from 'bun:test';
 import { MessageHub } from '../src/message-hub/message-hub';
 import type { IMessageTransport, ConnectionState, CallContext } from '../src/message-hub/types';
 import type { HubMessage } from '../src/message-hub/types';
-import { MessageType, createRequestMessage } from '../src/message-hub/protocol';
+import { createRequestMessage } from '../src/message-hub/protocol';
 import type { HubMessageWithMetadata } from '../src/message-hub/protocol';
 
 // Minimal mock transport that lets tests inject messages directly
@@ -54,11 +54,11 @@ describe('CallContext.clientId', () => {
 	test('clientId is present in CallContext when message carries a clientId (WebSocket-like)', async () => {
 		const { hub, transport } = buildHubWithTransport();
 
-		let capturedContext: CallContext | undefined;
-
-		hub.onRequest('test.method', (_data, ctx) => {
-			capturedContext = ctx;
-			return { ok: true };
+		const handlerCalled = new Promise<CallContext>((resolve) => {
+			hub.onRequest('test.method', (_data, ctx) => {
+				resolve(ctx);
+				return { ok: true };
+			});
 		});
 
 		// Build a request message with a clientId attached (as WebSocketServerTransport does)
@@ -71,11 +71,8 @@ describe('CallContext.clientId', () => {
 
 		transport.inject(req);
 
-		// Give the async handler a tick to run
-		await new Promise<void>((resolve) => setTimeout(resolve, 10));
-
-		expect(capturedContext).toBeDefined();
-		expect(capturedContext!.clientId).toBe('ws-client-abc');
+		const capturedContext = await handlerCalled;
+		expect(capturedContext.clientId).toBe('ws-client-abc');
 
 		hub.cleanup();
 	});
@@ -83,11 +80,11 @@ describe('CallContext.clientId', () => {
 	test('clientId is absent in CallContext when message has no clientId (in-process call)', async () => {
 		const { hub, transport } = buildHubWithTransport();
 
-		let capturedContext: CallContext | undefined;
-
-		hub.onRequest('test.method', (_data, ctx) => {
-			capturedContext = ctx;
-			return { ok: true };
+		const handlerCalled = new Promise<CallContext>((resolve) => {
+			hub.onRequest('test.method', (_data, ctx) => {
+				resolve(ctx);
+				return { ok: true };
+			});
 		});
 
 		// Plain request message — no clientId attached
@@ -99,10 +96,8 @@ describe('CallContext.clientId', () => {
 
 		transport.inject(req);
 
-		await new Promise<void>((resolve) => setTimeout(resolve, 10));
-
-		expect(capturedContext).toBeDefined();
-		expect(capturedContext!.clientId).toBeUndefined();
+		const capturedContext = await handlerCalled;
+		expect(capturedContext.clientId).toBeUndefined();
 
 		hub.cleanup();
 	});

--- a/packages/shared/tests/call-context-clientid.test.ts
+++ b/packages/shared/tests/call-context-clientid.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for CallContext.clientId plumbing
+ *
+ * Verifies that clientId is populated in CallContext for WebSocket-originated
+ * requests and absent for in-process calls.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { MessageHub } from '../src/message-hub/message-hub';
+import type { IMessageTransport, ConnectionState, CallContext } from '../src/message-hub/types';
+import type { HubMessage } from '../src/message-hub/types';
+import { MessageType, createRequestMessage } from '../src/message-hub/protocol';
+import type { HubMessageWithMetadata } from '../src/message-hub/protocol';
+
+// Minimal mock transport that lets tests inject messages directly
+class MockTransport implements IMessageTransport {
+	readonly name = 'mock-transport';
+	private messageHandlers: Set<(message: HubMessage) => void> = new Set();
+	private stateHandlers: Set<(state: ConnectionState) => void> = new Set();
+
+	async initialize(): Promise<void> {}
+	async close(): Promise<void> {}
+	async send(_message: HubMessage): Promise<void> {}
+	isReady(): boolean {
+		return true;
+	}
+	getState(): ConnectionState {
+		return 'connected';
+	}
+	onMessage(handler: (message: HubMessage) => void): () => void {
+		this.messageHandlers.add(handler);
+		return () => this.messageHandlers.delete(handler);
+	}
+	onConnectionChange(handler: (state: ConnectionState) => void): () => void {
+		this.stateHandlers.add(handler);
+		return () => this.stateHandlers.delete(handler);
+	}
+
+	inject(message: HubMessage): void {
+		for (const h of this.messageHandlers) {
+			h(message);
+		}
+	}
+}
+
+function buildHubWithTransport(): { hub: MessageHub; transport: MockTransport } {
+	const transport = new MockTransport();
+	const hub = new MessageHub({ defaultSessionId: 'global' });
+	hub.registerTransport(transport);
+	return { hub, transport };
+}
+
+describe('CallContext.clientId', () => {
+	test('clientId is present in CallContext when message carries a clientId (WebSocket-like)', async () => {
+		const { hub, transport } = buildHubWithTransport();
+
+		let capturedContext: CallContext | undefined;
+
+		hub.onRequest('test.method', (_data, ctx) => {
+			capturedContext = ctx;
+			return { ok: true };
+		});
+
+		// Build a request message with a clientId attached (as WebSocketServerTransport does)
+		const req = createRequestMessage({
+			method: 'test.method',
+			data: {},
+			sessionId: 'global',
+		}) as HubMessageWithMetadata;
+		req.clientId = 'ws-client-abc';
+
+		transport.inject(req);
+
+		// Give the async handler a tick to run
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		expect(capturedContext).toBeDefined();
+		expect(capturedContext!.clientId).toBe('ws-client-abc');
+
+		hub.cleanup();
+	});
+
+	test('clientId is absent in CallContext when message has no clientId (in-process call)', async () => {
+		const { hub, transport } = buildHubWithTransport();
+
+		let capturedContext: CallContext | undefined;
+
+		hub.onRequest('test.method', (_data, ctx) => {
+			capturedContext = ctx;
+			return { ok: true };
+		});
+
+		// Plain request message — no clientId attached
+		const req = createRequestMessage({
+			method: 'test.method',
+			data: {},
+			sessionId: 'global',
+		});
+
+		transport.inject(req);
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		expect(capturedContext).toBeDefined();
+		expect(capturedContext!.clientId).toBeUndefined();
+
+		hub.cleanup();
+	});
+});


### PR DESCRIPTION
Add optional clientId field to the CallContext interface so RPC
handlers can identify which WebSocket client originated the request.

- Add clientId optional string to CallContext in message-hub/types.ts
- Populate clientId from the already-extracted metadata in
  handleIncomingRequest when the message carries one
- Add unit tests verifying clientId is present for WebSocket-originated
  requests and absent for in-process calls
