### PR TITLE
refactor: remove state.groupMessages.delta listener from TaskConversationRenderer

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2147,7 +2147,7 @@ export class RoomRuntime {
 	 *
 	 * Subscribes to DaemonHub sdk.message events, persists each enriched message
 	 * to session_group_messages (for LiveQuery), and broadcasts deltas via
-	 * state.groupMessages.delta for any legacy subscribers still present.
+	 * state.groupMessages.delta (retained for backward compatibility / debugging).
 	 */
 	private setupMirroring(group: SessionGroup): void {
 		if (!this.daemonHub) return;
@@ -2205,14 +2205,21 @@ export class RoomRuntime {
 						'type' in event.message && typeof event.message.type === 'string'
 							? event.message.type
 							: 'assistant';
-					this.groupRepo.appendGroupMessage({
-						groupId: group.id,
-						sessionId,
-						role,
-						messageType: sdkMsgType,
-						content: JSON.stringify(enrichedMessage),
-						createdAt: sdkNow,
-					});
+					try {
+						this.groupRepo.appendGroupMessage({
+							groupId: group.id,
+							sessionId,
+							role,
+							messageType: sdkMsgType,
+							content: JSON.stringify(enrichedMessage),
+							createdAt: sdkNow,
+						});
+					} catch (err) {
+						log.warn(
+							`[setupMirroring] Failed to persist SDK message to session_group_messages ` +
+								`(group=${group.id}, session=${sessionId}): ${err instanceof Error ? err.message : String(err)}`
+						);
+					}
 					if (this.messageHub) {
 						this.messageHub.event(
 							'state.groupMessages.delta',

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -316,15 +316,23 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 
 			if (failed.length > 0) {
 				// Partial or total delivery failure — report what was and was not delivered.
+				if (delivered.length > 0) {
+					// Partial success: at least one delivery succeeded
+					return jsonResult({
+						success: true,
+						delivered,
+						partialFailures: failed,
+						notFoundRoles: notFound.length > 0 ? notFound : undefined,
+						message: `Message delivered to ${delivered.length} peer(s) but failed for ${failed.length} peer(s).`,
+					});
+				}
+				// All deliveries failed
 				return jsonResult({
-					success: delivered.length > 0 ? 'partial' : false,
+					success: false,
 					delivered,
-					failed,
+					partialFailures: failed,
 					notFoundRoles: notFound.length > 0 ? notFound : undefined,
-					message:
-						delivered.length > 0
-							? `Message delivered to ${delivered.length} peer(s) but failed for ${failed.length} peer(s).`
-							: `Message delivery failed for all ${failed.length} target(s).`,
+					error: `Failed to deliver message to all ${failed.length} target(s).`,
 				});
 			}
 

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -567,9 +567,9 @@ describe('step-agent-tools: send_feedback', () => {
 		const data = JSON.parse(result.content[0].text);
 
 		// Partial success — one delivered, one failed
-		expect(data.success).toBe('partial');
+		expect(data.success).toBe(true);
 		expect(data.delivered).toHaveLength(1);
-		expect(data.failed).toHaveLength(1);
+		expect(data.partialFailures).toHaveLength(1);
 		// Both targets were attempted (best-effort, not stop-on-first-error)
 		expect(callCount).toBe(2);
 	});
@@ -589,7 +589,7 @@ describe('step-agent-tools: send_feedback', () => {
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
-		expect(data.failed).toHaveLength(1);
+		expect(data.partialFailures).toHaveLength(1);
 		expect(data.delivered).toHaveLength(0);
 	});
 
@@ -646,10 +646,10 @@ describe('step-agent-tools: send_feedback', () => {
 		const data = JSON.parse(result.content[0].text);
 
 		// Should NOT return success: false for total failure — it's partial
-		expect(data.success).toBe('partial');
+		expect(data.success).toBe(true);
 		expect(data.delivered).toHaveLength(1);
-		expect(data.failed).toHaveLength(1);
-		expect(data.failed[0].error).toContain('session not available');
+		expect(data.partialFailures).toHaveLength(1);
+		expect(data.partialFailures[0].error).toContain('session not available');
 		// Both targets were attempted (best-effort, not stop-on-first-error)
 		expect(callCount).toBe(2);
 	});
@@ -671,7 +671,7 @@ describe('step-agent-tools: send_feedback', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.delivered).toHaveLength(0);
-		expect(data.failed).toHaveLength(1);
+		expect(data.partialFailures).toHaveLength(1);
 	});
 });
 

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -2,16 +2,18 @@
  * Tests for TaskConversationRenderer Component
  *
  * Verifies that the component:
- * - Renders messages fetched from task.getGroupMessages
+ * - Renders messages from the useGroupMessages hook
  * - Calls onMessageCountChange when the message list changes
- * - Supports pagination with "Load older messages" button
+ * - Shows loading state while the hook is loading
+ * - Reacts to live updates when the hook delivers new messages
  * - Does NOT own a scroll container (no overflow-y-auto div)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor, act, fireEvent } from '@testing-library/preact';
+import { render, cleanup, waitFor, act } from '@testing-library/preact';
 
 import { TaskConversationRenderer } from './TaskConversationRenderer';
+import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 // -------------------------------------------------------
 // Mocks
@@ -41,7 +43,18 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
+		isConnected: true,
 	}),
+}));
+
+// useGroupMessages mock — module-level result variable so tests can update it
+let mockGroupMessagesResult: { messages: SessionGroupMessage[]; isLoading: boolean } = {
+	messages: [],
+	isLoading: false,
+};
+
+vi.mock('../../hooks/useGroupMessages.ts', () => ({
+	useGroupMessages: () => mockGroupMessagesResult,
 }));
 
 // SDKMessageRenderer mock that captures rendered props for inspection
