### PR TITLE
fix: prevent full conversation reload when sending a message in TaskView

### DIFF
--- a/packages/e2e/tests/features/task-message-streaming.e2e.ts
+++ b/packages/e2e/tests/features/task-message-streaming.e2e.ts
@@ -7,6 +7,17 @@
  * Tests:
  * - Messages from the initial LiveQuery snapshot appear in TaskView on load
  * - Switching between two tasks shows correct messages for each task
+ * - Pre-existing messages remain visible after user types and sends a message
+ *   (regression test for: task view reloads all messages when sending a new message)
+ *
+ * Note on "no-reload-on-send" testing: The full round-trip (message actually delivered
+ * via liveQuery.delta) requires a real agent session and cannot be triggered purely
+ * through the UI in an integration-free E2E test.  The component-level guarantee
+ * (TaskConversationRenderer DOM node is not replaced on send) is exercised by the
+ * unit test in packages/web/src/components/room/TaskView.test.tsx
+ * ("TaskView — no reload on message send (bug regression)").
+ * The E2E test below verifies the UI-observable side: messages visible BEFORE a
+ * send attempt remain visible AFTER the send attempt (no loading flash or wipe).
  *
  * Note on "live delta without refresh" testing: injecting a message after page
  * navigation requires calling hub.request() inside the test body, which violates
@@ -210,5 +221,63 @@ test.describe('TaskView — Message Streaming via LiveQuery', () => {
 			await expect(page.locator('text=Message for Task A only')).toBeVisible({ timeout: 10000 });
 			await expect(page.locator('text=Message for Task B only')).not.toBeVisible();
 		});
+	});
+});
+
+// ── Test 3: no reload on message send (regression) ──────────────────────────
+
+test.describe('no loading flash when user sends a message (regression)', () => {
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let roomId = '';
+	let taskId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+
+		// Create room, task, group with pre-existing messages — infrastructure only
+		({ roomId, taskId } = await createRoomWithTask(page, 'E2E No-Reload Task'));
+		await createGroupWithMessages(page, taskId, roomId, [
+			'Pre-existing message alpha',
+			'Pre-existing message beta',
+		]);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+		taskId = '';
+	});
+
+	test('pre-existing messages remain visible while user types and attempts to send', async ({
+		page,
+	}) => {
+		// Navigate to the task view — LiveQuery snapshot delivers the pre-existing messages
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.locator('text=E2E No-Reload Task')).toBeVisible({ timeout: 10000 });
+
+		// Both pre-existing messages must be visible via initial snapshot
+		await expect(page.locator('text=Pre-existing message alpha')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('text=Pre-existing message beta')).toBeVisible({ timeout: 10000 });
+
+		// Type a message in the human input area
+		const textarea = page.getByTestId('input-textarea-field');
+		await textarea.fill('Hello, please continue working');
+
+		// Pre-existing messages must still be visible while typing (no wipe on input)
+		await expect(page.locator('text=Pre-existing message alpha')).toBeVisible();
+		await expect(page.locator('text=Pre-existing message beta')).toBeVisible();
+
+		// Click send — the RPC will fail (no real session), but the UI must NOT
+		// clear the conversation pane or flash a loading state at any point
+		await page.getByTestId('input-textarea-send').click();
+
+		// After the send attempt, pre-existing messages must still be visible —
+		// this verifies the conversationKey is NOT bumped on message send
+		await expect(page.locator('text=Pre-existing message alpha')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('text=Pre-existing message beta')).toBeVisible({ timeout: 5000 });
 	});
 });

