### PR TITLE
feat: add git branch and session status to TaskInfoPanel expanded view

### DIFF
--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -19,6 +19,18 @@ import { getModelLabel } from '../../lib/session-utils.ts';
 import { CopyButton } from '../ui/CopyButton.tsx';
 
 /**
+ * Map session status to a CSS color class.
+ * - green  → active (live, processing)
+ * - amber  → paused / pending_worktree_choice (live but waiting)
+ * - gray   → ended / archived (terminal)
+ */
+function sessionStatusColor(status: string): string {
+	if (status === 'active') return 'text-green-400';
+	if (status === 'paused' || status === 'pending_worktree_choice') return 'text-amber-400';
+	return 'text-gray-500';
+}
+
+/**
  * Get the last N segments of a path
  */
 function getLastPathSegments(path: string, segments: number = 2): string {
@@ -70,8 +82,13 @@ export function TaskInfoPanel({
 	const hasWorktreeInfo = worktreePath || workerSession || leaderSession;
 	const displayPath = worktreePath ? getLastPathSegments(worktreePath) : null;
 
-	// Git branch: prefer worktree branch, fall back to session gitBranch
-	const gitBranch = workerSession?.worktree?.branch ?? workerSession?.gitBranch ?? null;
+	// Git branch: prefer worker worktree branch, then worker gitBranch, then leader equivalents
+	const gitBranch =
+		workerSession?.worktree?.branch ??
+		workerSession?.gitBranch ??
+		leaderSession?.worktree?.branch ??
+		leaderSession?.gitBranch ??
+		null;
 
 	const hasVisibleActions =
 		visibleActions.complete || visibleActions.cancel || visibleActions.archive;
@@ -117,7 +134,7 @@ export function TaskInfoPanel({
 										{workerSession.id.slice(0, 8)}...
 									</span>
 									<span
-										class={`text-xs flex-shrink-0 ${workerSession.status === 'active' ? 'text-green-400' : 'text-gray-500'}`}
+										class={`text-xs flex-shrink-0 ${sessionStatusColor(workerSession.status)}`}
 										data-testid="worker-session-status"
 									>
 										{workerSession.status}
@@ -132,7 +149,7 @@ export function TaskInfoPanel({
 										{leaderSession.id.slice(0, 8)}...
 									</span>
 									<span
-										class={`text-xs flex-shrink-0 ${leaderSession.status === 'active' ? 'text-green-400' : 'text-gray-500'}`}
+										class={`text-xs flex-shrink-0 ${sessionStatusColor(leaderSession.status)}`}
 										data-testid="leader-session-status"
 									>
 										{leaderSession.status}

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -70,6 +70,9 @@ export function TaskInfoPanel({
 	const hasWorktreeInfo = worktreePath || workerSession || leaderSession;
 	const displayPath = worktreePath ? getLastPathSegments(worktreePath) : null;
 
+	// Git branch: prefer worktree branch, fall back to session gitBranch
+	const gitBranch = workerSession?.worktree?.branch ?? workerSession?.gitBranch ?? null;
+
 	const hasVisibleActions =
 		visibleActions.complete || visibleActions.cancel || visibleActions.archive;
 
@@ -95,12 +98,29 @@ export function TaskInfoPanel({
 								</div>
 							)}
 
+							{/* Git branch */}
+							{gitBranch && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-12">Branch:</span>
+									<span class="text-gray-300 font-mono truncate flex-1" title={gitBranch}>
+										{gitBranch}
+									</span>
+									<CopyButton text={gitBranch} />
+								</div>
+							)}
+
 							{/* Session IDs */}
 							{workerSession && (
 								<div class="flex items-center gap-2">
 									<span class="text-gray-500 flex-shrink-0 w-12">Worker:</span>
 									<span class="text-gray-300 font-mono truncate flex-1" title={workerSession.id}>
 										{workerSession.id.slice(0, 8)}...
+									</span>
+									<span
+										class={`text-xs flex-shrink-0 ${workerSession.status === 'active' ? 'text-green-400' : 'text-gray-500'}`}
+										data-testid="worker-session-status"
+									>
+										{workerSession.status}
 									</span>
 									<CopyButton text={workerSession.id} />
 								</div>
@@ -110,6 +130,12 @@ export function TaskInfoPanel({
 									<span class="text-gray-500 flex-shrink-0 w-12">Leader:</span>
 									<span class="text-gray-300 font-mono truncate flex-1" title={leaderSession.id}>
 										{leaderSession.id.slice(0, 8)}...
+									</span>
+									<span
+										class={`text-xs flex-shrink-0 ${leaderSession.status === 'active' ? 'text-green-400' : 'text-gray-500'}`}
+										data-testid="leader-session-status"
+									>
+										{leaderSession.status}
 									</span>
 									<CopyButton text={leaderSession.id} />
 								</div>

--- a/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
@@ -61,9 +61,76 @@ describe('TaskInfoPanel', () => {
 			expect(pathElement).toBeTruthy();
 		});
 
+		it('should show git branch from worktree metadata', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+				worktree: {
+					isWorktree: true,
+					branch: 'feature/my-branch',
+					worktreePath: '/tmp/wt',
+					mainRepoPath: '/tmp',
+				},
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Branch:');
+			expect(container.textContent).toContain('feature/my-branch');
+		});
+
+		it('should show git branch from session gitBranch when no worktree', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+				gitBranch: 'main',
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Branch:');
+			expect(container.textContent).toContain('main');
+		});
+
+		it('should not show branch row when no branch info available', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).not.toContain('Branch:');
+		});
+
 		it('should show worker session info when provided', () => {
 			const workerSession = {
 				id: 'worker-session-id-1234',
+				status: 'active',
 				config: { model: 'claude-sonnet-4-6' },
 			} as never;
 
@@ -80,9 +147,31 @@ describe('TaskInfoPanel', () => {
 			expect(container.textContent).toContain('worker-s'); // first 8 chars + '...'
 		});
 
+		it('should show worker session status', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="worker-session-status"]');
+			expect(statusEl).toBeTruthy();
+			expect(statusEl?.textContent).toBe('active');
+		});
+
 		it('should show leader session info when provided', () => {
 			const leaderSession = {
 				id: 'leader-session-id-5678',
+				status: 'active',
 				config: { model: 'claude-sonnet-4-6' },
 			} as never;
 
@@ -97,6 +186,27 @@ describe('TaskInfoPanel', () => {
 
 			expect(container.textContent).toContain('Leader:');
 			expect(container.textContent).toContain('leader-s'); // first 8 chars + '...'
+		});
+
+		it('should show leader session status', () => {
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'ended',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="leader-session-status"]');
+			expect(statusEl).toBeTruthy();
+			expect(statusEl?.textContent).toBe('ended');
 		});
 
 		it('should show model when session has model config', () => {

--- a/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
@@ -209,6 +209,155 @@ describe('TaskInfoPanel', () => {
 			expect(statusEl?.textContent).toBe('ended');
 		});
 
+		it('should apply green color for active worker session status', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="worker-session-status"]');
+			expect(statusEl?.className).toContain('text-green-400');
+		});
+
+		it('should apply amber color for paused worker session status', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'paused',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="worker-session-status"]');
+			expect(statusEl?.className).toContain('text-amber-400');
+		});
+
+		it('should apply amber color for pending_worktree_choice worker session status', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'pending_worktree_choice',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="worker-session-status"]');
+			expect(statusEl?.className).toContain('text-amber-400');
+		});
+
+		it('should apply gray color for ended leader session status', () => {
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'ended',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="leader-session-status"]');
+			expect(statusEl?.className).toContain('text-gray-500');
+		});
+
+		it('should apply gray color for archived leader session status', () => {
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'archived',
+				config: { model: 'claude-sonnet-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			const statusEl = container.querySelector('[data-testid="leader-session-status"]');
+			expect(statusEl?.className).toContain('text-gray-500');
+		});
+
+		it('should show branch from leader session when worker has no branch info', () => {
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+				gitBranch: 'task/leader-branch',
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Branch:');
+			expect(container.textContent).toContain('task/leader-branch');
+		});
+
+		it('should prefer worker branch over leader branch when both are present', () => {
+			const workerSession = {
+				id: 'worker-session-id-1234',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+				gitBranch: 'task/worker-branch',
+			} as never;
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'active',
+				config: { model: 'claude-sonnet-4-6' },
+				gitBranch: 'task/leader-branch',
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					workerSession={workerSession}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('task/worker-branch');
+			expect(container.textContent).not.toContain('task/leader-branch');
+		});
+
 		it('should show model when session has model config', () => {
 			const workerSession = {
 				id: 'worker-session-id-1234',


### PR DESCRIPTION
Show the worker's git branch (from worktree metadata or gitBranch field)
and per-session status badges (active/ended/etc.) in the gear panel info
section, giving additional context for debugging task execution.
