### PR TITLE
fix: fix TaskView not showing messages after daemon restart

### DIFF
--- a/packages/web/src/components/room/TaskConversationRenderer.test.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.test.tsx
@@ -533,3 +533,87 @@ describe('TaskConversationRenderer — session question state props', () => {
 		});
 	});
 });
+
+describe('TaskConversationRenderer — isReconnecting state', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockRequest.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+			if (method === 'liveQuery.subscribe') {
+				lastSubscriptionId = params.subscriptionId as string;
+				return { ok: true };
+			}
+			if (method === 'liveQuery.unsubscribe') return { ok: true };
+			if (method === 'session.get') return { session: null };
+			return {};
+		});
+		mockOnEvent.mockClear();
+		snapshotHandler = null;
+		deltaHandler = null;
+		lastSubscriptionId = null;
+		sessionStateHandlers.length = 0;
+		capturedSDKProps.length = 0;
+		resetSubscriptionCounterForTesting();
+		// Reset to connected by default.
+		mockIsConnected.value = true;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders "Reconnecting…" when WebSocket is disconnected and groupId is set', async () => {
+		// Simulate a WebSocket disconnect while the component is mounted with a group.
+		mockIsConnected.value = false;
+
+		const { container } = render(<TaskConversationRenderer groupId="group-1" />);
+
+		// isReconnecting = !isConnected && groupId !== null → true
+		// The component should show "Reconnecting…" not "Waiting for agent activity…"
+		await waitFor(() => {
+			expect(container.textContent).toContain('Reconnecting');
+		});
+		expect(container.textContent).not.toContain('Waiting for agent activity');
+	});
+
+	it('renders "Loading conversation…" when connected but snapshot has not arrived yet', async () => {
+		mockIsConnected.value = true;
+
+		const { container } = render(<TaskConversationRenderer groupId="group-1" />);
+
+		// isReconnecting = false (connected), isLoading = true (snapshot pending)
+		await waitFor(() => {
+			expect(container.textContent).toContain('Loading conversation');
+		});
+		expect(container.textContent).not.toContain('Reconnecting');
+	});
+
+	it('renders messages normally once snapshot arrives after reconnect', async () => {
+		// Start disconnected.
+		mockIsConnected.value = false;
+		const { container, rerender } = render(<TaskConversationRenderer groupId="group-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).toContain('Reconnecting');
+		});
+
+		// Reconnect.
+		mockIsConnected.value = true;
+		rerender(<TaskConversationRenderer groupId="group-1" />);
+
+		// Now in loading state (connected, waiting for snapshot).
+		await waitFor(() => {
+			expect(container.textContent).toContain('Loading conversation');
+		});
+
+		// Snapshot arrives.
+		await act(async () => {
+			fireSnapshot([makeRawMessage(1, 'assistant', 'uuid-reconnect-1')]);
+		});
+
+		await waitFor(() => {
+			expect(container.querySelector('[data-testid="msg-uuid-reconnect-1"]')).not.toBeNull();
+		});
+		expect(container.textContent).not.toContain('Reconnecting');
+		expect(container.textContent).not.toContain('Loading conversation');
+	});
+});