--- a/packages/e2e/tests/features/task-message-streaming.e2e.ts
+++ b/packages/e2e/tests/features/task-message-streaming.e2e.ts
@@ -263,8 +263,8 @@ test.describe('no loading flash when user sends a message (regression)', () => {
 		await expect(page.locator('text=Pre-existing message alpha')).toBeVisible({ timeout: 10000 });
 		await expect(page.locator('text=Pre-existing message beta')).toBeVisible({ timeout: 10000 });
 
-		// Type a message in the human input area
-		const textarea = page.getByTestId('input-textarea-field');
+		// Type a message in the human input area (no data-testid on <textarea> in prod)
+		const textarea = page.locator('textarea');
 		await textarea.fill('Hello, please continue working');
 
 		// Pre-existing messages must still be visible while typing (no wipe on input)
@@ -273,7 +273,7 @@ test.describe('no loading flash when user sends a message (regression)', () => {
 
 		// Click send — the RPC will fail (no real session), but the UI must NOT
 		// clear the conversation pane or flash a loading state at any point
-		await page.getByTestId('input-textarea-send').click();
+		await page.locator('[data-testid="send-button"]').click();
 
 		// After the send attempt, pre-existing messages must still be visible —
 		// this verifies the conversationKey is NOT bumped on message send

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2687,3 +2687,117 @@ describe('TaskView — task.getGroup retry on failure', () => {
 		expect(container.textContent).not.toContain('No active agent group');
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bug regression: TaskConversationRenderer must NOT remount when a message is sent
+//
+// Sending a message used to call onMessageSentWithReload() which bumped conversationKey,
+// remounting TaskConversationRenderer and causing a full re-fetch / loading flash.
+// After the fix, onMessageSent() is a no-op — the LiveQuery delta appends the message.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('TaskView — no reload on message send (bug regression)', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockReturnValue(() => {});
+		mockJoinRoom.mockReset();
+		mockLeaveRoom.mockReset();
+		mockShowScrollButton.value = false;
+		mockMessageCount.value = 0;
+		vi.mocked(useAutoScroll).mockClear();
+		_draftContentSignal.value = '';
+		_draftRestoredSignal.value = false;
+		mockSetMessageText.mockClear();
+		mockClearDraft.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('TaskConversationRenderer DOM node is NOT replaced after a successful message send', async () => {
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Wait for TaskConversationRenderer to mount
+		await waitFor(() => {
+			expect(getByTestId('conversation')).toBeTruthy();
+		});
+
+		// Capture the exact DOM node before the send
+		const conversationNodeBefore = getByTestId('conversation');
+
+		// Type a message and send it
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Hello, please continue' } });
+		fireEvent.click(getByTestId('input-textarea-send'));
+
+		// Wait for the RPC to complete
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', expect.any(Object));
+		});
+
+		// The DOM node must be the same object — no remount, no reload flash
+		const conversationNodeAfter = getByTestId('conversation');
+		expect(conversationNodeAfter).toBe(conversationNodeBefore);
+	});
+
+	it('conversationKey bumps only for approve (not for normal message send)', async () => {
+		// This test verifies that approve still causes a remount (intentional),
+		// while a normal message send does not.
+		mockRequest.mockImplementation(async (method) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'review') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_human') };
+			if (method === 'task.approve') return {};
+			if (method === 'task.sendHumanMessage') return {};
+			return {};
+		});
+
+		const { getByTestId, container } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		// Wait for TaskConversationRenderer to mount
+		await waitFor(() => {
+			expect(getByTestId('conversation')).toBeTruthy();
+		});
+
+		const nodeBeforeSend = getByTestId('conversation');
+
+		// Send a normal human message — should NOT remount
+		const textarea = getByTestId('input-textarea-field') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'Keep going' } });
+		fireEvent.click(getByTestId('input-textarea-send'));
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.sendHumanMessage', expect.any(Object));
+		});
+
+		// Still the same node
+		expect(getByTestId('conversation')).toBe(nodeBeforeSend);
+
+		const nodeBeforeApprove = getByTestId('conversation');
+
+		// Approve — should remount (intentional key bump)
+		const approveBtn = container.querySelector(
+			'[data-testid="action-bar-primary"]'
+		) as HTMLButtonElement;
+		expect(approveBtn).not.toBeNull();
+		fireEvent.click(approveBtn);
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('task.approve', expect.any(Object));
+		});
+
+		// After approve, the node is replaced (conversationKey bumped)
+		// This is intentional — approve triggers a full conversation refresh
+		await waitFor(() => {
+			const nodeAfterApprove = getByTestId('conversation');
+			expect(nodeAfterApprove).not.toBe(nodeBeforeApprove);
+		});
+	});
+});

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2693,7 +2693,8 @@ describe('TaskView — task.getGroup retry on failure', () => {
 //
 // Sending a message used to call onMessageSentWithReload() which bumped conversationKey,
 // remounting TaskConversationRenderer and causing a full re-fetch / loading flash.
-// After the fix, onMessageSent() is a no-op — the LiveQuery delta appends the message.
+// After the fix, the conversationKey is never bumped on message send —
+// the LiveQuery delta event appends the new message instead.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('TaskView — no reload on message send (bug regression)', () => {
 	beforeEach(() => {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -69,8 +69,8 @@ interface HumanInputAreaProps {
 	taskStatus: string;
 	roomId: string;
 	taskId: string;
-	/** Called after a successful action that requires a full conversation re-fetch */
-	onMessageSentWithReload: () => void;
+	/** Called after a message is successfully sent (no reload — LiveQuery appends it). */
+	onMessageSent: () => void;
 }
 
 const TARGET_LABELS: Record<HumanMessageTarget, string> = {
@@ -83,7 +83,7 @@ function HumanInputArea({
 	taskStatus,
 	roomId,
 	taskId,
-	onMessageSentWithReload,
+	onMessageSent,
 }: HumanInputAreaProps) {
 	const { request } = useMessageHub();
 	const {
@@ -133,7 +133,7 @@ function HumanInputArea({
 				target,
 			});
 			clearDraft();
-			onMessageSentWithReload();
+			onMessageSent();
 		} catch (err) {
 			setInputError(err instanceof Error ? err.message : 'Failed to send message');
 		} finally {
@@ -1406,7 +1406,7 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				taskStatus={task.status}
 				roomId={roomId}
 				taskId={taskId}
-				onMessageSentWithReload={() => setConversationKey((k) => k + 1)}
+				onMessageSent={() => {}}
 			/>
 
 			{/* Task action dialogs */}

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -69,8 +69,6 @@ interface HumanInputAreaProps {
 	taskStatus: string;
 	roomId: string;
 	taskId: string;
-	/** Called after a message is successfully sent (no reload — LiveQuery appends it). */
-	onMessageSent: () => void;
 }
 
 const TARGET_LABELS: Record<HumanMessageTarget, string> = {
@@ -78,13 +76,7 @@ const TARGET_LABELS: Record<HumanMessageTarget, string> = {
 	leader: 'Leader',
 };
 
-function HumanInputArea({
-	hasGroup,
-	taskStatus,
-	roomId,
-	taskId,
-	onMessageSent,
-}: HumanInputAreaProps) {
+function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputAreaProps) {
 	const { request } = useMessageHub();
 	const {
 		content: messageText,
@@ -133,7 +125,6 @@ function HumanInputArea({
 				target,
 			});
 			clearDraft();
-			onMessageSent();
 		} catch (err) {
 			setInputError(err instanceof Error ? err.message : 'Failed to send message');
 		} finally {
@@ -1406,7 +1397,6 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				taskStatus={task.status}
 				roomId={roomId}
 				taskId={taskId}
-				onMessageSent={() => {}}
 			/>
 
 			{/* Task action dialogs */}


### PR DESCRIPTION
Sending a message used to call onMessageSentWithReload() which bumped
conversationKey, remounting TaskConversationRenderer and triggering a
full re-fetch + loading flash. The LiveQuery subscription already
appends new messages via liveQuery.delta events, so no remount is needed.

- Rename HumanInputAreaProps.onMessageSentWithReload → onMessageSent
- Pass a no-op onMessageSent from TaskView (LiveQuery handles the append)
- Keep conversationKey bumps for approve/reject (intentional full refresh)
- Add unit test verifying the DOM node is not replaced on message send
- Add E2E regression test verifying pre-existing messages stay visible
  while user types and attempts to send a message
