### PR TITLE
feat: add step agent peer communication tools (channel-validated)

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -191,6 +191,20 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 			`- If this step has no declared channels: all communication goes through \`request_peer_input\`\n` +
 			`- All communication is scoped to this group — you cannot message agents in other tasks`
 	);
+	sections.push(`\n### Recognizing inbound peer messages\n`);
+	sections.push(
+		`**\`[Feedback from {role}]: ...\`** — a peer has sent you a direct message via \`send_feedback\`. ` +
+			`Read and incorporate it into your work.`
+	);
+	sections.push(
+		`**\`[Peer response from {role}]: ...\`** — an async reply via the Task Agent ` +
+			`(response to a previous \`request_peer_input\` call). Read and incorporate it.`
+	);
+	sections.push(
+		`**\`[Peer input request from '{role}' ... to '{your-role}']: ...\`** ` +
+			`(where \`{your-role}\` is your own role, e.g. \`${customAgent.role}\`) — ` +
+			`a peer is requesting input from you via the Task Agent. Provide a helpful response.`
+	);
 
 	// Review feedback handling
 	sections.push(`\n## Addressing Review Feedback\n`);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -269,7 +269,11 @@ export class TaskAgentManager {
 
 			// --- Build and attach MCP server with live runtime dependencies
 			const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
-			const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
+			const subSessionFactory = this.createSubSessionFactory(
+				taskId,
+				spaceId,
+				workflowRun?.id ?? ''
+			);
 
 			const workflowRunId = workflowRun?.id ?? '';
 
@@ -409,7 +413,8 @@ export class TaskAgentManager {
 	async createSubSession(
 		taskId: string,
 		sessionId: string,
-		init: AgentSessionInit
+		init: AgentSessionInit,
+		mcpServers?: Record<string, McpServerConfig>
 	): Promise<string> {
 		const subSession = AgentSession.fromInit(
 			init,
@@ -419,6 +424,11 @@ export class TaskAgentManager {
 			this.config.getApiKey,
 			this.config.defaultModel
 		);
+
+		// Attach MCP servers before streaming starts so tools are available from turn 1.
+		if (mcpServers) {
+			subSession.setRuntimeMcpServers(mcpServers);
+		}
 
 		// Determine step ID from session convention or task context.
 		// The subSessions map uses the actual session ID as both the map key and session ID.
@@ -663,14 +673,39 @@ export class TaskAgentManager {
 	/**
 	 * Create a `SubSessionFactory` implementation bound to a specific taskId.
 	 * Passed to `createTaskAgentMcpServer()` for the given Task Agent session.
+	 *
+	 * @param workflowRunId  The active workflow run ID — forwarded to the step agent
+	 *   MCP server so it can read the resolved channel topology from run.config.
 	 */
-	private createSubSessionFactory(taskId: string, spaceId: string): SubSessionFactory {
+	private createSubSessionFactory(
+		taskId: string,
+		spaceId: string,
+		workflowRunId: string
+	): SubSessionFactory {
 		return {
 			create: async (
 				init: AgentSessionInit,
 				memberInfo?: SubSessionMemberInfo
 			): Promise<string> => {
-				const sessionId = await this.createSubSession(taskId, init.sessionId, init);
+				// Build the step agent MCP server BEFORE creating the sub-session.
+				// The sessionId is known from init.sessionId (randomUUID set by spawn_step_agent).
+				// The MCP server closures capture it for group lookups and messageInjector calls.
+				const stepAgentMcpServer = createStepAgentMcpServer({
+					ownSessionId: init.sessionId,
+					ownRole: memberInfo?.role ?? 'agent',
+					taskId,
+					workflowRunId,
+					sessionGroupRepo: this.config.sessionGroupRepo,
+					workflowRunRepo: this.config.workflowRunRepo,
+					messageInjector: (targetSessionId, message) =>
+						this.injectSubSessionMessage(targetSessionId, message),
+					getGroupId: () => this.taskGroupIds.get(taskId),
+					taskAgentMessageInjector: (message) => this.injectTaskAgentMessage(taskId, message),
+				});
+
+				const sessionId = await this.createSubSession(taskId, init.sessionId, init, {
+					'step-agent': stepAgentMcpServer as unknown as McpServerConfig,
+				});
 
 				// Add the sub-session as a member of the task's group (non-fatal).
 				const groupId = this.taskGroupIds.get(taskId);
@@ -1087,7 +1122,7 @@ export class TaskAgentManager {
 
 		// --- Build and attach MCP server (runtime-only, not persisted)
 		const runtime = await this.config.spaceRuntimeService.createOrGetRuntime(spaceId);
-		const subSessionFactory = this.createSubSessionFactory(taskId, spaceId);
+		const subSessionFactory = this.createSubSessionFactory(taskId, spaceId, workflowRun?.id ?? '');
 
 		const rehydrateWorkflowRunId = workflowRun?.id ?? '';
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -682,30 +682,22 @@ export class TaskAgentManager {
 		spaceId: string,
 		workflowRunId: string
 	): SubSessionFactory {
+		if (!workflowRunId) {
+			log.warn(
+				`TaskAgentManager: createSubSessionFactory called with empty workflowRunId for task ${taskId}. ` +
+					`Step agent channel topology will be unavailable — send_feedback will report no channels declared.`
+			);
+		}
 		return {
 			create: async (
 				init: AgentSessionInit,
 				memberInfo?: SubSessionMemberInfo
 			): Promise<string> => {
-				// Build the step agent MCP server BEFORE creating the sub-session.
-				// The sessionId is known from init.sessionId (randomUUID set by spawn_step_agent).
-				// The MCP server closures capture it for group lookups and messageInjector calls.
-				const stepAgentMcpServer = createStepAgentMcpServer({
-					ownSessionId: init.sessionId,
-					ownRole: memberInfo?.role ?? 'agent',
-					taskId,
-					workflowRunId,
-					sessionGroupRepo: this.config.sessionGroupRepo,
-					workflowRunRepo: this.config.workflowRunRepo,
-					messageInjector: (targetSessionId, message) =>
-						this.injectSubSessionMessage(targetSessionId, message),
-					getGroupId: () => this.taskGroupIds.get(taskId),
-					taskAgentMessageInjector: (message) => this.injectTaskAgentMessage(taskId, message),
-				});
-
-				const sessionId = await this.createSubSession(taskId, init.sessionId, init, {
-					'step-agent': stepAgentMcpServer as unknown as McpServerConfig,
-				});
+				// Step agent MCP server is attached via buildStepAgentMcpServer callback
+				// in spawn_step_agent (task-agent-tools.ts), which injects it into init.mcpServers
+				// before calling sessionFactory.create(). createSubSession passes init through
+				// AgentSession.fromInit(), so the server is already in the session at construction.
+				const sessionId = await this.createSubSession(taskId, init.sessionId, init);
 
 				// Add the sub-session as a member of the task's group (non-fatal).
 				const groupId = this.taskGroupIds.get(taskId);

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -62,7 +62,7 @@ export const SendFeedbackSchema = z.object({
 			"Target role(s): a role name (e.g., 'coder'), '*' for broadcast to all permitted targets, or an array of role names for multicast"
 		),
 	/** The message to send to the target(s). */
-	message: z.string().min(1).describe('The message content to send to the target peer(s)'),
+	message: z.string().min(1).max(10000).describe('The message content to send to the target peer(s)'),
 });
 
 export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;
@@ -93,6 +93,7 @@ export const RequestPeerInputSchema = z.object({
 	question: z
 		.string()
 		.min(1)
+		.max(10000)
 		.describe('The question or request to relay to the peer through the Task Agent'),
 });
 

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -62,7 +62,11 @@ export const SendFeedbackSchema = z.object({
 			"Target role(s): a role name (e.g., 'coder'), '*' for broadcast to all permitted targets, or an array of role names for multicast"
 		),
 	/** The message to send to the target(s). */
-	message: z.string().min(1).max(10000).describe('The message content to send to the target peer(s)'),
+	message: z
+		.string()
+		.min(1)
+		.max(10000)
+		.describe('The message content to send to the target peer(s)'),
 });
 
 export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;


### PR DESCRIPTION
## Summary

- Adds three MCP tools for step agents to communicate with peers in the same session group: `send_feedback` (primary, channel-validated direct messaging), `list_peers` (peer discovery with topology info), and `request_peer_input` (Task Agent-mediated fallback for undeclared channels)
- `send_feedback` validates send direction against declared channel topology via `ChannelResolver.canSend()`, supports point-to-point / broadcast (`*`) / multicast (`[role1, role2]`) targets, and returns clear errors suggesting `request_peer_input` on failure
- `request_peer_input` is non-blocking: injects a formatted `[PEER_REQUEST from {role}]` message into the Task Agent session, which relays it; the async response flows back prefixed `[Peer response from {role}]: ...`
- `TaskAgentManager.createSubSessionFactory` now accepts `workflowRunId` and builds/attaches the step agent MCP server before streaming starts
- System prompt in `custom-agent.ts` updated with a "Peer Communication" section documenting all three tools

## Test plan

- [x] 31 new unit tests in `step-agent-tools.test.ts` covering: no-topology rejection, one-way/bidirectional channels, hub-spoke enforcement (spoke-to-spoke blocked), wildcard broadcast, multicast, self-exclusion, injection failure, no-group errors, no-active-sessions, `request_peer_input` message formatting and async acknowledgment, MCP server tool registration
- [x] Full space unit test suite passes (1289 tests, 0 failures)
- [x] TypeScript type check clean
- [x] Lint and formatting clean