### PR TITLE
feat: audit and fix room agent MCP tools parity vs backend capabilities

### DIFF
--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -125,6 +125,19 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			if (!goal) {
 				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
 			}
+			// Guard: require at least one field to update
+			if (
+				args.title === undefined &&
+				args.description === undefined &&
+				args.status === undefined &&
+				args.priority === undefined &&
+				args.mission_type === undefined &&
+				args.autonomy_level === undefined &&
+				args.structured_metrics === undefined
+			) {
+				return jsonResult({ success: false, error: 'No update fields provided.' });
+			}
+
 			let updated = goal;
 
 			// Collect patch fields: title, description, priority, missionType, autonomyLevel, structuredMetrics

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -7,12 +7,20 @@
  *
  * Tools: create_goal, list_goals, update_goal, create_task, list_tasks,
  *        update_task, cancel_task, stop_session, get_room_status, approve_task, reject_task,
- *        send_message_to_task, get_task_detail
+ *        send_message_to_task, get_task_detail, set_schedule, pause_schedule, resume_schedule,
+ *        record_metric, get_metrics, list_executions
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { TaskStatus, TaskType, AgentType } from '@neokai/shared';
+import type {
+	TaskStatus,
+	TaskType,
+	AgentType,
+	MissionType,
+	AutonomyLevel,
+	MissionMetric,
+} from '@neokai/shared';
 import type { GoalManager } from '../managers/goal-manager';
 import type { TaskManager } from '../managers/task-manager';
 import type { SessionGroupRepository } from '../state/session-group-repository';
@@ -52,11 +60,32 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			title: string;
 			description?: string;
 			priority?: 'low' | 'normal' | 'high' | 'urgent';
+			mission_type?: MissionType;
+			autonomy_level?: AutonomyLevel;
+			structured_metrics?: Array<{
+				name: string;
+				target: number;
+				current?: number;
+				unit?: string;
+				direction?: 'increase' | 'decrease';
+				baseline?: number;
+			}>;
 		}): Promise<ToolResult> {
+			const metrics: MissionMetric[] | undefined = args.structured_metrics?.map((m) => ({
+				name: m.name,
+				target: m.target,
+				current: m.current ?? 0,
+				...(m.unit ? { unit: m.unit } : {}),
+				...(m.direction ? { direction: m.direction } : {}),
+				...(m.baseline !== undefined ? { baseline: m.baseline } : {}),
+			}));
 			const goal = await goalManager.createGoal({
 				title: args.title,
 				description: args.description,
 				priority: args.priority,
+				missionType: args.mission_type,
+				autonomyLevel: args.autonomy_level,
+				structuredMetrics: metrics,
 			});
 			// Notify runtime so it schedules a tick immediately (instead of waiting for the timer)
 			if (daemonHub) {
@@ -77,20 +106,61 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 
 		async update_goal(args: {
 			goal_id: string;
+			title?: string;
+			description?: string;
 			status?: 'active' | 'needs_human' | 'completed' | 'archived';
 			priority?: 'low' | 'normal' | 'high' | 'urgent';
+			mission_type?: MissionType;
+			autonomy_level?: AutonomyLevel;
+			structured_metrics?: Array<{
+				name: string;
+				target: number;
+				current?: number;
+				unit?: string;
+				direction?: 'increase' | 'decrease';
+				baseline?: number;
+			}>;
 		}): Promise<ToolResult> {
 			const goal = await goalManager.getGoal(args.goal_id);
 			if (!goal) {
 				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
 			}
 			let updated = goal;
+
+			// Collect patch fields: title, description, priority, missionType, autonomyLevel, structuredMetrics
+			const hasPatchFields =
+				args.title !== undefined ||
+				args.description !== undefined ||
+				args.priority !== undefined ||
+				args.mission_type !== undefined ||
+				args.autonomy_level !== undefined ||
+				args.structured_metrics !== undefined;
+
+			if (hasPatchFields) {
+				const patch: Record<string, unknown> = {};
+				if (args.title !== undefined) patch.title = args.title;
+				if (args.description !== undefined) patch.description = args.description;
+				if (args.priority !== undefined) patch.priority = args.priority;
+				if (args.mission_type !== undefined) patch.missionType = args.mission_type;
+				if (args.autonomy_level !== undefined) patch.autonomyLevel = args.autonomy_level;
+				if (args.structured_metrics !== undefined) {
+					patch.structuredMetrics = args.structured_metrics.map((m) => ({
+						name: m.name,
+						target: m.target,
+						current: m.current ?? 0,
+						...(m.unit ? { unit: m.unit } : {}),
+						...(m.direction ? { direction: m.direction } : {}),
+						...(m.baseline !== undefined ? { baseline: m.baseline } : {}),
+					}));
+				}
+				updated = await goalManager.patchGoal(args.goal_id, patch);
+			}
+
+			// Status update is a distinct operation from patch (changes state + timestamps)
 			if (args.status) {
 				updated = await goalManager.updateGoalStatus(args.goal_id, args.status);
 			}
-			if (args.priority) {
-				updated = await goalManager.updateGoalPriority(args.goal_id, args.priority);
-			}
+
 			return jsonResult({ success: true, goal: updated });
 		},
 
@@ -153,7 +223,12 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 		},
 
 		async list_tasks(args: { goal_id?: string; status?: TaskStatus }): Promise<ToolResult> {
-			let tasks = await taskManager.listTasks(args.status ? { status: args.status } : undefined);
+			// When explicitly filtering by 'archived', we must pass includeArchived:true
+			// because listTasks excludes archived tasks by default.
+			const filter = args.status
+				? { status: args.status, ...(args.status === 'archived' ? { includeArchived: true } : {}) }
+				: undefined;
+			let tasks = await taskManager.listTasks(filter);
 			if (args.goal_id) {
 				const goal = await goalManager.getGoal(args.goal_id);
 				if (goal) {
@@ -440,10 +515,15 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			// Apply status change
 			let updatedTask: typeof task;
 			try {
-				updatedTask = await taskManager.setTaskStatus(args.task_id, args.status, {
-					result: args.result,
-					error: args.error,
-				});
+				if (args.status === 'archived') {
+					// archiveTask() sets archivedAt timestamp; setTaskStatus('archived') does not
+					updatedTask = await taskManager.archiveTask(args.task_id);
+				} else {
+					updatedTask = await taskManager.setTaskStatus(args.task_id, args.status, {
+						result: args.result,
+						error: args.error,
+					});
+				}
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				return jsonResult({ success: false, error: message });
@@ -742,6 +822,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 					},
 					tasks: {
 						total: tasks.length,
+						draft: tasks.filter((t) => t.status === 'draft').length,
 						pending: tasks.filter((t) => t.status === 'pending').length,
 						inProgress: tasks.filter((t) => t.status === 'in_progress').length,
 						review: tasks.filter((t) => t.status === 'review').length,
@@ -834,6 +915,20 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				}),
 			});
 		},
