### PR TITLE
feat: wire room.tick handler into RoomRuntimeService and fix stopRuntime bug

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -10,7 +10,10 @@
 
 import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
 import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
+import type { JobQueueProcessor } from '../../../storage/job-queue-processor';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import { ROOM_TICK } from '../../job-queue-constants';
+import { createRoomTickHandler } from '../../job-handlers/room-tick.handler';
 import { generateUUID, MAX_CONCURRENT_GROUPS_LIMIT, MAX_REVIEW_ROUNDS_LIMIT } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
@@ -54,6 +57,11 @@ export interface RoomRuntimeServiceConfig {
 	 * instead of using in-process timers.
 	 */
 	jobQueue?: JobQueueRepository;
+	/**
+	 * Job processor used to register the room.tick handler.
+	 * Must be provided for the job-queue-based tick loop to function.
+	 */
+	jobProcessor?: JobQueueProcessor;
 }
 
 export class RoomRuntimeService {
@@ -65,6 +73,14 @@ export class RoomRuntimeService {
 	constructor(private ctx: RoomRuntimeServiceConfig) {}
 
 	async start(): Promise<void> {
+		// Register the room.tick handler synchronously before any async work so that
+		// no pending tick job is dequeued without a handler when jobProcessor starts.
+		if (this.ctx.jobProcessor && this.ctx.jobQueue) {
+			this.ctx.jobProcessor.register(
+				ROOM_TICK,
+				createRoomTickHandler((roomId) => this.runtimes.get(roomId) ?? null, this.ctx.jobQueue)
+			);
+		}
 		this.subscribeToEvents();
 		await this.initializeExistingRooms();
 		log.info('RoomRuntimeService started');
@@ -134,6 +150,7 @@ export class RoomRuntimeService {
 		const runtime = this.runtimes.get(roomId);
 		if (!runtime) return false;
 		runtime.stop();
+		this.runtimes.delete(roomId);
 		return true;
 	}
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -62,8 +62,7 @@ import { SpaceAgentRepository } from '../../storage/repositories/space-agent-rep
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import { SpaceSessionGroupRepository } from '../../storage/repositories/space-session-group-repository';
-import { ROOM_TICK } from '../job-queue-constants';
-import { createRoomTickHandler, enqueueRoomTick } from '../job-handlers/room-tick.handler';
+import { enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -172,18 +171,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultModel: deps.config.defaultModel,
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
 		reactiveDb: deps.reactiveDb,
-		// Pass the job queue so each RoomRuntime schedules ticks via enqueueRoomTick.
 		jobQueue: deps.jobQueue,
+		jobProcessor: deps.jobProcessor,
 	});
-	// Register room.tick job handler before starting the service so no tick jobs
-	// fired during recovery are picked up without a handler.
-	deps.jobProcessor.register(
-		ROOM_TICK,
-		createRoomTickHandler(
-			(roomId) => roomRuntimeService.getRuntime(roomId) ?? undefined,
-			deps.jobQueue
-		)
-	);
 
 	// Seed an initial room.tick job for every room after startup, and for each
 	// newly created room. The handler's finally block keeps the loop going; this

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, it, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,
 } from '../../../src/lib/room/runtime/room-runtime-service';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { createRoomTickHandler } from '../../../src/lib/job-handlers/room-tick.handler';
 import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
 import type { RoomRuntime } from '../../../src/lib/room/runtime/room-runtime';
+
+const CREATE_TABLE_SQL = `
+	CREATE TABLE IF NOT EXISTS job_queue (
+		id TEXT PRIMARY KEY,
+		queue TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'pending'
+			CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+		payload TEXT NOT NULL DEFAULT '{}',
+		result TEXT,
+		error TEXT,
+		priority INTEGER NOT NULL DEFAULT 0,
+		max_retries INTEGER NOT NULL DEFAULT 3,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		run_at INTEGER NOT NULL,
+		created_at INTEGER NOT NULL,
+		started_at INTEGER,
+		completed_at INTEGER
+	);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status);
+`;
 
 /** Minimal daemonHub mock that supports on() subscriptions */
 function makeDaemonHub() {
@@ -153,5 +177,57 @@ describe('RoomRuntimeService.startRuntime()', () => {
 	it('returns false when the room does not exist', () => {
 		const service = new RoomRuntimeService(makeConfig());
 		expect(service.startRuntime('non-existent')).toBe(false);
+	});
+});
+
+describe('stopRuntime() + room.tick handler interaction', () => {
+	it('tick handler returns { skipped, reason } for a room whose runtime was deleted by stopRuntime()', async () => {
+		// Set up an in-memory job queue so we can build a real handler
+		const db = new Database(':memory:');
+		db.exec(CREATE_TABLE_SQL);
+		const jobQueue = new JobQueueRepository(db as never);
+
+		const service = new RoomRuntimeService(makeConfig());
+
+		// Inject a running runtime into the map
+		const mockRuntime = {
+			stop: () => {},
+			getState: () => 'running',
+		} as unknown as RoomRuntime;
+		(service as unknown as { runtimes: Map<string, RoomRuntime> }).runtimes.set(
+			'room-stop',
+			mockRuntime
+		);
+
+		// Stop the runtime — this deletes it from the map
+		service.stopRuntime('room-stop');
+		expect(service.getRuntime('room-stop')).toBeNull();
+
+		// Build the handler using the same runtime-lookup closure as RoomRuntimeService.start()
+		const handler = createRoomTickHandler((roomId) => service.getRuntime(roomId), jobQueue);
+
+		// Simulate a tick job that was already in-flight when stopRuntime() was called
+		const job = {
+			id: 'test-tick-job',
+			queue: ROOM_TICK,
+			status: 'processing' as const,
+			payload: { roomId: 'room-stop' },
+			result: null,
+			error: null,
+			priority: 0,
+			maxRetries: 0,
+			retryCount: 0,
+			runAt: Date.now(),
+			createdAt: Date.now(),
+			startedAt: Date.now(),
+			completedAt: null,
+		};
+
+		const result = await handler(job);
+
+		// Handler must skip and not re-schedule — the loop is terminated
+		expect(result).toEqual({ skipped: true, reason: 'not running' });
+		const pending = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(pending).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+	RoomRuntimeService,
+	type RoomRuntimeServiceConfig,
+} from '../../../src/lib/room/runtime/room-runtime-service';
+import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
+import type { RoomRuntime } from '../../../src/lib/room/runtime/room-runtime';
+
+/** Minimal daemonHub mock that supports on() subscriptions */
+function makeDaemonHub() {
+	return {
+		on: () => () => {},
+	};
+}
+
+/** Minimal roomManager mock with no rooms */
+function makeRoomManager() {
+	return {
+		listRooms: () => [],
+		getRoom: () => null,
+	};
+}
+
+/** Minimal jobProcessor mock that records registered handler names */
+function makeJobProcessor() {
+	const registered: string[] = [];
+	return {
+		registered,
+		register: (name: string) => {
+			registered.push(name);
+		},
+	};
+}
+
+function makeConfig(overrides: Partial<RoomRuntimeServiceConfig> = {}): RoomRuntimeServiceConfig {
+	return {
+		db: {} as never,
+		messageHub: {} as never,
+		daemonHub: makeDaemonHub() as never,
+		getApiKey: async () => null,
+		roomManager: makeRoomManager() as never,
+		sessionManager: {} as never,
+		defaultWorkspacePath: '/tmp',
+		defaultModel: 'test-model',
+		getGlobalSettings: () => ({}) as never,
+		reactiveDb: {} as never,
+		...overrides,
+	};
+}
+
+describe('RoomRuntimeService - handler registration', () => {
+	it('registers room.tick handler on start() when jobProcessor and jobQueue are provided', async () => {
+		const jobProcessor = makeJobProcessor();
+		const jobQueue = {
+			listJobs: () => [],
+			enqueue: () => ({
+				id: 'j1',
+				queue: ROOM_TICK,
+				status: 'pending',
+				payload: {},
+				result: null,
+				error: null,
+				priority: 0,
+				maxRetries: 0,
+				retryCount: 0,
+				runAt: 0,
+				createdAt: 0,
+				startedAt: null,
+				completedAt: null,
+			}),
+		};
+
+		const service = new RoomRuntimeService(
+			makeConfig({ jobProcessor: jobProcessor as never, jobQueue: jobQueue as never })
+		);
+
+		await service.start();
+
+		expect(jobProcessor.registered).toContain(ROOM_TICK);
+	});
+
+	it('does NOT register room.tick handler on start() when jobProcessor is absent', async () => {
+		const service = new RoomRuntimeService(makeConfig());
+
+		// Should not throw even without jobProcessor
+		await service.start();
+		// No assertion needed — just verifying no error is thrown
+	});
+
+	it('does NOT register room.tick handler when jobQueue is absent', async () => {
+		const jobProcessor = makeJobProcessor();
+
+		const service = new RoomRuntimeService(makeConfig({ jobProcessor: jobProcessor as never }));
+
+		await service.start();
+
+		expect(jobProcessor.registered).not.toContain(ROOM_TICK);
+	});
+});
+
+describe('RoomRuntimeService.stopRuntime()', () => {
+	let service: RoomRuntimeService;
+
+	beforeEach(() => {
+		service = new RoomRuntimeService(makeConfig());
+	});
+
+	it('returns false when runtime does not exist', () => {
+		expect(service.stopRuntime('non-existent')).toBe(false);
+	});
+
+	it('calls stop() on the runtime and removes it from the runtimes map', () => {
+		let stopped = false;
+		const mockRuntime = {
+			stop: () => {
+				stopped = true;
+			},
+			getState: () => 'running',
+		} as unknown as RoomRuntime;
+
+		// Inject directly into the private map
+		(service as unknown as { runtimes: Map<string, RoomRuntime> }).runtimes.set(
+			'room-1',
+			mockRuntime
+		);
+
+		const result = service.stopRuntime('room-1');
+
+		expect(result).toBe(true);
+		expect(stopped).toBe(true);
+		// Runtime must be removed so heartbeat liveness check works correctly
+		expect(service.getRuntime('room-1')).toBeNull();
+	});
+
+	it('returns false on a second stopRuntime() call after the first removes the runtime', () => {
+		const mockRuntime = {
+			stop: () => {},
+			getState: () => 'running',
+		} as unknown as RoomRuntime;
+
+		(service as unknown as { runtimes: Map<string, RoomRuntime> }).runtimes.set(
+			'room-2',
+			mockRuntime
+		);
+
+		service.stopRuntime('room-2');
+		// Second call: runtime is already gone
+		expect(service.stopRuntime('room-2')).toBe(false);
+	});
+});
+
+describe('RoomRuntimeService.startRuntime()', () => {
+	it('returns false when the room does not exist', () => {
+		const service = new RoomRuntimeService(makeConfig());
+		expect(service.startRuntime('non-existent')).toBe(false);
+	});
+});


### PR DESCRIPTION
- Add `jobProcessor` to `RoomRuntimeServiceConfig`
- In `start()`, register the `room.tick` handler on `jobProcessor` before any
  async work (before subscribeToEvents/initializeExistingRooms), ensuring it
  is registered before `jobProcessor.start()` per the startup ordering
- Fix `stopRuntime()`: call `this.runtimes.delete(roomId)` after `runtime.stop()`
  so the heartbeat liveness check sees the runtime as gone
- Move handler registration out of `rpc-handlers/index.ts` and into
  `RoomRuntimeService.start()`, passing `jobProcessor` via config
- Add 7 unit tests verifying handler registration and stopRuntime fix