@@ -81,7 +94,7 @@ function fireSessionStateEvent(channel: string, data: unknown): void {
 // Helpers
 // -------------------------------------------------------
 
-function makeRawMessage(id: number, role: string, uuid: string) {
+function makeRawMessage(id: number, role: string, uuid: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
@@ -93,31 +106,15 @@ function makeRawMessage(id: number, role: string, uuid: string) {
 	};
 }
 
-function makeStatusMessage(id: number, text: string) {
+function makeStatusMessage(id: number, text: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
-		sessionId: null as string | null,
+		sessionId: null,
 		role: 'system',
 		messageType: 'status',
 		content: text,
 		createdAt: Date.now(),
-	};
-}
-
-// Default API response format
-type TestMessage = ReturnType<typeof makeRawMessage> | ReturnType<typeof makeStatusMessage>;
-
-function makeApiResponse(
-	messages: TestMessage[],
-	options?: { hasOlder?: boolean; oldestCursor?: string | null }
-) {
-	return {
-		messages,
-		hasMore: false,
-		nextCursor: messages.length > 0 ? 'cursor-end' : null,
-		hasOlder: options?.hasOlder ?? false,
-		oldestCursor: options?.oldestCursor ?? (messages.length > 0 ? 'cursor-start' : null),
 	};
 }
 
@@ -133,6 +130,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		mockLeaveRoom.mockReset();
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
+		mockGroupMessagesResult = { messages: [], isLoading: false };
 	});
 
 	afterEach(() => {
@@ -144,7 +142,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 			makeRawMessage(1, 'assistant', 'uuid-1'),
 			makeRawMessage(2, 'assistant', 'uuid-2'),
 		];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = { messages, isLoading: false };
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -154,9 +152,8 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 	});
 
-	it('calls onMessageCountChange with 0 during loading', () => {
-		// Request never resolves → still loading
-		mockRequest.mockImplementation(() => new Promise(() => {}));
+	it('calls onMessageCountChange with 0 while the hook is loading', () => {
+		mockGroupMessagesResult = { messages: [], isLoading: true };
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -164,9 +161,43 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		expect(onCountChange).toHaveBeenCalledWith(0);
 	});
 
+	it('calls onMessageCountChange with updated count when hook delivers new messages (live update)', async () => {
+		// Start with one message
+		mockGroupMessagesResult = {
+			messages: [makeRawMessage(1, 'assistant', 'uuid-1')],
+			isLoading: false,
+		};
+
+		const onCountChange = vi.fn();
+		const { rerender } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
+		);
+
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
+
+		// Simulate a new message arriving via the hook (LiveQuery delta)
+		mockGroupMessagesResult = {
+			messages: [
+				makeRawMessage(1, 'assistant', 'uuid-1'),
+				makeRawMessage(2, 'assistant', 'uuid-2'),
+			],
+			isLoading: false,
+		};
+
+		await act(async () => {
+			rerender(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+		});
+
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(2);
+		});
+	});
+
 	it('does NOT render a scroll container (no overflow-y-auto on root element)', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = { messages, isLoading: false };
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -184,8 +215,10 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('renders status messages as centered dividers', async () => {
-		const messages = [makeStatusMessage(1, 'Task started')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = {
+			messages: [makeStatusMessage(1, 'Task started')],
+			isLoading: false,
+		};
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -197,8 +230,10 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('works without onMessageCountChange prop', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = {
+			messages: [makeRawMessage(1, 'assistant', 'uuid-1')],
+			isLoading: false,
+		};
 
 		let container: Element | undefined;
 		expect(() => {
@@ -210,239 +245,29 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 			expect(container?.firstChild).not.toBeNull();
 		});
 	});
-});
 
-describe('TaskConversationRenderer — pagination', () => {
-	beforeEach(() => {
-		mockRequest.mockReset();
-		mockOnEvent.mockClear();
-		mockJoinRoom.mockReset();
-		mockLeaveRoom.mockReset();
-		sessionStateHandlers.length = 0;
-		capturedSDKProps.length = 0;
-	});
+	it('shows loading state while the hook is loading', async () => {
+		mockGroupMessagesResult = { messages: [], isLoading: true };
 
-	afterEach(() => {
-		cleanup();
-	});
-
-	it('shows "Load older messages" button when hasOlder is true', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: true, oldestCursor: 'cursor-older' })
-		);
-
-		const { getByText } = render(
+		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
 		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
+			expect(container.textContent).toContain('Loading conversation');
 		});
 	});
 
-	it('does not show "Load older messages" button when hasOlder is false', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: false, oldestCursor: null })
-		);
+	it('shows waiting state when hook has no messages and is not loading', async () => {
+		mockGroupMessagesResult = { messages: [], isLoading: false };
 
-		const { queryByText } = render(
+		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
 		await waitFor(() => {
-			expect(queryByText('Load older messages')).toBeNull();
+			expect(container.textContent).toContain('Waiting for agent activity');
 		});
-	});
-
-	it('loads older messages when button is clicked', async () => {
-		const initialMessages = [makeRawMessage(3, 'assistant', 'uuid-3')];
-		const olderMessages = [
-			makeRawMessage(1, 'assistant', 'uuid-1'),
-			makeRawMessage(2, 'assistant', 'uuid-2'),
-		];
-
-		let callCount = 0;
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				callCount++;
-				if (params.before) {
-					// Second call - loading older
-					return makeApiResponse(olderMessages, { hasOlder: false, oldestCursor: 'cursor-oldest' });
-				}
-				// First call - initial load
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const onCountChange = vi.fn();
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should have called API twice (initial + load older)
-		await waitFor(() => {
-			expect(callCount).toBe(2);
-		});
-
-		// Should have 3 messages now (2 older + 1 initial)
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(3);
-		});
-	});
-
-	it('shows loading state while loading older messages', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let resolveOlder: () => void;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					// Delay the older messages response
-					return new Promise((resolve) => {
-						resolveOlder = () => resolve(makeApiResponse([], { hasOlder: false }));
-					});
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Button should show loading state
-		await waitFor(() => {
-			expect(getByText('Loading…')).toBeDefined();
-		});
-
-		// Resolve the older messages request
-		await act(async () => {
-			resolveOlder!();
-		});
-
-		// Button should return to normal state (hidden since no more older messages)
-		await waitFor(() => {
-			expect(queryByText('Loading…')).toBeNull();
-		});
-	});
-
-	it('shows error message when initial fetch fails with no buffered messages', async () => {
-		mockRequest.mockRejectedValue(new Error('Network error'));
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		// Should show retry button
-		expect(getByText('Retry')).toBeDefined();
-	});
-
-	it('retry button refetches messages instead of reloading page', async () => {
-		let fetchCount = 0;
-
-		mockRequest.mockImplementation(async (method: string) => {
-			if (method === 'task.getGroupMessages') {
-				fetchCount++;
-				if (fetchCount === 1) {
-					throw new Error('Network error');
-				}
-				// Second fetch succeeds
-				return makeApiResponse([makeRawMessage(1, 'assistant', 'uuid-1')]);
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial error
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		expect(fetchCount).toBe(1);
-
-		// Click retry button
-		await act(async () => {
-			fireEvent.click(getByText('Retry'));
-		});
-
-		// Should have made a second fetch request
-		await waitFor(() => {
-			expect(fetchCount).toBe(2);
-		});
-
-		// Error should be cleared and messages should render
-		await waitFor(() => {
-			expect(queryByText('Network error')).toBeNull();
-		});
-	});
-
-	it('shows error message when loading older messages fails', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let olderCallCount = 0;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					olderCallCount++;
-					throw new Error('Failed to load older');
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should show error message
-		await waitFor(() => {
-			expect(getByText('Failed to load older')).toBeDefined();
-		});
-
-		// Button should still be visible for retry
-		expect(getByText('Load older messages')).toBeDefined();
 	});
 });
 
