### PR TITLE
feat: add step agent peer communication tools (send_feedback, request_peer_input, list_peers)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -665,6 +665,18 @@ export class TaskAgentManager {
 	 * Passed to `createTaskAgentMcpServer()` for the given Task Agent session.
 	 */
 	private createSubSessionFactory(taskId: string, spaceId: string): SubSessionFactory {
+		// Capture workflowRunId once at factory-creation time to avoid a DB round-trip
+		// on every spawn. The run ID is immutable once assigned, so this is safe.
+		// Log a warning if the task lacks a workflow run — step-agent tools will
+		// produce an empty ChannelResolver (no declared channels) in that case.
+		const taskWorkflowRunId = this.config.taskRepo.getTask(taskId)?.workflowRunId ?? '';
+		if (!taskWorkflowRunId) {
+			log.warn(
+				`TaskAgentManager.createSubSessionFactory: task ${taskId} has no workflowRunId — ` +
+					`step-agent channel topology will be unavailable (request_peer_input still works)`
+			);
+		}
+
 		return {
 			create: async (
 				init: AgentSessionInit,
@@ -1157,8 +1169,16 @@ export class TaskAgentManager {
 		// --- Rebuild subSessions map from step tasks in the same workflow run
 		// Sub-sessions are not fully rehydrated (no streaming restart) — the Task Agent
 		// will re-spawn them as needed after receiving the re-orientation message.
+		// Step-agent MCP tools are runtime-only (not persisted), so we must re-attach
+		// them here the same way createSubSessionFactory.create() does it.
 		if (task.workflowRunId) {
-			const stepTasks = this.config.taskRepo.listByWorkflowRun(task.workflowRunId);
+			const workflowRunId = task.workflowRunId;
+
+			// Load the group once; we need it to look up each sub-session's role.
+			const groupId = this.taskGroupIds.get(taskId);
+			const group = groupId ? this.config.sessionGroupRepo.getGroup(groupId) : null;
+
+			const stepTasks = this.config.taskRepo.listByWorkflowRun(workflowRunId);
 			for (const stepTask of stepTasks) {
 				const subSessionId = stepTask.taskAgentSessionId;
 				if (!subSessionId || stepTask.id === taskId) continue;
@@ -1175,6 +1195,22 @@ export class TaskAgentManager {
 					this.config.getApiKey
 				);
 				if (!subSession) continue;
+
+				// Re-attach step-agent MCP tools (runtime-only, not persisted to DB).
+				// Look up the member's role from the session group; fall back to 'agent'.
+				const memberRole =
+					group?.members.find((m) => m.sessionId === subSessionId)?.role ?? 'agent';
+
+				const stepAgentMcpServer = this.buildStepAgentMcpServerForSession(
+					taskId,
+					subSessionId,
+					memberRole,
+					spaceId,
+					workflowRunId
+				);
+				subSession.setRuntimeMcpServers({
+					'step-agent': stepAgentMcpServer as unknown as McpServerConfig,
+				});
 
 				if (!this.subSessions.has(taskId)) {
 					this.subSessions.set(taskId, new Map());

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -274,56 +274,67 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 				});
 			}
 
-			// Resolve target roles to session IDs from group members
-			// Multiple members can share the same role (parallel instances)
-			const targetMembers = group.members.filter(
-				(m) =>
-					targetRoles.includes(m.role) && m.sessionId !== mySessionId && m.role !== 'task-agent'
+			// Find peer sessions for each target role (exclude self and task-agent)
+			const peers = group.members.filter(
+				(m) => m.sessionId !== mySessionId && m.role !== 'task-agent'
 			);
+			const delivered: Array<{ role: string; sessionId: string }> = [];
+			const notFound: string[] = [];
+			const failed: Array<{ role: string; sessionId: string; error: string }> = [];
 
-			if (targetMembers.length === 0) {
-				return jsonResult({
-					success: false,
-					error:
-						`No active sessions found for target role(s): ${targetRoles.join(', ')}. ` +
-						`Use list_peers to check which peers are currently active.`,
-					targetRoles,
-				});
-			}
-
-			// Prefix message with sender identity so the receiver can attribute it.
-			// Without this, agents in multi-peer groups cannot tell who sent the message.
-			const attributedMessage = `[Feedback from ${myRole}]: ${message}`;
-
-			// Inject message into each target session
-			const injected: Array<{ sessionId: string; role: string }> = [];
-			const failed: Array<{ sessionId: string; role: string; error: string }> = [];
-
-			for (const member of targetMembers) {
-				try {
-					await messageInjector(member.sessionId, attributedMessage);
-					injected.push({ sessionId: member.sessionId, role: member.role });
-				} catch (err) {
-					const msg = err instanceof Error ? err.message : String(err);
-					failed.push({ sessionId: member.sessionId, role: member.role, error: msg });
+			// Best-effort delivery: attempt all targets, aggregate errors.
+			// This avoids the partial-delivery / stop-on-first-error problem where
+			// some peers receive the message while others don't, and the caller gets
+			// success: false despite partial delivery having already occurred.
+			for (const targetRole of targetRoles) {
+				const targetSessions = peers.filter((m) => m.role === targetRole);
+				if (targetSessions.length === 0) {
+					notFound.push(targetRole);
+					continue;
+				}
+				for (const targetMember of targetSessions) {
+					const prefixedMessage = `[Feedback from ${myRole}]: ${message}`;
+					try {
+						await messageInjector(targetMember.sessionId, prefixedMessage);
+						delivered.push({ role: targetRole, sessionId: targetMember.sessionId });
+					} catch (err) {
+						const errMsg = err instanceof Error ? err.message : String(err);
+						failed.push({ role: targetRole, sessionId: targetMember.sessionId, error: errMsg });
+					}
 				}
 			}
 
-			if (injected.length === 0) {
+			if (notFound.length > 0 && delivered.length === 0 && failed.length === 0) {
 				return jsonResult({
 					success: false,
-					error: `Failed to deliver message to any target. All injections failed.`,
+					error:
+						`No active sessions found for target role(s): ${notFound.join(', ')}. ` +
+						`Use list_peers to check which peers are currently active.`,
+					notFoundRoles: notFound,
+				});
+			}
+
+			if (failed.length > 0) {
+				// Partial or total delivery failure — report what was and was not delivered.
+				return jsonResult({
+					success: delivered.length > 0 ? 'partial' : false,
+					delivered,
 					failed,
+					notFoundRoles: notFound.length > 0 ? notFound : undefined,
+					message:
+						delivered.length > 0
+							? `Message delivered to ${delivered.length} peer(s) but failed for ${failed.length} peer(s).`
+							: `Message delivery failed for all ${failed.length} target(s).`,
 				});
 			}
 
 			return jsonResult({
 				success: true,
-				delivered: injected,
-				...(failed.length > 0 ? { partialFailures: failed } : {}),
+				delivered,
+				notFoundRoles: notFound.length > 0 ? notFound : undefined,
 				message:
-					`Message delivered to ${injected.length} peer(s): ` +
-					injected.map((t) => `${t.role} (${t.sessionId})`).join(', ') +
+					`Message delivered to ${delivered.length} peer(s): ` +
+					delivered.map((t) => `${t.role} (${t.sessionId})`).join(', ') +
 					'.',
 			});
 		},

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -158,6 +158,22 @@ describe('buildCustomAgentSystemPrompt', () => {
 		expect(prompt).toContain('pullrequestreview');
 	});
 
+	it('includes peer communication section with all three tools', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('Peer Communication');
+		expect(prompt).toContain('list_peers');
+		expect(prompt).toContain('send_feedback');
+		expect(prompt).toContain('request_peer_input');
+	});
+
+	it('explains async nature of request_peer_input', () => {
+		const agent = makeAgent();
+		const prompt = buildCustomAgentSystemPrompt(agent);
+		expect(prompt).toContain('[Peer response from {role}]:');
+		expect(prompt).toContain('async and non-blocking');
+	});
+
 	it('no role produces role-specific instructions (roles are display labels only)', () => {
 		for (const role of ['coder', 'general', 'planner', 'reviewer', 'custom-role']) {
 			const agent = makeAgent({ role });

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -544,7 +544,7 @@ describe('step-agent-tools: send_feedback', () => {
 		expect(data.error).toContain('No active sessions found for target role(s): tester');
 	});
 
-	test('handles partial injection failures gracefully', async () => {
+	test('handles partial injection failures gracefully (partial success)', async () => {
 		// Add second reviewer to group
 		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-reviewer-2', {
 			role: 'reviewer',
@@ -556,7 +556,7 @@ describe('step-agent-tools: send_feedback', () => {
 		let callCount = 0;
 		const config = makeConfig(ctx, {
 			workflowRunId,
-			messageInjector: async (sid) => {
+			messageInjector: async (_sid) => {
 				callCount++;
 				if (callCount === 1) throw new Error('injection failed');
 				// second call succeeds
@@ -566,10 +566,12 @@ describe('step-agent-tools: send_feedback', () => {
 		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
-		// Partial success — one injected, one failed
-		expect(data.success).toBe(true);
+		// Partial success — one delivered, one failed
+		expect(data.success).toBe('partial');
 		expect(data.delivered).toHaveLength(1);
-		expect(data.partialFailures).toHaveLength(1);
+		expect(data.failed).toHaveLength(1);
+		// Both targets were attempted (best-effort, not stop-on-first-error)
+		expect(callCount).toBe(2);
 	});
 
 	test('fails entirely when all injections fail', async () => {
@@ -588,6 +590,7 @@ describe('step-agent-tools: send_feedback', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.failed).toHaveLength(1);
+		expect(data.delivered).toHaveLength(0);
 	});
 
 	test('returns error when group not found', async () => {
@@ -598,6 +601,77 @@ describe('step-agent-tools: send_feedback', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No session group found');
+	});
+
+	test('returns error when group ID returned but not in DB', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			getGroupId: () => 'nonexistent-group-id',
+		});
+		const handlers = createStepAgentToolHandlers(config);
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'Hello' });
+		const data = JSON.parse(result.content[0].text);
+		expect(data.success).toBe(false);
+		expect(data.error).toMatch(/not found/);
+	});
+
+	test('best-effort multicast: first delivery succeeds, second fails — partial success', async () => {
+		// Add security member so we can send to two different non-task-agent roles
+		ctx.sessionGroupRepo.addMember(ctx.groupId, 'session-security', {
+			role: 'security',
+			status: 'active',
+		});
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+			makeResolvedChannel('coder', 'security'),
+		]);
+
+		let callCount = 0;
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async (_sid, _msg) => {
+				callCount++;
+				if (callCount === 2) throw new Error('session not available');
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+
+		const result = await handlers.send_feedback({
+			target: ['reviewer', 'security'],
+			message: 'Hello',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		// Should NOT return success: false for total failure — it's partial
+		expect(data.success).toBe('partial');
+		expect(data.delivered).toHaveLength(1);
+		expect(data.failed).toHaveLength(1);
+		expect(data.failed[0].error).toContain('session not available');
+		// Both targets were attempted (best-effort, not stop-on-first-error)
+		expect(callCount).toBe(2);
+	});
+
+	test('best-effort multicast: all deliveries fail — success: false', async () => {
+		const workflowRunId = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeResolvedChannel('coder', 'reviewer'),
+		]);
+		const config = makeConfig(ctx, {
+			workflowRunId,
+			messageInjector: async () => {
+				throw new Error('all sessions unavailable');
+			},
+		});
+		const handlers = createStepAgentToolHandlers(config);
+
+		const result = await handlers.send_feedback({ target: 'reviewer', message: 'Hello' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.delivered).toHaveLength(0);
+		expect(data.failed).toHaveLength(1);
 	});
 });
 

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1979,6 +1979,80 @@ describe('TaskAgentManager', () => {
 			restoreSpy.mockRestore();
 		});
 
+		test('step-agent MCP server is re-attached on rehydrated sub-sessions', async () => {
+			// Seed a workflow run so sub-sessions are rebuilt
+			const wfId = 'wf-rehydrate-step-mcp';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Step MCP', now, now);
+			const wfRunId = 'run-rehydrate-step-mcp';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const mainTask = await ctx.taskManager.createTask({
+				title: 'Main task step-mcp',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const mainSessionId = `space:${ctx.spaceId}:task:${mainTask.id}`;
+			ctx.taskRepo.updateTask(mainTask.id, { taskAgentSessionId: mainSessionId });
+			ctx.mockDb.createSession({ id: mainSessionId, type: 'space_task_agent' });
+
+			// Create a sub-session task
+			const subSessionId = '550e8400-e29b-41d4-a716-step-mcp-sub01';
+			await ctx.taskManager.createTask({
+				title: 'Sub task step-mcp',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+				taskAgentSessionId: subSessionId,
+			});
+			ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+			// Create a group and add the sub-session as a member with role 'coder'
+			const group = ctx.sessionGroupRepo.createGroup({
+				spaceId: ctx.spaceId,
+				name: `task:${mainTask.id}`,
+				taskId: mainTask.id,
+			});
+			ctx.sessionGroupRepo.addMember(group.id, mainSessionId, {
+				role: 'task-agent',
+				status: 'active',
+				orderIndex: 0,
+			});
+			ctx.sessionGroupRepo.addMember(group.id, subSessionId, {
+				role: 'coder',
+				status: 'active',
+				orderIndex: 1,
+			});
+
+			const restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+				const session = makeMockSession(sessionId);
+				ctx.createdSessions.set(sessionId, session);
+				return session as unknown as AgentSession;
+			});
+
+			await ctx.manager.rehydrate();
+
+			// The rehydrated sub-session should have the step-agent MCP server attached
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			expect(subSession).toBeDefined();
+			expect(Object.keys(subSession._mcpServers)).toContain('step-agent');
+
+			restoreSpy.mockRestore();
+		});
+
 		test('taskGroupIds is restored from DB after rehydration', async () => {
 			const { task } = await seedInProgressTask(ctx);
 


### PR DESCRIPTION
## Summary

Implements Task 6.2 — Step Agent Peer Communication Tools (Channel-Validated).

- **`send_feedback(target, message)`** — primary direct-messaging tool for step agents, validated against the declared channel topology via `ChannelResolver`. Supports single role (`'reviewer'`), broadcast (`'*'`), and multicast (`['coder','reviewer']`). Unauthorized directions return a clear error with available channels and suggest `request_peer_input` as fallback.
- **`request_peer_input(targetRole, question)`** — fallback Task Agent-mediated routing for undeclared channels. Async/non-blocking — response flows back as a user turn prefixed `[Peer response from <role>]: ...`.
- **`list_peers()`** — returns all other group members with role, status, sessionId, and `canSendDirectly` flag per the declared channel topology.
- Step agent system prompt updated with Peer Communication section explaining when to use each tool, async nature of `request_peer_input`, and hub-spoke enforcement.

## Topology patterns supported

| Pattern | Description | send_feedback behavior |
|---------|-------------|------------------------|
| A→B one-way | A sends to B | B cannot reply via send_feedback |
| A↔B bidirectional | Both directions | Both directions permitted |
| hub→[A,B,C] fan-out | Hub to all spokes | Spokes cannot message each other |
| hub↔[A,B,C] hub-spoke | Hub and spoke bidirectional | Spokes can only reply to hub |

## Implementation details

- New `step-agent-tools.ts` with `StepAgentToolsConfig`, handlers, and MCP server factory
- `task-agent-manager.ts`: `createSubSessionFactory.create()` now builds and attaches a step agent MCP server to `init.mcpServers` before `AgentSession.fromInit()` is called — ensures tools are available when the first message is processed
- The `peerMessageInjector` reuses the existing `injectSubSessionMessage()` callback; `taskAgentMessageInjector` routes to `injectTaskAgentMessage()` for `request_peer_input`

## Test plan

- [x] 27 unit tests in `step-agent-tools.test.ts` covering all topology patterns, error cases, and MCP server registration
- [x] 2 new tests in `custom-agent.test.ts` for system prompt peer communication section
- [x] All 1287 space unit tests pass (0 fail)
- [x] Lint: 0 warnings, 0 errors
- [x] Format: clean
- [x] TypeScript: no errors