### PR TITLE
feat: enable Bash and full MCP access for Room Agent session

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -185,13 +185,15 @@ export class QueryOptionsBuilder {
 		};
 
 		// ============ Room Session Restrictions ============
-		// Room chat sessions are orchestrators only — they must not
-		// have access to built-in file/shell tools or user-configured MCP servers.
+		// Room chat sessions are orchestrators — they have read tools, Bash for diagnostics,
+		// and explicitly configured MCP servers (room-agent-tools + project MCP servers).
+		// File editing tools (Write/Edit/NotebookEdit) are excluded.
 		if (this.ctx.session.type === 'room_chat') {
 			const roomAllowedBuiltinTools = [
 				'Read',
 				'Glob',
 				'Grep',
+				'Bash',
 				'WebFetch',
 				'WebSearch',
 				'ToolSearch',
@@ -202,7 +204,6 @@ export class QueryOptionsBuilder {
 				'Task',
 				'TaskOutput',
 				'TaskStop',
-				'Bash',
 				'Edit',
 				'Write',
 				'NotebookEdit',
@@ -218,20 +219,25 @@ export class QueryOptionsBuilder {
 				queryOptions.systemPrompt = undefined;
 			}
 
-			// Restrict room chat to a safe, read-oriented built-in tool set.
+			// Restrict room chat to coordinator-appropriate built-in tool set.
 			queryOptions.tools = roomAllowedBuiltinTools;
+
+			// Auto-allow all explicitly configured MCP server tools (room-agent-tools + project MCP servers).
+			const mcpServerWildcards = Object.keys(queryOptions.mcpServers ?? {}).map(
+				(name) => `${name}__*`
+			);
 			queryOptions.allowedTools = [
 				...new Set([
 					...(queryOptions.allowedTools ?? []),
 					...roomAllowedBuiltinTools,
-					'room-agent-tools__*',
+					...mcpServerWildcards,
 				]),
 			];
 
 			queryOptions.disallowedTools = [
 				...new Set([...(queryOptions.disallowedTools ?? []), ...restrictedBuiltinTools]),
 			];
-			// Prevent user-configured MCP servers from being merged in.
+			// Prevent user-configured MCP servers from being merged in (only runtime-injected servers allowed).
 			queryOptions.strictMcpConfig = true;
 			// Skip settings file loading so user's settings.json doesn't inject extra tools.
 			queryOptions.settingSources = [];

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -512,12 +512,12 @@ export class RoomRuntimeService {
 					}
 				}
 
-				// Merge project-configured MCP servers with the room-agent-tools server so the
+				// Merge user/project-configured MCP servers with the room-agent-tools server so the
 				// room agent can use GitHub MCP, etc. for coordination tasks.
 				// room-agent-tools is placed last to ensure it always takes precedence.
-				const projectMcpServers = this.ctx.settingsManager.getProjectMcpServersConfig();
+				const enabledMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
 				roomChatSession.setRuntimeMcpServers({
-					...projectMcpServers,
+					...enabledMcpServers,
 					'room-agent-tools': roomAgentMcpServer,
 				});
 				// Inject the room chat system prompt so the agent knows the proper

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Room, McpServerConfig, RuntimeState, GlobalSettings } from '@neokai/shared';
+import type { SettingsManager } from '../../settings-manager';
 import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../../storage/job-queue-processor';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
@@ -50,6 +51,8 @@ export interface RoomRuntimeServiceConfig {
 	defaultModel: string;
 	/** Get current global settings including fallbackModels for auto-fallback on rate limits */
 	getGlobalSettings: () => GlobalSettings;
+	/** Settings manager for reading project-configured MCP servers */
+	settingsManager: SettingsManager;
 	/** Reactive database wrapper for change event emission */
 	reactiveDb: ReactiveDatabase;
 	/**
@@ -509,7 +512,12 @@ export class RoomRuntimeService {
 					}
 				}
 
+				// Merge project-configured MCP servers with the room-agent-tools server so the
+				// room agent can use GitHub MCP, etc. for coordination tasks.
+				// room-agent-tools is placed last to ensure it always takes precedence.
+				const projectMcpServers = this.ctx.settingsManager.getProjectMcpServersConfig();
 				roomChatSession.setRuntimeMcpServers({
+					...projectMcpServers,
 					'room-agent-tools': roomAgentMcpServer,
 				});
 				// Inject the room chat system prompt so the agent knows the proper

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -175,6 +175,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		defaultWorkspacePath: deps.config.workspaceRoot,
 		defaultModel: deps.config.defaultModel,
 		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
+		settingsManager: deps.settingsManager,
 		reactiveDb: deps.reactiveDb,
 		jobQueue: deps.jobQueue,
 		jobProcessor: deps.jobProcessor,

--- a/packages/daemon/src/lib/settings-manager.ts
+++ b/packages/daemon/src/lib/settings-manager.ts
@@ -497,6 +497,14 @@ export class SettingsManager {
 			);
 		}
 
+		// Respect per-server allow/deny settings — exclude servers the user has explicitly disallowed.
+		const mcpServerSettings = globalSettings.mcpServerSettings || {};
+		for (const name of Object.keys(result)) {
+			if (mcpServerSettings[name]?.allowed === false) {
+				delete result[name];
+			}
+		}
+
 		return result;
 	}
 

--- a/packages/daemon/src/lib/settings-manager.ts
+++ b/packages/daemon/src/lib/settings-manager.ts
@@ -10,6 +10,7 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type { GlobalSettings, SessionSettings, SettingSource } from '@neokai/shared';
+import type { McpServerConfig } from '@neokai/shared/types/sdk-config';
 
 /**
  * MCP server info from a setting source
@@ -442,6 +443,61 @@ export class SettingsManager {
 		};
 
 		this.updateGlobalSettings({ mcpServerSettings });
+	}
+
+	/**
+	 * Get full MCP server configs from project and user settings files.
+	 *
+	 * Reads raw MCP server config objects (command, args, env, type, url, etc.) from:
+	 * - User: ~/.claude/settings.json and ~/.mcp.json
+	 * - Project: .claude/settings.json and .mcp.json in workspace
+	 * - Local: .claude/settings.local.json in workspace
+	 *
+	 * Only includes servers from enabled sources. Returns a merged map where
+	 * later sources (local > project > user) override earlier ones with the same name.
+	 */
+	getProjectMcpServersConfig(): Record<string, McpServerConfig> {
+		const globalSettings = this.getGlobalSettings();
+		const enabledSources = globalSettings.settingSources || ['user', 'project', 'local'];
+
+		const readRawMcpServers = (filePath: string): Record<string, McpServerConfig> => {
+			try {
+				if (!existsSync(filePath)) return {};
+				const content = readFileSync(filePath, 'utf-8');
+				const settings = JSON.parse(content) as Record<string, unknown>;
+				const mcpServers = settings.mcpServers;
+				if (!mcpServers || typeof mcpServers !== 'object') return {};
+				return mcpServers as Record<string, McpServerConfig>;
+			} catch {
+				return {};
+			}
+		};
+
+		const result: Record<string, McpServerConfig> = {};
+
+		if (enabledSources.includes('user')) {
+			const userBaseDir = process.env.TEST_USER_SETTINGS_DIR || join(homedir(), '.claude');
+			Object.assign(result, readRawMcpServers(join(userBaseDir, 'settings.json')));
+			const userMcpDir = process.env.TEST_USER_SETTINGS_DIR || homedir();
+			Object.assign(result, readRawMcpServers(join(userMcpDir, '.mcp.json')));
+		}
+
+		if (enabledSources.includes('project')) {
+			Object.assign(
+				result,
+				readRawMcpServers(join(this.workspacePath, '.claude', 'settings.json'))
+			);
+			Object.assign(result, readRawMcpServers(join(this.workspacePath, '.mcp.json')));
+		}
+
+		if (enabledSources.includes('local')) {
+			Object.assign(
+				result,
+				readRawMcpServers(join(this.workspacePath, '.claude', 'settings.local.json'))
+			);
+		}
+
+		return result;
 	}
 
 	/**

--- a/packages/daemon/src/lib/settings-manager.ts
+++ b/packages/daemon/src/lib/settings-manager.ts
@@ -446,17 +446,21 @@ export class SettingsManager {
 	}
 
 	/**
-	 * Get full MCP server configs from project and user settings files.
+	 * Get full MCP server configs from user and project settings files.
 	 *
 	 * Reads raw MCP server config objects (command, args, env, type, url, etc.) from:
 	 * - User: ~/.claude/settings.json and ~/.mcp.json
 	 * - Project: .claude/settings.json and .mcp.json in workspace
-	 * - Local: .claude/settings.local.json in workspace
+	 *
+	 * The `local` source (.claude/settings.local.json) is intentionally excluded because
+	 * the daemon itself writes to that file via writeFileOnlySettings. Including it would
+	 * create a bypass vector where the daemon could inject servers into room agent sessions.
 	 *
 	 * Only includes servers from enabled sources. Returns a merged map where
-	 * later sources (local > project > user) override earlier ones with the same name.
+	 * project servers override user servers with the same name.
+	 * Excludes servers the user has explicitly set to `allowed: false`.
 	 */
-	getProjectMcpServersConfig(): Record<string, McpServerConfig> {
+	getEnabledMcpServersConfig(): Record<string, McpServerConfig> {
 		const globalSettings = this.getGlobalSettings();
 		const enabledSources = globalSettings.settingSources || ['user', 'project', 'local'];
 
@@ -490,12 +494,7 @@ export class SettingsManager {
 			Object.assign(result, readRawMcpServers(join(this.workspacePath, '.mcp.json')));
 		}
 
-		if (enabledSources.includes('local')) {
-			Object.assign(
-				result,
-				readRawMcpServers(join(this.workspacePath, '.claude', 'settings.local.json'))
-			);
-		}
+		// NOTE: 'local' source (.claude/settings.local.json) is excluded — see doc comment above.
 
 		// Respect per-server allow/deny settings — exclude servers the user has explicitly disallowed.
 		const mcpServerSettings = globalSettings.mcpServerSettings || {};

--- a/packages/daemon/tests/unit/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/agent/query-options-builder.test.ts
@@ -379,13 +379,14 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.settingSources).toEqual([]);
 		});
 
-		it('should enforce room built-in tool allowlist', async () => {
+		it('should enforce room built-in tool allowlist including Bash', async () => {
 			mockSession.type = 'room_chat';
 			const options = await builder.build();
 			expect(options.tools).toEqual([
 				'Read',
 				'Glob',
 				'Grep',
+				'Bash',
 				'WebFetch',
 				'WebSearch',
 				'ToolSearch',
@@ -397,13 +398,37 @@ describe('QueryOptionsBuilder', () => {
 					'Read',
 					'Glob',
 					'Grep',
+					'Bash',
 					'WebFetch',
 					'WebSearch',
 					'ToolSearch',
 					'AskUserQuestion',
 					'Skill',
-					'room-agent-tools__*',
 				])
+			);
+		});
+
+		it('should not include Write/Edit/NotebookEdit in room tool allowlist', async () => {
+			mockSession.type = 'room_chat';
+			const options = await builder.build();
+			expect(options.disallowedTools).toEqual(
+				expect.arrayContaining(['Edit', 'Write', 'NotebookEdit'])
+			);
+			expect(options.tools).not.toContain('Edit');
+			expect(options.tools).not.toContain('Write');
+			expect(options.tools).not.toContain('NotebookEdit');
+		});
+
+		it('should auto-allow wildcards for all configured MCP servers', async () => {
+			mockSession.type = 'room_chat';
+			mockSession.config.mcpServers = {
+				'room-agent-tools': { command: 'room-cmd' },
+				github: { command: 'github-cmd' },
+			};
+
+			const options = await builder.build();
+			expect(options.allowedTools).toEqual(
+				expect.arrayContaining(['room-agent-tools__*', 'github__*'])
 			);
 		});
 

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -67,6 +67,7 @@ function makeConfig(overrides: Partial<RoomRuntimeServiceConfig> = {}): RoomRunt
 		defaultWorkspacePath: '/tmp',
 		defaultModel: 'test-model',
 		getGlobalSettings: () => ({}) as never,
+		settingsManager: { getProjectMcpServersConfig: () => ({}) } as never,
 		reactiveDb: {} as never,
 		...overrides,
 	};

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -67,7 +67,7 @@ function makeConfig(overrides: Partial<RoomRuntimeServiceConfig> = {}): RoomRunt
 		defaultWorkspacePath: '/tmp',
 		defaultModel: 'test-model',
 		getGlobalSettings: () => ({}) as never,
-		settingsManager: { getProjectMcpServersConfig: () => ({}) } as never,
+		settingsManager: { getEnabledMcpServersConfig: () => ({}) } as never,
 		reactiveDb: {} as never,
 		...overrides,
 	};

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, it, beforeEach } from 'bun:test';
+import { describe, expect, it, beforeEach, mock } from 'bun:test';
 import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,
 } from '../../../src/lib/room/runtime/room-runtime-service';
 import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
 import type { Room } from '@neokai/shared';