--- a/packages/web/src/components/room/TaskConversationRenderer.tsx
+++ b/packages/web/src/components/room/TaskConversationRenderer.tsx
@@ -159,7 +159,7 @@ export function TaskConversationRenderer({
 	const workerQuestionState = useSessionQuestionState(workerSessionId);
 
 	// Subscribe to group messages via LiveQuery (handles initial snapshot + live deltas)
-	const { messages: rawMessages, isLoading } = useGroupMessages(groupId);
+	const { messages: rawMessages, isLoading, isReconnecting } = useGroupMessages(groupId);
 
 	const messages = useMemo(
 		() => rawMessages.map(parseGroupMessage).filter((m): m is SDKMessage => m !== null),
@@ -256,6 +256,14 @@ export function TaskConversationRenderer({
 		}
 		return transitions;
 	}, [messages]);
+
+	if (isReconnecting) {
+		return (
+			<div class="flex-1 flex items-center justify-center">
+				<p class="text-gray-400 text-sm">Reconnecting…</p>
+			</div>
+		);
+	}
 
 	if (isLoading) {
 		return (

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2605,3 +2605,84 @@ describe('TaskView — goal badge', () => {
 		expect(badge?.getAttribute('title')).toBe('Mission: Tooltip Mission Title');
 	});
 });
+
+describe('TaskView — task.getGroup retry on failure', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+		_draftContentSignal.value = '';
+		_draftRestoredSignal.value = false;
+		mockSetMessageText.mockClear();
+		mockClearDraft.mockClear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it('retries task.getGroup once after 1s if first attempt throws', async () => {
+		let getGroupCallCount = 0;
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') {
+				getGroupCallCount++;
+				if (getGroupCallCount === 1) throw new Error('daemon not ready');
+				return { group: makeGroup('awaiting_human') };
+			}
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Initial render (task.get resolves, task.getGroup fails).
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		// First getGroup call failed — advance the 1s retry delay.
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+			await Promise.resolve();
+		});
+
+		// Retry succeeded — group should now be loaded.
+		await waitFor(() => {
+			expect(getGroupCallCount).toBe(2);
+		});
+
+		// The "Awaiting your review" badge (from group.submittedForReview) should be visible.
+		await waitFor(() => {
+			expect(container.querySelector('.animate-pulse')?.textContent).toContain(
+				'Awaiting your review'
+			);
+		});
+	});
+
+	it('shows "Loading conversation history" for review task while group is null', async () => {
+		// task.getGroup always returns null (daemon just restarted, group not yet returned).
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: null };
+			return {};
+		});
+
+		const { container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(container.textContent).not.toContain('Loading task');
+		});
+
+		// Should show the helpful "Loading conversation history" message, not the generic empty state.
+		expect(container.textContent).toContain('Loading conversation history');
+		// Should NOT show the old generic "No active agent group" title for review tasks.
+		expect(container.textContent).not.toContain('No active agent group');
+	});
+});

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 		onEvent: mockOnEvent,
 		joinRoom: mockJoinRoom,
 		leaveRoom: mockLeaveRoom,