@@ -454,6 +279,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		mockLeaveRoom.mockReset();
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
+		mockGroupMessagesResult = { messages: [], isLoading: false };
 	});
 
 	afterEach(() => {
@@ -461,8 +287,10 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('accepts leaderSessionId and workerSessionId props without errors', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = {
+			messages: [makeRawMessage(1, 'assistant', 'uuid-1')],
+			isLoading: false,
+		};
 
 		const { container } = render(
 			<TaskConversationRenderer
@@ -478,8 +306,10 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = {
+			messages: [makeRawMessage(1, 'assistant', 'uuid-1')],
+			isLoading: false,
+		};
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -490,8 +320,10 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('joins session channels for leader and worker when both session IDs provided', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessagesResult = {
+			messages: [makeRawMessage(1, 'assistant', 'uuid-1')],
+			isLoading: false,
+		};
 
 		render(
 			<TaskConversationRenderer
@@ -504,7 +336,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		await waitFor(() => {
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
-			expect(joinedRooms).toContain('group:group-1');
+			// Session channels are joined by useSessionQuestionState for question state
 			expect(joinedRooms).toContain('session:leader-session-123');
 			expect(joinedRooms).toContain('session:worker-session-456');
 		});
@@ -521,7 +353,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		leaderMsg.content = JSON.stringify(parsed);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
+		mockGroupMessagesResult = { messages: [leaderMsg], isLoading: false };
 
 		render(
 			<TaskConversationRenderer
@@ -562,7 +394,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		workerMsg.content = JSON.stringify(parsedWorker);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg, workerMsg]));
+		mockGroupMessagesResult = { messages: [leaderMsg, workerMsg], isLoading: false };
 
 		render(
 			<TaskConversationRenderer
@@ -617,7 +449,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		unknownMsg.content = JSON.stringify(parsedUnknown);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([unknownMsg]));
+		mockGroupMessagesResult = { messages: [unknownMsg], isLoading: false };
 
 		render(
 			<TaskConversationRenderer

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -2,18 +2,16 @@
  * Tests for TaskConversationRenderer Component
  *
  * Verifies that the component:
- * - Renders messages provided by useGroupMessages
+ * - Renders messages fetched from task.getGroupMessages
  * - Calls onMessageCountChange when the message list changes
- * - Shows a loading state while useGroupMessages is loading
- * - Renders status messages as centered dividers
+ * - Supports pagination with "Load older messages" button
  * - Does NOT own a scroll container (no overflow-y-auto div)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor, act } from '@testing-library/preact';
+import { render, cleanup, waitFor, act, fireEvent } from '@testing-library/preact';
 
 import { TaskConversationRenderer } from './TaskConversationRenderer';
-import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 // -------------------------------------------------------
 // Mocks
@@ -43,16 +41,7 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
-		isConnected: true,
 	}),
-}));
-
-// Mock useGroupMessages — tests control the returned messages/loading state
-let mockGroupMessages: SessionGroupMessage[] = [];
-let mockGroupIsLoading = false;
-
-vi.mock('../../hooks/useGroupMessages.ts', () => ({
-	useGroupMessages: () => ({ messages: mockGroupMessages, isLoading: mockGroupIsLoading }),
 }));
 
 // SDKMessageRenderer mock that captures rendered props for inspection