+import type { SettingsManager } from '../../../src/lib/settings-manager';
 
 describe('RoomRuntimeService', () => {
 	let service: RoomRuntimeService;
 	let mockRoomManager: RoomManager;
+	let mockSettingsManager: SettingsManager;
 
 	// Helper to create a room mock
 	function makeRoom(overrides: Partial<Room> = {}): Room {
@@ -32,6 +34,10 @@ describe('RoomRuntimeService', () => {
 			getRoom: () => null,
 		} as unknown as RoomManager;
 
+		mockSettingsManager = {
+			getProjectMcpServersConfig: mock(() => ({})),
+		} as unknown as SettingsManager;
+
 		const config: RoomRuntimeServiceConfig = {
 			db: {} as never,
 			messageHub: {} as never,
@@ -42,6 +48,7 @@ describe('RoomRuntimeService', () => {
 			defaultWorkspacePath: '/tmp',
 			defaultModel: 'global-default-model',
 			getGlobalSettings: () => ({}) as never,
+			settingsManager: mockSettingsManager,
 			reactiveDb: {} as never,
 		};
 
@@ -140,6 +147,26 @@ describe('RoomRuntimeService', () => {
 
 			expect(leaderResult).toBe('sonnet-4.6');
 			expect(workerResult).toBe('haiku-4');
+		});
+	});
+
+	describe('settingsManager integration', () => {
+		it('should expose getProjectMcpServersConfig on the settings manager', () => {
+			// Verify the mock settings manager has the expected method
+			const result = mockSettingsManager.getProjectMcpServersConfig();
+			expect(result).toEqual({});
+		});
+
+		it('should return project MCP servers config when configured', () => {
+			const projectServers = {
+				github: { type: 'stdio' as const, command: 'npx', args: ['@github/mcp'] },
+			};
+			(mockSettingsManager.getProjectMcpServersConfig as ReturnType<typeof mock>).mockReturnValue(
+				projectServers
+			);
+
+			const result = mockSettingsManager.getProjectMcpServersConfig();
+			expect(result).toEqual(projectServers);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -36,7 +36,7 @@ describe('RoomRuntimeService', () => {
 		} as unknown as RoomManager;
 
 		mockSettingsManager = {
-			getProjectMcpServersConfig: mock(() => ({})),
+			getEnabledMcpServersConfig: mock(() => ({})),
 		} as unknown as SettingsManager;
 
 		const config: RoomRuntimeServiceConfig = {
@@ -205,7 +205,7 @@ describe('RoomRuntimeService', () => {
 				github: { command: 'npx', args: ['@github/mcp'] },
 			};
 			mockSettingsManager = {
-				getProjectMcpServersConfig: mock(() => projectServers),
+				getEnabledMcpServersConfig: mock(() => projectServers),
 			} as unknown as SettingsManager;
 
 			// Mock roomManager — listRooms returns empty so initializeExistingRooms is a no-op
@@ -261,7 +261,7 @@ describe('RoomRuntimeService', () => {
 
 		it('should give room-agent-tools precedence over project servers with same name', async () => {
 			// Override: project server also named 'room-agent-tools' — should be overridden
-			(mockSettingsManager.getProjectMcpServersConfig as ReturnType<typeof mock>).mockReturnValue({
+			(mockSettingsManager.getEnabledMcpServersConfig as ReturnType<typeof mock>).mockReturnValue({
 				'room-agent-tools': { command: 'project-version', args: [] },
 				'other-tool': { command: 'other-cmd' },
 			});
@@ -284,7 +284,7 @@ describe('RoomRuntimeService', () => {
 		});
 
 		it('should call setRuntimeMcpServers with only room-agent-tools when no project servers', async () => {
-			(mockSettingsManager.getProjectMcpServersConfig as ReturnType<typeof mock>).mockReturnValue(
+			(mockSettingsManager.getEnabledMcpServersConfig as ReturnType<typeof mock>).mockReturnValue(
 				{}
 			);
 

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,
@@ -150,23 +151,152 @@ describe('RoomRuntimeService', () => {
 		});
 	});
 
-	describe('settingsManager integration', () => {
-		it('should expose getProjectMcpServersConfig on the settings manager', () => {
-			// Verify the mock settings manager has the expected method
-			const result = mockSettingsManager.getProjectMcpServersConfig();
-			expect(result).toEqual({});
+	describe('setupRoomAgentSession MCP merging', () => {
+		let db: Database;
+		let setRuntimeMcpServersSpy: ReturnType<typeof mock>;
+		let roomCreatedHandler: ((event: { room: Room }) => void) | undefined;
+
+		const mockRoom = (): Room => ({
+			id: 'room-test',
+			name: 'Test Room',
+			allowedPaths: [],
+			defaultPath: undefined,
+			defaultModel: 'claude-3',
+			allowedModels: undefined,
+			sessionIds: [],
+			status: 'active',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
 		});
 
-		it('should return project MCP servers config when configured', () => {
-			const projectServers = {
-				github: { type: 'stdio' as const, command: 'npx', args: ['@github/mcp'] },
+		beforeEach(() => {
+			// Real in-memory SQLite — no schema needed since repo constructors don't execute SQL
+			db = new Database(':memory:');
+
+			setRuntimeMcpServersSpy = mock(() => {});
+
+			// DaemonHub mock that captures the room.created handler
+			const daemonHub = {
+				on: (event: string, handler: (data: unknown) => void, opts?: { sessionId?: string }) => {
+					if (event === 'room.created' && opts?.sessionId === 'global') {
+						roomCreatedHandler = handler as (event: { room: Room }) => void;
+					}
+					return () => {};
+				},
 			};
+
+			// Mock AgentSession returned by sessionManager
+			const mockAgentSession = {
+				getSessionData: () => ({
+					config: { model: 'claude-3', provider: 'anthropic' },
+				}),
+				setRuntimeMcpServers: setRuntimeMcpServersSpy,
+				setRuntimeSystemPrompt: mock(() => {}),
+			};
+
+			// Mock SessionManager: getSessionAsync resolves immediately with mock session
+			const sessionManager = {
+				getSessionAsync: mock(async () => mockAgentSession),
+				updateSession: mock(async () => {}),
+			};
+
+			// Mock settingsManager with project MCP servers
+			const projectServers = {
+				github: { command: 'npx', args: ['@github/mcp'] },
+			};
+			mockSettingsManager = {
+				getProjectMcpServersConfig: mock(() => projectServers),
+			} as unknown as SettingsManager;
+
+			// Mock roomManager — listRooms returns empty so initializeExistingRooms is a no-op
+			mockRoomManager = {
+				listRooms: () => [],
+				getRoom: () => null,
+			} as unknown as RoomManager;
+
+			const config: RoomRuntimeServiceConfig = {
+				db: {
+					getDatabase: () => db,
+					getSession: () => null,
+				} as never,
+				messageHub: { onRequest: () => {} } as never,
+				daemonHub: daemonHub as never,
+				getApiKey: async () => null,
+				roomManager: mockRoomManager,
+				sessionManager: sessionManager as never,
+				defaultWorkspacePath: '/tmp',
+				defaultModel: 'global-default-model',
+				getGlobalSettings: () => ({}) as never,
+				settingsManager: mockSettingsManager,
+				reactiveDb: { onChange: () => () => {}, emit: async () => {} } as never,
+			};
+
+			service = new RoomRuntimeService(config);
+		});
+
+		afterEach(() => {
+			db.close();
+			roomCreatedHandler = undefined;
+		});
+
+		it('should call setRuntimeMcpServers with project servers merged with room-agent-tools', async () => {
+			// Start service — subscribes to room.created, initializes no rooms
+			await service.start();
+
+			// Trigger room.created which calls createOrGetRuntime → setupRoomAgentSession
+			expect(roomCreatedHandler).toBeDefined();
+			roomCreatedHandler!({ room: mockRoom() });
+
+			// Wait for the async .then() inside setupRoomAgentSession to settle
+			await new Promise((r) => setTimeout(r, 0));
+
+			expect(setRuntimeMcpServersSpy).toHaveBeenCalledTimes(1);
+			const callArg = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<string, unknown>;
+
+			// Should include the project server
+			expect(callArg).toHaveProperty('github');
+			// Should include room-agent-tools (takes precedence, set last)
+			expect(callArg).toHaveProperty('room-agent-tools');
+		});
+
+		it('should give room-agent-tools precedence over project servers with same name', async () => {
+			// Override: project server also named 'room-agent-tools' — should be overridden
+			(mockSettingsManager.getProjectMcpServersConfig as ReturnType<typeof mock>).mockReturnValue({
+				'room-agent-tools': { command: 'project-version', args: [] },
+				'other-tool': { command: 'other-cmd' },
+			});
+
+			await service.start();
+			expect(roomCreatedHandler).toBeDefined();
+			roomCreatedHandler!({ room: mockRoom() });
+			await new Promise((r) => setTimeout(r, 0));
+
+			expect(setRuntimeMcpServersSpy).toHaveBeenCalledTimes(1);
+			const callArg = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<string, unknown>;
+
+			// room-agent-tools should be the runtime version, not the project version
+			expect(callArg['room-agent-tools']).not.toEqual({
+				command: 'project-version',
+				args: [],
+			});
+			// other-tool should still be present
+			expect(callArg).toHaveProperty('other-tool');
+		});
+
+		it('should call setRuntimeMcpServers with only room-agent-tools when no project servers', async () => {
 			(mockSettingsManager.getProjectMcpServersConfig as ReturnType<typeof mock>).mockReturnValue(
-				projectServers
+				{}
 			);
 
-			const result = mockSettingsManager.getProjectMcpServersConfig();
-			expect(result).toEqual(projectServers);
+			await service.start();
+			expect(roomCreatedHandler).toBeDefined();
+			roomCreatedHandler!({ room: mockRoom() });
+			await new Promise((r) => setTimeout(r, 0));
+
+			expect(setRuntimeMcpServersSpy).toHaveBeenCalledTimes(1);
+			const callArg = setRuntimeMcpServersSpy.mock.calls[0][0] as Record<string, unknown>;
+
+			expect(Object.keys(callArg)).toEqual(['room-agent-tools']);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/session/settings-manager.test.ts
+++ b/packages/daemon/tests/unit/session/settings-manager.test.ts
@@ -722,9 +722,9 @@ describe('SettingsManager', () => {
 		});
 	});
 
-	describe('getProjectMcpServersConfig', () => {
+	describe('getEnabledMcpServersConfig', () => {
 		it('should return empty object when no settings files exist', () => {
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toEqual({});
 		});
 
@@ -740,7 +740,7 @@ describe('SettingsManager', () => {
 				})
 			);
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toHaveProperty('github');
 			expect((result['github'] as { command: string }).command).toBe('npx');
 		});
@@ -755,7 +755,7 @@ describe('SettingsManager', () => {
 				})
 			);
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toHaveProperty('my-tool');
 		});
 
@@ -771,7 +771,7 @@ describe('SettingsManager', () => {
 				JSON.stringify({ mcpServers: { tool2: { command: 'cmd2' } } })
 			);
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toHaveProperty('tool1');
 			expect(result).toHaveProperty('tool2');
 		});
@@ -790,7 +790,7 @@ describe('SettingsManager', () => {
 				JSON.stringify({ mcpServers: { project_tool: { command: 'project-cmd' } } })
 			);
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).not.toHaveProperty('project_tool');
 		});
 
@@ -802,7 +802,7 @@ describe('SettingsManager', () => {
 				JSON.stringify({ someOtherConfig: 'value' })
 			);
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toEqual({});
 		});
 
@@ -811,7 +811,7 @@ describe('SettingsManager', () => {
 			mkdirSync(settingsDir, { recursive: true });
 			writeFileSync(join(settingsDir, 'settings.json'), 'not valid json {{{');
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toEqual({});
 		});
 
@@ -835,7 +835,7 @@ describe('SettingsManager', () => {
 				},
 			});
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toHaveProperty('allowed_tool');
 			expect(result).not.toHaveProperty('denied_tool');
 		});
@@ -859,9 +859,71 @@ describe('SettingsManager', () => {
 				},
 			});
 
-			const result = settingsManager.getProjectMcpServersConfig();
+			const result = settingsManager.getEnabledMcpServersConfig();
 			expect(result).toHaveProperty('tool_explicit_allow');
 			expect(result).toHaveProperty('tool_no_setting');
+		});
+
+		it('should read MCP servers from user settings.json', () => {
+			// TEST_USER_SETTINGS_DIR points to the isolated user settings dir
+			const userSettingsPath = join(process.env.TEST_USER_SETTINGS_DIR!, 'settings.json');
+			writeFileSync(
+				userSettingsPath,
+				JSON.stringify({
+					mcpServers: {
+						user_tool: { command: 'user-cmd', args: ['--user'] },
+					},
+				})
+			);
+
+			const result = settingsManager.getEnabledMcpServersConfig();
+			expect(result).toHaveProperty('user_tool');
+			expect((result['user_tool'] as { command: string }).command).toBe('user-cmd');
+		});
+
+		it('should not include servers from settings.local.json (local source excluded)', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.local.json'),
+				JSON.stringify({
+					mcpServers: {
+						local_only_tool: { command: 'local-cmd' },
+					},
+				})
+			);
+
+			const result = settingsManager.getEnabledMcpServersConfig();
+			expect(result).not.toHaveProperty('local_only_tool');
+		});
+
+		it('project source overrides user source for same server name', () => {
+			// User has a server named 'shared-tool'
+			const userSettingsPath = join(process.env.TEST_USER_SETTINGS_DIR!, 'settings.json');
+			writeFileSync(
+				userSettingsPath,
+				JSON.stringify({
+					mcpServers: {
+						'shared-tool': { command: 'user-version' },
+					},
+				})
+			);
+
+			// Project overrides 'shared-tool' with a different command
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({
+					mcpServers: {
+						'shared-tool': { command: 'project-version' },
+					},
+				})
+			);
+
+			const result = settingsManager.getEnabledMcpServersConfig();
+			expect(result).toHaveProperty('shared-tool');
+			expect((result['shared-tool'] as { command: string }).command).toBe('project-version');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/session/settings-manager.test.ts
+++ b/packages/daemon/tests/unit/session/settings-manager.test.ts
@@ -814,5 +814,54 @@ describe('SettingsManager', () => {
 			const result = settingsManager.getProjectMcpServersConfig();
 			expect(result).toEqual({});
 		});
+
+		it('should exclude servers with allowed === false in mcpServerSettings', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({
+					mcpServers: {
+						allowed_tool: { command: 'allowed-cmd' },
+						denied_tool: { command: 'denied-cmd' },
+					},
+				})
+			);
+			(mockDb.getGlobalSettings as ReturnType<typeof mock>).mockReturnValue({
+				...DEFAULT_GLOBAL_SETTINGS,
+				mcpServerSettings: {
+					denied_tool: { allowed: false },
+					allowed_tool: { allowed: true },
+				},
+			});
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toHaveProperty('allowed_tool');
+			expect(result).not.toHaveProperty('denied_tool');
+		});
+
+		it('should include servers with allowed === true or no setting', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({
+					mcpServers: {
+						tool_explicit_allow: { command: 'cmd1' },
+						tool_no_setting: { command: 'cmd2' },
+					},
+				})
+			);
+			(mockDb.getGlobalSettings as ReturnType<typeof mock>).mockReturnValue({
+				...DEFAULT_GLOBAL_SETTINGS,
+				mcpServerSettings: {
+					tool_explicit_allow: { allowed: true },
+				},
+			});
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toHaveProperty('tool_explicit_allow');
+			expect(result).toHaveProperty('tool_no_setting');
+		});
 	});
 });

--- a/packages/daemon/tests/unit/session/settings-manager.test.ts
+++ b/packages/daemon/tests/unit/session/settings-manager.test.ts
@@ -721,4 +721,98 @@ describe('SettingsManager', () => {
 			expect(existsSync(settingsDir)).toBe(true);
 		});
 	});
+
+	describe('getProjectMcpServersConfig', () => {
+		it('should return empty object when no settings files exist', () => {
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toEqual({});
+		});
+
+		it('should read MCP servers from project .claude/settings.json', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({
+					mcpServers: {
+						github: { command: 'npx', args: ['@github/mcp'] },
+					},
+				})
+			);
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toHaveProperty('github');
+			expect((result['github'] as { command: string }).command).toBe('npx');
+		});
+
+		it('should read MCP servers from project .mcp.json', () => {
+			writeFileSync(
+				join(workspacePath, '.mcp.json'),
+				JSON.stringify({
+					mcpServers: {
+						'my-tool': { command: 'my-cmd', args: ['--flag'] },
+					},
+				})
+			);
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toHaveProperty('my-tool');
+		});
+
+		it('should merge project settings.json and .mcp.json', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({ mcpServers: { tool1: { command: 'cmd1' } } })
+			);
+			writeFileSync(
+				join(workspacePath, '.mcp.json'),
+				JSON.stringify({ mcpServers: { tool2: { command: 'cmd2' } } })
+			);
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toHaveProperty('tool1');
+			expect(result).toHaveProperty('tool2');
+		});
+
+		it('should skip sources excluded from global settingSources', () => {
+			// Disable project source
+			(mockDb.getGlobalSettings as ReturnType<typeof mock>).mockReturnValue({
+				...DEFAULT_GLOBAL_SETTINGS,
+				settingSources: ['user', 'local'],
+			});
+
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({ mcpServers: { project_tool: { command: 'project-cmd' } } })
+			);
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).not.toHaveProperty('project_tool');
+		});
+
+		it('should return empty object when file has no mcpServers field', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, 'settings.json'),
+				JSON.stringify({ someOtherConfig: 'value' })
+			);
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toEqual({});
+		});
+
+		it('should handle malformed JSON gracefully', () => {
+			const settingsDir = join(workspacePath, '.claude');
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(join(settingsDir, 'settings.json'), 'not valid json {{{');
+
+			const result = settingsManager.getProjectMcpServersConfig();
+			expect(result).toEqual({});
+		});
+	});
 });


### PR DESCRIPTION
- Add Bash to room agent allowed tools so it can run diagnostics (git, gh, sqlite)
- Remove Bash from restricted tools list; keep Write/Edit/NotebookEdit restricted
- Add SettingsManager.getProjectMcpServersConfig() to read full raw MCP configs from project/user settings files
- Pass settingsManager to RoomRuntimeServiceConfig and use it in setupRoomAgentSession to merge project-configured MCP servers (GitHub MCP, etc.) with room-agent-tools
- Update allowedTools in query-options-builder to dynamically include wildcards for all configured MCP servers instead of hardcoded room-agent-tools__*
- Update all related unit tests and add new coverage for the new behavior
