### PR TITLE
feat: step agent peer communication tools (send_feedback, request_peer_input, list_peers)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -149,6 +149,49 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 			`If you need to modify any files, follow the normal git/PR workflow instead.`
 	);
 
+	// Peer communication model
+	sections.push(`\n## Peer Communication\n`);
+	sections.push(
+		`You are part of a multi-agent team within this workflow step. ` +
+			`You have MCP tools for communicating with peer agents in the same group.`
+	);
+	sections.push(`\n### Primary: \`send_feedback\` (channel-validated direct messaging)\n`);
+	sections.push(
+		`Use \`send_feedback\` to send messages directly to permitted peers based on the declared channel topology.`
+	);
+	sections.push(
+		`- \`target: 'role'\` — point-to-point to a specific role (e.g., \`'coder'\`)\n` +
+			`- \`target: '*'\` — broadcast to all permitted targets\n` +
+			`- \`target: ['role1', 'role2']\` — multicast to multiple roles`
+	);
+	sections.push(
+		`This tool validates against declared channels. ` +
+			`If the channel is not declared, it returns an error with available channels and suggests \`request_peer_input\`.`
+	);
+	sections.push(`\n### Fallback: \`request_peer_input\` (Task Agent mediated)\n`);
+	sections.push(
+		`Use \`request_peer_input\` when no direct channel is declared or as a fallback when \`send_feedback\` fails validation.`
+	);
+	sections.push(
+		`This is **async and non-blocking** — the tool returns immediately with an acknowledgment. ` +
+			`The peer's answer will arrive as a separate user turn prefixed with: \`[Peer response from {role}]: ...\``
+	);
+	sections.push(
+		`**Do NOT wait for an immediate reply.** Continue your work and handle peer responses when they arrive.`
+	);
+	sections.push(`\n### Discovering peers: \`list_peers\`\n`);
+	sections.push(
+		`Use \`list_peers\` to see all other agents in this step's group, their roles, statuses, ` +
+			`and permitted outgoing channels for \`send_feedback\`.`
+	);
+	sections.push(`\n### Communication model rules\n`);
+	sections.push(
+		`- If this step has declared channels: use \`send_feedback\` for permitted directions, ` +
+			`\`request_peer_input\` for undeclared directions\n` +
+			`- If this step has no declared channels: all communication goes through \`request_peer_input\`\n` +
+			`- All communication is scoped to this group — you cannot message agents in other tasks`
+	);
+
 	// Review feedback handling
 	sections.push(`\n## Addressing Review Feedback\n`);
 	sections.push(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -66,6 +66,7 @@ import type {
 	SubSessionState,
 } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
+import { createStepAgentMcpServer } from '../tools/step-agent-tools';
 import { createTaskAgentInit, buildTaskAgentInitialMessage } from '../agents/task-agent';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
@@ -270,10 +271,12 @@ export class TaskAgentManager {
 			const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
 			const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
 
+			const workflowRunId = workflowRun?.id ?? '';
+
 			const mcpServer = createTaskAgentMcpServer({
 				taskId,
 				space,
-				workflowRunId: workflowRun?.id ?? '',
+				workflowRunId,
 				workspacePath: space.workspacePath,
 				runtime,
 				workflowManager: this.config.spaceWorkflowManager,
@@ -289,6 +292,14 @@ export class TaskAgentManager {
 				sessionGroupRepo: this.config.sessionGroupRepo,
 				getGroupId: () => this.taskGroupIds.get(taskId),
 				daemonHub: this.config.daemonHub,
+				buildStepAgentMcpServer: (subSessionId, role) =>
+					this.buildStepAgentMcpServerForSession(
+						taskId,
+						subSessionId,
+						role,
+						spaceId,
+						workflowRunId
+					) as unknown as McpServerConfig,
 			});
 
 			// setRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`
@@ -1078,10 +1089,12 @@ export class TaskAgentManager {
 		const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
 		const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
 
+		const rehydrateWorkflowRunId = workflowRun?.id ?? '';
+
 		const mcpServer = createTaskAgentMcpServer({
 			taskId,
 			space,
-			workflowRunId: workflowRun?.id ?? '',
+			workflowRunId: rehydrateWorkflowRunId,
 			workspacePath: space.workspacePath,
 			runtime,
 			workflowManager: this.config.spaceWorkflowManager,
@@ -1097,6 +1110,14 @@ export class TaskAgentManager {
 			daemonHub: this.config.daemonHub,
 			sessionGroupRepo: this.config.sessionGroupRepo,
 			getGroupId: () => this.taskGroupIds.get(taskId),
+			buildStepAgentMcpServer: (subSessionId, role) =>
+				this.buildStepAgentMcpServerForSession(
+					taskId,
+					subSessionId,
+					role,
+					spaceId,
+					rehydrateWorkflowRunId
+				) as unknown as McpServerConfig,
 		});
 
 		agentSession.setRuntimeMcpServers({
@@ -1282,5 +1303,36 @@ export class TaskAgentManager {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Build a step agent MCP server for a newly spawned sub-session.
+	 * Called from the `buildStepAgentMcpServer` callback passed to createTaskAgentMcpServer().
+	 *
+	 * The server gives the step agent peer communication tools (list_peers, send_feedback,
+	 * request_peer_input) that are scoped to its group and channel topology.
+	 *
+	 * The `injectToTaskAgent` callback routes `request_peer_input` requests through the
+	 * Task Agent, which has unrestricted relay access to all group members.
+	 */
+	private buildStepAgentMcpServerForSession(
+		taskId: string,
+		subSessionId: string,
+		role: string,
+		spaceId: string,
+		workflowRunId: string
+	) {
+		return createStepAgentMcpServer({
+			mySessionId: subSessionId,
+			myRole: role,
+			taskId,
+			workflowRunId,
+			sessionGroupRepo: this.config.sessionGroupRepo,
+			getGroupId: () => this.taskGroupIds.get(taskId),
+			workflowRunRepo: this.config.workflowRunRepo,
+			messageInjector: (targetSessionId, message) =>
+				this.injectSubSessionMessage(targetSessionId, message),
+			injectToTaskAgent: (message) => this.injectTaskAgentMessage(taskId, message),
+		});
 	}
 }

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -62,7 +62,7 @@ export const SendFeedbackSchema = z.object({
 			"Target role(s): a role name (e.g., 'coder'), '*' for broadcast to all permitted targets, or an array of role names for multicast"
 		),
 	/** The message to send to the target(s). */
-	message: z.string().describe('The message content to send to the target peer(s)'),
+	message: z.string().min(1).describe('The message content to send to the target peer(s)'),
 });
 
 export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;
@@ -92,6 +92,7 @@ export const RequestPeerInputSchema = z.object({
 	/** The question or request to send to the peer via the Task Agent. */
 	question: z
 		.string()
+		.min(1)
 		.describe('The question or request to relay to the peer through the Task Agent'),
 });
 

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -1,0 +1,113 @@
+/**
+ * Step Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 3
+ * peer communication tools available to step agent sub-sessions.
+ *
+ * Tools:
+ *   list_peers          — list other group members with their roles, statuses, and permitted channels
+ *   send_feedback       — primary channel-validated direct messaging tool
+ *   request_peer_input  — fallback Task Agent mediated messaging tool
+ *
+ * This file contains only schema definitions — no runtime logic or side effects.
+ *
+ * Style conventions (matching task-agent-tool-schemas.ts):
+ *   - z.string().describe() on every field — .describe() before .optional()
+ *   - optional fields use .optional() after .describe()
+ *   - union types use z.union([...]) for discriminated inputs
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// list_peers
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_peers` input.
+ * Lists all other members of the current workflow step group.
+ * No arguments — the group and self are inferred from the step agent context.
+ */
+export const ListPeersSchema = z.object({});
+
+export type ListPeersInput = z.infer<typeof ListPeersSchema>;
+
+// ---------------------------------------------------------------------------
+// send_feedback
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `send_feedback` input.
+ *
+ * Primary direct messaging tool for step agents. Validates against declared channel
+ * topology before routing. Supports three target forms:
+ *   - Point-to-point: `target: 'coder'`
+ *   - Broadcast to all permitted: `target: '*'`
+ *   - Multicast: `target: ['coder', 'reviewer']`
+ *
+ * Returns an error with available channels and suggests `request_peer_input` when
+ * the channel topology does not permit the requested direction.
+ */
+export const SendFeedbackSchema = z.object({
+	/**
+	 * Target role(s) to send the message to.
+	 * - String: point-to-point to a single role (e.g., 'coder')
+	 * - '*': broadcast to all roles permitted by channel topology
+	 * - Array of strings: multicast to multiple specific roles
+	 */
+	target: z
+		.union([
+			z.string().describe('Role name or * for broadcast'),
+			z.array(z.string()).describe('Array of role names for multicast'),
+		])
+		.describe(
+			"Target role(s): a role name (e.g., 'coder'), '*' for broadcast to all permitted targets, or an array of role names for multicast"
+		),
+	/** The message to send to the target(s). */
+	message: z.string().describe('The message content to send to the target peer(s)'),
+});
+
+export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;
+
+// ---------------------------------------------------------------------------
+// request_peer_input
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `request_peer_input` input.
+ *
+ * Fallback Task Agent mediated communication tool. Available when no direct channel
+ * is declared for the target role, or when `send_feedback` fails validation.
+ *
+ * This is ASYNC and NON-BLOCKING — the tool returns an acknowledgment immediately.
+ * The peer's answer will arrive as a separate user turn prefixed with:
+ *   `[Peer response from {role}]: ...`
+ *
+ * Do NOT wait for an immediate reply. Continue working and handle the peer's
+ * response when it arrives in the conversation.
+ */
+export const RequestPeerInputSchema = z.object({
+	/** Role of the peer to ask (e.g., 'reviewer', 'coder'). */
+	target_role: z
+		.string()
+		.describe("Role of the peer to request input from (e.g., 'reviewer', 'coder')"),
+	/** The question or request to send to the peer via the Task Agent. */
+	question: z
+		.string()
+		.describe('The question or request to relay to the peer through the Task Agent'),
+});
+
+export type RequestPeerInputInput = z.infer<typeof RequestPeerInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Aggregate export
+// ---------------------------------------------------------------------------
+
+/**
+ * All step agent tool schemas keyed by tool name.
+ */
+export const STEP_AGENT_TOOL_SCHEMAS = {
+	list_peers: ListPeersSchema,
+	send_feedback: SendFeedbackSchema,
+	request_peer_input: RequestPeerInputSchema,
+} as const;
+
+export type StepAgentToolName = keyof typeof STEP_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -26,7 +26,8 @@
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
  * - Dependencies are injected via `StepAgentToolsConfig`.
- * - The `messageInjector` serializes writes per-session for safe concurrency.
+ * - `messageInjector` is backed by `injectSubSessionMessage` → `injectMessageIntoSession`
+ *   → `session.messageQueue.enqueueWithId()`, which provides per-session write ordering.
  * - The `injectToTaskAgent` callback is used by `request_peer_input` for routing.
  */
 
@@ -106,22 +107,23 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		injectToTaskAgent,
 	} = config;
 
-	/**
-	 * Helper: load the group and build a ChannelResolver from the current run config.
-	 * Returns null with an error ToolResult if the group cannot be found.
-	 */
-	function loadGroupAndResolver(): {
-		group: ReturnType<typeof sessionGroupRepo.getGroup>;
+	type GroupLoaded = {
+		ok: true;
+		group: NonNullable<ReturnType<typeof sessionGroupRepo.getGroup>>;
 		resolver: ChannelResolver;
 		groupId: string;
-		error?: ToolResult;
-	} {
+	};
+	type GroupError = { ok: false; error: ToolResult };
+
+	/**
+	 * Helper: load the group and build a ChannelResolver from the current run config.
+	 * Returns a discriminated union — callers check `result.ok` before accessing `group`.
+	 */
+	function loadGroupAndResolver(): GroupLoaded | GroupError {
 		const groupId = getGroupId();
 		if (!groupId) {
 			return {
-				group: null,
-				resolver: new ChannelResolver([]),
-				groupId: '',
+				ok: false,
 				error: jsonResult({
 					success: false,
 					error:
@@ -134,9 +136,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		const group = sessionGroupRepo.getGroup(groupId);
 		if (!group) {
 			return {
-				group: null,
-				resolver: new ChannelResolver([]),
-				groupId,
+				ok: false,
 				error: jsonResult({
 					success: false,
 					error: `Session group ${groupId} not found in the database.`,
@@ -150,7 +150,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 			run?.config as Record<string, unknown> | undefined
 		);
 
-		return { group, resolver, groupId };
+		return { ok: true, group, resolver, groupId };
 	}
 
 	return {
@@ -164,11 +164,12 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		 * Returns permittedTargets: roles this agent can directly send to via send_feedback.
 		 */
 		async list_peers(_args: ListPeersInput): Promise<ToolResult> {
-			const { group, resolver, error } = loadGroupAndResolver();
-			if (error) return error;
+			const loaded = loadGroupAndResolver();
+			if (!loaded.ok) return loaded.error;
+			const { group, resolver } = loaded;
 
 			// Filter out self and task-agent (coordinator)
-			const peers = group!.members
+			const peers = group.members
 				.filter((m) => m.sessionId !== mySessionId && m.role !== 'task-agent')
 				.map((m) => ({
 					sessionId: m.sessionId,
@@ -214,8 +215,23 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		async send_feedback(args: SendFeedbackInput): Promise<ToolResult> {
 			const { target, message } = args;
 
-			const { group, resolver, error } = loadGroupAndResolver();
-			if (error) return error;
+			const loaded = loadGroupAndResolver();
+			if (!loaded.ok) return loaded.error;
+			const { group, resolver } = loaded;
+
+			// When no channel topology is declared for this step, all send_feedback calls
+			// fail. Agents in a step with no declared channels must use request_peer_input
+			// so that all inter-agent communication is mediated by the Task Agent.
+			if (resolver.isEmpty()) {
+				return jsonResult({
+					success: false,
+					error:
+						`No channel topology declared for this step. ` +
+						`Direct messaging via send_feedback is not available. ` +
+						`Use request_peer_input to communicate with peers through the Task Agent.`,
+					suggestion: 'request_peer_input',
+				});
+			}
 
 			// Resolve target roles from the target argument
 			let targetRoles: string[];
@@ -224,16 +240,6 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 				// Broadcast: expand to all permitted targets
 				const permitted = resolver.getPermittedTargets(myRole);
 				if (permitted.length === 0) {
-					if (resolver.isEmpty()) {
-						return jsonResult({
-							success: false,
-							error:
-								`No channel topology declared for this step. ` +
-								`Direct messaging via send_feedback is not available. ` +
-								`Use request_peer_input to communicate with peers through the Task Agent.`,
-							suggestion: 'request_peer_input',
-						});
-					}
 					return jsonResult({
 						success: false,
 						error:
@@ -253,26 +259,24 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 			}
 
 			// Validate all requested target roles against channel topology
-			if (!resolver.isEmpty()) {
-				const unauthorizedRoles = targetRoles.filter((role) => !resolver.canSend(myRole, role));
-				if (unauthorizedRoles.length > 0) {
-					const permittedTargets = resolver.getPermittedTargets(myRole);
-					return jsonResult({
-						success: false,
-						error:
-							`Channel topology does not permit '${myRole}' to send to: ${unauthorizedRoles.join(', ')}. ` +
-							`Permitted targets: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`,
-						unauthorizedRoles,
-						permittedTargets,
-						suggestion:
-							'Use request_peer_input to route through the Task Agent for undeclared channels.',
-					});
-				}
+			const unauthorizedRoles = targetRoles.filter((role) => !resolver.canSend(myRole, role));
+			if (unauthorizedRoles.length > 0) {
+				const permittedTargets = resolver.getPermittedTargets(myRole);
+				return jsonResult({
+					success: false,
+					error:
+						`Channel topology does not permit '${myRole}' to send to: ${unauthorizedRoles.join(', ')}. ` +
+						`Permitted targets: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`,
+					unauthorizedRoles,
+					permittedTargets,
+					suggestion:
+						'Use request_peer_input to route through the Task Agent for undeclared channels.',
+				});
 			}
 
 			// Resolve target roles to session IDs from group members
 			// Multiple members can share the same role (parallel instances)
-			const targetMembers = group!.members.filter(
+			const targetMembers = group.members.filter(
 				(m) =>
 					targetRoles.includes(m.role) && m.sessionId !== mySessionId && m.role !== 'task-agent'
 			);
@@ -287,13 +291,17 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 				});
 			}
 
+			// Prefix message with sender identity so the receiver can attribute it.
+			// Without this, agents in multi-peer groups cannot tell who sent the message.
+			const attributedMessage = `[Feedback from ${myRole}]: ${message}`;
+
 			// Inject message into each target session
 			const injected: Array<{ sessionId: string; role: string }> = [];
 			const failed: Array<{ sessionId: string; role: string; error: string }> = [];
 
 			for (const member of targetMembers) {
 				try {
-					await messageInjector(member.sessionId, message);
+					await messageInjector(member.sessionId, attributedMessage);
 					injected.push({ sessionId: member.sessionId, role: member.role });
 				} catch (err) {
 					const msg = err instanceof Error ? err.message : String(err);
@@ -400,6 +408,7 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 			'request_peer_input',
 			'Route a question or request to a peer through the Task Agent. ' +
 				'Use this when no direct channel is declared or as a fallback when send_feedback fails. ' +
+				'Call list_peers first to verify the target_role exists in the group. ' +
 				'ASYNC: returns immediately. The peer response arrives later as a user turn prefixed with [Peer response from {role}]: ...',
 			RequestPeerInputSchema.shape,
 			(args) => handlers.request_peer_input(args)

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -1,0 +1,412 @@
+/**
+ * Step Agent Tools — MCP tool handlers for step agent sub-sessions.
+ *
+ * These handlers implement peer communication tools for step agents within
+ * the same workflow step group:
+ *
+ *   list_peers          — discover other group members with roles and permitted channels
+ *   send_feedback       — primary channel-validated direct messaging tool
+ *   request_peer_input  — fallback Task Agent mediated messaging (async)
+ *
+ * Communication model:
+ * - Step agents communicate via declared channel topology (`send_feedback`).
+ * - When no channel is declared, or as a fallback, use `request_peer_input`
+ *   which routes through the Task Agent.
+ * - `list_peers` reveals who is in the group and what channels are available.
+ *
+ * Channel topology patterns supported:
+ *   - Bidirectional point-to-point: A↔B (both directions permitted)
+ *   - One-way: A→B (only A can send to B)
+ *   - Fan-out one-way: hub→[spoke1, spoke2, ...]
+ *   - Hub-spoke: hub↔spokes (hub sends to all, spokes only reply to hub)
+ *
+ * When no channels are declared for a step, all `send_feedback` calls fail with
+ * a suggestion to use `request_peer_input` instead.
+ *
+ * Design:
+ * - Handlers are pure functions tested independently of any MCP server layer.
+ * - Dependencies are injected via `StepAgentToolsConfig`.
+ * - The `messageInjector` serializes writes per-session for safe concurrency.
+ * - The `injectToTaskAgent` callback is used by `request_peer_input` for routing.
+ */
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { SpaceSessionGroupRepository } from '../../../storage/repositories/space-session-group-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import { ChannelResolver } from '../runtime/channel-resolver';
+import { jsonResult } from './tool-result';
+import type { ToolResult } from './tool-result';
+import {
+	ListPeersSchema,
+	SendFeedbackSchema,
+	RequestPeerInputSchema,
+} from './step-agent-tool-schemas';
+import type {
+	ListPeersInput,
+	SendFeedbackInput,
+	RequestPeerInputInput,
+} from './step-agent-tool-schemas';
+
+// Re-export for consumers that want the shared type
+export type { ToolResult };
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies injected into createStepAgentToolHandlers().
+ * All fields are required — the caller (TaskAgentManager) wires them up.
+ */
+export interface StepAgentToolsConfig {
+	/** Session ID of this step agent (used to exclude self from list_peers). */
+	mySessionId: string;
+	/** Role of this step agent (e.g., 'coder', 'reviewer'). */
+	myRole: string;
+	/** ID of the parent task (used for error messages). */
+	taskId: string;
+	/** Workflow run ID — used to load channel topology from run config. */
+	workflowRunId: string;
+	/** Session group repository for looking up group members. */
+	sessionGroupRepo: SpaceSessionGroupRepository;
+	/** Returns the group ID for this task from the in-memory map. */
+	getGroupId: () => string | undefined;
+	/** Workflow run repository for reading run config (channel topology). */
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	/**
+	 * Injects a message into a peer sub-session as a user turn.
+	 * Used by `send_feedback` to deliver messages to target sessions.
+	 */
+	messageInjector: (sessionId: string, message: string) => Promise<void>;
+	/**
+	 * Injects a message into the Task Agent session.
+	 * Used by `request_peer_input` to route questions through the Task Agent.
+	 */
+	injectToTaskAgent: (message: string) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Tool handlers (separated for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create handler functions for the step agent peer communication tools.
+ * Returns a map of tool name → async handler function.
+ */
+export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
+	const {
+		mySessionId,
+		myRole,
+		taskId,
+		workflowRunId,
+		sessionGroupRepo,
+		getGroupId,
+		workflowRunRepo,
+		messageInjector,
+		injectToTaskAgent,
+	} = config;
+
+	/**
+	 * Helper: load the group and build a ChannelResolver from the current run config.
+	 * Returns null with an error ToolResult if the group cannot be found.
+	 */
+	function loadGroupAndResolver(): {
+		group: ReturnType<typeof sessionGroupRepo.getGroup>;
+		resolver: ChannelResolver;
+		groupId: string;
+		error?: ToolResult;
+	} {
+		const groupId = getGroupId();
+		if (!groupId) {
+			return {
+				group: null,
+				resolver: new ChannelResolver([]),
+				groupId: '',
+				error: jsonResult({
+					success: false,
+					error:
+						`No session group found for task ${taskId}. ` +
+						`The group may not have been created yet.`,
+				}),
+			};
+		}
+
+		const group = sessionGroupRepo.getGroup(groupId);
+		if (!group) {
+			return {
+				group: null,
+				resolver: new ChannelResolver([]),
+				groupId,
+				error: jsonResult({
+					success: false,
+					error: `Session group ${groupId} not found in the database.`,
+				}),
+			};
+		}
+
+		// Build ChannelResolver from the active workflow run's config
+		const run = workflowRunRepo.getRun(workflowRunId);
+		const resolver = ChannelResolver.fromRunConfig(
+			run?.config as Record<string, unknown> | undefined
+		);
+
+		return { group, resolver, groupId };
+	}
+
+	return {
+		/**
+		 * List all peers (other group members) with their roles, statuses, session IDs,
+		 * and permitted channel connections.
+		 *
+		 * Does NOT include self (filtered by `mySessionId`).
+		 * Does NOT include the Task Agent (filtered by role 'task-agent').
+		 *
+		 * Returns permittedTargets: roles this agent can directly send to via send_feedback.
+		 */
+		async list_peers(_args: ListPeersInput): Promise<ToolResult> {
+			const { group, resolver, error } = loadGroupAndResolver();
+			if (error) return error;
+
+			// Filter out self and task-agent (coordinator)
+			const peers = group!.members
+				.filter((m) => m.sessionId !== mySessionId && m.role !== 'task-agent')
+				.map((m) => ({
+					sessionId: m.sessionId,
+					role: m.role,
+					agentId: m.agentId ?? null,
+					status: m.status,
+				}));
+
+			const permittedTargets = resolver.getPermittedTargets(myRole);
+			const channelTopologyDeclared = !resolver.isEmpty();
+
+			return jsonResult({
+				success: true,
+				myRole,
+				peers,
+				permittedTargets,
+				channelTopologyDeclared,
+				message:
+					`Found ${peers.length} peer(s). ` +
+					(channelTopologyDeclared
+						? `Permitted direct targets via send_feedback: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`
+						: 'No channel topology declared — use request_peer_input to communicate with peers.'),
+			});
+		},
+
+		/**
+		 * Send a message directly to one or more peer agents.
+		 *
+		 * Validates the requested direction(s) against the declared channel topology
+		 * before routing. On validation failure, returns an error with available channels
+		 * and suggests `request_peer_input` as a fallback.
+		 *
+		 * Target forms:
+		 *   - `target: 'coder'` — point-to-point to a single role
+		 *   - `target: '*'` — broadcast to all permitted targets
+		 *   - `target: ['coder', 'reviewer']` — multicast to multiple roles
+		 *
+		 * Fan-out one-way and hub-spoke enforcement:
+		 *   - Spokes can only send to roles where canSend(myRole, targetRole) is true
+		 *   - Hub-spoke isolation is enforced by channel topology (spoke→spoke channels
+		 *     are not declared; spokes can only reply to hub)
+		 */
+		async send_feedback(args: SendFeedbackInput): Promise<ToolResult> {
+			const { target, message } = args;
+
+			const { group, resolver, error } = loadGroupAndResolver();
+			if (error) return error;
+
+			// Resolve target roles from the target argument
+			let targetRoles: string[];
+
+			if (target === '*') {
+				// Broadcast: expand to all permitted targets
+				const permitted = resolver.getPermittedTargets(myRole);
+				if (permitted.length === 0) {
+					if (resolver.isEmpty()) {
+						return jsonResult({
+							success: false,
+							error:
+								`No channel topology declared for this step. ` +
+								`Direct messaging via send_feedback is not available. ` +
+								`Use request_peer_input to communicate with peers through the Task Agent.`,
+							suggestion: 'request_peer_input',
+						});
+					}
+					return jsonResult({
+						success: false,
+						error:
+							`No permitted targets for role '${myRole}' in the declared channel topology. ` +
+							`Broadcast ('*') requires at least one permitted outgoing channel.`,
+						availableTargets: [],
+						suggestion: 'request_peer_input',
+					});
+				}
+				targetRoles = permitted;
+			} else if (Array.isArray(target)) {
+				// Multicast: validate each requested role
+				targetRoles = target;
+			} else {
+				// Point-to-point: single role
+				targetRoles = [target];
+			}
+
+			// Validate all requested target roles against channel topology
+			if (!resolver.isEmpty()) {
+				const unauthorizedRoles = targetRoles.filter((role) => !resolver.canSend(myRole, role));
+				if (unauthorizedRoles.length > 0) {
+					const permittedTargets = resolver.getPermittedTargets(myRole);
+					return jsonResult({
+						success: false,
+						error:
+							`Channel topology does not permit '${myRole}' to send to: ${unauthorizedRoles.join(', ')}. ` +
+							`Permitted targets: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`,
+						unauthorizedRoles,
+						permittedTargets,
+						suggestion:
+							'Use request_peer_input to route through the Task Agent for undeclared channels.',
+					});
+				}
+			}
+
+			// Resolve target roles to session IDs from group members
+			// Multiple members can share the same role (parallel instances)
+			const targetMembers = group!.members.filter(
+				(m) =>
+					targetRoles.includes(m.role) && m.sessionId !== mySessionId && m.role !== 'task-agent'
+			);
+
+			if (targetMembers.length === 0) {
+				return jsonResult({
+					success: false,
+					error:
+						`No active sessions found for target role(s): ${targetRoles.join(', ')}. ` +
+						`Use list_peers to check which peers are currently active.`,
+					targetRoles,
+				});
+			}
+
+			// Inject message into each target session
+			const injected: Array<{ sessionId: string; role: string }> = [];
+			const failed: Array<{ sessionId: string; role: string; error: string }> = [];
+
+			for (const member of targetMembers) {
+				try {
+					await messageInjector(member.sessionId, message);
+					injected.push({ sessionId: member.sessionId, role: member.role });
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					failed.push({ sessionId: member.sessionId, role: member.role, error: msg });
+				}
+			}
+
+			if (injected.length === 0) {
+				return jsonResult({
+					success: false,
+					error: `Failed to deliver message to any target. All injections failed.`,
+					failed,
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				delivered: injected,
+				...(failed.length > 0 ? { partialFailures: failed } : {}),
+				message:
+					`Message delivered to ${injected.length} peer(s): ` +
+					injected.map((t) => `${t.role} (${t.sessionId})`).join(', ') +
+					'.',
+			});
+		},
+
+		/**
+		 * Route a question or request through the Task Agent to a peer.
+		 *
+		 * This is the FALLBACK tool for when no direct channel is declared, or when
+		 * `send_feedback` fails validation. It routes through the Task Agent, which
+		 * has unrestricted relay access to all group members.
+		 *
+		 * ASYNC and NON-BLOCKING — returns immediately with an acknowledgment.
+		 * The peer's answer will arrive as a separate user turn in this session,
+		 * prefixed with: `[Peer response from {role}]: ...`
+		 *
+		 * Do NOT wait for an immediate reply. Continue working and process the peer's
+		 * response when it arrives.
+		 */
+		async request_peer_input(args: RequestPeerInputInput): Promise<ToolResult> {
+			const { target_role, question } = args;
+
+			// Format the routing request for the Task Agent
+			const routingMessage =
+				`[Peer input request from '${myRole}' (session ${mySessionId}) to '${target_role}']: ` +
+				`${question}\n\n` +
+				`Please relay this question to the '${target_role}' peer and forward their response back to '${myRole}' ` +
+				`(session ${mySessionId}) prefixed with: [Peer response from ${target_role}]: ...`;
+
+			try {
+				await injectToTaskAgent(routingMessage);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				return jsonResult({
+					success: false,
+					error: `Failed to route request through Task Agent: ${msg}`,
+				});
+			}
+
+			return jsonResult({
+				success: true,
+				targetRole: target_role,
+				message:
+					`Request routed to Task Agent for delivery to '${target_role}'. ` +
+					`This is async — continue your work. ` +
+					`The peer's response will arrive as a user turn prefixed with: [Peer response from ${target_role}]: ...`,
+				async: true,
+			});
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// MCP server factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an MCP server exposing all step agent peer communication tools.
+ * Pass the returned server to the AgentSessionInit.mcpServers for step agent sessions.
+ */
+export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
+	const handlers = createStepAgentToolHandlers(config);
+
+	const tools = [
+		tool(
+			'list_peers',
+			'List all other agents in this workflow step group with their roles, statuses, session IDs, ' +
+				'and permitted channel connections. ' +
+				'Use this to discover which peers are active and what direct messaging channels are available.',
+			ListPeersSchema.shape,
+			(args) => handlers.list_peers(args)
+		),
+		tool(
+			'send_feedback',
+			'Send a message directly to one or more peer agents via declared channel topology. ' +
+				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
+				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
+				'Use request_peer_input as a fallback when no channel is declared.',
+			SendFeedbackSchema.shape,
+			(args) => handlers.send_feedback(args)
+		),
+		tool(
+			'request_peer_input',
+			'Route a question or request to a peer through the Task Agent. ' +
+				'Use this when no direct channel is declared or as a fallback when send_feedback fails. ' +
+				'ASYNC: returns immediately. The peer response arrives later as a user turn prefixed with [Peer response from {role}]: ...',
+			RequestPeerInputSchema.shape,
+			(args) => handlers.request_peer_input(args)
+		),
+	];
+
+	return createSdkMcpServer({ name: 'step-agent', tools });
+}
+
+export type StepAgentMcpServer = ReturnType<typeof createStepAgentMcpServer>;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -21,7 +21,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
-import type { Space } from '@neokai/shared';
+import type { Space, McpServerConfig } from '@neokai/shared';
 import type { DaemonHub } from '../../daemon-hub';
 import { Logger } from '../../logger';
 import type { AgentSessionInit } from '../../agent/agent-session';
@@ -182,6 +182,13 @@ export interface TaskAgentToolsConfig {
 	 * Optional — if omitted, no events are emitted (e.g. in unit tests that don't need them).
 	 */
 	daemonHub?: DaemonHub;
+	/**
+	 * Factory to build a step agent MCP server for a spawned sub-session.
+	 * Called in `spawn_step_agent` after resolving the session ID and agent role.
+	 * Returns a McpServerConfig to attach to the sub-session's init.mcpServers.
+	 * Optional — if omitted, no step agent MCP server is attached (e.g. in unit tests).
+	 */
+	buildStepAgentMcpServer?: (sessionId: string, role: string) => McpServerConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,6 +217,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		sessionGroupRepo,
 		getGroupId,
 		daemonHub,
+		buildStepAgentMcpServer,
 	} = config;
 
 	return {
@@ -324,6 +332,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			// resolveAgentInit() already validated the agent exists, so this lookup
 			// should always succeed — null here would be a data inconsistency.
 			const agentForMember = agentManager.getById(effectiveTask.customAgentId!);
+
+			// Attach step agent peer communication MCP server if a factory is provided.
+			// The server is built with the resolved session ID and agent role so it can
+			// validate channels and inject messages into the correct peer sessions.
+			const agentRole = agentForMember?.role ?? 'agent';
+			if (buildStepAgentMcpServer) {
+				const stepMcpServer = buildStepAgentMcpServer(subSessionId, agentRole);
+				init = {
+					...init,
+					mcpServers: { ...init.mcpServers, 'step-agent': stepMcpServer },
+				};
+			}
 
 			// Create and start the sub-session
 			let actualSessionId: string;

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -326,7 +326,7 @@ describe('step-agent-tools: send_feedback', () => {
 		expect(data.delivered[0].sessionId).toBe(ctx.reviewerSessionId);
 		expect(data.delivered[0].role).toBe('reviewer');
 		expect(injected).toHaveLength(1);
-		expect(injected[0].message).toBe('LGTM!');
+		expect(injected[0].message).toBe('[Feedback from coder]: LGTM!');
 	});
 
 	test('point-to-point fails when channel not declared', async () => {
@@ -344,18 +344,17 @@ describe('step-agent-tools: send_feedback', () => {
 		expect(data.suggestion).toContain('request_peer_input');
 	});
 
-	test('returns error when no channels declared at all', async () => {
+	test('returns error when no channels declared at all (empty topology blocks send_feedback)', async () => {
 		const config = makeConfig(ctx); // no workflowRunId, no channels
 		const handlers = createStepAgentToolHandlers(config);
 		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
-		// When topology is empty, canSend returns false but we don't validate — we just skip
-		// validation and try to inject. Let's verify the actual behavior:
 		const data = JSON.parse(result.content[0].text);
 
-		// With empty topology, no validation happens (isEmpty=true), so it should succeed
-		// if the target exists in the group
-		expect(data.success).toBe(true);
-		expect(data.delivered[0].role).toBe('reviewer');
+		// With no declared channels, send_feedback is unavailable — all communication
+		// must go through request_peer_input (Task Agent mediated).
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No channel topology declared');
+		expect(data.suggestion).toBe('request_peer_input');
 	});
 
 	test('broadcast (*) succeeds and delivers to all permitted targets', async () => {

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -1,0 +1,777 @@
+/**
+ * Unit tests for createStepAgentToolHandlers()
+ *
+ * Covers all 3 step agent peer communication tools:
+ *   list_peers          — list peers excluding self and task-agent
+ *   send_feedback       — channel-validated direct messaging
+ *   request_peer_input  — Task Agent mediated async fallback
+ *
+ * Tests use a real SQLite database (via runMigrations) and mock message
+ * injectors so no real agent sessions are created.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { SpaceSessionGroupRepository } from '../../../src/storage/repositories/space-session-group-repository.ts';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository.ts';
+import {
+	createStepAgentToolHandlers,
+	createStepAgentMcpServer,
+	type StepAgentToolsConfig,
+} from '../../../src/lib/space/tools/step-agent-tools.ts';
+import type { ResolvedChannel } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-step-agent-tools',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, status, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Workflow run helper
+// ---------------------------------------------------------------------------
+
+function seedWorkflowRunWithChannels(
+	db: BunDatabase,
+	spaceId: string,
+	channels: ResolvedChannel[]
+): string {
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflow = workflowRepo.createWorkflow({
+		spaceId,
+		name: 'Test Workflow',
+		description: '',
+		steps: [],
+		transitions: [],
+		startStepId: '',
+		rules: [],
+	});
+
+	const runRepo = new SpaceWorkflowRunRepository(db);
+	const run = runRepo.createRun({
+		spaceId,
+		workflowId: workflow.id,
+		title: 'Test Run',
+		triggeredBy: 'test',
+	});
+
+	// Store resolved channels in config
+	if (channels.length > 0) {
+		runRepo.updateRun(run.id, {
+			config: { _resolvedChannels: channels },
+		});
+	}
+
+	return run.id;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeResolvedChannel(
+	fromRole: string,
+	toRole: string,
+	isHubSpoke = false
+): ResolvedChannel {
+	return {
+		fromRole,
+		toRole,
+		fromAgentId: `agent-${fromRole}`,
+		toAgentId: `agent-${toRole}`,
+		direction: 'one-way',
+		isHubSpoke,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test context
+// ---------------------------------------------------------------------------
+
+interface TestCtx {
+	db: BunDatabase;
+	dir: string;
+	spaceId: string;
+	sessionGroupRepo: SpaceSessionGroupRepository;
+	groupId: string;
+	coderSessionId: string;
+	reviewerSessionId: string;
+	taskAgentSessionId: string;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+}
+
+function makeCtx(): TestCtx {
+	const { db, dir } = makeDb();
+	const spaceId = 'space-step-tools-test';
+
+	seedSpaceRow(db, spaceId);
+
+	const sessionGroupRepo = new SpaceSessionGroupRepository(db);
+
+	// Create a session group for the task
+	const group = sessionGroupRepo.createGroup({
+		spaceId,
+		name: 'task:test-task-1',
+		taskId: 'test-task-1',
+	});
+
+	// Add members: task-agent, coder, reviewer
+	const taskAgentSessionId = 'session-task-agent';
+	const coderSessionId = 'session-coder';
+	const reviewerSessionId = 'session-reviewer';
+
+	sessionGroupRepo.addMember(group.id, taskAgentSessionId, {
+		role: 'task-agent',
+		status: 'active',
+		orderIndex: 0,
+	});
+	sessionGroupRepo.addMember(group.id, coderSessionId, {
+		role: 'coder',
+		status: 'active',
+		agentId: 'agent-coder',
+		orderIndex: 1,
+	});
+	sessionGroupRepo.addMember(group.id, reviewerSessionId, {
+		role: 'reviewer',
+		status: 'active',
+		agentId: 'agent-reviewer',
+		orderIndex: 2,
+	});
+
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+
+	return {
+		db,
+		dir,
+		spaceId,
+		sessionGroupRepo,
+		groupId: group.id,
+		coderSessionId,
+		reviewerSessionId,
+		taskAgentSessionId,
+		workflowRunRepo,
+	};
+}
+
+function makeConfig(
+	ctx: TestCtx,
+	overrides: Partial<StepAgentToolsConfig> = {}
+): StepAgentToolsConfig {
+	const injectedMessages: Array<{ sessionId: string; message: string }> = [];
+	const taskAgentMessages: string[] = [];
+
+	return {
+		mySessionId: ctx.coderSessionId,
+		myRole: 'coder',
+		taskId: 'test-task-1',
+		workflowRunId: '',
+		sessionGroupRepo: ctx.sessionGroupRepo,
+		getGroupId: () => ctx.groupId,
+		workflowRunRepo: ctx.workflowRunRepo,
+		messageInjector: async (sessionId, message) => {
+			injectedMessages.push({ sessionId, message });
+		},
+		injectToTaskAgent: async (message) => {
+			taskAgentMessages.push(message);
+		},
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: list_peers
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: list_peers', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns peers excluding self and task-agent', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.peers).toHaveLength(1); // only reviewer (coder=self, task-agent=excluded)
+		expect(data.peers[0].role).toBe('reviewer');
+		expect(data.peers[0].sessionId).toBe(ctx.reviewerSessionId);
+		expect(data.myRole).toBe('coder');
+	});
+
+	test('reports no channel topology when none declared', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.channelTopologyDeclared).toBe(false);
+		expect(data.permittedTargets).toEqual([]);
+	});
+
+	test('reports permitted targets when channels declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.channelTopologyDeclared).toBe(true);
+		expect(data.permittedTargets).toEqual(['reviewer']);
+	});
+
+	test('returns error when group not found', async () => {
+		const config = makeConfig(ctx, { getGroupId: () => undefined });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No session group found');
+	});
+
+	test('returns empty peer list when only self and task-agent in group', async () => {
+		// Create a group with just task-agent and coder (no reviewer)
+		const isolatedGroup = ctx.sessionGroupRepo.createGroup({
+			spaceId: ctx.spaceId,
+			name: 'task:isolated',
+			taskId: 'isolated-task',
+		});
+		ctx.sessionGroupRepo.addMember(isolatedGroup.id, 'session-isolated-ta', {
+			role: 'task-agent',
+			status: 'active',
+		});
+		ctx.sessionGroupRepo.addMember(isolatedGroup.id, ctx.coderSessionId, {
+			role: 'coder',
+			status: 'active',
+		});
+
+		const config = makeConfig(ctx, { getGroupId: () => isolatedGroup.id });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.list_peers({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.peers).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: send_feedback
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: send_feedback', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('point-to-point succeeds when channel declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const injected: Array<{ sessionId: string; message: string }> = [];
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid, msg) => {
+				injected.push({ sessionId: sid, message: msg });
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'LGTM!' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.delivered).toHaveLength(1);
+		expect(data.delivered[0].sessionId).toBe(ctx.reviewerSessionId);
+		expect(data.delivered[0].role).toBe('reviewer');
+		expect(injected).toHaveLength(1);
+		expect(injected[0].message).toBe('LGTM!');
+	});
+
+	test('point-to-point fails when channel not declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('reviewer', 'coder'), // reverse direction only
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain("does not permit 'coder' to send to: reviewer");
+		expect(data.unauthorizedRoles).toContain('reviewer');
+		expect(data.suggestion).toContain('request_peer_input');
+	});
+
+	test('returns error when no channels declared at all', async () => {
+		const config = makeConfig(ctx); // no workflowRunId, no channels
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		// When topology is empty, canSend returns false but we don't validate — we just skip
+		// validation and try to inject. Let's verify the actual behavior:
+		const data = JSON.parse(result.content[0].text);
+
+		// With empty topology, no validation happens (isEmpty=true), so it should succeed
+		// if the target exists in the group
+		expect(data.success).toBe(true);
+		expect(data.delivered[0].role).toBe('reviewer');
+	});
+
+	test('broadcast (*) succeeds and delivers to all permitted targets', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const injected: string[] = [];
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid) => {
+				injected.push(sid);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: '*', message: 'broadcast!' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.delivered).toHaveLength(1);
+		expect(injected).toContain(ctx.reviewerSessionId);
+	});
+
+	test('broadcast (*) fails when no channels declared', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('reviewer', 'coder'), // coder has no outgoing channels
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: '*', message: 'broadcast' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain("No permitted targets for role 'coder'");
+		expect(data.suggestion).toBe('request_peer_input');
+	});
+
+	test('broadcast (*) with empty topology returns suggestion to use request_peer_input', async () => {
+		// No channels declared at all
+		const config = makeConfig(ctx);
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: '*', message: 'broadcast' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No channel topology declared');
+		expect(data.suggestion).toBe('request_peer_input');
+	});
+
+	test('multicast delivers to all specified target roles', async () => {
+		// Add a third member (security) to the group
+		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-security', {
+			role: 'security',
+			status: 'active',
+		});
+
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+			makeResolvedChannel('coder', 'security'),
+		]);
+		const injected: string[] = [];
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid) => {
+				injected.push(sid);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({
+			target: ['reviewer', 'security'],
+			message: 'multicast!',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.delivered).toHaveLength(2);
+		expect(injected).toContain(ctx.reviewerSessionId);
+		expect(injected).toContain('session-security');
+	});
+
+	test('multicast partial authorization fails with full error', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+			// no coder → security channel
+		]);
+		// Add security member
+		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-security', {
+			role: 'security',
+			status: 'active',
+		});
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({
+			target: ['reviewer', 'security'],
+			message: 'msg',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.unauthorizedRoles).toContain('security');
+	});
+
+	test('hub-spoke: spoke cannot send to other spokes', async () => {
+		// Hub-spoke topology: hub ↔ coder, hub ↔ reviewer (coder cannot send to reviewer directly)
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('hub', 'coder', true),
+			makeResolvedChannel('coder', 'hub', true),
+			makeResolvedChannel('hub', 'reviewer', true),
+			makeResolvedChannel('reviewer', 'hub', true),
+		]);
+		const config = makeConfig(ctx, { workflowRunId }); // myRole='coder'
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain("does not permit 'coder' to send to: reviewer");
+	});
+
+	test('hub-spoke: spoke can reply to hub', async () => {
+		// Add hub member to group
+		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-hub', {
+			role: 'hub',
+			status: 'active',
+		});
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('hub', 'coder', true),
+			makeResolvedChannel('coder', 'hub', true),
+		]);
+		const injected: string[] = [];
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid) => {
+				injected.push(sid);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'hub', message: 'done!' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(injected).toContain('session-hub');
+	});
+
+	test('bidirectional: both directions work', async () => {
+		// coder ↔ reviewer
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+			makeResolvedChannel('reviewer', 'coder'),
+		]);
+		const injectedToReviewer: string[] = [];
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid) => {
+				injectedToReviewer.push(sid);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+
+		// coder → reviewer
+		const r1 = await handlers.send_feedback({ target: 'reviewer', message: 'code ready' });
+		expect(JSON.parse(r1.content[0].text).success).toBe(true);
+
+		// reviewer → coder (as reviewer)
+		const configAsReviewer = makeConfig(ctx, {
+			workflowRunId,
+			mySessionId: ctx.reviewerSessionId,
+			myRole: 'reviewer',
+			messageInjector: async (sid) => {
+				injectedToReviewer.push(sid);
+			},
+		});
+		const handlersAsReviewer = createStepAgentToolHandlers(configAsReviewer);
+		const r2 = await handlersAsReviewer.send_feedback({ target: 'coder', message: 'approved' });
+		expect(JSON.parse(r2.content[0].text).success).toBe(true);
+	});
+
+	test('returns error when target role has no active sessions', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'tester'), // 'tester' role not in group
+		]);
+		const config = makeConfig(ctx, { workflowRunId });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'tester', message: 'test pls' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No active sessions found for target role(s): tester');
+	});
+
+	test('handles partial injection failures gracefully', async () => {
+		// Add second reviewer to group
+		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-reviewer-2', {
+			role: 'reviewer',
+			status: 'active',
+		});
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		let callCount = 0;
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (sid) => {
+				callCount++;
+				if (callCount === 1) throw new Error('injection failed');
+				// second call succeeds
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const data = JSON.parse(result.content[0].text);
+
+		// Partial success — one injected, one failed
+		expect(data.success).toBe(true);
+		expect(data.delivered).toHaveLength(1);
+		expect(data.partialFailures).toHaveLength(1);
+	});
+
+	test('fails entirely when all injections fail', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async () => {
+				throw new Error('always fails');
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.failed).toHaveLength(1);
+	});
+
+	test('returns error when group not found', async () => {
+		const config = makeConfig(ctx, { getGroupId: () => undefined });
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('No session group found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: request_peer_input
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: request_peer_input', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('routes request to Task Agent and returns acknowledgment', async () => {
+		const taskAgentMessages: string[] = [];
+		const config = makeConfig(ctx, {
+			injectToTaskAgent: async (msg) => {
+				taskAgentMessages.push(msg);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.request_peer_input({
+			target_role: 'reviewer',
+			question: 'Can you review my PR?',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.targetRole).toBe('reviewer');
+		expect(data.async).toBe(true);
+		expect(data.message).toContain('async');
+		expect(data.message).toContain('[Peer response from reviewer]:');
+		expect(taskAgentMessages).toHaveLength(1);
+		expect(taskAgentMessages[0]).toContain("from 'coder'");
+		expect(taskAgentMessages[0]).toContain("to 'reviewer'");
+		expect(taskAgentMessages[0]).toContain('Can you review my PR?');
+	});
+
+	test('formats routing message with session ID prefix', async () => {
+		let capturedMessage = '';
+		const config = makeConfig(ctx, {
+			injectToTaskAgent: async (msg) => {
+				capturedMessage = msg;
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		await handlers.request_peer_input({
+			target_role: 'reviewer',
+			question: 'Is the code correct?',
+		});
+
+		expect(capturedMessage).toContain(`session ${ctx.coderSessionId}`);
+		expect(capturedMessage).toContain('reviewer');
+		expect(capturedMessage).toContain('[Peer response from reviewer]:');
+	});
+
+	test('returns error when Task Agent injection fails', async () => {
+		const config = makeConfig(ctx, {
+			injectToTaskAgent: async () => {
+				throw new Error('Task Agent unavailable');
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.request_peer_input({
+			target_role: 'reviewer',
+			question: 'Help?',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Task Agent unavailable');
+	});
+
+	test('is available when no channels declared (fallback mode)', async () => {
+		// No workflowRunId means no channels declared — request_peer_input should work
+		const taskAgentMessages: string[] = [];
+		const config = makeConfig(ctx, {
+			injectToTaskAgent: async (msg) => {
+				taskAgentMessages.push(msg);
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.request_peer_input({
+			target_role: 'coder',
+			question: 'What should I do?',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(taskAgentMessages).toHaveLength(1);
+	});
+
+	test('sends acknowledgment regardless of whether target role exists in group', async () => {
+		// request_peer_input does NOT validate group membership — that's the Task Agent's job
+		const config = makeConfig(ctx, {
+			injectToTaskAgent: async () => {
+				/* no-op */
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.request_peer_input({
+			target_role: 'nonexistent-role',
+			question: 'Are you there?',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		// request_peer_input does not validate target role existence
+		expect(data.success).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: createStepAgentMcpServer (factory)
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: createStepAgentMcpServer', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('creates an MCP server with expected tools', () => {
+		const config = makeConfig(ctx);
+		const server = createStepAgentMcpServer(config);
+
+		// Server should be an object with a server property (MCP SDK server)
+		expect(server).toBeDefined();
+		expect(typeof server).toBe('object');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: step agent system prompt
+// ---------------------------------------------------------------------------
+
+describe('step-agent-tools: system prompt includes peer communication section', () => {
+	test('buildCustomAgentSystemPrompt includes Peer Communication section', async () => {
+		const { buildCustomAgentSystemPrompt } = await import(
+			'../../../src/lib/space/agents/custom-agent.ts'
+		);
+
+		const prompt = buildCustomAgentSystemPrompt({
+			id: 'agent-1',
+			spaceId: 'space-1',
+			name: 'Coder',
+			role: 'coder',
+			description: '',
+			model: null,
+			tools: [],
+			systemPrompt: null,
+			injectWorkflowContext: false,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		});
+
+		expect(prompt).toContain('Peer Communication');
+		expect(prompt).toContain('send_feedback');
+		expect(prompt).toContain('request_peer_input');
+		expect(prompt).toContain('list_peers');
+		expect(prompt).toContain('channel-validated');
+		expect(prompt).toContain('async and non-blocking');
+		expect(prompt).toContain('[Peer response from {role}]:');
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `send_feedback(target, message)` MCP tool to step agents — channel-validated direct messaging with support for point-to-point, broadcast (`'*'`), and multicast (`string[]`). Validates against `ChannelResolver` before routing; returns clear error with available channels and suggests `request_peer_input` on failure. Enforces hub-spoke and one-way topology.
- Adds `request_peer_input(targetRole, question)` MCP tool — async/non-blocking fallback that routes through the Task Agent when no direct channel is declared. Peer response arrives as a user turn prefixed `[Peer response from {role}]: ...`.
- Adds `list_peers()` MCP tool — returns other group members (excluding self and task-agent) with role, status, sessionId, and permitted channel connections.
- `buildCustomAgentSystemPrompt()` updated with a "Peer Communication" section explaining the communication model, tool selection rules, and async nature of `request_peer_input`.
- `TaskAgentManager.buildStepAgentMcpServerForSession()` wires all peer tool dependencies (messageInjector, injectToTaskAgent, sessionGroupRepo, workflowRunRepo) and attaches the MCP server to each spawned sub-session via `buildStepAgentMcpServer` factory in `TaskAgentToolsConfig`.

## Test plan

- [x] 27 new unit tests in `step-agent-tools.test.ts` covering:
  - `list_peers`: excludes self + task-agent, reports topology, handles missing group
  - `send_feedback`: point-to-point, broadcast, multicast, hub-spoke enforcement, bidirectional, unauthorized direction, partial injection failures, no-target-found
  - `request_peer_input`: routing format, async acknowledgment, Task Agent injection failure, fallback with no channels, non-existent role
  - MCP server factory creation
  - System prompt includes Peer Communication section
- [x] All existing space unit tests (1285 tests) continue to pass
- [x] All pre-commit checks passed (lint, format, typecheck, knip)