@@ -92,7 +81,7 @@ function fireSessionStateEvent(channel: string, data: unknown): void {
 // Helpers
 // -------------------------------------------------------
 
-function makeRawMessage(id: number, role: string, uuid: string): SessionGroupMessage {
+function makeRawMessage(id: number, role: string, uuid: string) {
 	return {
 		id,
 		groupId: 'group-1',
@@ -104,15 +93,31 @@ function makeRawMessage(id: number, role: string, uuid: string): SessionGroupMes
 	};
 }
 
-function makeStatusMessage(id: number, text: string): SessionGroupMessage {
+function makeStatusMessage(id: number, text: string) {
 	return {
 		id,
 		groupId: 'group-1',
-		sessionId: null,
+		sessionId: null as string | null,
 		role: 'system',
 		messageType: 'status',
 		content: text,
 		createdAt: Date.now(),
+	};
+}
+
+// Default API response format
+type TestMessage = ReturnType<typeof makeRawMessage> | ReturnType<typeof makeStatusMessage>;
+
+function makeApiResponse(
+	messages: TestMessage[],
+	options?: { hasOlder?: boolean; oldestCursor?: string | null }
+) {
+	return {
+		messages,
+		hasMore: false,
+		nextCursor: messages.length > 0 ? 'cursor-end' : null,
+		hasOlder: options?.hasOlder ?? false,
+		oldestCursor: options?.oldestCursor ?? (messages.length > 0 ? 'cursor-start' : null),
 	};
 }
 
@@ -126,8 +131,6 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		mockGroupMessages = [];
-		mockGroupIsLoading = false;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
 	});
@@ -137,10 +140,11 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('calls onMessageCountChange with the initial message count', async () => {
-		mockGroupMessages = [
+		const messages = [
 			makeRawMessage(1, 'assistant', 'uuid-1'),
 			makeRawMessage(2, 'assistant', 'uuid-2'),
 		];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -150,9 +154,9 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 	});
 
-	it('calls onMessageCountChange with 0 while loading', () => {
-		mockGroupIsLoading = true;
-		mockGroupMessages = [];
+	it('calls onMessageCountChange with 0 during loading', () => {
+		// Request never resolves → still loading
+		mockRequest.mockImplementation(() => new Promise(() => {}));
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -160,34 +164,9 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		expect(onCountChange).toHaveBeenCalledWith(0);
 	});
 
-	it('calls onMessageCountChange with updated count when messages change', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-
-		const onCountChange = vi.fn();
-		const { rerender } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
-		);
-
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Simulate new message arriving via LiveQuery
-		mockGroupMessages = [
-			makeRawMessage(1, 'assistant', 'uuid-1'),
-			makeRawMessage(2, 'assistant', 'uuid-2'),
-		];
-		act(() => {
-			rerender(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-		});
-
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(2);
-		});
-	});
-
 	it('does NOT render a scroll container (no overflow-y-auto on root element)', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -205,7 +184,8 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('renders status messages as centered dividers', async () => {
-		mockGroupMessages = [makeStatusMessage(1, 'Task started')];
+		const messages = [makeStatusMessage(1, 'Task started')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -217,7 +197,8 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('works without onMessageCountChange prop', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		let container: Element | undefined;
 		expect(() => {
@@ -229,27 +210,239 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 			expect(container?.firstChild).not.toBeNull();
 		});
 	});
+});
 
-	it('shows loading state while useGroupMessages is loading', () => {
-		mockGroupIsLoading = true;
-		mockGroupMessages = [];
-
-		const { container } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		expect(container.textContent).toContain('Loading conversation');
+describe('TaskConversationRenderer — pagination', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockClear();
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		sessionStateHandlers.length = 0;
+		capturedSDKProps.length = 0;
 	});
 
-	it('shows empty state when not loading and no messages', () => {
-		mockGroupIsLoading = false;
-		mockGroupMessages = [];
+	afterEach(() => {
+		cleanup();
+	});
 
-		const { container } = render(
+	it('shows "Load older messages" button when hasOlder is true', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () =>
+			makeApiResponse(messages, { hasOlder: true, oldestCursor: 'cursor-older' })
+		);
+
+		const { getByText } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
-		expect(container.textContent).toContain('Waiting for agent activity');
+		await waitFor(() => {
+			expect(getByText('Load older messages')).toBeDefined();
+		});
+	});
+
+	it('does not show "Load older messages" button when hasOlder is false', async () => {
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () =>
+			makeApiResponse(messages, { hasOlder: false, oldestCursor: null })
+		);
+
+		const { queryByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		await waitFor(() => {
+			expect(queryByText('Load older messages')).toBeNull();
+		});
+	});
+
+	it('loads older messages when button is clicked', async () => {
+		const initialMessages = [makeRawMessage(3, 'assistant', 'uuid-3')];
+		const olderMessages = [
+			makeRawMessage(1, 'assistant', 'uuid-1'),
+			makeRawMessage(2, 'assistant', 'uuid-2'),
+		];
+
+		let callCount = 0;
+		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
+			if (method === 'task.getGroupMessages') {
+				callCount++;
+				if (params.before) {
+					// Second call - loading older
+					return makeApiResponse(olderMessages, { hasOlder: false, oldestCursor: 'cursor-oldest' });
+				}
+				// First call - initial load
+				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
+			}
+			return {};
+		});
+
+		const onCountChange = vi.fn();
+		const { getByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
+		);
+
+		// Wait for initial load
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(1);
+		});
+
+		// Click "Load older messages"
+		await act(async () => {
+			fireEvent.click(getByText('Load older messages'));
+		});
+
+		// Should have called API twice (initial + load older)
+		await waitFor(() => {
+			expect(callCount).toBe(2);
+		});
+
+		// Should have 3 messages now (2 older + 1 initial)
+		await waitFor(() => {
+			expect(onCountChange).toHaveBeenCalledWith(3);
+		});
+	});
+
+	it('shows loading state while loading older messages', async () => {
+		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		let resolveOlder: () => void;
+
+		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
+			if (method === 'task.getGroupMessages') {
+				if (params.before) {
+					// Delay the older messages response
+					return new Promise((resolve) => {
+						resolveOlder = () => resolve(makeApiResponse([], { hasOlder: false }));
+					});
+				}
+				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
+			}
+			return {};
+		});
+
+		const { getByText, queryByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		// Wait for initial load
+		await waitFor(() => {
+			expect(getByText('Load older messages')).toBeDefined();
+		});
+
+		// Click "Load older messages"
+		await act(async () => {
+			fireEvent.click(getByText('Load older messages'));
+		});
+
+		// Button should show loading state
+		await waitFor(() => {
+			expect(getByText('Loading…')).toBeDefined();
+		});
+
+		// Resolve the older messages request
+		await act(async () => {
+			resolveOlder!();
+		});
+
+		// Button should return to normal state (hidden since no more older messages)
+		await waitFor(() => {
+			expect(queryByText('Loading…')).toBeNull();
+		});
+	});
+
+	it('shows error message when initial fetch fails with no buffered messages', async () => {
+		mockRequest.mockRejectedValue(new Error('Network error'));
+
+		const { getByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		await waitFor(() => {
+			expect(getByText('Network error')).toBeDefined();
+		});
+
+		// Should show retry button
+		expect(getByText('Retry')).toBeDefined();
+	});
+
+	it('retry button refetches messages instead of reloading page', async () => {
+		let fetchCount = 0;
+
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'task.getGroupMessages') {
+				fetchCount++;
+				if (fetchCount === 1) {
+					throw new Error('Network error');
+				}
+				// Second fetch succeeds
+				return makeApiResponse([makeRawMessage(1, 'assistant', 'uuid-1')]);
+			}
+			return {};
+		});
+
+		const { getByText, queryByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		// Wait for initial error
+		await waitFor(() => {
+			expect(getByText('Network error')).toBeDefined();
+		});
+
+		expect(fetchCount).toBe(1);
+
+		// Click retry button
+		await act(async () => {
+			fireEvent.click(getByText('Retry'));
+		});
+
+		// Should have made a second fetch request
+		await waitFor(() => {
+			expect(fetchCount).toBe(2);
+		});
+
+		// Error should be cleared and messages should render
+		await waitFor(() => {
+			expect(queryByText('Network error')).toBeNull();
+		});
+	});
+
+	it('shows error message when loading older messages fails', async () => {
+		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		let olderCallCount = 0;
+
+		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
+			if (method === 'task.getGroupMessages') {
+				if (params.before) {
+					olderCallCount++;
+					throw new Error('Failed to load older');
+				}
+				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
+			}
+			return {};
+		});
+
+		const { getByText } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
+		);
+
+		// Wait for initial load
+		await waitFor(() => {
+			expect(getByText('Load older messages')).toBeDefined();
+		});
+
+		// Click "Load older messages"
+		await act(async () => {
+			fireEvent.click(getByText('Load older messages'));
+		});
+
+		// Should show error message
+		await waitFor(() => {
+			expect(getByText('Failed to load older')).toBeDefined();
+		});
+
+		// Button should still be visible for retry
+		expect(getByText('Load older messages')).toBeDefined();
 	});
 });
 
