### PR TITLE
feat: display active agents in SpaceTaskPane with real-time status badges

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -249,7 +249,7 @@ export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 	}
 
 	const task = tasks.find((t) => t.id === taskId);
-	const taskGroups = taskId ? (sessionGroupsByTask.get(taskId) ?? []) : [];
+	const taskGroups = sessionGroupsByTask.get(taskId) ?? [];
 
 	if (!task) {
 		return (

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -8,7 +8,13 @@
 import { useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
-import type { SpaceTask, SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
+import type {
+	SpaceTask,
+	SpaceTaskStatus,
+	SpaceTaskPriority,
+	SpaceSessionGroup,
+	SpaceSessionGroupMember,
+} from '@neokai/shared';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -124,8 +130,115 @@ function HumanInputArea({ task }: HumanInputAreaProps) {
 	);
 }
 
+function MemberStatusBadge({ status }: { status: SpaceSessionGroupMember['status'] }) {
+	if (status === 'active') {
+		return (
+			<span class="inline-flex items-center gap-1 text-xs text-blue-300">
+				<span class="relative flex h-2 w-2">
+					<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+					<span class="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+				</span>
+				Active
+			</span>
+		);
+	}
+	if (status === 'completed') {
+		return (
+			<span class="inline-flex items-center gap-1 text-xs text-green-400">
+				<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2.5}
+						d="M5 13l4 4L19 7"
+					/>
+				</svg>
+				Done
+			</span>
+		);
+	}
+	// failed
+	return (
+		<span class="inline-flex items-center gap-1 text-xs text-red-400">
+			<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2.5}
+					d="M6 18L18 6M6 6l12 12"
+				/>
+			</svg>
+			Failed
+		</span>
+	);
+}
+
+interface WorkingAgentsProps {
+	groups: SpaceSessionGroup[];
+}
+
+function WorkingAgents({ groups }: WorkingAgentsProps) {
+	const agents = spaceStore.agents.value;
+
+	// Sort groups newest first so most recent work shows on top
+	const sortedGroups = [...groups].sort((a, b) => b.createdAt - a.createdAt);
+
+	return (
+		<div>
+			<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+				Working Agents
+			</h3>
+			<div class="space-y-2">
+				{sortedGroups.map((group) => (
+					<div
+						key={group.id}
+						class="rounded-lg border border-dark-600 bg-dark-800/50 overflow-hidden"
+					>
+						{/* Group header */}
+						<div class="flex items-center justify-between px-3 py-2 border-b border-dark-700">
+							<span class="text-xs font-medium text-gray-300 truncate">{group.name}</span>
+							<span class="text-xs text-gray-600 flex-shrink-0 ml-2">
+								{new Date(group.createdAt).toLocaleTimeString([], {
+									hour: '2-digit',
+									minute: '2-digit',
+								})}
+							</span>
+						</div>
+
+						{/* Members */}
+						<div class="divide-y divide-dark-700">
+							{group.members.map((member) => {
+								const agent = member.agentId ? agents.find((a) => a.id === member.agentId) : null;
+								return (
+									<div key={member.id} class="flex items-center gap-2 px-3 py-2">
+										<div class="flex-1 min-w-0">
+											<div class="flex items-center gap-1.5">
+												<span class="text-xs font-medium text-gray-300 capitalize truncate">
+													{agent?.name ?? member.role}
+												</span>
+												{agent && (
+													<span class="text-xs text-gray-600 truncate">({member.role})</span>
+												)}
+											</div>
+										</div>
+										<MemberStatusBadge status={member.status} />
+									</div>
+								);
+							})}
+							{group.members.length === 0 && (
+								<div class="px-3 py-2 text-xs text-gray-600">No members yet</div>
+							)}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
 export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 	const tasks = spaceStore.tasks.value;
+	const sessionGroupsByTask = spaceStore.sessionGroupsByTask.value;
 
 	if (!taskId) {
 		return (
@@ -136,6 +249,7 @@ export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 	}
 
 	const task = tasks.find((t) => t.id === taskId);
+	const taskGroups = taskId ? (sessionGroupsByTask.get(taskId) ?? []) : [];
 
 	if (!task) {
 		return (
@@ -275,6 +389,9 @@ export function SpaceTaskPane({ taskId, onClose }: SpaceTaskPaneProps) {
 						</a>
 					</div>
 				)}
+
+				{/* Working agents */}
+				{taskGroups.length > 0 && <WorkingAgents groups={taskGroups} />}
 
 				{/* Human input area */}
 				{task.status === 'needs_attention' && <HumanInputArea task={task} />}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -22,16 +22,31 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
-import { signal } from '@preact/signals';
-import type { SpaceTask } from '@neokai/shared';
+import { signal, computed } from '@preact/signals';
+import type { SpaceTask, SpaceAgent, SpaceSessionGroup } from '@neokai/shared';
 
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
+let mockSessionGroups: ReturnType<typeof signal<SpaceSessionGroup[]>>;
 const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
+		const sessionGroupsByTask = computed(() => {
+			const map = new Map<string, SpaceSessionGroup[]>();
+			for (const group of mockSessionGroups.value) {
+				if (group.taskId) {
+					const existing = map.get(group.taskId) ?? [];
+					map.set(group.taskId, [...existing, group]);
+				}
+			}
+			return map;
+		});
 		return {
 			tasks: mockTasks,
+			agents: mockAgents,
+			sessionGroups: mockSessionGroups,
+			sessionGroupsByTask,
 			updateTask: mockUpdateTask,
 		};
 	},
@@ -43,6 +58,8 @@ vi.mock('../../../lib/utils', () => ({
 
 // Initialize signals
 mockTasks = signal<SpaceTask[]>([]);
+mockAgents = signal<SpaceAgent[]>([]);
+mockSessionGroups = signal<SpaceSessionGroup[]>([]);
 
 import { SpaceTaskPane } from '../SpaceTaskPane';
 
@@ -61,10 +78,40 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
 	};
 }
 
+function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
+	return {
+		id: 'agent-1',
+		spaceId: 'space-1',
+		name: 'Backend Engineer',
+		role: 'coder',
+		description: '',
+		capabilities: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSessionGroup(overrides: Partial<SpaceSessionGroup> = {}): SpaceSessionGroup {
+	return {
+		id: 'group-1',
+		spaceId: 'space-1',
+		name: 'task:task-1',
+		taskId: 'task-1',
+		status: 'active',
+		members: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
 describe('SpaceTaskPane', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
+		mockAgents.value = [];
+		mockSessionGroups.value = [];
 		mockUpdateTask.mockClear();
 	});
 
@@ -191,12 +238,179 @@ describe('SpaceTaskPane', () => {
 		const { container } = render(<SpaceTaskPane taskId="task-1" />);
 		expect(container.querySelector('[aria-label="Close task pane"]')).toBeNull();
 	});
+
+	it('does NOT render Working Agents section when no session groups exist for task', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [];
+		const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByText('Working Agents')).toBeNull();
+	});
+
+	it('renders Working Agents section when a session group exists for the task', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'coder',
+						status: 'active',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Working Agents')).toBeTruthy();
+	});
+
+	it('renders member role as name when no agentId is set', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'task-agent',
+						status: 'active',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('task-agent')).toBeTruthy();
+	});
+
+	it('resolves agent name from agents signal when agentId is set', () => {
+		mockTasks.value = [makeTask()];
+		mockAgents.value = [makeAgent({ id: 'agent-1', name: 'Backend Engineer', role: 'coder' })];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'coder',
+						agentId: 'agent-1',
+						status: 'active',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Backend Engineer')).toBeTruthy();
+		// role shown in parens next to agent name
+		expect(getByText('(coder)')).toBeTruthy();
+	});
+
+	it('shows active pulse indicator for active member status', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'coder',
+						status: 'active',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Active')).toBeTruthy();
+	});
+
+	it('shows done indicator for completed member status', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'coder',
+						status: 'completed',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Done')).toBeTruthy();
+	});
+
+	it('shows failed indicator for failed member status', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				members: [
+					{
+						id: 'mem-1',
+						groupId: 'group-1',
+						sessionId: 'session-1',
+						role: 'coder',
+						status: 'failed',
+						orderIndex: 0,
+						createdAt: Date.now(),
+					},
+				],
+			}),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Failed')).toBeTruthy();
+	});
+
+	it('renders multiple groups for the same task', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({ id: 'group-1', name: 'Step 1 Group', taskId: 'task-1', members: [] }),
+			makeSessionGroup({ id: 'group-2', name: 'Step 2 Group', taskId: 'task-1', members: [] }),
+		];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Step 1 Group')).toBeTruthy();
+		expect(getByText('Step 2 Group')).toBeTruthy();
+	});
+
+	it('does NOT show groups from a different task', () => {
+		mockTasks.value = [makeTask({ id: 'task-1' })];
+		mockSessionGroups.value = [
+			makeSessionGroup({ id: 'group-other', name: 'Other Task Group', taskId: 'task-other' }),
+		];
+		const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(queryByText('Working Agents')).toBeNull();
+		expect(queryByText('Other Task Group')).toBeNull();
+	});
+
+	it('shows "No members yet" for a group with empty members', () => {
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [makeSessionGroup({ members: [] })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('No members yet')).toBeTruthy();
+	});
 });
 
 describe('SpaceTaskPane — HumanInputArea submit behavior', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
+		mockAgents.value = [];
+		mockSessionGroups.value = [];
 		mockUpdateTask.mockClear();
 	});
 

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -85,7 +85,6 @@ function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
 		name: 'Backend Engineer',
 		role: 'coder',
 		description: '',
