### PR TITLE
test: add online test for room tick via job queue

### DIFF
--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -218,9 +218,10 @@ describe('room.tick via job queue (online)', () => {
 		const daemonCtx = getDaemonCtx(daemon);
 		const roomId = await createRoom(daemon, 'tick-dedup-test');
 
-		// Immediately after room creation: exactly 1 pending/processing tick exists.
-		// scheduleTick(delay=0) fires synchronously inside start(), so the job is
-		// visible right away — no race between the RPC returning and the enqueue.
+		// Wait for the tick to appear: room.created handlers fire via queueMicrotask
+		// after the RPC returns, so the enqueue is not guaranteed to have happened
+		// the moment createRoom() resolves. Poll until it does, then assert count=1.
+		await waitForTickJob(daemonCtx, roomId, ['pending', 'processing']);
 		const atStartup = listTickJobs(daemonCtx, roomId, ['pending', 'processing']);
 		expect(atStartup.length).toBe(1);
 

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -11,7 +11,8 @@
  * - Pause cancels pending tick jobs
  * - Resume enqueues a fresh immediate tick
  * - Stopping a room cancels pending ticks and prevents further scheduling
- * - Restarting a room resumes tick scheduling
+ * - Restarting a room resumes tick scheduling (new job post-restart is identified)
+ * - Dead tick job (maxRetries=0) does not produce a ghost pending tick
  *
  * The room.tick handler calls runtime.tick() which is a no-op for an empty
  * room (no active task groups, no goals). No real AI calls are made.
@@ -73,7 +74,7 @@ function listTickJobs(daemonCtx: DaemonAppContext, roomId: string, statuses: Job
  * Poll the job queue until at least one room.tick job for the given room
  * exists with one of the specified statuses, or until the timeout expires.
  *
- * Returns the first matching job, or throws on timeout.
+ * Throws on timeout with a full diagnostic snapshot.
  */
 async function waitForTickJob(
 	daemonCtx: DaemonAppContext,
@@ -94,6 +95,29 @@ async function waitForTickJob(
 	throw new Error(
 		`Timeout waiting for room.tick job for room "${roomId}" with status [${statuses.join(',')}] after ${timeoutMs}ms. ` +
 			`All room.tick jobs: ${JSON.stringify(all.map((j) => ({ id: j.id, payload: j.payload, status: j.status, runAt: j.runAt })))}`
+	);
+}
+
+/**
+ * Poll until no room.tick jobs with the given statuses exist for the room,
+ * or throw on timeout.
+ */
+async function waitForNoTickJobs(
+	daemonCtx: DaemonAppContext,
+	roomId: string,
+	statuses: JobStatus[],
+	timeoutMs: number = JOB_WAIT_TIMEOUT_MS
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const jobs = listTickJobs(daemonCtx, roomId, statuses);
+		if (jobs.length === 0) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+	const remaining = listTickJobs(daemonCtx, roomId, statuses);
+	throw new Error(
+		`Timeout waiting for room.tick jobs [${statuses.join(',')}] to clear for room "${roomId}" after ${timeoutMs}ms. ` +
+			`Remaining: ${JSON.stringify(remaining.map((j) => ({ id: j.id, status: j.status })))}`
 	);
 }
 
@@ -163,6 +187,8 @@ describe('room.tick via job queue (online)', () => {
 		expect(completed.status).toBe('completed');
 		expect(completed.completedAt).not.toBeNull();
 		expect((completed.payload as { roomId: string }).roomId).toBe(roomId);
+		// maxRetries=0 by design: tick failures are terminal (no silent retry loop).
+		expect(completed.maxRetries).toBe(0);
 	}, 15_000);
 
 	// -------------------------------------------------------------------------
@@ -173,13 +199,11 @@ describe('room.tick via job queue (online)', () => {
 		const daemonCtx = getDaemonCtx(daemon);
 		const roomId = await createRoom(daemon, 'tick-rescheduled-test');
 
-		// Wait for the initial tick to complete.
-		const firstCompleted = await waitForTickJob(daemonCtx, roomId, ['completed']);
-		expect(firstCompleted).toBeDefined();
+		// Wait for the initial tick to complete (discard result — waitForTickJob throws on timeout).
+		await waitForTickJob(daemonCtx, roomId, ['completed']);
 
 		// The handler's finally block enqueues the next tick with DEFAULT_TICK_INTERVAL_MS (30s).
 		const next = await waitForTickJob(daemonCtx, roomId, ['pending']);
-		expect(next).toBeDefined();
 		expect((next.payload as { roomId: string }).roomId).toBe(roomId);
 
 		// Next tick should be scheduled ~30 s in the future (at least 10 s to avoid flakiness).
@@ -187,24 +211,26 @@ describe('room.tick via job queue (online)', () => {
 	}, 15_000);
 
 	// -------------------------------------------------------------------------
-	// Test 4: Dedup — at most one pending tick per room
+	// Test 4: Dedup — exactly one pending tick per room
 	// -------------------------------------------------------------------------
 
-	test('dedup: at most one pending room.tick job per room', async () => {
+	test('dedup: exactly one pending room.tick job per room', async () => {
 		const daemonCtx = getDaemonCtx(daemon);
 		const roomId = await createRoom(daemon, 'tick-dedup-test');
 
-		// Check immediately after room creation: at most 1 pending/processing tick.
+		// Immediately after room creation: exactly 1 pending/processing tick exists.
+		// scheduleTick(delay=0) fires synchronously inside start(), so the job is
+		// visible right away — no race between the RPC returning and the enqueue.
 		const atStartup = listTickJobs(daemonCtx, roomId, ['pending', 'processing']);
-		expect(atStartup.length).toBeLessThanOrEqual(1);
+		expect(atStartup.length).toBe(1);
 
 		// Wait for the initial tick to complete and the next one to be enqueued.
 		await waitForTickJob(daemonCtx, roomId, ['completed']);
 		await waitForTickJob(daemonCtx, roomId, ['pending']);
 
-		// Still at most 1 pending tick for this room.
+		// After self-scheduling: still exactly 1 pending tick — dedup prevents extras.
 		const afterReschedule = listTickJobs(daemonCtx, roomId, ['pending']);
-		expect(afterReschedule.length).toBeLessThanOrEqual(1);
+		expect(afterReschedule.length).toBe(1);
 	}, 15_000);
 
 	// -------------------------------------------------------------------------
@@ -215,17 +241,16 @@ describe('room.tick via job queue (online)', () => {
 		const daemonCtx = getDaemonCtx(daemon);
 		const roomId = await createRoom(daemon, 'tick-pause-test');
 
-		// Wait for the initial tick to complete (so we have a known pending next tick).
+		// Wait for the initial tick to complete (so we have a known pending next tick
+		// with runAt ≈ now+30s — safely in the future, won't be picked up mid-test).
 		await waitForTickJob(daemonCtx, roomId, ['completed']);
-
-		// Confirm there's a pending next tick before pausing.
 		await waitForTickJob(daemonCtx, roomId, ['pending']);
 
-		// Pause the runtime — this should cancel all pending ticks.
+		// Pause the runtime — cancelPendingTickJobs() runs synchronously inside pause(),
+		// so by the time this RPC returns all pending ticks are already deleted.
 		await daemon.messageHub.request('room.runtime.pause', { roomId });
 
-		// After a short wait, no pending ticks should remain.
-		await new Promise<void>((resolve) => setTimeout(resolve, 200));
+		// No sleep needed — cancellation is synchronous with the RPC.
 		const afterPause = listTickJobs(daemonCtx, roomId, ['pending']);
 		expect(afterPause.length).toBe(0);
 	}, 15_000);
@@ -242,24 +267,16 @@ describe('room.tick via job queue (online)', () => {
 		await waitForTickJob(daemonCtx, roomId, ['completed']);
 		await waitForTickJob(daemonCtx, roomId, ['pending']);
 
-		// Pause the runtime — cancels pending ticks.
+		// Pause — cancelPendingTickJobs() is synchronous; no sleep needed.
 		await daemon.messageHub.request('room.runtime.pause', { roomId });
-		await new Promise<void>((resolve) => setTimeout(resolve, 200));
-
-		// Verify no pending tick after pause.
 		const afterPause = listTickJobs(daemonCtx, roomId, ['pending']);
 		expect(afterPause.length).toBe(0);
 
 		// Resume — enqueues a fresh immediate tick (delay=0).
 		await daemon.messageHub.request('room.runtime.resume', { roomId });
 
-		// A new pending tick should appear promptly.
-		const freshTick = await waitForTickJob(daemonCtx, roomId, [
-			'pending',
-			'processing',
-			'completed',
-		]);
-		expect(freshTick).toBeDefined();
+		// A new pending or processing tick should appear promptly (delay=0).
+		const freshTick = await waitForTickJob(daemonCtx, roomId, ['pending', 'processing']);
 		expect((freshTick.payload as { roomId: string }).roomId).toBe(roomId);
 	}, 15_000);
 
@@ -277,21 +294,23 @@ describe('room.tick via job queue (online)', () => {
 		// Stop the runtime — cancels pending ticks and removes runtime from map.
 		await daemon.messageHub.request('room.runtime.stop', { roomId });
 
-		// Allow any in-flight job processor cycle to complete.
-		await new Promise<void>((resolve) => setTimeout(resolve, 500));
+		// If a tick was in-flight (processing) at the moment of stop, wait for it to
+		// finish. Once complete, the handler's finally block checks runtime.getState()
+		// (now 'stopped') and skips re-enqueuing.
+		await waitForNoTickJobs(daemonCtx, roomId, ['processing']);
 
 		// No pending ticks should remain after stop.
 		const afterStop = listTickJobs(daemonCtx, roomId, ['pending']);
 		expect(afterStop.length).toBe(0);
 
-		// Wait a bit longer — no new tick should be enqueued because runtime is stopped.
+		// Brief window to confirm no new tick is scheduled by any residual path.
 		await new Promise<void>((resolve) => setTimeout(resolve, 300));
 		const noNewPending = listTickJobs(daemonCtx, roomId, ['pending']);
 		expect(noNewPending.length).toBe(0);
 	}, 15_000);
 
 	// -------------------------------------------------------------------------
-	// Test 8: Restart resumes tick scheduling
+	// Test 8: Restart resumes tick scheduling with a verifiably new job
 	// -------------------------------------------------------------------------
 
 	test('restarting a stopped room resumes tick scheduling', async () => {
@@ -302,10 +321,14 @@ describe('room.tick via job queue (online)', () => {
 		await waitForTickJob(daemonCtx, roomId, ['pending', 'processing', 'completed']);
 		await daemon.messageHub.request('room.runtime.stop', { roomId });
 
-		// Verify no pending tick after stop.
-		await new Promise<void>((resolve) => setTimeout(resolve, 300));
+		// Wait for any in-flight tick to finish before asserting pending=0.
+		await waitForNoTickJobs(daemonCtx, roomId, ['processing']);
 		const afterStop = listTickJobs(daemonCtx, roomId, ['pending']);
 		expect(afterStop.length).toBe(0);
+
+		// Record timestamp immediately before restart so we can verify the post-restart
+		// job is genuinely new (createdAt >= beforeRestartTimestamp).
+		const beforeRestartTimestamp = Date.now();
 
 		// Restart — creates a fresh runtime and calls start() which enqueues an immediate tick.
 		await daemon.messageHub.request('room.runtime.start', { roomId });
@@ -316,7 +339,48 @@ describe('room.tick via job queue (online)', () => {
 			'processing',
 			'completed',
 		]);
-		expect(freshTick).toBeDefined();
 		expect((freshTick.payload as { roomId: string }).roomId).toBe(roomId);
+		// Confirm this is a newly created job, not a leftover from before the restart.
+		expect(freshTick.createdAt).toBeGreaterThanOrEqual(beforeRestartTimestamp);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 9: Dead tick job (maxRetries=0) does not produce a ghost pending tick
+	// -------------------------------------------------------------------------
+
+	test('dead tick job does not produce a ghost pending tick', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-dead-test');
+
+		// Wait for the initial job to complete so the state is predictable.
+		await waitForTickJob(daemonCtx, roomId, ['completed']);
+
+		// Pause to stop new ticks from being enqueued naturally.
+		await daemon.messageHub.request('room.runtime.pause', { roomId });
+		const afterPause = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterPause.length).toBe(0);
+
+		// Insert a 'dead' job directly, simulating what happens when the tick handler
+		// throws and maxRetries=0 is exhausted (no retries, status goes straight to dead).
+		const rawDb = daemonCtx.db.getDatabase();
+		const deadJobId = crypto.randomUUID();
+		const now = Date.now();
+		rawDb
+			.prepare(
+				`INSERT INTO job_queue
+				(id, queue, status, payload, result, error, priority, max_retries, retry_count, run_at, created_at, started_at, completed_at)
+				VALUES (?, ?, 'dead', ?, NULL, 'simulated handler throw', 0, 0, 0, ?, ?, ?, ?)`
+			)
+			.run(deadJobId, ROOM_TICK, JSON.stringify({ roomId }), now, now, now, now);
+
+		// Dead jobs are terminal — no automatic retry, no re-enqueue.
+		// Wait a moment and confirm no new pending tick appears.
+		await new Promise<void>((resolve) => setTimeout(resolve, 400));
+		const noPending = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(noPending.length).toBe(0);
+
+		// The dead job itself should remain in dead status (not reclaimed or retried).
+		const deadJobs = listTickJobs(daemonCtx, roomId, ['dead']);
+		expect(deadJobs.some((j) => j.id === deadJobId)).toBe(true);
 	}, 15_000);
 });

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Online test: room.tick job queue end-to-end
+ *
+ * Verifies that room ticks work end-to-end through the persistent job queue,
+ * including dedup, pause/resume job cancellation, and stop/restart recovery.
+ *
+ * Test coverage:
+ * - room.tick job is enqueued when a room runtime starts
+ * - Job transitions through pending -> processing -> completed
+ * - No duplicate tick jobs for the same room (at most one pending at a time)
+ * - Pause cancels pending tick jobs
+ * - Resume enqueues a fresh immediate tick
+ * - Stopping a room cancels pending ticks and prevents further scheduling
+ * - Restarting a room resumes tick scheduling
+ *
+ * The room.tick handler calls runtime.tick() which is a no-op for an empty
+ * room (no active task groups, no goals). No real AI calls are made.
+ *
+ * NOTE: dev proxy intercepts Anthropic API calls only. This test does not
+ * send any Claude messages, so no Anthropic calls are made either.
+ *
+ * Run:
+ *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/room/room-tick-job.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { DaemonServerContext } from '../../helpers/daemon-server';
+import { createDaemonServer } from '../../helpers/daemon-server';
+import type { DaemonAppContext } from '../../../src/app';
+import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
+import type { Job, JobStatus } from '../../../src/storage/repositories/job-queue-repository';
+
+// ---------------------------------------------------------------------------
+// Test configuration
+// ---------------------------------------------------------------------------
+
+/** Maximum time (ms) to wait for a job to reach a desired status. */
+const JOB_WAIT_TIMEOUT_MS = 8_000;
+
+/** Polling cadence for job-status checks. */
+const POLL_INTERVAL_MS = 50;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type InProcessDaemon = DaemonServerContext & { daemonContext?: DaemonAppContext };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the DaemonAppContext from an in-process daemon. Throws for spawned mode. */
+function getDaemonCtx(daemon: DaemonServerContext): DaemonAppContext {
+	const ctx = daemon as InProcessDaemon;
+	if (!ctx.daemonContext) {
+		throw new Error(
+			'daemonContext not available — did you run in spawned mode (DAEMON_TEST_SPAWN=true)?'
+		);
+	}
+	return ctx.daemonContext;
+}
+
+/**
+ * List all room.tick jobs for a specific room with the given status(es).
+ */
+function listTickJobs(daemonCtx: DaemonAppContext, roomId: string, statuses: JobStatus[]): Job[] {
+	const all = daemonCtx.jobQueue.listJobs({ queue: ROOM_TICK, status: statuses, limit: 10_000 });
+	return all.filter((j) => (j.payload as { roomId?: string }).roomId === roomId);
+}
+
+/**
+ * Poll the job queue until at least one room.tick job for the given room
+ * exists with one of the specified statuses, or until the timeout expires.
+ *
+ * Returns the first matching job, or throws on timeout.
+ */
+async function waitForTickJob(
+	daemonCtx: DaemonAppContext,
+	roomId: string,
+	statuses: JobStatus[],
+	timeoutMs: number = JOB_WAIT_TIMEOUT_MS
+): Promise<Job> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const jobs = listTickJobs(daemonCtx, roomId, statuses);
+		if (jobs.length > 0) {
+			return jobs[0];
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+	// Final snapshot for diagnostics
+	const all = daemonCtx.jobQueue.listJobs({ queue: ROOM_TICK, limit: 10_000 });
+	throw new Error(
+		`Timeout waiting for room.tick job for room "${roomId}" with status [${statuses.join(',')}] after ${timeoutMs}ms. ` +
+			`All room.tick jobs: ${JSON.stringify(all.map((j) => ({ id: j.id, payload: j.payload, status: j.status, runAt: j.runAt })))}`
+	);
+}
+
+/**
+ * Create a room via RPC and return its ID.
+ */
+async function createRoom(daemon: DaemonServerContext, name: string): Promise<string> {
+	const result = (await daemon.messageHub.request('room.create', { name })) as {
+		room: { id: string };
+	};
+	return result.room.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('room.tick via job queue (online)', () => {
+	let daemon: DaemonServerContext;
+
+	beforeEach(async () => {
+		daemon = await createDaemonServer();
+
+		const ctx = daemon as InProcessDaemon;
+		if (!ctx.daemonContext) {
+			throw new Error(
+				'room-tick-job tests require in-process daemon mode. ' +
+					'Unset DAEMON_TEST_SPAWN to run these tests.'
+			);
+		}
+	}, 30_000);
+
+	afterEach(async () => {
+		if (daemon) {
+			daemon.kill('SIGTERM');
+			await daemon.waitForExit();
+		}
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 1: Tick job is enqueued when room runtime starts
+	// -------------------------------------------------------------------------
+
+	test('room.tick job is enqueued after room creation', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-enqueue-test');
+
+		// The runtime starts synchronously on room.created and calls scheduleTick(delay=0),
+		// so a job should appear very quickly.
+		const job = await waitForTickJob(daemonCtx, roomId, ['pending', 'processing', 'completed']);
+
+		expect(job.queue).toBe(ROOM_TICK);
+		expect((job.payload as { roomId: string }).roomId).toBe(roomId);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 2: Job processes and reaches completed status
+	// -------------------------------------------------------------------------
+
+	test('room.tick job transitions through processing and reaches completed', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-completed-test');
+
+		// Wait for the first tick job to finish (empty room — tick is a no-op).
+		const completed = await waitForTickJob(daemonCtx, roomId, ['completed']);
+
+		expect(completed.status).toBe('completed');
+		expect(completed.completedAt).not.toBeNull();
+		expect((completed.payload as { roomId: string }).roomId).toBe(roomId);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 3: After completion, the handler re-schedules a new tick
+	// -------------------------------------------------------------------------
+
+	test('tick handler re-schedules next tick after completion', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-rescheduled-test');
+
+		// Wait for the initial tick to complete.
+		const firstCompleted = await waitForTickJob(daemonCtx, roomId, ['completed']);
+		expect(firstCompleted).toBeDefined();
+
+		// The handler's finally block enqueues the next tick with DEFAULT_TICK_INTERVAL_MS (30s).
+		const next = await waitForTickJob(daemonCtx, roomId, ['pending']);
+		expect(next).toBeDefined();
+		expect((next.payload as { roomId: string }).roomId).toBe(roomId);
+
+		// Next tick should be scheduled ~30 s in the future (at least 10 s to avoid flakiness).
+		expect(next.runAt).toBeGreaterThan(Date.now() + 10_000);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 4: Dedup — at most one pending tick per room
+	// -------------------------------------------------------------------------
+
+	test('dedup: at most one pending room.tick job per room', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-dedup-test');
+
+		// Check immediately after room creation: at most 1 pending/processing tick.
+		const atStartup = listTickJobs(daemonCtx, roomId, ['pending', 'processing']);
+		expect(atStartup.length).toBeLessThanOrEqual(1);
+
+		// Wait for the initial tick to complete and the next one to be enqueued.
+		await waitForTickJob(daemonCtx, roomId, ['completed']);
+		await waitForTickJob(daemonCtx, roomId, ['pending']);
+
+		// Still at most 1 pending tick for this room.
+		const afterReschedule = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterReschedule.length).toBeLessThanOrEqual(1);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 5: Pause cancels pending tick jobs
+	// -------------------------------------------------------------------------
+
+	test('pause cancels pending room.tick jobs', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-pause-test');
+
+		// Wait for the initial tick to complete (so we have a known pending next tick).
+		await waitForTickJob(daemonCtx, roomId, ['completed']);
+
+		// Confirm there's a pending next tick before pausing.
+		await waitForTickJob(daemonCtx, roomId, ['pending']);
+
+		// Pause the runtime — this should cancel all pending ticks.
+		await daemon.messageHub.request('room.runtime.pause', { roomId });
+
+		// After a short wait, no pending ticks should remain.
+		await new Promise<void>((resolve) => setTimeout(resolve, 200));
+		const afterPause = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterPause.length).toBe(0);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 6: Resume enqueues a fresh immediate tick
+	// -------------------------------------------------------------------------
+
+	test('resume enqueues a fresh room.tick job after pause', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-resume-test');
+
+		// Wait for the initial tick to complete so there's a predictable pending next tick.
+		await waitForTickJob(daemonCtx, roomId, ['completed']);
+		await waitForTickJob(daemonCtx, roomId, ['pending']);
+
+		// Pause the runtime — cancels pending ticks.
+		await daemon.messageHub.request('room.runtime.pause', { roomId });
+		await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+		// Verify no pending tick after pause.
+		const afterPause = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterPause.length).toBe(0);
+
+		// Resume — enqueues a fresh immediate tick (delay=0).
+		await daemon.messageHub.request('room.runtime.resume', { roomId });
+
+		// A new pending tick should appear promptly.
+		const freshTick = await waitForTickJob(daemonCtx, roomId, [
+			'pending',
+			'processing',
+			'completed',
+		]);
+		expect(freshTick).toBeDefined();
+		expect((freshTick.payload as { roomId: string }).roomId).toBe(roomId);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 7: Stop cancels pending ticks and prevents further scheduling
+	// -------------------------------------------------------------------------
+
+	test('stop cancels pending ticks and prevents further scheduling', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-stop-test');
+
+		// Wait for the initial tick job to appear.
+		await waitForTickJob(daemonCtx, roomId, ['pending', 'processing', 'completed']);
+
+		// Stop the runtime — cancels pending ticks and removes runtime from map.
+		await daemon.messageHub.request('room.runtime.stop', { roomId });
+
+		// Allow any in-flight job processor cycle to complete.
+		await new Promise<void>((resolve) => setTimeout(resolve, 500));
+
+		// No pending ticks should remain after stop.
+		const afterStop = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterStop.length).toBe(0);
+
+		// Wait a bit longer — no new tick should be enqueued because runtime is stopped.
+		await new Promise<void>((resolve) => setTimeout(resolve, 300));
+		const noNewPending = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(noNewPending.length).toBe(0);
+	}, 15_000);
+
+	// -------------------------------------------------------------------------
+	// Test 8: Restart resumes tick scheduling
+	// -------------------------------------------------------------------------
+
+	test('restarting a stopped room resumes tick scheduling', async () => {
+		const daemonCtx = getDaemonCtx(daemon);
+		const roomId = await createRoom(daemon, 'tick-restart-test');
+
+		// Wait for the initial tick to appear, then stop the runtime.
+		await waitForTickJob(daemonCtx, roomId, ['pending', 'processing', 'completed']);
+		await daemon.messageHub.request('room.runtime.stop', { roomId });
+
+		// Verify no pending tick after stop.
+		await new Promise<void>((resolve) => setTimeout(resolve, 300));
+		const afterStop = listTickJobs(daemonCtx, roomId, ['pending']);
+		expect(afterStop.length).toBe(0);
+
+		// Restart — creates a fresh runtime and calls start() which enqueues an immediate tick.
+		await daemon.messageHub.request('room.runtime.start', { roomId });
+
+		// A fresh tick job should appear.
+		const freshTick = await waitForTickJob(daemonCtx, roomId, [
+			'pending',
+			'processing',
+			'completed',
+		]);
+		expect(freshTick).toBeDefined();
+		expect((freshTick.payload as { roomId: string }).roomId).toBe(roomId);
+	}, 15_000);
+});

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -54,6 +54,7 @@ ROOM_FILES=(
   room-planner-two-phase.test.ts
   room-replan-recovery.test.ts
   room-reviewer-flow.test.ts
+  room-tick-job.test.ts
 )
 
 FEATURES_FILES=(


### PR DESCRIPTION
Adds packages/daemon/tests/online/room/room-tick-job.test.ts with 8 tests
covering the full room.tick job queue lifecycle:

- Tick job is enqueued when room runtime starts
- Job transitions through processing and reaches completed
- Handler re-schedules next tick after completion (30s delay)
- Dedup: at most one pending tick per room at any time
- Pause cancels pending tick jobs
- Resume enqueues a fresh immediate tick after pause
- Stop cancels pending ticks and prevents further scheduling
- Restart resumes tick scheduling with a fresh runtime

Also updates validate-online-test-matrix.sh to track room-tick-job.test.ts
in the ROOM_FILES registry (room tests are commented out in CI for resource
reasons but tracked for completeness).
