### PR TITLE
feat: add useGroupMessageLiveQuery hook for LiveQuery-based group message streaming

### DIFF
--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
+import type { GroupMessage } from '../../types/group-message';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import {
 	useSessionQuestionState,
@@ -39,16 +40,6 @@ interface TaskMeta {
 	authorSessionId: string;
 	turnId: string;
 	iteration: number;
-}
-
-interface GroupMessage {
-	id: number;
-	groupId: string;
-	sessionId: string | null;
-	role: string;
-	messageType: string;
-	content: string;
-	createdAt: number;
 }
 
 interface TaskConversationRendererProps {

--- a/packages/web/src/hooks/__tests__/useGroupMessageLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessageLiveQuery.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Unit tests for useGroupMessageLiveQuery hook
+ *
+ * Verifies that the hook:
+ * - Subscribes to `sessionGroupMessages.byGroup` on mount with a unique subscriptionId
+ * - Sets loading=true until the snapshot event arrives
+ * - Replaces messages on liveQuery.snapshot
+ * - Appends added messages on liveQuery.delta (ignores updated/removed)
+ * - Discards snapshot/delta events from prior subscriptions (stale-subscriptionId guard)
+ * - Calls liveQuery.unsubscribe on unmount
+ * - Re-subscribes when groupId changes (unsubscribes old first)
+ * - Handles null groupId: clears messages, does not subscribe
+ * - Surfaces subscribe RPC errors via error state
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/preact';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+import { useGroupMessageLiveQuery, type GroupMessage } from '../useGroupMessageLiveQuery';
+
+// -------------------------------------------------------
+// Mock helpers
+// -------------------------------------------------------
+
+// Handlers captured per event name so tests can fire them
+const snapshotHandlers: Array<(event: LiveQuerySnapshotEvent) => void> = [];
+const deltaHandlers: Array<(event: LiveQueryDeltaEvent) => void> = [];
+
+const mockRequest = vi.fn();
+const mockOnEvent = vi.fn(
+	(eventName: string, handler: (event: LiveQuerySnapshotEvent | LiveQueryDeltaEvent) => void) => {
+		if (eventName === 'liveQuery.snapshot') {
+			snapshotHandlers.push(handler as (e: LiveQuerySnapshotEvent) => void);
+		} else if (eventName === 'liveQuery.delta') {
+			deltaHandlers.push(handler as (e: LiveQueryDeltaEvent) => void);
+		}
+		// Return a no-op unsubscribe for simplicity; tests don't need to track these
+		return () => {};
+	}
+);
+
+vi.mock('../useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+	}),
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeMessage(id: number, groupId = 'grp-1'): GroupMessage {
+	return {
+		id,
+		groupId,
+		sessionId: null,
+		role: 'system',
+		messageType: 'status',
+		content: `message-${id}`,
+		createdAt: 1000 + id,
+	};
+}
+
+/** Fire a snapshot event to all registered snapshot handlers */
+function fireSnapshot(subscriptionId: string, rows: GroupMessage[]): void {
+	const event: LiveQuerySnapshotEvent = { subscriptionId, rows, version: 1 };
+	for (const h of snapshotHandlers) {
+		h(event);
+	}
+}
+
+/** Fire a delta event to all registered delta handlers */
+function fireDelta(subscriptionId: string, added?: GroupMessage[]): void {
+	const event: LiveQueryDeltaEvent = {
+		subscriptionId,
+		added,
+		version: 2,
+	};
+	for (const h of deltaHandlers) {
+		h(event);
+	}
+}
+
+/** Extract the subscriptionId from the most recent liveQuery.subscribe call */
+function lastSubscribeId(): string {
+	const calls = mockRequest.mock.calls;
+	for (let i = calls.length - 1; i >= 0; i--) {
+		const [method, data] = calls[i] as [string, { subscriptionId?: string }];
+		if (method === 'liveQuery.subscribe') {
+			return data.subscriptionId ?? '';
+		}
+	}
+	return '';
+}
+
+// -------------------------------------------------------
+// Setup / teardown
+// -------------------------------------------------------
+
+beforeEach(() => {
+	snapshotHandlers.length = 0;
+	deltaHandlers.length = 0;
+	mockRequest.mockResolvedValue({ ok: true });
+	mockOnEvent.mockClear();
+	mockRequest.mockClear();
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+describe('useGroupMessageLiveQuery', () => {
+	it('calls liveQuery.subscribe on mount with correct params', async () => {
+		renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({
+					queryName: 'sessionGroupMessages.byGroup',
+					params: ['grp-1'],
+					subscriptionId: expect.any(String),
+				})
+			);
+		});
+	});
+
+	it('registers snapshot and delta event listeners before subscribing', () => {
+		renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		// onEvent should be called for both snapshot and delta
+		const eventNames = mockOnEvent.mock.calls.map((args) => args[0] as string);
+		expect(eventNames).toContain('liveQuery.snapshot');
+		expect(eventNames).toContain('liveQuery.delta');
+	});
+
+	it('starts with loading=true', () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+		expect(result.current.loading).toBe(true);
+		expect(result.current.messages).toEqual([]);
+	});
+
+	it('replaces messages and clears loading on snapshot', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1), makeMessage(2)]);
+		});
+
+		expect(result.current.loading).toBe(false);
+		expect(result.current.messages).toHaveLength(2);
+		expect(result.current.messages[0].id).toBe(1);
+		expect(result.current.messages[1].id).toBe(2);
+	});
+
+	it('appends added messages on delta', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1)]);
+		});
+		expect(result.current.messages).toHaveLength(1);
+
+		act(() => {
+			fireDelta(subId, [makeMessage(2), makeMessage(3)]);
+		});
+
+		expect(result.current.messages).toHaveLength(3);
+		expect(result.current.messages[2].id).toBe(3);
+	});
+
+	it('ignores delta events with no added array', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1)]);
+		});
+		expect(result.current.messages).toHaveLength(1);
+
+		act(() => {
+			// Delta with only updated — append-only invariant, should be ignored
+			const event: LiveQueryDeltaEvent = {
+				subscriptionId: subId,
+				updated: [makeMessage(1)],
+				version: 2,
+			};
+			for (const h of deltaHandlers) h(event);
+		});
+
+		// Messages should be unchanged
+		expect(result.current.messages).toHaveLength(1);
+	});
+
+	it('discards snapshot from a stale subscriptionId (stale-event guard)', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const currentSubId = lastSubscribeId();
+
+		act(() => {
+			// Fire snapshot with a different, "stale" subscriptionId
+			fireSnapshot('stale-sub-id-000', [makeMessage(99)]);
+		});
+
+		// Messages should remain empty; loading still true
+		expect(result.current.messages).toHaveLength(0);
+		expect(result.current.loading).toBe(true);
+
+		// The real snapshot arrives
+		act(() => {
+			fireSnapshot(currentSubId, [makeMessage(1)]);
+		});
+
+		expect(result.current.messages).toHaveLength(1);
+		expect(result.current.loading).toBe(false);
+	});
+
+	it('discards delta from a stale subscriptionId (stale-event guard)', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1)]);
+		});
+		expect(result.current.messages).toHaveLength(1);
+
+		act(() => {
+			// Delta with stale subscriptionId — should be discarded
+			fireDelta('stale-sub-id-000', [makeMessage(2)]);
+		});
+
+		expect(result.current.messages).toHaveLength(1);
+	});
+
+	it('calls liveQuery.unsubscribe on unmount', async () => {
+		const { result, unmount } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		mockRequest.mockClear();
+		act(() => unmount());
+
+		expect(mockRequest).toHaveBeenCalledWith('liveQuery.unsubscribe', { subscriptionId: subId });
+	});
+
+	it('unsubscribes old and subscribes new when groupId changes', async () => {
+		const { result, rerender } = renderHook(
+			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' } }
+		);
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('liveQuery.subscribe', expect.any(Object))
+		);
+		const firstSubId = lastSubscribeId();
+
+		mockRequest.mockClear();
+
+		act(() => {
+			rerender({ groupId: 'grp-2' });
+		});
+
+		await waitFor(() => {
+			// Old subscription should be cleaned up
+			expect(mockRequest).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: firstSubId,
+			});
+			// New subscription should be created
+			expect(mockRequest).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({
+					queryName: 'sessionGroupMessages.byGroup',
+					params: ['grp-2'],
+					subscriptionId: expect.any(String),
+				})
+			);
+		});
+
+		// The new subscriptionId must differ from the old one
+		const newSubId = lastSubscribeId();
+		expect(newSubId).not.toBe(firstSubId);
+	});
+
+	it('clears messages and does not subscribe when groupId is null', () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery(null));
+
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.loading).toBe(false);
+		expect(result.current.error).toBeNull();
+
+		// No subscribe call should have been made
+		expect(mockRequest).not.toHaveBeenCalledWith('liveQuery.subscribe', expect.any(Object));
+	});
+
+	it('clears messages when groupId changes to null', async () => {
+		const { result, rerender } = renderHook(
+			({ groupId }: { groupId: string | null }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' as string | null } }
+		);
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1), makeMessage(2)]);
+		});
+		expect(result.current.messages).toHaveLength(2);
+
+		mockRequest.mockClear();
+		act(() => {
+			rerender({ groupId: null });
+		});
+
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.loading).toBe(false);
+		// Old subscription unsubscribed
+		expect(mockRequest).toHaveBeenCalledWith('liveQuery.unsubscribe', { subscriptionId: subId });
+	});
+
+	it('sets error and clears loading when liveQuery.subscribe fails', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'liveQuery.subscribe') {
+				return Promise.reject(new Error('Auth denied'));
+			}
+			return Promise.resolve({ ok: true });
+		});
+
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => {
+			expect(result.current.loading).toBe(false);
+			expect(result.current.error).toBe('Auth denied');
+		});
+	});
+
+	it('resets messages and loading=true when groupId changes', async () => {
+		const { result, rerender } = renderHook(
+			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' } }
+		);
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => {
+			fireSnapshot(subId, [makeMessage(1), makeMessage(2)]);
+		});
+		expect(result.current.messages).toHaveLength(2);
+		expect(result.current.loading).toBe(false);
+
+		// Switch to a new group — messages should reset and loading restart
+		act(() => {
+			rerender({ groupId: 'grp-2' });
+		});
+
+		expect(result.current.messages).toEqual([]);
+		expect(result.current.loading).toBe(true);
+	});
+
+	it('uses unique subscriptionIds for each subscription', async () => {
+		const { rerender } = renderHook(
+			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' } }
+		);
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const firstSubId = lastSubscribeId();
+
+		act(() => {
+			rerender({ groupId: 'grp-2' });
+		});
+
+		await waitFor(() => {
+			const calls = mockRequest.mock.calls.filter((args) => args[0] === 'liveQuery.subscribe');
+			expect(calls.length).toBeGreaterThanOrEqual(2);
+		});
+		const secondSubId = lastSubscribeId();
+
+		expect(firstSubId).not.toBe('');
+		expect(secondSubId).not.toBe('');
+		expect(firstSubId).not.toBe(secondSubId);
+	});
+});