-		capabilities: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,
@@ -385,6 +384,32 @@ describe('SpaceTaskPane', () => {
 		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
 		expect(getByText('Step 1 Group')).toBeTruthy();
 		expect(getByText('Step 2 Group')).toBeTruthy();
+	});
+
+	it('renders groups newest-first by createdAt', () => {
+		const now = Date.now();
+		mockTasks.value = [makeTask()];
+		mockSessionGroups.value = [
+			makeSessionGroup({
+				id: 'group-old',
+				name: 'Older Group',
+				taskId: 'task-1',
+				createdAt: now - 10000,
+				members: [],
+			}),
+			makeSessionGroup({
+				id: 'group-new',
+				name: 'Newer Group',
+				taskId: 'task-1',
+				createdAt: now,
+				members: [],
+			}),
+		];
+		const { container } = render(<SpaceTaskPane taskId="task-1" />);
+		const groupNames = Array.from(
+			container.querySelectorAll('.text-xs.font-medium.text-gray-300.truncate')
+		).map((el) => el.textContent);
+		expect(groupNames.indexOf('Newer Group')).toBeLessThan(groupNames.indexOf('Older Group'));
 	});
 
 	it('does NOT show groups from a different task', () => {


### PR DESCRIPTION
Adds a Working Agents section to SpaceTaskPane that shows session group
members for the current task. Each member displays the agent name (looked
up from agents signal via agentId), role, and a status badge — pulsing
blue for active, green check for completed, red X for failed. Groups are
sorted newest-first and the section is hidden when no groups exist for the
task. Adds 11 new unit tests covering all status badges, agent name
resolution, multi-group display, and edge cases.
