### PR TITLE
fix: remove emitGoalUpdated/emitGoalProgressUpdated from goal RPC handlers (Task 3.2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -80,38 +80,6 @@ export function setupGoalHandlers(
 			});
 	};
 
-	/**
-	 * Emit goal.updated event to notify UI clients
-	 */
-	const emitGoalUpdated = (roomId: string, goalId: string, goal?: RoomGoal) => {
-		daemonHub
-			.emit('goal.updated', {
-				sessionId: `room:${roomId}`,
-				roomId,
-				goalId,
-				goal,
-			})
-			.catch((error) => {
-				log.warn(`Failed to emit goal.updated for room ${roomId}:`, error);
-			});
-	};
-
-	/**
-	 * Emit goal.progressUpdated event to notify UI clients
-	 */
-	const emitGoalProgressUpdated = (roomId: string, goalId: string, progress: number) => {
-		daemonHub
-			.emit('goal.progressUpdated', {
-				sessionId: `room:${roomId}`,
-				roomId,
-				goalId,
-				progress,
-			})
-			.catch((error) => {
-				log.warn(`Failed to emit goal.progressUpdated for room ${roomId}:`, error);
-			});
-	};
-
 	// goal.create - Create a new goal
 	messageHub.onRequest('goal.create', async (data) => {
 		const params = data as {
@@ -254,8 +222,6 @@ export function setupGoalHandlers(
 			);
 		}
 
-		emitGoalUpdated(params.roomId, params.goalId, goal);
-
 		return { goal };
 	});
 
@@ -273,8 +239,6 @@ export function setupGoalHandlers(
 		const goalManager = goalManagerFactory(params.roomId);
 		const goal = await goalManager.needsHumanGoal(params.goalId);
 
-		emitGoalUpdated(params.roomId, params.goalId, goal);
-
 		return { goal };
 	});
 
@@ -291,8 +255,6 @@ export function setupGoalHandlers(
 
 		const goalManager = goalManagerFactory(params.roomId);
 		const goal = await goalManager.reactivateGoal(params.goalId);
-
-		emitGoalUpdated(params.roomId, params.goalId, goal);
 
 		return { goal };
 	});
@@ -331,10 +293,6 @@ export function setupGoalHandlers(
 			goal = await goalManager.linkTaskToGoal(params.goalId, params.taskId);
 		}
 
-		// Emit goal.updated event (task linked and progress recalculated)
-		emitGoalUpdated(params.roomId, params.goalId, goal);
-		emitGoalProgressUpdated(params.roomId, params.goalId, goal.progress);
-
 		return { goal };
 	});
 
@@ -351,9 +309,6 @@ export function setupGoalHandlers(
 
 		const goalManager = goalManagerFactory(params.roomId);
 		const success = await goalManager.deleteGoal(params.goalId);
-
-		// Emit goal.updated event with undefined goal to signal deletion
-		emitGoalUpdated(params.roomId, params.goalId);
 
 		return { success };
 	});
@@ -397,7 +352,6 @@ export function setupGoalHandlers(
 			missionType: 'recurring',
 		});
 
-		emitGoalUpdated(params.roomId, params.goalId, updated);
 		return { goal: updated, nextRunAt };
 	});
 
@@ -418,7 +372,6 @@ export function setupGoalHandlers(
 		const updated = await goalManager.updateGoalStatus(params.goalId, goal.status, {
 			schedulePaused: true,
 		});
-		emitGoalUpdated(params.roomId, params.goalId, updated);
 		return { goal: updated };
 	});
 
@@ -446,7 +399,6 @@ export function setupGoalHandlers(
 			schedulePaused: false,
 			nextRunAt: nextRunAt ?? undefined,
 		});
-		emitGoalUpdated(params.roomId, params.goalId, updated);
 		return { goal: updated, nextRunAt };
 	});
 

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -249,12 +249,6 @@ export class StateManager {
 			});
 		});
 