--- a/packages/web/src/hooks/__tests__/useGroupMessageLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessageLiveQuery.test.ts
@@ -4,17 +4,21 @@
  * Verifies that the hook:
  * - Subscribes to `sessionGroupMessages.byGroup` on mount with a unique subscriptionId
  * - Sets loading=true until the snapshot event arrives
- * - Replaces messages on liveQuery.snapshot
+ * - Replaces messages on liveQuery.snapshot (also clears prior errors)
  * - Appends added messages on liveQuery.delta (ignores updated/removed)
  * - Discards snapshot/delta events from prior subscriptions (stale-subscriptionId guard)
- * - Calls liveQuery.unsubscribe on unmount
+ * - Actually removes event listeners on unmount / groupId change (real unsub mock)
+ * - Calls liveQuery.unsubscribe RPC on unmount
  * - Re-subscribes when groupId changes (unsubscribes old first)
  * - Handles null groupId: clears messages, does not subscribe
  * - Surfaces subscribe RPC errors via error state
+ * - Stays loading=true when subscribe resolves but no snapshot arrives
+ * - Re-subscribes after WebSocket reconnect (isConnected false→true transition)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, cleanup, waitFor } from '@testing-library/preact';
+import { signal } from '@preact/signals';
 import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
 import { useGroupMessageLiveQuery, type GroupMessage } from '../useGroupMessageLiveQuery';
 
