### PR TITLE
feat: add stale-event guard for LiveQuery subscriptions (Task 3.6)

### DIFF
--- a/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
@@ -299,3 +299,99 @@ describe('RoomStore — stale-event guard (Task 3.6)', () => {
 		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
 	});
 });
+
+describe('RoomStore — reconnect re-subscribe and guard interaction (Task 3.6)', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('re-subscribes on reconnect and accepts the resulting snapshot', () => {
+		// Initial snapshot populates tasks
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+
+		// Simulate WebSocket reconnect
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+
+		// The reconnect handler must have sent a liveQuery.subscribe request
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.subscribe' &&
+				(params as { queryName: string }).queryName === 'tasks.byRoom'
+		);
+		expect(resubCall).toBeDefined();
+		expect(resubCall![1]).toMatchObject({
+			queryName: 'tasks.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: TASKS_SUB_ID,
+		});
+
+		// The server sends a fresh snapshot — guard must allow it through
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1'), makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+	});
+
+	it('does NOT re-subscribe on reconnect after unsubscribeRoom', () => {
+		// Unsubscribe (simulates component unmount / room switch away)
+		roomStore.unsubscribeRoom(ROOM_ID);
+		hub.request.mockClear();
+
+		// Reconnect fires — should NOT trigger re-subscribe since room is unsubscribed
+		hub.fireConnection('connected');
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const resubCall = calls.find(
+			([method, params]) =>
+				method === 'liveQuery.subscribe' &&
+				(params as { queryName: string }).queryName === 'tasks.byRoom'
+		);
+		expect(resubCall).toBeUndefined();
+	});
+
+	it('reconnect snapshot for goals passes the guard and clears goalsLoading', () => {
+		// Clear initial loading state with a snapshot
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+
+		// Simulate reconnect — reconnect handler sets goalsLoading = true
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		// Fresh snapshot from server must pass guard and clear loading
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 2,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+});

--- a/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-stale-event-guard.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for RoomStore stale-event guard (Task 3.6)
+ *
+ * Verifies that snapshot and delta events are discarded after unsubscribeRoom
+ * is called, even if the event was already queued in the JS event loop (i.e.,
+ * the handler function was captured before cleanup ran).
+ *
+ * This guards against rapid room switching where:
+ * 1. Events arrive for subscription A while the JS engine is in the middle of
+ *    switching to subscription B.
+ * 2. In-flight events from a prior connection arrive after re-subscription.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { TaskSummary, RoomGoal, GoalStatus } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	joinChannel: ReturnType<typeof vi.fn>;
+	leaveChannel: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('../connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock('../router', () => ({ navigateToRoom: vi.fn() }));
+vi.mock('../signals', () => ({
+	currentRoomSessionIdSignal: { value: null },
+	currentRoomIdSignal: { value: null },
+	currentRoomTaskIdSignal: { value: null },
+	currentSessionIdSignal: { value: null },
+	currentSpaceIdSignal: { value: null },
+	currentSpaceSessionIdSignal: { value: null },
+	currentSpaceTaskIdSignal: { value: null },
+	navSectionSignal: { value: 'lobby' },
+}));
+
+import { connectionManager } from '../connection-manager.js';
+import { roomStore } from '../room-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID = 'room-stale-guard';
+const TASKS_SUB_ID = `tasks-byRoom-${ROOM_ID}`;
+const GOALS_SUB_ID = `goals-byRoom-${ROOM_ID}`;
+
+function makeTask(id: string, overrides: Partial<TaskSummary> = {}): TaskSummary {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: `Task ${id}`,
+		description: '',
+		status: 'pending',
+		priority: 'normal',
+		progress: 0,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	} as TaskSummary;
+}
+
+function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: `Goal ${id}`,
+		description: '',
+		status: 'active' as GoalStatus,
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function setupHubRequests(hub: MockHub): void {
+	hub.request.mockImplementation((method: string) => {
+		if (method === 'room.get')
+			return Promise.resolve({ room: { id: ROOM_ID }, sessions: [], allTasks: [] });
+		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+		return Promise.resolve({ ok: true });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomStore — stale-event guard (Task 3.6)', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('discards a stale task snapshot after unsubscribeRoom (simulated in-flight event)', () => {
+		// Populate state via initial snapshot
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+
+		// Capture the live snapshot handlers BEFORE unsubscribeRoom removes them.
+		// This simulates an event already queued in the JS event loop that fires
+		// after the guard is cleared but before handler teardown completes.
+		const snapshotHandlers = [...(hub._handlers.get('liveQuery.snapshot') ?? [])];
+
+		// Perform room switch teardown — clears the stale-event guard immediately.
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		// Manually invoke the captured (now-stale) handler as if it were a queued event.
+		const staleRows = [makeTask('t1'), makeTask('t2')];
+		for (const h of snapshotHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: TASKS_SUB_ID,
+				rows: staleRows,
+				version: 2,
+			});
+		}
+
+		// Stale snapshot must NOT have updated tasks.value.
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+	});
+
+	it('discards a stale task delta after unsubscribeRoom (simulated in-flight event)', () => {
+		// Populate state
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+
+		// Capture delta handlers before teardown
+		const deltaHandlers = [...(hub._handlers.get('liveQuery.delta') ?? [])];
+
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		// Fire a stale delta that would have added t2
+		for (const h of deltaHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: TASKS_SUB_ID,
+				added: [makeTask('t2')],
+				version: 2,
+			});
+		}
+
+		// Stale delta must NOT have modified tasks.value.
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+	});
+
+	it('discards a stale goal snapshot after unsubscribeRoom (simulated in-flight event)', () => {
+		// Populate state
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+
+		const snapshotHandlers = [...(hub._handlers.get('liveQuery.snapshot') ?? [])];
+
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		// Fire stale goal snapshot
+		for (const h of snapshotHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: GOALS_SUB_ID,
+				rows: [makeGoal('g1'), makeGoal('g2')],
+				version: 2,
+			});
+		}
+
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+
+	it('discards a stale goal delta after unsubscribeRoom (simulated in-flight event)', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+
+		const deltaHandlers = [...(hub._handlers.get('liveQuery.delta') ?? [])];
+
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		for (const h of deltaHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: GOALS_SUB_ID,
+				added: [makeGoal('g2')],
+				version: 2,
+			});
+		}
+
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+
+	it('processes events normally while subscription is active', () => {
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			added: [makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+	});
+
+	it('re-establishes guard after subscribeRoom is called again for the same room', async () => {
+		// Initial snapshot
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+
+		// Unsubscribe and re-subscribe (simulates component remount)
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		// New snapshot should be accepted
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1'), makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+	});
+});

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -483,6 +483,9 @@ class RoomStore {
 					}
 				}
 				this.liveQueryCleanups.delete(roomId);
