### PR TITLE
feat: remove daemon-side state.groupMessages.delta emissions and add reconnect handling

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2146,11 +2146,12 @@ export class RoomRuntime {
 	// =========================================================================
 
 	/**
-	 * Set up live message forwarding for a group's worker/leader sessions.
+	 * Set up live message monitoring for a group's worker/leader sessions.
 	 *
 	 * Subscribes to DaemonHub sdk.message events, persists each enriched message
-	 * to session_group_messages (for LiveQuery), and broadcasts deltas via
-	 * state.groupMessages.delta for any legacy subscribers still present.
+	 * to session_group_messages (for LiveQuery). Does NOT broadcast
+	 * state.groupMessages.delta — message delivery to the frontend is handled
+	 * by the LiveQuery subscription (sessionGroupMessages.byGroup).
 	 */
 	private setupMirroring(group: SessionGroup): void {
 		if (!this.daemonHub) return;
@@ -2158,8 +2159,6 @@ export class RoomRuntime {
 		const mirroredUuids = new Set<string>();
 
 		const mirrorSession = (sessionId: string, role: string) => {
-			const shortSessionId = sessionId.slice(0, 8);
-
 			return this.daemonHub!.on(
 				'sdk.message',
 				(event) => {
@@ -2193,7 +2192,7 @@ export class RoomRuntime {
 					const iteration = currentGroup?.feedbackIteration ?? group.feedbackIteration;
 					const turnId = `turn_${group.id}_${iteration}_${shortSessionId}`;
 
-					// Persist to session_group_messages and broadcast enriched delta to frontends.
+					// Persist to session_group_messages so LiveQuery subscribers receive the event.
 					const enrichedMessage = {
 						...event.message,
 						_taskMeta: {
@@ -2216,13 +2215,6 @@ export class RoomRuntime {
 						content: JSON.stringify(enrichedMessage),
 						createdAt: sdkNow,
 					});
-					if (this.messageHub) {
-						this.messageHub.event(
-							'state.groupMessages.delta',
-							{ added: [{ ...enrichedMessage, timestamp: sdkNow }], timestamp: sdkNow },
-							{ channel: `group:${group.id}` }
-						);
-					}
 				},
 				{ sessionId }
 			);
@@ -2287,24 +2279,6 @@ export class RoomRuntime {
 			log.warn(
 				`appendGroupEvent: failed to persist group message for group ${groupId} (type=${messageType}, secondary write — ignored):`,
 				err
-			);
-		}
-
-		if (this.messageHub) {
-			this.messageHub.event(
-				'state.groupMessages.delta',
-				{
-					added: [
-						{
-							type: messageType,
-							text: payload?.text ?? kind,
-							timestamp: now,
-							...(payload ?? {}),
-						},
-					],
-					timestamp: now,
-				},
-				{ channel: `group:${groupId}` }
 			);
 		}
 	}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2159,6 +2159,8 @@ export class RoomRuntime {
 		const mirroredUuids = new Set<string>();
 
 		const mirrorSession = (sessionId: string, role: string) => {
+			const shortSessionId = sessionId.slice(0, 8);
+
 			return this.daemonHub!.on(
 				'sdk.message',
 				(event) => {

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -618,6 +618,8 @@ describe('StateManager', () => {
 				expect(eventHandlers.has('room.overview')).toBe(true);
 				expect(eventHandlers.has('room.runtime.stateChanged')).toBe(true);
 				expect(eventHandlers.has('goal.created')).toBe(true);
+				// goal.updated was removed in PR #695 (emitGoalUpdated dropped from goal handlers)
+				expect(eventHandlers.has('goal.updated')).toBe(false);
 				expect(eventHandlers.has('goal.completed')).toBe(true);
 				expect(eventHandlers.has('goal.progressUpdated')).toBe(true);
 			});
@@ -714,6 +716,15 @@ describe('StateManager', () => {
 					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.created', data, {
 						channel: 'room:room-123',
 					});
+				});
+			});
+
+			describe('goal.updated', () => {
+				it('is not forwarded via eventBus (removed in PR #695 — goal.updated is no longer emitted by goal RPC handlers)', () => {
+					// goal.updated was removed when emitGoalUpdated was dropped from goal handlers.
+					// Verify no handler is registered for this event so CI fails loudly if it
+					// is re-introduced without a corresponding test update.
+					expect(eventHandlers.has('goal.updated')).toBe(false);
 				});
 			});
 

--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -310,8 +310,11 @@ describe('TaskConversationRenderer — session question state props', () => {
 
 		await waitFor(() => {
 			const joinedRooms = mockJoinRoom.mock.calls.map((c: string[]) => c[0]);
+			// Session channels are joined via useSessionQuestionState
 			expect(joinedRooms).toContain('session:leader-session-123');
 			expect(joinedRooms).toContain('session:worker-session-456');
+			// TaskConversationRenderer no longer joins the group channel itself
+			expect(joinedRooms).not.toContain('group:group-1');
 		});
 	});
 


### PR DESCRIPTION
- Remove both state.groupMessages.delta emission sites from room-runtime.ts:
  - setupMirroring: removed broadcast block; rate-limit detection/backoff still active
  - appendGroupEvent: removed event broadcast; DB writes to task_group_events unchanged
- Update TaskConversationRenderer to use isConnected for reconnect re-fetch:
  - Remove state.groupMessages.delta subscription (events no longer emitted)
  - Add isConnected to effect deps; re-fetches via task.getGroupMessages on reconnect
  - Simplify component by removing buffering logic (fetchingRef, pendingDeltasRef)
- Update tests: remove delta-buffering tests, add isConnected=false guard test
