### PR TITLE
feat: replace state.groupMessages.delta listener with useGroupMessages LiveQuery hook

### DIFF
--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -2,24 +2,29 @@
  * Tests for TaskConversationRenderer Component
  *
  * Verifies that the component:
- * - Renders messages fetched from task.getGroupMessages
+ * - Renders messages delivered via useGroupMessages (LiveQuery)
  * - Calls onMessageCountChange when the message list changes
- * - Reacts to real-time state.groupMessages.delta events
- * - Supports pagination with "Load older messages" button
+ * - Reacts to real-time liveQuery.delta events (via useGroupMessages)
  * - Does NOT own a scroll container (no overflow-y-auto div)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, waitFor, act, fireEvent } from '@testing-library/preact';
+import { render, cleanup, waitFor, act } from '@testing-library/preact';
 
 import { TaskConversationRenderer } from './TaskConversationRenderer';
+import { useGroupMessages } from '../../hooks/useGroupMessages';
+import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 // -------------------------------------------------------
 // Mocks
 // -------------------------------------------------------
 
+// Mock useGroupMessages so tests control what messages and loading state the component sees.
+vi.mock('../../hooks/useGroupMessages.ts', () => ({
+	useGroupMessages: vi.fn().mockReturnValue({ messages: [], isLoading: true }),
+}));
+
 const mockRequest = vi.fn();
-let deltaHandler: ((event: { added: unknown[]; timestamp: number }) => void) | null = null;
 
 // state.session handlers keyed by the channel passed when the handler fires,
 // allowing tests to fire session-state events scoped to a specific session channel.
@@ -28,9 +33,7 @@ const sessionStateHandlers: SessionStateHandler[] = [];
 
 const mockOnEvent = vi.fn(
 	(eventName: string, handler: (data: unknown, context?: { channel?: string }) => void) => {
-		if (eventName === 'state.groupMessages.delta') {
-			deltaHandler = handler as (event: { added: unknown[]; timestamp: number }) => void;
-		} else if (eventName === 'state.session') {
+		if (eventName === 'state.session') {
 			sessionStateHandlers.push(handler as SessionStateHandler);
 		}
 		return () => {};
@@ -45,6 +48,7 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
+		isConnected: true,
 	}),
 }));
 
@@ -74,6 +78,9 @@ vi.mock('../sdk/SDKMessageRenderer.tsx', () => ({
 	},
 }));
 
