### PR TITLE
fix: remove emitTaskUpdate from task.fail RPC handler (Task 3.1)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -215,7 +215,6 @@ export function setupTaskHandlers(
 		const taskManager = taskManagerFactory(db, params.roomId);
 		const task = await taskManager.failTask(params.taskId, params.error ?? '');
 
-		emitTaskUpdate(params.roomId, task);
 		emitRoomOverview(params.roomId);
 
 		return { task };

--- a/packages/daemon/tests/online/rpc/rpc-live-query.test.ts
+++ b/packages/daemon/tests/online/rpc/rpc-live-query.test.ts
@@ -280,4 +280,68 @@ describe('LiveQuery — end-to-end reactive pipeline', () => {
 			await daemon.messageHub.request('liveQuery.unsubscribe', { subscriptionId: subId2 });
 		}
 	}, 20_000);
+
+	// -----------------------------------------------------------------------
+	// Test 5: task.fail triggers liveQuery.delta (no handler-layer emit needed)
+	// -----------------------------------------------------------------------
+
+	test('task.fail RPC triggers a liveQuery.delta for tasks.byRoom subscriber', async () => {
+		const roomId = await createRoom('task-fail-delta');
+		const subId = 'sub-task-fail-1';
+
+		// First create a task to fail
+		const task = await createTask(roomId, 'Task To Fail');
+
+		const snapshots: LiveQuerySnapshotEvent[] = [];
+		const deltas: LiveQueryDeltaEvent[] = [];
+
+		const unsubSnap = daemon.messageHub.onEvent<LiveQuerySnapshotEvent>(
+			'liveQuery.snapshot',
+			(ev) => {
+				if (ev.subscriptionId === subId) snapshots.push(ev);
+			}
+		);
+		const unsubDelta = daemon.messageHub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (ev) => {
+			if (ev.subscriptionId === subId) deltas.push(ev);
+		});
+
+		try {
+			// Subscribe after task is created
+			await daemon.messageHub.request('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom',
+				params: [roomId],
+				subscriptionId: subId,
+			});
+
+			// Wait for snapshot
+			await waitFor(() => snapshots.length > 0, DELTA_WAIT_TIMEOUT_MS, 'snapshot before fail');
+			const snapshotVersion = snapshots[0].version;
+
+			// Fail the task — triggers notifyChange('tasks') via TaskManager, no handler-layer emit
+			await daemon.messageHub.request('task.fail', {
+				roomId,
+				taskId: task.id,
+				error: 'Simulated failure',
+			});
+
+			// A delta must arrive reflecting the status change
+			await waitFor(() => deltas.length > 0, DELTA_WAIT_TIMEOUT_MS, 'delta after task.fail');
+
+			const delta = deltas[0];
+			expect(delta.subscriptionId).toBe(subId);
+			expect(delta.version).toBeGreaterThan(snapshotVersion);
+
+			// The updated task must appear in the delta
+			const allChanges = [...(delta.added ?? []), ...(delta.updated ?? [])];
+			const updatedTask = allChanges.find((r) => (r as Record<string, unknown>).id === task.id) as
+				| Record<string, unknown>
+				| undefined;
+			expect(updatedTask).toBeDefined();
+			expect(updatedTask!.status).toBe('needs_attention');
+		} finally {
+			unsubSnap();
+			unsubDelta();
+			await daemon.messageHub.request('liveQuery.unsubscribe', { subscriptionId: subId });
+		}
+	}, 20_000);
 });

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -427,17 +427,20 @@ describe('Task RPC Handlers', () => {
 			);
 		});
 
-		it('emits room overview and task update events', async () => {
+		it('emits room.overview but NOT room.task.update (redundant after LiveQuery)', async () => {
 			const handler = messageHubData.handlers.get('task.fail');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', taskId: 'task-123', error: 'Failed' }, {});
 
+			// room.overview must still fire so clients get updated session/task metadata
 			expect(roomManagerData.getRoomOverview).toHaveBeenCalledWith('room-123');
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'room.task.update',
-				expect.objectContaining({ roomId: 'room-123' })
+
+			// room.task.update must NOT be emitted — LiveQuery deltas replace this channel
+			const taskUpdateCalls = (daemonHubData.emit as ReturnType<typeof mock>).mock.calls.filter(
+				(args: unknown[]) => args[0] === 'room.task.update'
 			);
+			expect(taskUpdateCalls).toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
LiveQuery deltas now deliver task changes via notifyChange('tasks') →
LiveQueryEngine → sendToClient, making the handler-layer room.task.update
emit in task.fail redundant.

- Remove emitTaskUpdate() call from task.fail handler; emitRoomOverview()
  stays because room/session metadata still flows through that channel
- Update existing unit test: assert room.task.update is NOT emitted by
  task.fail, and room.overview IS still emitted
- Add online integration test (Test 5 in rpc-live-query.test.ts): verifies
  that task.fail triggers a liveQuery.delta with status needs_attention for
  a subscribed tasks.byRoom client
