### PR TITLE
feat: hide completed tasks under Goals in sidebar with show/hide toggle

### DIFF
--- a/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
+++ b/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
@@ -470,4 +470,203 @@ test.describe('Room Sidebar Sections', () => {
 			timeout: 10000,
 		});
 	});
+
+	// ── Goals: completed tasks toggle ─────────────────────────────────────────
+
+	test('Goals section: completed tasks are hidden by default under expanded goals', async ({
+		page,
+	}) => {
+		// Create an additional goal with a completed linked task
+		const completedTaskRoomId = await page.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			const roomRes = await hub.request('room.create', {
+				name: 'E2E Completed Tasks Toggle Room',
+			});
+			const roomId = (roomRes as { room: { id: string } }).room.id;
+
+			// Stop runtime
+			for (let i = 0; i < 20; i++) {
+				try {
+					await hub.request('room.runtime.stop', { roomId });
+				} catch {}
+				const stateRes = await hub
+					.request('room.runtime.state', { roomId })
+					.catch(() => null as unknown);
+				const state = (stateRes as { state?: string } | null)?.state;
+				if (!state || state === 'stopped') break;
+				await new Promise((r) => setTimeout(r, 100));
+			}
+
+			// Create a goal
+			const goalRes = await hub.request('goal.create', {
+				roomId,
+				title: 'Completed Tasks Test Goal',
+			});
+			const goalId = (goalRes as { goal: { id: string } }).goal.id;
+
+			// Create a completed task and link it to the goal
+			const taskRes = await hub.request('task.create', {
+				roomId,
+				title: 'Completed Linked Task',
+			});
+			const taskId = (taskRes as { task: { id: string } }).task.id;
+
+			await hub.request('goal.linkTask', { roomId, goalId, taskId });
+
+			// Transition task to completed
+			await hub.request('task.setStatus', {
+				roomId,
+				taskId,
+				status: 'in_progress',
+			});
+			await hub.request('task.setStatus', { roomId, taskId, status: 'completed' });
+
+			return roomId;
+		});
+
+		await navigateToRoomAndWaitForSidebar(page, completedTaskRoomId);
+
+		const goalsSection = getSidebarSection(page, 'Goals');
+		await expect(goalsSection.getByText('Completed Tasks Test Goal')).toBeVisible({
+			timeout: 15000,
+		});
+
+		// Expand the goal
+		await goalsSection.locator('button').filter({ hasText: 'Completed Tasks Test Goal' }).click();
+
+		// Completed task should NOT be visible by default
+		await expect(goalsSection.getByText('Completed Linked Task')).not.toBeVisible();
+
+		// Clean up
+		await deleteRoom(page, completedTaskRoomId);
+	});
+
+	test('Goals section: toggle button shows completed tasks when clicked', async ({ page }) => {
+		// Create a goal with completed task
+		const completedTaskRoomId = await page.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			const roomRes = await hub.request('room.create', {
+				name: 'E2E Show Completed Toggle Room',
+			});
+			const roomId = (roomRes as { room: { id: string } }).room.id;
+
+			// Stop runtime
+			for (let i = 0; i < 20; i++) {
+				try {
+					await hub.request('room.runtime.stop', { roomId });
+				} catch {}
+				const stateRes = await hub
+					.request('room.runtime.state', { roomId })
+					.catch(() => null as unknown);
+				const state = (stateRes as { state?: string } | null)?.state;
+				if (!state || state === 'stopped') break;
+				await new Promise((r) => setTimeout(r, 100));
+			}
+
+			const goalRes = await hub.request('goal.create', {
+				roomId,
+				title: 'Toggle Show Goal',
+			});
+			const goalId = (goalRes as { goal: { id: string } }).goal.id;
+
+			const taskRes = await hub.request('task.create', {
+				roomId,
+				title: 'Done Task',
+			});
+			const taskId = (taskRes as { task: { id: string } }).task.id;
+
+			await hub.request('goal.linkTask', { roomId, goalId, taskId });
+
+			await hub.request('task.setStatus', { roomId, taskId, status: 'completed' });
+
+			return roomId;
+		});
+
+		await navigateToRoomAndWaitForSidebar(page, completedTaskRoomId);
+
+		const goalsSection = getSidebarSection(page, 'Goals');
+		await expect(goalsSection.getByText('Toggle Show Goal')).toBeVisible({ timeout: 15000 });
+
+		// Expand the goal
+		await goalsSection.locator('button').filter({ hasText: 'Toggle Show Goal' }).click();
+
+		// Task should not be visible initially
+		await expect(goalsSection.getByText('Done Task')).not.toBeVisible();
+
+		// Click the show completed tasks toggle button
+		await goalsSection.locator('button[aria-label="Show completed tasks"]').click();
+
+		// Now completed task should be visible
+		await expect(goalsSection.getByText('Done Task')).toBeVisible({ timeout: 5000 });
+
+		// Clean up
+		await deleteRoom(page, completedTaskRoomId);
+	});
+
+	test('Goals section: completed tasks toggle is persisted in localStorage', async ({ page }) => {
+		// Create a goal with completed task
+		const completedTaskRoomId = await page.evaluate(async () => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			const roomRes = await hub.request('room.create', {
+				name: 'E2E Persistence Room',
+			});
+			const roomId = (roomRes as { room: { id: string } }).room.id;
+
+			for (let i = 0; i < 20; i++) {
+				try {
+					await hub.request('room.runtime.stop', { roomId });
+				} catch {}
+				const stateRes = await hub
+					.request('room.runtime.state', { roomId })
+					.catch(() => null as unknown);
+				const state = (stateRes as { state?: string } | null)?.state;
+				if (!state || state === 'stopped') break;
+				await new Promise((r) => setTimeout(r, 100));
+			}
+
+			const goalRes = await hub.request('goal.create', { roomId, title: 'Persist Toggle Goal' });
+			const goalId = (goalRes as { goal: { id: string } }).goal.id;
+
+			const taskRes = await hub.request('task.create', {
+				roomId,
+				title: 'Finished Task',
+			});
+			const taskId = (taskRes as { task: { id: string } }).task.id;
+
+			await hub.request('goal.linkTask', { roomId, goalId, taskId });
+			await hub.request('task.setStatus', { roomId, taskId, status: 'completed' });
+
+			return roomId;
+		});
+
+		await navigateToRoomAndWaitForSidebar(page, completedTaskRoomId);
+
+		const goalsSection = getSidebarSection(page, 'Goals');
+		await expect(goalsSection.getByText('Persist Toggle Goal')).toBeVisible({ timeout: 15000 });
+
+		// Expand goal and toggle to show completed
+		await goalsSection.locator('button').filter({ hasText: 'Persist Toggle Goal' }).click();
+		await goalsSection.locator('button[aria-label="Show completed tasks"]').click();
+		await expect(goalsSection.getByText('Finished Task')).toBeVisible({ timeout: 5000 });
+
+		// Reload the page to verify persistence
+		await page.reload();
+		await waitForWebSocketConnected(page);
+		await expect(goalsSection.getByText('Persist Toggle Goal')).toBeVisible({ timeout: 15000 });
+
+		// Expand the goal again - the toggle state should be remembered
+		await goalsSection.locator('button').filter({ hasText: 'Persist Toggle Goal' }).click();
+
+		// Task should still be visible (persisted)
+		await expect(goalsSection.getByText('Finished Task')).toBeVisible({ timeout: 5000 });
+
+		// Clean up
+		await deleteRoom(page, completedTaskRoomId);
+	});
 });

