### PR TITLE
fix: fix task cancellation cascade and allow manual UI state transitions

### DIFF
--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -188,15 +188,15 @@ export class TaskManager {
 	async setTaskStatus(
 		taskId: string,
 		newStatus: TaskStatus,
-		options?: { result?: string; error?: string }
+		options?: { result?: string; error?: string; mode?: 'runtime' | 'manual' }
 	): Promise<NeoTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
 
-		// Validate transition
-		if (!isValidStatusTransition(task.status, newStatus)) {
+		// Validate transition (skipped in manual mode — UI allows any transition)
+		if (options?.mode !== 'manual' && !isValidStatusTransition(task.status, newStatus)) {
 			throw new Error(
 				`Invalid status transition from '${task.status}' to '${newStatus}'. ` +
 					`Allowed transitions: ${VALID_STATUS_TRANSITIONS[task.status].join(', ') || 'none'}`
@@ -220,16 +220,31 @@ export class TaskManager {
 		}
 
 		// Clear error/result/progress when restarting from a terminal/failed state.
-		// Covers needs_attention, cancelled, and completed → reactivation transitions.
+		// Covers needs_attention, cancelled, completed → reactivation transitions.
+		// In manual mode, also covers archived → active and completed → pending transitions.
 		if (
 			((task.status === 'needs_attention' || task.status === 'cancelled') &&
 				(newStatus === 'pending' || newStatus === 'in_progress' || newStatus === 'review')) ||
-			(task.status === 'completed' && newStatus === 'in_progress')
+			(task.status === 'completed' && newStatus === 'in_progress') ||
+			(options?.mode === 'manual' &&
+				(task.status === 'archived' ||
+					task.status === 'completed' ||
+					task.status === 'cancelled' ||
+					task.status === 'needs_attention') &&
+				(newStatus === 'pending' ||
+					newStatus === 'in_progress' ||
+					newStatus === 'review' ||
+					newStatus === 'completed'))
 		) {
 			// Use null to explicitly clear these fields in the database
 			updates.error = null;
 			updates.result = null;
 			updates.progress = null;
+		}
+
+		// When transitioning FROM archived (unarchiving), clear the archived_at timestamp
+		if (task.status === 'archived') {
+			updates.archivedAt = null;
 		}
 
 		return this.updateTaskStatus(taskId, newStatus, updates);

--- a/packages/daemon/src/lib/room/managers/task-manager.ts
+++ b/packages/daemon/src/lib/room/managers/task-manager.ts
@@ -441,13 +441,13 @@ export class TaskManager {
 	 * Archive task - transitions to 'archived' status and sets archivedAt timestamp.
 	 * Validates that the current status allows transitioning to 'archived'.
 	 */
-	async archiveTask(taskId: string): Promise<NeoTask> {
+	async archiveTask(taskId: string, options?: { mode?: 'runtime' | 'manual' }): Promise<NeoTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
 
-		if (!isValidStatusTransition(task.status, 'archived')) {
+		if (options?.mode !== 'manual' && !isValidStatusTransition(task.status, 'archived')) {
 			throw new Error(
 				`Cannot archive task in '${task.status}' status. ` +
 					`Allowed transitions: ${VALID_STATUS_TRANSITIONS[task.status].join(', ') || 'none'}`

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -1757,7 +1757,10 @@ export class RoomRuntime {
 	 * 2. Cleans up the worktree to free disk space.
 	 * 3. Sets the task status to 'archived' with archivedAt timestamp.
 	 */
-	async archiveTaskGroup(taskId: string): Promise<boolean> {
+	async archiveTaskGroup(
+		taskId: string,
+		options?: { mode?: 'runtime' | 'manual' }
+	): Promise<boolean> {
 		const group = this.groupRepo.getGroupByTaskId(taskId);
 
 		if (group) {
@@ -1784,7 +1787,7 @@ export class RoomRuntime {
 		}
 
 		// Set archivedAt timestamp on task (transitions to 'archived' status)
-		await this.taskManager.archiveTask(taskId);
+		await this.taskManager.archiveTask(taskId, { mode: options?.mode });
 
 		return true;
 	}

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -357,17 +357,42 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					if (runtime) {
 						const group = groupRepo.getGroupByTaskId(args.task_id);
 						if (group && group.completedAt === null) {
-							// There's an active group - cancel it first if moving to terminal state
-							if (
-								args.status === 'completed' ||
-								args.status === 'needs_attention' ||
-								args.status === 'cancelled'
-							) {
-								const cancelledGroup = await runtime.taskGroupManager.cancel(group.id);
-								if (!cancelledGroup) {
+							if (args.status === 'cancelled') {
+								// Use runtime.cancelTask() which properly handles group termination
+								// AND cascades the cancellation to pending dependent tasks.
+								const cancelResult = await runtime.cancelTask(args.task_id);
+								if (!cancelResult.success) {
 									return jsonResult({
 										success: false,
-										error: `Failed to cancel active group for task ${args.task_id} — group may have been modified concurrently`,
+										error: `Failed to cancel task ${args.task_id} — runtime cancellation was unsuccessful`,
+									});
+								}
+								// cancelTask already set status and emitted task updates; emit UI updates and return
+								if (daemonHub) {
+									for (const cancelledId of cancelResult.cancelledTaskIds) {
+										const cancelledTask = await taskManager.getTask(cancelledId);
+										if (cancelledTask) {
+											void daemonHub.emit('room.task.update', {
+												sessionId: `room:${roomId}`,
+												roomId,
+												task: cancelledTask,
+											});
+										}
+									}
+								}
+								return jsonResult({
+									success: true,
+									message: `Task ${args.task_id} cancelled successfully.`,
+								});
+							} else if (args.status === 'completed' || args.status === 'needs_attention') {
+								// Terminate the group WITHOUT cascading cancellation to pending dependent tasks.
+								// Only cancellation of a dependency should affect dependents — completing or
+								// marking a task as needs_attention should leave dependents untouched.
+								const terminated = await runtime.terminateTaskGroup(args.task_id);
+								if (!terminated) {
+									return jsonResult({
+										success: false,
+										error: `Failed to terminate active group for task ${args.task_id} — group may have been modified concurrently`,
 									});
 								}
 							}

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -366,6 +366,7 @@ export function setupTaskHandlers(
 			status: TaskStatus;
 			result?: string;
 			error?: string;
+			mode?: 'manual' | 'runtime';
 		};
 
 		if (!params.roomId) {
@@ -384,17 +385,20 @@ export function setupTaskHandlers(
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
 
-		// Validate status transition
-		const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
-		if (!allowedTransitions.includes(params.status)) {
-			throw new Error(
-				`Invalid status transition from '${task.status}' to '${params.status}'. ` +
-					`Allowed: ${allowedTransitions.join(', ') || 'none'}`
-			);
+		// Validate status transition (skip in manual mode — user can do any transition)
+		if (params.mode !== 'manual') {
+			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
+			if (!allowedTransitions.includes(params.status)) {
+				throw new Error(
+					`Invalid status transition from '${task.status}' to '${params.status}'. ` +
+						`Allowed: ${allowedTransitions.join(', ') || 'none'}`
+				);
+			}
 		}
 
 		// Archiving: delegate entirely to archiveTaskGroup (terminates sessions + cleans worktree)
 		// or archiveTask (no runtime — sets archivedAt directly). Early return skips generic path.
+		// Only applies to transitioning TO 'archived' (unarchiving is handled by the generic path below).
 		if (params.status === 'archived') {
 			const runtime = runtimeService?.getRuntime(params.roomId);
 			if (runtime) {
@@ -448,7 +452,11 @@ export function setupTaskHandlers(
 
 		// Handle restart: reset cancelled/needs_attention group so runtime picks it up fresh.
 		// completed → in_progress uses lightweight revival (group preserved, no full wipe).
-		if (task.status === 'needs_attention' || task.status === 'cancelled') {
+		if (
+			task.status === 'needs_attention' ||
+			task.status === 'cancelled' ||
+			(params.mode === 'manual' && task.status === 'archived')
+		) {
 			if (params.status === 'pending' || params.status === 'in_progress') {
 				const groupRepo = makeGroupRepo();
 				const group = groupRepo.getGroupByTaskId(params.taskId);
@@ -467,6 +475,7 @@ export function setupTaskHandlers(
 		const updatedTask = await taskManager.setTaskStatus(params.taskId, params.status, {
 			result: params.result,
 			error: params.error,
+			mode: params.mode,
 		});
 
 		emitTaskUpdate(params.roomId, updatedTask);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -22,7 +22,7 @@ import type { Database } from '../../storage/database';
 import type { ReactiveDatabase } from '../../storage/reactive-database';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
-import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
+import { TaskManager } from '../room/managers/task-manager';
 import { TaskRepository } from '../../storage/repositories/task-repository';
 import { SessionGroupRepository } from '../room/state/session-group-repository';
 import { routeHumanMessageToGroup } from '../room/runtime/human-message-routing';
@@ -385,26 +385,17 @@ export function setupTaskHandlers(
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
 
-		// Validate status transition (skip in manual mode — user can do any transition)
-		if (params.mode !== 'manual') {
-			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
-			if (!allowedTransitions.includes(params.status)) {
-				throw new Error(
-					`Invalid status transition from '${task.status}' to '${params.status}'. ` +
-						`Allowed: ${allowedTransitions.join(', ') || 'none'}`
-				);
-			}
-		}
-
 		// Archiving: delegate entirely to archiveTaskGroup (terminates sessions + cleans worktree)
 		// or archiveTask (no runtime — sets archivedAt directly). Early return skips generic path.
 		// Only applies to transitioning TO 'archived' (unarchiving is handled by the generic path below).
+		// Transition validation is owned by archiveTask/setTaskStatus — no duplicate check here.
 		if (params.status === 'archived') {
 			const runtime = runtimeService?.getRuntime(params.roomId);
+			const modeOpts = params.mode ? { mode: params.mode } : undefined;
 			if (runtime) {
-				await runtime.archiveTaskGroup(params.taskId);
+				await runtime.archiveTaskGroup(params.taskId, modeOpts);
 			} else {
-				await taskManager.archiveTask(params.taskId);
+				await taskManager.archiveTask(params.taskId, modeOpts);
 			}
 
 			const archivedTask = await taskManager.getTask(params.taskId);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -22,7 +22,7 @@ import type { Database } from '../../storage/database';
 import type { ReactiveDatabase } from '../../storage/reactive-database';
 import type { RoomManager } from '../room/managers/room-manager';
 import type { RoomRuntimeService } from '../room/runtime/room-runtime-service';
-import { TaskManager } from '../room/managers/task-manager';
+import { TaskManager, VALID_STATUS_TRANSITIONS } from '../room/managers/task-manager';
 import { TaskRepository } from '../../storage/repositories/task-repository';
 import { SessionGroupRepository } from '../room/state/session-group-repository';
 import { routeHumanMessageToGroup } from '../room/runtime/human-message-routing';
@@ -385,10 +385,22 @@ export function setupTaskHandlers(
 			throw new Error(`Task not found: ${params.taskId}`);
 		}
 
+		// Validate status transition for runtime mode. This must happen here (not just in the
+		// manager) because the cancel and archive paths below use early returns that bypass
+		// setTaskStatus/archiveTask validation. Manual mode bypasses this check.
+		if (params.mode !== 'manual') {
+			const allowedTransitions = VALID_STATUS_TRANSITIONS[task.status];
+			if (!allowedTransitions.includes(params.status)) {
+				throw new Error(
+					`Invalid status transition from '${task.status}' to '${params.status}'. ` +
+						`Allowed: ${allowedTransitions.join(', ') || 'none'}`
+				);
+			}
+		}
+
 		// Archiving: delegate entirely to archiveTaskGroup (terminates sessions + cleans worktree)
 		// or archiveTask (no runtime — sets archivedAt directly). Early return skips generic path.
 		// Only applies to transitioning TO 'archived' (unarchiving is handled by the generic path below).
-		// Transition validation is owned by archiveTask/setTaskStatus — no duplicate check here.
 		if (params.status === 'archived') {
 			const runtime = runtimeService?.getRuntime(params.roomId);
 			const modeOpts = params.mode ? { mode: params.mode } : undefined;

--- a/packages/daemon/src/storage/repositories/task-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-repository.ts
@@ -182,6 +182,10 @@ export class TaskRepository {
 			fields.push('pr_created_at = ?');
 			values.push(params.prCreatedAt ?? null);
 		}
+		if (params.archivedAt !== undefined) {
+			fields.push('archived_at = ?');
+			values.push(params.archivedAt ?? null);
+		}
 		if (params.inputDraft !== undefined) {
 			fields.push('input_draft = ?');
 			values.push(params.inputDraft ?? null);

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1599,7 +1599,7 @@ describe('Room Agent Tools', () => {
 			expect(result.error).toContain('Invalid status transition');
 		});
 
-		it('should return error when group cancellation fails due to version conflict', async () => {
+		it('should return error when terminateTaskGroup fails for completed transition', async () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
@@ -1609,11 +1609,9 @@ describe('Room Agent Tools', () => {
 			// Create an active group
 			insertGroup(taskId, 'awaiting_human');
 
-			// Create handler with mock runtime that returns null from cancel (simulating version conflict)
+			// Create handler with mock runtime where terminateTaskGroup returns false (version conflict)
 			const mockRuntime = {
-				taskGroupManager: {
-					cancel: async () => null, // Returns null to simulate version conflict
-				},
+				terminateTaskGroup: async () => false, // Returns false to simulate version conflict
 			};
 			const h = createRoomAgentToolHandlers({
 				roomId,
@@ -1623,14 +1621,14 @@ describe('Room Agent Tools', () => {
 				runtimeService: { getRuntime: () => mockRuntime as never },
 			});
 
-			// Try to complete the task - should fail because group cancellation failed
+			// Try to complete the task - should fail because group termination failed
 			const result = parseResult(await h.set_task_status({ task_id: taskId, status: 'completed' }));
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('Failed to cancel active group');
+			expect(result.error).toContain('Failed to terminate active group');
 			expect(result.error).toContain('group may have been modified concurrently');
 		});
 
-		it('should succeed when group cancellation succeeds', async () => {
+		it('should succeed when terminateTaskGroup succeeds for completed transition', async () => {
 			const created = parseResult(await handlers.create_task({ title: 'T', description: 'd' }));
 			const taskId = created.taskId as string;
 
@@ -1638,15 +1636,13 @@ describe('Room Agent Tools', () => {
 			await taskManager.startTask(taskId);
 
 			// Create an active group
-			const groupId = insertGroup(taskId, 'awaiting_human');
+			insertGroup(taskId, 'awaiting_human');
 
-			// Create handler with mock runtime that successfully cancels
+			// Create handler with mock runtime that successfully terminates
 			const mockRuntime = {
-				taskGroupManager: {
-					cancel: async (gId: string) => {
-						expect(gId).toBe(groupId);
-						return { id: gId, state: 'cancelled' };
-					},
+				terminateTaskGroup: async (_taskId: string) => {
+					expect(_taskId).toBe(taskId);
+					return true;
 				},
 			};
 			const h = createRoomAgentToolHandlers({
@@ -1657,7 +1653,8 @@ describe('Room Agent Tools', () => {
 				runtimeService: { getRuntime: () => mockRuntime as never },
 			});
 
-			// Complete the task - should succeed because group cancellation succeeded
+			// Complete the task — should succeed because group termination succeeded
+			// NOTE: completing a task does NOT cascade-cancel dependent tasks (bug fix)
 			const result = parseResult(await h.set_task_status({ task_id: taskId, status: 'completed' }));
 			expect(result.success).toBe(true);
 			expect(result.task.status).toBe('completed');

--- a/packages/daemon/tests/unit/room/task-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-manager.test.ts
@@ -1187,6 +1187,135 @@ describe('TaskManager', () => {
 	});
 });
 
+describe('setTaskStatus — manual mode', () => {
+	let db: Database;
+	let taskManager: TaskManager;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createTables(db);
+		const roomManager = new RoomManager(db);
+		const room = roomManager.createRoom({
+			name: 'Test Room',
+			allowedPaths: [{ path: '/workspace/test' }],
+			defaultPath: '/workspace/test',
+		});
+		taskManager = new TaskManager(db, room.id, { notifyChange: () => {} } as never);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('should allow any status transition when mode is manual', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		// completed is not normally reachable from pending in one step, but manual mode allows it
+		const updated = await taskManager.setTaskStatus(task.id, 'completed', { mode: 'manual' });
+		expect(updated.status).toBe('completed');
+	});
+
+	it('should allow archived → pending transition in manual mode (not allowed in runtime mode)', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		// Archive the task first using updateTaskStatus (bypasses state machine)
+		await taskManager.updateTaskStatus(task.id, 'archived');
+		expect((await taskManager.getTask(task.id))!.status).toBe('archived');
+
+		// Manual mode should allow unarchiving
+		const unarchived = await taskManager.setTaskStatus(task.id, 'pending', { mode: 'manual' });
+		expect(unarchived.status).toBe('pending');
+		// archivedAt should be cleared
+		expect(unarchived.archivedAt).toBeUndefined();
+	});
+
+	it('should reject invalid transitions in runtime mode (default)', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		// pending → completed is not valid in runtime mode
+		await expect(taskManager.setTaskStatus(task.id, 'completed')).rejects.toThrow(
+			"Invalid status transition from 'pending' to 'completed'"
+		);
+	});
+
+	it('should reject invalid transitions in explicit runtime mode', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		await expect(
+			taskManager.setTaskStatus(task.id, 'completed', { mode: 'runtime' })
+		).rejects.toThrow("Invalid status transition from 'pending' to 'completed'");
+	});
+
+	it('should clear error/result/progress when manually unarchiving', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		// Put the task in completed state with result
+		await taskManager.updateTaskStatus(task.id, 'completed', { result: 'done', progress: 100 });
+		// Archive it
+		await taskManager.updateTaskStatus(task.id, 'archived');
+
+		// Unarchive via manual mode
+		const unarchived = await taskManager.setTaskStatus(task.id, 'pending', { mode: 'manual' });
+		expect(unarchived.status).toBe('pending');
+		expect(unarchived.result).toBeUndefined();
+		expect(unarchived.progress).toBeUndefined();
+	});
+
+	it('should clear error when manually restarting from needs_attention to review', async () => {
+		const task = await taskManager.createTask({ title: 'T', description: '' });
+		await taskManager.updateTaskStatus(task.id, 'in_progress');
+		await taskManager.failTask(task.id, 'Some error');
+		expect((await taskManager.getTask(task.id))!.error).toBe('Some error');
+
+		const revived = await taskManager.setTaskStatus(task.id, 'review', { mode: 'manual' });
+		expect(revived.status).toBe('review');
+		expect(revived.error).toBeUndefined();
+	});
+
+	it('completing a task does not affect its dependent tasks in runtime mode', async () => {
+		// Create parent and dependent tasks
+		const parent = await taskManager.createTask({ title: 'Parent', description: '' });
+		const dep1 = await taskManager.createTask({
+			title: 'Dependent 1',
+			description: '',
+			dependsOn: [parent.id],
+		});
+		const dep2 = await taskManager.createTask({
+			title: 'Dependent 2',
+			description: '',
+			dependsOn: [parent.id],
+		});
+
+		// Start and complete the parent task
+		await taskManager.updateTaskStatus(parent.id, 'in_progress');
+		await taskManager.completeTask(parent.id, 'done');
+
+		// Dependent tasks should remain in pending state (not cancelled)
+		const dep1After = await taskManager.getTask(dep1.id);
+		const dep2After = await taskManager.getTask(dep2.id);
+		expect(dep1After!.status).toBe('pending');
+		expect(dep2After!.status).toBe('pending');
+	});
+
+	it('cancelling a task cascades to pending dependents', async () => {
+		// Create parent and dependent tasks
+		const parent = await taskManager.createTask({ title: 'Parent', description: '' });
+		const dep1 = await taskManager.createTask({
+			title: 'Dependent 1',
+			description: '',
+			dependsOn: [parent.id],
+		});
+		const dep2 = await taskManager.createTask({
+			title: 'Dependent 2',
+			description: '',
+			dependsOn: [parent.id],
+		});
+
+		// Cancel the parent task — should cascade to dependents
+		await taskManager.cancelTask(parent.id);
+
+		const dep1After = await taskManager.getTask(dep1.id);
+		const dep2After = await taskManager.getTask(dep2.id);
+		expect(dep1After!.status).toBe('cancelled');
+		expect(dep2After!.status).toBe('cancelled');
+	});
+});
+
 describe('extractPrNumber', () => {
 	it('should extract PR number from GitHub URL', () => {
 		expect(extractPrNumber('https://github.com/org/repo/pull/123')).toBe(123);

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -1159,6 +1159,76 @@ describe('task.setStatus RPC Handler', () => {
 			).rejects.toThrow('Invalid status transition');
 		});
 	});
+
+	describe('manual mode', () => {
+		it('allows invalid transitions when mode is manual', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
+
+			// pending → completed is invalid in runtime mode but allowed in manual mode
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'manual' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...pendingTask, status: 'completed' } });
+		});
+
+		it('allows archived → pending transition in manual mode', async () => {
+			const archivedTask = { ...mockTask, status: 'archived' as const };
+			setup({ task: archivedTask, runtimeService: makeNullRuntimeService() });
+
+			// archived → pending is normally terminal (no transitions), but manual mode allows it
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'pending', mode: 'manual' },
+				{}
+			);
+			expect(result).toEqual({ task: { ...archivedTask, status: 'pending' } });
+		});
+
+		it('still enforces transitions in runtime mode (explicitly)', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
+
+			await expect(
+				getHandler()(
+					{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'runtime' },
+					{}
+				)
+			).rejects.toThrow('Invalid status transition');
+		});
+
+		it('still enforces transitions when mode is not provided (default runtime behavior)', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			setup({ task: pendingTask, runtimeService: makeNullRuntimeService() });
+
+			await expect(
+				getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'completed' }, {})
+			).rejects.toThrow('Invalid status transition');
+		});
+
+		it('passes mode to setTaskStatus', async () => {
+			const pendingTask = { ...mockTask, status: 'pending' as const };
+			const factory = makeSetStatusTaskManagerFactory(pendingTask);
+			setup({
+				task: pendingTask,
+				runtimeService: makeNullRuntimeService(),
+				taskManagerFactory: factory,
+			});
+
+			await getHandler()(
+				{ roomId: 'room-1', taskId: 'task-1', status: 'completed', mode: 'manual' },
+				{}
+			);
+
+			// Verify that setTaskStatus was called with mode: 'manual'
+			const taskManagerInstance = (factory as ReturnType<typeof mock>).mock.results[0].value;
+			expect(taskManagerInstance.setTaskStatus).toHaveBeenCalledWith(
+				'task-1',
+				'completed',
+				expect.objectContaining({ mode: 'manual' })
+			);
+		});
+	});
 });
 
 // ─── task.interruptSession Tests ───

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -15,6 +15,7 @@ import { MessageHub } from '@neokai/shared';
 import type { NeoTask } from '@neokai/shared';
 import { setupTaskHandlers } from '../../../src/lib/rpc-handlers/task-handlers';
 import type { TaskManagerFactory } from '../../../src/lib/rpc-handlers/task-handlers';
+import { VALID_STATUS_TRANSITIONS } from '../../../src/lib/room/managers/task-manager';
 import type { DaemonHub } from '../../../src/lib/daemon-hub';
 import type { RoomRuntimeService } from '../../../src/lib/room/runtime/room-runtime-service';
 import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
@@ -807,10 +808,26 @@ describe('task.setStatus RPC Handler', () => {
 			listTasks: mock(async () => []),
 			failTask: mock(async () => task!),
 			cancelTask: mock(async () => ({ ...task!, status: 'cancelled' as const })),
-			setTaskStatus: mock(async (_id: string, status: string, _opts?: unknown) => ({
-				...task!,
-				status: status as NeoTask['status'],
-			})),
+			setTaskStatus: mock(async (_id: string, status: string, opts?: { mode?: string }) => {
+				// Validate transition like the real manager (single source of truth)
+				if (
+					opts?.mode !== 'manual' &&
+					!VALID_STATUS_TRANSITIONS[task!.status]?.includes(status as NeoTask['status'])
+				) {
+					throw new Error(`Invalid status transition from '${task!.status}' to '${status}'.`);
+				}
+				return { ...task!, status: status as NeoTask['status'] };
+			}),
+			archiveTask: mock(async (_id: string, opts?: { mode?: string }) => {
+				// Validate archival like the real manager (single source of truth)
+				if (
+					opts?.mode !== 'manual' &&
+					!VALID_STATUS_TRANSITIONS[task!.status]?.includes('archived' as NeoTask['status'])
+				) {
+					throw new Error(`Invalid status transition from '${task!.status}' to 'archived'.`);
+				}
+				return { ...task!, status: 'archived' as const };
+			}),
 		};
 		return mock(() => manager);
 	}
@@ -1094,7 +1111,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			await getHandler()({ roomId: 'room-1', taskId: 'task-1', status: 'archived' }, {});
 
-			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1');
+			expect(runtime.archiveTaskGroup).toHaveBeenCalledWith('task-1', undefined);
 		});
 
 		it('emits task update and room overview after archiving via runtime', async () => {
@@ -1131,7 +1148,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1');
+			).toHaveBeenCalledWith('task-1', undefined);
 		});
 
 		it('calls taskManager.archiveTask when runtime has no runtime for room', async () => {
@@ -1147,7 +1164,7 @@ describe('task.setStatus RPC Handler', () => {
 
 			expect(
 				(factory as unknown as { _archiveTask: ReturnType<typeof mock> })._archiveTask
-			).toHaveBeenCalledWith('task-1');
+			).toHaveBeenCalledWith('task-1', undefined);
 		});
 
 		it('throws for invalid transition from in_progress to archived', async () => {

--- a/packages/daemon/tests/unit/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/session/state-manager.test.ts
@@ -618,7 +618,6 @@ describe('StateManager', () => {
 				expect(eventHandlers.has('room.overview')).toBe(true);
 				expect(eventHandlers.has('room.runtime.stateChanged')).toBe(true);
 				expect(eventHandlers.has('goal.created')).toBe(true);
-				expect(eventHandlers.has('goal.updated')).toBe(true);
 				expect(eventHandlers.has('goal.completed')).toBe(true);
 				expect(eventHandlers.has('goal.progressUpdated')).toBe(true);
 			});
@@ -713,26 +712,6 @@ describe('StateManager', () => {
 					handler!(data);
 
 					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.created', data, {
-						channel: 'room:room-123',
-					});
-				});
-			});
-
-			describe('goal.updated', () => {
-				it('should forward goal updates to room channel', () => {
-					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
-
-					const handler = eventHandlers.get('goal.updated');
-					const data = {
-						sessionId: 'room:room-123',
-						roomId: 'room-123',
-						goalId: 'goal-1',
-						goal: { title: 'Updated Goal 1' },
-					};
-
-					handler!(data);
-
-					expect(mockMessageHub.event).toHaveBeenCalledWith('goal.updated', data, {
 						channel: 'room:room-123',
 					});
 				});

--- a/packages/shared/src/types/neo.ts
+++ b/packages/shared/src/types/neo.ts
@@ -373,6 +373,8 @@ export interface UpdateTaskParams {
 	prNumber?: number | null;
 	prCreatedAt?: number | null;
 	inputDraft?: string | null;
+	/** Timestamp when the task was archived. Set to null to clear when unarchiving. */
+	archivedAt?: number | null;
 }
 
 // ============================================================================

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -53,18 +53,21 @@ export interface TaskInfoPanelProps {
 		onComplete?: () => void;
 		onCancel?: () => void;
 		onArchive?: () => void;
+		onSetStatus?: () => void;
 	};
 	/** Whether each action should be shown (context-aware) */
 	visibleActions: {
 		complete?: boolean;
 		cancel?: boolean;
 		archive?: boolean;
+		setStatus?: boolean;
 	};
 	/** Whether each action is disabled */
 	disabledActions?: {
 		complete?: boolean;
 		cancel?: boolean;
 		archive?: boolean;
+		setStatus?: boolean;
 	};
 }
 
@@ -91,7 +94,10 @@ export function TaskInfoPanel({
 		null;
 
 	const hasVisibleActions =
-		visibleActions.complete || visibleActions.cancel || visibleActions.archive;
+		visibleActions.complete ||
+		visibleActions.cancel ||
+		visibleActions.archive ||
+		visibleActions.setStatus;
 
 	return (
 		<div
@@ -235,6 +241,26 @@ export function TaskInfoPanel({
 										/>
 									</svg>
 									Archive
+								</button>
+							)}
+
+							{visibleActions.setStatus && actions.onSetStatus && (
+								<button
+									type="button"
+									onClick={actions.onSetStatus}
+									disabled={disabledActions?.setStatus}
+									data-testid="task-info-panel-set-status"
+									class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-dark-600 text-gray-400 hover:text-blue-400 hover:border-blue-700/60"
+								>
+									<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M4 6h16M4 12h8m-8 6h16"
+										/>
+									</svg>
+									Set Status
 								</button>
 							)}
 						</div>

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2309,6 +2309,157 @@ describe('TaskView — Reactivate and Archive actions', () => {
 	});
 });
 
+describe('TaskView — SetStatusModal', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: null };
+			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
+			return {};
+		});
+	});
+
+	it('opens SetStatusModal when Set Status button is clicked from info panel', async () => {
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open info panel
+		const trigger = container.querySelector(
+			'[data-testid="task-info-panel-trigger"]'
+		) as HTMLElement;
+		expect(trigger).not.toBeNull();
+		fireEvent.click(trigger);
+
+		// Click Set Status button
+		const setStatusButton = container.querySelector(
+			'[data-testid="task-info-panel-set-status"]'
+		) as HTMLElement;
+		expect(setStatusButton).not.toBeNull();
+
+		await act(async () => {
+			fireEvent.click(setStatusButton);
+		});
+
+		// Modal should appear
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="set-status-confirm"]')).not.toBeNull();
+		});
+	});
+
+	it('calls task.setStatus with mode: manual when status is selected and confirmed', async () => {
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open info panel and click Set Status
+		fireEvent.click(
+			container.querySelector('[data-testid="task-info-panel-trigger"]') as HTMLElement
+		);
+		await act(async () => {
+			fireEvent.click(
+				container.querySelector('[data-testid="task-info-panel-set-status"]') as HTMLElement
+			);
+		});
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="set-status-confirm"]')).not.toBeNull();
+		});
+
+		// Select 'pending' from the dropdown (portal renders in document.body)
+		const select = document.querySelector('select') as HTMLSelectElement;
+		await act(async () => {
+			fireEvent.change(select, { target: { value: 'pending' } });
+		});
+
+		// Confirm
+		await act(async () => {
+			fireEvent.click(document.querySelector('[data-testid="set-status-confirm"]') as HTMLElement);
+		});
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.setStatus', {
+				roomId: 'room-1',
+				taskId: 'task-1',
+				status: 'pending',
+				mode: 'manual',
+			});
+		});
+	});
+
+	it('shows destructive warning when transitioning from archived', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'archived') };
+			if (method === 'task.getGroup') return { group: null };
+			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
+			return {};
+		});
+
+		// archived tasks don't show the Set Status button — verify it's hidden
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open the info panel
+		const trigger = container.querySelector(
+			'[data-testid="task-info-panel-trigger"]'
+		) as HTMLElement;
+		// For archived tasks, the info panel trigger may still exist but setStatus button should not
+		if (trigger) {
+			fireEvent.click(trigger);
+			expect(container.querySelector('[data-testid="task-info-panel-set-status"]')).toBeNull();
+		}
+	});
+
+	it('shows destructive warning for completed→pending transition', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'completed') };
+			if (method === 'task.getGroup') return { group: null };
+			if (method === 'task.setStatus') return { task: makeTask('task-1', 'pending') };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Open info panel and click Set Status
+		fireEvent.click(
+			container.querySelector('[data-testid="task-info-panel-trigger"]') as HTMLElement
+		);
+		await act(async () => {
+			fireEvent.click(
+				container.querySelector('[data-testid="task-info-panel-set-status"]') as HTMLElement
+			);
+		});
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-testid="set-status-confirm"]')).not.toBeNull();
+		});
+
+		// Select 'pending' to trigger destructive warning
+		const select = document.querySelector('select') as HTMLSelectElement;
+		await act(async () => {
+			fireEvent.change(select, { target: { value: 'pending' } });
+		});
+
+		// Warning text should appear in the modal
+		await waitFor(() => {
+			expect(document.body.textContent).toContain('Previous results will be cleared');
+		});
+	});
+});
+
 // Import roomStore to set up goal associations for goal badge tests
 import { roomStore } from '../../lib/room-store.ts';
 import { currentRoomTabSignal } from '../../lib/signals.ts';

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -1340,6 +1340,7 @@ describe('TaskView — Task options dropdown menu', () => {
 				taskId: 'task-1',
 				status: 'completed',
 				result: 'Marked complete by user',
+				mode: 'manual',
 			});
 			expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
 		});