+/** Typed reference to the mocked useGroupMessages. */
+const mockUseGroupMessages = vi.mocked(useGroupMessages);
+
 /** Fire a state.session event on the given channel to all registered handlers */
 function fireSessionStateEvent(channel: string, data: unknown): void {
 	for (const handler of sessionStateHandlers) {
@@ -85,7 +92,7 @@ function fireSessionStateEvent(channel: string, data: unknown): void {
 // Helpers
 // -------------------------------------------------------
 
-function makeRawMessage(id: number, role: string, uuid: string) {
+function makeRawMessage(id: number, role: string, uuid: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
@@ -97,7 +104,7 @@ function makeRawMessage(id: number, role: string, uuid: string) {
 	};
 }
 
-function makeStatusMessage(id: number, text: string) {
+function makeStatusMessage(id: number, text: string): SessionGroupMessage {
 	return {
 		id,
 		groupId: 'group-1',
@@ -109,22 +116,6 @@ function makeStatusMessage(id: number, text: string) {
 	};
 }
 
-// Default API response format
-type TestMessage = ReturnType<typeof makeRawMessage> | ReturnType<typeof makeStatusMessage>;
-
-function makeApiResponse(
-	messages: TestMessage[],
-	options?: { hasOlder?: boolean; oldestCursor?: string | null }
-) {
-	return {
-		messages,
-		hasMore: false,
-		nextCursor: messages.length > 0 ? 'cursor-end' : null,
-		hasOlder: options?.hasOlder ?? false,
-		oldestCursor: options?.oldestCursor ?? (messages.length > 0 ? 'cursor-start' : null),
-	};
-}
-
 // -------------------------------------------------------
 // Tests
 // -------------------------------------------------------
@@ -132,12 +123,14 @@ function makeApiResponse(
 describe('TaskConversationRenderer — onMessageCountChange', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
+		mockRequest.mockResolvedValue({ session: { config: { model: null } } });
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		deltaHandler = null;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
+		// Default: loading state
+		mockUseGroupMessages.mockReturnValue({ messages: [], isLoading: true });
 	});
 
 	afterEach(() => {
@@ -149,7 +142,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 			makeRawMessage(1, 'assistant', 'uuid-1'),
 			makeRawMessage(2, 'assistant', 'uuid-2'),
 		];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -160,8 +153,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 	});
 
 	it('calls onMessageCountChange with 0 during loading', () => {
-		// Request never resolves → still loading
-		mockRequest.mockImplementation(() => new Promise(() => {}));
+		mockUseGroupMessages.mockReturnValue({ messages: [], isLoading: true });
 
 		const onCountChange = vi.fn();
 		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
@@ -169,22 +161,24 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		expect(onCountChange).toHaveBeenCalledWith(0);
 	});
 
-	it('calls onMessageCountChange with updated count on delta event', async () => {
+	it('calls onMessageCountChange with updated count when new messages arrive', async () => {
 		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(initial));
+		mockUseGroupMessages.mockReturnValue({ messages: initial, isLoading: false });
 
 		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
+		const { rerender } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
+		);
 
 		await waitFor(() => {
 			expect(onCountChange).toHaveBeenCalledWith(1);
 		});
 
-		// Simulate a delta event adding one more message
-		const newMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(newMsg.content);
+		// Simulate delta: useGroupMessages delivers one more message
+		const updated = [...initial, makeRawMessage(2, 'assistant', 'uuid-2')];
+		mockUseGroupMessages.mockReturnValue({ messages: updated, isLoading: false });
 		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
+			rerender(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
 		});
 
 		await waitFor(() => {
@@ -194,7 +188,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 
 	it('does NOT render a scroll container (no overflow-y-auto on root element)', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -213,7 +207,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 
 	it('renders status messages as centered dividers', async () => {
 		const messages = [makeStatusMessage(1, 'Task started')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -226,7 +220,7 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 
 	it('works without onMessageCountChange prop', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		let container: Element | undefined;
 		expect(() => {
@@ -239,445 +233,39 @@ describe('TaskConversationRenderer — onMessageCountChange', () => {
 		});
 	});
 
-	it('merges delta messages that arrive while the initial fetch is in-flight', async () => {
-		// The fetch is delayed via a Promise that we resolve manually.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
+	it('shows loading state while useGroupMessages is loading', () => {
+		mockUseGroupMessages.mockReturnValue({ messages: [], isLoading: true });
+
+		const { container } = render(
+			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives BEFORE the fetch resolves — should be buffered
-		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Resolve the fetch now
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		// Both the fetched message AND the buffered delta should appear
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(2);
-		});
+		expect(container.textContent).toContain('Loading conversation');
 	});
 
-	it('deduplicates delta messages already included in the fetch response', async () => {
-		// The delta fires with uuid-1, which is also returned by the fetch.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
+	it('shows waiting state when no messages and not loading', async () => {
+		mockUseGroupMessages.mockReturnValue({ messages: [], isLoading: false });
 
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives with uuid-1 — same as the fetch result
-		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Fetch resolves with uuid-1 — the delta duplicate should be dropped
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		await waitFor(() => {
-			// Should be 1, not 2 — the duplicate is deduplicated
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-	});
-
-	it('deduplicates within-buffer duplicates (same delta fires twice before fetch)', async () => {
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Same delta fires twice before the fetch resolves — buffer should deduplicate
-		const deltaMsg = makeRawMessage(2, 'assistant', 'uuid-2');
-		const parsed = JSON.parse(deltaMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() }); // duplicate
-		});
-
-		act(() => {
-			resolveFetch(makeApiResponse(initial));
-		});
-
-		// 1 fetched + 1 unique buffered delta (duplicate dropped) = 2 total
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(2);
-		});
-		await act(async () => {}); // flush pending async effects
-		expect(onCountChange).not.toHaveBeenCalledWith(3);
-	});
-
-	it('deduplicates live post-fetch delta replays (same uuid arrives again after fetch)', async () => {
-		const initial = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(initial));
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Wait for initial fetch to complete
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Same message replayed via delta after fetch (e.g. WebSocket reconnect)
-		const parsed = JSON.parse(initial[0].content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-		await act(async () => {}); // flush pending async effects
-
-		// Count must remain 1 — replay is silently dropped
-		expect(onCountChange).not.toHaveBeenCalledWith(2);
-	});
-
-	it('deduplicates status messages by turnId when buffered and fetched', async () => {
-		// Status messages have no uuid — dedup uses _taskMeta.turnId instead.
-		let resolveFetch!: (value: ReturnType<typeof makeApiResponse>) => void;
-		const statusMsg = makeStatusMessage(1, 'Task started');
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<ReturnType<typeof makeApiResponse>>((resolve) => {
-					resolveFetch = resolve;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta sends the already-parsed SDKMessage form of the same status message
-		const parsedStatus = {
-			type: 'status',
-			text: 'Task started',
-			_taskMeta: {
-				authorRole: 'system',
-				authorSessionId: '',
-				turnId: 'status-1',
-				iteration: 0,
-			},
-		};
-		act(() => {
-			deltaHandler?.({ added: [parsedStatus], timestamp: Date.now() });
-		});
-
-		// Fetch resolves with the same status message — should deduplicate via turnId
-		act(() => {
-			resolveFetch(makeApiResponse([statusMsg]));
-		});
-
-		// Should be 1, not 2 — turnId-based dedup prevents the status divider appearing twice
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-		await act(async () => {}); // flush pending async effects
-		expect(onCountChange).not.toHaveBeenCalledWith(2);
-	});
-
-	it('preserves buffered deltas when the initial fetch fails', async () => {
-		// Use a deferred reject so the delta is guaranteed to be buffered before the error fires.
-		let rejectFetch!: (err: Error) => void;
-		mockRequest.mockImplementation(
-			() =>
-				new Promise<never>((_, reject) => {
-					rejectFetch = reject;
-				})
-		);
-
-		const onCountChange = vi.fn();
-		render(<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />);
-
-		// Delta arrives while the doomed fetch is in-flight (deterministically buffered now)
-		const liveMsg = makeRawMessage(1, 'assistant', 'uuid-live');
-		const parsed = JSON.parse(liveMsg.content) as { uuid?: string };
-		act(() => {
-			deltaHandler?.({ added: [parsed], timestamp: Date.now() });
-		});
-
-		// Reject the fetch now — delta is already in the buffer, guaranteed
-		act(() => {
-			rejectFetch(new Error('network error'));
-		});
-
-		// After the rejection, buffered delta should surface
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-	});
-});
-
-describe('TaskConversationRenderer — pagination', () => {
-	beforeEach(() => {
-		mockRequest.mockReset();
-		mockOnEvent.mockClear();
-		mockJoinRoom.mockReset();
-		mockLeaveRoom.mockReset();
-		deltaHandler = null;
-		sessionStateHandlers.length = 0;
-		capturedSDKProps.length = 0;
-	});
-
-	afterEach(() => {
-		cleanup();
-	});
-
-	it('shows "Load older messages" button when hasOlder is true', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: true, oldestCursor: 'cursor-older' })
-		);
-
-		const { getByText } = render(
+		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
 		);
 
 		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
+			expect(container.textContent).toContain('Waiting for agent activity');
 		});
-	});
-
-	it('does not show "Load older messages" button when hasOlder is false', async () => {
-		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () =>
-			makeApiResponse(messages, { hasOlder: false, oldestCursor: null })
-		);
-
-		const { queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		await waitFor(() => {
-			expect(queryByText('Load older messages')).toBeNull();
-		});
-	});
-
-	it('loads older messages when button is clicked', async () => {
-		const initialMessages = [makeRawMessage(3, 'assistant', 'uuid-3')];
-		const olderMessages = [
-			makeRawMessage(1, 'assistant', 'uuid-1'),
-			makeRawMessage(2, 'assistant', 'uuid-2'),
-		];
-
-		let callCount = 0;
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				callCount++;
-				if (params.before) {
-					// Second call - loading older
-					return makeApiResponse(olderMessages, { hasOlder: false, oldestCursor: 'cursor-oldest' });
-				}
-				// First call - initial load
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const onCountChange = vi.fn();
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={onCountChange} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(1);
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should have called API twice (initial + load older)
-		await waitFor(() => {
-			expect(callCount).toBe(2);
-		});
-
-		// Should have 3 messages now (2 older + 1 initial)
-		await waitFor(() => {
-			expect(onCountChange).toHaveBeenCalledWith(3);
-		});
-	});
-
-	it('shows loading state while loading older messages', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let resolveOlder: () => void;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					// Delay the older messages response
-					return new Promise((resolve) => {
-						resolveOlder = () => resolve(makeApiResponse([], { hasOlder: false }));
-					});
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Button should show loading state
-		await waitFor(() => {
-			expect(getByText('Loading…')).toBeDefined();
-		});
-
-		// Resolve the older messages request
-		await act(async () => {
-			resolveOlder!();
-		});
-
-		// Button should return to normal state (hidden since no more older messages)
-		await waitFor(() => {
-			expect(queryByText('Loading…')).toBeNull();
-		});
-	});
-
-	it('shows error message when initial fetch fails with no buffered messages', async () => {
-		mockRequest.mockRejectedValue(new Error('Network error'));
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		// Should show retry button
-		expect(getByText('Retry')).toBeDefined();
-	});
-
-	it('retry button refetches messages instead of reloading page', async () => {
-		let fetchCount = 0;
-
-		mockRequest.mockImplementation(async (method: string) => {
-			if (method === 'task.getGroupMessages') {
-				fetchCount++;
-				if (fetchCount === 1) {
-					throw new Error('Network error');
-				}
-				// Second fetch succeeds
-				return makeApiResponse([makeRawMessage(1, 'assistant', 'uuid-1')]);
-			}
-			return {};
-		});
-
-		const { getByText, queryByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial error
-		await waitFor(() => {
-			expect(getByText('Network error')).toBeDefined();
-		});
-
-		expect(fetchCount).toBe(1);
-
-		// Click retry button
-		await act(async () => {
-			fireEvent.click(getByText('Retry'));
-		});
-
-		// Should have made a second fetch request
-		await waitFor(() => {
-			expect(fetchCount).toBe(2);
-		});
-
-		// Error should be cleared and messages should render
-		await waitFor(() => {
-			expect(queryByText('Network error')).toBeNull();
-		});
-	});
-
-	it('shows error message when loading older messages fails', async () => {
-		const initialMessages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		let olderCallCount = 0;
-
-		mockRequest.mockImplementation(async (method: string, params: { before?: string }) => {
-			if (method === 'task.getGroupMessages') {
-				if (params.before) {
-					olderCallCount++;
-					throw new Error('Failed to load older');
-				}
-				return makeApiResponse(initialMessages, { hasOlder: true, oldestCursor: 'cursor-older' });
-			}
-			return {};
-		});
-
-		const { getByText } = render(
-			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
-		);
-
-		// Wait for initial load
-		await waitFor(() => {
-			expect(getByText('Load older messages')).toBeDefined();
-		});
-
-		// Click "Load older messages"
-		await act(async () => {
-			fireEvent.click(getByText('Load older messages'));
-		});
-
-		// Should show error message
-		await waitFor(() => {
-			expect(getByText('Failed to load older')).toBeDefined();
-		});
-
-		// Button should still be visible for retry
-		expect(getByText('Load older messages')).toBeDefined();
 	});
 });
 
 describe('TaskConversationRenderer — session question state props', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
+		mockRequest.mockResolvedValue({ session: { config: { model: null } } });
 		mockOnEvent.mockClear();
 		mockJoinRoom.mockReset();
 		mockLeaveRoom.mockReset();
-		deltaHandler = null;
 		sessionStateHandlers.length = 0;
 		capturedSDKProps.length = 0;
+		mockUseGroupMessages.mockReturnValue({ messages: [], isLoading: false });
 	});
 
 	afterEach(() => {
@@ -686,7 +274,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 	it('accepts leaderSessionId and workerSessionId props without errors', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		const { container } = render(
 			<TaskConversationRenderer
@@ -703,7 +291,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 	it('renders without leaderSessionId or workerSessionId (backward-compatible)', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		const { container } = render(
 			<TaskConversationRenderer groupId="group-1" onMessageCountChange={vi.fn()} />
@@ -715,7 +303,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 	it('joins session channels for leader and worker when both session IDs provided', async () => {
 		const messages = [makeRawMessage(1, 'assistant', 'uuid-1')];
-		mockRequest.mockImplementation(async () => makeApiResponse(messages));
+		mockUseGroupMessages.mockReturnValue({ messages, isLoading: false });
 
 		render(
 			<TaskConversationRenderer
@@ -728,7 +316,6 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		await waitFor(() => {
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
-			expect(joinedRooms).toContain('group:group-1');
 			expect(joinedRooms).toContain('session:leader-session-123');
 			expect(joinedRooms).toContain('session:worker-session-456');
 		});
@@ -745,7 +332,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		leaderMsg.content = JSON.stringify(parsed);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg]));
+		mockUseGroupMessages.mockReturnValue({ messages: [leaderMsg], isLoading: false });
 
 		render(
 			<TaskConversationRenderer
@@ -786,7 +373,10 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		workerMsg.content = JSON.stringify(parsedWorker);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([leaderMsg, workerMsg]));
+		mockUseGroupMessages.mockReturnValue({
+			messages: [leaderMsg, workerMsg],
+			isLoading: false,
+		});
 
 		render(
 			<TaskConversationRenderer
@@ -841,7 +431,7 @@ describe('TaskConversationRenderer — session question state props', () => {
 		};
 		unknownMsg.content = JSON.stringify(parsedUnknown);
 
-		mockRequest.mockImplementation(async () => makeApiResponse([unknownMsg]));
+		mockUseGroupMessages.mockReturnValue({ messages: [unknownMsg], isLoading: false });
 
 		render(
 			<TaskConversationRenderer

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -2,19 +2,13 @@
  * TaskConversationRenderer
  *
  * Renders a flat chronological conversation timeline for a task group.
- * Uses pagination to load messages efficiently:
- * - Initial load: fetches the newest N messages (default 50)
- * - "Load older" button at the top to load more history
- * - Real-time updates via state.groupMessages.delta events
+ * Messages are streamed via LiveQuery (liveQuery.subscribe) for real-time updates.
  *
  * Each message is rendered inline with a thin colored left border indicating
  * which agent produced it. Role transitions show a small divider label.
- *
- * Subscribes to state.groupMessages.delta on channel group:{groupId} for
- * real-time updates.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { SessionInfo } from '@neokai/shared';
 import { useMessageHub } from '../../hooks/useMessageHub';
@@ -26,6 +20,7 @@ import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import MarkdownRenderer from '../chat/MarkdownRenderer';
 import { getModelLabel } from '../../lib/session-utils';
+import { useGroupMessages, type SessionGroupMessage } from '../../hooks/useGroupMessages';
 
 /** Empty question state used as a safe fallback for messages with unknown session IDs */
 const NO_OP_QUESTION_STATE: SessionQuestionState = {
@@ -39,16 +34,6 @@ interface TaskMeta {
 	authorSessionId: string;
 	turnId: string;
 	iteration: number;
-}
-
-interface GroupMessage {
-	id: number;
-	groupId: string;
-	sessionId: string | null;
-	role: string;
-	messageType: string;
-	content: string;
-	createdAt: number;
 }
 
 interface TaskConversationRendererProps {
@@ -72,7 +57,7 @@ const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: s
 	lead: { border: 'border-l-purple-500', label: 'Lead', labelColor: 'text-purple-400' },
 };
 
-function parseGroupMessage(msg: GroupMessage): SDKMessage | null {
+function parseGroupMessage(msg: SessionGroupMessage): SDKMessage | null {
 	// messageType is used for DB records; type is used for WebSocket real-time events.
 	// Normalize to whichever field is set.
 	const msgAny = msg as unknown as Record<string, unknown>;
@@ -146,51 +131,25 @@ function getTaskMeta(msg: SDKMessage): TaskMeta | null {
 	return meta ?? null;
 }
 
-/**
- * Returns a stable deduplication key for a message.
- * Agent messages use their uuid; status messages use _taskMeta.turnId as a fallback.
- * Returns null for messages with no identifiable key (they pass through unfiltered).
- */
-function getMessageId(msg: SDKMessage): string | null {
-	const uuid = (msg as SDKMessage & { uuid?: string }).uuid;
-	if (uuid) return uuid;
-	return getTaskMeta(msg)?.turnId ?? null;
-}
-
-const PAGE_SIZE = 50;
-
 export function TaskConversationRenderer({
 	groupId,
 	leaderSessionId,
 	workerSessionId,
 	onMessageCountChange,
 }: TaskConversationRendererProps) {
-	const { request, joinRoom, leaveRoom, onEvent } = useMessageHub();
+	const { request } = useMessageHub();
 
 	// Subscribe to question state for each agent session so AskUserQuestion
 	// renders as an interactive form rather than a plain message
 	const leaderQuestionState = useSessionQuestionState(leaderSessionId);
 	const workerQuestionState = useSessionQuestionState(workerSessionId);
-	const [messages, setMessages] = useState<SDKMessage[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [loadingOlder, setLoadingOlder] = useState(false);
-	const [hasOlder, setHasOlder] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	// Incremented to trigger a retry of the initial fetch
-	const [retryKey, setRetryKey] = useState(0);
-	// Track the oldest cursor for loading older messages
-	const oldestCursorRef = useRef<string | null>(null);
-	// Refs for useCallback guards (avoids recreating callback on state changes)
-	const loadingOlderRef = useRef(false);
-	const hasOlderRef = useRef(false);
-	// Tracks every message ID (uuid or turnId) added to state, enabling deduplication
-	// across: the initial fetch, buffered pre-fetch deltas, and live post-fetch deltas
-	// (e.g. replays on WebSocket reconnect).
-	const seenIdsRef = useRef<Set<string>>(new Set());
-	// Guards the fetch/delta race: deltas received while the fetch is in-flight are
-	// buffered here and merged (with dedup) once the fetch resolves.
-	const fetchingRef = useRef(true);
-	const pendingDeltasRef = useRef<SDKMessage[]>([]);
+
+	const { messages: rawMessages, isLoading } = useGroupMessages(groupId);
+
+	const messages = useMemo(
+		() => rawMessages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null),
+		[rawMessages]
+	);
 
 	// Fetch session model info for leader and worker
 	const [sessionModels, setSessionModels] = useState<{
@@ -256,165 +215,6 @@ export function TaskConversationRenderer({
 		return { label: base.label, labelColor: base.labelColor };
 	}
 
-	useEffect(() => {
-		const channel = `group:${groupId}`;
-		joinRoom(channel);
-		seenIdsRef.current.clear();
-		fetchingRef.current = true;
-		pendingDeltasRef.current = [];
-		oldestCursorRef.current = null;
-		loadingOlderRef.current = false;
-		hasOlderRef.current = false;
-		setError(null);
-		let cancelled = false;
-
-		// Subscribe first so no live messages can slip through before the fetch starts.
-		const unsub = onEvent<{ added: SDKMessage[]; timestamp: number }>(
-			'state.groupMessages.delta',
-			(event) => {
-				if (event.added && event.added.length > 0) {
-					if (fetchingRef.current) {
-						// Buffer deltas that arrive while the initial fetch is in-flight.
-						pendingDeltasRef.current = [...pendingDeltasRef.current, ...event.added];
-					} else {
-						// Deduplicate against seenIds — handles replays on reconnect and
-						// the same event firing twice within the buffer.
-						const newMessages = event.added.filter((m) => {
-							const id = getMessageId(m);
-							if (id && seenIdsRef.current.has(id)) return false;
-							if (id) seenIdsRef.current.add(id);
-							return true;
-						});
-						if (newMessages.length > 0) {
-							setMessages((prev) => [...prev, ...newMessages]);
-						}
-					}
-				}
-			}
-		);
-
-		const fetchInitialMessages = async () => {
-			try {
-				const res: {
-					messages: GroupMessage[];
-					hasMore: boolean;
-					nextCursor: string | null;
-					hasOlder: boolean;
-					oldestCursor: string | null;
-				} = await request('task.getGroupMessages', {
-					groupId,
-					limit: PAGE_SIZE,
-				});
-
-				if (!cancelled) {
-					// Merge fetched messages with buffered deltas.
-					const parsed = res.messages
-						.map(parseGroupMessage)
-						.filter((m): m is SDKMessage => m !== null);
-
-					const uniqueParsed = parsed.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-
-					// Merge buffered deltas, deduplicating against seenIds.
-					const newDeltas = pendingDeltasRef.current.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-
-					if (uniqueParsed.length > 0 || newDeltas.length > 0) {
-						setMessages([...uniqueParsed, ...newDeltas]);
-					}
-					setHasOlder(res.hasOlder);
-					hasOlderRef.current = res.hasOlder;
-					oldestCursorRef.current = res.oldestCursor;
-					fetchingRef.current = false;
-					pendingDeltasRef.current = [];
-					setLoading(false);
-				}
-			} catch (err) {
-				if (!cancelled) {
-					// On fetch failure, still surface any buffered deltas
-					const newDeltas = pendingDeltasRef.current.filter((m) => {
-						const id = getMessageId(m);
-						if (id && seenIdsRef.current.has(id)) return false;
-						if (id) seenIdsRef.current.add(id);
-						return true;
-					});
-					if (newDeltas.length > 0) {
-						setMessages([...newDeltas]);
-					}
-					fetchingRef.current = false;
-					pendingDeltasRef.current = [];
-					setLoading(false);
-					setError(err instanceof Error ? err.message : 'Failed to load messages');
-				}
-			}
-		};
-
-		fetchInitialMessages();
-
-		return () => {
-			cancelled = true;
-			unsub();
-			leaveRoom(channel);
-		};
-	}, [groupId, retryKey, joinRoom, leaveRoom, onEvent, request]);
-
-	const retryInitialFetch = useCallback(() => {
-		setRetryKey((k) => k + 1);
-	}, []);
-
-	const loadOlderMessages = useCallback(async () => {
-		// Use refs for guards to avoid recreating callback on state changes
-		if (loadingOlderRef.current || !hasOlderRef.current || !oldestCursorRef.current) return;
-
-		loadingOlderRef.current = true;
-		setLoadingOlder(true);
-		setError(null); // Clear previous errors on retry
-		try {
-			const res: {
-				messages: GroupMessage[];
-				hasMore: boolean;
-				nextCursor: string | null;
-				hasOlder: boolean;
-				oldestCursor: string | null;
-			} = await request('task.getGroupMessages', {
-				groupId,
-				before: oldestCursorRef.current,
-				limit: PAGE_SIZE,
-			});
-
-			const parsed = res.messages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null);
-
-			// Deduplicate and prepend to existing messages
-			const uniqueParsed = parsed.filter((m) => {
-				const id = getMessageId(m);
-				if (id && seenIdsRef.current.has(id)) return false;
-				if (id) seenIdsRef.current.add(id);
-				return true;
-			});
-
-			if (uniqueParsed.length > 0) {
-				setMessages((prev) => [...uniqueParsed, ...prev]);
-			}
-			setHasOlder(res.hasOlder);
-			hasOlderRef.current = res.hasOlder;
-			oldestCursorRef.current = res.oldestCursor;
-		} catch (err) {
-			// Show error feedback to user
-			setError(err instanceof Error ? err.message : 'Failed to load older messages');
-		} finally {
-			loadingOlderRef.current = false;
-			setLoadingOlder(false);
-		}
-	}, [groupId, request]);
-
 	// Notify parent when message count changes so it can drive autoscroll
 	useEffect(() => {
 		onMessageCountChange?.(messages.length);
@@ -437,24 +237,10 @@ export function TaskConversationRenderer({
 		return transitions;
 	}, [messages]);
 
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div class="flex-1 flex items-center justify-center">
 				<p class="text-gray-400 text-sm">Loading conversation…</p>
-			</div>
-		);
-	}
-
-	if (messages.length === 0 && error) {
-		return (
-			<div class="flex-1 flex flex-col items-center justify-center gap-2">
-				<p class="text-red-400 text-sm">{error}</p>
-				<button
-					class="text-xs text-blue-400 hover:text-blue-300 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-					onClick={retryInitialFetch}
-				>
-					Retry
-				</button>
 			</div>
 		);
 	}
@@ -469,19 +255,6 @@ export function TaskConversationRenderer({
 
 	return (
 		<div class="px-4 py-3 space-y-0.5">
-			{/* Load older messages button */}
-			{hasOlder && (
-				<div class="flex flex-col items-center gap-2 py-2">
-					{error && <p class="text-xs text-red-400">{error}</p>}
-					<button
-						class="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50 px-3 py-1.5 rounded bg-dark-800 hover:bg-dark-700 transition-colors"
-						onClick={loadOlderMessages}
-						disabled={loadingOlder}
-					>
-						{loadingOlder ? 'Loading…' : 'Load older messages'}
-					</button>
-				</div>
-			)}
 			{messages.map((msg, i) => {
 				const meta = getTaskMeta(msg);
 				const role = meta?.authorRole ?? 'system';


### PR DESCRIPTION
Removes the old state.groupMessages.delta event subscription and manual
task.getGroupMessages fetch logic from TaskConversationRenderer, replacing
both with the standardized useGroupMessages hook (LiveQuery protocol).

- Integrates useGroupMessages(groupId) for real-time message streaming
  via liveQuery.snapshot/delta instead of the legacy delta event
- Removes manual fetch+buffer deduplication logic and pagination UI
- Updates tests to mock useGroupMessages directly rather than simulating
  state.groupMessages.delta events