@@ -259,8 +452,6 @@ describe('TaskConversationRenderer — session question state props', () => {
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		mockGroupMessages = [];
-		mockGroupIsLoading = false;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
 	});
@@ -270,7 +461,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('accepts leaderSessionId and workerSessionId props without errors', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const { container } = render(
 			<TaskConversationRenderer
@@ -286,7 +478,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -297,7 +490,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('joins session channels for leader and worker when both session IDs provided', async () => {
-		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
+		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		render(
 			<TaskConversationRenderer
@@ -310,6 +504,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		await waitFor(() => {
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
+			expect(joinedRooms).toContain('group:group-1');
 			expect(joinedRooms).toContain('session:leader-session-123');
 			expect(joinedRooms).toContain('session:worker-session-456');
 		});
@@ -325,7 +520,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 			iteration: 0,
 		};
 		leaderMsg.content = JSON.stringify(parsed);
-		mockGroupMessages = [leaderMsg];
+
+		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
 
 		render(
 			<TaskConversationRenderer
@@ -366,7 +562,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		workerMsg.content = JSON.stringify(parsedWorker);
 
-		mockGroupMessages = [leaderMsg, workerMsg];
+		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg, workerMsg]));
 
 		render(
 			<TaskConversationRenderer
@@ -420,7 +616,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 			iteration: 0,
 		};
 		unknownMsg.content = JSON.stringify(parsedUnknown);
-		mockGroupMessages = [unknownMsg];
+
+		mockRequest.mockImplementation(async () => makeApiResponse([unknownMsg]));
 
 		render(
 			<TaskConversationRenderer

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -2,15 +2,16 @@
  * TaskConversationRenderer
  *
  * Renders a flat chronological conversation timeline for a task group.
- * Uses pagination to load messages efficiently:
- * - Initial load: fetches the newest N messages (default 50)
- * - "Load older" button at the top to load more history
+ * Uses the useGroupMessages hook for real-time message streaming via LiveQuery:
+ * - Initial snapshot delivered on subscribe
+ * - Append-only deltas streamed as new messages arrive
+ * - Automatic re-subscription on WebSocket reconnect
  *
  * Each message is rendered inline with a thin colored left border indicating
  * which agent produced it. Role transitions show a small divider label.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
@@ -22,6 +23,8 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
+import { useGroupMessages } from '../../hooks/useGroupMessages';
+import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -35,16 +38,6 @@ interface TaskMeta {
 	authorSessionId: string;
 	turnId: string;
 	iteration: number;
-}
-
-interface GroupMessage {
-	id: number;
-	groupId: string;
-	sessionId: string | null;
-	role: string;
-	messageType: string;
-	content: string;
-	createdAt: number;
 }
 
 interface TaskConversationRendererProps {
@@ -68,11 +61,8 @@ const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: s
 	lead: { border: 'border-l-purple-500', label: 'Lead', labelColor: 'text-purple-400' },
 };
 
-function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
-	// messageType is used for DB records; type is used for WebSocket real-time events.
-	// Normalize to whichever field is set.
-	const msgAny = msg as unknown as Record<string, unknown>;
-	const msgType = msgAny.messageType ?? msgAny.type;
+function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
+	const msgType = msg.messageType;
 
 	// Status messages are plain text, not JSON
 	if (msgType === 'status') {
@@ -142,46 +132,28 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
-/**
- * Returns a stable deduplication key for a message.
- * Agent messages use their uuid; status messages use _taskMeta.turnId as a fallback.
- * Returns null for messages with no identifiable key (they pass through unfiltered).
- */
-function getMessageId(msg: SDKMessage): string | null {
-	const uuid = (msg as SDKMessage & { uuid?: string }).uuid;
-	if (uuid) return uuid;
-	return getTaskMeta(msg)?.turnId ?? null;
-}
-
-const PAGE_SIZE = 50;
-
 export function TaskConversationRenderer({
 	groupId,
 	leaderSessionId,
 	workerSessionId,
 	onMessageCountChange,
 }: TaskConversationRendererProps) {
-	const { request, joinRoom, leaveRoom } = useMessageHub();
+	const { request } = useMessageHub();
 
 	// Subscribe to question state for each agent session so AskUserQuestion
 	// renders as an interactive form rather than a plain message
 	const leaderQuestionState = useSessionQuestionState(leaderSessionId);
 	const workerQuestionState = useSessionQuestionState(workerSessionId);
-	const [messages, setMessages] = useState<SDKMessage[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [loadingOlder, setLoadingOlder] = useState(false);
-	const [hasOlder, setHasOlder] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	// Incremented to trigger a retry of the initial fetch
-	const [retryKey, setRetryKey] = useState(0);
-	// Track the oldest cursor for loading older messages
-	const oldestCursorRef = useRef<string | null>(null);
-	// Refs for useCallback guards (avoids recreating callback on state changes)
-	const loadingOlderRef = useRef(false);
-	const hasOlderRef = useRef(false);
-	// Tracks every message ID (uuid or turnId) added to state, enabling deduplication
-	// across the initial fetch and load-older pages.
-	const seenIdsRef = useRef<Set<string>>(new Set());
+
+	// Subscribe to group messages via LiveQuery for real-time streaming.
+	// The hook handles initial snapshot, append-only deltas, and reconnect.
+	const { messages: rawMessages, isLoading } = useGroupMessages(groupId);
+
+	// Parse raw DB records into SDKMessage format for rendering
+	const messages = useMemo(
+		() => rawMessages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null),
+		[rawMessages]
+	);
 
 	// Fetch session model info for leader and worker
 	const [sessionModels, setSessionModels] = useState<{
@@ -247,114 +219,6 @@ export function TaskConversationRenderer({
 		return { label: base.label, labelColor: base.labelColor };
 	}
 
-	useEffect(() => {
-		const channel = `group:${groupId}`;
-		joinRoom(channel);
-		seenIdsRef.current.clear();
-		oldestCursorRef.current = null;
-		loadingOlderRef.current = false;
-		hasOlderRef.current = false;
-		setError(null);
-		let cancelled = false;
-
-		const fetchInitialMessages = async () => {
-			try {
-				const res: {
-					messages: GroupMessage[];
-					hasMore: boolean;
-					nextCursor: string | null;
-					hasOlder: boolean;
-					oldestCursor: string | null;
-				} = await request('task.getGroupMessages', {
-					groupId,
-					limit: PAGE_SIZE,
-				});
-
-				if (!cancelled) {
-					const parsed = res.messages
-						.map(parseGroupMessage)
-						.filter((m): m is SDKMessage => m !== null);
-
-					const uniqueParsed = parsed.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-
-					if (uniqueParsed.length > 0) {
-						setMessages(uniqueParsed);
-					}
-					setHasOlder(res.hasOlder);
-					hasOlderRef.current = res.hasOlder;
-					oldestCursorRef.current = res.oldestCursor;
-					setLoading(false);
-				}
-			} catch (err) {
-				if (!cancelled) {
-					setLoading(false);
-					setError(err instanceof Error ? err.message : 'Failed to load messages');
-				}
-			}
-		};
-
-		fetchInitialMessages();
-
-		return () => {
-			cancelled = true;
-			leaveRoom(channel);
-		};
-	}, [groupId, retryKey, joinRoom, leaveRoom, request]);
-
-	const retryInitialFetch = useCallback(() => {
-		setRetryKey((k) => k + 1);
-	}, []);
-
-	const loadOlderMessages = useCallback(async () => {
-		// Use refs for guards to avoid recreating callback on state changes
-		if (loadingOlderRef.current || !hasOlderRef.current || !oldestCursorRef.current) return;
-
-		loadingOlderRef.current = true;
-		setLoadingOlder(true);
-		setError(null); // Clear previous errors on retry
-		try {
-			const res: {
-				messages: GroupMessage[];
-				hasMore: boolean;
-				nextCursor: string | null;
-				hasOlder: boolean;
-				oldestCursor: string | null;
-			} = await request('task.getGroupMessages', {
-				groupId,
-				before: oldestCursorRef.current,
-				limit: PAGE_SIZE,
-			});
-
-			const parsed = res.messages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null);
-
-			// Deduplicate and prepend to existing messages
-			const uniqueParsed = parsed.filter((m) => {
-				const id = getMessageId(m);
-				if (id && seenIdsRef.current.has(id)) return false;
-				if (id) seenIdsRef.current.add(id);
-				return true;
-			});
-
-			if (uniqueParsed.length > 0) {
-				setMessages((prev) => [...uniqueParsed, ...prev]);
-			}
-			setHasOlder(res.hasOlder);
-			hasOlderRef.current = res.hasOlder;
-			oldestCursorRef.current = res.oldestCursor;
-		} catch (err) {
-			// Show error feedback to user
-			setError(err instanceof Error ? err.message : 'Failed to load older messages');
-		} finally {
-			loadingOlderRef.current = false;
-			setLoadingOlder(false);
-		}
-	}, [groupId, request]);
-
 	// Notify parent when message count changes so it can drive autoscroll
 	useEffect(() => {
 		onMessageCountChange?.(messages.length);
@@ -377,24 +241,10 @@ export function TaskConversationRenderer({
 		return transitions;
 	}, [messages]);
 
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div class="flex-1 flex items-center justify-center">
 				<p class="text-gray-400 text-sm">Loading conversation…</p>
-			</div>
-		);
-	}
-
-	if (messages.length === 0 && error) {
-		return (
-			<div class="flex-1 flex flex-col items-center justify-center gap-2">
-				<p class="text-red-400 text-sm">{error}</p>
-				<button
-					class="text-xs text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-					onClick={retryInitialFetch}
-				>
-					Retry
-				</button>
 			</div>
 		);
 	}
@@ -409,19 +259,6 @@ export function TaskConversationRenderer({
 
 	return (
 		<div class="px-4 py-3 space-y-0.5">
-			{/* Load older messages button */}
-			{hasOlder && (
-				<div class="flex flex-col items-center gap-2 py-2">
-					{error && <p class="text-xs text-red-400">{error}</p>}
-					<button
-						class="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-						onClick={loadOlderMessages}
-						disabled={loadingOlder}
-					>
-						{loadingOlder ? 'Loading…' : 'Load older messages'}
-					</button>
-				</div>
-			)}
 			{messages.map((msg, i) => {
 				const meta = getTaskMeta(msg);
 				const role = meta?.authorRole ?? 'system';

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -23,8 +23,7 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
-import { useGroupMessages } from '../../hooks/useGroupMessages';
-import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
+import { useGroupMessages, type SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -92,11 +91,18 @@ function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Rate limited: rendered as an amber notification
+	// Rate limited: stored as JSON with rich payload (resetsAt, sessionRole).
+	// Fall back to content as plain text if not valid JSON.
 	if (msgType === 'rate_limited') {
+		let parsed: Record<string, unknown> = {};
+		try {
+			parsed = JSON.parse(msg.content) as Record<string, unknown>;
+		} catch {
+			parsed = { text: msg.content };
+		}
 		return {
+			...parsed,
 			type: 'rate_limited',
-			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',
@@ -106,11 +112,18 @@ function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Model fallback: rendered as an amber notification
+	// Model fallback: stored as JSON with rich payload (fromModel, toModel, sessionRole).
+	// Fall back to content as plain text if not valid JSON.
 	if (msgType === 'model_fallback') {
+		let parsed: Record<string, unknown> = {};
+		try {
+			parsed = JSON.parse(msg.content) as Record<string, unknown>;
+		} catch {
+			parsed = { text: msg.content };
+		}
 		return {
+			...parsed,
 			type: 'model_fallback',
-			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -2,13 +2,15 @@
  * TaskConversationRenderer
  *
  * Renders a flat chronological conversation timeline for a task group.
- * Subscribes to real-time message streaming via the useGroupMessages hook (LiveQuery).
+ * Uses pagination to load messages efficiently:
+ * - Initial load: fetches the newest N messages (default 50)
+ * - "Load older" button at the top to load more history
  *
  * Each message is rendered inline with a thin colored left border indicating
  * which agent produced it. Role transitions show a small divider label.
  */
 
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
@@ -20,7 +22,6 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
-import { useGroupMessages, type SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -34,6 +35,16 @@ interface TaskMeta {
 	authorSessionId: string;
 	turnId: string;
 	iteration: number;
+}
+
+interface GroupMessage {
+	id: number;
+	groupId: string;
+	sessionId: string | null;
+	role: string;
+	messageType: string;
+	content: string;
+	createdAt: number;
 }
 
 interface TaskConversationRendererProps {
@@ -57,7 +68,7 @@ const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: s
 	lead: { border: 'border-l-purple-500', label: 'Lead', labelColor: 'text-purple-400' },
 };
 
-function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
+function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 	// messageType is used for DB records; type is used for WebSocket real-time events.
 	// Normalize to whichever field is set.
 	const msgAny = msg as unknown as Record<string, unknown>;
@@ -91,18 +102,11 @@ function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Rate limited: stored as JSON with rich payload (resetsAt, sessionRole).
-	// Fall back to content as plain text if not valid JSON.
+	// Rate limited: rendered as an amber notification
 	if (msgType === 'rate_limited') {
-		let parsed: Record<string, unknown> = {};
-		try {
-			parsed = JSON.parse(msg.content) as Record<string, unknown>;
-		} catch {
-			parsed = { text: msg.content };
-		}
 		return {
-			...parsed,
 			type: 'rate_limited',
+			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',
@@ -112,18 +116,11 @@ function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Model fallback: stored as JSON with rich payload (fromModel, toModel, sessionRole).
-	// Fall back to content as plain text if not valid JSON.
+	// Model fallback: rendered as an amber notification
 	if (msgType === 'model_fallback') {
-		let parsed: Record<string, unknown> = {};
-		try {
-			parsed = JSON.parse(msg.content) as Record<string, unknown>;
-		} catch {
-			parsed = { text: msg.content };
-		}
 		return {
-			...parsed,
 			type: 'model_fallback',
+			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',
@@ -145,26 +142,46 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
+/**
+ * Returns a stable deduplication key for a message.
+ * Agent messages use their uuid; status messages use _taskMeta.turnId as a fallback.
+ * Returns null for messages with no identifiable key (they pass through unfiltered).
+ */
+function getMessageId(msg: SDKMessage): string | null {
+	const uuid = (msg as SDKMessage & { uuid?: string }).uuid;
+	if (uuid) return uuid;
+	return getTaskMeta(msg)?.turnId ?? null;
+}
+
+const PAGE_SIZE = 50;
+
 export function TaskConversationRenderer({
 	groupId,
 	leaderSessionId,
 	workerSessionId,
 	onMessageCountChange,
 }: TaskConversationRendererProps) {
-	const { request } = useMessageHub();
+	const { request, joinRoom, leaveRoom } = useMessageHub();
 
 	// Subscribe to question state for each agent session so AskUserQuestion
 	// renders as an interactive form rather than a plain message
 	const leaderQuestionState = useSessionQuestionState(leaderSessionId);
 	const workerQuestionState = useSessionQuestionState(workerSessionId);
-
-	// Subscribe to group messages via LiveQuery (handles initial snapshot + live deltas)
-	const { messages: rawMessages, isLoading } = useGroupMessages(groupId);
-
-	const messages = useMemo(
-		() => rawMessages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null),
-		[rawMessages]
-	);
+	const [messages, setMessages] = useState<SDKMessage[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [loadingOlder, setLoadingOlder] = useState(false);
+	const [hasOlder, setHasOlder] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	// Incremented to trigger a retry of the initial fetch
+	const [retryKey, setRetryKey] = useState(0);
+	// Track the oldest cursor for loading older messages
+	const oldestCursorRef = useRef<string | null>(null);
+	// Refs for useCallback guards (avoids recreating callback on state changes)
+	const loadingOlderRef = useRef(false);
+	const hasOlderRef = useRef(false);
+	// Tracks every message ID (uuid or turnId) added to state, enabling deduplication
+	// across the initial fetch and load-older pages.
+	const seenIdsRef = useRef<Set<string>>(new Set());
 
 	// Fetch session model info for leader and worker
 	const [sessionModels, setSessionModels] = useState<{
@@ -173,17 +190,12 @@ export function TaskConversationRenderer({
 	}>({ leaderModel: null, workerModel: null });
 
 	useEffect(() => {
-		if (!leaderSessionId && !workerSessionId) return;
 		let cancelled = false;
 		const fetchSessionModels = async () => {
 			try {
 				const [leaderRes, workerRes] = await Promise.all([
-					leaderSessionId
-						? request<{ session: SessionInfo }>('session.get', { sessionId: leaderSessionId })
-						: Promise.resolve({ session: null }),
-					workerSessionId
-						? request<{ session: SessionInfo }>('session.get', { sessionId: workerSessionId })
-						: Promise.resolve({ session: null }),
+					request<{ session: SessionInfo }>('session.get', { sessionId: leaderSessionId }),
+					request<{ session: SessionInfo }>('session.get', { sessionId: workerSessionId }),
 				]);
 				if (!cancelled) {
 					setSessionModels({
@@ -235,6 +247,114 @@ export function TaskConversationRenderer({
 		return { label: base.label, labelColor: base.labelColor };
 	}
 
+	useEffect(() => {
+		const channel = `group:${groupId}`;
+		joinRoom(channel);
+		seenIdsRef.current.clear();
+		oldestCursorRef.current = null;
+		loadingOlderRef.current = false;
+		hasOlderRef.current = false;
+		setError(null);
+		let cancelled = false;
+
+		const fetchInitialMessages = async () => {
+			try {
+				const res: {
+					messages: GroupMessage[];
+					hasMore: boolean;
+					nextCursor: string | null;
+					hasOlder: boolean;
+					oldestCursor: string | null;
+				} = await request('task.getGroupMessages', {
+					groupId,
+					limit: PAGE_SIZE,
+				});
+
+				if (!cancelled) {
+					const parsed = res.messages
+						.map(parseGroupMessage)
+						.filter((m): m is SDKMessage => m !== null);
+
+					const uniqueParsed = parsed.filter((m) => {
+						const id = getMessageId(m);
+						if (id && seenIdsRef.current.has(id)) return false;
+						if (id) seenIdsRef.current.add(id);
+						return true;
+					});
+
+					if (uniqueParsed.length > 0) {
+						setMessages(uniqueParsed);
+					}
+					setHasOlder(res.hasOlder);
+					hasOlderRef.current = res.hasOlder;
+					oldestCursorRef.current = res.oldestCursor;
+					setLoading(false);
+				}
+			} catch (err) {
+				if (!cancelled) {
+					setLoading(false);
+					setError(err instanceof Error ? err.message : 'Failed to load messages');
+				}
+			}
+		};
+
+		fetchInitialMessages();
+
+		return () => {
+			cancelled = true;
+			leaveRoom(channel);
+		};
+	}, [groupId, retryKey, joinRoom, leaveRoom, request]);
+
+	const retryInitialFetch = useCallback(() => {
+		setRetryKey((k) => k + 1);
+	}, []);
+
+	const loadOlderMessages = useCallback(async () => {
+		// Use refs for guards to avoid recreating callback on state changes
+		if (loadingOlderRef.current || !hasOlderRef.current || !oldestCursorRef.current) return;
+
+		loadingOlderRef.current = true;
+		setLoadingOlder(true);
+		setError(null); // Clear previous errors on retry
+		try {
+			const res: {
+				messages: GroupMessage[];
+				hasMore: boolean;
+				nextCursor: string | null;
+				hasOlder: boolean;
+				oldestCursor: string | null;
+			} = await request('task.getGroupMessages', {
+				groupId,
+				before: oldestCursorRef.current,
+				limit: PAGE_SIZE,
+			});
+
+			const parsed = res.messages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null);
+
+			// Deduplicate and prepend to existing messages
+			const uniqueParsed = parsed.filter((m) => {
+				const id = getMessageId(m);
+				if (id && seenIdsRef.current.has(id)) return false;
+				if (id) seenIdsRef.current.add(id);
+				return true;
+			});
+
+			if (uniqueParsed.length > 0) {
+				setMessages((prev) => [...uniqueParsed, ...prev]);
+			}
+			setHasOlder(res.hasOlder);
+			hasOlderRef.current = res.hasOlder;
+			oldestCursorRef.current = res.oldestCursor;
+		} catch (err) {
+			// Show error feedback to user
+			setError(err instanceof Error ? err.message : 'Failed to load older messages');
+		} finally {
+			loadingOlderRef.current = false;
+			setLoadingOlder(false);
+		}
+	}, [groupId, request]);
+
 	// Notify parent when message count changes so it can drive autoscroll
 	useEffect(() => {
 		onMessageCountChange?.(messages.length);
@@ -257,10 +377,24 @@ export function TaskConversationRenderer({
 		return transitions;
 	}, [messages]);
 
-	if (isLoading) {
+	if (loading) {
 		return (
 			<div class="flex-1 flex items-center justify-center">
 				<p class="text-gray-400 text-sm">Loading conversation…</p>
+			</div>
+		);
+	}
+
+	if (messages.length === 0 && error) {
+		return (
+			<div class="flex-1 flex flex-col items-center justify-center gap-2">
+				<p class="text-red-400 text-sm">{error}</p>
+				<button
+					class="text-xs text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
+					onClick={retryInitialFetch}
+				>
+					Retry
+				</button>
 			</div>
 		);
 	}
@@ -275,6 +409,19 @@ export function TaskConversationRenderer({
 
 	return (
 		<div class="px-4 py-3 space-y-0.5">
+			{/* Load older messages button */}
+			{hasOlder && (
+				<div class="flex flex-col items-center gap-2 py-2">
+					{error && <p class="text-xs text-red-400">{error}</p>}
+					<button
+						class="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
+						onClick={loadOlderMessages}
+						disabled={loadingOlder}
+					>
+						{loadingOlder ? 'Loading…' : 'Load older messages'}
+					</button>
+				</div>
+			)}
 			{messages.map((msg, i) => {
 				const meta = getTaskMeta(msg);
 				const role = meta?.authorRole ?? 'system';

--- a/packages/web/src/hooks/useGroupMessages.ts
+++ b/packages/web/src/hooks/useGroupMessages.ts
@@ -70,7 +70,10 @@ export function resetSubscriptionCounterForTesting(): void {
 export function useGroupMessages(groupId: string | null): UseGroupMessagesResult {
 	const { request, onEvent, isConnected } = useMessageHub();
 	const [messages, setMessages] = useState<SessionGroupMessage[]>([]);
-	const [isLoading, setIsLoading] = useState(false);
+	// Initialise to true when a groupId is present so the component shows
+	// "Loading conversation…" immediately rather than flashing "Waiting for
+	// agent activity…" for one render cycle before the effect fires.
+	const [isLoading, setIsLoading] = useState(groupId !== null);
 
 	// Track the active subscriptionId to guard against stale events from prior
 	// group subscriptions (e.g., rapid task switching or reconnect cycles).


### PR DESCRIPTION
Removes the old real-time streaming listener and its supporting buffer/dedup
logic (fetchingRef, pendingDeltasRef) in favour of the new LiveQuery-based
approach via the useGroupMessages hook. Updates the JSDoc and test file
to remove all references to state.groupMessages.delta.
