### PR TITLE
fix: address root causes of duplicate and stale session groups

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -445,6 +445,15 @@ export class RoomRuntime {
 		}
 		this.mirroringCleanups.clear();
 		this.observer.dispose();
+
+		// Safety net: mark zombie groups (active groups for terminal tasks) as completed.
+		// Runs synchronously at stop time — no session recovery, just DB consistency.
+		const zombiesCleaned = this.groupRepo.cleanupZombieGroupsForRoom(this.roomId);
+		if (zombiesCleaned > 0) {
+			log.warn(
+				`[stop] Room ${this.roomId}: cleaned up ${zombiesCleaned} zombie group(s) on runtime stop`
+			);
+		}
 	}
 
 	getState(): RuntimeState {
@@ -3147,10 +3156,12 @@ export class RoomRuntime {
 	private async spawnGroupForTask(task: NeoTask): Promise<void> {
 		// Defense-in-depth: verify no active group exists for this task right before spawning.
 		// Catches races that slip past the executeTick() filter (e.g., concurrent ticks).
-		const existingGroup = this.groupRepo.getGroupByTaskId(task.id);
-		if (existingGroup && existingGroup.completedAt === null) {
+		// Check ALL active groups, not just the most recent — a stale older group with
+		// completedAt === null would be missed by getGroupByTaskId() which returns only the latest.
+		const allActiveGroups = this.groupRepo.getActiveGroupsForTask(task.id);
+		if (allActiveGroups.length > 0) {
 			log.warn(
-				`[spawnGroupForTask] Task ${task.id} ("${task.title}") already has active group ${existingGroup.id} — skipping duplicate spawn`
+				`[spawnGroupForTask] Task ${task.id} ("${task.title}") already has ${allActiveGroups.length} active group(s) (${allActiveGroups.map((g) => g.id).join(', ')}) — skipping duplicate spawn`
 			);
 			return;
 		}

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -562,17 +562,19 @@ export class TaskGroupManager {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
-		// Complete the group
-		const updated = this.groupRepo.completeGroup(groupId, group.version);
-		if (!updated) return null;
-
-		// Safety net: clean up any other stale active groups for this task
+		// Safety net: clean up any other stale active groups for this task BEFORE completing
+		// the canonical group. This ensures we aren't racing against the unique index, and
+		// any stale duplicates are resolved before the primary group transitions.
 		const staleCount = this.groupRepo.cleanupStaleGroupsForTask(group.taskId, groupId);
 		if (staleCount > 0) {
 			log.warn(
-				`[complete] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) on completion`
+				`[complete] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) before completion`
 			);
 		}
+
+		// Complete the group
+		const updated = this.groupRepo.completeGroup(groupId, group.version);
+		if (!updated) return null;
 
 		// Complete the task
 		await this.taskManager.completeTask(group.taskId, summary);
@@ -596,17 +598,19 @@ export class TaskGroupManager {
 		const group = this.groupRepo.getGroup(groupId);
 		if (!group) return null;
 
-		// Fail the group
-		const updated = this.groupRepo.failGroup(groupId, group.version);
-		if (!updated) return null;
-
-		// Safety net: clean up any other stale active groups for this task
+		// Safety net: clean up any other stale active groups for this task BEFORE failing
+		// the canonical group. This ensures stale duplicates are resolved before the
+		// primary group transitions.
 		const staleCount = this.groupRepo.cleanupStaleGroupsForTask(group.taskId, groupId);
 		if (staleCount > 0) {
 			log.warn(
-				`[fail] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) on failure`
+				`[fail] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) before failure`
 			);
 		}
+
+		// Fail the group
+		const updated = this.groupRepo.failGroup(groupId, group.version);
+		if (!updated) return null;
 
 		// Fail the task
 		await this.taskManager.failTask(group.taskId, reason);

--- a/packages/daemon/src/lib/room/runtime/task-group-manager.ts
+++ b/packages/daemon/src/lib/room/runtime/task-group-manager.ts
@@ -566,6 +566,14 @@ export class TaskGroupManager {
 		const updated = this.groupRepo.completeGroup(groupId, group.version);
 		if (!updated) return null;
 
+		// Safety net: clean up any other stale active groups for this task
+		const staleCount = this.groupRepo.cleanupStaleGroupsForTask(group.taskId, groupId);
+		if (staleCount > 0) {
+			log.warn(
+				`[complete] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) on completion`
+			);
+		}
+
 		// Complete the task
 		await this.taskManager.completeTask(group.taskId, summary);
 
@@ -591,6 +599,14 @@ export class TaskGroupManager {
 		// Fail the group
 		const updated = this.groupRepo.failGroup(groupId, group.version);
 		if (!updated) return null;
+
+		// Safety net: clean up any other stale active groups for this task
+		const staleCount = this.groupRepo.cleanupStaleGroupsForTask(group.taskId, groupId);
+		if (staleCount > 0) {
+			log.warn(
+				`[fail] Task ${group.taskId}: cleaned up ${staleCount} stale active group(s) on failure`
+			);
+		}
 
 		// Fail the task
 		await this.taskManager.failTask(group.taskId, reason);

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -291,6 +291,30 @@ export class SessionGroupRepository {
 		return this.rowToGroup(row);
 	}
 
+	/**
+	 * Returns ALL active (completedAt IS NULL) groups for a specific task.
+	 * Used for defense-in-depth deduplication in spawnGroupForTask — checks every
+	 * active group, not just the most recent, to catch stale zombie groups that
+	 * would otherwise allow a duplicate spawn.
+	 */
+	getActiveGroupsForTask(taskId: string): SessionGroup[] {
+		const rows = this.db
+			.prepare(
+				`SELECT
+					sg.id, sg.group_type, sg.ref_id, sg.version, sg.metadata,
+					sg.created_at, sg.completed_at,
+					worker.session_id AS worker_session_id,
+					leader.session_id AS leader_session_id
+				FROM session_groups sg
+				LEFT JOIN session_group_members worker ON worker.group_id = sg.id AND worker.role = 'worker'
+				LEFT JOIN session_group_members leader ON leader.group_id = sg.id AND leader.role = 'leader'
+				WHERE sg.ref_id = ? AND sg.group_type IN ('task', 'task_pair') AND sg.completed_at IS NULL
+				ORDER BY sg.created_at DESC`
+			)
+			.all(taskId) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToGroup(r));
+	}
+
 	getActiveGroups(roomId: string): SessionGroup[] {
 		const rows = this.db
 			.prepare(
@@ -333,6 +357,57 @@ export class SessionGroupRepository {
 		if (result.changes === 0) return null;
 		this.reactiveDb.notifyChange('session_groups');
 		return this.getGroup(groupId);
+	}
+
+	/**
+	 * DB-level zombie cleanup for a room: marks active session groups as completed
+	 * when their task is in a terminal state (completed, cancelled, archived).
+	 *
+	 * Synchronous and safe to call from stop() without async/await.
+	 * Returns the number of groups cleaned up.
+	 */
+	cleanupZombieGroupsForRoom(roomId: string): number {
+		const now = Date.now();
+		const result = this.db
+			.prepare(
+				`UPDATE session_groups
+				 SET completed_at = ?, version = version + 1
+				 WHERE completed_at IS NULL
+				   AND group_type IN ('task', 'task_pair')
+				   AND ref_id IN (
+				     SELECT t.id FROM tasks t
+				     WHERE t.room_id = ?
+				       AND t.status IN ('completed', 'cancelled', 'archived')
+				   )`
+			)
+			.run(now, roomId);
+		if (result.changes > 0) {
+			this.reactiveDb.notifyChange('session_groups');
+		}
+		return result.changes;
+	}
+
+	/**
+	 * Force-complete all active groups for a task except the specified one.
+	 * Used as a safety net in complete()/fail() to clean up any duplicate/stale
+	 * groups that slipped past the deduplication check.
+	 *
+	 * Returns the number of groups cleaned up.
+	 */
+	cleanupStaleGroupsForTask(taskId: string, keepGroupId: string): number {
+		const now = Date.now();
+		const result = this.db
+			.prepare(
+				`UPDATE session_groups
+				 SET completed_at = ?, version = version + 1
+				 WHERE ref_id = ? AND group_type IN ('task', 'task_pair')
+				   AND completed_at IS NULL AND id != ?`
+			)
+			.run(now, taskId, keepGroupId);
+		if (result.changes > 0) {
+			this.reactiveDb.notifyChange('session_groups');
+		}
+		return result.changes;
 	}
 
 	/**

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -361,7 +361,12 @@ export class SessionGroupRepository {
 
 	/**
 	 * DB-level zombie cleanup for a room: marks active session groups as completed
-	 * when their task is in a terminal state (completed, cancelled, archived).
+	 * when their task is in a terminal state
+	 * (completed, cancelled, archived, needs_attention).
+	 *
+	 * 'needs_attention' is the renamed 'failed' status (migration 24) and IS terminal —
+	 * TaskGroupManager.fail() sets it via failTask(). Zombies arise when the group's
+	 * completed_at was never set due to a crash after failTask() ran.
 	 *
 	 * Synchronous and safe to call from stop() without async/await.
 	 * Returns the number of groups cleaned up.
@@ -377,7 +382,7 @@ export class SessionGroupRepository {
 				   AND ref_id IN (
 				     SELECT t.id FROM tasks t
 				     WHERE t.room_id = ?
-				       AND t.status IN ('completed', 'cancelled', 'archived')
+				       AND t.status IN ('completed', 'cancelled', 'archived', 'needs_attention')
 				   )`
 			)
 			.run(now, roomId);
@@ -433,18 +438,24 @@ export class SessionGroupRepository {
 	 * lightweight revive intended for the "send message to failed task" flow.
 	 */
 	reviveGroup(groupId: string): SessionGroup | null {
-		const result = this.db
-			.prepare(
-				`UPDATE session_groups
-				 SET completed_at = NULL,
-				     version = version + 1
-				 WHERE id = ?`
-			)
-			.run(groupId);
+		try {
+			const result = this.db
+				.prepare(
+					`UPDATE session_groups
+					 SET completed_at = NULL,
+					     version = version + 1
+					 WHERE id = ?`
+				)
+				.run(groupId);
 
-		if (result.changes === 0) return null;
-		this.reactiveDb.notifyChange('session_groups');
-		return this.getGroup(groupId);
+			if (result.changes === 0) return null;
+			this.reactiveDb.notifyChange('session_groups');
+			return this.getGroup(groupId);
+		} catch {
+			// Unique constraint violation: another active group already exists for this ref_id.
+			// Return null so callers treat this the same as a "group not found" condition.
+			return null;
+		}
 	}
 
 	/**
@@ -464,19 +475,25 @@ export class SessionGroupRepository {
 			deferredLeader: current.deferredLeader,
 		};
 
-		const result = this.db
-			.prepare(
-				`UPDATE session_groups
-				 SET completed_at = NULL,
-				     metadata = ?,
-				     version = version + 1
-				 WHERE id = ?`
-			)
-			.run(JSON.stringify(resetMetadata), groupId);
+		try {
+			const result = this.db
+				.prepare(
+					`UPDATE session_groups
+					 SET completed_at = NULL,
+					     metadata = ?,
+					     version = version + 1
+					 WHERE id = ?`
+				)
+				.run(JSON.stringify(resetMetadata), groupId);
 
-		if (result.changes === 0) return null;
-		this.reactiveDb.notifyChange('session_groups');
-		return this.getGroup(groupId);
+			if (result.changes === 0) return null;
+			this.reactiveDb.notifyChange('session_groups');
+			return this.getGroup(groupId);
+		} catch {
+			// Unique constraint violation: another active group already exists for this ref_id.
+			// Return null so callers treat this the same as a "group not found" condition.
+			return null;
+		}
 	}
 
 	// ===== Metadata update helpers (partial merge pattern) =====

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -451,10 +451,13 @@ export class SessionGroupRepository {
 			if (result.changes === 0) return null;
 			this.reactiveDb.notifyChange('session_groups');
 			return this.getGroup(groupId);
-		} catch {
-			// Unique constraint violation: another active group already exists for this ref_id.
-			// Return null so callers treat this the same as a "group not found" condition.
-			return null;
+		} catch (err) {
+			// Only swallow unique constraint violations (another active group exists for ref_id).
+			// All other DB errors (disk full, closed DB, etc.) are re-thrown.
+			if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+				return null;
+			}
+			throw err;
 		}
 	}
 
@@ -489,10 +492,13 @@ export class SessionGroupRepository {
 			if (result.changes === 0) return null;
 			this.reactiveDb.notifyChange('session_groups');
 			return this.getGroup(groupId);
-		} catch {
-			// Unique constraint violation: another active group already exists for this ref_id.
-			// Return null so callers treat this the same as a "group not found" condition.
-			return null;
+		} catch (err) {
+			// Only swallow unique constraint violations (another active group exists for ref_id).
+			// All other DB errors (disk full, closed DB, etc.) are re-thrown.
+			if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+				return null;
+			}
+			throw err;
 		}
 	}
 

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -378,10 +378,12 @@ function createIndexes(db: BunDatabase): void {
 	);
 	// Room Runtime indexes
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_session_groups_ref ON session_groups(ref_id)`);
-	// Partial unique index: at most one active group per task ref_id at the DB level
+	// Partial unique index: at most one active group per task ref_id at the DB level.
+	// Scoped to task/task_pair group types only — other future group types may share
+	// ref_id values without violating this constraint.
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
-		 ON session_groups(ref_id) WHERE completed_at IS NULL`
+		 ON session_groups(ref_id) WHERE completed_at IS NULL AND (group_type = 'task' OR group_type = 'task_pair')`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sgm_session ON session_group_members(session_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tge_group ON task_group_events(group_id, id)`);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -378,6 +378,11 @@ function createIndexes(db: BunDatabase): void {
 	);
 	// Room Runtime indexes
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_session_groups_ref ON session_groups(ref_id)`);
+	// Partial unique index: at most one active group per task ref_id at the DB level
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
+		 ON session_groups(ref_id) WHERE completed_at IS NULL`
+	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sgm_session ON session_group_members(session_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tge_group ON task_group_events(group_id, id)`);
 	db.exec(

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2466,14 +2466,16 @@ function runMigration41(db: BunDatabase): void {
  * Migration 42: Clean up stale/zombie session groups and enforce uniqueness.
  *
  * Step 1: Mark active groups as completed when their task is in a terminal state
- *         (completed, cancelled, archived). These are zombie groups that were never
- *         cleaned up when the task finished.
+ *         (completed, cancelled, archived, needs_attention). These are zombie groups
+ *         that were never cleaned up when the task finished.
  *
  * Step 2: For tasks that still have multiple active groups after step 1, keep the
- *         most recent one and mark all older ones as completed (deduplication).
+ *         one with the highest rowid (the true insert order tiebreaker), and mark all
+ *         others as completed. Uses rowid instead of created_at to avoid failures when
+ *         two groups share an identical millisecond timestamp.
  *
- * Step 3: Add a partial unique index on session_groups(ref_id) WHERE completed_at IS NULL
- *         to enforce DB-level uniqueness: only ONE active group per task at any time.
+ * Step 3: Add a partial unique index on session_groups(ref_id) WHERE completed_at IS NULL,
+ *         scoped to task/task_pair group types, to enforce DB-level uniqueness.
  */
 function runMigration42(db: BunDatabase): void {
 	if (!tableExists(db, 'session_groups') || !tableExists(db, 'tasks')) {
@@ -2482,41 +2484,44 @@ function runMigration42(db: BunDatabase): void {
 
 	const now = Date.now();
 
-	// Step 1: Complete groups whose tasks are already in a terminal state
-	db.exec(`
-		UPDATE session_groups
-		SET completed_at = ${now}
-		WHERE completed_at IS NULL
-		  AND group_type IN ('task', 'task_pair')
-		  AND ref_id IN (
-		    SELECT id FROM tasks
-		    WHERE status IN ('completed', 'cancelled', 'archived')
-		  )
-	`);
+	// Step 1: Complete groups whose tasks are already in a terminal state.
+	// Includes 'needs_attention' (the renamed 'failed' status from migration 24).
+	db.prepare(
+		`UPDATE session_groups
+		 SET completed_at = ?, version = version + 1
+		 WHERE completed_at IS NULL
+		   AND group_type IN ('task', 'task_pair')
+		   AND ref_id IN (
+		     SELECT id FROM tasks
+		     WHERE status IN ('completed', 'cancelled', 'archived', 'needs_attention')
+		   )`
+	).run(now);
 
-	// Step 2: For tasks with multiple active groups, keep the newest, complete the rest
-	// Find all ref_ids that still have more than one active group
+	// Step 2: For tasks with multiple active groups, keep the one with the highest rowid
+	// (true insert order, no timestamp tie risk) and complete all others.
 	const duplicateTasks = db
 		.prepare(
-			`SELECT ref_id, MAX(created_at) AS max_created_at
+			`SELECT ref_id, MAX(rowid) AS max_rowid
 			 FROM session_groups
 			 WHERE completed_at IS NULL AND group_type IN ('task', 'task_pair')
 			 GROUP BY ref_id
 			 HAVING COUNT(*) > 1`
 		)
-		.all() as { ref_id: string; max_created_at: number }[];
+		.all() as { ref_id: string; max_rowid: number }[];
 
-	for (const { ref_id, max_created_at } of duplicateTasks) {
+	for (const { ref_id, max_rowid } of duplicateTasks) {
 		db.prepare(
 			`UPDATE session_groups
-			 SET completed_at = ?
-			 WHERE ref_id = ? AND completed_at IS NULL AND created_at < ?`
-		).run(now, ref_id, max_created_at);
+			 SET completed_at = ?, version = version + 1
+			 WHERE ref_id = ? AND completed_at IS NULL AND rowid < ?`
+		).run(now, ref_id, max_rowid);
 	}
 
-	// Step 3: Add partial unique index — only one active group per task at the DB level
+	// Step 3: Add partial unique index — only one active task/task_pair group per ref_id.
+	// Scoped to task/task_pair so future group types with different semantics can share
+	// ref_id values without violating this constraint.
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
-		 ON session_groups(ref_id) WHERE completed_at IS NULL`
+		 ON session_groups(ref_id) WHERE completed_at IS NULL AND (group_type = 'task' OR group_type = 'task_pair')`
 	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -156,6 +156,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// This table was dropped in migration 19 (legacy mirror table). It is recreated here
 	// as an append-only store for the LiveQuery protocol (Milestone 4).
 	runMigration41(db);
+
+	// Migration 42: Clean up stale/zombie session groups and add partial unique index
+	// on session_groups(ref_id) WHERE completed_at IS NULL to prevent future duplicates.
+	runMigration42(db);
 }
 
 /**
@@ -2455,5 +2459,64 @@ function runMigration41(db: BunDatabase): void {
 	`);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_sgm_group ON session_group_messages(group_id, created_at, id)`
+	);
+}
+
+/**
+ * Migration 42: Clean up stale/zombie session groups and enforce uniqueness.
+ *
+ * Step 1: Mark active groups as completed when their task is in a terminal state
+ *         (completed, cancelled, archived). These are zombie groups that were never
+ *         cleaned up when the task finished.
+ *
+ * Step 2: For tasks that still have multiple active groups after step 1, keep the
+ *         most recent one and mark all older ones as completed (deduplication).
+ *
+ * Step 3: Add a partial unique index on session_groups(ref_id) WHERE completed_at IS NULL
+ *         to enforce DB-level uniqueness: only ONE active group per task at any time.
+ */
+function runMigration42(db: BunDatabase): void {
+	if (!tableExists(db, 'session_groups') || !tableExists(db, 'tasks')) {
+		return;
+	}
+
+	const now = Date.now();
+
+	// Step 1: Complete groups whose tasks are already in a terminal state
+	db.exec(`
+		UPDATE session_groups
+		SET completed_at = ${now}
+		WHERE completed_at IS NULL
+		  AND group_type IN ('task', 'task_pair')
+		  AND ref_id IN (
+		    SELECT id FROM tasks
+		    WHERE status IN ('completed', 'cancelled', 'archived')
+		  )
+	`);
+
+	// Step 2: For tasks with multiple active groups, keep the newest, complete the rest
+	// Find all ref_ids that still have more than one active group
+	const duplicateTasks = db
+		.prepare(
+			`SELECT ref_id, MAX(created_at) AS max_created_at
+			 FROM session_groups
+			 WHERE completed_at IS NULL AND group_type IN ('task', 'task_pair')
+			 GROUP BY ref_id
+			 HAVING COUNT(*) > 1`
+		)
+		.all() as { ref_id: string; max_created_at: number }[];
+
+	for (const { ref_id, max_created_at } of duplicateTasks) {
+		db.prepare(
+			`UPDATE session_groups
+			 SET completed_at = ?
+			 WHERE ref_id = ? AND completed_at IS NULL AND created_at < ?`
+		).run(now, ref_id, max_created_at);
+	}
+
+	// Step 3: Add partial unique index — only one active group per task at the DB level
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
+		 ON session_groups(ref_id) WHERE completed_at IS NULL`
 	);
 }

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -328,6 +328,35 @@ describe('SessionGroupRepository', () => {
 			const reset = repo.resetGroupForRestart(group.id);
 			expect(reset!.version).toBe(group.version + 2); // +1 for failGroup, +1 for reset
 		});
+
+		it('returns null (not throws) when unique constraint prevents restart', () => {
+			// Install the partial unique index to simulate production schema
+			db.exec(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
+				 ON session_groups(ref_id) WHERE completed_at IS NULL AND (group_type = 'task' OR group_type = 'task_pair')`
+			);
+
+			const now = Date.now();
+			// Create a completed group for the task
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+				VALUES ('completed-grp2', 'task', '${taskId}', 0, '{}', ${now - 2000}, ${now - 1000});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('completed-grp2', 'w-c2', 'worker', ${now}), ('completed-grp2', 'l-c2', 'leader', ${now});
+			`);
+
+			// Create another active group for the same task (bypasses index since completed-grp2 is done)
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('active-grp2', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('active-grp2', 'w-a2', 'worker', ${now}), ('active-grp2', 'l-a2', 'leader', ${now});
+			`);
+
+			// Resetting the completed group would violate the unique index — must return null, not throw
+			const result = repo.resetGroupForRestart('completed-grp2');
+			expect(result).toBeNull();
+		});
 	});
 
 	describe('reviveGroup', () => {
@@ -373,6 +402,35 @@ describe('SessionGroupRepository', () => {
 
 			repo.reviveGroup(group.id);
 			expect(repo.getActiveGroups(roomId)).toHaveLength(1);
+		});
+
+		it('returns null (not throws) when unique constraint prevents revive', () => {
+			// Install the partial unique index to simulate production schema
+			db.exec(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_session_groups_active_ref
+				 ON session_groups(ref_id) WHERE completed_at IS NULL AND (group_type = 'task' OR group_type = 'task_pair')`
+			);
+
+			const now = Date.now();
+			// Create a completed group for the task
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+				VALUES ('completed-grp', 'task', '${taskId}', 0, '{}', ${now - 2000}, ${now - 1000});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('completed-grp', 'w-old', 'worker', ${now}), ('completed-grp', 'l-old', 'leader', ${now});
+			`);
+
+			// Create another active group for the same task (bypasses the index since completed-grp is completed)
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('active-grp', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('active-grp', 'w-new', 'worker', ${now}), ('active-grp', 'l-new', 'leader', ${now});
+			`);
+
+			// Now attempting to revive the completed group should return null (violates unique index)
+			const result = repo.reviveGroup('completed-grp');
+			expect(result).toBeNull();
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -843,7 +843,7 @@ describe('SessionGroupRepository', () => {
 			expect(zombie!.completedAt).not.toBeNull();
 		});
 
-		it('handles cancelled and archived tasks', () => {
+		it('handles cancelled, archived, and needs_attention tasks', () => {
 			const now = Date.now();
 			db.exec(`
 				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
@@ -853,10 +853,10 @@ describe('SessionGroupRepository', () => {
 				UPDATE tasks SET status = 'cancelled' WHERE id = '${taskId}';
 
 				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
-				VALUES ('zombie-archived', 'task', 'task-2', 0, '{}', ${now});
+				VALUES ('zombie-needs-attn', 'task', 'task-2', 0, '{}', ${now});
 				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
-				VALUES ('zombie-archived', 'wa', 'worker', ${now}), ('zombie-archived', 'la', 'leader', ${now});
-				UPDATE tasks SET status = 'archived' WHERE id = 'task-2';
+				VALUES ('zombie-needs-attn', 'wa', 'worker', ${now}), ('zombie-needs-attn', 'la', 'leader', ${now});
+				UPDATE tasks SET status = 'needs_attention' WHERE id = 'task-2';
 			`);
 			const cleaned = repo.cleanupZombieGroupsForRoom(roomId);
 			expect(cleaned).toBe(2);

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -689,4 +689,192 @@ describe('SessionGroupRepository', () => {
 			expect(updated.leaderProgressSummary).toBe('Progress so far');
 		});
 	});
+
+	describe('getActiveGroupsForTask', () => {
+		it('returns empty array when no groups exist', () => {
+			expect(repo.getActiveGroupsForTask(taskId)).toEqual([]);
+		});
+
+		it('returns the single active group for a task', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const result = repo.getActiveGroupsForTask(taskId);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe(group.id);
+		});
+
+		it('returns multiple active groups for the same task', () => {
+			// Bypass createGroup (which would conflict with unique constraint if enabled)
+			// by using direct DB inserts with unique session IDs
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('group-a', 'task', '${taskId}', 0, '{}', ${now - 1000});
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('group-b', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('group-a', 'worker-a', 'worker', ${now}),
+				       ('group-a', 'leader-a', 'leader', ${now}),
+				       ('group-b', 'worker-b', 'worker', ${now}),
+				       ('group-b', 'leader-b', 'leader', ${now});
+			`);
+			const result = repo.getActiveGroupsForTask(taskId);
+			expect(result).toHaveLength(2);
+			// Should be ordered by created_at DESC (newest first)
+			expect(result[0].id).toBe('group-b');
+			expect(result[1].id).toBe('group-a');
+		});
+
+		it('does not return completed groups', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+				VALUES ('group-done', 'task', '${taskId}', 0, '{}', ${now - 2000}, ${now - 1000});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('group-done', 'worker-done', 'worker', ${now}),
+				       ('group-done', 'leader-done', 'leader', ${now});
+			`);
+			const result = repo.getActiveGroupsForTask(taskId);
+			expect(result).toHaveLength(0);
+		});
+
+		it('does not return groups for other tasks', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('group-task2', 'task', 'task-2', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('group-task2', 'worker-t2', 'worker', ${now}),
+				       ('group-task2', 'leader-t2', 'leader', ${now});
+			`);
+			const result = repo.getActiveGroupsForTask(taskId);
+			expect(result).toHaveLength(0);
+			expect(repo.getActiveGroupsForTask('task-2')).toHaveLength(1);
+		});
+
+		it('returns only active groups when mix of active and completed exists', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+				VALUES ('group-old', 'task', '${taskId}', 0, '{}', ${now - 2000}, ${now - 1000});
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('group-new', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('group-old', 'worker-old', 'worker', ${now}),
+				       ('group-old', 'leader-old', 'leader', ${now}),
+				       ('group-new', 'worker-new', 'worker', ${now}),
+				       ('group-new', 'leader-new', 'leader', ${now});
+			`);
+			const result = repo.getActiveGroupsForTask(taskId);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('group-new');
+		});
+	});
+
+	describe('cleanupStaleGroupsForTask', () => {
+		it('returns 0 when no other active groups exist', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const cleaned = repo.cleanupStaleGroupsForTask(taskId, group.id);
+			expect(cleaned).toBe(0);
+		});
+
+		it('marks other active groups as completed, leaving the kept group active', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('stale-group-1', 'task', '${taskId}', 0, '{}', ${now - 2000}),
+				       ('stale-group-2', 'task', '${taskId}', 0, '{}', ${now - 1000}),
+				       ('active-group', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('stale-group-1', 'w1', 'worker', ${now}), ('stale-group-1', 'l1', 'leader', ${now}),
+				       ('stale-group-2', 'w2', 'worker', ${now}), ('stale-group-2', 'l2', 'leader', ${now}),
+				       ('active-group', 'w3', 'worker', ${now}), ('active-group', 'l3', 'leader', ${now});
+			`);
+			const cleaned = repo.cleanupStaleGroupsForTask(taskId, 'active-group');
+			expect(cleaned).toBe(2);
+
+			// Kept group is still active
+			const kept = repo.getGroup('active-group');
+			expect(kept!.completedAt).toBeNull();
+
+			// Stale groups are now completed
+			const stale1 = repo.getGroup('stale-group-1');
+			expect(stale1!.completedAt).not.toBeNull();
+			const stale2 = repo.getGroup('stale-group-2');
+			expect(stale2!.completedAt).not.toBeNull();
+		});
+
+		it('does not touch already-completed groups', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+				VALUES ('already-done', 'task', '${taskId}', 0, '{}', ${now - 2000}, ${now - 1000});
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('kept-group', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('already-done', 'w-done', 'worker', ${now}), ('already-done', 'l-done', 'leader', ${now}),
+				       ('kept-group', 'w-kept', 'worker', ${now}), ('kept-group', 'l-kept', 'leader', ${now});
+			`);
+			const cleaned = repo.cleanupStaleGroupsForTask(taskId, 'kept-group');
+			expect(cleaned).toBe(0);
+		});
+	});
+
+	describe('cleanupZombieGroupsForRoom', () => {
+		it('returns 0 when no zombie groups exist', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const cleaned = repo.cleanupZombieGroupsForRoom(roomId);
+			// Task is still pending, so the active group is NOT a zombie
+			expect(cleaned).toBe(0);
+			expect(repo.getGroup(group.id)!.completedAt).toBeNull();
+		});
+
+		it('completes active groups for tasks in terminal state', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('zombie-1', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('zombie-1', 'w-z', 'worker', ${now}), ('zombie-1', 'l-z', 'leader', ${now});
+				UPDATE tasks SET status = 'completed' WHERE id = '${taskId}';
+			`);
+			const cleaned = repo.cleanupZombieGroupsForRoom(roomId);
+			expect(cleaned).toBe(1);
+			const zombie = repo.getGroup('zombie-1');
+			expect(zombie!.completedAt).not.toBeNull();
+		});
+
+		it('handles cancelled and archived tasks', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('zombie-cancelled', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('zombie-cancelled', 'wc', 'worker', ${now}), ('zombie-cancelled', 'lc', 'leader', ${now});
+				UPDATE tasks SET status = 'cancelled' WHERE id = '${taskId}';
+
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('zombie-archived', 'task', 'task-2', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('zombie-archived', 'wa', 'worker', ${now}), ('zombie-archived', 'la', 'leader', ${now});
+				UPDATE tasks SET status = 'archived' WHERE id = 'task-2';
+			`);
+			const cleaned = repo.cleanupZombieGroupsForRoom(roomId);
+			expect(cleaned).toBe(2);
+		});
+
+		it('does not touch active groups for non-terminal tasks', () => {
+			const now = Date.now();
+			db.exec(`
+				INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				VALUES ('in-progress-group', 'task', '${taskId}', 0, '{}', ${now});
+				INSERT INTO session_group_members (group_id, session_id, role, joined_at)
+				VALUES ('in-progress-group', 'wip', 'worker', ${now}), ('in-progress-group', 'lip', 'leader', ${now});
+				UPDATE tasks SET status = 'in_progress' WHERE id = '${taskId}';
+			`);
+			const cleaned = repo.cleanupZombieGroupsForRoom(roomId);
+			expect(cleaned).toBe(0);
+			const group = repo.getGroup('in-progress-group');
+			expect(group!.completedAt).toBeNull();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/storage/migrations/migration-42_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-42_test.ts
@@ -1,0 +1,280 @@
+/**
+ * Migration 42 Tests
+ *
+ * Tests for Migration 42: Clean up stale/zombie session groups and add partial
+ * unique index on session_groups(ref_id) WHERE completed_at IS NULL.
+ *
+ * Covers:
+ * - Fresh DB: unique index exists after full migration chain
+ * - Fresh DB: duplicate active groups are rejected by the unique constraint
+ * - Existing DB with zombie groups (active groups for terminal tasks): zombies are completed
+ * - Existing DB with duplicate active groups: older duplicates are completed, newest kept
+ * - Idempotency: running migration twice does not error
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+
+function indexExists(db: BunDatabase, indexName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+		.get(indexName);
+	return !!result;
+}
+
+describe('Migration 42: Zombie group cleanup + partial unique index', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-42', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Fresh DB — full schema + migration chain
+	// -------------------------------------------------------------------------
+
+	test('fresh DB: idx_session_groups_active_ref unique index exists', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+		expect(indexExists(db, 'idx_session_groups_active_ref')).toBe(true);
+	});
+
+	test('fresh DB: unique constraint prevents two active groups for same task', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Insert first active group
+		db.prepare(
+			`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			 VALUES ('group-a', 'task', 'task-x', 0, '{}', ?)`
+		).run(now);
+
+		// Second insert for same ref_id with completed_at IS NULL should fail
+		expect(() => {
+			db.prepare(
+				`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				 VALUES ('group-b', 'task', 'task-x', 0, '{}', ?)`
+			).run(now + 1);
+		}).toThrow();
+	});
+
+	test('fresh DB: completed groups do not violate the unique constraint', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Insert a completed group
+		db.prepare(
+			`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at, completed_at)
+			 VALUES ('group-a', 'task', 'task-x', 0, '{}', ?, ?)`
+		).run(now - 1000, now - 500);
+
+		// A new active group for the same ref_id is allowed (completed_at IS NULL)
+		expect(() => {
+			db.prepare(
+				`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				 VALUES ('group-b', 'task', 'task-x', 0, '{}', ?)`
+			).run(now);
+		}).not.toThrow();
+	});
+
+	// -------------------------------------------------------------------------
+	// Existing DB with zombie groups (active groups for terminal tasks)
+	// -------------------------------------------------------------------------
+
+	test('existing DB: zombie groups for terminal tasks are completed by migration', () => {
+		// Build a pre-migration DB state with stale groups.
+		// The tasks status CHECK must include 'review' (and not 'escalated') to prevent
+		// migration 16 from attempting to recreate the table with missing columns.
+		db.exec('PRAGMA foreign_keys = ON');
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL REFERENCES rooms(id),
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding',
+				assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			);
+			CREATE TABLE IF NOT EXISTS session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+			CREATE TABLE IF NOT EXISTS session_group_members (
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				joined_at INTEGER NOT NULL,
+				PRIMARY KEY (group_id, session_id)
+			);
+		`);
+
+		const now = Date.now();
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${now}, ${now});
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES ('task-done', 'room-1', 'Done Task', 'desc', 'completed', ${now});
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES ('task-active', 'room-1', 'Active Task', 'desc', 'in_progress', ${now});
+
+			-- Zombie: active group for a completed task
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('zombie-grp', 'task', 'task-done', 0, '{}', ${now - 1000});
+
+			-- Legitimate: active group for an in-progress task
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('legit-grp', 'task', 'task-active', 0, '{}', ${now});
+		`);
+
+		// Run migrations (which includes migration 42)
+		runMigrations(db, () => {});
+
+		// Zombie should be completed
+		const zombie = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'zombie-grp'`)
+			.get() as { completed_at: number | null };
+		expect(zombie.completed_at).not.toBeNull();
+
+		// Legitimate group should still be active
+		const legit = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'legit-grp'`)
+			.get() as { completed_at: number | null };
+		expect(legit.completed_at).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Existing DB with duplicate active groups
+	// -------------------------------------------------------------------------
+
+	test('existing DB: oldest duplicates are completed, newest kept active', () => {
+		db.exec('PRAGMA foreign_keys = ON');
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL REFERENCES rooms(id),
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding',
+				assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			);
+			CREATE TABLE IF NOT EXISTS session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+			CREATE TABLE IF NOT EXISTS session_group_members (
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				joined_at INTEGER NOT NULL,
+				PRIMARY KEY (group_id, session_id)
+			);
+		`);
+
+		const now = Date.now();
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${now}, ${now});
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES ('task-1', 'room-1', 'Task 1', 'desc', 'in_progress', ${now});
+
+			-- Three active groups for same task (duplicate problem)
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('old-grp', 'task', 'task-1', 0, '{}', ${now - 2000});
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('mid-grp', 'task', 'task-1', 0, '{}', ${now - 1000});
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('new-grp', 'task', 'task-1', 0, '{}', ${now});
+		`);
+
+		runMigrations(db, () => {});
+
+		// Newest group should remain active
+		const newGrp = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'new-grp'`)
+			.get() as { completed_at: number | null };
+		expect(newGrp.completed_at).toBeNull();
+
+		// Older groups should be completed
+		const oldGrp = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'old-grp'`)
+			.get() as { completed_at: number | null };
+		expect(oldGrp.completed_at).not.toBeNull();
+
+		const midGrp = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'mid-grp'`)
+			.get() as { completed_at: number | null };
+		expect(midGrp.completed_at).not.toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency
+	// -------------------------------------------------------------------------
+
+	test('idempotency: running migrations twice does not error', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-42_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-42_test.ts
@@ -101,6 +101,26 @@ describe('Migration 42: Zombie group cleanup + partial unique index', () => {
 		}).not.toThrow();
 	});
 
