### PR TITLE
fix: model switch now always restarts query when queryObject exists

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -723,6 +723,20 @@ export class AgentSession
 		await this.lifecycleManager.restartQuery();
 	}
 
+	/**
+	 * Force-restart the query, preserving the SDK session if possible.
+	 *
+	 * Unlike restartQuery() which defers restart if the queue isn't running,
+	 * this method always stops and restarts the query immediately.
+	 * Preserves pending messages and attempts to resume the SDK session.
+	 *
+	 * Use case: Manual restart from UI to apply model/provider changes
+	 * while preserving conversation history.
+	 */
+	async restart(): Promise<void> {
+		await this.lifecycleManager.restart();
+	}
+
 	// ============================================================================
 	// Rewind Feature (delegated to RewindHandler)
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -52,7 +52,6 @@ export interface ModelSwitchHandlerContext {
 
 	// SDK state
 	readonly queryObject: Query | null;
-	readonly firstMessageReceived: boolean;
 }
 
 /**
@@ -226,6 +225,15 @@ export class ModelSwitchHandler {
 
 				// Update context tracker model
 				contextTracker.setModel(resolvedModel);
+
+				// Emit session.updated event so state-manager and UI know the model changed
+				// This prevents stale model display during the restart window before
+				// the restarted query emits a fresh system:init with the new model
+				await daemonHub.emit('session.updated', {
+					sessionId: session.id,
+					source: 'model-switch',
+					session: { config: session.config },
+				});
 
 				// Restart the query via lifecycle manager
 				// This spawns a new SDK subprocess with the new model configuration

--- a/packages/daemon/src/lib/agent/model-switch-handler.ts
+++ b/packages/daemon/src/lib/agent/model-switch-handler.ts
@@ -102,7 +102,6 @@ export class ModelSwitchHandler {
 			logger,
 			lifecycleManager,
 			queryObject,
-			firstMessageReceived,
 		} = this.ctx;
 
 		try {
@@ -161,9 +160,6 @@ export class ModelSwitchHandler {
 				{ channel: `session:${session.id}` }
 			);
 
-			// Check if query is running AND ProcessTransport is ready
-			const transportReady = firstMessageReceived;
-
 			// Locate the provider instance for the new model.
 			// newProvider is a required string, so detectProviderForModel always receives
 			// an explicit provider — no heuristic fallback is needed.
@@ -179,8 +175,8 @@ export class ModelSwitchHandler {
 				return { success: false, model: session.config.model, error: errMsg };
 			}
 
-			if (!queryObject || !transportReady) {
-				// Query not started yet OR transport not ready - just update config
+			if (!queryObject) {
+				// Query hasn't been created yet - just update config, it will be used when query starts
 				session.config.model = resolvedModel;
 				// newProviderInstance is guaranteed non-null here (we returned early above).
 				session.config.provider = newProviderInstance.id as Provider;
@@ -204,7 +200,12 @@ export class ModelSwitchHandler {
 					session: { config: session.config },
 				});
 			} else {
-				// Query is running - restart it to ensure system:init is regenerated with new model
+				// Query exists - always restart to apply the new model/provider.
+				// We must restart even if firstMessageReceived is false because the SDK
+				// subprocess is already running with the old model. The restart spawns a new
+				// subprocess with the updated config and resumes the conversation if the
+				// SDK session file is still valid.
+				//
 				// FIX: SDK's setModel() doesn't update the cached system:init message,
 				// causing MessageInfoDropdown to show stale model info.
 				// Restarting forces SDK to emit fresh system:init with correct model.

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -140,6 +140,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 	// Reset events
 	'agent.resetRequest': { sessionId: string; restartQuery?: boolean };
 	'agent.reset': { sessionId: string; success: boolean; error?: string };
+	'agent.restart': { sessionId: string; success: boolean; error?: string };
 
 	// Message sending events
 	'message.sendRequest': {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -779,9 +779,17 @@ export function setupSessionHandlers(
 			// Call restart directly - preserves SDK session and pending messages
 			await agentSession.restart();
 
+			// Emit event so StateManager and UI can react to the restart
+			await daemonHub.emit('agent.restart', { sessionId: targetSessionId, success: true });
+
 			return { success: true };
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			await daemonHub.emit('agent.restart', {
+				sessionId: targetSessionId,
+				success: false,
+				error: errorMessage,
+			});
 			return { success: false, error: errorMessage };
 		}
 	});

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -761,6 +761,31 @@ export function setupSessionHandlers(
 		return result;
 	});
 
+	// Handle restarting the query while preserving the SDK session.
+	// Unlike resetQuery which clears pending messages and resets state,
+	// this method preserves pending messages and attempts to resume
+	// the same SDK session for conversation continuity.
+	// Use case: Manual restart from UI to refresh the agent without losing context
+	messageHub.onRequest('session.restart', async (data) => {
+		const { sessionId: targetSessionId } = data as { sessionId: string };
+
+		// Verify session exists
+		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
+		if (!agentSession) {
+			throw new Error('Session not found');
+		}
+
+		try {
+			// Call restart directly - preserves SDK session and pending messages
+			await agentSession.restart();
+
+			return { success: true };
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			return { success: false, error: errorMessage };
+		}
+	});
+
 	// Handle triggering saved messages to be sent (Manual query mode)
 	// Use case: When user wants to manually send all saved messages in Manual mode
 	// ARCHITECTURE: Fire-and-forget via EventBus, AgentSession handles the actual sending

--- a/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/model-switch-handler.test.ts
@@ -384,12 +384,28 @@ describe('ModelSwitchHandler', () => {
 		});
 
 		describe('when transport not ready', () => {
-			it('should update config only when transport not ready', async () => {
+			it('should restart query when queryObject exists even if transport not ready', async () => {
+				// When queryObject exists but firstMessageReceived is false, we still need to
+				// restart because the SDK subprocess is already running with the old model.
+				// Without restart, the new model would not take effect.
 				handler = createHandler({ firstMessageReceived: false });
 				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
 
 				expect(result.success).toBe(true);
 				expect(updateSessionSpy).toHaveBeenCalled();
+				// Restart IS called because queryObject exists - the new model must take effect
+				expect(restartSpy).toHaveBeenCalled();
+			});
+
+			it('should not restart when queryObject does not exist (query not started)', async () => {
+				// Only when query hasn't been created at all should we skip restart.
+				// The new model will be used when the query finally starts.
+				handler = createHandler({ queryObject: null, firstMessageReceived: false });
+				const result = await handler.switchModel(VALID_MODEL, 'anthropic');
+
+				expect(result.success).toBe(true);
+				expect(updateSessionSpy).toHaveBeenCalled();
+				// No restart because queryObject doesn't exist
 				expect(restartSpy).not.toHaveBeenCalled();
 			});
 		});

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -115,6 +115,7 @@ function createMockAgentSession(overrides: Partial<AgentSession> = {}): {
 		getCurrentModel: ReturnType<typeof mock>;
 		handleModelSwitch: ReturnType<typeof mock>;
 		resetQuery: ReturnType<typeof mock>;
+		restart: ReturnType<typeof mock>;
 		handleQueryTrigger: ReturnType<typeof mock>;
 		setMaxThinkingTokens: ReturnType<typeof mock>;
 		setPermissionMode: ReturnType<typeof mock>;
@@ -148,6 +149,7 @@ function createMockAgentSession(overrides: Partial<AgentSession> = {}): {
 		getCurrentModel: mock(() => ({ id: 'claude-sonnet-4-20250514' })),
 		handleModelSwitch: mock(async () => ({ success: true, model: 'claude-opus-4-6' })),
 		resetQuery: mock(async () => ({ success: true })),
+		restart: mock(async () => {}),
 		handleQueryTrigger: mock(async () => ({ triggered: true, count: 1 })),
 		setMaxThinkingTokens: mock(async () => ({ success: true })),
 		setPermissionMode: mock(async () => ({ success: true })),
@@ -1167,6 +1169,46 @@ describe('Session RPC Handlers', () => {
 
 		it('throws error when session not found', async () => {
 			const handler = messageHubData.handlers.get('session.resetQuery');
+			expect(handler).toBeDefined();
+
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);
+
+			await expect(handler!({ sessionId: 'non-existent' }, {})).rejects.toThrow(
+				'Session not found'
+			);
+		});
+	});
+
+	describe('session.restart', () => {
+		it('restarts query and preserves SDK session', async () => {
+			const handler = messageHubData.handlers.get('session.restart');
+			expect(handler).toBeDefined();
+
+			const { agentSession, mocks } = createMockAgentSession();
+			mocks.restart.mockResolvedValueOnce();
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			const result = await handler!({ sessionId: 'session-123' }, {});
+
+			expect(result).toEqual({ success: true });
+			expect(mocks.restart).toHaveBeenCalled();
+		});
+
+		it('returns error when restart fails', async () => {
+			const handler = messageHubData.handlers.get('session.restart');
+			expect(handler).toBeDefined();
+
+			const { agentSession, mocks } = createMockAgentSession();
+			mocks.restart.mockRejectedValueOnce(new Error('Restart failed'));
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
+
+			const result = await handler!({ sessionId: 'session-123' }, {});
+
+			expect(result).toEqual({ success: false, error: 'Restart failed' });
+		});
+
+		it('throws error when session not found', async () => {
+			const handler = messageHubData.handlers.get('session.restart');
 			expect(handler).toBeDefined();
 
 			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);


### PR DESCRIPTION
The previous condition `!queryObject || !transportReady` would skip the restart
when firstMessageReceived was false, even if a query was running. This caused
model switches to not take effect for room task sessions that were waiting for
messages.

Now the condition is simplified to `!queryObject` - if a query exists, we always
restart to apply the new model/provider configuration.

Also added:
- AgentSession.restart() method that calls lifecycleManager.restart() directly
- session.restart RPC handler for manual query restart that preserves SDK session
- Updated unit tests to verify the new behavior
