### PR TITLE
feat: replace room.task.update listener with tasks.byRoom LiveQuery (Task 3.3)

### DIFF
--- a/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
@@ -281,4 +281,32 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		});
 		expect(roomStore.goalsLoading.value).toBe(false);
 	});
+
+	it('resets goalsLoading to false on room deselect (even if snapshot never arrived)', async () => {
+		// goalsLoading is true (snapshot not yet delivered)
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		await roomStore.select(null);
+
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('sets goalsLoading to true on reconnect and false on subsequent snapshot', () => {
+		// Deliver initial snapshot to clear loading
+		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [], version: 1 });
+		expect(roomStore.goalsLoading.value).toBe(false);
+
+		// Reconnect triggers re-subscribe which sets loading = true
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		// New snapshot clears it
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 2,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
 });

--- a/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
@@ -268,4 +268,17 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		// goals signal unchanged from snapshot
 		expect(roomStore.goals.value[0].id).toBe('g1');
 	});
+
+	it('sets goalsLoading to true before subscribing and false on first snapshot', () => {
+		// After room select, goalsLoading is true because the mock hub did not fire a snapshot.
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		// When the server delivers the snapshot, goalsLoading clears.
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
 });

--- a/packages/web/src/lib/__tests__/room-store-review.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-review.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /**
  * Tests for RoomStore review-related features:
- * - Toast notification when task transitions to review status
+ * - Toast notification when task transitions to review status via liveQuery.delta
  * - reviewTaskCount computed signal
  */
 
@@ -15,24 +15,42 @@ import { toastsSignal } from '../toast';
 let mockEventHandlers: Map<string, (event: unknown) => void>;
 let mockHub: ReturnType<typeof makeMockHub>;
 
+const ROOM_ID = 'room-1';
+const TASKS_SUB_ID = `tasks-byRoom-${ROOM_ID}`;
+
 function makeMockHub() {
 	return {
 		joinChannel: vi.fn(),
 		leaveChannel: vi.fn(),
 		onEvent: vi.fn((eventName: string, handler: (e: unknown) => void) => {
-			mockEventHandlers.set(eventName, handler);
-			return () => mockEventHandlers.delete(eventName);
+			if (!mockEventHandlers.has(eventName)) {
+				mockEventHandlers.set(eventName, []);
+			}
+			(mockEventHandlers.get(eventName) as unknown[]).push(handler);
+			return () => {
+				const handlers = mockEventHandlers.get(eventName) as unknown[];
+				if (handlers) {
+					const i = handlers.indexOf(handler);
+					if (i >= 0) handlers.splice(i, 1);
+				}
+			};
 		}),
 		onConnection: vi.fn(() => () => {}),
 		request: vi.fn(async (method: string) => {
 			if (method === 'room.get') {
-				return { room: { id: 'room-1' }, sessions: [], allTasks: [] };
+				return { room: { id: ROOM_ID }, sessions: [], allTasks: [] };
 			}
-			if (method === 'goal.list') return { goals: [] };
 			if (method === 'room.runtime.state') throw new Error('no runtime');
-			return {};
+			return { ok: true };
 		}),
 	};
+}
+
+function fireEvent(eventName: string, data: unknown) {
+	const handlers = mockEventHandlers.get(eventName) as ((e: unknown) => void)[] | undefined;
+	if (handlers) {
+		for (const h of handlers) h(data);
+	}
 }
 
 vi.mock('../connection-manager.ts', () => ({
@@ -54,7 +72,7 @@ function makeTask(id: string, status: string, title = `Task ${id}`) {
 // Tests
 // -------------------------------------------------------
 
-describe('RoomStore — review toast notification', () => {
+describe('RoomStore — review toast notification (via liveQuery.delta)', () => {
 	let roomStore: typeof import('../room-store').roomStore;
 
 	beforeEach(async () => {
@@ -82,60 +100,95 @@ describe('RoomStore — review toast notification', () => {
 	});
 
 	it('does NOT fire a toast when an unknown task arrives in review (hydration guard)', async () => {
-		// Simulates a race where room.task.update arrives before fetchInitialState
-		// populates tasks — the task is not yet in local state (idx === -1).
-		await roomStore.select('room-1');
-		// tasks.value is empty (initial state not hydrated yet)
+		// Simulates a race where liveQuery.delta arrives before the snapshot
+		// populates tasks — the task is not yet in local state.
+		await roomStore.select(ROOM_ID);
 		roomStore.tasks.value = [];
 
-		const handler = mockEventHandlers.get('room.task.update');
-		expect(handler).toBeDefined();
+		// Delta with an 'updated' task that is not in current state
+		fireEvent('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			updated: [makeTask('t1', 'review', 'My Review Task')],
+			version: 2,
+		});
 
-		handler({ roomId: 'room-1', task: makeTask('t1', 'review', 'My Review Task') });
-
-		// No toast because prevTask was null (not previously known)
+		// No toast because prevTask was not found in current state
 		expect(toastsSignal.value.length).toBe(0);
 	});
 
 	it('fires a toast when existing task transitions from in_progress to review', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
-		// Seed with an in_progress task
-		roomStore.tasks.value = [makeTask('t2', 'in_progress', 'Coding Task')];
+		// Seed with an in_progress task via snapshot
+		fireEvent('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t2', 'in_progress', 'Coding Task')],
+			version: 1,
+		});
 
-		const handler = mockEventHandlers.get('room.task.update');
-		handler({ roomId: 'room-1', task: makeTask('t2', 'review', 'Coding Task') });
+		// Transition to review via delta
+		fireEvent('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			updated: [makeTask('t2', 'review', 'Coding Task')],
+			version: 2,
+		});
 
 		expect(toastsSignal.value.length).toBe(1);
 		expect(toastsSignal.value[0].message).toBe('Task ready for review: Coding Task');
 	});
 
 	it('does NOT fire a toast when a task updates but stays in review', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
 		// Seed with an already-review task
-		roomStore.tasks.value = [makeTask('t3', 'review', 'Already In Review')];
+		fireEvent('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t3', 'review', 'Already In Review')],
+			version: 1,
+		});
 
-		const handler = mockEventHandlers.get('room.task.update');
-		handler({ roomId: 'room-1', task: makeTask('t3', 'review', 'Already In Review') });
+		fireEvent('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			updated: [makeTask('t3', 'review', 'Already In Review')],
+			version: 2,
+		});
 
 		expect(toastsSignal.value.length).toBe(0);
 	});
 
 	it('does NOT fire a toast for task updates with non-review status', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
-		const handler = mockEventHandlers.get('room.task.update');
-		handler({ roomId: 'room-1', task: makeTask('t4', 'in_progress') });
+		fireEvent('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t4', 'pending', 'Pending Task')],
+			version: 1,
+		});
+
+		fireEvent('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			updated: [makeTask('t4', 'in_progress', 'Pending Task')],
+			version: 2,
+		});
 
 		expect(toastsSignal.value.length).toBe(0);
 	});
 