+		isConnected: true,
 	}),
 }));
 

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -823,18 +823,31 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 
 		const fetchGroup = async () => {
 			const seq = ++fetchGroupSeq;
-			try {
-				const res = await request<{ group: TaskGroupInfo | null }>('task.getGroup', {
-					roomId,
-					taskId,
-				});
-				if (!cancelled && seq === fetchGroupSeq) {
-					setGroup(res.group);
-					// Fetch session info for worker and leader
-					void fetchSessionInfo(res.group);
+
+			const tryFetch = async (): Promise<{ group: TaskGroupInfo | null } | null> => {
+				try {
+					return await request<{ group: TaskGroupInfo | null }>('task.getGroup', {
+						roomId,
+						taskId,
+					});
+				} catch {
+					return null;
 				}
-			} catch {
-				// Group fetch failure is non-fatal — task may not have a group yet
+			};
+
+			let res = await tryFetch();
+			// Retry once after 1s if the first attempt fails (e.g. daemon just restarted)
+			if (res === null && !cancelled && seq === fetchGroupSeq) {
+				await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+				if (!cancelled && seq === fetchGroupSeq) {
+					res = await tryFetch();
+				}
+			}
+
+			if (res !== null && !cancelled && seq === fetchGroupSeq) {
+				setGroup(res.group);
+				// Fetch session info for worker and leader
+				void fetchSessionInfo(res.group);
 			}
 		};
 
@@ -1323,7 +1336,11 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 					) : (
 						<div class="flex-1 flex items-center justify-center text-center p-8">
 							<div>
-								<p class="text-gray-400 mb-1">No active agent group</p>
+								<p class="text-gray-400 mb-1">
+									{task.status === 'review'
+										? 'Loading conversation history…'
+										: 'No active agent group'}
+								</p>
 								<p class="text-sm text-gray-500">
 									{task.status === 'pending'
 										? 'Waiting for the runtime to pick up this task.'
@@ -1332,7 +1349,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 											: task.status === 'needs_attention'
 												? 'This task needs attention.'
 												: task.status === 'review'
-													? 'This task is awaiting human review.'
+													? 'If this takes too long, try reloading the page.'
 													: task.status === 'draft'
 														? 'This task is a draft and has not been scheduled yet.'
 														: task.status === 'cancelled'

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -726,7 +726,7 @@ function SetStatusModal({ task, isOpen, onClose, onConfirm }: SetStatusModalProp
 }
 
 export function TaskView({ roomId, taskId }: TaskViewProps) {
-	const { request, onEvent, joinRoom, leaveRoom } = useMessageHub();
+	const { request, onEvent, joinRoom, leaveRoom, isConnected } = useMessageHub();
 	const [task, setTask] = useState<NeoTask | null>(null);
 
 	// Look up the goal associated with this task (reverse lookup from roomStore)
@@ -904,7 +904,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			unsub();
 			leaveRoom(channel);
 		};
-	}, [roomId, taskId]);
+	}, [roomId, taskId, isConnected]);
 
 	if (loading) {
 		return (

--- a/packages/web/src/hooks/__tests__/useGroupMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessages.test.ts
@@ -509,22 +509,85 @@ describe('useGroupMessages', () => {
 	});
 
 	describe('subscribe error handling', () => {
-		it('clears isLoading when subscribe request fails', async () => {
-			mockRequest.mockRejectedValueOnce(new Error('subscribe failed'));
+		it('clears isLoading after all retries are exhausted', async () => {
+			vi.useFakeTimers();
+			// All 3 attempts (initial + 2 retries) fail.
+			mockRequest.mockRejectedValue(new Error('subscribe failed'));
 
 			const { result } = renderHook(() => useGroupMessages('group-1'));
 
 			expect(result.current.isLoading).toBe(true);
 
-			// Let microtasks drain so the .catch() handler runs.
+			// Drain microtasks for first failure.
 			await act(async () => {
-				await new Promise((resolve) => setTimeout(resolve, 0));
+				await Promise.resolve();
+			});
+			// Still loading — retries pending.
+			expect(result.current.isLoading).toBe(true);
+
+			// Advance past first retry delay (500ms) and drain its microtasks.
+			await act(async () => {
+				vi.advanceTimersByTime(500);
+				await Promise.resolve();
+			});
+			// Still loading — second retry pending.
+			expect(result.current.isLoading).toBe(true);
+
+			// Advance past second retry delay (1500ms) and drain its microtasks.
+			await act(async () => {
+				vi.advanceTimersByTime(1500);
+				await Promise.resolve();
 			});
 
+			// All retries exhausted — isLoading must be false now.
 			expect(result.current.isLoading).toBe(false);
+
+			vi.useRealTimers();
+		});
+
+		it('succeeds on retry after initial subscribe failure', async () => {
+			vi.useFakeTimers();
+
+			// First call fails, second succeeds.
+			mockRequest
+				.mockRejectedValueOnce(new Error('first attempt failed'))
+				.mockResolvedValue({ ok: true });
+
+			const { result } = renderHook(() => useGroupMessages('group-1'));
+
+			// Drain microtasks for the first failure.
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			// Advance past first retry delay and let the retry request run.
+			await act(async () => {
+				vi.advanceTimersByTime(500);
+				await Promise.resolve();
+			});
+
+			// Retry succeeded — still loading (waiting for snapshot).
+			expect(result.current.isLoading).toBe(true);
+
+			// Snapshot arrives on the new subscription.
+			const subId = lastSubscribeSubId();
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: subId,
+					rows: [makeMessage(1)],
+					version: 1,
+				});
+			});
+
+			expect(result.current.messages).toHaveLength(1);
+			expect(result.current.isLoading).toBe(false);
+
+			vi.useRealTimers();
 		});
 
 		it('does not clear isLoading after error if groupId already changed', async () => {
+			vi.useFakeTimers();
+
 			let rejectSubscribe: (err: Error) => void;
 			// First call (group-1 subscribe) hangs.
 			mockRequest.mockReturnValueOnce(
@@ -546,12 +609,101 @@ describe('useGroupMessages', () => {
 			// Reject group-1's subscribe after the switch.
 			await act(async () => {
 				rejectSubscribe(new Error('late failure'));
-				await new Promise((resolve) => setTimeout(resolve, 0));
+				await Promise.resolve();
 			});
 
 			// group-2 is still loading (snapshot hasn't arrived) — stale error must
 			// not clear the loading flag.
 			expect(result.current.isLoading).toBe(true);
+
+			vi.useRealTimers();
+		});
+
+		it('cancels pending retry when groupId changes', async () => {
+			vi.useFakeTimers();
+
+			// group-1 subscribe fails → retry scheduled.
+			mockRequest.mockRejectedValueOnce(new Error('fail'));
+			// All subsequent calls resolve (unsubscribe, group-2 subscribe).
+			mockRequest.mockResolvedValue({ ok: true });
+
+			const { result, rerender } = renderHook(
+				({ groupId }: { groupId: string | null }) => useGroupMessages(groupId),
+				{ initialProps: { groupId: 'group-1' } }
+			);
+
+			// Drain microtasks so the failure registers.
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			// Switch groupId — this cancels the pending retry for group-1.
+			rerender({ groupId: 'group-2' });
+
+			// Advance past retry delay — the retry should NOT fire for group-2.
+			await act(async () => {
+				vi.advanceTimersByTime(600);
+				await Promise.resolve();
+			});
+
+			// group-2 subscribe was called exactly once (no extra retry calls for group-1).
+			const group2Calls = mockRequest.mock.calls.filter(
+				(call) => call[0] === 'liveQuery.subscribe' && call[1]?.params?.[0] === 'group-2'
+			);
+			expect(group2Calls).toHaveLength(1);
+
+			// group-2 is still loading (snapshot hasn't arrived).
+			expect(result.current.isLoading).toBe(true);
+
+			vi.useRealTimers();
+		});
+	});
+
+	describe('isReconnecting state', () => {
+		it('is false when connected with a groupId', () => {
+			mockIsConnected.value = true;
+			const { result } = renderHook(() => useGroupMessages('group-1'));
+			expect(result.current.isReconnecting).toBe(false);
+		});
+
+		it('is false when groupId is null regardless of connection state', () => {
+			mockIsConnected.value = false;
+			const { result } = renderHook(() => useGroupMessages(null));
+			expect(result.current.isReconnecting).toBe(false);
+		});
+
+		it('is true when disconnected but groupId is set', () => {
+			const { result, rerender } = renderHook(
+				({ isConn }: { isConn: boolean }) => {
+					mockIsConnected.value = isConn;
+					return useGroupMessages('group-1');
+				},
+				{ initialProps: { isConn: true } }
+			);
+
+			expect(result.current.isReconnecting).toBe(false);
+
+			act(() => {
+				rerender({ isConn: false });
+			});
+
+			expect(result.current.isReconnecting).toBe(true);
+		});
+
+		it('transitions back to false once reconnected', () => {
+			const { result, rerender } = renderHook(
+				({ isConn }: { isConn: boolean }) => {
+					mockIsConnected.value = isConn;
+					return useGroupMessages('group-1');
+				},
+				{ initialProps: { isConn: true } }
+			);
+
+			act(() => rerender({ isConn: false }));
+			expect(result.current.isReconnecting).toBe(true);
+
+			act(() => rerender({ isConn: true }));
+			expect(result.current.isReconnecting).toBe(false);
 		});
 	});
 

--- a/packages/web/src/hooks/useGroupMessages.ts
+++ b/packages/web/src/hooks/useGroupMessages.ts
@@ -30,6 +30,8 @@ export interface SessionGroupMessage {
 export interface UseGroupMessagesResult {
 	messages: SessionGroupMessage[];
 	isLoading: boolean;
+	/** True when the WebSocket is disconnected but a groupId is set — messages will reload on reconnect. */
+	isReconnecting: boolean;
 }
 
 let _subscriptionCounter = 0;
@@ -106,16 +108,33 @@ export function useGroupMessages(groupId: string | null): UseGroupMessagesResult
 			}
 		});
 
-		// Send the subscribe request. Errors are non-fatal: clear loading state.
-		request('liveQuery.subscribe', {
-			queryName: 'sessionGroupMessages.byGroup',
-			params: [groupId],
-			subscriptionId,
-		}).catch(() => {
-			if (activeSubIdRef.current === subscriptionId) {
-				setIsLoading(false);
-			}
-		});
+		// Send the subscribe request with retry on failure.
+		// Up to MAX_RETRIES additional attempts after the first, with increasing delays.
+		const MAX_RETRIES = 2;
+		const RETRY_DELAYS_MS = [500, 1500];
+
+		const subscribeWithRetry = (attempt: number): void => {
+			request('liveQuery.subscribe', {
+				queryName: 'sessionGroupMessages.byGroup',
+				params: [groupId],
+				subscriptionId,
+			}).catch(() => {
+				if (activeSubIdRef.current !== subscriptionId) return;
+				if (attempt < MAX_RETRIES) {
+					setTimeout(() => {
+						if (activeSubIdRef.current === subscriptionId) {
+							subscribeWithRetry(attempt + 1);
+						}
+					}, RETRY_DELAYS_MS[attempt]);
+				} else {
+					if (activeSubIdRef.current === subscriptionId) {
+						setIsLoading(false);
+					}
+				}
+			});
+		};
+
+		subscribeWithRetry(0);
 
 		return () => {
 			// Remove event listeners first.
@@ -135,5 +154,5 @@ export function useGroupMessages(groupId: string | null): UseGroupMessagesResult
 		};
 	}, [groupId, isConnected, request, onEvent]);
 