+
+		async list_executions(args: { goal_id: string; limit?: number }): Promise<ToolResult> {
+			const goal = await goalManager.getGoal(args.goal_id);
+			if (!goal) {
+				return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+			}
+			const executions = goalManager.listExecutions(args.goal_id, args.limit ?? 20);
+			return jsonResult({
+				success: true,
+				goalId: args.goal_id,
+				missionType: goal.missionType ?? 'one_shot',
+				executions,
+			});
+		},
 	};
 }
 
@@ -852,20 +947,74 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 					.optional()
 					.default('normal')
 					.describe('Goal priority'),
+				mission_type: z
+					.enum(['one_shot', 'measurable', 'recurring'])
+					.optional()
+					.describe(
+						'Mission type: one_shot (default, single-run), measurable (tracks numeric KPIs), recurring (runs on a cron schedule)'
+					),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe(
+						'Autonomy level: supervised (default, PRs require human review), semi_autonomous (can merge approved PRs automatically)'
+					),
+				structured_metrics: z
+					.array(
+						z.object({
+							name: z.string().describe('Metric name (e.g. "test_coverage")'),
+							target: z.number().describe('Target value to reach'),
+							current: z.number().optional().describe('Current value (defaults to 0)'),
+							unit: z.string().optional().describe('Unit label (e.g. "%" or "ms")'),
+							direction: z
+								.enum(['increase', 'decrease'])
+								.optional()
+								.describe('Direction of improvement (default: increase)'),
+							baseline: z
+								.number()
+								.optional()
+								.describe('Baseline value (required when direction is decrease)'),
+						})
+					)
+					.optional()
+					.describe('Structured metrics for measurable missions'),
 			},
 			(args) => handlers.create_goal(args)
 		),
 		tool('list_goals', 'List all goals in this room', {}, () => handlers.list_goals()),
 		tool(
 			'update_goal',
-			'Update an existing goal',
+			'Update an existing goal. Provide only the fields you want to change; omitted fields keep their current values.',
 			{
 				goal_id: z.string().describe('ID of the goal to update'),
+				title: z.string().trim().min(1).optional().describe('New title for the goal'),
+				description: z.string().optional().describe('New description for the goal'),
 				status: z
 					.enum(['active', 'needs_human', 'completed', 'archived'])
 					.optional()
 					.describe('New status'),
 				priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('New priority'),
+				mission_type: z
+					.enum(['one_shot', 'measurable', 'recurring'])
+					.optional()
+					.describe('Change mission type'),
+				autonomy_level: z
+					.enum(['supervised', 'semi_autonomous'])
+					.optional()
+					.describe('Change autonomy level'),
+				structured_metrics: z
+					.array(
+						z.object({
+							name: z.string().describe('Metric name'),
+							target: z.number().describe('Target value'),
+							current: z.number().optional().describe('Current value (defaults to 0)'),
+							unit: z.string().optional().describe('Unit label'),
+							direction: z.enum(['increase', 'decrease']).optional(),
+							baseline: z.number().optional(),
+						})
+					)
+					.optional()
+					.describe('Replace structured metrics for measurable missions'),
 			},
 			(args) => handlers.update_goal(args)
 		),