@@ -22,19 +26,34 @@ import { useGroupMessageLiveQuery, type GroupMessage } from '../useGroupMessageL
 // Mock helpers
 // -------------------------------------------------------
 
-// Handlers captured per event name so tests can fire them
+// Captured handlers — stored so tests can fire them directly.
+// These two arrays MUST be cleared in beforeEach (mockOnEvent.mockClear() only
+// clears vi.fn() call records, not the captured handler arrays).
 const snapshotHandlers: Array<(event: LiveQuerySnapshotEvent) => void> = [];
 const deltaHandlers: Array<(event: LiveQueryDeltaEvent) => void> = [];
 
 const mockRequest = vi.fn();
+
+// isConnected is a signal so the hook can react to connection state changes.
+const mockIsConnected = signal(true);
+
+// mockOnEvent returns a *real* unsub function that splices the handler out of
+// the captured arrays — this makes listener removal observable in tests.
 const mockOnEvent = vi.fn(
 	(eventName: string, handler: (event: LiveQuerySnapshotEvent | LiveQueryDeltaEvent) => void) => {
 		if (eventName === 'liveQuery.snapshot') {
 			snapshotHandlers.push(handler as (e: LiveQuerySnapshotEvent) => void);
+			return () => {
+				const i = snapshotHandlers.indexOf(handler as (e: LiveQuerySnapshotEvent) => void);
+				if (i !== -1) snapshotHandlers.splice(i, 1);
+			};
 		} else if (eventName === 'liveQuery.delta') {
 			deltaHandlers.push(handler as (e: LiveQueryDeltaEvent) => void);
+			return () => {
+				const i = deltaHandlers.indexOf(handler as (e: LiveQueryDeltaEvent) => void);
+				if (i !== -1) deltaHandlers.splice(i, 1);
+			};
 		}
-		// Return a no-op unsubscribe for simplicity; tests don't need to track these
 		return () => {};
 	}
 );