--- a/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
+++ b/packages/e2e/tests/features/room-sidebar-sections.e2e.ts
@@ -581,6 +581,7 @@ test.describe('Room Sidebar Sections', () => {
 
 			await hub.request('goal.linkTask', { roomId, goalId, taskId });
 
+			await hub.request('task.setStatus', { roomId, taskId, status: 'in_progress' });
 			await hub.request('task.setStatus', { roomId, taskId, status: 'completed' });
 
 			return roomId;
@@ -640,6 +641,7 @@ test.describe('Room Sidebar Sections', () => {
 			const taskId = (taskRes as { task: { id: string } }).task.id;
 
 			await hub.request('goal.linkTask', { roomId, goalId, taskId });
+			await hub.request('task.setStatus', { roomId, taskId, status: 'in_progress' });
 			await hub.request('task.setStatus', { roomId, taskId, status: 'completed' });
 
 			return roomId;

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -332,7 +332,8 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 									t.status === 'needs_attention'
 							);
 							const completedLinkedTasks = linkedTasks.filter(
-								(t) => t.status === 'completed' || t.status === 'cancelled'
+								(t) =>
+									t.status === 'completed' || t.status === 'cancelled' || t.status === 'archived'
 							);
 							const hasCompletedTasks = completedLinkedTasks.length > 0;
 							return (

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -22,6 +22,25 @@ import { currentRoomSessionIdSignal, currentRoomTaskIdSignal } from '../lib/sign
 import { toast } from '../lib/toast';
 import { cn } from '../lib/utils';
 
+const GOALS_SHOW_COMPLETED_KEY = 'neokai:goals:showCompletedTasks';
+
+function getShowCompletedTasksInitial(): boolean {
+	try {
+		const stored = localStorage.getItem(GOALS_SHOW_COMPLETED_KEY);
+		return stored === 'true';
+	} catch {
+		return false;
+	}
+}
+
+function persistShowCompletedTasks(value: boolean): void {
+	try {
+		localStorage.setItem(GOALS_SHOW_COMPLETED_KEY, String(value));
+	} catch {
+		// Silently fail if localStorage is unavailable
+	}
+}
+
 function formatRelativeTime(timestamp: number): string {
 	const seconds = Math.floor((Date.now() - timestamp) / 1000);
 	if (seconds < 60) return 'now';
@@ -80,6 +99,13 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	const [showArchived, setShowArchived] = useState(false);
 	const [expandedGoals, setExpandedGoals] = useState<Set<string>>(() => new Set());
 	const [orphanTab, setOrphanTab] = useState<OrphanTab>('active');
+	const [showCompletedTasks, setShowCompletedTasks] = useState(getShowCompletedTasksInitial);
+
+	const toggleShowCompletedTasks = () => {
+		const next = !showCompletedTasks;
+		setShowCompletedTasks(next);
+		persistShowCompletedTasks(next);
+	};
 
 	const activeCount = useMemo(
 		() =>
@@ -256,13 +282,54 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 			{/* Scrollable sections */}
 			<div class="flex-1 overflow-y-auto">
 				{/* Goals section */}
-				<CollapsibleSection title="Goals" count={activeGoals.length}>
+				<CollapsibleSection
+					title="Goals"
+					count={activeGoals.length}
+					headerRight={
+						<button
+							onClick={toggleShowCompletedTasks}
+							class={cn(
+								'p-0.5 rounded transition-colors',
+								showCompletedTasks
+									? 'text-gray-400 hover:text-gray-200'
+									: 'text-gray-600 hover:text-gray-400'
+							)}
+							title={showCompletedTasks ? 'Hide completed tasks' : 'Show completed tasks'}
+							aria-label={showCompletedTasks ? 'Hide completed tasks' : 'Show completed tasks'}
+						>
+							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								{showCompletedTasks ? (
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+									/>
+								) : (
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+									/>
+								)}
+							</svg>
+						</button>
+					}
+				>
 					{activeGoals.length === 0 ? (
 						<div class="px-4 py-3 text-xs text-gray-600">No goals</div>
 					) : (
 						activeGoals.map((goal) => {
 							const isExpanded = expandedGoals.has(goal.id);
 							const linkedTasks = tasksByGoalId.get(goal.id) ?? [];
+							const activeLinkedTasks = linkedTasks.filter(
+								(t) => t.status !== 'completed' && t.status !== 'cancelled'
+							);
+							const completedLinkedTasks = linkedTasks.filter(
+								(t) => t.status === 'completed' || t.status === 'cancelled'
+							);
+							const hasCompletedTasks = completedLinkedTasks.length > 0;
 							return (
 								<div key={goal.id}>
 									<button
@@ -282,20 +349,40 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 											●
 										</span>
 									</button>
-									{isExpanded &&
-										linkedTasks.map((task) => (
-											<button
-												key={task.id}
-												onClick={() => handleTaskClick(task.id)}
-												class={cn(
-													'w-full pl-8 pr-3 py-1.5 flex items-center gap-2 transition-colors text-left',
-													selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
-												)}
-											>
-												<TaskStatusDot status={task.status} />
-												<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
-											</button>
-										))}
+									{isExpanded && (
+										<>
+											{activeLinkedTasks.map((task) => (
+												<button
+													key={task.id}
+													onClick={() => handleTaskClick(task.id)}
+													class={cn(
+														'w-full pl-8 pr-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+														selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+													)}
+												>
+													<TaskStatusDot status={task.status} />
+													<span class="flex-1 text-sm text-gray-400 truncate">{task.title}</span>
+												</button>
+											))}
+											{showCompletedTasks &&
+												hasCompletedTasks &&
+												completedLinkedTasks.map((task) => (
+													<button
+														key={task.id}
+														onClick={() => handleTaskClick(task.id)}
+														class={cn(
+															'w-full pl-8 pr-3 py-1.5 flex items-center gap-2 transition-colors text-left',
+															selectedTaskId === task.id ? 'bg-dark-700' : 'hover:bg-dark-800'
+														)}
+													>
+														<TaskStatusDot status={task.status} />
+														<span class="flex-1 text-sm text-gray-600 truncate line-through">
+															{task.title}
+														</span>
+													</button>
+												))}
+										</>
+									)}
 								</div>
 							);
 						})

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -324,7 +324,12 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 							const isExpanded = expandedGoals.has(goal.id);
 							const linkedTasks = tasksByGoalId.get(goal.id) ?? [];
 							const activeLinkedTasks = linkedTasks.filter(
-								(t) => t.status !== 'completed' && t.status !== 'cancelled'
+								(t) =>
+									t.status === 'draft' ||
+									t.status === 'pending' ||
+									t.status === 'in_progress' ||
+									t.status === 'review' ||
+									t.status === 'needs_attention'
 							);
 							const completedLinkedTasks = linkedTasks.filter(
 								(t) => t.status === 'completed' || t.status === 'cancelled'

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -12,6 +12,23 @@ import { signal, computed, type Signal, type ReadonlySignal } from '@preact/sign
 import type { NeoTask, RoomGoal, SessionSummary } from '@neokai/shared';
 
 // -------------------------------------------------------
+// localStorage mock
+// -------------------------------------------------------
+
+const storage = new Map<string, string>();
+const mockLocalStorage = {
+	getItem: (key: string) => storage.get(key) ?? null,
+	setItem: (key: string, value: string) => storage.set(key, value),
+	removeItem: (key: string) => storage.delete(key),
+	clear: () => storage.clear(),
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+	value: mockLocalStorage,
+	writable: true,
+});
+
+// -------------------------------------------------------
 // Hoisted mocks
 // -------------------------------------------------------
 
@@ -180,6 +197,7 @@ describe('RoomContextPanel', () => {
 	beforeEach(() => {
 		cleanup();
 		vi.clearAllMocks();
+		storage.clear();
 		initSignals();
 		// Restore default resolved value after clearAllMocks (which clears call history
 		// but not implementations). Required so reordering tests doesn't break the
@@ -354,6 +372,99 @@ describe('RoomContextPanel', () => {
 	it('shows "No goals" when goal list is empty', () => {
 		render(<RoomContextPanel roomId="room-1" />);
 		expect(screen.getByText('No goals')).toBeTruthy();
+	});
+
+	// -- Goals section: completed tasks toggle --
+
+	it('hides completed and cancelled tasks under goals by default', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Completed Task', 'completed'),
+			makeTask('t3', 'Cancelled Task', 'cancelled'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2', 't3'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand the goal
+		fireEvent.click(screen.getByText('My Goal'));
+
+		// Active task should be visible
+		expect(screen.getByText('Active Task')).toBeTruthy();
+		// Completed and cancelled tasks should NOT be visible by default
+		expect(screen.queryByText('Completed Task')).toBeNull();
+		expect(screen.queryByText('Cancelled Task')).toBeNull();
+	});
+
+	it('shows completed tasks when toggle is clicked', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Completed Task', 'completed'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand the goal first
+		fireEvent.click(screen.getByText('My Goal'));
+		expect(screen.queryByText('Completed Task')).toBeNull();
+
+		// Click the show/hide completed tasks toggle button
+		const toggleBtn = screen.getByLabelText('Show completed tasks');
+		fireEvent.click(toggleBtn);
+
+		// Now completed task should be visible
+		expect(screen.getByText('Completed Task')).toBeTruthy();
+	});
+
+	it('hides completed tasks again when toggle is clicked a second time', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Completed Task', 'completed'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand the goal
+		fireEvent.click(screen.getByText('My Goal'));
+
+		// Toggle to show
+		const toggleBtn = screen.getByLabelText('Show completed tasks');
+		fireEvent.click(toggleBtn);
+		expect(screen.getByText('Completed Task')).toBeTruthy();
+
+		// Toggle to hide again
+		fireEvent.click(screen.getByLabelText('Hide completed tasks'));
+		expect(screen.queryByText('Completed Task')).toBeNull();
+	});
+
+	it('completed tasks shown with muted styling (strikethrough and gray text)', () => {
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Done Task', 'completed'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand goal and toggle to show completed
+		fireEvent.click(screen.getByText('My Goal'));
+		fireEvent.click(screen.getByLabelText('Show completed tasks'));
+
+		// The completed task should have strikethrough styling
+		const doneTaskBtn = screen.getByText('Done Task').closest('button');
+		const span = doneTaskBtn?.querySelector('span');
+		expect(span?.className).toContain('line-through');
+		expect(span?.className).toContain('text-gray-600');
+	});
+
+	it('does not show toggle button when goal has no completed tasks', () => {
+		mockTasksSignal.value = [makeTask('t1', 'Active Task', 'in_progress')];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand the goal
+		fireEvent.click(screen.getByText('My Goal'));
+
+		// Toggle button should still be present in header
+		expect(screen.getByLabelText('Show completed tasks')).toBeTruthy();
 	});
 
 	// -- Tasks section (orphan tasks) --

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -467,6 +467,23 @@ describe('RoomContextPanel', () => {
 		expect(screen.getByLabelText('Show completed tasks')).toBeTruthy();
 	});
 
+	it('reads persisted show-completed state from localStorage on mount', () => {
+		// Pre-set localStorage to show completed tasks
+		storage.set('neokai:goals:showCompletedTasks', 'true');
+		mockTasksSignal.value = [
+			makeTask('t1', 'Active Task', 'in_progress'),
+			makeTask('t2', 'Completed Task', 'completed'),
+		];
+		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1', 't2'])];
+		render(<RoomContextPanel roomId="room-1" />);
+
+		// Expand the goal
+		fireEvent.click(screen.getByText('My Goal'));
+
+		// Completed task should be visible immediately because localStorage says so
+		expect(screen.getByText('Completed Task')).toBeTruthy();
+	});
+
 	// -- Tasks section (orphan tasks) --
 
 	it('shows orphan tasks under Active tab by default', () => {

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -455,7 +455,7 @@ describe('RoomContextPanel', () => {
 		expect(span?.className).toContain('text-gray-600');
 	});
 
-	it('does not show toggle button when goal has no completed tasks', () => {
+	it('toggle button is always visible in Goals header even without completed tasks', () => {
 		mockTasksSignal.value = [makeTask('t1', 'Active Task', 'in_progress')];
 		mockGoalsSignal.value = [makeGoal('g1', 'My Goal', ['t1'])];
 		render(<RoomContextPanel roomId="room-1" />);


### PR DESCRIPTION
## Summary
- Hide completed/cancelled tasks under Goals section by default
- Add eye toggle button in Goals header to show/hide completed tasks
- Persist toggle state in localStorage so it remembers user preference
- Show completed tasks with muted styling (strikethrough + gray text) when toggled on

## Test plan
- [x] Unit tests added for toggle behavior
- [x] E2E tests added for toggle visibility and localStorage persistence