@@ -912,6 +1061,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 						'completed',
 						'needs_attention',
 						'cancelled',
+						'archived',
 					])
 					.optional()
 					.describe('Filter by status'),
@@ -947,7 +1097,7 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 		),
 		tool(
 			'set_task_status',
-			'Set task status to any valid status. Use this to complete, fail, restart, or change status of any task. Validates that the status transition is allowed.',
+			'Set task status to any valid status. Use this to complete, fail, restart, archive, or change status of any task. Validates that the status transition is allowed.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
 				status: z
@@ -959,8 +1109,11 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 						'completed',
 						'needs_attention',
 						'cancelled',
+						'archived',
 					])
-					.describe('New status for the task'),
+					.describe(
+						'New status for the task. Use archived to permanently archive completed/cancelled/needs_attention tasks.'
+					),
 				result: z.string().optional().describe('Result description (for completed status)'),
 				error: z.string().optional().describe('Error message (for needs_attention status)'),
 			},
@@ -1051,6 +1204,21 @@ export function createRoomAgentMcpServer(config: RoomAgentToolsConfig) {
 			},
 			(args) => handlers.get_metrics(args)
 		),
+		tool(
+			'list_executions',
+			'List execution history for a recurring mission. Returns the most recent executions with their status, timestamps, and result summaries.',
+			{
+				goal_id: z.string().describe('ID of the recurring mission goal'),
+				limit: z
+					.number()
+					.int()
+					.positive()
+					.optional()
+					.default(20)
+					.describe('Maximum number of executions to return (default: 20)'),
+			},
+			(args) => handlers.list_executions(args)
+		),
 	];
 
 	return createSdkMcpServer({ name: 'room-agent', tools });
@@ -1106,6 +1274,7 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 						'completed',
 						'needs_attention',
 						'cancelled',
+						'archived',
 					])
 					.optional()
 					.describe('Filter by status'),