@@ -43,6 +62,7 @@ vi.mock('../useMessageHub.ts', () => ({
 	useMessageHub: () => ({
 		request: mockRequest,
 		onEvent: mockOnEvent,
+		isConnected: mockIsConnected.value,
 	}),
 }));
 
@@ -62,22 +82,29 @@ function makeMessage(id: number, groupId = 'grp-1'): GroupMessage {
 	};
 }
 
+// Monotonic version counter so snapshot/delta events have increasing versions.
+let versionCounter = 0;
+function nextVersion(): number {
+	return ++versionCounter;
+}
+
 /** Fire a snapshot event to all registered snapshot handlers */
 function fireSnapshot(subscriptionId: string, rows: GroupMessage[]): void {
-	const event: LiveQuerySnapshotEvent = { subscriptionId, rows, version: 1 };
-	for (const h of snapshotHandlers) {
+	const event: LiveQuerySnapshotEvent = { subscriptionId, rows, version: nextVersion() };
+	// Copy array before iterating — handlers may splice themselves during iteration
+	for (const h of [...snapshotHandlers]) {
 		h(event);
 	}
 }
 
 /** Fire a delta event to all registered delta handlers */
-function fireDelta(subscriptionId: string, added?: GroupMessage[]): void {
-	const event: LiveQueryDeltaEvent = {
-		subscriptionId,
-		added,
-		version: 2,
-	};
-	for (const h of deltaHandlers) {
+function fireDelta(
+	subscriptionId: string,
+	added?: GroupMessage[],
+	extra?: Partial<LiveQueryDeltaEvent>
+): void {
+	const event: LiveQueryDeltaEvent = { subscriptionId, added, ...extra, version: nextVersion() };
+	for (const h of [...deltaHandlers]) {
 		h(event);
 	}
 }
@@ -99,11 +126,14 @@ function lastSubscribeId(): string {
 // -------------------------------------------------------
 
 beforeEach(() => {
+	// Clear captured handler arrays AND vi.fn() call records
 	snapshotHandlers.length = 0;
 	deltaHandlers.length = 0;
+	versionCounter = 0;
 	mockRequest.mockResolvedValue({ ok: true });
 	mockOnEvent.mockClear();
 	mockRequest.mockClear();
+	mockIsConnected.value = true;
 });
 
 afterEach(() => {
@@ -133,7 +163,7 @@ describe('useGroupMessageLiveQuery', () => {
 	it('registers snapshot and delta event listeners before subscribing', () => {
 		renderHook(() => useGroupMessageLiveQuery('grp-1'));
 
-		// onEvent should be called for both snapshot and delta
+		// onEvent should be called for both snapshot and delta before request
 		const eventNames = mockOnEvent.mock.calls.map((args) => args[0] as string);
 		expect(eventNames).toContain('liveQuery.snapshot');
 		expect(eventNames).toContain('liveQuery.delta');
@@ -161,6 +191,34 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages[1].id).toBe(2);
 	});
 
+	it('clears prior error when snapshot arrives', async () => {
+		// First mount with a failing subscribe
+		mockRequest.mockRejectedValueOnce(new Error('Auth denied'));
+		const { result, rerender } = renderHook(
+			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' } }
+		);
+
+		await waitFor(() => expect(result.current.error).toBe('Auth denied'));
+
+		// Switch to same group again to re-trigger — use groupId change as retry vehicle
+		mockRequest.mockResolvedValue({ ok: true });
+		act(() => rerender({ groupId: 'grp-2' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({ params: ['grp-2'] })
+			)
+		);
+		const subId = lastSubscribeId();
+
+		act(() => fireSnapshot(subId, [makeMessage(1)]));
+
+		expect(result.current.error).toBeNull();
+		expect(result.current.messages).toHaveLength(1);
+	});
+
 	it('appends added messages on delta', async () => {
 		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
 
@@ -180,7 +238,7 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages[2].id).toBe(3);
 	});
 
-	it('ignores delta events with no added array', async () => {
+	it('ignores delta events with no added array (append-only invariant)', async () => {
 		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
 
 		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
@@ -192,16 +250,10 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages).toHaveLength(1);
 
 		act(() => {
-			// Delta with only updated — append-only invariant, should be ignored
-			const event: LiveQueryDeltaEvent = {
-				subscriptionId: subId,
-				updated: [makeMessage(1)],
-				version: 2,
-			};
-			for (const h of deltaHandlers) h(event);
+			// Delta with only updated / removed — must be ignored per append-only invariant
+			fireDelta(subId, undefined, { updated: [makeMessage(1)], removed: [makeMessage(1)] });
 		});
 
-		// Messages should be unchanged
 		expect(result.current.messages).toHaveLength(1);
 	});
 
@@ -241,7 +293,6 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages).toHaveLength(1);
 
 		act(() => {
-			// Delta with stale subscriptionId — should be discarded
 			fireDelta('stale-sub-id-000', [makeMessage(2)]);
 		});
 
@@ -249,7 +300,7 @@ describe('useGroupMessageLiveQuery', () => {
 	});
 
 	it('calls liveQuery.unsubscribe on unmount', async () => {
-		const { result, unmount } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+		const { unmount } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
 
 		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
 		const subId = lastSubscribeId();
@@ -260,8 +311,23 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(mockRequest).toHaveBeenCalledWith('liveQuery.unsubscribe', { subscriptionId: subId });
 	});
 
+	it('removes event listeners on unmount', async () => {
+		const { unmount } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		// Listeners are registered
+		expect(snapshotHandlers).toHaveLength(1);
+		expect(deltaHandlers).toHaveLength(1);
+
+		act(() => unmount());
+
+		// Real unsub functions splice them out — verify removal
+		expect(snapshotHandlers).toHaveLength(0);
+		expect(deltaHandlers).toHaveLength(0);
+	});
+
 	it('unsubscribes old and subscribes new when groupId changes', async () => {
-		const { result, rerender } = renderHook(
+		const { rerender } = renderHook(
 			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
 			{ initialProps: { groupId: 'grp-1' } }
 		);
@@ -293,9 +359,32 @@ describe('useGroupMessageLiveQuery', () => {
 			);
 		});
 
-		// The new subscriptionId must differ from the old one
 		const newSubId = lastSubscribeId();
 		expect(newSubId).not.toBe(firstSubId);
+	});
+
+	it('removes old listeners and registers new ones when groupId changes', async () => {
+		const { rerender } = renderHook(
+			({ groupId }: { groupId: string }) => useGroupMessageLiveQuery(groupId),
+			{ initialProps: { groupId: 'grp-1' } }
+		);
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		expect(snapshotHandlers).toHaveLength(1);
+		expect(deltaHandlers).toHaveLength(1);
+
+		act(() => rerender({ groupId: 'grp-2' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({ params: ['grp-2'] })
+			)
+		);
+
+		// Old handlers replaced by new ones — still exactly 1 of each
+		expect(snapshotHandlers).toHaveLength(1);
+		expect(deltaHandlers).toHaveLength(1);
 	});
 
 	it('clears messages and does not subscribe when groupId is null', () => {
@@ -305,7 +394,6 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.loading).toBe(false);
 		expect(result.current.error).toBeNull();
 
-		// No subscribe call should have been made
 		expect(mockRequest).not.toHaveBeenCalledWith('liveQuery.subscribe', expect.any(Object));
 	});
 
@@ -324,23 +412,15 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages).toHaveLength(2);
 
 		mockRequest.mockClear();
-		act(() => {
-			rerender({ groupId: null });
-		});
+		act(() => rerender({ groupId: null }));
 
 		expect(result.current.messages).toEqual([]);
 		expect(result.current.loading).toBe(false);
-		// Old subscription unsubscribed
 		expect(mockRequest).toHaveBeenCalledWith('liveQuery.unsubscribe', { subscriptionId: subId });
 	});
 
 	it('sets error and clears loading when liveQuery.subscribe fails', async () => {
-		mockRequest.mockImplementation((method: string) => {
-			if (method === 'liveQuery.subscribe') {
-				return Promise.reject(new Error('Auth denied'));
-			}
-			return Promise.resolve({ ok: true });
-		});
+		mockRequest.mockRejectedValue(new Error('Auth denied'));
 
 		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
 
@@ -348,6 +428,22 @@ describe('useGroupMessageLiveQuery', () => {
 			expect(result.current.loading).toBe(false);
 			expect(result.current.error).toBe('Auth denied');
 		});
+	});
+
+	it('stays loading=true when subscribe resolves but no snapshot arrives', async () => {
+		// subscribe RPC resolves immediately but server never pushes a snapshot —
+		// loading should remain true (the UI shows an indefinite spinner in this state)
+		mockRequest.mockResolvedValue({ ok: true });
+
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+
+		// Give async processing a moment
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(result.current.loading).toBe(true);
+		expect(result.current.messages).toHaveLength(0);
 	});
 
 	it('resets messages and loading=true when groupId changes', async () => {
@@ -365,10 +461,7 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(result.current.messages).toHaveLength(2);
 		expect(result.current.loading).toBe(false);
 
-		// Switch to a new group — messages should reset and loading restart
-		act(() => {
-			rerender({ groupId: 'grp-2' });
-		});
+		act(() => rerender({ groupId: 'grp-2' }));
 
 		expect(result.current.messages).toEqual([]);
 		expect(result.current.loading).toBe(true);
@@ -383,9 +476,7 @@ describe('useGroupMessageLiveQuery', () => {
 		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
 		const firstSubId = lastSubscribeId();
 
-		act(() => {
-			rerender({ groupId: 'grp-2' });
-		});
+		act(() => rerender({ groupId: 'grp-2' }));
 
 		await waitFor(() => {
 			const calls = mockRequest.mock.calls.filter((args) => args[0] === 'liveQuery.subscribe');
@@ -396,5 +487,90 @@ describe('useGroupMessageLiveQuery', () => {
 		expect(firstSubId).not.toBe('');
 		expect(secondSubId).not.toBe('');
 		expect(firstSubId).not.toBe(secondSubId);
+	});
+
+	it('re-subscribes with same subscriptionId after WebSocket reconnect', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => fireSnapshot(subId, [makeMessage(1)]));
+		expect(result.current.messages).toHaveLength(1);
+
+		// Simulate disconnect → reconnect
+		mockRequest.mockClear();
+		act(() => {
+			mockIsConnected.value = false;
+		});
+		act(() => {
+			mockIsConnected.value = true;
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith(
+				'liveQuery.subscribe',
+				expect.objectContaining({
+					queryName: 'sessionGroupMessages.byGroup',
+					params: ['grp-1'],
+					subscriptionId: subId, // same ID so existing handlers accept the snapshot
+				})
+			);
+		});
+	});
+
+	it('re-subscribe after reconnect delivers fresh snapshot via existing handlers', async () => {
+		const { result } = renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		const subId = lastSubscribeId();
+
+		act(() => fireSnapshot(subId, [makeMessage(1)]));
+		expect(result.current.messages).toHaveLength(1);
+
+		// Simulate reconnect
+		act(() => {
+			mockIsConnected.value = false;
+		});
+		act(() => {
+			mockIsConnected.value = true;
+		});
+
+		// Server re-sends snapshot with same subscriptionId (simulated)
+		act(() => fireSnapshot(subId, [makeMessage(1), makeMessage(2), makeMessage(3)]));
+
+		expect(result.current.messages).toHaveLength(3);
+	});
+
+	it('does not re-subscribe when isConnected goes from true to false', async () => {
+		renderHook(() => useGroupMessageLiveQuery('grp-1'));
+
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		mockRequest.mockClear();
+
+		act(() => {
+			mockIsConnected.value = false;
+		});
+
+		await new Promise((r) => setTimeout(r, 10));
+
+		// No new subscribe call should have fired for a disconnect
+		expect(mockRequest).not.toHaveBeenCalledWith('liveQuery.subscribe', expect.any(Object));
+	});
+
+	it('does not re-subscribe on reconnect when groupId is null', async () => {
+		renderHook(() => useGroupMessageLiveQuery(null));
+
+		act(() => {
+			mockIsConnected.value = false;
+		});
+		mockRequest.mockClear();
+		act(() => {
+			mockIsConnected.value = true;
+		});
+
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(mockRequest).not.toHaveBeenCalledWith('liveQuery.subscribe', expect.any(Object));
 	});
 });

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -46,3 +46,8 @@ export {
 	type UseAutoScrollOptions,
 	type UseAutoScrollResult,
 } from './useAutoScroll';
+export {
+	useGroupMessageLiveQuery,
+	type GroupMessage,
+	type UseGroupMessageLiveQueryResult,
+} from './useGroupMessageLiveQuery';

--- a/packages/web/src/hooks/useGroupMessageLiveQuery.ts
+++ b/packages/web/src/hooks/useGroupMessageLiveQuery.ts
@@ -9,9 +9,13 @@
  * - On mount (or groupId change): registers snapshot/delta event listeners, then calls
  *   `liveQuery.subscribe` with a fresh subscriptionId.
  * - `liveQuery.snapshot`: replaces the message list entirely (server sends the full current
- *   set of rows). Stale events from superseded subscriptions are discarded.
+ *   set of rows). Stale events from superseded subscriptions are discarded. Clears any
+ *   prior error state.
  * - `liveQuery.delta`: appends messages from the `added` array only — `session_group_messages`
  *   is append-only so `updated`/`removed` are ignored. Stale events discarded.
+ * - On reconnect: re-issues `liveQuery.subscribe` with the same subscriptionId so the server
+ *   delivers a fresh snapshot, resyncing stale state. The old server-side handle is already
+ *   disposed on disconnect so no unsubscribe is sent first.
  * - On unmount / groupId change: fires `liveQuery.unsubscribe` (fire-and-forget) and
  *   removes event listeners.
  * - null groupId: clears messages immediately, no subscription is created.
@@ -19,17 +23,10 @@
 
 import { useEffect, useRef, useState } from 'preact/hooks';
 import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+import type { GroupMessage } from '../types/group-message';
 import { useMessageHub } from './useMessageHub';
 
-export interface GroupMessage {
-	id: number;
-	groupId: string;
-	sessionId: string | null;
-	role: string;
-	messageType: string;
-	content: string;
-	createdAt: number;
-}
+export type { GroupMessage } from '../types/group-message';
 
 export interface UseGroupMessageLiveQueryResult {
 	messages: GroupMessage[];
@@ -43,26 +40,30 @@ export interface UseGroupMessageLiveQueryResult {
  * @param groupId - The group to subscribe to, or null to clear and not subscribe.
  */
 export function useGroupMessageLiveQuery(groupId: string | null): UseGroupMessageLiveQueryResult {
-	const { request, onEvent } = useMessageHub();
+	const { request, onEvent, isConnected } = useMessageHub();
 	const [messages, setMessages] = useState<GroupMessage[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 
-	// Track the active subscriptionId so snapshot/delta handlers can discard stale events
-	// from prior subscriptions during rapid group switching.
+	// Refs that persist the active subscription state across renders so the
+	// reconnect effect can re-issue subscribe without touching the main effect.
 	const activeSubIdRef = useRef<string | null>(null);
+	const activeGroupIdRef = useRef<string | null>(null);
 
+	// ── Main subscription effect ──────────────────────────────────────────────
 	useEffect(() => {
 		if (!groupId) {
 			setMessages([]);
 			setLoading(false);
 			setError(null);
 			activeSubIdRef.current = null;
+			activeGroupIdRef.current = null;
 			return;
 		}
 
 		const subscriptionId = crypto.randomUUID();
 		activeSubIdRef.current = subscriptionId;
+		activeGroupIdRef.current = groupId;
 
 		setLoading(true);
 		setError(null);
@@ -74,7 +75,9 @@ export function useGroupMessageLiveQuery(groupId: string | null): UseGroupMessag
 		// event can slip through between registering and the RPC resolving.
 		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
 			if (event.subscriptionId !== subscriptionId || cancelled) return;
+			// rows is unknown[] from the protocol; we trust the server schema here.
 			setMessages((event.rows as GroupMessage[]) ?? []);
+			setError(null); // Clear any prior subscribe error if snapshot arrives late
 			setLoading(false);
 		});
 
@@ -104,6 +107,7 @@ export function useGroupMessageLiveQuery(groupId: string | null): UseGroupMessag
 
 			if (activeSubIdRef.current === subscriptionId) {
 				activeSubIdRef.current = null;
+				activeGroupIdRef.current = null;
 			}
 
 			unsubSnapshot();
@@ -114,6 +118,34 @@ export function useGroupMessageLiveQuery(groupId: string | null): UseGroupMessag
 			request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
 		};
 	}, [groupId, request, onEvent]);
+
+	// ── Reconnect re-subscribe effect ─────────────────────────────────────────
+	// After a WebSocket reconnect (false → true transition), re-issue the subscribe
+	// RPC with the same subscriptionId so the server delivers a fresh snapshot.
+	// The old server-side handle is already disposed on disconnect, so no unsubscribe
+	// is needed first. The existing snapshot/delta handlers will accept the re-delivered
+	// snapshot because the subscriptionId is unchanged.
+	const prevConnectedRef = useRef<boolean>(isConnected);
+	useEffect(() => {
+		const wasConnected = prevConnectedRef.current;
+		prevConnectedRef.current = isConnected;
+
+		// Only act on a false → true (reconnect) transition
+		if (!isConnected || wasConnected) return;
+
+		const subId = activeSubIdRef.current;
+		const gId = activeGroupIdRef.current;
+		if (!subId || !gId) return;
+
+		request<{ ok: true }>('liveQuery.subscribe', {
+			queryName: 'sessionGroupMessages.byGroup',
+			params: [gId],
+			subscriptionId: subId,
+		}).catch(() => {
+			// Reconnect re-subscribe failure is transient; ignore — the next reconnect
+			// cycle will retry automatically.
+		});
+	}, [isConnected, request]);
 
 	return { messages, loading, error };
 }

--- a/packages/web/src/hooks/useGroupMessageLiveQuery.ts
+++ b/packages/web/src/hooks/useGroupMessageLiveQuery.ts
@@ -1,0 +1,119 @@
+/**
+ * useGroupMessageLiveQuery
+ *
+ * Subscribes to the `sessionGroupMessages.byGroup` LiveQuery named query for a given group ID.
+ * Replaces polling / `state.groupMessages.delta` event listening with the standardized
+ * LiveQuery protocol.
+ *
+ * Lifecycle:
+ * - On mount (or groupId change): registers snapshot/delta event listeners, then calls
+ *   `liveQuery.subscribe` with a fresh subscriptionId.
+ * - `liveQuery.snapshot`: replaces the message list entirely (server sends the full current
+ *   set of rows). Stale events from superseded subscriptions are discarded.
+ * - `liveQuery.delta`: appends messages from the `added` array only — `session_group_messages`
+ *   is append-only so `updated`/`removed` are ignored. Stale events discarded.
+ * - On unmount / groupId change: fires `liveQuery.unsubscribe` (fire-and-forget) and
+ *   removes event listeners.
+ * - null groupId: clears messages immediately, no subscription is created.
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent } from '@neokai/shared';
+import { useMessageHub } from './useMessageHub';
+
+export interface GroupMessage {
+	id: number;
+	groupId: string;
+	sessionId: string | null;
+	role: string;
+	messageType: string;
+	content: string;
+	createdAt: number;
+}
+
+export interface UseGroupMessageLiveQueryResult {
+	messages: GroupMessage[];
+	loading: boolean;
+	error: string | null;
+}
+
+/**
+ * Subscribe to session group messages via LiveQuery for a given group.
+ *
+ * @param groupId - The group to subscribe to, or null to clear and not subscribe.
+ */
+export function useGroupMessageLiveQuery(groupId: string | null): UseGroupMessageLiveQueryResult {
+	const { request, onEvent } = useMessageHub();
+	const [messages, setMessages] = useState<GroupMessage[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	// Track the active subscriptionId so snapshot/delta handlers can discard stale events
+	// from prior subscriptions during rapid group switching.
+	const activeSubIdRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!groupId) {
+			setMessages([]);
+			setLoading(false);
+			setError(null);
+			activeSubIdRef.current = null;
+			return;
+		}
+
+		const subscriptionId = crypto.randomUUID();
+		activeSubIdRef.current = subscriptionId;
+
+		setLoading(true);
+		setError(null);
+		setMessages([]);
+
+		let cancelled = false;
+
+		// Register snapshot handler before calling subscribe so that no snapshot
+		// event can slip through between registering and the RPC resolving.
+		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+			if (event.subscriptionId !== subscriptionId || cancelled) return;
+			setMessages((event.rows as GroupMessage[]) ?? []);
+			setLoading(false);
+		});
+
+		// Register delta handler — append-only: only process `added`.
+		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			if (event.subscriptionId !== subscriptionId || cancelled) return;
+			if (event.added && event.added.length > 0) {
+				setMessages((prev) => [...prev, ...(event.added as GroupMessage[])]);
+			}
+		});
+
+		// Issue the subscribe RPC. The server sends `liveQuery.snapshot` synchronously
+		// before returning so the event listeners above will capture it.
+		request<{ ok: true }>('liveQuery.subscribe', {
+			queryName: 'sessionGroupMessages.byGroup',
+			params: [groupId],
+			subscriptionId,
+		}).catch((err: unknown) => {
+			if (!cancelled) {
+				setError(err instanceof Error ? err.message : 'Failed to subscribe to group messages');
+				setLoading(false);
+			}
+		});
+
+		return () => {
+			cancelled = true;
+
+			if (activeSubIdRef.current === subscriptionId) {
+				activeSubIdRef.current = null;
+			}
+
+			unsubSnapshot();
+			unsubDelta();
+
+			// Tell the server to dispose the subscription. Fire-and-forget — if the
+			// connection is already gone the server will clean up on disconnect anyway.
+			request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
+		};
+	}, [groupId, request, onEvent]);
+
+	return { messages, loading, error };
+}