@@ -2060,6 +2061,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 				roomId: 'room-1',
 				taskId: 'task-1',
 				status: 'in_progress',
+				mode: 'manual',
 			});
 		});
 	});
@@ -2130,6 +2132,7 @@ describe('TaskView — Reactivate and Archive actions', () => {
 				roomId: 'room-1',
 				taskId: 'task-1',
 				status: 'archived',
+				mode: 'manual',
 			});
 		});
 	});

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -549,6 +549,182 @@ function ArchiveTaskDialog({ task, isOpen, onClose, onConfirm }: ArchiveTaskDial
 	);
 }
 
+interface SetStatusModalProps {
+	task: NeoTask;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: (newStatus: import('@neokai/shared').TaskStatus) => Promise<void>;
+}
+
+const ALL_TASK_STATUSES: import('@neokai/shared').TaskStatus[] = [
+	'pending',
+	'in_progress',
+	'review',
+	'completed',
+	'needs_attention',
+	'cancelled',
+	'archived',
+	'draft',
+];
+
+const STATUS_LABELS: Record<import('@neokai/shared').TaskStatus, string> = {
+	pending: 'Pending',
+	in_progress: 'In Progress',
+	review: 'In Review',
+	completed: 'Completed',
+	needs_attention: 'Needs Attention',
+	cancelled: 'Cancelled',
+	archived: 'Archived',
+	draft: 'Draft',
+};
+
+/**
+ * Returns true if the transition from `from` to `to` is considered destructive
+ * and warrants an extra warning in the confirmation modal.
+ */
+function isDestructiveTransition(
+	from: import('@neokai/shared').TaskStatus,
+	to: import('@neokai/shared').TaskStatus
+): boolean {
+	if (from === 'archived') return true; // restoring an archived task
+	if (from === 'completed' && to === 'pending') return true; // reopening completed task
+	if (from === 'cancelled' && to === 'completed') return true; // force-completing cancelled task
+	return false;
+}
+
+function destructiveTransitionWarning(
+	from: import('@neokai/shared').TaskStatus,
+	to: import('@neokai/shared').TaskStatus
+): string | null {
+	if (from === 'archived') {
+		return "You're restoring an archived task. The archived timestamp will be cleared.";
+	}
+	if (from === 'completed' && to === 'pending') {
+		return 'This will restart the task as pending. Previous results will be cleared.';
+	}
+	if (from === 'cancelled' && to === 'completed') {
+		return 'This will force-complete this cancelled task. Use with caution.';
+	}
+	return null;
+}
+
+function SetStatusModal({ task, isOpen, onClose, onConfirm }: SetStatusModalProps) {
+	const [selectedStatus, setSelectedStatus] = useState<import('@neokai/shared').TaskStatus | null>(
+		null
+	);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const availableStatuses = ALL_TASK_STATUSES.filter((s) => s !== task.status);
+
+	const handleClose = () => {
+		setSelectedStatus(null);
+		setError(null);
+		onClose();
+	};
+
+	const handleConfirm = async () => {
+		if (!selectedStatus) return;
+		setLoading(true);
+		setError(null);
+		try {
+			await onConfirm(selectedStatus);
+			setSelectedStatus(null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to update task status');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const warning = selectedStatus ? destructiveTransitionWarning(task.status, selectedStatus) : null;
+	const isDestructive = selectedStatus
+		? isDestructiveTransition(task.status, selectedStatus)
+		: false;
+
+	return (
+		<Modal isOpen={isOpen} onClose={handleClose} title="Set Task Status">
+			<div class="flex flex-col gap-4">
+				<p class="text-sm text-gray-400">
+					Current status:{' '}
+					<span class="font-medium text-gray-200">{STATUS_LABELS[task.status]}</span>
+				</p>
+
+				<div class="flex flex-col gap-1.5">
+					<label class="text-xs text-gray-500 font-medium uppercase tracking-wide">
+						New Status
+					</label>
+					<select
+						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-600"
+						value={selectedStatus ?? ''}
+						onChange={(e) => {
+							const val = (e.target as HTMLSelectElement).value;
+							setSelectedStatus((val as import('@neokai/shared').TaskStatus) || null);
+							setError(null);
+						}}
+					>
+						<option value="">Select a status…</option>
+						{availableStatuses.map((s) => (
+							<option key={s} value={s}>
+								{STATUS_LABELS[s]}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{warning && (
+					<div class="flex items-start gap-2 bg-amber-900/20 border border-amber-700/40 rounded-lg px-3 py-2.5">
+						<svg
+							class="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+							/>
+						</svg>
+						<p class="text-sm text-amber-300">{warning}</p>
+					</div>
+				)}
+
+				{error && (
+					<p class="text-sm text-red-400 bg-red-900/20 border border-red-800/50 rounded px-3 py-2">
+						{error}
+					</p>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-2">
+					<button
+						type="button"
+						onClick={handleClose}
+						disabled={loading}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={() => void handleConfirm()}
+						disabled={loading || !selectedStatus}
+						data-testid="set-status-confirm"
+						class={`px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:cursor-not-allowed flex items-center gap-1.5 ${
+							isDestructive
+								? 'bg-amber-600 hover:bg-amber-700 text-white disabled:bg-amber-600/50'
+								: 'bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-600/50'
+						}`}
+					>
+						{loading ? 'Updating…' : isDestructive ? 'Force Set Status' : 'Set Status'}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}
+
 export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const { request, onEvent, joinRoom, leaveRoom } = useMessageHub();
 	const [task, setTask] = useState<NeoTask | null>(null);
@@ -587,6 +763,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 	const cancelModal = useModal();
 	const rejectModal = useModal();
 	const archiveModal = useModal();
+	const setStatusModal = useModal();
 
 	// Review state — approve/reject for tasks awaiting human review
 	const [approving, setApproving] = useState(false);
@@ -761,6 +938,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			taskId,
 			status: 'completed',
 			result: summary || 'Marked complete by user',
+			mode: 'manual',
 		});
 		completeModal.close();
 		toast.success('Task completed');
@@ -780,7 +958,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 		if (reactivating) return;
 		setReactivating(true);
 		try {
-			await request('task.setStatus', { roomId, taskId, status: 'in_progress' });
+			await request('task.setStatus', { roomId, taskId, status: 'in_progress', mode: 'manual' });
 			toast.success('Task reactivated');
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : 'Failed to reactivate task');
@@ -791,10 +969,25 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 
 	// Archive task handler — transitions to archived (permanent)
 	const archiveTask = async () => {
-		await request('task.setStatus', { roomId, taskId, status: 'archived' });
+		await request('task.setStatus', { roomId, taskId, status: 'archived', mode: 'manual' });
 		archiveModal.close();
 		toast.info('Task archived');
 		navigateToRoom(roomId);
+	};
+
+	// Set task status manually — allows any transition (manual mode, no server-side validation)
+	const setTaskStatusManually = async (newStatus: import('@neokai/shared').TaskStatus) => {
+		await request('task.setStatus', {
+			roomId,
+			taskId,
+			status: newStatus,
+			mode: 'manual',
+		});
+		setStatusModal.close();
+		toast.success(`Task status set to ${newStatus.replace('_', ' ')}`);
+		if (newStatus === 'archived') {
+			navigateToRoom(roomId);
+		}
 	};
 
 	// Interrupt button shown only when task has active agent sessions
@@ -1050,16 +1243,25 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 								archiveModal.open();
 							}
 						: undefined,
+					onSetStatus:
+						task.status !== 'archived'
+							? () => {
+									setIsInfoPanelOpen(false);
+									setStatusModal.open();
+								}
+							: undefined,
 				}}
 				visibleActions={{
 					complete: canComplete && task.status !== 'review',
 					cancel: canCancel,
 					archive: canArchive,
+					setStatus: task.status !== 'archived',
 				}}
 				disabledActions={{
 					complete: interrupting,
 					cancel: interrupting,
 					archive: false,
+					setStatus: false,
 				}}
 			/>
 
@@ -1202,6 +1404,12 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				isOpen={archiveModal.isOpen}
 				onClose={archiveModal.close}
 				onConfirm={archiveTask}
+			/>
+			<SetStatusModal
+				task={task}
+				isOpen={setStatusModal.isOpen}
+				onClose={setStatusModal.close}
+				onConfirm={setTaskStatusManually}
 			/>
 			{/* Reject dialog — for tasks awaiting human review */}
 			<RejectModal


### PR DESCRIPTION
- Fix bug in room-agent-tools.ts: only cascade cancellation for 'cancelled'
  transitions; use terminateTaskGroup for 'completed'/'needs_attention' to
  avoid incorrectly cancelling dependent tasks
- Add mode parameter ('runtime'|'manual') to setTaskStatus allowing UI to
  bypass strict state machine rules for manual transitions
- Add SetStatusModal in TaskView for arbitrary status changes with
  destructive transition warnings
- Support unarchiving by clearing archivedAt when transitioning from archived
- Update task-handlers RPC to accept and pass through manual mode
- Add unit tests for manual mode in task-manager and task-handlers
