### PR TITLE
feat: replace state.groupMessages.delta listener with useGroupMessages hook

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2191,14 +2191,21 @@ export class RoomRuntime {
 			messageType === 'rate_limited' || messageType === 'model_fallback'
 				? JSON.stringify({ ...payload, type: messageType })
 				: (payload?.text ?? kind);
-		this.groupRepo.appendGroupMessage({
-			groupId,
-			sessionId: null,
-			role: 'system',
-			messageType,
-			content,
-			createdAt: now,
-		});
+		try {
+			this.groupRepo.appendGroupMessage({
+				groupId,
+				sessionId: null,
+				role: 'system',
+				messageType,
+				content,
+				createdAt: now,
+			});
+		} catch (err) {
+			log.warn(
+				`appendGroupEvent: failed to persist group message for group ${groupId} (type=${messageType}, secondary write — ignored):`,
+				err
+			);
+		}
 
 		if (this.messageHub) {
 			this.messageHub.event(

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2065,12 +2065,9 @@ export class RoomRuntime {
 	/**
 	 * Set up live message forwarding for a group's worker/leader sessions.
 	 *
-	 * Subscribes to DaemonHub sdk.message events and broadcasts enriched deltas
-	 * on state.groupMessages.delta for TaskConversationRenderer.
-	 *
-	 * IMPORTANT: We intentionally do NOT mirror worker/leader SDK messages into
-	 * any group message table anymore. Task view history is reconstructed from each
-	 * session's sdk_messages stream via task.getGroupMessages.
+	 * Subscribes to DaemonHub sdk.message events, persists each enriched message
+	 * to session_group_messages (for LiveQuery), and broadcasts deltas via
+	 * state.groupMessages.delta for any legacy subscribers still present.
 	 */
 	private setupMirroring(group: SessionGroup): void {
 		if (!this.daemonHub) return;
@@ -2113,20 +2110,33 @@ export class RoomRuntime {
 					const iteration = currentGroup?.feedbackIteration ?? group.feedbackIteration;
 					const turnId = `turn_${group.id}_${iteration}_${shortSessionId}`;
 
-					// Broadcast enriched delta to subscribed frontends.
+					// Persist to session_group_messages and broadcast enriched delta to frontends.
+					const enrichedMessage = {
+						...event.message,
+						_taskMeta: {
+							authorRole: role,
+							authorSessionId: sessionId,
+							turnId,
+							iteration,
+						},
+					};
+					const sdkNow = Date.now();
+					const sdkMsgType =
+						'type' in event.message && typeof event.message.type === 'string'
+							? event.message.type
+							: 'assistant';
+					this.groupRepo.appendGroupMessage({
+						groupId: group.id,
+						sessionId,
+						role,
+						messageType: sdkMsgType,
+						content: JSON.stringify(enrichedMessage),
+						createdAt: sdkNow,
+					});
 					if (this.messageHub) {
-						const enrichedMessage = {
-							...event.message,
-							_taskMeta: {
-								authorRole: role,
-								authorSessionId: sessionId,
-								turnId,
-								iteration,
-							},
-						};
 						this.messageHub.event(
 							'state.groupMessages.delta',
-							{ added: [{ ...enrichedMessage, timestamp: Date.now() }], timestamp: Date.now() },
+							{ added: [{ ...enrichedMessage, timestamp: sdkNow }], timestamp: sdkNow },
 							{ channel: `group:${group.id}` }
 						);
 					}
@@ -2159,20 +2169,38 @@ export class RoomRuntime {
 			kind,
 			payloadJson: payload ? JSON.stringify(payload) : undefined,
 		});
+		const now = Date.now();
+		// Map event kinds to message types for the frontend.
+		// 'leader_summary' is a special case (rendered as a distinct card).
+		// 'rate_limited' and 'model_fallback' get their own type so the frontend
+		// can render them as prominent notifications.
+		const messageType =
+			kind === 'leader_summary'
+				? 'leader_summary'
+				: kind === 'rate_limited'
+					? 'rate_limited'
+					: kind === 'model_fallback'
+						? 'model_fallback'
+						: 'status';
+
+		// Persist to session_group_messages so LiveQuery subscribers receive the event.
+		// For rich event types (rate_limited, model_fallback) store the full payload as
+		// JSON so the frontend can render extra fields (resetsAt, sessionRole, etc.).
+		// For simple status/leader_summary, store just the text.
+		const content =
+			messageType === 'rate_limited' || messageType === 'model_fallback'
+				? JSON.stringify({ ...payload, type: messageType })
+				: (payload?.text ?? kind);
+		this.groupRepo.appendGroupMessage({
+			groupId,
+			sessionId: null,
+			role: 'system',
+			messageType,
+			content,
+			createdAt: now,
+		});
+
 		if (this.messageHub) {
-			const now = Date.now();
-			// Map event kinds to message types for the frontend.
-			// 'leader_summary' is a special case (rendered as a distinct card).
-			// 'rate_limited' and 'model_fallback' get their own type so the frontend
-			// can render them as prominent notifications.
-			const messageType =
-				kind === 'leader_summary'
-					? 'leader_summary'
-					: kind === 'rate_limited'
-						? 'rate_limited'
-						: kind === 'model_fallback'
-							? 'model_fallback'
-							: 'status';
 			this.messageHub.event(
 				'state.groupMessages.delta',
 				{
@@ -2181,6 +2209,7 @@ export class RoomRuntime {
 							type: messageType,
 							text: payload?.text ?? kind,
 							timestamp: now,
+							...(payload ?? {}),
 						},
 					],
 					timestamp: now,

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -837,6 +837,37 @@ export class SessionGroupRepository {
 		});
 	}
 
+	// ===== session_group_messages (LiveQuery message streaming) =====
+
+	/**
+	 * Insert a row into session_group_messages and notify LiveQuery subscribers.
+	 * Called from both setupMirroring (SDK messages) and appendGroupEvent (status/event messages).
+	 */
+	appendGroupMessage(params: {
+		groupId: string;
+		sessionId?: string | null;
+		role: string;
+		messageType: string;
+		content: string;
+		createdAt: number;
+	}): number {
+		const result = this.db
+			.prepare(
+				`INSERT INTO session_group_messages (group_id, session_id, role, message_type, content, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				params.groupId,
+				params.sessionId ?? null,
+				params.role,
+				params.messageType,
+				params.content,
+				params.createdAt
+			);
+		this.reactiveDb.notifyChange('session_group_messages');
+		return Number(result.lastInsertRowid);
+	}
+
 	// ===== Group events (status/system timeline, no mirrored SDK chat) =====
 
 	appendEvent(params: { groupId: string; kind: string; payloadJson?: string }): number {

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -105,6 +105,15 @@ describe('Room Agent Tools', () => {
 				payload_json TEXT,
 				created_at INTEGER NOT NULL
 			);
+			CREATE TABLE session_group_messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT,
+				role TEXT NOT NULL DEFAULT 'system',
+				message_type TEXT NOT NULL DEFAULT 'status',
+				content TEXT NOT NULL DEFAULT '',
+				created_at INTEGER NOT NULL
+			);
 			CREATE TABLE mission_metric_history (
 				id TEXT PRIMARY KEY,
 				goal_id TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -181,6 +181,15 @@ const DB_SCHEMA = `
 		payload_json TEXT,
 		created_at INTEGER NOT NULL
 	);
+	CREATE TABLE session_group_messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+		session_id TEXT,
+		role TEXT NOT NULL DEFAULT 'system',
+		message_type TEXT NOT NULL DEFAULT 'status',
+		content TEXT NOT NULL DEFAULT '',
+		created_at INTEGER NOT NULL
+	);
 	CREATE TABLE mission_metric_history (
 		id TEXT PRIMARY KEY,
 		goal_id TEXT NOT NULL,

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -162,6 +162,15 @@ describe('Runtime Recovery', () => {
 				payload_json TEXT,
 				created_at INTEGER NOT NULL
 			);
+			CREATE TABLE session_group_messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT,
+				role TEXT NOT NULL DEFAULT 'system',
+				message_type TEXT NOT NULL DEFAULT 'status',
+				content TEXT NOT NULL DEFAULT '',
+				created_at INTEGER NOT NULL
+			);
 			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${Date.now()}, ${Date.now()});
 		`);
 

--- a/packages/daemon/tests/unit/room/session-group-repository-reactive.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository-reactive.test.ts
@@ -71,6 +71,15 @@ CREATE TABLE task_group_events (
     payload_json TEXT,
     created_at INTEGER NOT NULL
 );
+CREATE TABLE session_group_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+    session_id TEXT,
+    role TEXT NOT NULL DEFAULT 'system',
+    message_type TEXT NOT NULL DEFAULT 'status',
+    content TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+);
 `;
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/room/session-group-repository.test.ts
+++ b/packages/daemon/tests/unit/room/session-group-repository.test.ts
@@ -68,6 +68,15 @@ describe('SessionGroupRepository', () => {
 				payload_json TEXT,
 				created_at INTEGER NOT NULL
 			);
+			CREATE TABLE session_group_messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT,
+				role TEXT NOT NULL DEFAULT 'system',
+				message_type TEXT NOT NULL DEFAULT 'status',
+				content TEXT NOT NULL DEFAULT '',
+				created_at INTEGER NOT NULL
+			);
 
 			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test Room', ${Date.now()}, ${Date.now()});
 			INSERT INTO tasks (id, room_id, title, description, created_at) VALUES ('${taskId}', '${roomId}', 'Test Task', 'desc', ${Date.now()});
@@ -487,6 +496,85 @@ describe('SessionGroupRepository', () => {
 			const page2 = repo.getEvents(group.id, { afterId: page1.events.at(-1)!.id });
 			expect(page2.events).toHaveLength(2);
 			expect(page2.hasMore).toBe(false);
+		});
+	});
+
+	describe('appendGroupMessage', () => {
+		it('inserts a row and returns an autoincrement id', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const id = repo.appendGroupMessage({
+				groupId: group.id,
+				sessionId: 'sess-1',
+				role: 'leader',
+				messageType: 'assistant',
+				content: JSON.stringify({ type: 'assistant', uuid: 'abc' }),
+				createdAt: Date.now(),
+			});
+			expect(id).toBeGreaterThan(0);
+		});
+
+		it('retrieves the inserted row from the DB', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			const now = Date.now();
+			repo.appendGroupMessage({
+				groupId: group.id,
+				sessionId: 'sess-1',
+				role: 'coder',
+				messageType: 'assistant',
+				content: '{"type":"assistant","uuid":"u1"}',
+				createdAt: now,
+			});
+
+			const rows = db
+				.prepare('SELECT * FROM session_group_messages WHERE group_id = ?')
+				.all(group.id) as Record<string, unknown>[];
+			expect(rows).toHaveLength(1);
+			expect(rows[0].group_id).toBe(group.id);
+			expect(rows[0].session_id).toBe('sess-1');
+			expect(rows[0].role).toBe('coder');
+			expect(rows[0].message_type).toBe('assistant');
+			expect(rows[0].content).toBe('{"type":"assistant","uuid":"u1"}');
+			expect(rows[0].created_at).toBe(now);
+		});
+
+		it('allows null sessionId for system events', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+			repo.appendGroupMessage({
+				groupId: group.id,
+				sessionId: null,
+				role: 'system',
+				messageType: 'status',
+				content: 'Task started',
+				createdAt: Date.now(),
+			});
+
+			const rows = db
+				.prepare('SELECT session_id FROM session_group_messages WHERE group_id = ?')
+				.all(group.id) as Record<string, unknown>[];
+			expect(rows[0].session_id).toBeNull();
+		});
+
+		it('notifies reactiveDb so LiveQuery subscribers are triggered', () => {
+			const group = repo.createGroup(taskId, workerSessionId, leaderSessionId);
+
+			// Track notifyChange calls via a real ReactiveDatabase
+			let notified = false;
+			const rdb = createReactiveDatabase(db as never);
+			const testRepo = new SessionGroupRepository(db, rdb);
+			rdb.on('change:session_group_messages', () => {
+				notified = true;
+			});
+
+			testRepo.appendGroupMessage({
+				groupId: group.id,
+				sessionId: null,
+				role: 'system',
+				messageType: 'status',
+				content: 'hello',
+				createdAt: Date.now(),
+			});
+
+			expect(notified).toBe(true);
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -262,6 +262,15 @@ describe('TaskGroupManager', () => {
 				payload_json TEXT,
 				created_at INTEGER NOT NULL
 			);
+			CREATE TABLE session_group_messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT,
+				role TEXT NOT NULL DEFAULT 'system',
+				message_type TEXT NOT NULL DEFAULT 'status',
+				content TEXT NOT NULL DEFAULT '',
+				created_at INTEGER NOT NULL
+			);
 			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('room-1', 'Test', ${Date.now()}, ${Date.now()});
 		`);
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-41_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-41_test.ts
@@ -1,0 +1,197 @@
+/**
+ * Migration 41 Tests
+ *
+ * Tests for Migration 41: Create session_group_messages table for LiveQuery streaming.
+ *
+ * The original session_group_messages table was dropped in migration 19.
+ * Migration 41 recreates it for existing (migrated) databases as an append-only
+ * store for the LiveQuery message streaming path (Milestone 4).
+ * Fresh databases already have the table from createTables().
+ *
+ * Covers:
+ * - Fresh DB (full migration chain + createTables): table and index exist
+ * - Table has the correct columns and defaults (verified via PRAGMA)
+ * - Existing DB that already has the table: migration is a no-op (idempotency)
+ * - Existing DB that does NOT have the table: migration creates it with correct schema
+ * - idx_sgm_group index is created
+ * - Running migrations twice does not error
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+function columnInfo(db: BunDatabase, table: string): Array<{ name: string; dflt_value: unknown }> {
+	return db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+		name: string;
+		dflt_value: unknown;
+	}>;
+}
+
+function indexExists(db: BunDatabase, indexName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+		.get(indexName);
+	return !!result;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 41: session_group_messages table', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-41', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Fresh DB — full migration chain followed by createTables (production flow)
+	// -------------------------------------------------------------------------
+
+	test('fresh DB: session_group_messages table exists after migrations + createTables', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		expect(tableExists(db, 'session_group_messages')).toBe(true);
+	});
+
+	test('fresh DB: table has all required columns', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		const cols = columnInfo(db, 'session_group_messages').map((c) => c.name);
+		expect(cols).toContain('id');
+		expect(cols).toContain('group_id');
+		expect(cols).toContain('session_id');
+		expect(cols).toContain('role');
+		expect(cols).toContain('message_type');
+		expect(cols).toContain('content');
+		expect(cols).toContain('created_at');
+	});
+
+	test('fresh DB: role defaults to "system" (verified via PRAGMA)', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		const cols = columnInfo(db, 'session_group_messages');
+		const roleCol = cols.find((c) => c.name === 'role');
+		expect(roleCol?.dflt_value).toBe("'system'");
+	});
+
+	test('fresh DB: message_type defaults to "status" (verified via PRAGMA)', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		const cols = columnInfo(db, 'session_group_messages');
+		const mtCol = cols.find((c) => c.name === 'message_type');
+		expect(mtCol?.dflt_value).toBe("'status'");
+	});
+
+	test('fresh DB: idx_sgm_group index exists', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		expect(indexExists(db, 'idx_sgm_group')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// Idempotency — table already present (fresh DB re-migration)
+	// -------------------------------------------------------------------------
+
+	test('idempotency: running migrations twice does not error', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+		expect(() => {
+			runMigrations(db, () => {});
+			createTables(db);
+		}).not.toThrow();
+		expect(tableExists(db, 'session_group_messages')).toBe(true);
+		expect(indexExists(db, 'idx_sgm_group')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// Existing DB missing the table (simulates pre-migration-41 state)
+	// -------------------------------------------------------------------------
+
+	test('creates table when it does not exist in an existing DB', () => {
+		// Bootstrap only session_groups (the table session_group_messages FK-references).
+		// We intentionally omit tasks/rooms so migration 16 skips its tasks path
+		// (it guards on tableExists('tasks')). Migration 41 only needs session_groups
+		// to exist at CREATE TABLE time; FK enforcement is deferred to inserts.
+		db.exec(`
+			CREATE TABLE session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+		`);
+
+		// Verify the table is absent before migration
+		expect(tableExists(db, 'session_group_messages')).toBe(false);
+
+		// Run the full migration chain — migration 41 should create the table
+		runMigrations(db, () => {});
+
+		expect(tableExists(db, 'session_group_messages')).toBe(true);
+		expect(indexExists(db, 'idx_sgm_group')).toBe(true);
+	});
+
+	test('existing DB: table schema is correct after migration 41 creates it', () => {
+		// Minimal pre-migration-41 schema (only session_groups needed for the FK)
+		db.exec(`
+			CREATE TABLE session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+		`);
+
+		runMigrations(db, () => {});
+
+		const cols = columnInfo(db, 'session_group_messages').map((c) => c.name);
+		expect(cols).toContain('id');
+		expect(cols).toContain('group_id');
+		expect(cols).toContain('session_id');
+		expect(cols).toContain('role');
+		expect(cols).toContain('message_type');
+		expect(cols).toContain('content');
+		expect(cols).toContain('created_at');
+	});
+});

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -2,24 +2,24 @@
  * Tests for TaskConversationRenderer Component
  *
  * Verifies that the component:
- * - Renders messages fetched from task.getGroupMessages
+ * - Renders messages provided by useGroupMessages
  * - Calls onMessageCountChange when the message list changes
- * - Reacts to real-time state.groupMessages.delta events
- * - Supports pagination with "Load older messages" button
+ * - Shows a loading state while useGroupMessages is loading
+ * - Renders status messages as centered dividers
  * - Does NOT own a scroll container (no overflow-y-auto div)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor, act, fireEvent } from '@testing-library/preact';
+import { render, cleanup, waitFor, act } from '@testing-library/preact';
 
 import { TaskConversationRenderer } from './TaskConversationRenderer';
+import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 // -------------------------------------------------------
 // Mocks
 // -------------------------------------------------------
 
 const mockRequest = vi.fn();
-let deltaHandler: ((event: { added: unknown[]; timestamp: number }) => void) | null = null;
 
 // state.session handlers keyed by the channel passed when the handler fires,
 // allowing tests to fire session-state events scoped to a specific session channel.
@@ -28,9 +28,7 @@ const sessionStateHandlers: SessionStateHandler[] = [];
 
 const mockOnEvent = vi.fn(
 	(eventName: string, handler: (data: unknown, context?: { channel?: string }) => void) => {
-		if (eventName === 'state.groupMessages.delta') {
-			deltaHandler = handler as (event: { added: unknown[]; timestamp: number }) => void;
-		} else if (eventName === 'state.session') {
+		if (eventName === 'state.session') {
 			sessionStateHandlers.push(handler as SessionStateHandler);
 		}
 		return () => {};
@@ -45,7 +43,16 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
+		isConnected: true,
 	}),
+}));
+
+// Mock useGroupMessages — tests control the returned messages/loading state
+let mockGroupMessages: SessionGroupMessage[] = [];
+let mockGroupIsLoading = false;
+
+vi.mock('../../hooks/useGroupMessages.ts', () => ({
+	useGroupMessages: () => ({ messages: mockGroupMessages, isLoading: mockGroupIsLoading }),
 }));
 
 // SDKMessageRenderer mock that captures rendered props for inspection
@@ -85,7 +92,7 @@ function fireSessionStateEvent(channel: string, data: unknown): void {
 // Helpers
 // -------------------------------------------------------
 
-function makeRawMessage(id: number, role: string, uuid: string) {
+function makeRawMessage(id: number, role: string, uuid: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
@@ -97,31 +104,15 @@ function makeRawMessage(id: number, role: string, uuid: string) {
 	};
 }
 
-function makeStatusMessage(id: number, text: string) {
+function makeStatusMessage(id: number, text: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
-		sessionId: null as string | null,
+		sessionId: null,
 		role: 'system',
 		messageType: 'status',
 		content: text,
 		createdAt: Date.now(),
-	};
-}
-
-// Default API response format
-type TestMessage = ReturnType<typeof makeRawMessage> | ReturnType<typeof makeStatusMessage>;
-
-function makeApiResponse(
-	messages: TestMessage[],
-	options?: { hasOlder?: boolean; oldestCursor?: string | null }
-) {
-	return {
-		messages,
-		hasMore: false,
-		nextCursor: messages.length > 0 ? 'cursor-end' : null,
-		hasOlder: options?.hasOlder ?? false,
-		oldestCursor: options?.oldestCursor ?? (messages.length > 0 ? 'cursor-start' : null),
 	};
 }
 
@@ -135,7 +126,8 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		deltaHandler = null;
+		mockGroupMessages = [];
+		mockGroupIsLoading = false;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
 	});
@@ -145,11 +137,10 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('calls onMessageCountChange with the initial message count', async () => {
-		const messages = [
+		mockGroupMessages = [
 			makeRawMessage(1, 'assistant', 'uuid-1'),
 			makeRawMessage(2, 'assistant', 'uuid-2'),
 		];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -159,9 +150,9 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 	});
 
-	it('calls onMessageCountChange with 0 during loading', () => {
-		// Request never resolves → still loading
-		mockRequest.mockImplementation(() => new Promise(() => {}));
+	it('calls onMessageCountChange with 0 while loading', () => {
+		mockGroupIsLoading = true;
+		mockGroupMessages = [];
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -169,22 +160,25 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		expect(onCountChange).toHaveBeenCalledWith(0);
 	});
 
-	it('calls onMessageCountChange with updated count on delta event', async () => {
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(initial));
+	it('calls onMessageCountChange with updated count when messages change', async () => {
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+		const { rerender } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
+		);
 
 		await waitFor(() => {
 			expect(onCountChange).toHaveBeenCalledWith(1);
 		});
 
-		// Simulate a delta event adding one more message
-		const newMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(newMsg.content);
+		// Simulate new message arriving via LiveQuery
+		mockGroupMessages = [
+			makeRawMessage(1, 'assistant', 'uuid-1'),
+			makeRawMessage(2, 'assistant', 'uuid-2'),
+		];
 		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+			rerender(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
 		});
 
 		await waitFor(() => {
@@ -193,8 +187,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('does NOT render a scroll container (no overflow-y-auto on root element)', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -212,8 +205,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('renders status messages as centered dividers', async () => {
-		const messages = [makeStatusMessage(1, 'Task started')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeStatusMessage(1, 'Task started')];
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -225,8 +217,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('works without onMessageCountChange prop', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		let container: Element | undefined;
 		expect(() => {
@@ -239,433 +230,26 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 	});
 
-	it('merges delta messages that arrive while the initial fetch is in-flight', async () => {
-		// The fetch is delayed via a Promise that we resolve manually.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
+	it('shows loading state while useGroupMessages is loading', () => {
+		mockGroupIsLoading = true;
+		mockGroupMessages = [];
 
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives BEFORE the fetch resolves — should be buffered
-		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Resolve the fetch now
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		// Both the fetched message AND the buffered delta should appear
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(2);
-		});
-	});
-
-	it('deduplicates delta messages already included in the fetch response', async () => {
-		// The delta fires with uuid-1, which is also returned by the fetch.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives with uuid-1 — same as the fetch result
-		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Fetch resolves with uuid-1 — the delta duplicate should be dropped
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		await waitFor(() => {
-			// Should be 1, not 2 — the duplicate is deduplicated
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-	});
-
-	it('deduplicates within-buffer duplicates (same delta fires twice before fetch)', async () => {
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Same delta fires twice before the fetch resolves — buffer should deduplicate
-		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() }); // duplicate
-		});
-
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		// 1 fetched + 1 unique buffered delta (duplicate dropped) = 2 total
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(2);
-		});
-		await act(async () => {}); // flush pending async effects
-		expect(onCountChange).not.toHaveBeenCalledWith(3);
-	});
-
-	it('deduplicates live post-fetch delta replays (same uuid arrives again after fetch)', async () => {
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(initial));
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Wait for initial fetch to complete
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Same message replayed via delta after fetch (e.g. WebSocket reconnect)
-		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-		await act(async () => {}); // flush pending async effects
-
-		// Count must remain 1 — replay is silently dropped
-		expect(onCountChange).not.toHaveBeenCalledWith(2);
-	});
-
-	it('deduplicates status messages by turnId when buffered and fetched', async () => {
-		// Status messages have no uuid — dedup uses _taskMeta.turnId instead.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const statusMsg = makeStatusMessage(1, 'Task started');
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta sends the already-parsed SDKMessage form of the same status message
-		const parsedStatus = {
-			type: 'status',
-			text: 'Task started',
-			_taskMeta: {
-				authorRole: 'system',
-				authorSessionId: '',
-				turnId: 'status-1',
-				iteration: 0,
-			},
-		};
-		act(() => {
-			deltaHandler?.({ added: [parsedStatus], timestamp: Date.now() });
-		});
-
-		// Fetch resolves with the same status message — should deduplicate via turnId
-		act(() => {
-			resolveFetch(makeApiResponse([statusMsg]));
-		});
-
-		// Should be 1, not 2 — turnId-based dedup prevents the status divider appearing twice
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-		await act(async () => {}); // flush pending async effects
-		expect(onCountChange).not.toHaveBeenCalledWith(2);
-	});
-
-	it('preserves buffered deltas when the initial fetch fails', async () => {
-		// Use a deferred reject so the delta is guaranteed to be buffered before the error fires.
-		let rejectFetch!: (err: Error) => void;
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<never>((_, reject) => {
-					rejectFetch = reject;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives while the doomed fetch is in-flight (deterministically buffered now)
-		const liveMsg = makeRawMessage(1, 'assistant', 'uuid-live');
-		const parsed = JSON.parse(liveMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Reject the fetch now — delta is already in the buffer, guaranteed
-		act(() => {
-			rejectFetch(new Error('network error'));
-		});
-
-		// After the rejection, buffered delta should surface
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-	});
-});
-
-describe('TaskConversationRenderer — pagination', () => {
-	beforeEach(() => {
-		mockRequest.mockReset();
-		mockOnEvent.mockClear();
-		mockJoinRoom.mockReset();
-		mockLeaveRoom.mockReset();
-		deltaHandler = null;
-		sessionStateHandlers.length = 0;
-		capturedSDKProps.length = 0;
-	});
-
-	afterEach(() => {
-		cleanup();
-	});
-
-	it('shows "Load older messages" button when hasOlder is true', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: true, oldestCursor: 'cursor-older' })
-		);
-
-		const { getByText } = render(
+		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
+		expect(container.textContent).toContain('Loading conversation');
 	});
 
-	it('does not show "Load older messages" button when hasOlder is false', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: false, oldestCursor: null })
-		);
+	it('shows empty state when not loading and no messages', () => {
+		mockGroupIsLoading = false;
+		mockGroupMessages = [];
 
-		const { queryByText } = render(
+		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
-		await waitFor(() => {
-			expect(queryByText('Load older messages')).toBeNull();
-		});
-	});
-
-	it('loads older messages when button is clicked', async () => {
-		const initialMessages = [makeRawMessage(3, 'assistant', 'uuid-3')];
-		const olderMessages = [
-			makeRawMessage(1, 'assistant', 'uuid-1'),
-			makeRawMessage(2, 'assistant', 'uuid-2'),
-		];
-
-		let callCount = 0;
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				callCount++;
-				if (params.before) {
-					// Second call - loading older
-					return makeApiResponse(olderMessages, { hasOlder: false, oldestCursor: 'cursor-oldest' });
-				}
-				// First call - initial load
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const onCountChange = vi.fn();
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should have called API twice (initial + load older)
-		await waitFor(() => {
-			expect(callCount).toBe(2);
-		});
-
-		// Should have 3 messages now (2 older + 1 initial)
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(3);
-		});
-	});
-
-	it('shows loading state while loading older messages', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let resolveOlder: () => void;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					// Delay the older messages response
-					return new Promise((resolve) => {
-						resolveOlder = () => resolve(makeApiResponse([], { hasOlder: false }));
-					});
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Button should show loading state
-		await waitFor(() => {
-			expect(getByText('Loading…')).toBeDefined();
-		});
-
-		// Resolve the older messages request
-		await act(async () => {
-			resolveOlder!();
-		});
-
-		// Button should return to normal state (hidden since no more older messages)
-		await waitFor(() => {
-			expect(queryByText('Loading…')).toBeNull();
-		});
-	});
-
-	it('shows error message when initial fetch fails with no buffered messages', async () => {
-		mockRequest.mockRejectedValue(new Error('Network error'));
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		// Should show retry button
-		expect(getByText('Retry')).toBeDefined();
-	});
-
-	it('retry button refetches messages instead of reloading page', async () => {
-		let fetchCount = 0;
-
-		mockRequest.mockImplementation(async (method: string) => {
-			if (method === 'task.getGroupMessages') {
-				fetchCount++;
-				if (fetchCount === 1) {
-					throw new Error('Network error');
-				}
-				// Second fetch succeeds
-				return makeApiResponse([makeRawMessage(1, 'assistant', 'uuid-1')]);
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial error
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		expect(fetchCount).toBe(1);
-
-		// Click retry button
-		await act(async () => {
-			fireEvent.click(getByText('Retry'));
-		});
-
-		// Should have made a second fetch request
-		await waitFor(() => {
-			expect(fetchCount).toBe(2);
-		});
-
-		// Error should be cleared and messages should render
-		await waitFor(() => {
-			expect(queryByText('Network error')).toBeNull();
-		});
-	});
-
-	it('shows error message when loading older messages fails', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let olderCallCount = 0;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					olderCallCount++;
-					throw new Error('Failed to load older');
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should show error message
-		await waitFor(() => {
-			expect(getByText('Failed to load older')).toBeDefined();
-		});
-
-		// Button should still be visible for retry
-		expect(getByText('Load older messages')).toBeDefined();
+		expect(container.textContent).toContain('Waiting for agent activity');
 	});
 });
 
@@ -675,7 +259,8 @@ describe('TaskConversationRenderer — session question state props', () => {
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		deltaHandler = null;
+		mockGroupMessages = [];
+		mockGroupIsLoading = false;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
 	});
@@ -685,8 +270,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('accepts leaderSessionId and workerSessionId props without errors', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		const { container } = render(
 			<TaskConversationRenderer
@@ -702,8 +286,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -714,8 +297,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 	});
 
 	it('joins session channels for leader and worker when both session IDs provided', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockGroupMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
 
 		render(
 			<TaskConversationRenderer
@@ -728,7 +310,6 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		await waitFor(() => {
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
-			expect(joinedRooms).toContain('group:group-1');
 			expect(joinedRooms).toContain('session:leader-session-123');
 			expect(joinedRooms).toContain('session:worker-session-456');
 		});
@@ -744,8 +325,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 			iteration: 0,
 		};
 		leaderMsg.content = JSON.stringify(parsed);
-
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
+		mockGroupMessages = [leaderMsg];
 
 		render(
 			<TaskConversationRenderer
@@ -786,7 +366,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		workerMsg.content = JSON.stringify(parsedWorker);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg, workerMsg]));
+		mockGroupMessages = [leaderMsg, workerMsg];
 
 		render(
 			<TaskConversationRenderer
@@ -840,8 +420,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 			iteration: 0,
 		};
 		unknownMsg.content = JSON.stringify(parsedUnknown);
-
-		mockRequest.mockImplementation(async () => makeApiResponse([unknownMsg]));
+		mockGroupMessages = [unknownMsg];
 
 		render(
 			<TaskConversationRenderer

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -173,12 +173,17 @@ export function TaskConversationRenderer({
 	}>({ leaderModel: null, workerModel: null });
 
 	useEffect(() => {
+		if (!leaderSessionId && !workerSessionId) return;
 		let cancelled = false;
 		const fetchSessionModels = async () => {
 			try {
 				const [leaderRes, workerRes] = await Promise.all([
-					request<{ session: SessionInfo }>('session.get', { sessionId: leaderSessionId }),
-					request<{ session: SessionInfo }>('session.get', { sessionId: workerSessionId }),
+					leaderSessionId
+						? request<{ session: SessionInfo }>('session.get', { sessionId: leaderSessionId })
+						: Promise.resolve({ session: null }),
+					workerSessionId
+						? request<{ session: SessionInfo }>('session.get', { sessionId: workerSessionId })
+						: Promise.resolve({ session: null }),
 				]);
 				if (!cancelled) {
 					setSessionModels({

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -20,7 +20,7 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
-import { useGroupMessages } from '../../hooks/useGroupMessages';
+import { useGroupMessages, type SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -34,16 +34,6 @@ interface TaskMeta {
 	authorSessionId: string;
 	turnId: string;
 	iteration: number;
-}
-
-interface GroupMessage {
-	id: number;
-	groupId: string;
-	sessionId: string | null;
-	role: string;
-	messageType: string;
-	content: string;
-	createdAt: number;
 }
 
 interface TaskConversationRendererProps {
@@ -67,7 +57,7 @@ const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: s
 	lead: { border: 'border-l-purple-500', label: 'Lead', labelColor: 'text-purple-400' },
 };
 
-function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
+function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 	// messageType is used for DB records; type is used for WebSocket real-time events.
 	// Normalize to whichever field is set.
 	const msgAny = msg as unknown as Record<string, unknown>;
@@ -101,11 +91,18 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Rate limited: rendered as an amber notification
+	// Rate limited: stored as JSON with rich payload (resetsAt, sessionRole).
+	// Fall back to content as plain text if not valid JSON.
 	if (msgType === 'rate_limited') {
+		let parsed: Record<string, unknown> = {};
+		try {
+			parsed = JSON.parse(msg.content) as Record<string, unknown>;
+		} catch {
+			parsed = { text: msg.content };
+		}
 		return {
+			...parsed,
 			type: 'rate_limited',
-			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',
@@ -115,11 +112,18 @@ function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
 		} as unknown as SDKMessage;
 	}
 
-	// Model fallback: rendered as an amber notification
+	// Model fallback: stored as JSON with rich payload (fromModel, toModel, sessionRole).
+	// Fall back to content as plain text if not valid JSON.
 	if (msgType === 'model_fallback') {
+		let parsed: Record<string, unknown> = {};
+		try {
+			parsed = JSON.parse(msg.content) as Record<string, unknown>;
+		} catch {
+			parsed = { text: msg.content };
+		}
 		return {
+			...parsed,
 			type: 'model_fallback',
-			text: msg.content,
 			_taskMeta: {
 				authorRole: 'system',
 				authorSessionId: '',

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -2,19 +2,13 @@
  * TaskConversationRenderer
  *
  * Renders a flat chronological conversation timeline for a task group.
- * Uses pagination to load messages efficiently:
- * - Initial load: fetches the newest N messages (default 50)
- * - "Load older" button at the top to load more history
- * - Real-time updates via state.groupMessages.delta events
+ * Subscribes to real-time message streaming via the useGroupMessages hook (LiveQuery).
  *
  * Each message is rendered inline with a thin colored left border indicating
  * which agent produced it. Role transitions show a small divider label.
- *
- * Subscribes to state.groupMessages.delta on channel group:{groupId} for
- * real-time updates.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
@@ -26,6 +20,7 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
+import { useGroupMessages } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -146,51 +141,26 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
-/**
- * Returns a stable deduplication key for a message.
- * Agent messages use their uuid; status messages use _taskMeta.turnId as a fallback.
- * Returns null for messages with no identifiable key (they pass through unfiltered).
- */
-function getMessageId(msg: SDKMessage): string | null {
-	const uuid = (msg as SDKMessage & { uuid?: string }).uuid;
-	if (uuid) return uuid;
-	return getTaskMeta(msg)?.turnId ?? null;
-}
-
-const PAGE_SIZE = 50;
-
 export function TaskConversationRenderer({
 	groupId,
 	leaderSessionId,
 	workerSessionId,
 	onMessageCountChange,
 }: TaskConversationRendererProps) {
-	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
+	const { request } = useMessageHub();
 
 	// Subscribe to question state for each agent session so AskUserQuestion
 	// renders as an interactive form rather than a plain message
 	const leaderQuestionState = useSessionQuestionState(leaderSessionId);
 	const workerQuestionState = useSessionQuestionState(workerSessionId);
-	const [messages, setMessages] = useState<SDKMessage[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [loadingOlder, setLoadingOlder] = useState(false);
-	const [hasOlder, setHasOlder] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	// Incremented to trigger a retry of the initial fetch
-	const [retryKey, setRetryKey] = useState(0);
-	// Track the oldest cursor for loading older messages
-	const oldestCursorRef = useRef<string | null>(null);
-	// Refs for useCallback guards (avoids recreating callback on state changes)
-	const loadingOlderRef = useRef(false);
-	const hasOlderRef = useRef(false);
-	// Tracks every message ID (uuid or turnId) added to state, enabling deduplication
-	// across: the initial fetch, buffered pre-fetch deltas, and live post-fetch deltas
-	// (e.g. replays on WebSocket reconnect).
-	const seenIdsRef = useRef<Set<string>>(new Set());
-	// Guards the fetch/delta race: deltas received while the fetch is in-flight are
-	// buffered here and merged (with dedup) once the fetch resolves.
-	const fetchingRef = useRef(true);
-	const pendingDeltasRef = useRef<SDKMessage[]>([]);
+
+	// Subscribe to group messages via LiveQuery (handles initial snapshot + live deltas)
+	const { messages: rawMessages, isLoading } = useGroupMessages(groupId);
+
+	const messages = useMemo(
+		() => rawMessages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null),
+		[rawMessages]
+	);
 
 	// Fetch session model info for leader and worker
 	const [sessionModels, setSessionModels] = useState<{
@@ -256,165 +226,6 @@ export function TaskConversationRenderer({
 		return { label: base.label, labelColor: base.labelColor };
 	}
 
-	useEffect(() => {
-		const channel = `group:${groupId}`;
-		joinRoom(channel);
-		seenIdsRef.current.clear();
-		fetchingRef.current = true;
-		pendingDeltasRef.current = [];
-		oldestCursorRef.current = null;
-		loadingOlderRef.current = false;
-		hasOlderRef.current = false;
-		setError(null);
-		let cancelled = false;
-
-		// Subscribe first so no live messages can slip through before the fetch starts.
-		const unsub = onEvent<{ added: SDKMessage[]; timestamp: number }>(
-			'state.groupMessages.delta',
-			(event) => {
-				if (event.added && event.added.length > 0) {
-					if (fetchingRef.current) {
-						// Buffer deltas that arrive while the initial fetch is in-flight.
-						pendingDeltasRef.current = [...pendingDeltasRef.current, ...event.added];
-					} else {
-						// Deduplicate against seenIds — handles replays on reconnect and
-						// the same event firing twice within the buffer.
-						const newMessages = event.added.filter((m) => {
-							const id = getMessageId(m);
-							if (id && seenIdsRef.current.has(id)) return false;
-							if (id) seenIdsRef.current.add(id);
-							return true;
-						});
-						if (newMessages.length > 0) {
-							setMessages((prev) => [...prev, ...newMessages]);
-						}
-					}
-				}
-			}
-		);
-
-		const fetchInitialMessages = async () => {
-			try {
-				const res: {
-					messages: GroupMessage[];
-					hasMore: boolean;
-					nextCursor: string | null;
-					hasOlder: boolean;
-					oldestCursor: string | null;
-				} = await request('task.getGroupMessages', {
-					groupId,
-					limit: PAGE_SIZE,
-				});
-
-				if (!cancelled) {
-					// Merge fetched messages with buffered deltas.
-					const parsed = res.messages
-						.map(parseGroupMessage)
-						.filter((m): m is SDKMessage => m !== null);
-
-					const uniqueParsed = parsed.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-
-					// Merge buffered deltas, deduplicating against seenIds.
-					const newDeltas = pendingDeltasRef.current.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-
-					if (uniqueParsed.length > 0 || newDeltas.length > 0) {
-						setMessages([...uniqueParsed, ...newDeltas]);
-					}
-					setHasOlder(res.hasOlder);
-					hasOlderRef.current = res.hasOlder;
-					oldestCursorRef.current = res.oldestCursor;
-					fetchingRef.current = false;
-					pendingDeltasRef.current = [];
-					setLoading(false);
-				}
-			} catch (err) {
-				if (!cancelled) {
-					// On fetch failure, still surface any buffered deltas
-					const newDeltas = pendingDeltasRef.current.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-					if (newDeltas.length > 0) {
-						setMessages([...newDeltas]);
-					}
-					fetchingRef.current = false;
-					pendingDeltasRef.current = [];
-					setLoading(false);
-					setError(err instanceof Error ? err.message : 'Failed to load messages');
-				}
-			}
-		};
-
-		fetchInitialMessages();
-
-		return () => {
-			cancelled = true;
-			unsub();
-			leaveRoom(channel);
-		};
-	}, [groupId, retryKey, joinRoom, leaveRoom, onEvent, request]);
-
-	const retryInitialFetch = useCallback(() => {
-		setRetryKey((k) => k + 1);
-	}, []);
-
-	const loadOlderMessages = useCallback(async () => {
-		// Use refs for guards to avoid recreating callback on state changes
-		if (loadingOlderRef.current || !hasOlderRef.current || !oldestCursorRef.current) return;
-
-		loadingOlderRef.current = true;
-		setLoadingOlder(true);
-		setError(null); // Clear previous errors on retry
-		try {
-			const res: {
-				messages: GroupMessage[];
-				hasMore: boolean;
-				nextCursor: string | null;
-				hasOlder: boolean;
-				oldestCursor: string | null;
-			} = await request('task.getGroupMessages', {
-				groupId,
-				before: oldestCursorRef.current,
-				limit: PAGE_SIZE,
-			});
-
-			const parsed = res.messages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null);
-
-			// Deduplicate and prepend to existing messages
-			const uniqueParsed = parsed.filter((m) => {
-				const id = getMessageId(m);
-				if (id && seenIdsRef.current.has(id)) return false;
-				if (id) seenIdsRef.current.add(id);
-				return true;
-			});
-
-			if (uniqueParsed.length > 0) {
-				setMessages((prev) => [...uniqueParsed, ...prev]);
-			}
-			setHasOlder(res.hasOlder);
-			hasOlderRef.current = res.hasOlder;
-			oldestCursorRef.current = res.oldestCursor;
-		} catch (err) {
-			// Show error feedback to user
-			setError(err instanceof Error ? err.message : 'Failed to load older messages');
-		} finally {
-			loadingOlderRef.current = false;
-			setLoadingOlder(false);
-		}
-	}, [groupId, request]);
-
 	// Notify parent when message count changes so it can drive autoscroll
 	useEffect(() => {
 		onMessageCountChange?.(messages.length);
@@ -437,24 +248,10 @@ export function TaskConversationRenderer({
 		return transitions;
 	}, [messages]);
 
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div class="flex-1 flex items-center justify-center">
 				<p class="text-gray-400 text-sm">Loading conversation…</p>
-			</div>
-		);
-	}
-
-	if (messages.length === 0 && error) {
-		return (
-			<div class="flex-1 flex flex-col items-center justify-center gap-2">
-				<p class="text-red-400 text-sm">{error}</p>
-				<button
-					class="text-xs text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-					onClick={retryInitialFetch}
-				>
-					Retry
-				</button>
 			</div>
 		);
 	}
@@ -469,19 +266,6 @@ export function TaskConversationRenderer({
 
 	return (
 		<div class="px-4 py-3 space-y-0.5">
-			{/* Load older messages button */}
-			{hasOlder && (
-				<div class="flex flex-col items-center gap-2 py-2">
-					{error && <p class="text-xs text-red-400">{error}</p>}
-					<button
-						class="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-						onClick={loadOlderMessages}
-						disabled={loadingOlder}
-					>
-						{loadingOlder ? 'Loading…' : 'Load older messages'}
-					</button>
-				</div>
-			)}
 			{messages.map((msg, i) => {
 				const meta = getTaskMeta(msg);
 				const role = meta?.authorRole ?? 'system';


### PR DESCRIPTION
Removes the old state.groupMessages.delta event listener and associated
fetch/buffering/dedup/pagination logic from TaskConversationRenderer.
Replaces with useGroupMessages (LiveQuery) which delivers an initial
snapshot plus append-only deltas automatically.

Updates the test file to mock useGroupMessages directly, removing tests
for implementation details (buffering, dedup) that are now covered by
the useGroupMessages hook's own test suite.