--- a/packages/web/src/types/group-message.ts
+++ b/packages/web/src/types/group-message.ts
@@ -1,0 +1,16 @@
+/**
+ * GroupMessage — a row from the session_group_messages table as returned by
+ * the `sessionGroupMessages.byGroup` LiveQuery named query (and the
+ * `task.getGroupMessages` RPC for backward compatibility).
+ *
+ * Column names are camelCased via SQL aliasing in the named-query registry.
+ */
+export interface GroupMessage {
+	id: number;
+	groupId: string;
+	sessionId: string | null;
+	role: string;
+	messageType: string;
+	content: string;
+	createdAt: number;
+}


### PR DESCRIPTION
Introduces useGroupMessageLiveQuery, a Preact hook that subscribes to the
sessionGroupMessages.byGroup named query via the LiveQuery protocol.

- Calls liveQuery.subscribe on mount; generates a UUID subscriptionId per
  subscription for stale-event guards during rapid task switching
- Handles liveQuery.snapshot: replaces message list; stale guard discards
  events from superseded subscriptions
- Handles liveQuery.delta: appends from added array only (append-only
  invariant); stale guard applied
- Calls liveQuery.unsubscribe (fire-and-forget) on unmount or groupId change
- null groupId: clears messages immediately, no subscription created
- 15 Vitest tests covering all lifecycle paths

Exports hook and types from hooks/index.ts.