+	test('fresh DB: non-task group types with same ref_id are not blocked by the constraint', () => {
+		createTables(db);
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		// Insert an active task group
+		db.prepare(
+			`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			 VALUES ('task-grp', 'task', 'shared-ref', 0, '{}', ?)`
+		).run(now);
+
+		// A different group type with the same ref_id should NOT be blocked
+		expect(() => {
+			db.prepare(
+				`INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+				 VALUES ('other-grp', 'planning', 'shared-ref', 0, '{}', ?)`
+			).run(now + 1);
+		}).not.toThrow();
+	});
+
 	// -------------------------------------------------------------------------
 	// Existing DB with zombie groups (active groups for terminal tasks)
 	// -------------------------------------------------------------------------
@@ -185,6 +205,69 @@ describe('Migration 42: Zombie group cleanup + partial unique index', () => {
 		expect(legit.completed_at).toBeNull();
 	});
 
+	test('existing DB: zombie groups for needs_attention tasks are completed by migration', () => {
+		db.exec('PRAGMA foreign_keys = ON');
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL REFERENCES rooms(id),
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding',
+				assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			);
+			CREATE TABLE IF NOT EXISTS session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+			CREATE TABLE IF NOT EXISTS session_group_members (
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				joined_at INTEGER NOT NULL,
+				PRIMARY KEY (group_id, session_id)
+			);
+		`);
+
+		const now = Date.now();
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${now}, ${now});
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES ('task-failed', 'room-1', 'Failed Task', 'desc', 'needs_attention', ${now});
+
+			-- Zombie: active group for a needs_attention task (crash after failTask ran)
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('zombie-failed', 'task', 'task-failed', 0, '{}', ${now - 1000});
+		`);
+
+		runMigrations(db, () => {});
+
+		const zombie = db
+			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'zombie-failed'`)
+			.get() as { completed_at: number | null };
+		expect(zombie.completed_at).not.toBeNull();
+	});
+
 	// -------------------------------------------------------------------------
 	// Existing DB with duplicate active groups
 	// -------------------------------------------------------------------------
@@ -266,6 +349,79 @@ describe('Migration 42: Zombie group cleanup + partial unique index', () => {
 			.prepare(`SELECT completed_at FROM session_groups WHERE id = 'mid-grp'`)
 			.get() as { completed_at: number | null };
 		expect(midGrp.completed_at).not.toBeNull();
+	});
+
+	test('existing DB: duplicate groups with identical created_at are deduped via rowid', () => {
+		db.exec('PRAGMA foreign_keys = ON');
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS rooms (
+				id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL REFERENCES rooms(id),
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding',
+				assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+			);
+			CREATE TABLE IF NOT EXISTS session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+			CREATE TABLE IF NOT EXISTS session_group_members (
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				joined_at INTEGER NOT NULL,
+				PRIMARY KEY (group_id, session_id)
+			);
+		`);
+
+		const now = Date.now();
+		db.exec(`
+			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${now}, ${now});
+			INSERT INTO tasks (id, room_id, title, description, status, created_at)
+			VALUES ('task-1', 'room-1', 'Task 1', 'desc', 'in_progress', ${now});
+
+			-- Two groups with IDENTICAL created_at (timestamp collision under load)
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('grp-a', 'task', 'task-1', 0, '{}', ${now});
+			INSERT INTO session_groups (id, group_type, ref_id, version, metadata, created_at)
+			VALUES ('grp-b', 'task', 'task-1', 0, '{}', ${now});
+		`);
+
+		// Should not throw even with identical created_at (rowid tiebreaker handles it)
+		expect(() => runMigrations(db, () => {})).not.toThrow();
+
+		// One group should remain active, one should be completed
+		const grpA = db.prepare(`SELECT completed_at FROM session_groups WHERE id = 'grp-a'`).get() as {
+			completed_at: number | null;
+		};
+		const grpB = db.prepare(`SELECT completed_at FROM session_groups WHERE id = 'grp-b'`).get() as {
+			completed_at: number | null;
+		};
+
+		// Exactly one should be active (completed_at IS NULL), one should be completed
+		const activeCount = [grpA, grpB].filter((g) => g.completed_at === null).length;
+		expect(activeCount).toBe(1);
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Comprehensively fixes the zombie/stale session group problem:

