### PR TITLE
fix: reuse existing dev proxy instance instead of failing on startup

### DIFF
--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -20,7 +20,6 @@
 
 import { spawn, spawnSync } from 'child_process';
 import path from 'path';
-import net from 'net';
 import { MessageHub, WebSocketClientTransport } from '@neokai/shared';
 import { createDaemonApp, type DaemonAppContext } from '../../src/app';
 import { getConfig } from '../../src/config';
@@ -214,37 +213,6 @@ function installSharedDevProxyExitHook(): void {
 	});
 }
 
-async function isTcpPortOpen(port: number, host = '127.0.0.1', timeoutMs = 1000): Promise<boolean> {
-	return new Promise((resolve) => {
-		const socket = net.createConnection({ port, host });
-		const done = (result: boolean) => {
-			socket.removeAllListeners();
-			socket.destroy();
-			resolve(result);
-		};
-
-		socket.setTimeout(timeoutMs);
-		socket.once('connect', () => done(true));
-		socket.once('timeout', () => done(false));
-		socket.once('error', () => done(false));
-	});
-}
-
-async function waitForTcpPortOpen(
-	port: number,
-	host = '127.0.0.1',
-	timeoutMs = 4000
-): Promise<boolean> {
-	const start = Date.now();
-	while (Date.now() - start < timeoutMs) {
-		if (await isTcpPortOpen(port, host, 500)) {
-			return true;
-		}
-		await new Promise((resolve) => setTimeout(resolve, 100));
-	}
-	return false;
-}
-
 async function acquireDevProxyLease(
 	shouldUseDevProxy: boolean,
 	devProxyOptions?: DevProxyOptions
@@ -305,8 +273,13 @@ async function acquireDevProxyLease(
 	}
 
 	// For reuse mode, only register as shared controller when we own the proxy
-	// process.  External instances are not registered so the exit hook won't try
-	// to stop them when the test process exits.
+	// process.  External instances are intentionally not pooled in
+	// sharedDevProxyController: the exit hook (installSharedDevProxyExitHook)
+	// unconditionally runs `devproxy stop` on process exit, which would kill a
+	// proxy that belongs to another session.  With external instances each
+	// acquireDevProxyLease call creates a lightweight controller that performs a
+	// TCP probe on start and a no-op on stop — cheap enough that skipping the
+	// pool is acceptable.
 	if (reuse && !devProxy.isExternal) {
 		sharedDevProxyController = devProxy;
 		sharedDevProxyPort = devProxyPort;

--- a/packages/daemon/tests/helpers/daemon-server.ts
+++ b/packages/daemon/tests/helpers/daemon-server.ts
@@ -285,36 +285,29 @@ async function acquireDevProxyLease(
 		};
 	}
 
-	let devProxy: DevProxyController | null = createDevProxyController({
+	const devProxy: DevProxyController = createDevProxyController({
 		// Daemon helper explicitly sets env vars for both in-process and spawned modes.
 		// Keep proxy lifecycle independent from parent-process env mutation.
 		setEnvVars: false,
 		...devProxyOptions,
 	});
-	let startedByHelper = false;
 
 	try {
+		// start() will adopt an existing proxy (isExternal=true) rather than failing
+		// when a devproxy instance is already listening on the port.
 		await devProxy.start();
-		startedByHelper = true;
 	} catch (error) {
-		devProxy = null;
 		const errorMessage = error instanceof Error ? error.message : String(error);
-		// If another worker/process just started Dev Proxy, give it extra time to bind.
-		const readyTimeout = errorMessage.includes('already running') ? 12000 : 3000;
-		const proxyAlreadyRunning = await waitForTcpPortOpen(devProxyPort, '127.0.0.1', readyTimeout);
-		if (!proxyAlreadyRunning) {
-			throw new Error(
-				`Dev Proxy is required for this test run but is unavailable on ${devProxyBaseUrl}. ` +
-					`Startup error: ${errorMessage}`
-			);
-		}
-		console.warn(
-			`Warning: Could not start Dev Proxy controller, using existing proxy at ${devProxyBaseUrl}. ` +
+		throw new Error(
+			`Dev Proxy is required for this test run but failed to start on ${devProxyBaseUrl}. ` +
 				`Error: ${errorMessage}`
 		);
 	}
 
-	if (reuse && startedByHelper && devProxy) {
+	// For reuse mode, only register as shared controller when we own the proxy
+	// process.  External instances are not registered so the exit hook won't try
+	// to stop them when the test process exits.
+	if (reuse && !devProxy.isExternal) {
 		sharedDevProxyController = devProxy;
 		sharedDevProxyPort = devProxyPort;
 		sharedDevProxyRefCount = 1;
@@ -333,10 +326,9 @@ async function acquireDevProxyLease(
 	return {
 		controller: devProxy,
 		release: async () => {
-			if (devProxy && startedByHelper) {
-				await devProxy.stop();
-				devProxy.restoreEnv();
-			}
+			// stop() is a no-op for external instances, so it's always safe to call.
+			await devProxy.stop();
+			devProxy.restoreEnv();
 		},
 	};
 }

--- a/packages/daemon/tests/helpers/dev-proxy.ts
+++ b/packages/daemon/tests/helpers/dev-proxy.ts
@@ -95,13 +95,16 @@ export interface DevProxyOptions {
  */
 export interface DevProxyController {
 	/**
-	 * Start Dev Proxy process
+	 * Start Dev Proxy process.
+	 * If a proxy is already listening on the configured port, it is adopted as an
+	 * external instance (isExternal becomes true) and no new process is started.
 	 * @throws Error if proxy fails to start within timeout
 	 */
 	start(): Promise<void>;
 
 	/**
-	 * Stop Dev Proxy process gracefully
+	 * Stop Dev Proxy process gracefully.
+	 * Has no effect when the proxy was adopted as an external instance (isExternal === true).
 	 */
 	stop(): Promise<void>;
 
@@ -136,6 +139,13 @@ export interface DevProxyController {
 	 * Get the process PID (if running)
 	 */
 	readonly pid: number | undefined;
+
+	/**
+	 * Whether this controller adopted a pre-existing proxy instance rather than
+	 * starting one itself.  When true, stop() is a no-op so we don't terminate a
+	 * proxy that belongs to another process.
+	 */
+	readonly isExternal: boolean;
 
 	/**
 	 * Restore original environment variables that were modified
@@ -307,6 +317,7 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 
 	// State
 	let running = false;
+	let external = false; // true when we adopted a pre-existing proxy
 	let originalEnv: Record<string, string | undefined> = {};
 
 	const runDevProxyCommand = async (
@@ -410,9 +421,25 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 			return undefined;
 		},
 
+		get isExternal() {
+			return external;
+		},
+
 		async start() {
 			if (running) {
 				throw new Error('Dev Proxy is already running');
+			}
+
+			// Proactively check if a proxy is already listening on the port.
+			// If so, adopt it as an external instance instead of trying to start a new
+			// one (which would fail with "already running" and cause test failures).
+			if (await checkProxyReady()) {
+				running = true;
+				external = true;
+				if (setEnvVars) {
+					setProxyEnvVars();
+				}
+				return;
 			}
 
 			// Check if devproxy is installed
@@ -446,6 +473,17 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 			);
 
 			if (startResult.code !== 0) {
+				// Even when `devproxy --detach` exits non-zero (e.g. because it races
+				// with another process starting the proxy simultaneously), the proxy may
+				// already be up.  Do one final port check before giving up.
+				if (await checkProxyReady()) {
+					running = true;
+					external = true;
+					if (setEnvVars) {
+						setProxyEnvVars();
+					}
+					return;
+				}
 				throw new Error(
 					`Failed to start Dev Proxy (exit ${startResult.code ?? 'unknown'}): ` +
 						(startResult.stderr || startResult.stdout || 'no output')
@@ -456,6 +494,7 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 			while (Date.now() - startTime < startTimeout) {
 				if (await checkProxyReady()) {
 					running = true;
+					external = false;
 					if (setEnvVars) {
 						setProxyEnvVars();
 					}
@@ -469,6 +508,13 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 
 		async stop() {
 			if (!running) {
+				return;
+			}
+
+			// Don't stop a proxy we didn't start — it belongs to another process.
+			if (external) {
+				running = false;
+				external = false;
 				return;
 			}
 

--- a/packages/daemon/tests/helpers/dev-proxy.ts
+++ b/packages/daemon/tests/helpers/dev-proxy.ts
@@ -45,6 +45,7 @@
  */
 
 import { spawn } from 'child_process';
+import net from 'net';
 import path from 'path';
 import fs from 'fs';
 import { setTimeout as sleep } from 'timers/promises';
@@ -364,7 +365,6 @@ export function createDevProxyController(options: DevProxyOptions = {}): DevProx
 		// Try to connect to the proxy port using a TCP connection check
 		// This is more reliable than fetch() for HTTPS proxies
 		return new Promise((resolve) => {
-			const net = require('net');
 			const socket = new net.Socket();
 
 			socket.setTimeout(1000);

--- a/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
+++ b/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import net from 'net';
 import path from 'path';
 import fs from 'fs';
 import {
@@ -15,6 +16,27 @@ import {
 	getGlobalDevProxy,
 	type DevProxyOptions,
 } from '../../helpers/dev-proxy';
+
+/**
+ * Bind a TCP server on a random available port and return the server + port.
+ * Used to simulate an already-running proxy process in tests.
+ */
+async function bindTcpServer(): Promise<{ server: net.Server; port: number }> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address() as net.AddressInfo;
+			resolve({ server, port: addr.port });
+		});
+		server.on('error', reject);
+	});
+}
+
+async function closeTcpServer(server: net.Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((err) => (err ? reject(err) : resolve()));
+	});
+}
 
 // Check if devproxy is available
 async function isDevProxyInstalled(): Promise<boolean> {
@@ -27,7 +49,23 @@ async function isDevProxyInstalled(): Promise<boolean> {
 	}
 }
 
+/**
+ * Returns true if a devproxy process is already running on this machine.
+ * devproxy enforces a single-instance constraint regardless of port, so when
+ * it is already running, tests that need to start a fresh instance must skip.
+ */
+async function isDevProxyAlreadyRunning(): Promise<boolean> {
+	return new Promise((resolve) => {
+		// pgrep -x matches the exact process name (macOS / Linux)
+		const proc = Bun.spawn(['pgrep', '-x', 'devproxy'], { stdout: 'ignore', stderr: 'ignore' });
+		proc.exited.then((code) => resolve(code === 0)).catch(() => resolve(false));
+	});
+}
+
 const DEV_PROXY_INSTALLED = await isDevProxyInstalled();
+// Tests that need to start a fresh devproxy instance must skip when one is already running
+// because devproxy enforces a single-instance constraint (any port).
+const DEV_PROXY_FREE_TO_START = DEV_PROXY_INSTALLED && !(await isDevProxyAlreadyRunning());
 
 describe('Dev Proxy Helper', () => {
 	describe('createDevProxyController', () => {
@@ -37,6 +75,7 @@ describe('Dev Proxy Helper', () => {
 			expect(controller.port).toBe(8000);
 			expect(controller.proxyUrl).toBe('http://127.0.0.1:8000');
 			expect(controller.isRunning()).toBe(false);
+			expect(controller.isExternal).toBe(false);
 			expect(controller.pid).toBeUndefined();
 		});
 
@@ -60,8 +99,10 @@ describe('Dev Proxy Helper', () => {
 	});
 
 	describe('start/stop lifecycle', () => {
-		// Skip these tests if devproxy is not installed
-		const itif = DEV_PROXY_INSTALLED ? it : it.skip;
+		// Skip when devproxy is not installed or when an instance is already running.
+		// devproxy enforces a single-instance constraint so a second start attempt
+		// on any port will fail when the binary is already in use.
+		const itif = DEV_PROXY_FREE_TO_START ? it : it.skip;
 
 		itif(
 			'should start and stop proxy',
@@ -161,7 +202,7 @@ describe('Dev Proxy Helper', () => {
 	});
 
 	describe('Global Dev Proxy', () => {
-		const itif = DEV_PROXY_INSTALLED ? it : it.skip;
+		const itif = DEV_PROXY_FREE_TO_START ? it : it.skip;
 
 		afterEach(async () => {
 			await stopGlobalDevProxy();
@@ -200,6 +241,138 @@ describe('Dev Proxy Helper', () => {
 		);
 	});
 
+	describe('isExternal — reuse existing proxy', () => {
+		it('isExternal is false on a fresh controller', () => {
+			const controller = createDevProxyController();
+			expect(controller.isExternal).toBe(false);
+		});
+
+		it('adopts an existing proxy on the port without starting a new process', async () => {
+			// Bind a real TCP server to simulate an already-running proxy
+			const { server, port } = await bindTcpServer();
+
+			try {
+				const controller = createDevProxyController({
+					port,
+					setEnvVars: false, // avoid mutating process.env in unit tests
+				});
+
+				await controller.start();
+
+				expect(controller.isRunning()).toBe(true);
+				expect(controller.isExternal).toBe(true);
+			} finally {
+				await closeTcpServer(server);
+			}
+		});
+
+		it('stop() does not close the external proxy port', async () => {
+			const { server, port } = await bindTcpServer();
+
+			try {
+				const controller = createDevProxyController({
+					port,
+					setEnvVars: false,
+				});
+
+				await controller.start();
+				expect(controller.isRunning()).toBe(true);
+				expect(controller.isExternal).toBe(true);
+
+				await controller.stop();
+
+				// Controller should report not running after stop
+				expect(controller.isRunning()).toBe(false);
+				// The TCP server (external proxy) must still be accepting connections
+				await expect(
+					new Promise<void>((resolve, reject) => {
+						const socket = net.createConnection({ port, host: '127.0.0.1' });
+						socket.once('connect', () => {
+							socket.destroy();
+							resolve();
+						});
+						socket.once('error', reject);
+					})
+				).resolves.toBeUndefined();
+			} finally {
+				await closeTcpServer(server);
+			}
+		});
+
+		it('isExternal resets to false after stop()', async () => {
+			const { server, port } = await bindTcpServer();
+
+			try {
+				const controller = createDevProxyController({
+					port,
+					setEnvVars: false,
+				});
+
+				await controller.start();
+				expect(controller.isExternal).toBe(true);
+
+				await controller.stop();
+				expect(controller.isExternal).toBe(false);
+			} finally {
+				await closeTcpServer(server);
+			}
+		});
+
+		it('sets env vars when setEnvVars=true and adopting external proxy', async () => {
+			const { server, port } = await bindTcpServer();
+			const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+
+			try {
+				const controller = createDevProxyController({
+					port,
+					setEnvVars: true,
+				});
+
+				await controller.start();
+
+				try {
+					expect(controller.isExternal).toBe(true);
+					expect(process.env.ANTHROPIC_BASE_URL).toBe(`http://127.0.0.1:${port}`);
+				} finally {
+					controller.restoreEnv();
+					await controller.stop();
+				}
+			} finally {
+				await closeTcpServer(server);
+				// Ensure env is restored regardless
+				if (originalBaseUrl === undefined) {
+					delete process.env.ANTHROPIC_BASE_URL;
+				} else {
+					process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+				}
+			}
+		});
+
+		it('can be restarted after stopping an external proxy', async () => {
+			const { server, port } = await bindTcpServer();
+
+			try {
+				const controller = createDevProxyController({
+					port,
+					setEnvVars: false,
+				});
+
+				// First adoption
+				await controller.start();
+				expect(controller.isExternal).toBe(true);
+				await controller.stop();
+
+				// Second adoption (same external server still running)
+				await controller.start();
+				expect(controller.isExternal).toBe(true);
+				expect(controller.isRunning()).toBe(true);
+				await controller.stop();
+			} finally {
+				await closeTcpServer(server);
+			}
+		});
+	});
+
 	describe('loadMockFile', () => {
 		it('should throw for non-existent mock file', () => {
 			const controller = createDevProxyController();
@@ -211,11 +384,9 @@ describe('Dev Proxy Helper', () => {
 
 	describe('when devproxy is not installed', () => {
 		it('should throw error on start if not installed', async () => {
-			// This test only runs if devproxy IS installed, to verify the error message
-			// Skip if not installed since the test would pass trivially
+			// Only meaningful when devproxy is not installed and no process is running
 			if (DEV_PROXY_INSTALLED) {
-				// We can't easily test this case when devproxy IS installed
-				// So skip it
+				// Can't test this path when devproxy IS installed
 				return;
 			}
 

--- a/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
+++ b/packages/daemon/tests/unit/helpers/dev-proxy.test.ts
@@ -247,34 +247,48 @@ describe('Dev Proxy Helper', () => {
 			expect(controller.isExternal).toBe(false);
 		});
 
-		it('adopts an existing proxy on the port without starting a new process', async () => {
-			// Bind a real TCP server to simulate an already-running proxy
-			const { server, port } = await bindTcpServer();
+		// All tests below need a live TCP server to simulate a pre-existing proxy.
+		// A shared server + controller are set up in beforeEach and torn down in
+		// afterEach so the framework guarantees cleanup even when assertions throw.
+		describe('with a simulated pre-existing proxy', () => {
+			let tcpServer: net.Server;
+			let tcpPort: number;
+			let controller: ReturnType<typeof createDevProxyController>;
+			let originalBaseUrl: string | undefined;
 
-			try {
-				const controller = createDevProxyController({
-					port,
-					setEnvVars: false, // avoid mutating process.env in unit tests
-				});
+			beforeEach(async () => {
+				const bound = await bindTcpServer();
+				tcpServer = bound.server;
+				tcpPort = bound.port;
+				controller = createDevProxyController({ port: tcpPort, setEnvVars: false });
+				originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
+			});
 
+			afterEach(async () => {
+				// Stop controller first (no-op for external, but keeps state consistent).
+				if (controller.isRunning()) {
+					await controller.stop();
+				}
+				controller.restoreEnv();
+				// Restore env regardless of what each test did.
+				if (originalBaseUrl === undefined) {
+					delete process.env.ANTHROPIC_BASE_URL;
+				} else {
+					process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
+				}
+				// Close the TCP server last so the controller stop() check above
+				// (which probes the port) still sees it open.
+				await closeTcpServer(tcpServer);
+			});
+
+			it('adopts an existing proxy on the port without starting a new process', async () => {
 				await controller.start();
 
 				expect(controller.isRunning()).toBe(true);
 				expect(controller.isExternal).toBe(true);
-			} finally {
-				await closeTcpServer(server);
-			}
-		});
+			});
 
-		it('stop() does not close the external proxy port', async () => {
-			const { server, port } = await bindTcpServer();
-
-			try {
-				const controller = createDevProxyController({
-					port,
-					setEnvVars: false,
-				});
-
+			it('stop() does not close the external proxy port', async () => {
 				await controller.start();
 				expect(controller.isRunning()).toBe(true);
 				expect(controller.isExternal).toBe(true);
@@ -286,7 +300,7 @@ describe('Dev Proxy Helper', () => {
 				// The TCP server (external proxy) must still be accepting connections
 				await expect(
 					new Promise<void>((resolve, reject) => {
-						const socket = net.createConnection({ port, host: '127.0.0.1' });
+						const socket = net.createConnection({ port: tcpPort, host: '127.0.0.1' });
 						socket.once('connect', () => {
 							socket.destroy();
 							resolve();
@@ -294,69 +308,28 @@ describe('Dev Proxy Helper', () => {
 						socket.once('error', reject);
 					})
 				).resolves.toBeUndefined();
-			} finally {
-				await closeTcpServer(server);
-			}
-		});
+			});
 
-		it('isExternal resets to false after stop()', async () => {
-			const { server, port } = await bindTcpServer();
-
-			try {
-				const controller = createDevProxyController({
-					port,
-					setEnvVars: false,
-				});
-
+			it('isExternal resets to false after stop()', async () => {
 				await controller.start();
 				expect(controller.isExternal).toBe(true);
 
 				await controller.stop();
 				expect(controller.isExternal).toBe(false);
-			} finally {
-				await closeTcpServer(server);
-			}
-		});
+			});
 
-		it('sets env vars when setEnvVars=true and adopting external proxy', async () => {
-			const { server, port } = await bindTcpServer();
-			const originalBaseUrl = process.env.ANTHROPIC_BASE_URL;
-
-			try {
-				const controller = createDevProxyController({
-					port,
-					setEnvVars: true,
-				});
+			it('sets env vars when setEnvVars=true and adopting external proxy', async () => {
+				// Re-create controller with setEnvVars=true for this specific test.
+				controller = createDevProxyController({ port: tcpPort, setEnvVars: true });
 
 				await controller.start();
 
-				try {
-					expect(controller.isExternal).toBe(true);
-					expect(process.env.ANTHROPIC_BASE_URL).toBe(`http://127.0.0.1:${port}`);
-				} finally {
-					controller.restoreEnv();
-					await controller.stop();
-				}
-			} finally {
-				await closeTcpServer(server);
-				// Ensure env is restored regardless
-				if (originalBaseUrl === undefined) {
-					delete process.env.ANTHROPIC_BASE_URL;
-				} else {
-					process.env.ANTHROPIC_BASE_URL = originalBaseUrl;
-				}
-			}
-		});
+				expect(controller.isExternal).toBe(true);
+				expect(process.env.ANTHROPIC_BASE_URL).toBe(`http://127.0.0.1:${tcpPort}`);
+				// afterEach will call restoreEnv() and reset ANTHROPIC_BASE_URL.
+			});
 
-		it('can be restarted after stopping an external proxy', async () => {
-			const { server, port } = await bindTcpServer();
-
-			try {
-				const controller = createDevProxyController({
-					port,
-					setEnvVars: false,
-				});
-
+			it('can be restarted after stopping an external proxy', async () => {
 				// First adoption
 				await controller.start();
 				expect(controller.isExternal).toBe(true);
@@ -366,10 +339,7 @@ describe('Dev Proxy Helper', () => {
 				await controller.start();
 				expect(controller.isExternal).toBe(true);
 				expect(controller.isRunning()).toBe(true);
-				await controller.stop();
-			} finally {
-				await closeTcpServer(server);
-			}
+			});
 		});
 	});
 


### PR DESCRIPTION
When a devproxy process from a previous session is still running,
`devproxy --detach` exits non-zero and tests would fail with
"Dev Proxy is already running (PID: XXXXX)".

Fix by proactively checking the configured port before attempting to
start devproxy.  If the port is already open, the controller adopts
the running instance as `external: true` and skips the start command.
`stop()` is a no-op for external instances so the pre-existing process
is left undisturbed after tests finish.

Also simplifies `acquireDevProxyLease` in daemon-server.ts to rely on
the controller's `isExternal` flag instead of ad-hoc error-message
parsing, and adds `DEV_PROXY_FREE_TO_START` guard in unit tests so
lifecycle tests skip gracefully when devproxy is already in use.
