### PR TITLE
test: online test for room tick via job queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,6 +200,12 @@ jobs:
           - module: rewind
             test_path: tests/online/rewind
             mock_sdk: true
+          # room-tick-job uses Dev Proxy only (no real API calls) — enabled independently
+          # of the broader room test cohort which requires real credentials.
+          - module: room-tick-job
+            test_path: tests/online/room/room-tick-job.test.ts
+            mock_sdk: true
+            timeout: 10
           # Room tests temporarily disabled during refactoring
           # - module: room-1
           #   test_path: >-

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -49,7 +49,12 @@ const JOB_WAIT_TIMEOUT_MS = 10_000;
 /** Polling interval for job-status checks. */
 const POLL_INTERVAL_MS = 50;
 
-/** How long to wait after a control operation before asserting no tick exists. */
+/**
+ * How long to wait after a control operation before asserting no tick exists.
+ * 300 ms is sufficient: the job processor's poll cycle is 1 s, so any pending
+ * enqueue triggered synchronously by pause/stop/resume will complete well
+ * within this window without waiting for a full processor cycle.
+ */
 const SETTLE_MS = 300;
 
 // ---------------------------------------------------------------------------
@@ -111,10 +116,17 @@ async function waitForTickJob(
 function acceleratePendingTick(daemonCtx: DaemonAppContext, roomId: string): void {
 	const pending = listTickJobs(daemonCtx, roomId, ['pending']);
 	for (const job of pending) {
+		// Direct DB delete bypasses any higher-level state machine, but
+		// JobQueueRepository.deleteJob() is a raw DELETE with no side effects —
+		// there is no state machine to bypass. The tradeoff is acceptable here
+		// because this is test-only code whose sole purpose is to accelerate the
+		// runAt timestamp, and deleteJob() is part of the public repository API.
 		daemonCtx.jobQueue.deleteJob(job.id);
 	}
 	// enqueueRoomTick with delay=0 schedules an immediate tick via the same
-	// production code path used by RoomRuntime.start() / resume().
+	// production code path used by RoomRuntime.start() / resume(). If
+	// RoomRuntime.scheduleTick() fires between the delete and re-enqueue,
+	// enqueueRoomTick's dedup guard absorbs the duplicate.
 	enqueueRoomTick(roomId, daemonCtx.jobQueue, 0);
 }
 
@@ -383,13 +395,15 @@ describe('room.tick via job queue (online)', () => {
 		// Start daemon2 using createDaemonApp() directly with the preserved DB.
 		// This exercises initializeExistingRooms() which reads rooms from the DB
 		// and re-enqueues tick jobs for each one.
-		const originalWorkspacePath = process.env.NEOKAI_WORKSPACE_PATH;
-		process.env.NEOKAI_WORKSPACE_PATH = workspacePath;
-
 		let daemonCtx2: DaemonAppContext | null = null;
 		let hub2: MessageHub | null = null;
 		let transport2: WebSocketClientTransport | null = null;
+		// originalWorkspacePath is captured inside the try block so the finally
+		// restoration is always paired with the mutation, even on sync failures.
+		let originalWorkspacePath: string | undefined;
 		try {
+			originalWorkspacePath = process.env.NEOKAI_WORKSPACE_PATH;
+			process.env.NEOKAI_WORKSPACE_PATH = workspacePath;
 			const config = getConfig();
 			config.port = 0;
 			config.dbPath = dbPath;
@@ -420,7 +434,7 @@ describe('room.tick via job queue (online)', () => {
 			// Verify the runtime is actively running in daemon2.
 			const stateResult = (await hub2.request('room.runtime.state', {
 				roomId,
-			})) as { state: string | null };
+			})) as { state: string };
 			expect(stateResult.state).toBe('running');
 		} finally {
 			// Restore environment.

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -10,6 +10,10 @@
  * - Stopping a room cancels pending ticks and prevents further scheduling
  * - Restarting a room enqueues a new tick job
  * - Job processes and re-schedules (self-scheduling chain)
+ * - Tick handler skips re-scheduling when runtime is stopped
+ * - Each room gets its own independent tick job
+ * - Daemon restart: existing rooms get tick jobs re-enqueued via
+ *   initializeExistingRooms → recoverRoomRuntime → runtime.start()
  *
  * These tests exercise the persistent job queue mechanics (enqueueRoomTick,
  * cancelPendingTickJobs, createRoomTickHandler) introduced in Task 4.1–4.3.
@@ -23,9 +27,13 @@
  *   NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/room/room-tick-job.test.ts
  */
 
+import path from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { WebSocketClientTransport, MessageHub } from '@neokai/shared';
 import type { DaemonServerContext } from '../../helpers/daemon-server';
 import { createDaemonServer } from '../../helpers/daemon-server';
+import { createDaemonApp } from '../../../src/app';
+import { getConfig } from '../../../src/config';
 import type { DaemonAppContext } from '../../../src/app';
 import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
 import { enqueueRoomTick } from '../../../src/lib/job-handlers/room-tick.handler';
@@ -287,8 +295,12 @@ describe('room.tick via job queue (online)', () => {
 	// -------------------------------------------------------------------------
 
 	test('tick handler skips re-scheduling when runtime is stopped', async () => {
-		// Stop the runtime first — this removes the runtime from the runtimes map
-		// (via runtimes.delete in stopRuntime) and cancels pending ticks.
+		// Wait for the runtime to be ready before stopping — room.created fires
+		// via queueMicrotask so the runtime may not be in the map yet when
+		// room.create resolves.
+		await waitForTickJob(daemonCtx, roomId, ['pending', 'processing', 'completed']);
+
+		// Stop the runtime — removes it from the runtimes map and cancels pending ticks.
 		await daemon.messageHub.request('room.runtime.stop', { roomId });
 		await new Promise<void>((resolve) => setTimeout(resolve, SETTLE_MS));
 		expect(listTickJobs(daemonCtx, roomId, ['pending']).length).toBe(0);
@@ -342,4 +354,103 @@ describe('room.tick via job queue (online)', () => {
 		expect(pendingRoom1.length).toBe(0);
 		expect(pendingRoom2.length).toBeGreaterThanOrEqual(1);
 	}, 20_000);
+
+	// -------------------------------------------------------------------------
+	// Daemon restart: existing rooms get tick jobs re-enqueued
+	// -------------------------------------------------------------------------
+
+	test('daemon restart: existing rooms get tick jobs re-enqueued via initializeExistingRooms', async () => {
+		// Confirm the initial tick appears so we know the room is fully set up.
+		const firstTick = await waitForTickJob(daemonCtx, roomId, [
+			'pending',
+			'processing',
+			'completed',
+		]);
+		expect(firstTick).toBeDefined();
+
+		// Preserve the DB path before shutdown.
+		const dbPath = daemonCtx.db.getDatabasePath();
+		const workspacePath = path.dirname(dbPath);
+
+		// Shut down daemon1 cleanly but WITHOUT deleting the workspace so the DB
+		// is preserved for daemon2. We call daemonCtx.cleanup() directly instead
+		// of daemon.waitForExit() (which would rm -rf the workspace).
+		daemon.kill('SIGTERM'); // no-op for in-process
+		await daemonCtx.cleanup();
+		// Prevent afterEach from double-calling cleanup.
+		daemon = null as unknown as DaemonServerContext;
+
+		// Start daemon2 using createDaemonApp() directly with the preserved DB.
+		// This exercises initializeExistingRooms() which reads rooms from the DB
+		// and re-enqueues tick jobs for each one.
+		const originalWorkspacePath = process.env.NEOKAI_WORKSPACE_PATH;
+		process.env.NEOKAI_WORKSPACE_PATH = workspacePath;
+
+		let daemonCtx2: DaemonAppContext | null = null;
+		let hub2: MessageHub | null = null;
+		let transport2: WebSocketClientTransport | null = null;
+		try {
+			const config = getConfig();
+			config.port = 0;
+			config.dbPath = dbPath;
+
+			daemonCtx2 = await createDaemonApp({ config, verbose: false, standalone: false });
+
+			// Connect a client so the daemon is ready.
+			const actualPort = daemonCtx2.server.port;
+			transport2 = new WebSocketClientTransport({
+				url: `ws://127.0.0.1:${actualPort}/ws`,
+				autoReconnect: false,
+			});
+			hub2 = new MessageHub({ defaultSessionId: 'global' });
+			hub2.registerTransport(transport2);
+			await transport2.initialize();
+
+			// initializeExistingRooms calls runtime.start() for every room in the DB,
+			// which calls scheduleTick() → enqueueRoomTick(roomId, jobQueue, 0).
+			const tickJob = await waitForTickJob(daemonCtx2, roomId, [
+				'pending',
+				'processing',
+				'completed',
+			]);
+			expect(tickJob).toBeDefined();
+			expect(tickJob!.queue).toBe(ROOM_TICK);
+			expect((tickJob!.payload as { roomId: string }).roomId).toBe(roomId);
+
+			// Verify the runtime is actively running in daemon2.
+			const stateResult = (await hub2.request('room.runtime.state', {
+				roomId,
+			})) as { state: string | null };
+			expect(stateResult.state).toBe('running');
+		} finally {
+			// Restore environment.
+			if (originalWorkspacePath === undefined) {
+				delete process.env.NEOKAI_WORKSPACE_PATH;
+			} else {
+				process.env.NEOKAI_WORKSPACE_PATH = originalWorkspacePath;
+			}
+
+			// Tear down daemon2: cleanup hub first (rejects pending calls), then transport.
+			if (hub2) {
+				try {
+					hub2.cleanup();
+				} catch {
+					// Already cleaned up
+				}
+			}
+			if (transport2) {
+				try {
+					await transport2.close();
+				} catch {
+					// Already closed
+				}
+			}
+			if (daemonCtx2) {
+				await daemonCtx2.cleanup();
+			}
+
+			// Remove the shared workspace now that both daemons are done.
+			await Bun.$`rm -rf ${workspacePath}`.quiet();
+		}
+	}, 30_000);
 });

--- a/packages/daemon/tests/online/room/room-tick-job.test.ts
+++ b/packages/daemon/tests/online/room/room-tick-job.test.ts
@@ -184,6 +184,9 @@ describe('room.tick via job queue (online)', () => {
 
 		// Attempt to enqueue additional ticks via the RPC resume path (which calls
 		// enqueueRoomTick internally). The dedup guard must absorb these.
+		// Sequence ends on resume so the runtime is running and exactly one pending
+		// tick should exist — asserting toBe(1) (not just <=1) proves the dedup
+		// guard absorbed the duplicates while still leaving one job standing.
 		await daemon.messageHub.request('room.runtime.pause', { roomId });
 		await daemon.messageHub.request('room.runtime.resume', { roomId });
 		await daemon.messageHub.request('room.runtime.pause', { roomId });
@@ -193,7 +196,9 @@ describe('room.tick via job queue (online)', () => {
 		await new Promise<void>((resolve) => setTimeout(resolve, SETTLE_MS));
 
 		const pendingJobs = listTickJobs(daemonCtx, roomId, ['pending']);
-		expect(pendingJobs.length).toBeLessThanOrEqual(1);
+		// Exactly 1: dedup absorbed the extra enqueue calls; the runtime is running
+		// so the one surviving tick was not cancelled.
+		expect(pendingJobs.length).toBe(1);
 	}, 15_000);
 
 	// -------------------------------------------------------------------------
@@ -408,6 +413,12 @@ describe('room.tick via job queue (online)', () => {
 			config.port = 0;
 			config.dbPath = dbPath;
 
+			// Note: createDaemonApp inherits the current process environment, which
+			// includes ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY set by daemon1's
+			// createInProcessDaemonServer (Dev Proxy routing). Daemon2 will silently
+			// use the proxy for any LLM calls it makes. This is harmless here because
+			// the room tick handler makes no LLM calls, but future changes that add
+			// LLM paths to the tick handler should be aware of this implicit coupling.
 			daemonCtx2 = await createDaemonApp({ config, verbose: false, standalone: false });
 
 			// Connect a client so the daemon is ready.


### PR DESCRIPTION
## Summary

- Add `packages/daemon/tests/online/room/room-tick-job.test.ts` — 10 tests covering end-to-end `room.tick` job queue mechanics without real API calls (empty room tick is a no-op)
- Register the new file in `scripts/validate-online-test-matrix.sh` ROOM_FILES so the validator stays green

> **CI note:** All `room/*` shards are intentionally commented out in `.github/workflows/main.yml` (see lines 204–220) due to resource usage. This file is tracked by the validator but does **not** run automatically in CI. Run locally with `NEOKAI_USE_DEV_PROXY=1 bun test packages/daemon/tests/online/room/room-tick-job.test.ts`, or re-enable the shard explicitly when needed.

## Tests

| Test | What it verifies |
|------|-----------------|
| job enqueued on runtime start | `runtime.start()` calls `enqueueRoomTick(roomId, jobQueue, 0)` |
| no duplicate pending tick jobs | at most one pending `room.tick` per room at any time |
| pause cancels pending ticks | `room.runtime.pause` → `cancelPendingTickJobs` removes all pending jobs |
| resume enqueues fresh tick | `room.runtime.resume` → `scheduleTick()` → new pending job appears |
| stop cancels pending ticks | `room.runtime.stop` cancels pending jobs |
| restart resumes scheduling | `room.runtime.start` creates fresh runtime and enqueues a new tick |
| job processes and re-schedules | tick transitions `pending → processing → completed`, then re-enqueues with ~30s delay |
| tick handler skips re-scheduling when stopped | handler returns `{skipped: true}` when runtime is gone; no new tick enqueued |
| each room gets its own independent tick job | pausing room1 does not affect room2's pending tick |
| daemon restart recovery | `initializeExistingRooms` re-enqueues ticks for all DB rooms on daemon2 startup |

## Test plan

- [x] All 10 tests pass locally with `NEOKAI_USE_DEV_PROXY=1`
- [x] `bash scripts/validate-online-test-matrix.sh` passes
- [x] Lint, format, typecheck, knip all pass