1. Add `getActiveGroupsForTask(taskId)` to SessionGroupRepository — returns
   ALL active groups for a task (not just the most recent), enabling correct
   deduplication checks.

2. Fix `spawnGroupForTask` deduplication — now uses `getActiveGroupsForTask`
   instead of `getGroupByTaskId`, catching stale older groups that would
   otherwise slip through and allow a duplicate spawn.

3. Add `cleanupStaleGroupsForTask(taskId, keepGroupId)` to the repository —
   marks all other active groups for a task as completed. Called from
   `complete()` and `fail()` in TaskGroupManager as a safety net.

4. Add `cleanupZombieGroupsForRoom(roomId)` to the repository — synchronous
   DB-level cleanup that marks active groups as completed when their task is
   in a terminal state. Called from `RoomRuntime.stop()`.

5. Migration 42 — one-time cleanup of existing zombie/duplicate groups, plus
   `CREATE UNIQUE INDEX ... ON session_groups(ref_id) WHERE completed_at IS NULL`
   to enforce DB-level uniqueness: at most one active group per task.

6. Update `createIndexes()` in schema/index.ts to include the partial unique
   index for fresh DB installations.

Tests: add unit tests for all three new repository methods and a migration-42
test covering fresh DB index creation, unique constraint enforcement, zombie
cleanup, and duplicate deduplication.