@@ -1152,14 +1321,24 @@ export function createLeaderContextMcpServer(config: LeaderContextMcpConfig) {
 		),
 		tool(
 			'update_task_status',
-			'Change a task status with transition validation. Use to retry failed tasks (needs_attention → pending), revive to review, or move between valid states.',
+			'Change a task status with transition validation. Use to retry failed tasks (needs_attention → pending), revive to review, archive completed tasks, or move between valid states.',
 			{
 				task_id: z.string().describe('ID of the task to update'),
 				// 'draft' is intentionally excluded: tasks reach draft status only via the planning
 				// phase (planner agent creates them). The leader must not put tasks back to draft.
 				status: z
-					.enum(['pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled'])
-					.describe('New status for the task'),
+					.enum([
+						'pending',
+						'in_progress',
+						'review',
+						'completed',
+						'needs_attention',
+						'cancelled',
+						'archived',
+					])
+					.describe(
+						'New status for the task. Use archived to permanently archive completed/cancelled/needs_attention tasks.'
+					),
 				result: z.string().optional().describe('Result summary (for completed status)'),
 				error: z.string().optional().describe('Error message (for needs_attention status)'),
 			},

--- a/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/goal-handlers.ts
@@ -11,6 +11,8 @@
  * - goal.linkTask - Link a task to a goal
  * - goal.delete - Delete a goal
  * - goal.listExecutions - List execution history for a recurring mission
+ * - goal.recordMetric - Record a metric value for a measurable mission
+ * - goal.getMetrics - Get current metric state for a goal
  * - task.approve - Human approves a task PR (resumes worker for phase 2)
  */
 
@@ -50,6 +52,8 @@ export type GoalManagerLike = Pick<
 	| 'getActiveExecution'
 	| 'updateNextRunAt'
 	| 'listExecutions'
+	| 'recordMetric'
+	| 'checkMetricTargets'
 >;
 
 export type GoalManagerFactory = (roomId: string) => GoalManagerLike;
@@ -415,6 +419,74 @@ export function setupGoalHandlers(
 
 		const executions = goalManager.listExecutions(params.goalId, params.limit ?? 20);
 		return { executions };
+	});
+
+	// goal.recordMetric - Record a metric value for a measurable mission
+	messageHub.onRequest('goal.recordMetric', async (data) => {
+		const params = data as { roomId: string; goalId: string; metricName: string; value: number };
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+		if (!params.metricName) throw new Error('Metric name is required');
+		if (typeof params.value !== 'number') throw new Error('Value must be a number');
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goal = await goalManager.getGoal(params.goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+		if (goal.missionType !== 'measurable') {
+			throw new Error(
+				`Goal ${params.goalId} is not a measurable mission (missionType: ${goal.missionType ?? 'one_shot'})`
+			);
+		}
+
+		const updated = await goalManager.recordMetric(params.goalId, params.metricName, params.value);
+		return {
+			goal: updated,
+			metric: {
+				name: params.metricName,
+				value: params.value,
+				goalProgress: updated.progress,
+			},
+		};
+	});
+
+	// goal.getMetrics - Get current metric state and targets for a goal
+	messageHub.onRequest('goal.getMetrics', async (data) => {
+		const params = data as { roomId: string; goalId: string };
+
+		if (!params.roomId) throw new Error('Room ID is required');
+		if (!params.goalId) throw new Error('Goal ID is required');
+
+		const goalManager = goalManagerFactory(params.roomId);
+		const goal = await goalManager.getGoal(params.goalId);
+		if (!goal) throw new Error(`Goal not found: ${params.goalId}`);
+
+		if (!goal.structuredMetrics || goal.structuredMetrics.length === 0) {
+			return {
+				missionType: goal.missionType ?? 'one_shot',
+				structuredMetrics: [],
+				legacyMetrics: goal.metrics ?? {},
+				note: 'No structured metrics configured. For measurable missions, add structuredMetrics to the goal.',
+			};
+		}
+
+		const checkResult = await goalManager.checkMetricTargets(params.goalId);
+		return {
+			missionType: goal.missionType ?? 'one_shot',
+			allTargetsMet: checkResult.allMet,
+			metrics: checkResult.results.map((r) => {
+				const metric = goal.structuredMetrics!.find((m) => m.name === r.name);
+				return {
+					name: r.name,
+					current: r.current,
+					target: r.target,
+					met: r.met,
+					direction: metric?.direction ?? 'increase',
+					...(metric?.baseline !== undefined ? { baseline: metric.baseline } : {}),
+					...(metric?.unit ? { unit: metric.unit } : {}),
+				};
+			}),
+		};
 	});
 
 	// task.approve - Human approves the PR; resume leader to complete task flow

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -226,6 +226,14 @@ describe('Room Agent Tools', () => {
 			);
 			expect(result.success).toBe(false);
 		});