-		this.eventBus.on('goal.updated', (data) => {
-			this.messageHub.event('goal.updated', data, {
-				channel: data.sessionId, // 'room:${roomId}'
-			});
-		});
-
 		this.eventBus.on('goal.completed', (data) => {
 			this.messageHub.event('goal.completed', data, {
 				channel: data.sessionId, // 'room:${roomId}'

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -559,7 +559,7 @@ describe('Goal RPC Handlers', () => {
 			).rejects.toThrow('No update fields provided');
 		});
 
-		it('emits goal.updated event', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.update');
 			expect(handler).toBeDefined();
 
@@ -568,14 +568,7 @@ describe('Goal RPC Handlers', () => {
 				{}
 			);
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-				})
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 
@@ -610,20 +603,13 @@ describe('Goal RPC Handlers', () => {
 			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
 		});
 
-		it('emits goal.updated event', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.needsHuman');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-				})
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 
@@ -658,20 +644,13 @@ describe('Goal RPC Handlers', () => {
 			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
 		});
 
-		it('emits goal.updated event', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.reactivate');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-				})
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 
@@ -719,27 +698,16 @@ describe('Goal RPC Handlers', () => {
 			);
 		});
 
-		it('emits goal.updated and goal.progressUpdated events', async () => {
+		it('does not emit goal.updated or goal.progressUpdated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.linkTask');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123', taskId: 'task-456' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-				})
-			);
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith(
 				'goal.progressUpdated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-				})
+				expect.anything()
 			);
 		});
 
@@ -841,21 +809,13 @@ describe('Goal RPC Handlers', () => {
 			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
 		});
 
-		it('emits goal.updated event with undefined goal to signal deletion', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.delete');
 			expect(handler).toBeDefined();
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({
-					sessionId: 'room:room-123',
-					roomId: 'room-123',
-					goalId: 'goal-123',
-					goal: undefined,
-				})
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 
 		it('returns false when delete fails', async () => {
@@ -969,17 +929,14 @@ describe('Goal RPC Handlers', () => {
 			).rejects.toThrow('Invalid cron expression');
 		});
 
-		it('emits goal.updated event on success', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.setSchedule')!;
 			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
 			mockGoalManager.updateGoalStatus.mockResolvedValueOnce(recurringGoal);
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123', cronExpression: '@weekly' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 
@@ -1029,7 +986,7 @@ describe('Goal RPC Handlers', () => {
 			);
 		});
 
-		it('emits goal.updated event on success', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.pauseSchedule')!;
 			mockGoalManager.getGoal.mockResolvedValueOnce(recurringGoal);
 			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
@@ -1039,10 +996,7 @@ describe('Goal RPC Handlers', () => {
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 
@@ -1107,7 +1061,7 @@ describe('Goal RPC Handlers', () => {
 			);
 		});
 
-		it('emits goal.updated event on success', async () => {
+		it('does not emit goal.updated (superseded by LiveQuery delta delivery)', async () => {
 			const handler = messageHubData.handlers.get('goal.resumeSchedule')!;
 			mockGoalManager.getGoal.mockResolvedValueOnce(pausedGoal);
 			mockGoalManager.updateGoalStatus.mockResolvedValueOnce({
@@ -1117,10 +1071,7 @@ describe('Goal RPC Handlers', () => {
 
 			await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {});
 
-			expect(daemonHubData.emit).toHaveBeenCalledWith(
-				'goal.updated',
-				expect.objectContaining({ roomId: 'room-123', goalId: 'goal-123' })
-			);
+			expect(daemonHubData.emit).not.toHaveBeenCalledWith('goal.updated', expect.anything());
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-computed-signals.test.ts
@@ -30,6 +30,7 @@ function makeMockHub() {
 				if (idx >= 0) mockEventHandlers.splice(idx, 1);
 			};
 		}),
+		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
 				return { room: { id: 'room-1' }, sessions: [], allTasks: [] };

--- a/packages/web/src/lib/__tests__/room-store-create-session.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-create-session.test.ts
@@ -34,6 +34,7 @@ function makeMockHub() {
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),
 		onEvent: vi.fn(() => () => {}),
+		onConnection: vi.fn(() => () => {}),
 		request: mockRequestFn,
 	};
 }

--- a/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for RoomStore goal LiveQuery subscription (Task 3.2/3.3)
+ *
+ * Verifies that goals are updated exclusively via liveQuery.snapshot /
+ * liveQuery.delta events rather than legacy goal.created / goal.updated /
+ * goal.completed events.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { RoomGoal, GoalStatus } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	joinChannel: ReturnType<typeof vi.fn>;
+	leaveChannel: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('../connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock('../router', () => ({ navigateToRoom: vi.fn() }));
+vi.mock('../signals', () => ({
+	currentRoomSessionIdSignal: { value: null },
+	currentRoomIdSignal: { value: null },
+	currentRoomTaskIdSignal: { value: null },
+	currentSessionIdSignal: { value: null },
+	currentSpaceIdSignal: { value: null },
+	currentSpaceSessionIdSignal: { value: null },
+	currentSpaceTaskIdSignal: { value: null },
+	navSectionSignal: { value: 'lobby' },
+}));
+
+import { connectionManager } from '../connection-manager.js';
+import { roomStore } from '../room-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID = 'room-test';
+const GOALS_SUB_ID = `goals-byRoom-${ROOM_ID}`;
+
+function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: `Goal ${id}`,
+		description: '',
+		status: 'active' as GoalStatus,
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function setupHubRequests(hub: MockHub): void {
+	hub.request.mockImplementation((method: string) => {
+		if (method === 'room.get')
+			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+		// liveQuery.subscribe and liveQuery.unsubscribe return { ok: true }
+		return Promise.resolve({ ok: true });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('subscribes to goals.byRoom with a stable subscriptionId on room select', () => {
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCall = calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(subscribeCall).toBeDefined();
+		expect(subscribeCall![1]).toMatchObject({
+			queryName: 'goals.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: GOALS_SUB_ID,
+		});
+	});
+
+	it('does NOT subscribe via legacy goal.list on room select', () => {
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const goalListCall = calls.find(([method]) => method === 'goal.list');
+		expect(goalListCall).toBeUndefined();
+	});
+
+	it('populates goals.value from liveQuery.snapshot', () => {
+		const goals = [makeGoal('g1'), makeGoal('g2')];
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: goals, version: 1 });
+		expect(roomStore.goals.value).toEqual(goals);
+	});
+
+	it('ignores liveQuery.snapshot for a different subscriptionId', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: 'other-sub',
+			rows: [makeGoal('irrelevant')],
+			version: 1,
+		});
+		expect(roomStore.goals.value).toEqual([]);
+	});
+
+	it('appends goals from liveQuery.delta added', () => {
+		const g1 = makeGoal('g1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
+		const g2 = makeGoal('g2');
+		hub.fire('liveQuery.delta', { subscriptionId: GOALS_SUB_ID, added: [g2], version: 2 });
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+	});
+
+	it('removes goals from liveQuery.delta removed', () => {
+		const g1 = makeGoal('g1');
+		const g2 = makeGoal('g2');
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1, g2], version: 1 });
+		hub.fire('liveQuery.delta', { subscriptionId: GOALS_SUB_ID, removed: [g1], version: 2 });
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g2']);
+	});
+
+	it('replaces goals from liveQuery.delta updated', () => {
+		const g1 = makeGoal('g1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
+		const g1Updated = makeGoal('g1', { status: 'completed' as GoalStatus, progress: 100 });
+		hub.fire('liveQuery.delta', {
+			subscriptionId: GOALS_SUB_ID,
+			updated: [g1Updated],
+			version: 2,
+		});
+		expect(roomStore.goals.value[0].status).toBe('completed');
+		expect(roomStore.goals.value[0].progress).toBe(100);
+	});
+
+	it('ignores liveQuery.delta for a different subscriptionId', () => {
+		const g1 = makeGoal('g1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
+		hub.fire('liveQuery.delta', {
+			subscriptionId: 'other-sub',
+			removed: [g1],
+			version: 2,
+		});
+		// g1 should still be present
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+
+	it('unsubscribes from goals.byRoom on room deselect', async () => {
+		hub.request.mockClear();
+		await roomStore.select(null);
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const unsubCall = calls.find(([method]) => method === 'liveQuery.unsubscribe');
+		expect(unsubCall).toBeDefined();
+		expect(unsubCall![1]).toMatchObject({ subscriptionId: GOALS_SUB_ID });
+	});
+
+	it('re-subscribes to goals.byRoom on reconnect', () => {
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(resubCall).toBeDefined();
+		expect(resubCall![1]).toMatchObject({
+			queryName: 'goals.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: GOALS_SUB_ID,
+		});
+	});
+
+	it('does NOT re-subscribe on reconnect after room is deselected', async () => {
+		await roomStore.select(null);
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(resubCall).toBeUndefined();
+	});
+
+	it('does not update goals on legacy goal.updated event', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		// Legacy event should have no effect
+		hub.fire('goal.updated', { roomId: ROOM_ID, goalId: 'g1', goal: makeGoal('g1-modified') });
+		// goals signal unchanged from snapshot
+		expect(roomStore.goals.value[0].id).toBe('g1');
+	});
+});

--- a/packages/web/src/lib/__tests__/room-store-review.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-review.test.ts
@@ -23,6 +23,7 @@ function makeMockHub() {
 			mockEventHandlers.set(eventName, handler);
 			return () => mockEventHandlers.delete(eventName);
 		}),
+		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
 				return { room: { id: 'room-1' }, sessions: [], allTasks: [] };

--- a/packages/web/src/lib/__tests__/room-store-session-events.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-session-events.test.ts
@@ -59,6 +59,7 @@ type EventHandler<T = unknown> = (data: T) => void;
 interface MockHub {
 	_handlers: Map<string, EventHandler[]>;
 	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: ReturnType<typeof vi.fn>;
 	request: ReturnType<typeof vi.fn>;
 	joinChannel: ReturnType<typeof vi.fn>;
 	leaveChannel: ReturnType<typeof vi.fn>;
@@ -80,6 +81,7 @@ function createMockHub(): MockHub {
 				}
 			};
 		},
+		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(),
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -32,6 +32,8 @@ import type {
 	MissionMetric,
 	CronSchedule,
 	MissionExecution,
+	LiveQuerySnapshotEvent,
+	LiveQueryDeltaEvent,
 } from '@neokai/shared';
 
 /**
@@ -48,14 +50,6 @@ interface CreateGoalParams {
 	structuredMetrics?: MissionMetric[];
 	schedule?: CronSchedule;
 	schedulePaused?: boolean;
-}
-
-/**
- * Event payload for goal events
- */
-interface GoalEventPayload {
-	roomId: string;
-	goal: RoomGoal;
 }
 
 import { Logger } from '@neokai/shared';
@@ -349,52 +343,72 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubTaskUpdate);
 
-			// 3. Goal events (daemon emits goal.created, goal.updated, goal.completed)
-			const unsubGoalCreated = hub.onEvent<GoalEventPayload>('goal.created', (event) => {
-				if (event.roomId === roomId) {
-					this.goals.value = [...this.goals.value, event.goal];
-				}
-			});
-			this.cleanupFunctions.push(unsubGoalCreated);
+			// 3. Goals via LiveQuery — replaces goal.created/updated/completed event listeners.
+			// Register snapshot/delta handlers BEFORE subscribing so we never miss the
+			// initial snapshot that the server pushes synchronously before replying.
+			const goalsSubId = `goals-byRoom-${roomId}`;
 
-			const unsubGoalUpdated = hub.onEvent<GoalEventPayload & { goalId?: string }>(
-				'goal.updated',
+			const unsubGoalSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+				'liveQuery.snapshot',
 				(event) => {
-					if (event.roomId === roomId) {
-						if (event.goal) {
-							// Partial update
-							const idx = this.goals.value.findIndex((g) => g.id === event.goal.id);
-							if (idx >= 0) {
-								this.goals.value = [
-									...this.goals.value.slice(0, idx),
-									{ ...this.goals.value[idx], ...event.goal },
-									...this.goals.value.slice(idx + 1),
-								];
-							}
-						} else if (event.goalId) {
-							// goal.updated with no goal object signals deletion
-							this.goals.value = this.goals.value.filter((g) => g.id !== event.goalId);
-						} else {
-							logger.warn('goal.updated received with neither goal nor goalId', event);
-						}
+					if (event.subscriptionId === goalsSubId) {
+						this.goals.value = event.rows as RoomGoal[];
 					}
 				}
 			);
-			this.cleanupFunctions.push(unsubGoalUpdated);
+			this.cleanupFunctions.push(unsubGoalSnapshot);
 
-			const unsubGoalCompleted = hub.onEvent<GoalEventPayload>('goal.completed', (event) => {
-				if (event.roomId === roomId) {
-					const idx = this.goals.value.findIndex((g) => g.id === event.goal.id);
-					if (idx >= 0) {
-						this.goals.value = [
-							...this.goals.value.slice(0, idx),
-							event.goal,
-							...this.goals.value.slice(idx + 1),
-						];
-					}
+			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId !== goalsSubId) return;
+				let current = this.goals.value;
+				if (event.removed?.length) {
+					const removedIds = new Set((event.removed as RoomGoal[]).map((r) => r.id));
+					current = current.filter((g) => !removedIds.has(g.id));
+				}
+				if (event.updated?.length) {
+					const updatedMap = new Map((event.updated as RoomGoal[]).map((u) => [u.id, u]));
+					current = current.map((g) => updatedMap.get(g.id) ?? g);
+				}
+				if (event.added?.length) {
+					current = [...current, ...(event.added as RoomGoal[])];
+				}
+				this.goals.value = current;
+			});
+			this.cleanupFunctions.push(unsubGoalDelta);
+
+			// Subscribe to the goals.byRoom named query.
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'goals.byRoom',
+				params: [roomId],
+				subscriptionId: goalsSubId,
+			});
+
+			// Re-subscribe on reconnect: the server-side subscription is per-connection
+			// and is gone after a disconnect. Requesting liveQuery.subscribe again with
+			// the same subscriptionId delivers a fresh snapshot to the already-registered
+			// snapshot handler above.
+			const unsubReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || this.roomId.value !== roomId) return;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'goals.byRoom',
+						params: [roomId],
+						subscriptionId: goalsSubId,
+					})
+					.catch((err) => {
+						logger.warn('Goals LiveQuery re-subscribe failed, falling back to refetch:', err);
+						this.fetchGoals().catch(() => {});
+					});
+			});
+			this.cleanupFunctions.push(unsubReconnect);
+
+			// Cleanup: tell the server to dispose the subscription when leaving the room.
+			this.cleanupFunctions.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
 				}
 			});
-			this.cleanupFunctions.push(unsubGoalCompleted);
 
 			// 3b. Auto-completed task notifications (semi-autonomous mode)
 			const unsubAutoCompleted = hub.onEvent<{
@@ -498,7 +512,8 @@ class RoomStore {
 				this.error.value = 'Room not found';
 			}
 
-			await this.fetchGoals();
+			// Goals are delivered via the goals.byRoom LiveQuery snapshot pushed
+			// synchronously during liveQuery.subscribe in startSubscriptions.
 
 			// Fetch runtime state
 			try {


### PR DESCRIPTION
Removes all 8 emitGoalUpdated() call sites and both emitGoalProgressUpdated()
calls from goal-handlers.ts. Goal updates are now delivered exclusively via
LiveQuery delta notifications (notifyChange in GoalRepository). The
emitGoalCreated() call is preserved — room-runtime-service.ts subscribes to
goal.created on daemonHub to trigger scheduling.

Confirmed goal.completed is defined in daemon-hub.ts but never emitted.

Tests updated to assert goal.updated and goal.progressUpdated are NOT emitted.
