### PR TITLE
feat: define named-query registry with column aliasing and JSON parsing

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1,0 +1,200 @@
+/**
+ * LiveQuery RPC Handlers
+ *
+ * Defines the server-side named-query registry for the liveQuery.subscribe /
+ * liveQuery.unsubscribe RPC protocol.  Clients send a query name + parameters;
+ * the daemon resolves it to a pre-registered SQL template and row mapper.
+ * Clients never send raw SQL.
+ */
+
+// ============================================================================
+// Named-query registry types
+// ============================================================================
+
+export interface NamedQuery {
+	/** Parameterised SQL that will be executed by LiveQueryEngine */
+	sql: string;
+	/** Number of positional parameters the SQL expects */
+	paramCount: number;
+	/**
+	 * Optional row transformer applied after every query execution.
+	 * Must return a plain object whose keys match the frontend TypeScript types.
+	 */
+	mapRow?: (row: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ============================================================================
+// Row mappers
+// ============================================================================
+
+/**
+ * Map a raw SQLite row from the `tasks` table (with camelCase AS aliases) to
+ * the NeoTask shape expected by the frontend.
+ *
+ * JSON blob columns: `dependsOn` (stored as `depends_on`).
+ * All other snake_case→camelCase conversions are handled by AS aliases in the
+ * SQL itself so this mapper only handles post-processing that SQL cannot do.
+ */
+function mapTaskRow(row: Record<string, unknown>): Record<string, unknown> {
+	return {
+		...row,
+		dependsOn: JSON.parse((row.dependsOn as string | null) ?? '[]') as string[],
+	};
+}
+
+/**
+ * Map a raw SQLite row from the `goals` table (with camelCase AS aliases) to
+ * the RoomGoal shape expected by the frontend.
+ *
+ * JSON blob columns:
+ *   - `linkedTaskIds` (stored as `linked_task_ids`)
+ *   - `metrics`       (stored as `metrics`)
+ *   - `structuredMetrics` (stored as `structured_metrics`) — optional, null-safe
+ *   - `schedule`      (stored as `schedule`)               — optional, null-safe
+ *
+ * Boolean coercion:
+ *   - `schedulePaused` — SQLite stores 0/1; convert to JS boolean
+ *
+ * snake_case exceptions (per TypeScript type):
+ *   - `planning_attempts`    — kept as-is (not aliased in SQL, not converted here)
+ *   - `goal_review_attempts` — kept as-is (not aliased in SQL, not converted here)
+ */
+function mapGoalRow(row: Record<string, unknown>): Record<string, unknown> {
+	return {
+		...row,
+		linkedTaskIds: JSON.parse((row.linkedTaskIds as string | null) ?? '[]') as string[],
+		metrics: JSON.parse((row.metrics as string | null) ?? '{}') as Record<string, number>,
+		structuredMetrics:
+			row.structuredMetrics != null
+				? (JSON.parse(row.structuredMetrics as string) as unknown[])
+				: undefined,
+		schedule: row.schedule != null ? (JSON.parse(row.schedule as string) as unknown) : undefined,
+		schedulePaused: row.schedulePaused === 1,
+	};
+}
+
+// ============================================================================
+// SQL definitions
+// ============================================================================
+
+const TASKS_BY_ROOM_SQL = `
+SELECT
+  id,
+  room_id             AS roomId,
+  title,
+  description,
+  status,
+  priority,
+  progress,
+  current_step        AS currentStep,
+  result,
+  error,
+  depends_on          AS dependsOn,
+  created_at          AS createdAt,
+  started_at          AS startedAt,
+  completed_at        AS completedAt,
+  task_type           AS taskType,
+  assigned_agent      AS assignedAgent,
+  created_by_task_id  AS createdByTaskId,
+  archived_at         AS archivedAt,
+  active_session      AS activeSession,
+  pr_url              AS prUrl,
+  pr_number           AS prNumber,
+  pr_created_at       AS prCreatedAt,
+  input_draft         AS inputDraft,
+  updated_at          AS updatedAt
+FROM tasks
+WHERE room_id = ?
+ORDER BY created_at DESC, id DESC
+`.trim();
+
+const GOALS_BY_ROOM_SQL = `
+SELECT
+  id,
+  room_id                   AS roomId,
+  title,
+  description,
+  status,
+  priority,
+  progress,
+  linked_task_ids           AS linkedTaskIds,
+  metrics,
+  created_at                AS createdAt,
+  updated_at                AS updatedAt,
+  completed_at              AS completedAt,
+  planning_attempts,
+  goal_review_attempts,
+  mission_type              AS missionType,
+  autonomy_level            AS autonomyLevel,
+  schedule,
+  schedule_paused           AS schedulePaused,
+  next_run_at               AS nextRunAt,
+  structured_metrics        AS structuredMetrics,
+  max_consecutive_failures  AS maxConsecutiveFailures,
+  max_planning_attempts     AS maxPlanningAttempts,
+  consecutive_failures      AS consecutiveFailures,
+  replan_count              AS replanCount
+FROM goals
+WHERE room_id = ?
+ORDER BY priority DESC, created_at ASC, id ASC
+`.trim();
+
+/**
+ * session_group_messages is an append-only table populated in Milestone 4.
+ * The registry entry is defined here so the liveQuery.subscribe handler can
+ * validate query names at subscription time without coupling to that milestone.
+ */
+const SESSION_GROUP_MESSAGES_BY_GROUP_SQL = `
+SELECT
+  id,
+  group_id    AS groupId,
+  session_id  AS sessionId,
+  role,
+  message_type AS messageType,
+  content,
+  created_at  AS createdAt
+FROM session_group_messages
+WHERE group_id = ?
+ORDER BY created_at ASC, id ASC
+`.trim();
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+/**
+ * Server-side named-query registry.
+ *
+ * Keys are opaque identifiers sent by the client in `LiveQuerySubscribeRequest.queryName`.
+ * Each entry specifies the SQL template, expected parameter count, and an optional
+ * row mapper that performs post-processing (JSON parsing, type coercion).
+ *
+ * Exported for use in `liveQuery.subscribe` / `liveQuery.unsubscribe` handlers
+ * and for direct inspection in unit tests.
+ */
+export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
+	[
+		'tasks.byRoom',
+		{
+			sql: TASKS_BY_ROOM_SQL,
+			paramCount: 1,
+			mapRow: mapTaskRow,
+		},
+	],
+	[
+		'goals.byRoom',
+		{
+			sql: GOALS_BY_ROOM_SQL,
+			paramCount: 1,
+			mapRow: mapGoalRow,
+		},
+	],
+	[
+		'sessionGroupMessages.byGroup',
+		{
+			sql: SESSION_GROUP_MESSAGES_BY_GROUP_SQL,
+			paramCount: 1,
+			// No JSON blobs; all columns are scalar.
+		},
+	],
+]);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -303,6 +303,21 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
+	// session_group_messages: append-only table for persisted group conversation
+	// messages (SDK + status entries). Replaces the legacy mirrored table dropped
+	// in migration 19. Populated by the LiveQuery message streaming path (Milestone 4).
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS session_group_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+        session_id TEXT,
+        role TEXT NOT NULL DEFAULT 'system',
+        message_type TEXT NOT NULL DEFAULT 'status',
+        content TEXT NOT NULL DEFAULT '',
+        created_at INTEGER NOT NULL
+      )
+    `);
+
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,
@@ -365,6 +380,9 @@ function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_session_groups_ref ON session_groups(ref_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sgm_session ON session_group_members(session_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tge_group ON task_group_events(group_id, id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_sgm_group ON session_group_messages(group_id, created_at, id)`
+	);
 	// Job queue indexes
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC)`

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -151,6 +151,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 40: Flexible session groups — add task_id + status to space_session_groups,
 	// drop role CHECK constraint and add agent_id + status to space_session_group_members.
 	runMigration40(db);
+
+	// Migration 41: Create session_group_messages table for LiveQuery-based message streaming.
+	// This table was dropped in migration 19 (legacy mirror table). It is recreated here
+	// as an append-only store for the LiveQuery protocol (Milestone 4).
+	runMigration41(db);
 }
 
 /**
@@ -2419,4 +2424,36 @@ function runMigration40(db: BunDatabase): void {
 			db.exec('PRAGMA foreign_keys = ON');
 		}
 	}
+}
+
+/**
+ * Migration 41: Create session_group_messages table.
+ *
+ * The original session_group_messages table was a mirror of SDK messages and was
+ * dropped in migration 19 because it was redundant at the time.  This new table
+ * is an append-only store for the LiveQuery message streaming path introduced in
+ * Milestone 4.  Fresh databases already get the table from createTables(); this
+ * migration creates it for existing (migrated) databases.
+ *
+ * Idempotency: guarded by `CREATE TABLE IF NOT EXISTS` and a table-existence
+ * check so the migration is safe to run multiple times.
+ */
+function runMigration41(db: BunDatabase): void {
+	if (tableExists(db, 'session_group_messages')) {
+		return; // Already created (fresh DB or re-run)
+	}
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS session_group_messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+			session_id TEXT,
+			role TEXT NOT NULL DEFAULT 'system',
+			message_type TEXT NOT NULL DEFAULT 'status',
+			content TEXT NOT NULL DEFAULT '',
+			created_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_sgm_group ON session_group_messages(group_id, created_at, id)`
+	);
 }

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -19,14 +19,6 @@ import { NAMED_QUERY_REGISTRY } from '../../../src/lib/rpc-handlers/live-query-h
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function flushMicrotasks(): Promise<void> {
-	return new Promise((resolve) => queueMicrotask(resolve));
-}
-
-// ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
@@ -257,6 +249,69 @@ describe('NAMED_QUERY_REGISTRY', () => {
 	// -------------------------------------------------------------------------
 
 	describe('sessionGroupMessages.byGroup', () => {
+		const groupId = 'group-contract-test';
+
+		function insertGroup(): void {
+			db.exec(
+				`INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				 VALUES ('${groupId}', 'task', 'task-ref', 0, '{}', ${Date.now()})`
+			);
+		}
+
+		function insertMessage(
+			overrides: { sessionId?: string; role?: string; content?: string } = {}
+		): void {
+			db.exec(`
+				INSERT INTO session_group_messages (group_id, session_id, role, message_type, content, created_at)
+				VALUES (
+					'${groupId}',
+					${overrides.sessionId ? `'${overrides.sessionId}'` : 'NULL'},
+					'${overrides.role ?? 'system'}',
+					'status',
+					'${overrides.content ?? 'hello'}',
+					${Date.now()}
+				)
+			`);
+		}
+
+		function executeSQL(): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
+			return db.prepare(entry.sql).all(groupId) as Record<string, unknown>[];
+		}
+
+		test('SQL executes without error against the real schema (table exists)', () => {
+			insertGroup();
+			// Must not throw — if session_group_messages doesn't exist, SQLite throws
+			expect(() => executeSQL()).not.toThrow();
+		});
+
+		test('returns empty array when no messages exist for the group', () => {
+			insertGroup();
+			const rows = executeSQL();
+			expect(rows).toEqual([]);
+		});
+
+		test('returns camelCase column aliases in result rows', () => {
+			insertGroup();
+			insertMessage({ sessionId: 'sess-1', role: 'coder', content: 'test' });
+			const [row] = executeSQL();
+			expect(row).toHaveProperty('groupId', groupId);
+			expect(row).toHaveProperty('sessionId', 'sess-1');
+			expect(row).toHaveProperty('messageType', 'status');
+			expect(row).toHaveProperty('createdAt');
+			expect(row).not.toHaveProperty('group_id');
+			expect(row).not.toHaveProperty('session_id');
+			expect(row).not.toHaveProperty('message_type');
+			expect(row).not.toHaveProperty('created_at');
+		});
+
+		test('null sessionId is preserved as null', () => {
+			insertGroup();
+			insertMessage(); // sessionId defaults to NULL
+			const [row] = executeSQL();
+			expect(row.sessionId).toBeNull();
+		});
+
 		test('has no mapRow (all columns are scalar)', () => {
 			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
 			expect(entry.mapRow).toBeUndefined();

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Contract tests for the named-query registry defined in live-query-handlers.ts
+ *
+ * These tests verify that:
+ *  1. The registry is exported and contains the expected named queries.
+ *  2. Row shapes returned by executing the SQL (with the mapRow transform applied)
+ *     match the TypeScript types used by the frontend (NeoTask, RoomGoal).
+ *  3. JSON blob columns (`dependsOn`, `metrics`, `linkedTaskIds`, etc.) are parsed
+ *     to JS values before delivery.
+ *  4. snake_case exceptions for RoomGoal (`planning_attempts`, `goal_review_attempts`)
+ *     are preserved as-is.
+ *  5. All queries have deterministic ORDER BY with tiebreakers.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema';
+import { NAMED_QUERY_REGISTRY } from '../../../src/lib/rpc-handlers/live-query-handlers';
+import type { NeoTask, RoomGoal } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function flushMicrotasks(): Promise<void> {
+	return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('NAMED_QUERY_REGISTRY', () => {
+	let db: BunDatabase;
+	const roomId = 'room-contract-test';
+	const now = Date.now();
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		createTables(db);
+		// Insert minimal room row to satisfy FK constraints
+		db.exec(
+			`INSERT OR IGNORE INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test Room', ${now}, ${now})`
+		);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// Registry shape
+	// -------------------------------------------------------------------------
+
+	test('registry contains all expected query names', () => {
+		expect(NAMED_QUERY_REGISTRY.has('tasks.byRoom')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('goals.byRoom')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('sessionGroupMessages.byGroup')).toBe(true);
+	});
+
+	test('all registry entries have correct paramCount', () => {
+		expect(NAMED_QUERY_REGISTRY.get('tasks.byRoom')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('goals.byRoom')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.paramCount).toBe(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// tasks.byRoom — column aliasing and JSON parsing
+	// -------------------------------------------------------------------------
+
+	describe('tasks.byRoom', () => {
+		function insertTask(overrides: Record<string, unknown> = {}): string {
+			const id = `task-${Date.now()}-${Math.random()}`;
+			db.exec(`
+				INSERT INTO tasks (
+					id, room_id, title, description, status, priority,
+					depends_on, created_at, updated_at
+				) VALUES (
+					'${id}', '${roomId}', 'Test Task', 'Desc', 'pending', 'normal',
+					'${JSON.stringify(overrides.dependsOn ?? [])}', ${now}, ${now}
+				)
+			`);
+			return id;
+		}
+
+		function queryAndMap(): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get('tasks.byRoom')!;
+			const rows = db.prepare(entry.sql).all(roomId) as Record<string, unknown>[];
+			return entry.mapRow ? rows.map(entry.mapRow) : rows;
+		}
+
+		test('returns camelCase roomId column', () => {
+			insertTask();
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('roomId', roomId);
+			expect(row).not.toHaveProperty('room_id');
+		});
+
+		test('returns camelCase createdAt, updatedAt columns', () => {
+			insertTask();
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('createdAt');
+			expect(typeof row.createdAt).toBe('number');
+			expect(row).toHaveProperty('updatedAt');
+			expect(row).not.toHaveProperty('created_at');
+			expect(row).not.toHaveProperty('updated_at');
+		});
+
+		test('dependsOn is parsed as string[] (empty array by default)', () => {
+			insertTask();
+			const [row] = queryAndMap();
+			expect(Array.isArray(row.dependsOn)).toBe(true);
+			expect(row.dependsOn).toEqual([]);
+		});
+
+		test('dependsOn is parsed as string[] with values', () => {
+			insertTask({ dependsOn: ['task-a', 'task-b'] });
+			const [row] = queryAndMap();
+			expect(row.dependsOn).toEqual(['task-a', 'task-b']);
+		});
+
+		test('row shape matches NeoTask interface end-to-end', () => {
+			insertTask();
+			const [row] = queryAndMap();
+
+			// Type assertion — if the shape is wrong, TS will catch it in CI
+			const _typed = row as unknown as NeoTask;
+
+			// Verify key structural properties at runtime
+			expect(typeof _typed.id).toBe('string');
+			expect(typeof _typed.roomId).toBe('string');
+			expect(typeof _typed.title).toBe('string');
+			expect(typeof _typed.status).toBe('string');
+			expect(Array.isArray(_typed.dependsOn)).toBe(true);
+		});
+
+		test('ORDER BY is created_at DESC, id DESC (deterministic tiebreaker)', () => {
+			const sql = NAMED_QUERY_REGISTRY.get('tasks.byRoom')!.sql;
+			expect(sql).toContain('ORDER BY created_at DESC, id DESC');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// goals.byRoom — column aliasing, JSON parsing, snake_case exceptions
+	// -------------------------------------------------------------------------
+
+	describe('goals.byRoom', () => {
+		function insertGoal(overrides: Record<string, unknown> = {}): string {
+			const id = `goal-${Date.now()}-${Math.random()}`;
+			const linkedTaskIds = JSON.stringify(overrides.linkedTaskIds ?? []);
+			const metrics = JSON.stringify(overrides.metrics ?? {});
+			db.exec(`
+				INSERT INTO goals (
+					id, room_id, title, description, status, priority, progress,
+					linked_task_ids, metrics, created_at, updated_at
+				) VALUES (
+					'${id}', '${roomId}', 'Test Goal', 'Desc', 'active', 'normal', 0,
+					'${linkedTaskIds}', '${metrics}', ${now}, ${now}
+				)
+			`);
+			return id;
+		}
+
+		function queryAndMap(): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get('goals.byRoom')!;
+			const rows = db.prepare(entry.sql).all(roomId) as Record<string, unknown>[];
+			return entry.mapRow ? rows.map(entry.mapRow) : rows;
+		}
+
+		test('returns camelCase roomId column', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('roomId', roomId);
+			expect(row).not.toHaveProperty('room_id');
+		});
+
+		test('metrics is parsed as an object (empty object by default)', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(typeof row.metrics).toBe('object');
+			expect(row.metrics).toEqual({});
+		});
+
+		test('metrics is parsed as an object with values', () => {
+			insertGoal({ metrics: { velocity: 42, bugs: 3 } });
+			const [row] = queryAndMap();
+			expect(row.metrics).toEqual({ velocity: 42, bugs: 3 });
+		});
+
+		test('linkedTaskIds is parsed as string[] (empty array by default)', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(Array.isArray(row.linkedTaskIds)).toBe(true);
+			expect(row.linkedTaskIds).toEqual([]);
+		});
+
+		test('linkedTaskIds is parsed as string[] with values', () => {
+			insertGoal({ linkedTaskIds: ['task-x', 'task-y'] });
+			const [row] = queryAndMap();
+			expect(row.linkedTaskIds).toEqual(['task-x', 'task-y']);
+		});
+
+		test('planning_attempts remains snake_case (not aliased to camelCase)', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('planning_attempts');
+			expect(row).not.toHaveProperty('planningAttempts');
+		});
+
+		test('goal_review_attempts remains snake_case (not aliased to camelCase)', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(row).toHaveProperty('goal_review_attempts');
+			expect(row).not.toHaveProperty('goalReviewAttempts');
+		});
+
+		test('schedulePaused is converted from SQLite integer to boolean', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			// schedule_paused defaults to 0 → false
+			expect(row.schedulePaused).toBe(false);
+		});
+
+		test('structuredMetrics is undefined when null in DB', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(row.structuredMetrics).toBeUndefined();
+		});
+
+		test('schedule is undefined when null in DB', () => {
+			insertGoal();
+			const [row] = queryAndMap();
+			expect(row.schedule).toBeUndefined();
+		});
+
+		test('row shape matches RoomGoal interface end-to-end', () => {
+			insertGoal({ metrics: { coverage: 80 }, linkedTaskIds: ['t1'] });
+			const [row] = queryAndMap();
+
+			// Type assertion — if the shape is wrong, TS will catch it in CI
+			const _typed = row as unknown as RoomGoal;
+
+			expect(typeof _typed.id).toBe('string');
+			expect(typeof _typed.roomId).toBe('string');
+			expect(Array.isArray(_typed.linkedTaskIds)).toBe(true);
+			expect(typeof _typed.metrics).toBe('object');
+		});
+
+		test('ORDER BY is priority DESC, created_at ASC, id ASC (deterministic tiebreaker)', () => {
+			const sql = NAMED_QUERY_REGISTRY.get('goals.byRoom')!.sql;
+			expect(sql).toContain('ORDER BY priority DESC, created_at ASC, id ASC');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// sessionGroupMessages.byGroup — registry presence and structure
+	// -------------------------------------------------------------------------
+
+	describe('sessionGroupMessages.byGroup', () => {
+		test('has no mapRow (all columns are scalar)', () => {
+			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
+			expect(entry.mapRow).toBeUndefined();
+		});
+
+		test('SQL targets session_group_messages table', () => {
+			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
+			expect(entry.sql).toContain('FROM session_group_messages');
+		});
+
+		test('SQL filters by group_id parameter', () => {
+			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
+			expect(entry.sql).toContain('WHERE group_id = ?');
+		});
+
+		test('ORDER BY is created_at ASC, id ASC (deterministic tiebreaker)', () => {
+			const sql = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.sql;
+			expect(sql).toContain('ORDER BY created_at ASC, id ASC');
+		});
+
+		test('SQL selects camelCase aliases for snake_case columns', () => {
+			const entry = NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!;
+			expect(entry.sql).toContain('group_id    AS groupId');
+			expect(entry.sql).toContain('session_id  AS sessionId');
+			expect(entry.sql).toContain('message_type AS messageType');
+			expect(entry.sql).toContain('created_at  AS createdAt');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// General registry invariants
+	// -------------------------------------------------------------------------
+
+	describe('invariants', () => {
+		test('all entries have non-empty SQL', () => {
+			for (const [name, entry] of NAMED_QUERY_REGISTRY) {
+				expect(entry.sql.trim().length).toBeGreaterThan(0, `${name} has empty SQL`);
+			}
+		});
+
+		test('all entries have paramCount >= 1', () => {
+			for (const [name, entry] of NAMED_QUERY_REGISTRY) {
+				expect(entry.paramCount).toBeGreaterThanOrEqual(1, `${name} has paramCount < 1`);
+			}
+		});
+
+		test('all ORDER BY clauses include a deterministic tiebreaker (id column)', () => {
+			for (const [name, entry] of NAMED_QUERY_REGISTRY) {
+				const upperSql = entry.sql.toUpperCase();
+				expect(upperSql).toContain('ORDER BY');
+				// Must end with either `id ASC` or `id DESC` (tiebreaker)
+				const hasIdTiebreaker = /\bID\s+(ASC|DESC)\s*$/.test(upperSql.replace(/\s+/g, ' ').trim());
+				expect(hasIdTiebreaker).toBe(true, `${name} ORDER BY lacks deterministic id tiebreaker`);
+			}
+		});
+	});
+});


### PR DESCRIPTION
Adds `NAMED_QUERY_REGISTRY` in `live-query-handlers.ts` — a Map of three
initial named queries (tasks.byRoom, goals.byRoom,
sessionGroupMessages.byGroup) used by the upcoming liveQuery.subscribe
RPC handler.

- All snake_case columns are aliased to camelCase via SQL AS clauses
- RoomGoal snake_case exceptions preserved: planning_attempts,
  goal_review_attempts remain unaliased per the TypeScript type
- JSON blob columns parsed in mapRow: NeoTask.dependsOn, RoomGoal.linkedTaskIds,
  RoomGoal.metrics, RoomGoal.structuredMetrics, RoomGoal.schedule
- SQLite boolean coercion for RoomGoal.schedulePaused (0/1 → boolean)
- All ORDER BY clauses include deterministic id tiebreakers
- 28 contract tests cover column aliasing, JSON parsing, ORDER BY
  invariants, and end-to-end row shape vs TypeScript types
