### PR TITLE
feat: expand TaskView info panel with task ID, group ID, full session IDs, model switcher, and metadata

### DIFF
--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -5,9 +5,13 @@
  * is clicked. Shows task info and available actions.
  *
  * Info section:
+ * - Task ID (full, with copy button)
+ * - Session Group ID (full, with copy button)
  * - Worktree path (last 2 segments, full path on hover)
- * - Session IDs (worker/leader)
- * - Current model
+ * - Session IDs for worker and leader (full, with copy buttons)
+ * - Model switcher (allows changing model for current session)
+ * - Task creation time
+ * - PR number/link if available
  *
  * Actions section:
  * - Complete, Cancel, Archive buttons (context-aware based on task state)
@@ -15,8 +19,8 @@
 
 import type { SessionInfo } from '@neokai/shared';
 import { borderColors } from '../../lib/design-tokens.ts';
-import { getModelLabel } from '../../lib/session-utils.ts';
 import { CopyButton } from '../ui/CopyButton.tsx';
+import { TaskViewModelSelector } from './TaskViewModelSelector.tsx';
 
 /**
  * Map session status to a CSS color class.
@@ -40,8 +44,33 @@ function getLastPathSegments(path: string, segments: number = 2): string {
 	return '.../' + parts.slice(-segments).join('/');
 }
 
+/**
+ * Format a timestamp in milliseconds to a human-readable date/time string.
+ */
+function formatTimestamp(ms: number): string {
+	return new Date(ms).toLocaleString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+	});
+}
+
 export interface TaskInfoPanelProps {
 	isOpen: boolean;
+	/** Full task ID */
+	taskId?: string;
+	/** Full session group ID */
+	groupId?: string;
+	/** Feedback iteration number (0 = first run) */
+	feedbackIteration?: number;
+	/** Task creation timestamp in milliseconds */
+	taskCreatedAt?: number;
+	/** Pull request URL */
+	prUrl?: string | null;
+	/** Pull request number */
+	prNumber?: number | null;
 	/** Worktree path to display (full path shown on hover) */
 	worktreePath?: string;
 	/** Worker session info */
@@ -73,6 +102,12 @@ export interface TaskInfoPanelProps {
 
 export function TaskInfoPanel({
 	isOpen,
+	taskId,
+	groupId,
+	feedbackIteration,
+	taskCreatedAt,
+	prUrl,
+	prNumber,
 	worktreePath,
 	workerSession,
 	leaderSession,
@@ -82,7 +117,15 @@ export function TaskInfoPanel({
 }: TaskInfoPanelProps) {
 	if (!isOpen) return null;
 
-	const hasWorktreeInfo = worktreePath || workerSession || leaderSession;
+	const hasWorktreeInfo =
+		taskId ||
+		groupId ||
+		worktreePath ||
+		workerSession ||
+		leaderSession ||
+		taskCreatedAt ||
+		prUrl ||
+		prNumber;
 	const displayPath = worktreePath ? getLastPathSegments(worktreePath) : null;
 
 	// Git branch: prefer worker worktree branch, then worker gitBranch, then leader equivalents
@@ -99,6 +142,9 @@ export function TaskInfoPanel({
 		visibleActions.archive ||
 		visibleActions.setStatus;
 
+	// Model switcher: use worker session as primary, fall back to leader
+	const modelSession = workerSession ?? leaderSession;
+
 	return (
 		<div
 			class={`border-b ${borderColors.ui.secondary} bg-dark-850 flex-shrink-0`}
@@ -110,10 +156,40 @@ export function TaskInfoPanel({
 					<div>
 						<h3 class="text-xs font-semibold text-gray-500 mb-2 uppercase tracking-wide">Info</h3>
 						<div class="space-y-1.5 text-xs">
+							{/* Task ID */}
+							{taskId && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-14">Task ID:</span>
+									<span
+										class="text-gray-300 font-mono truncate flex-1 min-w-0"
+										title={taskId}
+										data-testid="task-info-panel-task-id"
+									>
+										{taskId}
+									</span>
+									<CopyButton text={taskId} />
+								</div>
+							)}
+
+							{/* Group ID */}
+							{groupId && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-14">Group ID:</span>
+									<span
+										class="text-gray-300 font-mono truncate flex-1 min-w-0"
+										title={groupId}
+										data-testid="task-info-panel-group-id"
+									>
+										{groupId}
+									</span>
+									<CopyButton text={groupId} />
+								</div>
+							)}
+
 							{/* Worktree path */}
 							{worktreePath && (
 								<div class="flex items-center gap-2">
-									<span class="text-gray-500 flex-shrink-0 w-12">Path:</span>
+									<span class="text-gray-500 flex-shrink-0 w-14">Path:</span>
 									<span class="text-gray-300 font-mono truncate flex-1" title={worktreePath}>
 										{displayPath}
 									</span>
@@ -124,7 +200,7 @@ export function TaskInfoPanel({
 							{/* Git branch */}
 							{gitBranch && (
 								<div class="flex items-center gap-2">
-									<span class="text-gray-500 flex-shrink-0 w-12">Branch:</span>
+									<span class="text-gray-500 flex-shrink-0 w-14">Branch:</span>
 									<span class="text-gray-300 font-mono truncate flex-1" title={gitBranch}>
 										{gitBranch}
 									</span>
@@ -132,12 +208,16 @@ export function TaskInfoPanel({
 								</div>
 							)}
 
-							{/* Session IDs */}
+							{/* Worker session */}
 							{workerSession && (
 								<div class="flex items-center gap-2">
-									<span class="text-gray-500 flex-shrink-0 w-12">Worker:</span>
-									<span class="text-gray-300 font-mono truncate flex-1" title={workerSession.id}>
-										{workerSession.id.slice(0, 8)}...
+									<span class="text-gray-500 flex-shrink-0 w-14">Worker:</span>
+									<span
+										class="text-gray-300 font-mono truncate flex-1 min-w-0"
+										title={workerSession.id}
+										data-testid="worker-session-id"
+									>
+										{workerSession.id}
 									</span>
 									<span
 										class={`text-xs flex-shrink-0 ${sessionStatusColor(workerSession.status)}`}
@@ -148,11 +228,17 @@ export function TaskInfoPanel({
 									<CopyButton text={workerSession.id} />
 								</div>
 							)}
+
+							{/* Leader session */}
 							{leaderSession && (
 								<div class="flex items-center gap-2">
-									<span class="text-gray-500 flex-shrink-0 w-12">Leader:</span>
-									<span class="text-gray-300 font-mono truncate flex-1" title={leaderSession.id}>
-										{leaderSession.id.slice(0, 8)}...
+									<span class="text-gray-500 flex-shrink-0 w-14">Leader:</span>
+									<span
+										class="text-gray-300 font-mono truncate flex-1 min-w-0"
+										title={leaderSession.id}
+										data-testid="leader-session-id"
+									>
+										{leaderSession.id}
 									</span>
 									<span
 										class={`text-xs flex-shrink-0 ${sessionStatusColor(leaderSession.status)}`}
@@ -164,13 +250,56 @@ export function TaskInfoPanel({
 								</div>
 							)}
 
-							{/* Model info */}
-							{(workerSession?.config.model || leaderSession?.config.model) && (
+							{/* Model switcher */}
+							{modelSession?.config.model && (
 								<div class="flex items-center gap-2">
-									<span class="text-gray-500 flex-shrink-0 w-12">Model:</span>
-									<span class="text-gray-300">
-										{getModelLabel(workerSession?.config.model ?? leaderSession?.config.model)}
+									<span class="text-gray-500 flex-shrink-0 w-14">Model:</span>
+									<TaskViewModelSelector
+										sessionId={modelSession.id}
+										currentModel={modelSession.config.model}
+										currentProvider={modelSession.config.provider}
+									/>
+								</div>
+							)}
+
+							{/* Feedback iteration */}
+							{feedbackIteration !== undefined && feedbackIteration > 0 && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-14">Iteration:</span>
+									<span class="text-gray-300" data-testid="task-info-panel-iteration">
+										{feedbackIteration}
 									</span>
+								</div>
+							)}
+
+							{/* Created at */}
+							{taskCreatedAt && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-14">Created:</span>
+									<span
+										class="text-gray-300"
+										title={new Date(taskCreatedAt).toISOString()}
+										data-testid="task-info-panel-created-at"
+									>
+										{formatTimestamp(taskCreatedAt)}
+									</span>
+								</div>
+							)}
+
+							{/* PR link */}
+							{prUrl && prNumber && (
+								<div class="flex items-center gap-2">
+									<span class="text-gray-500 flex-shrink-0 w-14">PR:</span>
+									<a
+										href={prUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="text-purple-400 hover:text-purple-300 transition-colors"
+										data-testid="task-info-panel-pr-link"
+									>
+										#{prNumber}
+									</a>
+									<CopyButton text={prUrl} />
 								</div>
 							)}
 						</div>

--- a/packages/web/src/components/room/TaskInfoPanel.tsx
+++ b/packages/web/src/components/room/TaskInfoPanel.tsx
@@ -123,9 +123,8 @@ export function TaskInfoPanel({
 		worktreePath ||
 		workerSession ||
 		leaderSession ||
-		taskCreatedAt ||
-		prUrl ||
-		prNumber;
+		taskCreatedAt !== undefined ||
+		prUrl;
 	const displayPath = worktreePath ? getLastPathSegments(worktreePath) : null;
 
 	// Git branch: prefer worker worktree branch, then worker gitBranch, then leader equivalents
@@ -273,7 +272,7 @@ export function TaskInfoPanel({
 							)}
 
 							{/* Created at */}
-							{taskCreatedAt && (
+							{taskCreatedAt !== undefined && (
 								<div class="flex items-center gap-2">
 									<span class="text-gray-500 flex-shrink-0 w-14">Created:</span>
 									<span

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -1220,6 +1220,12 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 			{/* Info panel — expands below header when gear is clicked */}
 			<TaskInfoPanel
 				isOpen={isInfoPanelOpen}
+				taskId={task.id}
+				groupId={group?.id}
+				feedbackIteration={group?.feedbackIteration}
+				taskCreatedAt={task.createdAt}
+				prUrl={task.prUrl}
+				prNumber={task.prNumber}
 				worktreePath={workerSession?.worktree?.worktreePath ?? workerSession?.workspacePath}
 				workerSession={workerSession}
 				leaderSession={leaderSession}

--- a/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
@@ -54,12 +54,18 @@ describe('TaskInfoPanel', () => {
 			expect(el?.textContent).toBe('task-abc123-def456-ghi789');
 		});
 
-		it('should show copy button for task ID', () => {
+		it('should show a copy button next to the task ID', () => {
 			const { container } = render(
 				<TaskInfoPanel isOpen={true} taskId="task-abc123" actions={{}} visibleActions={{}} />
 			);
 
-			expect(container.querySelector('[data-testid="task-info-panel-task-id"]')).toBeTruthy();
+			// The task ID row should contain a button (the CopyButton) with a copy title
+			const taskIdEl = container.querySelector('[data-testid="task-info-panel-task-id"]');
+			expect(taskIdEl).toBeTruthy();
+			// CopyButton renders a <button> with title="Copy" or "Copied!" in the same row
+			const row = taskIdEl?.closest('.flex');
+			const copyBtn = row?.querySelector('button[title]');
+			expect(copyBtn).toBeTruthy();
 		});
 
 		it('should not show task ID row when not provided', () => {

--- a/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskInfoPanel.test.tsx
@@ -8,6 +8,13 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, fireEvent } from '@testing-library/preact';
 import { TaskInfoPanel } from '../TaskInfoPanel';
 
+// Mock TaskViewModelSelector to avoid connectionManager dependency in tests
+vi.mock('../TaskViewModelSelector.tsx', () => ({
+	TaskViewModelSelector: ({ currentModel }: { currentModel: string }) => (
+		<span data-testid="model-selector-mock">{currentModel}</span>
+	),
+}));
+
 describe('TaskInfoPanel', () => {
 	afterEach(() => {
 		cleanup();
@@ -28,6 +35,62 @@ describe('TaskInfoPanel', () => {
 			);
 
 			expect(container.querySelector('[data-testid="task-info-panel"]')).toBeTruthy();
+		});
+	});
+
+	describe('Task ID and Group ID', () => {
+		it('should show full task ID when provided', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					taskId="task-abc123-def456-ghi789"
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Task ID:');
+			const el = container.querySelector('[data-testid="task-info-panel-task-id"]');
+			expect(el?.textContent).toBe('task-abc123-def456-ghi789');
+		});
+
+		it('should show copy button for task ID', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} taskId="task-abc123" actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.querySelector('[data-testid="task-info-panel-task-id"]')).toBeTruthy();
+		});
+
+		it('should not show task ID row when not provided', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('Task ID:');
+		});
+
+		it('should show full group ID when provided', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					groupId="group-xyz789-abc123"
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Group ID:');
+			const el = container.querySelector('[data-testid="task-info-panel-group-id"]');
+			expect(el?.textContent).toBe('group-xyz789-abc123');
+		});
+
+		it('should not show group ID row when not provided', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('Group ID:');
 		});
 	});
 
@@ -127,9 +190,9 @@ describe('TaskInfoPanel', () => {
 			expect(container.textContent).not.toContain('Branch:');
 		});
 
-		it('should show worker session info when provided', () => {
+		it('should show full worker session ID when provided', () => {
 			const workerSession = {
-				id: 'worker-session-id-1234',
+				id: 'worker-session-id-1234-5678-abcd',
 				status: 'active',
 				config: { model: 'claude-sonnet-4-6' },
 			} as never;
@@ -144,7 +207,9 @@ describe('TaskInfoPanel', () => {
 			);
 
 			expect(container.textContent).toContain('Worker:');
-			expect(container.textContent).toContain('worker-s'); // first 8 chars + '...'
+			// Should show the full session ID (not truncated)
+			const el = container.querySelector('[data-testid="worker-session-id"]');
+			expect(el?.textContent).toBe('worker-session-id-1234-5678-abcd');
 		});
 
 		it('should show worker session status', () => {
@@ -168,9 +233,9 @@ describe('TaskInfoPanel', () => {
 			expect(statusEl?.textContent).toBe('active');
 		});
 
-		it('should show leader session info when provided', () => {
+		it('should show full leader session ID when provided', () => {
 			const leaderSession = {
-				id: 'leader-session-id-5678',
+				id: 'leader-session-id-5678-efgh',
 				status: 'active',
 				config: { model: 'claude-sonnet-4-6' },
 			} as never;
@@ -185,7 +250,9 @@ describe('TaskInfoPanel', () => {
 			);
 
 			expect(container.textContent).toContain('Leader:');
-			expect(container.textContent).toContain('leader-s'); // first 8 chars + '...'
+			// Should show the full session ID (not truncated)
+			const el = container.querySelector('[data-testid="leader-session-id"]');
+			expect(el?.textContent).toBe('leader-session-id-5678-efgh');
 		});
 
 		it('should show leader session status', () => {
@@ -358,9 +425,10 @@ describe('TaskInfoPanel', () => {
 			expect(container.textContent).not.toContain('task/leader-branch');
 		});
 
-		it('should show model when session has model config', () => {
+		it('should render model selector when session has model config', () => {
 			const workerSession = {
 				id: 'worker-session-id-1234',
+				status: 'active',
 				config: { model: 'claude-sonnet-4-6' },
 			} as never;
 
@@ -374,6 +442,29 @@ describe('TaskInfoPanel', () => {
 			);
 
 			expect(container.textContent).toContain('Model:');
+			// Mock shows the model id
+			expect(container.querySelector('[data-testid="model-selector-mock"]')).toBeTruthy();
+		});
+
+		it('should use leader session for model when no worker session', () => {
+			const leaderSession = {
+				id: 'leader-session-id-5678',
+				status: 'active',
+				config: { model: 'claude-opus-4-6' },
+			} as never;
+
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					leaderSession={leaderSession}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Model:');
+			const modelEl = container.querySelector('[data-testid="model-selector-mock"]');
+			expect(modelEl?.textContent).toBe('claude-opus-4-6');
 		});
 
 		it('should show empty state when no info and no actions', () => {
@@ -382,6 +473,98 @@ describe('TaskInfoPanel', () => {
 			);
 
 			expect(container.textContent).toContain('No info or actions available');
+		});
+	});
+
+	describe('Timestamp and metadata', () => {
+		it('should show creation time when taskCreatedAt is provided', () => {
+			// Use a fixed timestamp that will be formatted consistently
+			const ts = new Date('2025-01-15T10:30:00').getTime();
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} taskCreatedAt={ts} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).toContain('Created:');
+			const el = container.querySelector('[data-testid="task-info-panel-created-at"]');
+			expect(el).toBeTruthy();
+			// Should have an ISO string as title
+			expect(el?.getAttribute('title')).toContain('2025-01-15');
+		});
+
+		it('should not show Created row when taskCreatedAt is not provided', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('Created:');
+		});
+
+		it('should show feedback iteration when > 0', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					taskId="task-abc"
+					feedbackIteration={3}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('Iteration:');
+			const el = container.querySelector('[data-testid="task-info-panel-iteration"]');
+			expect(el?.textContent).toBe('3');
+		});
+
+		it('should not show iteration when feedbackIteration is 0', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} feedbackIteration={0} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('Iteration:');
+		});
+
+		it('should not show iteration when feedbackIteration is undefined', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('Iteration:');
+		});
+
+		it('should show PR link when prUrl and prNumber are provided', () => {
+			const { container } = render(
+				<TaskInfoPanel
+					isOpen={true}
+					prUrl="https://github.com/org/repo/pull/42"
+					prNumber={42}
+					actions={{}}
+					visibleActions={{}}
+				/>
+			);
+
+			expect(container.textContent).toContain('PR:');
+			const link = container.querySelector(
+				'[data-testid="task-info-panel-pr-link"]'
+			) as HTMLAnchorElement;
+			expect(link).toBeTruthy();
+			expect(link?.textContent).toBe('#42');
+			expect(link?.href).toContain('github.com/org/repo/pull/42');
+		});
+
+		it('should not show PR row when prUrl is not provided', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('PR:');
+		});
+
+		it('should not show PR row when only prNumber is provided but no prUrl', () => {
+			const { container } = render(
+				<TaskInfoPanel isOpen={true} prNumber={42} actions={{}} visibleActions={{}} />
+			);
+
+			expect(container.textContent).not.toContain('PR:');
 		});
 	});
 


### PR DESCRIPTION
- Show full task ID with copy button in info panel
- Show full session group ID with copy button
- Display complete session IDs (worker and leader) instead of truncated
- Add TaskViewModelSelector for in-place model switching from the info panel
- Add feedback iteration, task creation timestamp, and PR link rows
- Update TaskInfoPanel props interface to accept new fields
- Update TaskView to pass taskId, groupId, feedbackIteration, taskCreatedAt, prUrl, prNumber
- Replace getModelLabel static display with interactive TaskViewModelSelector
- Add vi.mock for TaskViewModelSelector in tests to avoid connectionManager dep
- Update/extend TaskInfoPanel unit tests for all new fields and behaviors
