### PR TITLE
feat: create useRoomLiveQuery hook and integrate with Room.tsx (Task 3.5)

### DIFF
--- a/packages/web/src/hooks/__tests__/index.test.ts
+++ b/packages/web/src/hooks/__tests__/index.test.ts
@@ -15,6 +15,7 @@ import {
 	useInterrupt,
 	useFileAttachments,
 	useGroupMessages,
+	useRoomLiveQuery,
 } from '../index.ts';
 
 describe('Hooks Index', () => {
@@ -62,6 +63,11 @@ describe('Hooks Index', () => {
 		it('should export useGroupMessages', () => {
 			expect(useGroupMessages).toBeDefined();
 			expect(typeof useGroupMessages).toBe('function');
+		});
+
+		it('should export useRoomLiveQuery', () => {
+			expect(useRoomLiveQuery).toBeDefined();
+			expect(typeof useRoomLiveQuery).toBe('function');
 		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
@@ -1,0 +1,124 @@
+// @ts-nocheck
+/**
+ * Tests for useRoomLiveQuery Hook
+ *
+ * Verifies that the hook correctly manages the LiveQuery subscription
+ * lifecycle by delegating to roomStore.subscribeRoom / unsubscribeRoom:
+ *
+ * - Calls subscribeRoom(roomId) on mount
+ * - Calls unsubscribeRoom(oldRoomId) then subscribeRoom(newRoomId) on roomId change
+ * - Calls unsubscribeRoom(roomId) on unmount
+ * - Does NOT double-subscribe if called with the same roomId
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (must not import anything)
+// ---------------------------------------------------------------------------
+
+const { mockSubscribeRoom, mockUnsubscribeRoom } = vi.hoisted(() => ({
+	mockSubscribeRoom: vi.fn().mockResolvedValue(undefined),
+	mockUnsubscribeRoom: vi.fn(),
+}));
+
+// Mock roomStore so we control subscribeRoom and unsubscribeRoom directly.
+vi.mock('../../lib/room-store', () => ({
+	roomStore: {
+		subscribeRoom: mockSubscribeRoom,
+		unsubscribeRoom: mockUnsubscribeRoom,
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { useRoomLiveQuery } from '../useRoomLiveQuery';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useRoomLiveQuery', () => {
+	beforeEach(() => {
+		mockSubscribeRoom.mockClear();
+		mockUnsubscribeRoom.mockClear();
+	});
+
+	it('calls subscribeRoom(roomId) on mount', () => {
+		renderHook(() => useRoomLiveQuery('room-1'));
+
+		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-1');
+	});
+
+	it('calls unsubscribeRoom(roomId) on unmount', () => {
+		const { unmount } = renderHook(() => useRoomLiveQuery('room-1'));
+
+		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-1');
+	});
+
+	it('calls unsubscribeRoom(oldRoomId) then subscribeRoom(newRoomId) on roomId change', () => {
+		const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
+			initialProps: { roomId: 'room-1' },
+		});
+
+		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-1');
+		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
+
+		mockSubscribeRoom.mockClear();
+		mockUnsubscribeRoom.mockClear();
+
+		rerender({ roomId: 'room-2' });
+
+		// unsubscribeRoom for old room before subscribeRoom for new room
+		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-1');
+		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-2');
+
+		// Verify unsubscribe was called before subscribe by checking call order
+		const unsubCallOrder = mockUnsubscribeRoom.mock.invocationCallOrder[0];
+		const subCallOrder = mockSubscribeRoom.mock.invocationCallOrder[0];
+		expect(unsubCallOrder).toBeLessThan(subCallOrder);
+	});
+
+	it('does not re-subscribe when roomId is unchanged', () => {
+		const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
+			initialProps: { roomId: 'room-1' },
+		});
+
+		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
+		mockSubscribeRoom.mockClear();
+		mockUnsubscribeRoom.mockClear();
+
+		// Rerender with the same roomId
+		rerender({ roomId: 'room-1' });
+
+		expect(mockSubscribeRoom).not.toHaveBeenCalled();
+		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
+	});
+
+	it('calls unsubscribeRoom with the last active roomId on unmount after room change', () => {
+		const { rerender, unmount } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
+			initialProps: { roomId: 'room-1' },
+		});
+
+		rerender({ roomId: 'room-2' });
+
+		mockUnsubscribeRoom.mockClear();
+
+		unmount();
+
+		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
+		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-2');
+	});
+});

--- a/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Tests for useRoomLiveQuery Hook
  *

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -51,3 +51,4 @@ export {
 	type SessionGroupMessage,
 	type UseGroupMessagesResult,
 } from './useGroupMessages';
+export { useRoomLiveQuery } from './useRoomLiveQuery';

--- a/packages/web/src/hooks/useRoomLiveQuery.ts
+++ b/packages/web/src/hooks/useRoomLiveQuery.ts
@@ -1,0 +1,43 @@
+/**
+ * useRoomLiveQuery Hook
+ *
+ * Lifecycle adapter that manages LiveQuery subscriptions for a room.
+ *
+ * Responsibilities:
+ * - On mount: call roomStore.subscribeRoom(roomId)
+ * - On roomId change: call roomStore.unsubscribeRoom(oldRoomId) then
+ *   roomStore.subscribeRoom(newRoomId)
+ * - On unmount: call roomStore.unsubscribeRoom(roomId)
+ *
+ * The store owns the subscription handles and cleanup logic.
+ * This hook is purely a lifecycle adapter between the Preact component
+ * tree and the room store's LiveQuery methods.
+ */
+
+import { useEffect } from 'preact/hooks';
+import { roomStore } from '../lib/room-store';
+
+/**
+ * Manages the LiveQuery subscription lifecycle for a room.
+ *
+ * Must be mounted inside or alongside a component that is unconditionally
+ * rendered for the duration of the room view (e.g., the Room island).
+ *
+ * @param roomId - The ID of the room to subscribe to.
+ *
+ * @example
+ * ```tsx
+ * export default function Room({ roomId }: { roomId: string }) {
+ *   useRoomLiveQuery(roomId);
+ *   // ...
+ * }
+ * ```
+ */
+export function useRoomLiveQuery(roomId: string): void {
+	useEffect(() => {
+		roomStore.subscribeRoom(roomId);
+		return () => {
+			roomStore.unsubscribeRoom(roomId);
+		};
+	}, [roomId]);
+}

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { roomStore } from '../lib/room-store';
 import { navigateToHome, navigateToRoomTask, navigateToRoom } from '../lib/router';
 import { currentRoomTabSignal } from '../lib/signals';
+import { useRoomLiveQuery } from '../hooks/useRoomLiveQuery';
 import { RoomDashboard } from '../components/room/RoomDashboard';
 import ChatContainer from './ChatContainer';
 import { GoalsEditor, RoomContext, RoomSettings, RoomAgents } from '../components/room';
@@ -32,6 +33,9 @@ interface RoomProps {
 export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 	const [initialLoad, setInitialLoad] = useState(true);
 	const [activeTab, setActiveTab] = useState<RoomTab>('overview');
+
+	// Manage LiveQuery subscriptions for tasks and goals
+	useRoomLiveQuery(roomId);
 
 	useEffect(() => {
 		roomStore.select(roomId).finally(() => {

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -34,7 +34,10 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 	const [initialLoad, setInitialLoad] = useState(true);
 	const [activeTab, setActiveTab] = useState<RoomTab>('overview');
 
-	// Manage LiveQuery subscriptions for tasks and goals
+	// Manage LiveQuery subscriptions for tasks and goals.
+	// Intentionally declared before the select() effect so that LiveQuery
+	// handlers are registered before the hub request fires — both share
+	// [roomId] as their dependency and run in declaration order.
 	useRoomLiveQuery(roomId);
 
 	useEffect(() => {

--- a/packages/web/src/islands/__tests__/Room.test.tsx
+++ b/packages/web/src/islands/__tests__/Room.test.tsx
@@ -92,6 +92,8 @@ vi.mock('../../lib/room-store', () => ({
 				return mockAutoCompletedNotificationsSignal;
 			},
 			select: mockRoomStoreSelect,
+			subscribeRoom: vi.fn().mockResolvedValue(undefined),
+			unsubscribeRoom: vi.fn(),
 			createGoal: vi.fn(),
 			updateGoal: vi.fn(),
 			deleteGoal: vi.fn(),

--- a/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-goals-live-query.test.ts
@@ -131,9 +131,13 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
 		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
 		await roomStore.select(ROOM_ID);
+		// LiveQuery subscriptions are now managed by useRoomLiveQuery hook;
+		// simulate hook mount by calling subscribeRoom directly.
+		await roomStore.subscribeRoom(ROOM_ID);
 	});
 
 	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
 		await roomStore.select(null);
 		vi.clearAllMocks();
 	});
@@ -215,9 +219,9 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
 	});
 
-	it('unsubscribes from goals.byRoom on room deselect', async () => {
+	it('unsubscribes from goals.byRoom when unsubscribeRoom is called (hook unmount)', () => {
 		hub.request.mockClear();
-		await roomStore.select(null);
+		roomStore.unsubscribeRoom(ROOM_ID);
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const unsubCall = calls.find(
 			([method, params]) =>
@@ -244,8 +248,8 @@ describe('RoomStore — goals.byRoom LiveQuery subscription', () => {
 		});
 	});
 
-	it('does NOT re-subscribe on reconnect after room is deselected', async () => {
-		await roomStore.select(null);
+	it('does NOT re-subscribe on reconnect after unsubscribeRoom (hook unmount)', () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
 		hub.request.mockClear();
 		hub.fireConnection('connected');
 		const calls = hub.request.mock.calls as [string, unknown][];

--- a/packages/web/src/lib/__tests__/room-store-review.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-review.test.ts
@@ -87,7 +87,9 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 		const mod = await import('../room-store.ts');
 		roomStore = mod.roomStore;
 
-		// Force deselect so the next select() always re-runs startSubscriptions
+		// Force deselect so the next select() always re-runs startSubscriptions.
+		// Also unsubscribeRoom so liveQueryActive is cleared between tests.
+		roomStore.unsubscribeRoom(ROOM_ID);
 		if (roomStore.roomId.value !== null) {
 			await roomStore.select(null);
 		}
@@ -103,6 +105,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 		// Simulates a race where liveQuery.delta arrives before the snapshot
 		// populates tasks — the task is not yet in local state.
 		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
 		roomStore.tasks.value = [];
 
 		// Delta with an 'updated' task that is not in current state
@@ -118,6 +121,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 
 	it('fires a toast when existing task transitions from in_progress to review', async () => {
 		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
 
 		// Seed with an in_progress task via snapshot
 		fireEvent('liveQuery.snapshot', {
@@ -139,6 +143,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 
 	it('does NOT fire a toast when a task updates but stays in review', async () => {
 		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
 
 		// Seed with an already-review task
 		fireEvent('liveQuery.snapshot', {
@@ -158,6 +163,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 
 	it('does NOT fire a toast for task updates with non-review status', async () => {
 		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
 
 		fireEvent('liveQuery.snapshot', {
 			subscriptionId: TASKS_SUB_ID,
@@ -176,6 +182,7 @@ describe('RoomStore — review toast notification (via liveQuery.delta)', () => 
 
 	it('does NOT fire a toast for delta events with a different subscriptionId', async () => {
 		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
 
 		fireEvent('liveQuery.snapshot', {
 			subscriptionId: TASKS_SUB_ID,

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -306,3 +306,47 @@ describe('RoomStore — tasks.byRoom LiveQuery subscription', () => {
 		expect(roomStore.tasks.value).toEqual([]);
 	});
 });
+
+describe('RoomStore — subscribeRoom error path', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		// Ensure clean state before each test
+		roomStore.unsubscribeRoom(ROOM_ID);
+		if (roomStore.roomId.value !== null) {
+			await roomStore.select(null);
+		}
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('clears liveQueryActive on getHub() rejection so re-subscribe is possible', async () => {
+		await roomStore.select(ROOM_ID);
+
+		// Make getHub reject for the next call (which will be subscribeRoom)
+		vi.mocked(connectionManager.getHub).mockRejectedValueOnce(new Error('connection failed'));
+
+		// First subscribeRoom — hub rejects, should clean up liveQueryActive
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		// No snapshot/delta handlers should have been registered (hub was unavailable)
+		expect(hub._handlers.get('liveQuery.snapshot') ?? []).toHaveLength(0);
+
+		// Restore hub for the second call
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+
+		// Second subscribeRoom should succeed (liveQueryActive was cleared by error path)
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		// Handlers should now be registered
+		expect((hub._handlers.get('liveQuery.snapshot') ?? []).length).toBeGreaterThan(0);
+	});
+});

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -129,9 +129,13 @@ describe('RoomStore — tasks.byRoom LiveQuery subscription', () => {
 		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
 		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
 		await roomStore.select(ROOM_ID);
+		// LiveQuery subscriptions are now managed by useRoomLiveQuery hook;
+		// simulate hook mount by calling subscribeRoom directly.
+		await roomStore.subscribeRoom(ROOM_ID);
 	});
 
 	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
 		await roomStore.select(null);
 		vi.clearAllMocks();
 	});
@@ -212,9 +216,9 @@ describe('RoomStore — tasks.byRoom LiveQuery subscription', () => {
 		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
 	});
 
-	it('unsubscribes from tasks.byRoom on room deselect', async () => {
+	it('unsubscribes from tasks.byRoom when unsubscribeRoom is called (hook unmount)', () => {
 		hub.request.mockClear();
-		await roomStore.select(null);
+		roomStore.unsubscribeRoom(ROOM_ID);
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const unsubCall = calls.find(
 			([method, params]) =>
@@ -241,8 +245,8 @@ describe('RoomStore — tasks.byRoom LiveQuery subscription', () => {
 		});
 	});
 
-	it('does NOT re-subscribe on reconnect after room is deselected', async () => {
-		await roomStore.select(null);
+	it('does NOT re-subscribe on reconnect after unsubscribeRoom (hook unmount)', () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
 		hub.request.mockClear();
 		hub.fireConnection('connected');
 		const calls = hub.request.mock.calls as [string, unknown][];

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -224,6 +224,12 @@ class RoomStore {
 	/** Subscription cleanup functions */
 	private cleanupFunctions: Array<() => void> = [];
 
+	/** Per-room LiveQuery cleanup functions — owned by subscribeRoom/unsubscribeRoom */
+	private liveQueryCleanups = new Map<string, Array<() => void>>();
+
+	/** Set of room IDs that currently have an active LiveQuery subscription intent */
+	private liveQueryActive = new Set<string>();
+
 	// ========================================
 	// Room Selection (with Promise-Chain Lock)
 	// ========================================
@@ -292,26 +298,35 @@ class RoomStore {
 	// Subscription Management
 	// ========================================
 
+	// ========================================
+	// LiveQuery Subscription Lifecycle (managed by useRoomLiveQuery hook)
+	// ========================================
+
 	/**
-	 * Start subscriptions for a room
+	 * Subscribe this room's tasks and goals via LiveQuery.
+	 *
+	 * Called by the `useRoomLiveQuery` hook on mount / room change.
+	 * Registers snapshot/delta handlers then sends liveQuery.subscribe for
+	 * both tasks.byRoom and goals.byRoom named queries.
+	 *
+	 * Guards against races: if `unsubscribeRoom(roomId)` is called before
+	 * the async hub is available, the subscription is aborted cleanly.
 	 */
-	private async startSubscriptions(roomId: string): Promise<void> {
+	async subscribeRoom(roomId: string): Promise<void> {
+		// Guard: prevent double-subscription for the same roomId
+		if (this.liveQueryActive.has(roomId)) return;
+		this.liveQueryActive.add(roomId);
+
 		try {
 			const hub = await connectionManager.getHub();
 
-			// Join the room channel first
-			hub.joinChannel(`room:${roomId}`);
+			// Guard: unsubscribeRoom was called before hub became available
+			if (!this.liveQueryActive.has(roomId)) return;
 
-			// 1. Room overview subscription (room + sessions only — tasks come from LiveQuery)
-			const unsubRoomOverview = hub.onEvent<RoomOverview>('room.overview', (overview) => {
-				if (overview.room.id === roomId) {
-					this.room.value = overview.room;
-					this.sessions.value = overview.sessions;
-				}
-			});
-			this.cleanupFunctions.push(unsubRoomOverview);
+			const cleanups: Array<() => void> = [];
+			this.liveQueryCleanups.set(roomId, cleanups);
 
-			// 2. Tasks via LiveQuery — replaces room.task.update event listener.
+			// --- Tasks via LiveQuery ---
 			const tasksSubId = `tasks-byRoom-${roomId}`;
 
 			const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
@@ -322,7 +337,7 @@ class RoomStore {
 					}
 				}
 			);
-			this.cleanupFunctions.push(unsubTaskSnapshot);
+			cleanups.push(unsubTaskSnapshot);
 
 			const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== tasksSubId) return;
@@ -351,7 +366,7 @@ class RoomStore {
 				}
 				this.tasks.value = current;
 			});
-			this.cleanupFunctions.push(unsubTaskDelta);
+			cleanups.push(unsubTaskDelta);
 
 			await hub.request('liveQuery.subscribe', {
 				queryName: 'tasks.byRoom',
@@ -359,9 +374,22 @@ class RoomStore {
 				subscriptionId: tasksSubId,
 			});
 
+			// Guard: abort if unsubscribed while awaiting the subscribe request
+			if (!this.liveQueryActive.has(roomId)) {
+				for (const fn of cleanups) {
+					try {
+						fn();
+					} catch {
+						/* ignore */
+					}
+				}
+				this.liveQueryCleanups.delete(roomId);
+				return;
+			}
+
 			// Re-subscribe on reconnect: the server-side subscription is per-connection.
 			const unsubTaskReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || this.roomId.value !== roomId) return;
+				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
 				hub
 					.request('liveQuery.subscribe', {
 						queryName: 'tasks.byRoom',
@@ -372,17 +400,17 @@ class RoomStore {
 						logger.warn('Tasks LiveQuery re-subscribe failed:', err);
 					});
 			});
-			this.cleanupFunctions.push(unsubTaskReconnect);
+			cleanups.push(unsubTaskReconnect);
 
 			// Cleanup: tell the server to dispose the subscription when leaving the room.
-			this.cleanupFunctions.push(() => {
+			cleanups.push(() => {
 				const h = connectionManager.getHubIfConnected();
 				if (h) {
 					h.request('liveQuery.unsubscribe', { subscriptionId: tasksSubId }).catch(() => {});
 				}
 			});
 
-			// 3. Goals via LiveQuery — replaces goal.created/updated/completed event listeners.
+			// --- Goals via LiveQuery ---
 			// Register snapshot/delta handlers BEFORE subscribing so we never miss the
 			// initial snapshot that the server pushes synchronously before replying.
 			const goalsSubId = `goals-byRoom-${roomId}`;
@@ -396,7 +424,7 @@ class RoomStore {
 					}
 				}
 			);
-			this.cleanupFunctions.push(unsubGoalSnapshot);
+			cleanups.push(unsubGoalSnapshot);
 
 			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== goalsSubId) return;
@@ -414,7 +442,7 @@ class RoomStore {
 				}
 				this.goals.value = current;
 			});
-			this.cleanupFunctions.push(unsubGoalDelta);
+			cleanups.push(unsubGoalDelta);
 
 			// Subscribe to the goals.byRoom named query.
 			// Mark loading before subscribing; the snapshot handler clears it.
@@ -425,12 +453,25 @@ class RoomStore {
 				subscriptionId: goalsSubId,
 			});
 
+			// Guard: abort if unsubscribed while awaiting the subscribe request
+			if (!this.liveQueryActive.has(roomId)) {
+				for (const fn of cleanups) {
+					try {
+						fn();
+					} catch {
+						/* ignore */
+					}
+				}
+				this.liveQueryCleanups.delete(roomId);
+				return;
+			}
+
 			// Re-subscribe on reconnect: the server-side subscription is per-connection
 			// and is gone after a disconnect. Requesting liveQuery.subscribe again with
 			// the same subscriptionId delivers a fresh snapshot to the already-registered
 			// snapshot handler above.
-			const unsubReconnect = hub.onConnection((state) => {
-				if (state !== 'connected' || this.roomId.value !== roomId) return;
+			const unsubGoalReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
 				this.goalsLoading.value = true;
 				hub
 					.request('liveQuery.subscribe', {
@@ -443,17 +484,67 @@ class RoomStore {
 						this.goalsLoading.value = false;
 					});
 			});
-			this.cleanupFunctions.push(unsubReconnect);
+			cleanups.push(unsubGoalReconnect);
 
 			// Cleanup: tell the server to dispose the subscription when leaving the room.
-			this.cleanupFunctions.push(() => {
+			cleanups.push(() => {
 				const h = connectionManager.getHubIfConnected();
 				if (h) {
 					h.request('liveQuery.unsubscribe', { subscriptionId: goalsSubId }).catch(() => {});
 				}
 			});
+		} catch (err) {
+			this.liveQueryActive.delete(roomId);
+			this.liveQueryCleanups.delete(roomId);
+			logger.error('Failed to subscribe room LiveQuery:', err);
+		}
+	}
 
-			// 3b. Auto-completed task notifications (semi-autonomous mode)
+	/**
+	 * Unsubscribe LiveQuery subscriptions for a room.
+	 *
+	 * Called by the `useRoomLiveQuery` hook on unmount / room change.
+	 * Idempotent: safe to call even if subscribeRoom was never called.
+	 */
+	unsubscribeRoom(roomId: string): void {
+		this.liveQueryActive.delete(roomId);
+		const cleanups = this.liveQueryCleanups.get(roomId);
+		if (cleanups) {
+			for (const fn of cleanups) {
+				try {
+					fn();
+				} catch {
+					/* ignore */
+				}
+			}
+			this.liveQueryCleanups.delete(roomId);
+		}
+	}
+
+	// ========================================
+	// Channel + Event Subscriptions
+	// ========================================
+
+	/**
+	 * Start subscriptions for a room
+	 */
+	private async startSubscriptions(roomId: string): Promise<void> {
+		try {
+			const hub = await connectionManager.getHub();
+
+			// Join the room channel first
+			hub.joinChannel(`room:${roomId}`);
+
+			// 1. Room overview subscription (room + sessions only — tasks/goals come from LiveQuery)
+			const unsubRoomOverview = hub.onEvent<RoomOverview>('room.overview', (overview) => {
+				if (overview.room.id === roomId) {
+					this.room.value = overview.room;
+					this.sessions.value = overview.sessions;
+				}
+			});
+			this.cleanupFunctions.push(unsubRoomOverview);
+
+			// 2. Auto-completed task notifications (semi-autonomous mode)
 			const unsubAutoCompleted = hub.onEvent<{
 				roomId: string;
 				goalId: string;
@@ -477,7 +568,7 @@ class RoomStore {
 			});
 			this.cleanupFunctions.push(unsubAutoCompleted);
 
-			// 4. Runtime state changes
+			// 3. Runtime state changes
 			const unsubRuntimeState = hub.onEvent<{ roomId: string; state: RuntimeState }>(
 				'room.runtime.stateChanged',
 				(event) => {
@@ -488,7 +579,7 @@ class RoomStore {
 			);
 			this.cleanupFunctions.push(unsubRuntimeState);
 
-			// 5. Session lifecycle events (delete / status change)
+			// 4. Session lifecycle events (delete / status change)
 			// Re-fetch the authoritative session list from the server on meaningful session
 			// changes. This avoids manual array splicing and self-heals events missed during
 			// WebSocket reconnect gaps.
@@ -528,7 +619,7 @@ class RoomStore {
 			});
 			this.cleanupFunctions.push(unsubSessionUpdated);
 
-			// 6. Fetch initial state via RPC
+			// 5. Fetch initial state via RPC
 			await this.fetchInitialState(hub, roomId);
 		} catch (err) {
 			logger.error('Failed to start room subscriptions:', err);


### PR DESCRIPTION
## Summary

- Extracts `tasks.byRoom` and `goals.byRoom` LiveQuery subscriptions from `roomStore.startSubscriptions()` into new public `subscribeRoom()`/`unsubscribeRoom()` methods, so `select()` no longer calls `liveQuery.subscribe` internally
- Creates `useRoomLiveQuery` hook as a lifecycle adapter: calls `subscribeRoom` on mount, `unsubscribeRoom` on unmount, and correctly handles `roomId` changes via `useEffect` dependency array
- Adds race-condition guard: if `unsubscribeRoom` is called before the async hub resolves (rapid room switching or unmount), the subscription is aborted cleanly
- Mounts `useRoomLiveQuery` unconditionally inside `Room.tsx` alongside the existing `select()` effect
- No double-subscription: `liveQueryActive` set prevents calling `subscribeRoom` twice for the same room
- 5 new Vitest tests for hook lifecycle (mount, unmount, roomId change, no-resubscribe on same roomId, unmount after room change)
- Updated existing room-store tests to call `subscribeRoom`/`unsubscribeRoom` explicitly since they no longer happen inside `select()`

## Test plan

- [x] `useRoomLiveQuery` Vitest tests: 5 tests covering all lifecycle scenarios
- [x] Full web test suite passes (4997 tests)
- [x] TypeScript typecheck clean
- [x] Lint + format checks pass
- [x] Knip dead code detection clean