### PR TITLE
feat: implement liveQuery.subscribe and liveQuery.unsubscribe RPC handlers

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -259,6 +259,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobQueue,
 		jobProcessor,
 		reactiveDb,
+		liveQueries,
 	});
 
 	// Create WebSocket handlers

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -451,11 +451,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			// Cleanup MessageHub (rejects remaining calls)
 			messageHub.cleanup();
 
-			// Dispose live query engine
-			liveQueries.dispose();
-
-			// Cleanup RPC handlers
+			// Cleanup RPC handlers (disposes live query subscriptions) before
+			// tearing down the engine so handles are disposed against a live engine.
 			rpcHandlerCleanup();
+
+			// Dispose live query engine after all subscriptions are cleared
+			liveQueries.dispose();
 
 			// Stop GitHub service
 			if (gitHubService) {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -71,6 +71,8 @@ import { provisionGlobalSpacesAgent } from '../space/provision-global-agent';
 import { setupGlobalSpacesHandlers } from './global-spaces-handlers';
 import type { GlobalSpacesState } from '../space/tools/global-spaces-tools';
 import { setupSpaceSessionGroupHandlers } from './space-session-group-handlers';
+import { setupLiveQueryHandlers } from './live-query-handlers';
+import { LiveQueryEngine } from '../../storage/live-query';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -97,6 +99,8 @@ export interface RPCHandlerDependencies {
 	jobProcessor: JobQueueProcessor;
 	/** Reactive database wrapper for change event emission */
 	reactiveDb: ReactiveDatabase;
+	/** Live query engine for reactive SQL subscriptions */
+	liveQueries: LiveQueryEngine;
 }
 
 const log = new Logger('rpc-handlers');
@@ -240,6 +244,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
+
+	// LiveQuery subscribe/unsubscribe handlers
+	const unsubLiveQuery = setupLiveQueryHandlers(
+		deps.messageHub,
+		deps.liveQueries,
+		deps.db.getDatabase()
+	);
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase());
@@ -416,6 +427,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	return {
 		cleanup: () => {
 			unsubRoomCreated();
+			unsubLiveQuery();
 			roomRuntimeService.stop();
 			spaceRuntimeService.stop();
 		},

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -7,6 +7,20 @@
  * Clients never send raw SQL.
  */
 
+import { Database as BunDatabase } from 'bun:sqlite';
+import type { MessageHub } from '@neokai/shared';
+import { createEventMessage } from '@neokai/shared';
+import type {
+	LiveQuerySubscribeRequest,
+	LiveQuerySubscribeResponse,
+	LiveQueryUnsubscribeRequest,
+	LiveQueryUnsubscribeResponse,
+	LiveQuerySnapshotEvent,
+	LiveQueryDeltaEvent,
+} from '@neokai/shared';
+import type { LiveQueryEngine, LiveQueryHandle } from '../../storage/live-query';
+import { Logger } from '../logger';
+
 // ============================================================================
 // Named-query registry types
 // ============================================================================
@@ -198,3 +212,241 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		},
 	],
 ]);
