### PR TITLE
feat: add space session group RPC handlers and SpaceStore signals

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -511,6 +511,11 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		memberId: string;
 		member: import('@neokai/shared').SpaceSessionGroupMember;
 	};
+	'spaceSessionGroup.deleted': {
+		sessionId: string; // 'space:${spaceId}'
+		spaceId: string;
+		groupId: string;
+	};
 
 	// Space workflow definition events (global events - use 'global' as sessionId)
 	// NOTE: namespace is 'spaceWorkflow.*' (not 'space.workflow.*') — matches SpaceStore subscriptions in M5

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -71,6 +71,7 @@ import { setupSpaceExportImportHandlers } from './space-export-import-handlers';
 import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
+import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -364,6 +365,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceRuntimeService,
 		spaceWorkflowRunTaskManagerFactory,
 		deps.daemonHub
+	);
+
+	// Space session group admin handlers
+	setupSpaceSessionGroupHandlers(
+		deps.messageHub,
+		deps.daemonHub,
+		deps.spaceManager,
+		spaceSessionGroupRepo
 	);
 
 	// Provision the Global Spaces Agent session (spaces:global)

--- a/packages/daemon/src/lib/rpc-handlers/space-session-group-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-session-group-handlers.ts
@@ -53,6 +53,9 @@ export function setupSpaceSessionGroupHandlers(
 		if (!params.groupId) throw new Error('groupId is required');
 		if (!params.sessionId) throw new Error('sessionId is required');
 		if (!params.status) throw new Error('status is required');
+		if (!(['active', 'completed', 'failed'] as const).includes(params.status)) {
+			throw new Error('Invalid status: must be one of active, completed, failed');
+		}
 
 		const space = await spaceManager.getSpace(params.spaceId);
 		if (!space) {
@@ -79,7 +82,7 @@ export function setupSpaceSessionGroupHandlers(
 			throw new Error(`Member session ${params.sessionId} not found in group ${params.groupId}`);
 		}
 
-		daemonHub
+		await daemonHub
 			.emit('spaceSessionGroup.memberUpdated', {
 				sessionId: `space:${params.spaceId}`,
 				spaceId: params.spaceId,
@@ -116,6 +119,19 @@ export function setupSpaceSessionGroupHandlers(
 		}
 
 		const deleted = sessionGroupRepo.deleteGroup(params.groupId);
+
+		if (deleted) {
+			await daemonHub
+				.emit('spaceSessionGroup.deleted', {
+					sessionId: `space:${params.spaceId}`,
+					spaceId: params.spaceId,
+					groupId: params.groupId,
+				})
+				.catch((err) => {
+					log.warn('Failed to emit spaceSessionGroup.deleted:', err);
+				});
+		}
+
 		return { deleted };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-session-group-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-session-group-handlers.ts
@@ -1,0 +1,121 @@
+/**
+ * Space Session Group RPC Handlers
+ *
+ * Admin-oriented RPC handlers for session group management:
+ * - space.sessionGroup.list         - List all groups for a space
+ * - space.sessionGroup.updateMember - Force-update a member's status (admin / stuck recovery)
+ * - space.sessionGroup.delete       - Delete a stuck / orphaned group
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { DaemonHub } from '../daemon-hub';
+import type { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
+import type { SpaceManager } from '../space/managers/space-manager';
+import { Logger } from '../logger';
+
+const log = new Logger('space-session-group-handlers');
+
+export function setupSpaceSessionGroupHandlers(
+	messageHub: MessageHub,
+	daemonHub: DaemonHub,
+	spaceManager: SpaceManager,
+	sessionGroupRepo: SpaceSessionGroupRepository
+): void {
+	// ─── space.sessionGroup.list ─────────────────────────────────────────────────
+	messageHub.onRequest('space.sessionGroup.list', async (data) => {
+		const params = data as { spaceId: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const groups = sessionGroupRepo.getGroupsBySpace(params.spaceId);
+		return { groups };
+	});
+
+	// ─── space.sessionGroup.updateMember ─────────────────────────────────────────
+	// Admin operation: force-complete or mark failed a stuck member session.
+	messageHub.onRequest('space.sessionGroup.updateMember', async (data) => {
+		const params = data as {
+			spaceId: string;
+			groupId: string;
+			sessionId: string;
+			status: 'active' | 'completed' | 'failed';
+			role?: string;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.groupId) throw new Error('groupId is required');
+		if (!params.sessionId) throw new Error('sessionId is required');
+		if (!params.status) throw new Error('status is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const group = sessionGroupRepo.getGroup(params.groupId);
+		if (!group) {
+			throw new Error(`Session group not found: ${params.groupId}`);
+		}
+		if (group.spaceId !== params.spaceId) {
+			throw new Error(`Session group ${params.groupId} does not belong to space ${params.spaceId}`);
+		}
+
+		const updateParams: { status: 'active' | 'completed' | 'failed'; role?: string } = {
+			status: params.status,
+		};
+		if (params.role !== undefined) {
+			updateParams.role = params.role;
+		}
+
+		const member = sessionGroupRepo.updateMember(params.groupId, params.sessionId, updateParams);
+		if (!member) {
+			throw new Error(`Member session ${params.sessionId} not found in group ${params.groupId}`);
+		}
+
+		daemonHub
+			.emit('spaceSessionGroup.memberUpdated', {
+				sessionId: `space:${params.spaceId}`,
+				spaceId: params.spaceId,
+				groupId: params.groupId,
+				memberId: member.id,
+				member,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceSessionGroup.memberUpdated:', err);
+			});
+
+		return { member };
+	});
+
+	// ─── space.sessionGroup.delete ───────────────────────────────────────────────
+	// Admin operation: delete a stuck or orphaned session group.
+	messageHub.onRequest('space.sessionGroup.delete', async (data) => {
+		const params = data as { spaceId: string; groupId: string };
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.groupId) throw new Error('groupId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const group = sessionGroupRepo.getGroup(params.groupId);
+		if (!group) {
+			throw new Error(`Session group not found: ${params.groupId}`);
+		}
+		if (group.spaceId !== params.spaceId) {
+			throw new Error(`Session group ${params.groupId} does not belong to space ${params.spaceId}`);
+		}
+
+		const deleted = sessionGroupRepo.deleteGroup(params.groupId);
+		return { deleted };
+	});
+}

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -372,6 +372,12 @@ export class StateManager {
 			});
 		});
 
+		this.eventBus.on('spaceSessionGroup.deleted', (data) => {
+			this.messageHub.event('spaceSessionGroup.deleted', data, {
+				channel: data.sessionId, // 'space:${spaceId}'
+			});
+		});
+
 		// Space workflow definition events (global channel)
 		this.eventBus.on('spaceWorkflow.created', (data) => {
 			this.messageHub.event('spaceWorkflow.created', data, {

--- a/packages/daemon/tests/unit/rpc-handlers/space-session-group-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-session-group-handlers.test.ts
@@ -268,6 +268,17 @@ describe('space.sessionGroup.updateMember', () => {
 		).rejects.toThrow('status is required');
 	});
 
+	it('throws if status is not a valid enum value', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'group-1',
+				sessionId: 'session-1',
+				status: 'bogus',
+			})
+		).rejects.toThrow('Invalid status: must be one of active, completed, failed');
+	});
+
 	it('throws if space not found', async () => {
 		spaceManager = createMockSpaceManager(null);
 		const { hub, handlers: h } = createMockMessageHub();
@@ -401,5 +412,26 @@ describe('space.sessionGroup.delete', () => {
 		await expect(
 			h.get('space.sessionGroup.delete')!({ spaceId: 'space-1', groupId: 'group-1' })
 		).rejects.toThrow('does not belong to space space-1');
+	});
+
+	it('emits spaceSessionGroup.deleted event on successful delete', async () => {
+		await handlers.get('space.sessionGroup.delete')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+		});
+		expect(daemonHub.emit).toHaveBeenCalledWith('spaceSessionGroup.deleted', {
+			sessionId: 'space:space-1',
+			spaceId: 'space-1',
+			groupId: 'group-1',
+		});
+	});
+
+	it('does not emit spaceSessionGroup.deleted when repo returns false', async () => {
+		repo = createMockRepo({ deleteGroup: mock(() => false) });
+		const { hub, handlers: h } = createMockMessageHub();
+		const localDaemonHub = createMockDaemonHub();
+		setupSpaceSessionGroupHandlers(hub, localDaemonHub, spaceManager, repo);
+		await h.get('space.sessionGroup.delete')!({ spaceId: 'space-1', groupId: 'group-1' });
+		expect(localDaemonHub.emit).not.toHaveBeenCalled();
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-session-group-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-session-group-handlers.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for Space Session Group RPC Handlers
+ *
+ * Covers:
+ * - space.sessionGroup.list: happy path, missing spaceId, space not found
+ * - space.sessionGroup.updateMember: happy path, missing params, space/group/member not found,
+ *   cross-space group rejection, memberUpdated event emission, optional role update
+ * - space.sessionGroup.delete: happy path, missing params, space/group not found,
+ *   cross-space group rejection
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { Space, SpaceSessionGroup, SpaceSessionGroupMember } from '@neokai/shared';
+import { setupSpaceSessionGroupHandlers } from '../../../src/lib/rpc-handlers/space-session-group-handlers';
+import type { SpaceManager } from '../../../src/lib/space/managers/space-manager';
+import type { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository';
+import type { DaemonHub } from '../../../src/lib/daemon-hub';
+
+type RequestHandler = (data: unknown) => Promise<unknown>;
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = Date.now();
+
+const mockSpace: Space = {
+	id: 'space-1',
+	workspacePath: '/tmp/test-workspace',
+	name: 'Test Space',
+	description: '',
+	backgroundContext: '',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+const mockMember: SpaceSessionGroupMember = {
+	id: 'member-1',
+	groupId: 'group-1',
+	sessionId: 'session-1',
+	role: 'coder',
+	status: 'active',
+	orderIndex: 0,
+	createdAt: NOW,
+};
+
+const mockGroup: SpaceSessionGroup = {
+	id: 'group-1',
+	spaceId: 'space-1',
+	name: 'task:task-1',
+	status: 'active',
+	members: [mockMember],
+	taskId: 'task-1',
+	createdAt: NOW,
+	updatedAt: NOW,
+};
+
+// ─── Mock helpers ────────────────────────────────────────────────────────────
+
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): DaemonHub {
+	return {
+		emit: mock(async () => {}),
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+}
+
+function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
+	return {
+		getSpace: mock(async () => space),
+	} as unknown as SpaceManager;
+}
+
+function createMockRepo(
+	overrides?: Partial<SpaceSessionGroupRepository>
+): SpaceSessionGroupRepository {
+	return {
+		getGroupsBySpace: mock(() => [mockGroup]),
+		getGroup: mock(() => mockGroup),
+		updateMember: mock(() => mockMember),
+		deleteGroup: mock(() => true),
+		...overrides,
+	} as unknown as SpaceSessionGroupRepository;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('space.sessionGroup.list', () => {
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let repo: SpaceSessionGroupRepository;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		handlers = h;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager();
+		repo = createMockRepo();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+	});
+
+	it('returns all groups for the space', async () => {
+		const result = await handlers.get('space.sessionGroup.list')!({ spaceId: 'space-1' });
+		expect(result).toEqual({ groups: [mockGroup] });
+		expect(repo.getGroupsBySpace).toHaveBeenCalledWith('space-1');
+	});
+
+	it('throws if spaceId is missing', async () => {
+		await expect(handlers.get('space.sessionGroup.list')!({ spaceId: '' })).rejects.toThrow(
+			'spaceId is required'
+		);
+	});
+
+	it('throws if spaceId not provided at all', async () => {
+		await expect(handlers.get('space.sessionGroup.list')!({})).rejects.toThrow(
+			'spaceId is required'
+		);
+	});
+
+	it('throws if space not found', async () => {
+		spaceManager = createMockSpaceManager(null);
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(h.get('space.sessionGroup.list')!({ spaceId: 'bad-id' })).rejects.toThrow(
+			'Space not found: bad-id'
+		);
+	});
+
+	it('returns empty groups array when space has no groups', async () => {
+		repo = createMockRepo({ getGroupsBySpace: mock(() => []) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		const result = await h.get('space.sessionGroup.list')!({ spaceId: 'space-1' });
+		expect(result).toEqual({ groups: [] });
+	});
+});
+
+describe('space.sessionGroup.updateMember', () => {
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let repo: SpaceSessionGroupRepository;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		handlers = h;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager();
+		repo = createMockRepo();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+	});
+
+	it('updates member status and returns updated member', async () => {
+		const completedMember = { ...mockMember, status: 'completed' as const };
+		repo = createMockRepo({ updateMember: mock(() => completedMember) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+
+		const result = await h.get('space.sessionGroup.updateMember')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+			sessionId: 'session-1',
+			status: 'completed',
+		});
+		expect(result).toEqual({ member: completedMember });
+		expect(repo.updateMember).toHaveBeenCalledWith('group-1', 'session-1', { status: 'completed' });
+	});
+
+	it('emits spaceSessionGroup.memberUpdated event', async () => {
+		await handlers.get('space.sessionGroup.updateMember')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+			sessionId: 'session-1',
+			status: 'completed',
+		});
+		expect(daemonHub.emit).toHaveBeenCalledWith('spaceSessionGroup.memberUpdated', {
+			sessionId: 'space:space-1',
+			spaceId: 'space-1',
+			groupId: 'group-1',
+			memberId: mockMember.id,
+			member: mockMember,
+		});
+	});
+
+	it('includes optional role in update when provided', async () => {
+		await handlers.get('space.sessionGroup.updateMember')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+			sessionId: 'session-1',
+			status: 'active',
+			role: 'reviewer',
+		});
+		expect(repo.updateMember).toHaveBeenCalledWith('group-1', 'session-1', {
+			status: 'active',
+			role: 'reviewer',
+		});
+	});
+
+	it('throws if spaceId is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.updateMember')!({
+				groupId: 'group-1',
+				sessionId: 'session-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('spaceId is required');
+	});
+
+	it('throws if groupId is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				sessionId: 'session-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('groupId is required');
+	});
+
+	it('throws if sessionId is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'group-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('sessionId is required');
+	});
+
+	it('throws if status is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'group-1',
+				sessionId: 'session-1',
+			})
+		).rejects.toThrow('status is required');
+	});
+
+	it('throws if space not found', async () => {
+		spaceManager = createMockSpaceManager(null);
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.updateMember')!({
+				spaceId: 'bad-space',
+				groupId: 'group-1',
+				sessionId: 'session-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('Space not found: bad-space');
+	});
+
+	it('throws if group not found', async () => {
+		repo = createMockRepo({ getGroup: mock(() => null) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'bad-group',
+				sessionId: 'session-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('Session group not found: bad-group');
+	});
+
+	it('throws if group belongs to a different space', async () => {
+		repo = createMockRepo({
+			getGroup: mock(() => ({ ...mockGroup, spaceId: 'other-space' })),
+		});
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'group-1',
+				sessionId: 'session-1',
+				status: 'completed',
+			})
+		).rejects.toThrow('does not belong to space space-1');
+	});
+
+	it('throws if member not found in group', async () => {
+		repo = createMockRepo({ updateMember: mock(() => null) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.updateMember')!({
+				spaceId: 'space-1',
+				groupId: 'group-1',
+				sessionId: 'missing-session',
+				status: 'completed',
+			})
+		).rejects.toThrow('Member session missing-session not found in group group-1');
+	});
+});
+
+describe('space.sessionGroup.delete', () => {
+	let handlers: Map<string, RequestHandler>;
+	let daemonHub: DaemonHub;
+	let spaceManager: SpaceManager;
+	let repo: SpaceSessionGroupRepository;
+
+	beforeEach(() => {
+		const { hub, handlers: h } = createMockMessageHub();
+		handlers = h;
+		daemonHub = createMockDaemonHub();
+		spaceManager = createMockSpaceManager();
+		repo = createMockRepo();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+	});
+
+	it('deletes the group and returns deleted: true', async () => {
+		const result = await handlers.get('space.sessionGroup.delete')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+		});
+		expect(result).toEqual({ deleted: true });
+		expect(repo.deleteGroup).toHaveBeenCalledWith('group-1');
+	});
+
+	it('returns deleted: false if repo returns false', async () => {
+		repo = createMockRepo({ deleteGroup: mock(() => false) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		const result = await h.get('space.sessionGroup.delete')!({
+			spaceId: 'space-1',
+			groupId: 'group-1',
+		});
+		expect(result).toEqual({ deleted: false });
+	});
+
+	it('throws if spaceId is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.delete')!({ groupId: 'group-1' })
+		).rejects.toThrow('spaceId is required');
+	});
+
+	it('throws if groupId is missing', async () => {
+		await expect(
+			handlers.get('space.sessionGroup.delete')!({ spaceId: 'space-1' })
+		).rejects.toThrow('groupId is required');
+	});
+
+	it('throws if space not found', async () => {
+		spaceManager = createMockSpaceManager(null);
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.delete')!({ spaceId: 'bad-space', groupId: 'group-1' })
+		).rejects.toThrow('Space not found: bad-space');
+	});
+
+	it('throws if group not found', async () => {
+		repo = createMockRepo({ getGroup: mock(() => null) });
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.delete')!({ spaceId: 'space-1', groupId: 'bad-group' })
+		).rejects.toThrow('Session group not found: bad-group');
+	});
+
+	it('throws if group belongs to a different space', async () => {
+		repo = createMockRepo({
+			getGroup: mock(() => ({ ...mockGroup, spaceId: 'other-space' })),
+		});
+		const { hub, handlers: h } = createMockMessageHub();
+		setupSpaceSessionGroupHandlers(hub, daemonHub, spaceManager, repo);
+		await expect(
+			h.get('space.sessionGroup.delete')!({ spaceId: 'space-1', groupId: 'group-1' })
+		).rejects.toThrow('does not belong to space space-1');
+	});
+});

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -978,6 +978,11 @@ describe('StateManager', () => {
 			expect(eventHandlers.has('spaceAgent.created')).toBe(true);
 			expect(eventHandlers.has('spaceAgent.updated')).toBe(true);
 			expect(eventHandlers.has('spaceAgent.deleted')).toBe(true);
+			// Space session group events (space-scoped channel)
+			expect(eventHandlers.has('spaceSessionGroup.created')).toBe(true);
+			expect(eventHandlers.has('spaceSessionGroup.memberAdded')).toBe(true);
+			expect(eventHandlers.has('spaceSessionGroup.memberUpdated')).toBe(true);
+			expect(eventHandlers.has('spaceSessionGroup.deleted')).toBe(true);
 			// Space workflow definition events
 			expect(eventHandlers.has('spaceWorkflow.created')).toBe(true);
 			expect(eventHandlers.has('spaceWorkflow.updated')).toBe(true);
@@ -1118,6 +1123,74 @@ describe('StateManager', () => {
 				const data = { sessionId: 'space:s-1', spaceId: 's-1', agentId: 'a-1' };
 				eventHandlers.get('spaceAgent.deleted')!(data);
 				expect(mockMessageHub.event).toHaveBeenCalledWith('spaceAgent.deleted', data, {
+					channel: 'space:s-1',
+				});
+			});
+		});
+
+		describe('spaceSessionGroup events (space-scoped channel)', () => {
+			it('should forward spaceSessionGroup.created to space channel', () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+				const data = {
+					sessionId: 'space:s-1',
+					spaceId: 's-1',
+					taskId: 't-1',
+					group: { id: 'g-1', name: 'task:t-1' },
+				};
+				eventHandlers.get('spaceSessionGroup.created')!(data);
+				expect(mockMessageHub.event).toHaveBeenCalledWith('spaceSessionGroup.created', data, {
+					channel: 'space:s-1',
+				});
+			});
+
+			it('should forward spaceSessionGroup.memberAdded to space channel', () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+				const data = {
+					sessionId: 'space:s-1',
+					spaceId: 's-1',
+					groupId: 'g-1',
+					member: {
+						id: 'm-1',
+						groupId: 'g-1',
+						sessionId: 'sess-1',
+						role: 'coder',
+						status: 'active',
+						orderIndex: 0,
+					},
+				};
+				eventHandlers.get('spaceSessionGroup.memberAdded')!(data);
+				expect(mockMessageHub.event).toHaveBeenCalledWith('spaceSessionGroup.memberAdded', data, {
+					channel: 'space:s-1',
+				});
+			});
+
+			it('should forward spaceSessionGroup.memberUpdated to space channel', () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+				const data = {
+					sessionId: 'space:s-1',
+					spaceId: 's-1',
+					groupId: 'g-1',
+					memberId: 'm-1',
+					member: {
+						id: 'm-1',
+						groupId: 'g-1',
+						sessionId: 'sess-1',
+						role: 'coder',
+						status: 'completed',
+						orderIndex: 0,
+					},
+				};
+				eventHandlers.get('spaceSessionGroup.memberUpdated')!(data);
+				expect(mockMessageHub.event).toHaveBeenCalledWith('spaceSessionGroup.memberUpdated', data, {
+					channel: 'space:s-1',
+				});
+			});
+
+			it('should forward spaceSessionGroup.deleted to space channel', () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+				const data = { sessionId: 'space:s-1', spaceId: 's-1', groupId: 'g-1' };
+				eventHandlers.get('spaceSessionGroup.deleted')!(data);
+				expect(mockMessageHub.event).toHaveBeenCalledWith('spaceSessionGroup.deleted', data, {
 					channel: 'space:s-1',
 				});
 			});

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -262,6 +262,7 @@ describe('SpaceStore — space selection', () => {
 		expect(spaceStore.workflowRuns.value).toEqual([]);
 		expect(spaceStore.agents.value).toEqual([]);
 		expect(spaceStore.workflows.value).toEqual([]);
+		expect(spaceStore.sessionGroups.value).toEqual([]);
 	});
 
 	it('is a no-op when selecting the same space', async () => {
@@ -366,6 +367,10 @@ describe('SpaceStore — event subscriptions auto-cleanup', () => {
 		expect(mockEventHandlers.has('spaceWorkflow.created')).toBe(true);
 		expect(mockEventHandlers.has('spaceWorkflow.updated')).toBe(true);
 		expect(mockEventHandlers.has('spaceWorkflow.deleted')).toBe(true);
+		expect(mockEventHandlers.has('spaceSessionGroup.created')).toBe(true);
+		expect(mockEventHandlers.has('spaceSessionGroup.memberAdded')).toBe(true);
+		expect(mockEventHandlers.has('spaceSessionGroup.memberUpdated')).toBe(true);
+		expect(mockEventHandlers.has('spaceSessionGroup.deleted')).toBe(true);
 	});
 
 	it('removes event handlers on clearSpace()', async () => {
@@ -1334,5 +1339,36 @@ describe('SpaceStore — spaceSessionGroup events', () => {
 		});
 
 		expect(spaceStore.sessionGroups.value[0].members[0].status).toBe('active');
+	});
+
+	it('removes group on spaceSessionGroup.deleted', () => {
+		const g1 = makeSessionGroup('g1', 'task-1');
+		const g2 = makeSessionGroup('g2', 'task-2');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group: g1 });
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-2', group: g2 });
+		expect(spaceStore.sessionGroups.value).toHaveLength(2);
+
+		fireMockEvent('spaceSessionGroup.deleted', { spaceId: 'space-1', groupId: 'g1' });
+
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
+		expect(spaceStore.sessionGroups.value[0].id).toBe('g2');
+	});
+
+	it('ignores spaceSessionGroup.deleted from other spaces', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		fireMockEvent('spaceSessionGroup.deleted', { spaceId: 'space-other', groupId: 'g1' });
+
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
+	});
+
+	it('is a no-op when spaceSessionGroup.deleted targets unknown groupId', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		fireMockEvent('spaceSessionGroup.deleted', { spaceId: 'space-1', groupId: 'unknown-group' });
+
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
 	});
 });

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -12,7 +12,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Space, SpaceTask, SpaceWorkflowRun, SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+import type {
+	Space,
+	SpaceTask,
+	SpaceWorkflowRun,
+	SpaceAgent,
+	SpaceWorkflow,
+	SpaceSessionGroup,
+	SpaceSessionGroupMember,
+} from '@neokai/shared';
 
 // -------------------------------------------------------
 // Mocks — declared before imports so vi.mock hoisting works
@@ -98,6 +106,36 @@ function makeWorkflow(id: string): SpaceWorkflow {
 	};
 }
 
+function makeSessionGroupMember(
+	id: string,
+	groupId: string,
+	sessionId: string
+): SpaceSessionGroupMember {
+	return {
+		id,
+		groupId,
+		sessionId,
+		role: 'coder',
+		status: 'active',
+		orderIndex: 0,
+		createdAt: Date.now(),
+	};
+}
+
+function makeSessionGroup(id: string, taskId?: string): SpaceSessionGroup {
+	const member = makeSessionGroupMember(`${id}-m1`, id, `session-${id}`);
+	return {
+		id,
+		spaceId: 'space-1',
+		name: `task:${taskId ?? id}`,
+		status: 'active',
+		members: [member],
+		taskId,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
 function makeMockHub() {
 	return {
 		joinChannel: vi.fn(),
@@ -126,6 +164,7 @@ function makeMockHub() {
 			}
 			if (method === 'spaceAgent.list') return { agents: [] };
 			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			if (method === 'space.sessionGroup.list') return { groups: [] as SpaceSessionGroup[] };
 			// Daemon returns Space directly (not wrapped)
 			if (method === 'space.update') return makeSpace();
 			// Daemon returns SpaceTask directly (not wrapped)
@@ -1048,5 +1087,252 @@ describe('SpaceStore — refresh', () => {
 		await spaceStore.refresh();
 
 		expect(mockHub.request).not.toHaveBeenCalledWith('space.overview', expect.anything());
+	});
+});
+
+// -------------------------------------------------------
+// Session Groups
+// -------------------------------------------------------
+
+describe('SpaceStore — sessionGroups signal', () => {
+	beforeEach(async () => {
+		await resetStore();
+		resetGlobalListState();
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it('starts empty before space selected', () => {
+		expect(spaceStore.sessionGroups.value).toEqual([]);
+	});
+
+	it('clears sessionGroups when space deselected', async () => {
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview')
+				return { space: makeSpace(), tasks: [], workflowRuns: [], sessions: [] };
+			if (method === 'space.sessionGroup.list')
+				return { groups: [makeSessionGroup('g1', 'task-1')] as SpaceSessionGroup[] };
+			if (method === 'spaceAgent.list') return { agents: [] };
+			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
+
+		await spaceStore.clearSpace();
+		expect(spaceStore.sessionGroups.value).toEqual([]);
+	});
+
+	it('populates sessionGroups from space.sessionGroup.list on initial fetch', async () => {
+		const g1 = makeSessionGroup('g1', 'task-1');
+		const g2 = makeSessionGroup('g2', 'task-2');
+
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview')
+				return { space: makeSpace(), tasks: [], workflowRuns: [], sessions: [] };
+			if (method === 'space.sessionGroup.list') return { groups: [g1, g2] as SpaceSessionGroup[] };
+			if (method === 'spaceAgent.list') return { agents: [] };
+			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.sessionGroups.value).toEqual([g1, g2]);
+	});
+
+	it('keeps sessionGroups empty when space.sessionGroup.list RPC fails', async () => {
+		// The default mockHub.request returns { groups: [] as SpaceSessionGroup[] }
+		// Simulate the sessionGroup.list call throwing — should not propagate
+		const originalImpl = mockHub.request.getMockImplementation();
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.sessionGroup.list') throw new Error('RPC failure');
+			return originalImpl ? originalImpl(method) : {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.sessionGroups.value).toEqual([]);
+	});
+});
+
+describe('SpaceStore — sessionGroupsByTask computed', () => {
+	beforeEach(async () => {
+		await resetStore();
+		resetGlobalListState();
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it('returns empty map when no groups loaded', () => {
+		expect(spaceStore.sessionGroupsByTask.value.size).toBe(0);
+	});
+
+	it('maps taskId -> groups array', async () => {
+		const g1 = makeSessionGroup('g1', 'task-1');
+		const g2 = makeSessionGroup('g2', 'task-2');
+		const g3 = makeSessionGroup('g3', 'task-1'); // same task
+
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview')
+				return { space: makeSpace(), tasks: [], workflowRuns: [], sessions: [] };
+			if (method === 'space.sessionGroup.list')
+				return { groups: [g1, g2, g3] as SpaceSessionGroup[] };
+			if (method === 'spaceAgent.list') return { agents: [] };
+			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		const map = spaceStore.sessionGroupsByTask.value;
+
+		expect(map.get('task-1')).toEqual([g1, g3]);
+		expect(map.get('task-2')).toEqual([g2]);
+	});
+
+	it('ignores groups without taskId in the map', async () => {
+		const gWithTask = makeSessionGroup('g1', 'task-1');
+		const gNoTask = makeSessionGroup('g2'); // no taskId
+
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview')
+				return { space: makeSpace(), tasks: [], workflowRuns: [], sessions: [] };
+			if (method === 'space.sessionGroup.list')
+				return { groups: [gWithTask, gNoTask] as SpaceSessionGroup[] };
+			if (method === 'spaceAgent.list') return { agents: [] };
+			if (method === 'spaceWorkflow.list') return { workflows: [] };
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		const map = spaceStore.sessionGroupsByTask.value;
+
+		expect(map.has('g2')).toBe(false);
+		expect(map.get('task-1')).toEqual([gWithTask]);
+		expect(map.size).toBe(1);
+	});
+});
+
+describe('SpaceStore — spaceSessionGroup events', () => {
+	beforeEach(async () => {
+		await resetStore();
+		resetGlobalListState();
+		// Select a space with no initial groups
+		await spaceStore.selectSpace('space-1');
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it('appends new group on spaceSessionGroup.created', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', {
+			spaceId: 'space-1',
+			taskId: 'task-1',
+			group,
+		});
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
+		expect(spaceStore.sessionGroups.value[0]).toEqual(group);
+	});
+
+	it('does not duplicate group on repeated spaceSessionGroup.created', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+		expect(spaceStore.sessionGroups.value).toHaveLength(1);
+	});
+
+	it('ignores spaceSessionGroup.created from other spaces', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-other', taskId: 'task-1', group });
+		expect(spaceStore.sessionGroups.value).toHaveLength(0);
+	});
+
+	it('adds member on spaceSessionGroup.memberAdded', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		const newMember = makeSessionGroupMember('m2', 'g1', 'session-2');
+		fireMockEvent('spaceSessionGroup.memberAdded', {
+			spaceId: 'space-1',
+			groupId: 'g1',
+			member: newMember,
+		});
+
+		const updated = spaceStore.sessionGroups.value[0];
+		expect(updated.members).toHaveLength(2);
+		expect(updated.members[1]).toEqual(newMember);
+	});
+
+	it('does not duplicate member on repeated memberAdded', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		const member = group.members[0];
+		fireMockEvent('spaceSessionGroup.memberAdded', {
+			spaceId: 'space-1',
+			groupId: 'g1',
+			member,
+		});
+		// Same member added again — should not duplicate
+		fireMockEvent('spaceSessionGroup.memberAdded', {
+			spaceId: 'space-1',
+			groupId: 'g1',
+			member,
+		});
+
+		expect(spaceStore.sessionGroups.value[0].members).toHaveLength(1);
+	});
+
+	it('ignores memberAdded for unknown groupId', () => {
+		const newMember = makeSessionGroupMember('m1', 'unknown-group', 'session-1');
+		fireMockEvent('spaceSessionGroup.memberAdded', {
+			spaceId: 'space-1',
+			groupId: 'unknown-group',
+			member: newMember,
+		});
+		// No groups — nothing should throw
+		expect(spaceStore.sessionGroups.value).toHaveLength(0);
+	});
+
+	it('updates member status on spaceSessionGroup.memberUpdated', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		const originalMember = group.members[0];
+		const updatedMember = { ...originalMember, status: 'completed' as const };
+		fireMockEvent('spaceSessionGroup.memberUpdated', {
+			spaceId: 'space-1',
+			groupId: 'g1',
+			memberId: originalMember.id,
+			member: updatedMember,
+		});
+
+		const updatedGroup = spaceStore.sessionGroups.value[0];
+		expect(updatedGroup.members[0].status).toBe('completed');
+	});
+
+	it('ignores memberUpdated for unknown memberId', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		fireMockEvent('spaceSessionGroup.memberUpdated', {
+			spaceId: 'space-1',
+			groupId: 'g1',
+			memberId: 'unknown-member',
+			member: { ...group.members[0], status: 'completed' },
+		});
+
+		// Group unchanged
+		expect(spaceStore.sessionGroups.value[0].members[0].status).toBe('active');
+	});
+
+	it('ignores memberUpdated from other spaces', () => {
+		const group = makeSessionGroup('g1', 'task-1');
+		fireMockEvent('spaceSessionGroup.created', { spaceId: 'space-1', taskId: 'task-1', group });
+
+		fireMockEvent('spaceSessionGroup.memberUpdated', {
+			spaceId: 'space-other',
+			groupId: 'g1',
+			memberId: group.members[0].id,
+			member: { ...group.members[0], status: 'completed' },
+		});
+
+		expect(spaceStore.sessionGroups.value[0].members[0].status).toBe('active');
 	});
 });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -694,6 +694,18 @@ class SpaceStore {
 		});
 		this.cleanupFunctions.push(unsubMemberUpdated);
 
+		// --- spaceSessionGroup.deleted ---
+		const unsubGroupDeleted = hub.onEvent<{
+			sessionId: string;
+			spaceId: string;
+			groupId: string;
+		}>('spaceSessionGroup.deleted', (event) => {
+			if (event.spaceId === spaceId) {
+				this.sessionGroups.value = this.sessionGroups.value.filter((g) => g.id !== event.groupId);
+			}
+		});
+		this.cleanupFunctions.push(unsubGroupDeleted);
+
 		// Fetch initial state via RPC
 		await this.fetchInitialState(hub, spaceId);
 	}

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -14,6 +14,7 @@
  * - workflowRuns: SpaceWorkflowRun list for the space
  * - agents: SpaceAgent list for the space
  * - workflows: SpaceWorkflow list for the space
+ * - sessionGroups: SpaceSessionGroup list for the space (real-time via events)
  * - runtimeState: Runtime state (running/paused/stopped)
  * - loading: Loading state
  * - error: Error state
@@ -26,6 +27,8 @@ import type {
 	SpaceWorkflowRun,
 	SpaceAgent,
 	SpaceWorkflow,
+	SpaceSessionGroup,
+	SpaceSessionGroupMember,
 	RuntimeState,
 	CreateSpaceTaskParams,
 	UpdateSpaceTaskParams,
@@ -84,6 +87,9 @@ class SpaceStore {
 	/** Runtime state for this space */
 	readonly runtimeState = signal<RuntimeState | null>(null);
 
+	/** Session groups for this space */
+	readonly sessionGroups = signal<SpaceSessionGroup[]>([]);
+
 	/** Loading state */
 	readonly loading = signal<boolean>(false);
 
@@ -116,6 +122,18 @@ class SpaceStore {
 
 	/** Tasks not associated with any workflow run */
 	readonly standaloneTasks = computed(() => this.tasks.value.filter((t) => !t.workflowRunId));
+
+	/** Session groups indexed by taskId for O(1) lookup */
+	readonly sessionGroupsByTask = computed(() => {
+		const map = new Map<string, SpaceSessionGroup[]>();
+		for (const group of this.sessionGroups.value) {
+			if (group.taskId) {
+				const existing = map.get(group.taskId) ?? [];
+				map.set(group.taskId, [...existing, group]);
+			}
+		}
+		return map;
+	});
 
 	// ========================================
 	// Private State
@@ -355,6 +373,7 @@ class SpaceStore {
 		this.workflowRuns.value = [];
 		this.agents.value = [];
 		this.workflows.value = [];
+		this.sessionGroups.value = [];
 		this.runtimeState.value = null;
 		this.error.value = null;
 
@@ -603,6 +622,78 @@ class SpaceStore {
 		});
 		this.cleanupFunctions.push(unsubWorkflowDeleted);
 
+		// --- spaceSessionGroup.created ---
+		const unsubGroupCreated = hub.onEvent<{
+			sessionId: string;
+			spaceId: string;
+			taskId: string;
+			group: SpaceSessionGroup;
+		}>('spaceSessionGroup.created', (event) => {
+			if (event.spaceId === spaceId) {
+				const exists = this.sessionGroups.value.some((g) => g.id === event.group.id);
+				if (!exists) {
+					this.sessionGroups.value = [...this.sessionGroups.value, event.group];
+				}
+			}
+		});
+		this.cleanupFunctions.push(unsubGroupCreated);
+
+		// --- spaceSessionGroup.memberAdded ---
+		const unsubMemberAdded = hub.onEvent<{
+			sessionId: string;
+			spaceId: string;
+			groupId: string;
+			member: SpaceSessionGroupMember;
+		}>('spaceSessionGroup.memberAdded', (event) => {
+			if (event.spaceId === spaceId) {
+				const idx = this.sessionGroups.value.findIndex((g) => g.id === event.groupId);
+				if (idx >= 0) {
+					const group = this.sessionGroups.value[idx];
+					const memberExists = group.members.some((m) => m.id === event.member.id);
+					if (!memberExists) {
+						const updatedGroup = { ...group, members: [...group.members, event.member] };
+						this.sessionGroups.value = [
+							...this.sessionGroups.value.slice(0, idx),
+							updatedGroup,
+							...this.sessionGroups.value.slice(idx + 1),
+						];
+					}
+				}
+			}
+		});
+		this.cleanupFunctions.push(unsubMemberAdded);
+
+		// --- spaceSessionGroup.memberUpdated ---
+		const unsubMemberUpdated = hub.onEvent<{
+			sessionId: string;
+			spaceId: string;
+			groupId: string;
+			memberId: string;
+			member: SpaceSessionGroupMember;
+		}>('spaceSessionGroup.memberUpdated', (event) => {
+			if (event.spaceId === spaceId) {
+				const idx = this.sessionGroups.value.findIndex((g) => g.id === event.groupId);
+				if (idx >= 0) {
+					const group = this.sessionGroups.value[idx];
+					const memberIdx = group.members.findIndex((m) => m.id === event.memberId);
+					if (memberIdx >= 0) {
+						const updatedMembers = [
+							...group.members.slice(0, memberIdx),
+							event.member,
+							...group.members.slice(memberIdx + 1),
+						];
+						const updatedGroup = { ...group, members: updatedMembers };
+						this.sessionGroups.value = [
+							...this.sessionGroups.value.slice(0, idx),
+							updatedGroup,
+							...this.sessionGroups.value.slice(idx + 1),
+						];
+					}
+				}
+			}
+		});
+		this.cleanupFunctions.push(unsubMemberUpdated);
+
 		// Fetch initial state via RPC
 		await this.fetchInitialState(hub, spaceId);
 	}
@@ -630,8 +721,12 @@ class SpaceStore {
 		this.tasks.value = overview.tasks ?? [];
 		this.workflowRuns.value = overview.workflowRuns ?? [];
 
-		// Fetch agents and workflows in parallel
-		await Promise.all([this.fetchAgents(hub, spaceId), this.fetchWorkflows(hub, spaceId)]);
+		// Fetch agents, workflows, and session groups in parallel
+		await Promise.all([
+			this.fetchAgents(hub, spaceId),
+			this.fetchWorkflows(hub, spaceId),
+			this.fetchSessionGroups(hub, spaceId),
+		]);
 	}
 
 	/**
@@ -665,6 +760,23 @@ class SpaceStore {
 			this.workflows.value = result?.workflows ?? [];
 		} catch (err) {
 			logger.error('Failed to fetch workflows:', err);
+		}
+	}
+
+	/**
+	 * Fetch session groups for the space
+	 */
+	private async fetchSessionGroups(
+		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+		spaceId: string
+	): Promise<void> {
+		try {
+			const result = await hub.request<{ groups: SpaceSessionGroup[] }>('space.sessionGroup.list', {
+				spaceId,
+			});
+			this.sessionGroups.value = result?.groups ?? [];
+		} catch (err) {
+			logger.error('Failed to fetch session groups:', err);
 		}
 	}
 


### PR DESCRIPTION
- Add space.sessionGroup.list, space.sessionGroup.updateMember, and
  space.sessionGroup.delete RPC handlers in daemon for admin operations
- Register handlers in rpc-handlers/index.ts
- Add sessionGroups signal and sessionGroupsByTask computed to SpaceStore
- Subscribe to spaceSessionGroup.created/memberAdded/memberUpdated events
- Fetch initial session groups via space.sessionGroup.list on space select
- Clear sessionGroups on space deselect
- 23 daemon unit tests + 20 web store tests for new behavior
