### PR TITLE
fix: enqueueRoomTick replaces pending tick when new request is sooner

### DIFF
--- a/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
@@ -12,11 +12,15 @@ export const DEFAULT_TICK_INTERVAL_MS = 30_000;
 export type GetRuntimeForRoom = (roomId: string) => RoomRuntime | null | undefined;
 
 /**
- * Enqueues a room.tick job for a room if no pending tick job already exists for it.
- * Deduplication is by roomId — only one pending tick per room is allowed.
+ * Enqueues a room.tick job for a room, maintaining at most one pending tick per room.
  *
- * Uses a high limit (10_000) to safely cover deployments with thousands of rooms
- * while remaining bounded. At most one pending tick exists per room in steady state.
+ * When a pending tick already exists for the room:
+ * - If it will run at or before the requested time, keep it (no-op).
+ * - If the new request is sooner (e.g. an immediate tick triggered by goal creation),
+ *   delete the stale pending tick and enqueue a new one with the earlier runAt.
+ *
+ * This ensures event-driven ticks (scheduleTick with delay=0) are never silently
+ * dropped by a slower periodic tick that happens to be pending.
  */
 export function enqueueRoomTick(
 	roomId: string,
@@ -24,14 +28,22 @@ export function enqueueRoomTick(
 	delayMs: number = DEFAULT_TICK_INTERVAL_MS
 ): void {
 	const existing = jobQueue.listJobs({ queue: ROOM_TICK, status: ['pending'], limit: 10_000 });
-	const hasPending = existing.some((j) => (j.payload as { roomId?: string }).roomId === roomId);
-	if (hasPending) return;
+	const pendingJob = existing.find((j) => (j.payload as { roomId?: string }).roomId === roomId);
+
+	const desiredRunAt = Date.now() + delayMs;
+
+	if (pendingJob) {
+		// Existing tick will fire sooner or at the same time — keep it
+		if (pendingJob.runAt <= desiredRunAt) return;
+		// New request is sooner — replace the stale tick
+		jobQueue.deleteJob(pendingJob.id);
+	}
 
 	jobQueue.enqueue({
 		queue: ROOM_TICK,
 		payload: { roomId },
 		maxRetries: 0,
-		runAt: Date.now() + delayMs,
+		runAt: desiredRunAt,
 	});
 }
 

--- a/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/room-tick.handler.ts
@@ -35,8 +35,6 @@ export function enqueueRoomTick(
 	if (pendingJob) {
 		// Existing tick will fire sooner or at the same time — keep it
 		if (pendingJob.runAt <= desiredRunAt) return;
-		// New request is sooner — replace the stale tick
-		jobQueue.deleteJob(pendingJob.id);
 	}
 
 	jobQueue.enqueue({
@@ -45,6 +43,13 @@ export function enqueueRoomTick(
 		maxRetries: 0,
 		runAt: desiredRunAt,
 	});
+
+	// New request is sooner — best-effort cleanup of the stale pending tick.
+	// Enqueue first so a transient enqueue failure cannot drop the only pending
+	// tick and stall room progress.
+	if (pendingJob) {
+		jobQueue.deleteJob(pendingJob.id);
+	}
 }
 
 /**

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -196,6 +196,39 @@ describe('enqueueRoomTick', () => {
 		expect(after[0].runAt).toBeLessThan(before[0].runAt);
 	});
 
+	it('does not delete existing pending tick before enqueue succeeds', () => {
+		const pendingJob: Job = {
+			id: 'pending-1',
+			queue: ROOM_TICK,
+			status: 'pending',
+			payload: { roomId: 'room-a' },
+			result: null,
+			error: null,
+			priority: 0,
+			maxRetries: 0,
+			retryCount: 0,
+			runAt: Date.now() + 30_000,
+			createdAt: Date.now(),
+			startedAt: null,
+			completedAt: null,
+		};
+
+		let deletedId: string | null = null;
+		const mockRepo = {
+			listJobs: () => [pendingJob],
+			enqueue: () => {
+				throw new Error('enqueue failed');
+			},
+			deleteJob: (id: string) => {
+				deletedId = id;
+				return true;
+			},
+		} as unknown as JobQueueRepository;
+
+		expect(() => enqueueRoomTick('room-a', mockRepo, 0)).toThrow('enqueue failed');
+		expect(deletedId).toBeNull();
+	});
+
 	it('allows enqueueing for different rooms independently', () => {
 		enqueueRoomTick('room-a', repo, 1000);
 		enqueueRoomTick('room-b', repo, 1000);

--- a/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
+++ b/packages/daemon/tests/unit/job-handlers/room-tick-handler.test.ts
@@ -174,11 +174,26 @@ describe('enqueueRoomTick', () => {
 		expect((pending[0].payload as any).roomId).toBe('room-a');
 	});
 
-	it('deduplicates: second enqueue with existing pending job is a no-op', () => {
+	it('deduplicates: second enqueue with same or later delay is a no-op', () => {
 		enqueueRoomTick('room-a', repo, 1000);
 		enqueueRoomTick('room-a', repo, 1000);
 		const pending = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
 		expect(pending).toHaveLength(1);
+	});
+
+	it('replaces pending tick when new request has a sooner runAt', () => {
+		enqueueRoomTick('room-a', repo, 30_000);
+		const before = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(before).toHaveLength(1);
+		const oldId = before[0].id;
+
+		// Request an immediate tick — should replace the 30s-delayed one
+		enqueueRoomTick('room-a', repo, 0);
+		const after = repo.listJobs({ queue: ROOM_TICK, status: ['pending'] });
+		expect(after).toHaveLength(1);
+		expect(after[0].id).not.toBe(oldId);
+		// The new tick should run much sooner
+		expect(after[0].runAt).toBeLessThan(before[0].runAt);
 	});
 
 	it('allows enqueueing for different rooms independently', () => {


### PR DESCRIPTION
## Summary

- After the `setInterval` → job-queue migration (`e83e4c9c`), `scheduleTick()` calls `enqueueRoomTick(delay=0)` for immediate ticks (goal creation, task status changes, etc.)
- The dedup guard in `enqueueRoomTick` dropped these immediate ticks when a 30s periodic tick was already pending, effectively starving the runtime — goals never got planning tasks spawned, and pending tasks never moved to in_progress
- Fix: compare `runAt` timestamps — if the new request is sooner, delete the stale pending tick and enqueue the earlier one

## Test plan

- [x] Existing `enqueueRoomTick` dedup test updated for new behavior (same-or-later delay is still a no-op)
- [x] New test: immediate tick replaces a 30s-delayed pending tick
- [x] All 40 job handler unit tests pass
- [ ] Verify on running server: create a goal → planning task spawns within seconds (not 30s)
- [ ] Verify pending tasks move to in_progress after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)