+
+// ============================================================================
+// Logger
+// ============================================================================
+
+const log = new Logger('live-query-handlers');
+
+// ============================================================================
+// RPC handler setup
+// ============================================================================
+
+/**
+ * Register `liveQuery.subscribe` and `liveQuery.unsubscribe` RPC handlers.
+ *
+ * Returns an unsubscribe function that cleans up the client-disconnect listener.
+ */
+export function setupLiveQueryHandlers(
+	messageHub: MessageHub,
+	liveQueries: LiveQueryEngine,
+	db: BunDatabase
+): () => void {
+	// Map<clientId → Map<subscriptionId → LiveQueryHandle>>
+	const subscriptions = new Map<string, Map<string, LiveQueryHandle<Record<string, unknown>>>>();
+
+	// -------------------------------------------------------------------------
+	// liveQuery.subscribe
+	// -------------------------------------------------------------------------
+
+	messageHub.onRequest('liveQuery.subscribe', (data, context) => {
+		const { queryName, params, subscriptionId } = data as LiveQuerySubscribeRequest;
+		const { clientId, sessionId } = context;
+
+		// 1. Require WebSocket clientId
+		if (!clientId) {
+			throw new Error('liveQuery.subscribe requires a WebSocket connection (clientId absent)');
+		}
+
+		// 2. Resolve query from registry
+		const namedQuery = NAMED_QUERY_REGISTRY.get(queryName);
+		if (!namedQuery) {
+			throw new Error(`Unknown query name: "${queryName}"`);
+		}
+
+		// 3. Validate parameter count
+		if (params.length !== namedQuery.paramCount) {
+			throw new Error(
+				`Query "${queryName}" expects ${namedQuery.paramCount} parameter(s), got ${params.length}`
+			);
+		}
+
+		// 4. Authorization checks
+		if (queryName === 'tasks.byRoom' || queryName === 'goals.byRoom') {
+			const roomId = params[0] as string;
+			const room = db.prepare('SELECT id FROM rooms WHERE id = ?').get(roomId);
+			if (!room) {
+				throw new Error(`Unauthorized: room "${roomId}" not found`);
+			}
+		} else if (queryName === 'sessionGroupMessages.byGroup') {
+			const groupId = params[0] as string;
+			const group = db
+				.prepare('SELECT ref_id, group_type FROM session_groups WHERE id = ?')
+				.get(groupId) as { ref_id: string; group_type: string } | null;
+			if (!group) {
+				throw new Error(`Unauthorized: session group "${groupId}" not found`);
+			}
+			if (group.group_type === 'task') {
+				const task = db.prepare('SELECT room_id FROM tasks WHERE id = ?').get(group.ref_id) as {
+					room_id: string;
+				} | null;
+				if (!task) {
+					throw new Error(`Unauthorized: task "${group.ref_id}" not found`);
+				}
+				const room = db.prepare('SELECT id FROM rooms WHERE id = ?').get(task.room_id);
+				if (!room) {
+					throw new Error(`Unauthorized: room "${task.room_id}" not found`);
+				}
+			}
+		}
+
+		// 5. Get or create client subscription map
+		let clientSubs = subscriptions.get(clientId);
+		if (!clientSubs) {
+			clientSubs = new Map();
+			subscriptions.set(clientId, clientSubs);
+		}
+
+		// 6. Handle subscriptionId collision — dispose existing handle silently
+		const existing = clientSubs.get(subscriptionId);
+		if (existing) {
+			log.debug(
+				`liveQuery.subscribe: replacing subscription ${subscriptionId} for client ${clientId}`
+			);
+			existing.dispose();
+			clientSubs.delete(subscriptionId);
+		}
+
+		// 7. Subscribe to LiveQueryEngine
+		const { sql, mapRow } = namedQuery;
+		const applyMapRow = (row: Record<string, unknown>) => (mapRow ? mapRow(row) : row);
+		const applyMapRows = (rows: Record<string, unknown>[]) => rows.map(applyMapRow);
+
+		// Track whether the synchronous snapshot delivery failed so we can
+		// dispose the handle after subscribe() returns.
+		let snapshotDeliveryFailed = false;
+
+		const handle = liveQueries.subscribe(
+			sql,
+			params,
+			(diff: {
+				type: 'snapshot' | 'delta';
+				rows: Record<string, unknown>[];
+				added?: Record<string, unknown>[];
+				removed?: Record<string, unknown>[];
+				updated?: Record<string, unknown>[];
+				version: number;
+			}) => {
+				const router = messageHub.getRouter();
+				if (!router) {
+					log.warn(
+						`liveQuery: router unavailable; skipping event (clientId=${clientId}, subscriptionId=${subscriptionId})`
+					);
+					return;
+				}
+
+				let message: ReturnType<typeof createEventMessage>;
+
+				if (diff.type === 'snapshot') {
+					const eventData: LiveQuerySnapshotEvent = {
+						subscriptionId,
+						rows: applyMapRows(diff.rows),
+						version: diff.version,
+					};
+					message = createEventMessage({
+						method: 'liveQuery.snapshot',
+						data: eventData,
+						sessionId,
+					});
+				} else {
+					const eventData: LiveQueryDeltaEvent = {
+						subscriptionId,
+						added: diff.added ? applyMapRows(diff.added) : undefined,
+						removed: diff.removed ? applyMapRows(diff.removed) : undefined,
+						updated: diff.updated ? applyMapRows(diff.updated) : undefined,
+						version: diff.version,
+					};
+					message = createEventMessage({
+						method: 'liveQuery.delta',
+						data: eventData,
+						sessionId,
+					});
+				}
+
+				const sent = router.sendToClient(clientId, message);
+				if (!sent) {
+					if (diff.type === 'snapshot') {
+						// handle not yet assigned; defer cleanup to after subscribe() returns
+						snapshotDeliveryFailed = true;
+						log.warn(
+							`liveQuery: snapshot delivery failed for client ${clientId}; subscription ${subscriptionId} will be disposed`
+						);
+					} else {
+						// Delta: client disconnected — dispose now (handle is assigned)
+						log.warn(
+							`liveQuery: delta delivery failed for client ${clientId}; disposing subscription ${subscriptionId}`
+						);
+						handle.dispose();
+						const subs = subscriptions.get(clientId);
+						subs?.delete(subscriptionId);
+						if (subs?.size === 0) subscriptions.delete(clientId);
+					}
+				}
+			}
+		);
+
+		// If snapshot delivery failed, clean up immediately and bail out
+		if (snapshotDeliveryFailed) {
+			handle.dispose();
+			return { ok: true } satisfies LiveQuerySubscribeResponse;
+		}
+
+		// 8. Track the handle
+		clientSubs.set(subscriptionId, handle);
+		log.debug(
+			`liveQuery.subscribe: registered subscription ${subscriptionId} for client ${clientId}, query=${queryName}`
+		);
+
+		return { ok: true } satisfies LiveQuerySubscribeResponse;
+	});
+
+	// -------------------------------------------------------------------------
+	// liveQuery.unsubscribe
+	// -------------------------------------------------------------------------
+
+	messageHub.onRequest('liveQuery.unsubscribe', (data, context) => {
+		const { subscriptionId } = data as LiveQueryUnsubscribeRequest;
+		const { clientId } = context;
+
+		if (!clientId) {
+			throw new Error('liveQuery.unsubscribe requires a WebSocket connection (clientId absent)');
+		}
+
+		const clientSubs = subscriptions.get(clientId);
+		const handle = clientSubs?.get(subscriptionId);
+		if (handle) {
+			handle.dispose();
+			clientSubs!.delete(subscriptionId);
+			if (clientSubs!.size === 0) subscriptions.delete(clientId);
+			log.debug(
+				`liveQuery.unsubscribe: disposed subscription ${subscriptionId} for client ${clientId}`
+			);
+		} else {
+			log.debug(
+				`liveQuery.unsubscribe: subscription ${subscriptionId} not found for client ${clientId}`
+			);
+		}
+
+		return { ok: true } satisfies LiveQueryUnsubscribeResponse;
+	});
+
+	// -------------------------------------------------------------------------
+	// Client disconnect cleanup
+	// -------------------------------------------------------------------------
+
+	const unsubDisconnect = messageHub.onClientDisconnect((disconnectedClientId) => {
+		const clientSubs = subscriptions.get(disconnectedClientId);
+		if (!clientSubs || clientSubs.size === 0) return;
+
+		log.debug(
+			`liveQuery: client ${disconnectedClientId} disconnected; disposing ${clientSubs.size} subscription(s)`
+		);
+		for (const [, handle] of clientSubs) {
+			handle.dispose();
+		}
+		subscriptions.delete(disconnectedClientId);
+	});
+
+	return unsubDisconnect;
+}

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -226,7 +226,8 @@ const log = new Logger('live-query-handlers');
 /**
  * Register `liveQuery.subscribe` and `liveQuery.unsubscribe` RPC handlers.
  *
- * Returns an unsubscribe function that cleans up the client-disconnect listener.
+ * Returns a cleanup function that disposes all active subscriptions and
+ * unregisters the client-disconnect listener.
  */
 export function setupLiveQueryHandlers(
 	messageHub: MessageHub,
@@ -235,6 +236,13 @@ export function setupLiveQueryHandlers(
 ): () => void {
 	// Map<clientId → Map<subscriptionId → LiveQueryHandle>>
 	const subscriptions = new Map<string, Map<string, LiveQueryHandle<Record<string, unknown>>>>();
+
+	// Cache prepared statements once at setup time — compiled once per handler
+	// registration, not once per subscribe call (which would add compilation
+	// overhead on every subscribe RPC invocation).
+	const stmtRoom = db.prepare('SELECT id FROM rooms WHERE id = ?');
+	const stmtGroup = db.prepare('SELECT ref_id, group_type FROM session_groups WHERE id = ?');
+	const stmtTask = db.prepare('SELECT room_id FROM tasks WHERE id = ?');
 
 	// -------------------------------------------------------------------------
 	// liveQuery.subscribe
@@ -265,30 +273,31 @@ export function setupLiveQueryHandlers(
 		// 4. Authorization checks
 		if (queryName === 'tasks.byRoom' || queryName === 'goals.byRoom') {
 			const roomId = params[0] as string;
-			const room = db.prepare('SELECT id FROM rooms WHERE id = ?').get(roomId);
-			if (!room) {
+			if (!stmtRoom.get(roomId)) {
 				throw new Error(`Unauthorized: room "${roomId}" not found`);
 			}
 		} else if (queryName === 'sessionGroupMessages.byGroup') {
 			const groupId = params[0] as string;
-			const group = db
-				.prepare('SELECT ref_id, group_type FROM session_groups WHERE id = ?')
-				.get(groupId) as { ref_id: string; group_type: string } | null;
+			const group = stmtGroup.get(groupId) as { ref_id: string; group_type: string } | null;
 			if (!group) {
 				throw new Error(`Unauthorized: session group "${groupId}" not found`);
 			}
 			if (group.group_type === 'task') {
-				const task = db.prepare('SELECT room_id FROM tasks WHERE id = ?').get(group.ref_id) as {
-					room_id: string;
-				} | null;
+				// For task-typed groups, verify the full group → task → room chain.
+				// This ensures the requesting client has access to the room the task belongs to.
+				const task = stmtTask.get(group.ref_id) as { room_id: string } | null;
 				if (!task) {
 					throw new Error(`Unauthorized: task "${group.ref_id}" not found`);
 				}
-				const room = db.prepare('SELECT id FROM rooms WHERE id = ?').get(task.room_id);
-				if (!room) {
+				if (!stmtRoom.get(task.room_id)) {
 					throw new Error(`Unauthorized: room "${task.room_id}" not found`);
 				}
 			}
+			// Non-task group types (e.g., 'workflow', 'global') are authorized by group
+			// existence alone.  All current non-task groups are internal daemon constructs
+			// not directly reachable by client-supplied IDs without prior knowledge.
+			// If new group types with finer-grained access control are introduced, extend
+			// this block with the appropriate chain validation.
 		}
 
 		// 5. Get or create client subscription map
@@ -314,7 +323,9 @@ export function setupLiveQueryHandlers(
 		const applyMapRows = (rows: Record<string, unknown>[]) => rows.map(applyMapRow);
 
 		// Track whether the synchronous snapshot delivery failed so we can
-		// dispose the handle after subscribe() returns.
+		// dispose the handle after subscribe() returns.  The snapshot is fired
+		// inside liveQueries.subscribe() before it returns the handle, so we
+		// cannot call handle.dispose() directly during the callback.
 		let snapshotDeliveryFailed = false;
 
 		const handle = liveQueries.subscribe(
@@ -330,9 +341,16 @@ export function setupLiveQueryHandlers(
 			}) => {
 				const router = messageHub.getRouter();
 				if (!router) {
+					// Router not yet registered or already torn down.  Mark snapshot
+					// as failed so the handle is disposed after subscribe() returns;
+					// for deltas this is a no-op since the engine will never fire
+					// another callback after the handle is disposed.
 					log.warn(
 						`liveQuery: router unavailable; skipping event (clientId=${clientId}, subscriptionId=${subscriptionId})`
 					);
+					if (diff.type === 'snapshot') {
+						snapshotDeliveryFailed = true;
+					}
 					return;
 				}
 
@@ -379,14 +397,18 @@ export function setupLiveQueryHandlers(
 						);
 						handle.dispose();
 						const subs = subscriptions.get(clientId);
-						subs?.delete(subscriptionId);
-						if (subs?.size === 0) subscriptions.delete(clientId);
+						if (subs) {
+							subs.delete(subscriptionId);
+							if (subs.size === 0) subscriptions.delete(clientId);
+						}
 					}
 				}
 			}
 		);
 
-		// If snapshot delivery failed, clean up immediately and bail out
+		// If snapshot delivery failed (no router or client not found), clean up
+		// immediately and return ok — this is not a protocol error from the
+		// client's perspective.
 		if (snapshotDeliveryFailed) {
 			handle.dispose();
 			return { ok: true } satisfies LiveQuerySubscribeResponse;
@@ -448,5 +470,20 @@ export function setupLiveQueryHandlers(
 		subscriptions.delete(disconnectedClientId);
 	});
 
-	return unsubDisconnect;
+	// -------------------------------------------------------------------------
+	// Cleanup function
+	// -------------------------------------------------------------------------
+
+	return () => {
+		// Dispose all active handles before unregistering the disconnect listener.
+		// This ensures handles are cleaned up against the live engine before it
+		// may be disposed by the caller (e.g., createDaemonApp shutdown sequence).
+		for (const [, clientSubs] of subscriptions) {
+			for (const [, handle] of clientSubs) {
+				handle.dispose();
+			}
+		}
+		subscriptions.clear();
+		unsubDisconnect();
+	};
 }

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Unit tests for liveQuery.subscribe and liveQuery.unsubscribe RPC handlers
+ *
+ * Covers:
+ *  - subscribe → snapshot → delta → unsubscribe full lifecycle
+ *  - Unknown query name rejected
+ *  - Mismatched params count rejected
+ *  - Unauthorized room_id rejected (tasks.byRoom / goals.byRoom)
+ *  - Unauthorized group_id rejected (sessionGroupMessages.byGroup)
+ *  - Absent clientId rejected
+ *  - subscriptionId collision replaces prior subscription
+ *  - Snapshot delivered before delta
+ *  - Version monotonically increasing
+ *  - Client disconnect disposes all subscriptions
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import type { MessageHub } from '@neokai/shared';
+import { createTables } from '../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { ReactiveDatabase } from '../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../src/storage/live-query';
+import { setupLiveQueryHandlers } from '../../../src/lib/rpc-handlers/live-query-handlers';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RequestHandler = (data: unknown, context: Partial<CallCtx>) => Promise<unknown> | unknown;
+type CallCtx = {
+	clientId?: string;
+	sessionId: string;
+	messageId: string;
+	method: string;
+	timestamp: string;
+};
+
+interface SentMessage {
+	clientId: string;
+	message: {
+		method: string;
+		data: {
+			subscriptionId: string;
+			rows?: unknown[];
+			added?: unknown[];
+			removed?: unknown[];
+			updated?: unknown[];
+			version: number;
+		};
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock factory
+// ---------------------------------------------------------------------------
+
+function createMockSetup() {
+	const handlers = new Map<string, RequestHandler>();
+	let disconnectHandler: ((clientId: string) => void) | null = null;
+	const sentMessages: SentMessage[] = [];
+	let sendToClientResult = true; // override per-test if needed
+
+	const mockRouter = {
+		sendToClient: mock((clientId: string, message: unknown) => {
+			sentMessages.push({ clientId, message: message as SentMessage['message'] });
+			return sendToClientResult;
+		}),
+	};
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		getRouter: mock(() => mockRouter),
+		onClientDisconnect: mock((handler: (clientId: string) => void) => {
+			disconnectHandler = handler;
+			return () => {
+				disconnectHandler = null;
+			};
+		}),
+	} as unknown as MessageHub;
+
+	const callHandler = async (
+		method: string,
+		data: unknown,
+		ctx: Partial<CallCtx> = {}
+	): Promise<unknown> => {
+		const handler = handlers.get(method);
+		if (!handler) throw new Error(`No handler registered for method: ${method}`);
+		const fullCtx: CallCtx = {
+			clientId: 'client-1',
+			sessionId: 'global',
+			messageId: 'msg-1',
+			method,
+			timestamp: new Date().toISOString(),
+			...ctx,
+		};
+		return handler(data, fullCtx);
+	};
+
+	const fireDisconnect = (clientId: string) => {
+		disconnectHandler?.(clientId);
+	};
+
+	const setSendResult = (result: boolean) => {
+		sendToClientResult = result;
+	};
+
+	return { hub, handlers, sentMessages, callHandler, fireDisconnect, setSendResult, mockRouter };
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function createDb() {
+	const db = new BunDatabase(':memory:');
+	createTables(db);
+	return db;
+}
+
+function insertRoom(db: BunDatabase, roomId: string) {
+	const now = Date.now();
+	db.exec(
+		`INSERT OR IGNORE INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test Room', ${now}, ${now})`
+	);
+}
+
+function insertTask(db: BunDatabase, taskId: string, roomId: string) {
+	const now = Date.now();
+	db.exec(
+		`INSERT OR IGNORE INTO tasks (id, room_id, title, description, status, priority, task_type, created_at, updated_at)
+		 VALUES ('${taskId}', '${roomId}', 'Test Task', '', 'pending', 'normal', 'coding', ${now}, ${now})`
+	);
+}
+
+function insertSessionGroup(
+	db: BunDatabase,
+	groupId: string,
+	refId: string,
+	groupType: string = 'task'
+) {
+	const now = Date.now();
+	db.exec(
+		`INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, version, created_at)
+		 VALUES ('${groupId}', '${groupType}', '${refId}', 1, ${now})`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('setupLiveQueryHandlers', () => {
+	let db: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let engine: LiveQueryEngine;
+	let setup: ReturnType<typeof createMockSetup>;
+	const roomId = 'room-test-1';
+	const taskId = 'task-test-1';
+
+	beforeEach(() => {
+		db = createDb();
+		// Use a minimal facade wrapper that exposes getDatabase() for createReactiveDatabase
+		reactiveDb = createReactiveDatabase({ getDatabase: () => db } as never);
+		engine = new LiveQueryEngine(db, reactiveDb);
+		setup = createMockSetup();
+		setupLiveQueryHandlers(setup.hub, engine, db);
+		insertRoom(db, roomId);
+		insertTask(db, taskId, roomId);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		db.close();
+	});
+
+	// -----------------------------------------------------------------------
+	// Absent clientId
+	// -----------------------------------------------------------------------
+
+	test('subscribe: absent clientId throws', async () => {
+		await expect(
+			setup.callHandler(
+				'liveQuery.subscribe',
+				{ queryName: 'tasks.byRoom', params: [roomId], subscriptionId: 'sub-1' },
+				{ clientId: undefined }
+			)
+		).rejects.toThrow('clientId absent');
+	});
+
+	test('unsubscribe: absent clientId throws', async () => {
+		await expect(
+			setup.callHandler(
+				'liveQuery.unsubscribe',
+				{ subscriptionId: 'sub-1' },
+				{ clientId: undefined }
+			)
+		).rejects.toThrow('clientId absent');
+	});
+
+	// -----------------------------------------------------------------------
+	// Unknown query name
+	// -----------------------------------------------------------------------
+
+	test('subscribe: unknown query name throws', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'nonexistent.query',
+				params: ['x'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unknown query name');
+	});
+
+	// -----------------------------------------------------------------------
+	// Mismatched param count
+	// -----------------------------------------------------------------------
+
+	test('subscribe: mismatched params count throws', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom',
+				params: [], // expects 1
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('expects 1 parameter(s), got 0');
+	});
+
+	test('subscribe: too many params throws', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom',
+				params: [roomId, 'extra'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('expects 1 parameter(s), got 2');
+	});
+
+	// -----------------------------------------------------------------------
+	// Unauthorized room_id
+	// -----------------------------------------------------------------------
+
+	test('subscribe tasks.byRoom: nonexistent room rejected', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom',
+				params: ['room-does-not-exist'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	test('subscribe goals.byRoom: nonexistent room rejected', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'goals.byRoom',
+				params: ['room-does-not-exist'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	// -----------------------------------------------------------------------
+	// Unauthorized group_id
+	// -----------------------------------------------------------------------
+
+	test('subscribe sessionGroupMessages.byGroup: nonexistent group rejected', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'sessionGroupMessages.byGroup',
+				params: ['group-does-not-exist'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	test('subscribe sessionGroupMessages.byGroup: group with missing task rejected', async () => {
+		insertSessionGroup(db, 'grp-1', 'nonexistent-task', 'task');
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'sessionGroupMessages.byGroup',
+				params: ['grp-1'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	test('subscribe sessionGroupMessages.byGroup: task with missing room rejected', async () => {
+		// Insert a task with a room_id that doesn't exist
+		const orphanTask = 'orphan-task-1';
+		const missingRoom = 'missing-room-1';
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO tasks (id, room_id, title, description, status, priority, task_type, created_at, updated_at)
+			 VALUES ('${orphanTask}', '${missingRoom}', 'Orphan Task', '', 'pending', 'normal', 'coding', ${now}, ${now})`
+		);
+		insertSessionGroup(db, 'grp-2', orphanTask, 'task');
+
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'sessionGroupMessages.byGroup',
+				params: ['grp-2'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	test('subscribe sessionGroupMessages.byGroup: non-task group_type allowed without task lookup', async () => {
+		// group_type != 'task' should skip the task→room chain
+		insertSessionGroup(db, 'grp-other', 'some-ref', 'workflow');
+		const result = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'sessionGroupMessages.byGroup',
+			params: ['grp-other'],
+			subscriptionId: 'sub-1',
+		});
+		expect(result).toEqual({ ok: true });
+	});
+
+	// -----------------------------------------------------------------------
+	// Snapshot delivery on subscribe
+	// -----------------------------------------------------------------------
+
+	test('subscribe: snapshot delivered immediately on subscribe', async () => {
+		const result = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-1',
+		});
+		expect(result).toEqual({ ok: true });
+
+		// Snapshot should have been sent synchronously
+		expect(setup.sentMessages.length).toBe(1);
+		const msg = setup.sentMessages[0];
+		expect(msg.clientId).toBe('client-1');
+		expect(msg.message.method).toBe('liveQuery.snapshot');
+		expect(msg.message.data.subscriptionId).toBe('sub-1');
+		expect(Array.isArray(msg.message.data.rows)).toBe(true);
+		expect(typeof msg.message.data.version).toBe('number');
+	});
+
+	// -----------------------------------------------------------------------
+	// Full lifecycle: snapshot → delta → unsubscribe
+	// -----------------------------------------------------------------------
+
+	test('full lifecycle: subscribe → snapshot → delta → unsubscribe', async () => {
+		// Subscribe
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-lc',
+		});
+		expect(setup.sentMessages.length).toBe(1);
+		expect(setup.sentMessages[0].message.method).toBe('liveQuery.snapshot');
+
+		// Trigger a change to produce a delta (insert another task then notify)
+		insertTask(db, 'task-new-1', roomId);
+		reactiveDb.notifyChange('tasks');
+		// Let microtasks flush
+		await new Promise((r) => setTimeout(r, 10));
+
+		// At least the snapshot should be there; delta depends on reactive chain
+		expect(setup.sentMessages.length).toBeGreaterThanOrEqual(1);
+
+		// Unsubscribe
+		const unsubResult = await setup.callHandler('liveQuery.unsubscribe', {
+			subscriptionId: 'sub-lc',
+		});
+		expect(unsubResult).toEqual({ ok: true });
+	});
+
+	// -----------------------------------------------------------------------
+	// Snapshot before delta ordering
+	// -----------------------------------------------------------------------
+
+	test('snapshot always delivered before any delta', async () => {
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-order',
+		});
+
+		// Snapshot must be first
+		expect(setup.sentMessages[0].message.method).toBe('liveQuery.snapshot');
+		// Any subsequent messages must be deltas
+		for (let i = 1; i < setup.sentMessages.length; i++) {
+			expect(setup.sentMessages[i].message.method).toBe('liveQuery.delta');
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// subscriptionId collision replaces prior subscription
+	// -----------------------------------------------------------------------
+
+	test('subscriptionId collision: prior subscription replaced', async () => {
+		// First subscribe
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-collision',
+		});
+		const firstSnapshotCount = setup.sentMessages.length;
+		expect(firstSnapshotCount).toBe(1);
+
+		// Second subscribe with same subscriptionId
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-collision',
+		});
+		// Should have received a second snapshot
+		expect(setup.sentMessages.length).toBe(2);
+		expect(setup.sentMessages[1].message.method).toBe('liveQuery.snapshot');
+		expect(setup.sentMessages[1].message.data.subscriptionId).toBe('sub-collision');
+	});
+
+	// -----------------------------------------------------------------------
+	// Unsubscribe on unknown subscriptionId is safe
+	// -----------------------------------------------------------------------
+
+	test('unsubscribe: unknown subscriptionId returns ok (no error)', async () => {
+		const result = await setup.callHandler('liveQuery.unsubscribe', {
+			subscriptionId: 'non-existent-sub',
+		});
+		expect(result).toEqual({ ok: true });
+	});
+
+	// -----------------------------------------------------------------------
+	// Client disconnect cleanup
+	// -----------------------------------------------------------------------
+
+	test('client disconnect disposes all subscriptions for that client', async () => {
+		// Subscribe two different subscriptions for the same client
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-a',
+		});
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-b',
+		});
+		expect(setup.sentMessages.length).toBe(2); // two snapshots
+
+		// Simulate disconnect
+		setup.fireDisconnect('client-1');
+
+		// After disconnect, unsubscribing should be a no-op (already cleaned)
+		const result = await setup.callHandler('liveQuery.unsubscribe', {
+			subscriptionId: 'sub-a',
+		});
+		expect(result).toEqual({ ok: true });
+	});
+
+	// -----------------------------------------------------------------------
+	// sessionGroupMessages authorization: valid path allowed
+	// -----------------------------------------------------------------------
+
+	test('subscribe sessionGroupMessages.byGroup: valid group→task→room allowed', async () => {
+		insertSessionGroup(db, 'grp-valid', taskId, 'task');
+		const result = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'sessionGroupMessages.byGroup',
+			params: ['grp-valid'],
+			subscriptionId: 'sub-msg',
+		});
+		expect(result).toEqual({ ok: true });
+		expect(setup.sentMessages.length).toBe(1);
+		expect(setup.sentMessages[0].message.method).toBe('liveQuery.snapshot');
+	});
+
+	// -----------------------------------------------------------------------
+	// Snapshot delivery failure: still returns ok
+	// -----------------------------------------------------------------------
+
+	test('subscribe: snapshot delivery failure (client not found) returns ok gracefully', async () => {
+		setup.setSendResult(false);
+		const result = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-fail',
+		});
+		// Should not throw; the subscription was attempted
+		expect(result).toEqual({ ok: true });
+	});
+});

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts
@@ -60,6 +60,7 @@ function createMockSetup() {
 	let disconnectHandler: ((clientId: string) => void) | null = null;
 	const sentMessages: SentMessage[] = [];
 	let sendToClientResult = true; // override per-test if needed
+	let routerEnabled = true; // set to false to simulate null router
 
 	const mockRouter = {
 		sendToClient: mock((clientId: string, message: unknown) => {
@@ -73,7 +74,7 @@ function createMockSetup() {
 			handlers.set(method, handler);
 			return () => handlers.delete(method);
 		}),
-		getRouter: mock(() => mockRouter),
+		getRouter: mock(() => (routerEnabled ? mockRouter : null)),
 		onClientDisconnect: mock((handler: (clientId: string) => void) => {
 			disconnectHandler = handler;
 			return () => {
@@ -108,7 +109,20 @@ function createMockSetup() {
 		sendToClientResult = result;
 	};
 
-	return { hub, handlers, sentMessages, callHandler, fireDisconnect, setSendResult, mockRouter };
+	const setRouterEnabled = (enabled: boolean) => {
+		routerEnabled = enabled;
+	};
+
+	return {
+		hub,
+		handlers,
+		sentMessages,
+		callHandler,
+		fireDisconnect,
+		setSendResult,
+		setRouterEnabled,
+		mockRouter,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -484,5 +498,75 @@ describe('setupLiveQueryHandlers', () => {
 		});
 		// Should not throw; the subscription was attempted
 		expect(result).toEqual({ ok: true });
+	});
+
+	// -----------------------------------------------------------------------
+	// P1: Null router during snapshot — subscription disposed, returns ok
+	// -----------------------------------------------------------------------
+
+	test('subscribe: null router during snapshot disposes handle and returns ok', async () => {
+		setup.setRouterEnabled(false);
+		const result = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-no-router',
+		});
+		// No message was sent (router was null)
+		expect(setup.sentMessages.length).toBe(0);
+		// Returns ok — not a protocol error
+		expect(result).toEqual({ ok: true });
+
+		// After router is re-enabled, a second subscribe with the same id should work
+		// cleanly (old handle was disposed, not leaked into the tracking map)
+		setup.setRouterEnabled(true);
+		const result2 = await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-no-router',
+		});
+		expect(result2).toEqual({ ok: true });
+		expect(setup.sentMessages.length).toBe(1);
+		expect(setup.sentMessages[0].message.method).toBe('liveQuery.snapshot');
+	});
+
+	// -----------------------------------------------------------------------
+	// P1: Version monotonically increasing across deltas
+	// -----------------------------------------------------------------------
+
+	test('version is monotonically increasing across snapshot and deltas', async () => {
+		await setup.callHandler('liveQuery.subscribe', {
+			queryName: 'tasks.byRoom',
+			params: [roomId],
+			subscriptionId: 'sub-version',
+		});
+
+		// First message is snapshot
+		expect(setup.sentMessages.length).toBe(1);
+		const snapshotVersion = setup.sentMessages[0].message.data.version;
+		expect(typeof snapshotVersion).toBe('number');
+
+		// Trigger first delta
+		insertTask(db, 'task-v2', roomId);
+		reactiveDb.notifyChange('tasks');
+		await new Promise((r) => setTimeout(r, 10));
+
+		// Trigger second delta
+		insertTask(db, 'task-v3', roomId);
+		reactiveDb.notifyChange('tasks');
+		await new Promise((r) => setTimeout(r, 10));
+
+		// Collect all delta messages
+		const deltas = setup.sentMessages
+			.slice(1)
+			.filter((m) => m.message.method === 'liveQuery.delta');
+		expect(deltas.length).toBeGreaterThanOrEqual(1);
+
+		// Verify version is non-decreasing across snapshot → delta1 → delta2
+		let prevVersion = snapshotVersion;
+		for (const delta of deltas) {
+			const v = delta.message.data.version;
+			expect(v).toBeGreaterThanOrEqual(prevVersion);
+			prevVersion = v;
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- Implements `liveQuery.subscribe` and `liveQuery.unsubscribe` RPC handlers (Milestone 2, Task 2.5)
- Adds `liveQueries: LiveQueryEngine` to `RPCHandlerDependencies` and wires it from `createDaemonApp()`
- `setupLiveQueryHandlers()` registered in `setupRPCHandlers()` with cleanup on disconnect

## Behaviour

**`liveQuery.subscribe`:**
- Rejects if `clientId` absent (non-WebSocket call)
- Rejects unknown `queryName` with clear error
- Rejects mismatched `params` length
- Authorization: `tasks.byRoom` / `goals.byRoom` verify room exists; `sessionGroupMessages.byGroup` walks group → task → room chain
- `subscriptionId` collision silently replaces old handle (dispose + re-subscribe)
- Snapshot delivered synchronously via `router.sendToClient(clientId, message)` before returning `{ ok: true }`
- Subsequent deltas pushed on table change; `mapRow` transformer applied to all row batches

**`liveQuery.unsubscribe`:**
- Looks up handle by `clientId + subscriptionId`, disposes, removes tracking
- Returns `{ ok: true }` even for unknown subscriptionIds

**Disconnect cleanup:** `messageHub.onClientDisconnect` disposes all subscriptions for a disconnected client.

## Test plan

- [ ] 19 new unit tests in `live-query-subscribe.test.ts` covering all acceptance criteria
- [ ] Existing `live-query-handlers.test.ts` (32 tests) unaffected
- [ ] Full daemon test suite passes (pre-existing failures unrelated)
- [ ] Typecheck and lint clean