+				// Reset goalsLoading: it was set to true above but the snapshot
+				// handler (which normally clears it) will never fire.
+				this.goalsLoading.value = false;
 				return;
 			}
 
@@ -515,7 +518,22 @@ class RoomStore {
 			});
 		} catch (err) {
 			this.liveQueryActive.delete(roomId);
+			// Run any cleanups that were registered before the error, so that
+			// event handlers registered up to the point of failure are removed
+			// and activeSubscriptionIds entries are cleared.
+			const failedCleanups = this.liveQueryCleanups.get(roomId);
+			if (failedCleanups) {
+				for (const fn of failedCleanups) {
+					try {
+						fn();
+					} catch {
+						/* ignore */
+					}
+				}
+			}
 			this.liveQueryCleanups.delete(roomId);
+			// Reset goalsLoading in case the error occurred after it was set to true.
+			this.goalsLoading.value = false;
 			logger.error('Failed to subscribe room LiveQuery:', err);
 		}
 	}

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -230,6 +230,14 @@ class RoomStore {
 	/** Set of room IDs that currently have an active LiveQuery subscription intent */
 	private liveQueryActive = new Set<string>();
 
+	/**
+	 * Stale-event guard: set of currently active subscriptionIds.
+	 * Cleared immediately in unsubscribeRoom before handler teardown so that
+	 * any in-flight events (queued in the JS event loop between room switch and
+	 * handler removal) are discarded rather than applied to the wrong room's state.
+	 */
+	private activeSubscriptionIds = new Set<string>();
+
 	// ========================================
 	// Room Selection (with Promise-Chain Lock)
 	// ========================================
@@ -329,18 +337,25 @@ class RoomStore {
 			// --- Tasks via LiveQuery ---
 			const tasksSubId = `tasks-byRoom-${roomId}`;
 
+			// Stale-event guard: mark this subscriptionId as active before registering
+			// handlers. unsubscribeRoom clears it immediately so any event queued in the
+			// JS event loop after the room switch is discarded.
+			this.activeSubscriptionIds.add(tasksSubId);
+			cleanups.push(() => this.activeSubscriptionIds.delete(tasksSubId));
+
 			const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
 				'liveQuery.snapshot',
 				(event) => {
-					if (event.subscriptionId === tasksSubId) {
-						this.tasks.value = event.rows as TaskSummary[];
-					}
+					if (event.subscriptionId !== tasksSubId) return;
+					if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
+					this.tasks.value = event.rows as TaskSummary[];
 				}
 			);
 			cleanups.push(unsubTaskSnapshot);
 
 			const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== tasksSubId) return;
