### PR TITLE
Fix TaskView recovery after server restart

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -655,6 +655,10 @@ export class RoomRuntimeService {
 				const activeGroups = groupRepo.getActiveGroups(roomId);
 				for (const group of activeGroups) {
 					try {
+						// Re-attach runtime-only sdk.message mirroring before any continuation
+						// message is injected so recovered TaskView timelines keep streaming.
+						runtime.restoreRecoveredGroupMirroring(group);
+
 						// Restore MCP servers (planner-tools, leader-agent-tools)
 						await runtime.restoreMcpServersForGroup(group);
 

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -2141,6 +2141,18 @@ export class RoomRuntime {
 		}
 	}
 
+	/**
+	 * Re-attach runtime-only message mirroring for a recovered group.
+	 *
+	 * The TaskView timeline now reads exclusively from `session_group_messages`,
+	 * so recovered groups must re-subscribe to sdk.message events before any
+	 * continuation message is injected after restart.
+	 */
+	restoreRecoveredGroupMirroring(group: SessionGroup): void {
+		this.cleanupMirroring(group.id);
+		this.setupMirroring(group);
+	}
+
 	// =========================================================================
 	// Message Mirroring
 	// =========================================================================

--- a/packages/daemon/tests/unit/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service.test.ts
@@ -4,8 +4,15 @@ import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,
 } from '../../../src/lib/room/runtime/room-runtime-service';
+import { RoomRuntime } from '../../../src/lib/room/runtime/room-runtime';
+import { SessionObserver } from '../../../src/lib/room/state/session-observer';
+import { SessionGroupRepository } from '../../../src/lib/room/state/session-group-repository';
+import { TaskManager } from '../../../src/lib/room/managers/task-manager';
+import { GoalManager } from '../../../src/lib/room/managers/goal-manager';
 import type { RoomManager } from '../../../src/lib/room/managers/room-manager';
+import type { SessionFactory } from '../../../src/lib/room/runtime/task-group-manager';
 import type { Room } from '@neokai/shared';
+import { noOpReactiveDb } from '../../helpers/reactive-database';
 import type { SettingsManager } from '../../../src/lib/settings-manager';
 
 describe('RoomRuntimeService', () => {
@@ -298,5 +305,250 @@ describe('RoomRuntimeService', () => {
 
 			expect(Object.keys(callArg)).toEqual(['room-agent-tools']);
 		});
+	});
+});
+
+describe('RoomRuntimeService restart recovery', () => {
+	let rawDb: Database;
+
+	afterEach(() => {
+		rawDb?.close();
+	});
+
+	function makeDaemonHub() {
+		const listeners = new Map<string, Array<(data: unknown) => void>>();
+		return {
+			on(event: string, handler: (data: unknown) => void, options?: { sessionId?: string }) {
+				const key = `${event}:${options?.sessionId ?? '*'}`;
+				const current = listeners.get(key) ?? [];
+				current.push(handler);
+				listeners.set(key, current);
+				return () => {
+					const next = (listeners.get(key) ?? []).filter((fn) => fn !== handler);
+					if (next.length === 0) listeners.delete(key);
+					else listeners.set(key, next);
+				};
+			},
+			emit(event: string, data: Record<string, unknown> & { sessionId?: string }) {
+				for (const key of [`${event}:*`, `${event}:${data.sessionId ?? '*'}`]) {
+					for (const handler of listeners.get(key) ?? []) {
+						handler(data);
+					}
+				}
+			},
+		};
+	}
+
+	function createMockSessionFactory() {
+		return {
+			async createAndStartSession() {},
+			async injectMessage() {},
+			hasSession() {
+				return true;
+			},
+			async answerQuestion() {
+				return false;
+			},
+			async createWorktree() {
+				return null;
+			},
+			async restoreSession() {
+				return true;
+			},
+			async startSession() {
+				return true;
+			},
+			setSessionMcpServers() {
+				return true;
+			},
+			async removeWorktree() {
+				return false;
+			},
+		} satisfies SessionFactory;
+	}
+
+	it('reattaches group mirroring during restart recovery so TaskView timelines keep streaming', async () => {
+		rawDb = new Database(':memory:');
+		rawDb.exec(`
+			CREATE TABLE rooms (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			);
+			CREATE TABLE goals (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'active',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				progress INTEGER DEFAULT 0,
+				linked_task_ids TEXT DEFAULT '[]',
+				metrics TEXT DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				planning_attempts INTEGER DEFAULT 0,
+				goal_review_attempts INTEGER DEFAULT 0,
+				mission_type TEXT NOT NULL DEFAULT 'one_shot',
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				schedule TEXT,
+				schedule_paused INTEGER NOT NULL DEFAULT 0,
+				next_run_at INTEGER,
+				structured_metrics TEXT,
+				max_consecutive_failures INTEGER NOT NULL DEFAULT 3,
+				max_planning_attempts INTEGER NOT NULL DEFAULT 5,
+				consecutive_failures INTEGER NOT NULL DEFAULT 0,
+				replan_count INTEGER NOT NULL DEFAULT 0
+			);
+			CREATE TABLE tasks (
+				id TEXT PRIMARY KEY,
+				room_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT DEFAULT '[]',
+				task_type TEXT DEFAULT 'coding',
+				created_by_task_id TEXT,
+				assigned_agent TEXT DEFAULT 'coder',
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				archived_at INTEGER,
+				active_session TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				updated_at INTEGER
+			);
+			CREATE TABLE session_groups (
+				id TEXT PRIMARY KEY,
+				group_type TEXT NOT NULL DEFAULT 'task',
+				ref_id TEXT NOT NULL,
+				state TEXT NOT NULL DEFAULT 'awaiting_worker',
+				version INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				completed_at INTEGER
+			);
+			CREATE TABLE session_group_members (
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				joined_at INTEGER NOT NULL,
+				PRIMARY KEY (group_id, session_id)
+			);
+			CREATE TABLE task_group_events (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				kind TEXT NOT NULL,
+				payload_json TEXT,
+				created_at INTEGER NOT NULL
+			);
+			CREATE TABLE session_group_messages (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				group_id TEXT NOT NULL REFERENCES session_groups(id) ON DELETE CASCADE,
+				session_id TEXT,
+				role TEXT NOT NULL DEFAULT 'system',
+				message_type TEXT NOT NULL DEFAULT 'status',
+				content TEXT NOT NULL DEFAULT '',
+				created_at INTEGER NOT NULL
+			);
+		`);
+
+		const now = Date.now();
+		rawDb
+			.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+			.run('room-1', 'Test Room', now, now);
+		rawDb
+			.prepare(
+				`INSERT INTO tasks (id, room_id, title, description, status, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`
+			)
+			.run('task-1', 'room-1', 'Recovered task', 'Desc', 'in_progress', now);
+
+		const daemonHub = makeDaemonHub();
+		const groupRepo = new SessionGroupRepository(rawDb, noOpReactiveDb);
+		const taskManager = new TaskManager(rawDb as never, 'room-1', noOpReactiveDb);
+		const goalManager = new GoalManager(rawDb as never, 'room-1', noOpReactiveDb);
+		const observer = new SessionObserver(daemonHub as never);
+		const sessionFactory = createMockSessionFactory();
+		const group = groupRepo.createGroup('task-1', 'worker:task-1', 'leader:task-1');
+
+		const runtime = new RoomRuntime({
+			room: {
+				id: 'room-1',
+				name: 'Test Room',
+				allowedPaths: [{ path: '/workspace', label: 'ws' }],
+				defaultPath: '/workspace',
+				sessionIds: [],
+				status: 'active',
+				createdAt: now,
+				updatedAt: now,
+			},
+			groupRepo,
+			sessionObserver: observer,
+			taskManager,
+			goalManager,
+			sessionFactory,
+			workspacePath: '/workspace',
+			daemonHub: daemonHub as never,
+		});
+
+		const config: RoomRuntimeServiceConfig = {
+			db: {
+				getDatabase: () => rawDb,
+				getSession: (sessionId: string) =>
+					sessionId === 'worker:task-1' || sessionId === 'leader:task-1'
+						? ({ id: sessionId } as never)
+						: null,
+			} as never,
+			messageHub: {} as never,
+			daemonHub: daemonHub as never,
+			getApiKey: async () => null,
+			roomManager: {
+				getRoom: () => null,
+			} as unknown as RoomManager,
+			sessionManager: {} as never,
+			defaultWorkspacePath: '/workspace',
+			defaultModel: 'test-model',
+			getGlobalSettings: () => ({}) as never,
+			reactiveDb: noOpReactiveDb,
+		};
+
+		const service = new RoomRuntimeService(config);
+		const serviceAny = service as unknown as {
+			createSessionFactory: () => SessionFactory;
+			recoverRoomRuntime: (
+				roomId: string,
+				runtime: RoomRuntime,
+				observer: SessionObserver
+			) => Promise<void>;
+		};
+		serviceAny.createSessionFactory = () => sessionFactory;
+
+		await serviceAny.recoverRoomRuntime('room-1', runtime, observer);
+
+		daemonHub.emit('sdk.message', {
+			sessionId: 'worker:task-1',
+			message: {
+				uuid: 'msg-1',
+				type: 'assistant',
+				text: 'Recovered worker output',
+			},
+		});
+
+		const mirrored = rawDb
+			.prepare(`SELECT COUNT(*) AS count FROM session_group_messages WHERE group_id = ?`)
+			.get(group.id) as { count: number };
+		expect(mirrored.count).toBe(1);
+
+		runtime.stop();
 	});
 });


### PR DESCRIPTION
## Summary
- restore group message mirroring when room runtimes recover active task groups after restart
- reattach mirroring before continuation messages are injected so recovered TaskView timelines keep streaming into session_group_messages
- add a regression test covering restart recovery for TaskView message streaming

## Root cause
TaskView reads group timelines from session_group_messages. After server restart, recovery restored sessions, observers, and MCP servers, but did not reattach the sdk.message mirroring that populates session_group_messages for recovered groups. Existing tasks therefore showed an empty timeline and rendered "Waiting for agent activity…" even though session state still existed.

## Testing
- source ~/.zshrc && bun test packages/daemon/tests/unit/room/runtime-recovery.test.ts packages/daemon/tests/unit/room/room-runtime-service.test.ts