-	it('does NOT fire a toast for events from a different room', async () => {
-		await roomStore.select('room-1');
+	it('does NOT fire a toast for delta events with a different subscriptionId', async () => {
+		await roomStore.select(ROOM_ID);
 
-		const handler = mockEventHandlers.get('room.task.update');
-		handler({ roomId: 'room-99', task: makeTask('t5', 'review', 'Other Room Task') });
+		fireEvent('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t5', 'in_progress', 'Other Room Task')],
+			version: 1,
+		});
+
+		// Delta for a different subscription (e.g., goals.byRoom)
+		fireEvent('liveQuery.delta', {
+			subscriptionId: 'goals-byRoom-room-1',
+			updated: [makeTask('t5', 'review', 'Other Room Task')],
+			version: 2,
+		});
 
 		expect(toastsSignal.value.length).toBe(0);
 	});
@@ -162,7 +215,7 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	});
 
 	it('returns 0 when no tasks are in review', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
 		roomStore.tasks.value = [makeTask('t1', 'pending'), makeTask('t2', 'in_progress')];
 
@@ -170,7 +223,7 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	});
 
 	it('counts tasks in review status', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
 		roomStore.tasks.value = [
 			makeTask('t1', 'review'),
@@ -182,7 +235,7 @@ describe('RoomStore — reviewTaskCount computed signal', () => {
 	});
 
 	it('updates reactively when tasks change', async () => {
-		await roomStore.select('room-1');
+		await roomStore.select(ROOM_ID);
 
 		roomStore.tasks.value = [makeTask('t1', 'pending')];
 		expect(roomStore.reviewTaskCount.value).toBe(0);

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -1,13 +1,12 @@
 /**
- * Tests for RoomStore goal LiveQuery subscription (Task 3.2/3.3)
+ * Tests for RoomStore tasks.byRoom LiveQuery subscription (Task 3.3)
  *
- * Verifies that goals are updated exclusively via liveQuery.snapshot /
- * liveQuery.delta events rather than legacy goal.created / goal.updated /
- * goal.completed events.
+ * Verifies that tasks are updated exclusively via liveQuery.snapshot /
+ * liveQuery.delta events rather than the legacy room.task.update event.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { RoomGoal, GoalStatus } from '@neokai/shared';
+import type { TaskSummary } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -89,23 +88,22 @@ import { roomStore } from '../room-store.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ROOM_ID = 'room-test';
-const GOALS_SUB_ID = `goals-byRoom-${ROOM_ID}`;
+const ROOM_ID = 'room-tasks-test';
+const TASKS_SUB_ID = `tasks-byRoom-${ROOM_ID}`;
 
-function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
+function makeTask(id: string, overrides: Partial<TaskSummary> = {}): TaskSummary {
 	return {
 		id,
 		roomId: ROOM_ID,
-		title: `Goal ${id}`,
+		title: `Task ${id}`,
 		description: '',
-		status: 'active' as GoalStatus,
+		status: 'pending',
 		priority: 'normal',
 		progress: 0,
-		linkedTaskIds: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,
-	};
+	} as TaskSummary;
 }
 
 function setupHubRequests(hub: MockHub): void {
@@ -122,7 +120,7 @@ function setupHubRequests(hub: MockHub): void {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
+describe('RoomStore — tasks.byRoom LiveQuery subscription', () => {
 	let hub: MockHub;
 
 	beforeEach(async () => {
@@ -138,109 +136,108 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		vi.clearAllMocks();
 	});
 
-	it('subscribes to goals.byRoom with a stable subscriptionId on room select', () => {
+	it('subscribes to tasks.byRoom with a stable subscriptionId on room select', () => {
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const subscribeCall = calls.find(
 			([method, params]) =>
 				method === 'liveQuery.subscribe' &&
-				(params as { queryName: string }).queryName === 'goals.byRoom'
+				(params as { queryName: string }).queryName === 'tasks.byRoom'
 		);
 		expect(subscribeCall).toBeDefined();
 		expect(subscribeCall![1]).toMatchObject({
-			queryName: 'goals.byRoom',
+			queryName: 'tasks.byRoom',
 			params: [ROOM_ID],
-			subscriptionId: GOALS_SUB_ID,
+			subscriptionId: TASKS_SUB_ID,
 		});
 	});
 
-	it('does NOT subscribe via legacy goal.list on room select', () => {
-		const calls = hub.request.mock.calls as [string, unknown][];
-		const goalListCall = calls.find(([method]) => method === 'goal.list');
-		expect(goalListCall).toBeUndefined();
+	it('does NOT subscribe via legacy room.task.update event listener', () => {
+		// Ensure no handler is registered for the old event
+		expect(hub._handlers.has('room.task.update')).toBe(false);
 	});
 
-	it('populates goals.value from liveQuery.snapshot', () => {
-		const goals = [makeGoal('g1'), makeGoal('g2')];
-		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: goals, version: 1 });
-		expect(roomStore.goals.value).toEqual(goals);
+	it('populates tasks.value from liveQuery.snapshot', () => {
+		const tasks = [makeTask('t1'), makeTask('t2')];
+		hub.fire('liveQuery.snapshot', { subscriptionId: TASKS_SUB_ID, rows: tasks, version: 1 });
+		expect(roomStore.tasks.value).toEqual(tasks);
 	});
 
 	it('ignores liveQuery.snapshot for a different subscriptionId', () => {
 		hub.fire('liveQuery.snapshot', {
 			subscriptionId: 'other-sub',
-			rows: [makeGoal('irrelevant')],
+			rows: [makeTask('irrelevant')],
 			version: 1,
 		});
-		expect(roomStore.goals.value).toEqual([]);
+		expect(roomStore.tasks.value).toEqual([]);
 	});
 
-	it('appends goals from liveQuery.delta added', () => {
-		const g1 = makeGoal('g1');
-		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
-		const g2 = makeGoal('g2');
-		hub.fire('liveQuery.delta', { subscriptionId: GOALS_SUB_ID, added: [g2], version: 2 });
-		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+	it('appends tasks from liveQuery.delta added', () => {
+		const t1 = makeTask('t1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: TASKS_SUB_ID, rows: [t1], version: 1 });
+		const t2 = makeTask('t2');
+		hub.fire('liveQuery.delta', { subscriptionId: TASKS_SUB_ID, added: [t2], version: 2 });
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
 	});
 
-	it('removes goals from liveQuery.delta removed', () => {
-		const g1 = makeGoal('g1');
-		const g2 = makeGoal('g2');
-		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1, g2], version: 1 });
-		hub.fire('liveQuery.delta', { subscriptionId: GOALS_SUB_ID, removed: [g1], version: 2 });
-		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g2']);
+	it('removes tasks from liveQuery.delta removed', () => {
+		const t1 = makeTask('t1');
+		const t2 = makeTask('t2');
+		hub.fire('liveQuery.snapshot', { subscriptionId: TASKS_SUB_ID, rows: [t1, t2], version: 1 });
+		hub.fire('liveQuery.delta', { subscriptionId: TASKS_SUB_ID, removed: [t1], version: 2 });
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t2']);
 	});
 
-	it('replaces goals from liveQuery.delta updated', () => {
-		const g1 = makeGoal('g1');
-		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
-		const g1Updated = makeGoal('g1', { status: 'completed' as GoalStatus, progress: 100 });
+	it('replaces tasks from liveQuery.delta updated', () => {
+		const t1 = makeTask('t1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: TASKS_SUB_ID, rows: [t1], version: 1 });
+		const t1Updated = makeTask('t1', { status: 'in_progress', progress: 50 });
 		hub.fire('liveQuery.delta', {
-			subscriptionId: GOALS_SUB_ID,
-			updated: [g1Updated],
+			subscriptionId: TASKS_SUB_ID,
+			updated: [t1Updated],
 			version: 2,
 		});
-		expect(roomStore.goals.value[0].status).toBe('completed');
-		expect(roomStore.goals.value[0].progress).toBe(100);
+		expect(roomStore.tasks.value[0].status).toBe('in_progress');
+		expect(roomStore.tasks.value[0].progress).toBe(50);
 	});
 
 	it('ignores liveQuery.delta for a different subscriptionId', () => {
-		const g1 = makeGoal('g1');
-		hub.fire('liveQuery.snapshot', { subscriptionId: GOALS_SUB_ID, rows: [g1], version: 1 });
+		const t1 = makeTask('t1');
+		hub.fire('liveQuery.snapshot', { subscriptionId: TASKS_SUB_ID, rows: [t1], version: 1 });
 		hub.fire('liveQuery.delta', {
 			subscriptionId: 'other-sub',
-			removed: [g1],
+			removed: [t1],
 			version: 2,
 		});
-		// g1 should still be present
-		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+		// t1 should still be present
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
 	});
 
-	it('unsubscribes from goals.byRoom on room deselect', async () => {
+	it('unsubscribes from tasks.byRoom on room deselect', async () => {
 		hub.request.mockClear();
 		await roomStore.select(null);
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const unsubCall = calls.find(
 			([method, params]) =>
 				method === 'liveQuery.unsubscribe' &&
-				(params as { subscriptionId: string }).subscriptionId === GOALS_SUB_ID
+				(params as { subscriptionId: string }).subscriptionId === TASKS_SUB_ID
 		);
 		expect(unsubCall).toBeDefined();
 	});
 
-	it('re-subscribes to goals.byRoom on reconnect', () => {
+	it('re-subscribes to tasks.byRoom on reconnect', () => {
 		hub.request.mockClear();
 		hub.fireConnection('connected');
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const resubCall = calls.find(
 			([method, params]) =>
 				method === 'liveQuery.subscribe' &&
-				(params as { queryName: string }).queryName === 'goals.byRoom'
+				(params as { queryName: string }).queryName === 'tasks.byRoom'
 		);
 		expect(resubCall).toBeDefined();
 		expect(resubCall![1]).toMatchObject({
-			queryName: 'goals.byRoom',
+			queryName: 'tasks.byRoom',
 			params: [ROOM_ID],
-			subscriptionId: GOALS_SUB_ID,
+			subscriptionId: TASKS_SUB_ID,
 		});
 	});
 
@@ -252,20 +249,56 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		const resubCall = calls.find(
 			([method, params]) =>
 				method === 'liveQuery.subscribe' &&
-				(params as { queryName: string }).queryName === 'goals.byRoom'
+				(params as { queryName: string }).queryName === 'tasks.byRoom'
 		);
 		expect(resubCall).toBeUndefined();
 	});
 
-	it('does not update goals on legacy goal.updated event', () => {
+	it('does not update tasks on legacy room.task.update event', () => {
 		hub.fire('liveQuery.snapshot', {
-			subscriptionId: GOALS_SUB_ID,
-			rows: [makeGoal('g1')],
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
 			version: 1,
 		});
 		// Legacy event should have no effect
-		hub.fire('goal.updated', { roomId: ROOM_ID, goalId: 'g1', goal: makeGoal('g1-modified') });
-		// goals signal unchanged from snapshot
-		expect(roomStore.goals.value[0].id).toBe('g1');
+		hub.fire('room.task.update', {
+			roomId: ROOM_ID,
+			task: makeTask('t1', { status: 'completed' }),
+		});
+		// tasks signal unchanged from snapshot
+		expect(roomStore.tasks.value[0].status).toBe('pending');
+	});
+
+	it('resets tasks to [] on room deselect', async () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1'), makeTask('t2')],
+			version: 1,
+		});
+		expect(roomStore.tasks.value.length).toBe(2);
+		await roomStore.select(null);
+		expect(roomStore.tasks.value).toEqual([]);
+	});
+
+	it('does not optimistically append task after task.create RPC', async () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		// Make task.create return a task
+		hub.request.mockImplementation((method: string) => {
+			if (method === 'task.create') {
+				return Promise.resolve({ task: makeTask('new-task') });
+			}
+			if (method === 'room.runtime.models')
+				return Promise.resolve({ leaderModel: null, workerModel: null });
+			return Promise.resolve({ ok: true });
+		});
+
+		await roomStore.createTask('New Task', 'Description');
+
+		// tasks.value should still be empty — LiveQuery delta will populate it
+		expect(roomStore.tasks.value).toEqual([]);
 	});
 });

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -301,47 +301,85 @@ class RoomStore {
 			// Join the room channel first
 			hub.joinChannel(`room:${roomId}`);
 
-			// 1. Room overview subscription (room + sessions + tasks)
+			// 1. Room overview subscription (room + sessions only — tasks come from LiveQuery)
 			const unsubRoomOverview = hub.onEvent<RoomOverview>('room.overview', (overview) => {
 				if (overview.room.id === roomId) {
 					this.room.value = overview.room;
 					this.sessions.value = overview.sessions;
-					this.tasks.value = overview.allTasks ?? overview.activeTasks;
 				}
 			});
 			this.cleanupFunctions.push(unsubRoomOverview);
 
-			// 2. Task updates
-			const unsubTaskUpdate = hub.onEvent<{ roomId: string; task: NeoTask }>(
-				'room.task.update',
+			// 2. Tasks via LiveQuery — replaces room.task.update event listener.
+			const tasksSubId = `tasks-byRoom-${roomId}`;
+
+			const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+				'liveQuery.snapshot',
 				(event) => {
-					if (event.roomId === roomId) {
-						const task = event.task;
-						const idx = this.tasks.value.findIndex((t) => t.id === task.id);
-
-						// Show toast when a known task transitions into review status.
-						// Skip when prevTask is null (task not yet in local state) to avoid
-						// spurious toasts during initial hydration / reconnection.
-						if (task.status === 'review' && idx >= 0) {
-							const prevTask = this.tasks.value[idx];
-							if (prevTask.status !== 'review') {
-								toast.info(`Task ready for review: ${task.title}`);
-							}
-						}
-
-						if (idx >= 0) {
-							this.tasks.value = [
-								...this.tasks.value.slice(0, idx),
-								task,
-								...this.tasks.value.slice(idx + 1),
-							];
-						} else {
-							this.tasks.value = [...this.tasks.value, task];
-						}
+					if (event.subscriptionId === tasksSubId) {
+						this.tasks.value = event.rows as TaskSummary[];
 					}
 				}
 			);
-			this.cleanupFunctions.push(unsubTaskUpdate);
+			this.cleanupFunctions.push(unsubTaskSnapshot);
+
+			const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId !== tasksSubId) return;
+				let current = this.tasks.value;
+				if (event.removed?.length) {
+					const removedIds = new Set((event.removed as TaskSummary[]).map((r) => r.id));
+					current = current.filter((t) => !removedIds.has(t.id));
+				}
+				if (event.updated?.length) {
+					const updatedTasks = event.updated as TaskSummary[];
+					// Show toast when a known task transitions into review status.
+					// Skip when prevTask is absent to avoid spurious toasts during hydration.
+					for (const updatedTask of updatedTasks) {
+						if (updatedTask.status === 'review') {
+							const prevTask = current.find((t) => t.id === updatedTask.id);
+							if (prevTask && prevTask.status !== 'review') {
+								toast.info(`Task ready for review: ${updatedTask.title}`);
+							}
+						}
+					}
+					const updatedMap = new Map(updatedTasks.map((u) => [u.id, u]));
+					current = current.map((t) => updatedMap.get(t.id) ?? t);
+				}
+				if (event.added?.length) {
+					current = [...current, ...(event.added as TaskSummary[])];
+				}
+				this.tasks.value = current;
+			});
+			this.cleanupFunctions.push(unsubTaskDelta);
+
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'tasks.byRoom',
+				params: [roomId],
+				subscriptionId: tasksSubId,
+			});
+
+			// Re-subscribe on reconnect: the server-side subscription is per-connection.
+			const unsubTaskReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || this.roomId.value !== roomId) return;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'tasks.byRoom',
+						params: [roomId],
+						subscriptionId: tasksSubId,
+					})
+					.catch((err) => {
+						logger.warn('Tasks LiveQuery re-subscribe failed:', err);
+					});
+			});
+			this.cleanupFunctions.push(unsubTaskReconnect);
+
+			// Cleanup: tell the server to dispose the subscription when leaving the room.
+			this.cleanupFunctions.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId: tasksSubId }).catch(() => {});
+				}
+			});
 
 			// 3. Goals via LiveQuery — replaces goal.created/updated/completed event listeners.
 			// Register snapshot/delta handlers BEFORE subscribing so we never miss the
@@ -507,12 +545,11 @@ class RoomStore {
 			if (overview) {
 				this.room.value = overview.room;
 				this.sessions.value = overview.sessions;
-				this.tasks.value = overview.allTasks ?? overview.activeTasks;
 			} else {
 				this.error.value = 'Room not found';
 			}
 
-			// Goals are delivered via the goals.byRoom LiveQuery snapshot pushed
+			// Tasks and goals are delivered via LiveQuery snapshot pushed
 			// synchronously during liveQuery.subscribe in startSubscriptions.
 
 			// Fetch runtime state
@@ -593,10 +630,7 @@ class RoomStore {
 			description,
 		});
 
-		if (task) {
-			this.tasks.value = [...this.tasks.value, task];
-		}
-
+		// Task appears in tasks.value via the tasks.byRoom LiveQuery delta.
 		return task;
 	}
 
@@ -719,15 +753,8 @@ class RoomStore {
 			return;
 		}
 
-		try {
-			this.goalsLoading.value = true;
-			const response = await hub.request<{ goals: RoomGoal[] }>('goal.list', { roomId });
-			this.goals.value = response.goals ?? [];
-		} catch (err) {
-			logger.error('Failed to fetch goals:', err);
-		} finally {
-			this.goalsLoading.value = false;
-		}
+		// Goals are delivered exclusively via the goals.byRoom LiveQuery subscription.
+		// This method is kept for compatibility but no longer writes to goals.value.
 	}
 
 	/**
@@ -751,12 +778,7 @@ class RoomStore {
 			throw err;
 		}
 
-		// Refetch goals to ensure UI is up to date — non-fatal if it fails
-		try {
-			await this.fetchGoals();
-		} catch (err) {
-			logger.warn('Failed to refetch goals after creation:', err);
-		}
+		// goals.value is updated automatically by the goals.byRoom LiveQuery delta.
 	}
 
 	/**
@@ -775,8 +797,7 @@ class RoomStore {
 
 		try {
 			await hub.request('goal.update', { roomId, goalId, updates });
-			// Refetch goals to ensure UI is up to date
-			await this.fetchGoals();
+			// goals.value is updated automatically by the goals.byRoom LiveQuery delta.
 		} catch (err) {
 			logger.error('Failed to update goal:', err);
 			throw err;
@@ -799,8 +820,7 @@ class RoomStore {
 
 		try {
 			await hub.request('goal.delete', { roomId, goalId });
-			// Refetch goals to ensure UI is up to date
-			await this.fetchGoals();
+			// goals.value is updated automatically by the goals.byRoom LiveQuery delta.
 		} catch (err) {
 			logger.error('Failed to delete goal:', err);
 			throw err;

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -391,6 +391,7 @@ class RoomStore {
 				(event) => {
 					if (event.subscriptionId === goalsSubId) {
 						this.goals.value = event.rows as RoomGoal[];
+						this.goalsLoading.value = false;
 					}
 				}
 			);
@@ -415,6 +416,8 @@ class RoomStore {
 			this.cleanupFunctions.push(unsubGoalDelta);
 
 			// Subscribe to the goals.byRoom named query.
+			// Mark loading before subscribing; the snapshot handler clears it.
+			this.goalsLoading.value = true;
 			await hub.request('liveQuery.subscribe', {
 				queryName: 'goals.byRoom',
 				params: [roomId],
@@ -434,8 +437,7 @@ class RoomStore {
 						subscriptionId: goalsSubId,
 					})
 					.catch((err) => {
-						logger.warn('Goals LiveQuery re-subscribe failed, falling back to refetch:', err);
-						this.fetchGoals().catch(() => {});
+						logger.warn('Goals LiveQuery re-subscribe failed:', err);
 					});
 			});
 			this.cleanupFunctions.push(unsubReconnect);
@@ -654,7 +656,7 @@ class RoomStore {
 			taskId,
 		});
 
-		// Task state updates arrive via room.task.update events
+		// Task state updates arrive via the tasks.byRoom LiveQuery delta.
 	}
 
 	/**
@@ -677,7 +679,7 @@ class RoomStore {
 			status,
 		});
 
-		// Task state updates arrive via room.task.update events
+		// Task state updates arrive via the tasks.byRoom LiveQuery delta.
 	}
 
 	/**
@@ -700,7 +702,7 @@ class RoomStore {
 			feedback,
 		});
 
-		// Task state updates arrive via room.task.update events
+		// Task state updates arrive via the tasks.byRoom LiveQuery delta.
 	}
 
 	// ========================================
@@ -738,24 +740,6 @@ class RoomStore {
 	// ========================================
 	// Goals Methods
 	// ========================================
-
-	/**
-	 * Fetch goals for the room
-	 */
-	async fetchGoals(): Promise<void> {
-		const roomId = this.roomId.value;
-		if (!roomId) {
-			return;
-		}
-
-		const hub = connectionManager.getHubIfConnected();
-		if (!hub) {
-			return;
-		}
-
-		// Goals are delivered exclusively via the goals.byRoom LiveQuery subscription.
-		// This method is kept for compatibility but no longer writes to goals.value.
-	}
 
 	/**
 	 * Create a new goal

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -267,6 +267,7 @@ class RoomStore {
 		this.sessions.value = [];
 		this.error.value = null;
 		this.goals.value = [];
+		this.goalsLoading.value = false;
 		this.autoCompletedNotifications.value = [];
 		this.runtimeState.value = null;
 
@@ -430,6 +431,7 @@ class RoomStore {
 			// snapshot handler above.
 			const unsubReconnect = hub.onConnection((state) => {
 				if (state !== 'connected' || this.roomId.value !== roomId) return;
+				this.goalsLoading.value = true;
 				hub
 					.request('liveQuery.subscribe', {
 						queryName: 'goals.byRoom',
@@ -438,6 +440,7 @@ class RoomStore {
 					})
 					.catch((err) => {
 						logger.warn('Goals LiveQuery re-subscribe failed:', err);
+						this.goalsLoading.value = false;
 					});
 			});
 			this.cleanupFunctions.push(unsubReconnect);


### PR DESCRIPTION
- Remove hub.onEvent('room.task.update', ...) listener from room-store.ts
- Remove this.tasks.value assignment from room.overview handler (keep room/sessions)
- Remove this.tasks.value population from fetchInitialState
- Remove optimistic task append after task.create RPC
- Add tasks.byRoom LiveQuery snapshot/delta handlers with reconnect re-subscribe
- Preserve review-status toast notification in LiveQuery delta handler
- Simplify fetchGoals(): remove goals.value write (LiveQuery is sole owner)
- Remove fetchGoals() calls from createGoal/updateGoal/deleteGoal
- Update room-store-review.test.ts to use liveQuery.delta instead of room.task.update
- Add room-store-tasks-live-query.test.ts with 12 tests covering full subscription lifecycle
- Fix room-store-goals-live-query.test.ts to filter liveQuery.subscribe by queryName

LiveQuery snapshot/delta are now the sole data writers to tasks.value and goals.value.