+
+		it('should return error when no update fields provided', async () => {
+			const created = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = created.goalId as string;
+			const result = parseResult(await handlers.update_goal({ goal_id: goalId }));
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/No update fields provided/);
+		});
 	});
 
 	describe('create_task', () => {
@@ -2375,14 +2383,14 @@ describe('Room Agent Tools', () => {
 		it('should include draft task count', async () => {
 			// Create a regular (pending) task
 			await taskManager.createTask({ title: 'Pending', description: 'D' });
-			// Create a draft task
-			await taskManager.createTask({ title: 'Draft', description: 'D', status: 'draft' as never });
+			// Create a draft task (status param supported by CreateTaskParams)
+			await taskManager.createTask({ title: 'Draft', description: 'D', status: 'draft' });
 			const result = parseResult(await handlers.get_room_status());
 			expect(result.success).toBe(true);
 			const status = result.status as Record<string, unknown>;
 			const tasks = status.tasks as Record<string, number>;
-			expect(tasks.draft).toBeGreaterThanOrEqual(0);
-			expect(typeof tasks.draft).toBe('number');
+			expect(tasks.draft).toBe(1);
+			expect(tasks.pending).toBe(1);
 		});
 	});
 

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -124,6 +124,21 @@ describe('Room Agent Tools', () => {
 			);
 			CREATE INDEX IF NOT EXISTS idx_mission_metric_history_lookup
 				ON mission_metric_history(goal_id, metric_name, recorded_at);
+			CREATE TABLE mission_executions (
+				id TEXT PRIMARY KEY,
+				goal_id TEXT NOT NULL,
+				execution_number INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				status TEXT NOT NULL DEFAULT 'running',
+				result_summary TEXT,
+				task_ids TEXT NOT NULL DEFAULT '[]',
+				planning_attempts INTEGER NOT NULL DEFAULT 0,
+				FOREIGN KEY (goal_id) REFERENCES goals(id) ON DELETE CASCADE,
+				UNIQUE(goal_id, execution_number)
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_active
+				ON mission_executions(goal_id) WHERE status = 'running';
 			INSERT INTO rooms (id, name, created_at, updated_at) VALUES ('${roomId}', 'Test', ${Date.now()}, ${Date.now()});
 		`);
 
@@ -2122,10 +2137,10 @@ describe('Room Agent Tools', () => {
 			expect(fullServer.name).toBe('room-agent');
 		});
 
-		it('full server exposes all 19 tools', () => {
+		it('full server exposes all 20 tools', () => {
 			const fullServer = createRoomAgentMcpServer({ roomId, goalManager, taskManager, groupRepo });
 			const names = getRegisteredToolNames(fullServer as never);
-			expect(names).toHaveLength(19);
+			expect(names).toHaveLength(20);
 			expect(names).toContain('approve_task');
 			expect(names).toContain('reject_task');
 			expect(names).toContain('set_schedule');
@@ -2133,6 +2148,255 @@ describe('Room Agent Tools', () => {
 			expect(names).toContain('resume_schedule');
 			expect(names).toContain('record_metric');
 			expect(names).toContain('get_metrics');
+			expect(names).toContain('list_executions');
+		});
+	});
+
+	describe('create_goal Mission V2 fields', () => {
+		it('should create a measurable mission with structuredMetrics', async () => {
+			const result = parseResult(
+				await handlers.create_goal({
+					title: 'Improve coverage',
+					mission_type: 'measurable',
+					structured_metrics: [{ name: 'test_coverage', target: 90, current: 70, unit: '%' }],
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.missionType).toBe('measurable');
+			const metrics = goal.structuredMetrics as Array<Record<string, unknown>>;
+			expect(metrics).toHaveLength(1);
+			expect(metrics[0].name).toBe('test_coverage');
+			expect(metrics[0].target).toBe(90);
+			expect(metrics[0].current).toBe(70);
+			expect(metrics[0].unit).toBe('%');
+		});
+
+		it('should create a recurring mission', async () => {
+			const result = parseResult(
+				await handlers.create_goal({
+					title: 'Daily sync',
+					mission_type: 'recurring',
+					autonomy_level: 'semi_autonomous',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.missionType).toBe('recurring');
+			expect(goal.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('should default current to 0 when not provided in structured_metrics', async () => {
+			const result = parseResult(
+				await handlers.create_goal({
+					title: 'Perf goal',
+					mission_type: 'measurable',
+					structured_metrics: [
+						{ name: 'latency_p99', target: 100, direction: 'decrease', baseline: 500, unit: 'ms' },
+					],
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			const metrics = goal.structuredMetrics as Array<Record<string, unknown>>;
+			expect(metrics[0].current).toBe(0);
+			expect(metrics[0].direction).toBe('decrease');
+			expect(metrics[0].baseline).toBe(500);
+		});
+	});
+
+	describe('update_goal V2 fields', () => {
+		it('should update goal title and description via patchGoal', async () => {
+			const created = parseResult(await handlers.create_goal({ title: 'Old title' }));
+			const goalId = created.goalId as string;
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					title: 'New title',
+					description: 'Updated description',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.title).toBe('New title');
+			expect(goal.description).toBe('Updated description');
+		});
+
+		it('should update missionType and autonomyLevel via patchGoal', async () => {
+			const created = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = created.goalId as string;
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					mission_type: 'measurable',
+					autonomy_level: 'semi_autonomous',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.missionType).toBe('measurable');
+			expect(goal.autonomyLevel).toBe('semi_autonomous');
+		});
+
+		it('should update structuredMetrics via patchGoal', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Goal', mission_type: 'measurable' })
+			);
+			const goalId = created.goalId as string;
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					structured_metrics: [{ name: 'coverage', target: 80 }],
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			const metrics = goal.structuredMetrics as Array<Record<string, unknown>>;
+			expect(metrics).toHaveLength(1);
+			expect(metrics[0].name).toBe('coverage');
+			expect(metrics[0].current).toBe(0);
+		});
+
+		it('should update both patch fields and status together', async () => {
+			const created = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = created.goalId as string;
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					title: 'Renamed',
+					status: 'completed',
+				})
+			);
+			expect(result.success).toBe(true);
+			// Status update overwrites the last returned goal (status is applied after patch)
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.status).toBe('completed');
+		});
+
+		it('should update priority via patchGoal when provided with other patch fields', async () => {
+			const created = parseResult(await handlers.create_goal({ title: 'Goal' }));
+			const goalId = created.goalId as string;
+			const result = parseResult(
+				await handlers.update_goal({
+					goal_id: goalId,
+					title: 'Updated',
+					priority: 'urgent',
+				})
+			);
+			expect(result.success).toBe(true);
+			const goal = result.goal as Record<string, unknown>;
+			expect(goal.priority).toBe('urgent');
+		});
+	});
+
+	describe('list_executions', () => {
+		it('should return empty list for goal with no executions', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Recurring', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+			const result = parseResult(await handlers.list_executions({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			expect(result.goalId).toBe(goalId);
+			expect(result.missionType).toBe('recurring');
+			expect(result.executions).toEqual([]);
+		});
+
+		it('should return error for non-existent goal', async () => {
+			const result = parseResult(await handlers.list_executions({ goal_id: 'no-such' }));
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('not found');
+		});
+
+		it('should list executions after startExecution', async () => {
+			const created = parseResult(
+				await handlers.create_goal({ title: 'Recurring', mission_type: 'recurring' })
+			);
+			const goalId = created.goalId as string;
+			// Start an execution via goalManager
+			await goalManager.startExecution(goalId);
+			const result = parseResult(await handlers.list_executions({ goal_id: goalId }));
+			expect(result.success).toBe(true);
+			const executions = result.executions as Array<Record<string, unknown>>;
+			expect(executions).toHaveLength(1);
+			expect(executions[0].status).toBe('running');
+			expect(executions[0].executionNumber).toBe(1);
+		});
+	});
+
+	describe('set_task_status — archived', () => {
+		it('should archive a completed task', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'D' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: task.id, status: 'archived' })
+			);
+			expect(result.success).toBe(true);
+			const updated = await taskManager.getTask(task.id);
+			expect(updated?.status).toBe('archived');
+			expect(updated?.archivedAt).toBeDefined();
+		});
+
+		it('should archive a cancelled task', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'D' });
+			await taskManager.cancelTask(task.id);
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: task.id, status: 'archived' })
+			);
+			expect(result.success).toBe(true);
+			const updated = await taskManager.getTask(task.id);
+			expect(updated?.status).toBe('archived');
+		});
+
+		it('should archive a needs_attention task', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'D' });
+			await taskManager.startTask(task.id);
+			await taskManager.failTask(task.id, 'failed');
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: task.id, status: 'archived' })
+			);
+			expect(result.success).toBe(true);
+			const updated = await taskManager.getTask(task.id);
+			expect(updated?.status).toBe('archived');
+		});
+
+		it('should reject archiving a pending task (invalid transition)', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'D' });
+			const result = parseResult(
+				await handlers.set_task_status({ task_id: task.id, status: 'archived' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toBeDefined();
+		});
+	});
+
+	describe('get_room_status — draft count', () => {
+		it('should include draft task count', async () => {
+			// Create a regular (pending) task
+			await taskManager.createTask({ title: 'Pending', description: 'D' });
+			// Create a draft task
+			await taskManager.createTask({ title: 'Draft', description: 'D', status: 'draft' as never });
+			const result = parseResult(await handlers.get_room_status());
+			expect(result.success).toBe(true);
+			const status = result.status as Record<string, unknown>;
+			const tasks = status.tasks as Record<string, number>;
+			expect(tasks.draft).toBeGreaterThanOrEqual(0);
+			expect(typeof tasks.draft).toBe('number');
+		});
+	});
+
+	describe('list_tasks — archived filter', () => {
+		it('should filter by archived status', async () => {
+			const task = await taskManager.createTask({ title: 'T', description: 'D' });
+			await taskManager.startTask(task.id);
+			await taskManager.completeTask(task.id, 'done');
+			await taskManager.archiveTask(task.id);
+
+			const result = parseResult(await handlers.list_tasks({ status: 'archived' }));
+			expect(result.success).toBe(true);
+			const tasks = result.tasks as Array<Record<string, unknown>>;
+			expect(tasks.some((t) => t.id === task.id)).toBe(true);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -180,6 +180,45 @@ const mockGoalManager = {
 			updatedAt: Date.now(),
 		})
 	),
+	updateNextRunAt: mock(
+		async (): Promise<RoomGoal> => ({
+			id: 'goal-123',
+			roomId: 'room-123',
+			title: 'Test Goal',
+			description: '',
+			status: 'active' as GoalStatus,
+			priority: 'normal' as GoalPriority,
+			progress: 0,
+			linkedTaskIds: [],
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})
+	),
+	listExecutions: mock((): MissionExecution[] => []),
+	recordMetric: mock(
+		async (): Promise<RoomGoal> => ({
+			id: 'goal-123',
+			roomId: 'room-123',
+			title: 'Test Goal',
+			description: '',
+			status: 'active' as GoalStatus,
+			priority: 'normal' as GoalPriority,
+			progress: 50,
+			linkedTaskIds: [],
+			missionType: 'measurable',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})
+	),
+	checkMetricTargets: mock(
+		async (): Promise<{
+			allMet: boolean;
+			results: Array<{ name: string; current: number; target: number; met: boolean }>;
+		}> => ({
+			allMet: false,
+			results: [{ name: 'coverage', current: 70, target: 90, met: false }],
+		})
+	),
 };
 
 const createMockGoalManager = (): GoalManagerLike => mockGoalManager as unknown as GoalManagerLike;
@@ -253,6 +292,10 @@ describe('Goal RPC Handlers', () => {
 		mockGoalManager.deleteGoal.mockClear();
 		mockGoalManager.getActiveExecution.mockClear();
 		mockGoalManager.linkTaskToExecution.mockClear();
+		mockGoalManager.updateNextRunAt.mockClear();
+		mockGoalManager.listExecutions.mockClear();
+		mockGoalManager.recordMetric.mockClear();
+		mockGoalManager.checkMetricTargets.mockClear();
 
 		// Setup handlers with mocked dependencies
 		setupGoalHandlers(messageHubData.hub, daemonHubData.daemonHub, createMockGoalManager);
@@ -1187,6 +1230,144 @@ describe('Goal RPC Handlers', () => {
 
 			await expect(handler!({ roomId: 'room-123', taskId: 'task-123' }, {})).rejects.toThrow(
 				'Failed to resume task task-123'
+			);
+		});
+	});
+
+	describe('goal.recordMetric', () => {
+		it('records a metric for a measurable mission', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Metrics Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				missionType: 'measurable' as const,
+				structuredMetrics: [{ name: 'coverage', target: 90, current: 70 }],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+
+			const handler = messageHubData.handlers.get('goal.recordMetric');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!(
+				{ roomId: 'room-123', goalId: 'goal-123', metricName: 'coverage', value: 75 },
+				{}
+			)) as { goal: RoomGoal; metric: { name: string; value: number; goalProgress: number } };
+
+			expect(mockGoalManager.recordMetric).toHaveBeenCalledWith('goal-123', 'coverage', 75);
+			expect(result.metric.name).toBe('coverage');
+			expect(result.metric.value).toBe(75);
+		});
+
+		it('throws when goal not found', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => null);
+			const handler = messageHubData.handlers.get('goal.recordMetric');
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'no-such', metricName: 'x', value: 1 }, {})
+			).rejects.toThrow('Goal not found');
+		});
+
+		it('throws when goal is not measurable', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'One-shot',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				missionType: 'one_shot' as const,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+			const handler = messageHubData.handlers.get('goal.recordMetric');
+			await expect(
+				handler!({ roomId: 'room-123', goalId: 'goal-123', metricName: 'x', value: 1 }, {})
+			).rejects.toThrow('not a measurable mission');
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.recordMetric');
+			await expect(handler!({ goalId: 'goal-123', metricName: 'x', value: 1 }, {})).rejects.toThrow(
+				'Room ID is required'
+			);
+		});
+	});
+
+	describe('goal.getMetrics', () => {
+		it('returns metric targets for a measurable mission', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Metrics Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 50,
+				linkedTaskIds: [],
+				missionType: 'measurable' as const,
+				structuredMetrics: [{ name: 'coverage', target: 90, current: 70, unit: '%' }],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+
+			const handler = messageHubData.handlers.get('goal.getMetrics');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				missionType: string;
+				allTargetsMet: boolean;
+				metrics: Array<{ name: string; current: number; target: number; met: boolean }>;
+			};
+
+			expect(mockGoalManager.checkMetricTargets).toHaveBeenCalledWith('goal-123');
+			expect(result.missionType).toBe('measurable');
+			expect(result.allTargetsMet).toBe(false);
+			expect(result.metrics).toHaveLength(1);
+			expect(result.metrics[0].name).toBe('coverage');
+		});
+
+		it('returns legacy fallback when no structuredMetrics', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Legacy Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				missionType: 'one_shot' as const,
+				metrics: { old_metric: 42 },
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+
+			const handler = messageHubData.handlers.get('goal.getMetrics');
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				missionType: string;
+				structuredMetrics: unknown[];
+				legacyMetrics: Record<string, number>;
+				note: string;
+			};
+
+			expect(result.missionType).toBe('one_shot');
+			expect(result.structuredMetrics).toEqual([]);
+			expect(result.legacyMetrics).toEqual({ old_metric: 42 });
+			expect(result.note).toBeDefined();
+		});
+
+		it('throws when goal not found', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => null);
+			const handler = messageHubData.handlers.get('goal.getMetrics');
+			await expect(handler!({ roomId: 'room-123', goalId: 'no-such' }, {})).rejects.toThrow(
+				'Goal not found'
 			);
 		});
 	});

--- a/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/goal-handlers.test.ts
@@ -1298,6 +1298,13 @@ describe('Goal RPC Handlers', () => {
 				'Room ID is required'
 			);
 		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.recordMetric');
+			await expect(handler!({ roomId: 'room-123', metricName: 'x', value: 1 }, {})).rejects.toThrow(
+				'Goal ID is required'
+			);
+		});
 	});
 
 	describe('goal.getMetrics', () => {
@@ -1369,6 +1376,115 @@ describe('Goal RPC Handlers', () => {
 			await expect(handler!({ roomId: 'room-123', goalId: 'no-such' }, {})).rejects.toThrow(
 				'Goal not found'
 			);
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.getMetrics');
+			await expect(handler!({ goalId: 'goal-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.getMetrics');
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
+		});
+	});
+
+	describe('goal.listExecutions', () => {
+		it('is registered as a handler', () => {
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			expect(handler).toBeDefined();
+		});
+
+		it('throws when roomId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			await expect(handler!({ goalId: 'goal-123' }, {})).rejects.toThrow('Room ID is required');
+		});
+
+		it('throws when goalId is missing', async () => {
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			await expect(handler!({ roomId: 'room-123' }, {})).rejects.toThrow('Goal ID is required');
+		});
+
+		it('throws when goal not found', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => null);
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			await expect(handler!({ roomId: 'room-123', goalId: 'no-such' }, {})).rejects.toThrow(
+				'Goal not found'
+			);
+		});
+
+		it('returns empty executions list for goal with no executions', async () => {
+			// Some tests leave getGoal returning null — restore the default goal here
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Test Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				executions: MissionExecution[];
+			};
+			expect(mockGoalManager.getGoal).toHaveBeenCalledWith('goal-123');
+			expect(mockGoalManager.listExecutions).toHaveBeenCalledWith('goal-123', 20);
+			expect(result.executions).toEqual([]);
+		});
+
+		it('passes custom limit to listExecutions', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Test Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			await handler!({ roomId: 'room-123', goalId: 'goal-123', limit: 5 }, {});
+			expect(mockGoalManager.listExecutions).toHaveBeenCalledWith('goal-123', 5);
+		});
+
+		it('returns executions when present', async () => {
+			mockGoalManager.getGoal.mockImplementation(async () => ({
+				id: 'goal-123',
+				roomId: 'room-123',
+				title: 'Test Goal',
+				description: '',
+				status: 'active' as GoalStatus,
+				priority: 'normal' as GoalPriority,
+				progress: 0,
+				linkedTaskIds: [],
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}));
+			const fakeExecution: MissionExecution = {
+				id: 'exec-1',
+				goalId: 'goal-123',
+				executionNumber: 1,
+				status: 'completed',
+				startedAt: Date.now() - 1000,
+				completedAt: Date.now(),
+				resultSummary: 'done',
+				taskIds: [],
+				planningAttempts: 0,
+			};
+			mockGoalManager.listExecutions.mockImplementation(() => [fakeExecution]);
+			const handler = messageHubData.handlers.get('goal.listExecutions');
+			const result = (await handler!({ roomId: 'room-123', goalId: 'goal-123' }, {})) as {
+				executions: MissionExecution[];
+			};
+			expect(result.executions).toHaveLength(1);
+			expect(result.executions[0].id).toBe('exec-1');
 		});
 	});
 });


### PR DESCRIPTION
Comprehensive audit and fixes to bring MCP tools in full parity with backend:

**New/Fixed MCP tools in room-agent-tools.ts:**
- create_goal: add missionType, autonomyLevel, structuredMetrics params so agents
  can create measurable/recurring missions directly without RPC workarounds
- update_goal: add title, description, missionType, autonomyLevel, structuredMetrics
  params via patchGoal; priority is now also applied through patchGoal path
- list_executions: new tool exposing goalManager.listExecutions() for recurring
  mission execution history (was accessible via RPC but had no MCP exposure)
- list_tasks: add 'archived' to status filter enum; passes includeArchived:true
  to repository so archived tasks are actually returned when requested
- set_task_status / update_task_status (leader): add 'archived' status, routing
  to taskManager.archiveTask() which correctly sets archivedAt timestamp
- get_room_status: add 'draft' count to task breakdown object

**New RPC handlers in goal-handlers.ts:**
- goal.recordMetric: record metric value for measurable missions via RPC
  (previously only accessible via MCP tool's direct manager call)
- goal.getMetrics: get current metric state and targets via RPC

**Tests:**
- room-agent-tools.test.ts: 16 new tests covering all changes + mission_executions
  table added to in-memory DB setup
- goal-handlers.test.ts: 9 new tests for goal.recordMetric and goal.getMetrics;
  mocks updated with recordMetric, checkMetricTargets, updateNextRunAt, listExecutions