-	return { messages, isLoading };
+	return { messages, isLoading, isReconnecting: !isConnected && groupId !== null };
 }

--- a/packages/web/src/hooks/useGroupMessages.ts
+++ b/packages/web/src/hooks/useGroupMessages.ts
@@ -110,8 +110,12 @@ export function useGroupMessages(groupId: string | null): UseGroupMessagesResult
 
 		// Send the subscribe request with retry on failure.
 		// Up to MAX_RETRIES additional attempts after the first, with increasing delays.
+		// IMPORTANT: RETRY_DELAYS_MS must have exactly MAX_RETRIES entries — adding an extra
+		// retry without a corresponding delay entry causes setTimeout(fn, undefined) → 0ms.
 		const MAX_RETRIES = 2;
-		const RETRY_DELAYS_MS = [500, 1500];
+		const RETRY_DELAYS_MS: [number, number] = [500, 1500];
+
+		let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
 		const subscribeWithRetry = (attempt: number): void => {
 			request('liveQuery.subscribe', {
@@ -121,7 +125,8 @@ export function useGroupMessages(groupId: string | null): UseGroupMessagesResult
 			}).catch(() => {
 				if (activeSubIdRef.current !== subscriptionId) return;
 				if (attempt < MAX_RETRIES) {
-					setTimeout(() => {
+					retryTimer = setTimeout(() => {
+						retryTimer = null;
 						if (activeSubIdRef.current === subscriptionId) {
 							subscribeWithRetry(attempt + 1);
 						}
@@ -137,6 +142,13 @@ export function useGroupMessages(groupId: string | null): UseGroupMessagesResult
 		subscribeWithRetry(0);
 
 		return () => {
+			// Cancel any pending retry timer before clearing the subscription ID,
+			// so the timer callback cannot observe a matching subscription ID after cleanup.
+			if (retryTimer !== null) {
+				clearTimeout(retryTimer);
+				retryTimer = null;
+			}
+
 			// Remove event listeners first.
 			unsubSnapshot();
 			unsubDelta();


### PR DESCRIPTION
After daemon restart, review tasks showed "Waiting for agent activity…"
because:
1. useGroupMessages silently discarded liveQuery.subscribe failures with
   no retry, leaving the conversation in a permanent loading-but-empty state
2. task.getGroup also had no retry, so a transient RPC failure after restart
   would silently leave group=null for the entire session

Changes:
- useGroupMessages: add retry with backoff (2 retries, 500ms/1500ms delays)
  for liveQuery.subscribe failures; add isReconnecting state (true when
  disconnected but groupId is set) so TaskConversationRenderer can show
  "Reconnecting…" instead of the misleading "Waiting for agent activity…"
- TaskConversationRenderer: render "Reconnecting…" when isReconnecting
- TaskView: retry task.getGroup once after 1s on failure; show
  "Loading conversation history…" (not "No active agent group") when
  group=null for review-status tasks
- Tests: add retry/reconnect/isReconnecting unit tests for useGroupMessages;
  add group fetch retry and review empty-state tests for TaskView