+				if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
 				let current = this.tasks.value;
 				if (event.removed?.length) {
 					const removedIds = new Set((event.removed as TaskSummary[]).map((r) => r.id));
@@ -415,19 +430,24 @@ class RoomStore {
 			// initial snapshot that the server pushes synchronously before replying.
 			const goalsSubId = `goals-byRoom-${roomId}`;
 
+			// Stale-event guard for goals (same semantics as tasks above).
+			this.activeSubscriptionIds.add(goalsSubId);
+			cleanups.push(() => this.activeSubscriptionIds.delete(goalsSubId));
+
 			const unsubGoalSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
 				'liveQuery.snapshot',
 				(event) => {
-					if (event.subscriptionId === goalsSubId) {
-						this.goals.value = event.rows as RoomGoal[];
-						this.goalsLoading.value = false;
-					}
+					if (event.subscriptionId !== goalsSubId) return;
+					if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
+					this.goals.value = event.rows as RoomGoal[];
+					this.goalsLoading.value = false;
 				}
 			);
 			cleanups.push(unsubGoalSnapshot);
 
 			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 				if (event.subscriptionId !== goalsSubId) return;
+				if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
 				let current = this.goals.value;
 				if (event.removed?.length) {
 					const removedIds = new Set((event.removed as RoomGoal[]).map((r) => r.id));
@@ -508,6 +528,10 @@ class RoomStore {
 	 */
 	unsubscribeRoom(roomId: string): void {
 		this.liveQueryActive.delete(roomId);
+		// Stale-event guard: clear subscriptionIds immediately so any events already
+		// queued in the JS event loop are discarded before the handlers are removed.
+		this.activeSubscriptionIds.delete(`tasks-byRoom-${roomId}`);
+		this.activeSubscriptionIds.delete(`goals-byRoom-${roomId}`);
 		const cleanups = this.liveQueryCleanups.get(roomId);
 		if (cleanups) {
 			for (const fn of cleanups) {


### PR DESCRIPTION
Adds an explicit activeSubscriptionIds Set to RoomStore that is cleared
immediately in unsubscribeRoom before handler teardown. This ensures any
events already queued in the JS event loop during rapid room switching are
discarded rather than applied to stale state.

- Track active subscriptionIds per subscription (tasks.byRoom, goals.byRoom)
- Add guard check in all snapshot/delta handlers: discard if subscriptionId
  is no longer in the active set
- Clear guard in unsubscribeRoom before running cleanups (belt-and-suspenders)
- Guard cleanup also included in cleanups array (handles abort paths)
- 6 new stale-event guard tests: snapshot/delta discarded for tasks and goals
  after unsubscribeRoom, using captured-handler technique to simulate
  events queued between guard clear and handler removal

Existing reconnect re-subscribe and room-switch unsubscribe were already
implemented in Task 3.5; this task adds the explicit stale-event guard layer.
