### PR TITLE
fix(e2e): disambiguate Missions tab locator to avoid sidebar button clash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ package-lock.json
 
 # IDE
 .vscode/
+
+# CI Artifacts (downloaded test results)
+e2e-no-llm-results-*/
+e2e-no-llm-results-*
+e2e-results-llm-*/
 .idea/
 *.swp
 *.swo

--- a/docs/e2e-health-check-log.md
+++ b/docs/e2e-health-check-log.md
@@ -88,3 +88,58 @@ This meant LiveQuery subscriptions never fired when tasks were created/modified 
 - **Test**: `should cleanup worktree when session is deleted` (features/worktree-isolation.e2e.ts:113)
 - **Issue**: Race condition — page URL still contains deleted session ID after deletion confirmation
 - **Action needed**: Increase timeout or add explicit wait for navigation after session deletion
+
+---
+
+## 2026-03-22 — Check Run #23412078420 (post-PR#717 merge)
+
+### CI Run Overview
+- **Run ID**: 23412078420
+- **Branch**: dev (commit 0ad39bc01 — after PR #717 fix)
+- **Event**: push
+- **Status**: Completed with e2e failures
+
+### E2E Test Failures at #23412078420
+
+**17 failing tests** across 4 test suites. All failures are **test code bugs** introduced by PR #717, not genuine product bugs.
+
+#### Root Cause: Ambiguous Playwright Locator for "Missions" Button
+
+**Problem**: After renaming "Goals" → "Missions" in the UI, the locator `button:has-text("Missions")` now resolves to **2 elements** in strict mode:
+1. `<button aria-label="Missions section">` — sidebar CollapsibleSection header button
+2. `<button>Missions</button>` — room tab bar button
+
+Playwright's strict mode fails when a locator matches multiple elements. This affects all tests that use the ambiguous locator in room page contexts.
+
+**Fix**: Replace `button:has-text("Missions")` with `getByRole('button', { name: 'Missions', exact: true })` in all affected test files. The sidebar button has `aria-label="Missions section"` (accessible name = "Missions section"), so it will NOT match the exact name selector.
+
+**Affected tests** (all failing due to ambiguous locator):
+| Test Suite | Failing Tests | Root Cause |
+|---|---|---|
+| `features-mission-terminology` | 5/5 | Ambiguous `button:has-text("Missions")` locator |
+| `features-mission-creation` | 9/9 | Same — shared `openMissionsTab` helper |
+| `features-livequery-task-goal-updates` | 2/2 | Same — direct locator use |
+| `features-mission-detail` | (not failing in this run but affected) | Same — shared helper |
+| `features-task-goal-indicator` | (passing but affected) | Same — uses `h2:has-text("Missions")` (safe) |
+
+#### Root Cause 2: Space Workspace Path Issue (features-space-session-groups)
+
+**1 failing test**: `Working Agents section is hidden when no session groups exist`
+
+```
+Error: page.evaluate: TypeError: Cannot read properties of undefined (reading 'id')
+at createTestSpaceWithTask (/home/runner/work/neokai/neokai/packages/e2e/tests/features/space-session-groups.e2e.ts:55:14)
+```
+
+**Root cause**: The `space.create` RPC returns `undefined` because the workspace path (`/tmp/tmp.3fwp0Bczum`) is not a git repository. The daemon rejects space creation in non-git directories.
+
+**Context**: The test uses `getWorkspaceRoot(page)` to get the workspace path, which returns the server's workspace root. In CI, this may be a temp path that isn't properly initialized as a git repo.
+
+**Status**: Only 1 test in the suite failed (the first test, `Working Agents section is hidden when no session groups exist`). All other tests in the suite passed (implying the space creation succeeded in subsequent runs). This is a **suspected flaky** issue — likely a race condition or environment initialization timing issue in CI.
+
+**Action needed**: Investigate whether `space.create` should gracefully handle non-git workspace paths, or whether the test should use a dedicated git workspace. This may be an env issue rather than a test code bug.
+
+#### Pre-existing Flakes (still present)
+
+- **worktree-isolation session deletion**: Race condition in session deletion navigation (still failing)
+- **space-session-groups workspace path**: Likely env/race condition issue (1 failure in this run)

--- a/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
+++ b/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
@@ -278,7 +278,7 @@ test.describe('LiveQuery — goal deletion surfaces in Goals tab via removed del
 			timeout: 10000,
 		});
 
-		const goalsTab = page.locator('button:has-text("Missions")');
+		const goalsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(goalsTab).toBeVisible({ timeout: 10000 });
 		await goalsTab.click();
 
@@ -304,7 +304,7 @@ test.describe('LiveQuery — goal deletion surfaces in Goals tab via removed del
 			timeout: 10000,
 		});
 
-		const goalsTab = page.locator('button:has-text("Missions")');
+		const goalsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(goalsTab).toBeVisible({ timeout: 10000 });
 		await goalsTab.click();
 

--- a/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
+++ b/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
@@ -278,9 +278,9 @@ test.describe('LiveQuery — goal deletion surfaces in Goals tab via removed del
 			timeout: 10000,
 		});
 
-		const goalsTab = page.getByRole('button', { name: 'Missions', exact: true });
-		await expect(goalsTab).toBeVisible({ timeout: 10000 });
-		await goalsTab.click();
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+		await missionsTab.click();
 
 		// The goal must be visible
 		await expect(page.locator('text=Mission To Delete').first()).toBeVisible({ timeout: 10000 });
@@ -304,9 +304,9 @@ test.describe('LiveQuery — goal deletion surfaces in Goals tab via removed del
 			timeout: 10000,
 		});
 
-		const goalsTab = page.getByRole('button', { name: 'Missions', exact: true });
-		await expect(goalsTab).toBeVisible({ timeout: 10000 });
-		await goalsTab.click();
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
+		await expect(missionsTab).toBeVisible({ timeout: 10000 });
+		await missionsTab.click();
 
 		// Both goals must be visible
 		await expect(page.locator('text=Goal That Will Be Deleted').first()).toBeVisible({

--- a/packages/e2e/tests/features/mission-creation.e2e.ts
+++ b/packages/e2e/tests/features/mission-creation.e2e.ts
@@ -31,7 +31,9 @@ async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0])
 async function openMissionsTab(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
 ): Promise<void> {
-	const missionsTab = page.locator('button:has-text("Missions")');
+	// Use exact name to avoid matching the sidebar "Missions section" button
+	// (aria-label="Missions section") which also contains "Missions" text.
+	const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 	await expect(missionsTab).toBeVisible({ timeout: 10000 });
 	await missionsTab.click();
 	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });

--- a/packages/e2e/tests/features/mission-creation.e2e.ts
+++ b/packages/e2e/tests/features/mission-creation.e2e.ts
@@ -12,7 +12,7 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { deleteRoom, openMissionsTab } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -26,17 +26,6 @@ async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0])
 		});
 		return (res as { room: { id: string } }).room.id;
 	});
-}
-
-async function openMissionsTab(
-	page: Parameters<typeof waitForWebSocketConnected>[0]
-): Promise<void> {
-	// Use exact name to avoid matching the sidebar "Missions section" button
-	// (aria-label="Missions section") which also contains "Missions" text.
-	const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
-	await expect(missionsTab).toBeVisible({ timeout: 10000 });
-	await missionsTab.click();
-	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
 }
 
 async function openCreateMissionModal(

--- a/packages/e2e/tests/features/mission-detail.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail.e2e.ts
@@ -30,7 +30,9 @@ async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0])
 async function openMissionsTab(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
 ): Promise<void> {
-	const missionsTab = page.locator('button:has-text("Missions")');
+	// Use exact name to avoid matching the sidebar "Missions section" button
+	// (aria-label="Missions section") which also contains "Missions" text.
+	const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 	await expect(missionsTab).toBeVisible({ timeout: 10000 });
 	await missionsTab.click();
 	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });

--- a/packages/e2e/tests/features/mission-detail.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail.e2e.ts
@@ -11,7 +11,7 @@
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected } from '../helpers/wait-helpers';
-import { deleteRoom } from '../helpers/room-helpers';
+import { deleteRoom, openMissionsTab } from '../helpers/room-helpers';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -25,17 +25,6 @@ async function createRoom(page: Parameters<typeof waitForWebSocketConnected>[0])
 		});
 		return (res as { room: { id: string } }).room.id;
 	});
-}
-
-async function openMissionsTab(
-	page: Parameters<typeof waitForWebSocketConnected>[0]
-): Promise<void> {
-	// Use exact name to avoid matching the sidebar "Missions section" button
-	// (aria-label="Missions section") which also contains "Missions" text.
-	const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
-	await expect(missionsTab).toBeVisible({ timeout: 10000 });
-	await missionsTab.click();
-	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
 }
 
 async function openCreateMissionModal(

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -51,8 +51,9 @@ test.describe('Mission Terminology', () => {
 		await page.goto(`/room/${roomId}`);
 		await waitForWebSocketConnected(page);
 
-		// The "Missions" tab button should be visible
-		const missionsTab = page.locator('button:has-text("Missions")');
+		// The "Missions" tab button should be visible. Use exact name to avoid
+		// matching the sidebar "Missions section" button (aria-label="Missions section").
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(missionsTab).toBeVisible({ timeout: 10000 });
 	});
 
@@ -61,7 +62,9 @@ test.describe('Mission Terminology', () => {
 		await waitForWebSocketConnected(page);
 
 		// Wait for tabs to render
-		await expect(page.locator('button:has-text("Missions")')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByRole('button', { name: 'Missions', exact: true })).toBeVisible({
+			timeout: 10000,
+		});
 
 		// There should be no "Goals" tab button in the DOM at all
 		const goalsTab = page.locator('button:has-text("Goals")');
@@ -75,7 +78,7 @@ test.describe('Mission Terminology', () => {
 		await waitForWebSocketConnected(page);
 
 		// Click the Missions tab
-		const missionsTab = page.locator('button:has-text("Missions")');
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(missionsTab).toBeVisible({ timeout: 10000 });
 		await missionsTab.click();
 
@@ -88,7 +91,7 @@ test.describe('Mission Terminology', () => {
 		await waitForWebSocketConnected(page);
 
 		// Click the Missions tab
-		const missionsTab = page.locator('button:has-text("Missions")');
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(missionsTab).toBeVisible({ timeout: 10000 });
 		await missionsTab.click();
 
@@ -102,7 +105,7 @@ test.describe('Mission Terminology', () => {
 		await waitForWebSocketConnected(page);
 
 		// Click the Missions tab
-		const missionsTab = page.locator('button:has-text("Missions")');
+		const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
 		await expect(missionsTab).toBeVisible({ timeout: 10000 });
 		await missionsTab.click();
 

--- a/packages/e2e/tests/helpers/room-helpers.ts
+++ b/packages/e2e/tests/helpers/room-helpers.ts
@@ -5,7 +5,9 @@
  * All test actions and assertions must go through the browser UI.
  */
 
+import { expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { waitForWebSocketConnected } from './wait-helpers';
 
 /**
  * Delete a room via RPC. Best-effort — silently ignores errors so it can be
@@ -22,4 +24,19 @@ export async function deleteRoom(page: Page, roomId: string): Promise<void> {
 	} catch {
 		// Best-effort cleanup
 	}
+}
+
+/**
+ * Navigate to the Missions tab on a room page.
+ *
+ * Uses `exact: true` to avoid matching the sidebar CollapsibleSection header
+ * button (which has aria-label="Missions section" — accessible name is "Missions section",
+ * not "Missions"). Only the room tab bar button has accessible name "Missions".
+ */
+export async function openMissionsTab(page: Page): Promise<void> {
+	await waitForWebSocketConnected(page);
+	const missionsTab = page.getByRole('button', { name: 'Missions', exact: true });
+	await expect(missionsTab).toBeVisible({ timeout: 10000 });
+	await missionsTab.click();
+	await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
 }


### PR DESCRIPTION
After renaming Goals→Missions in PR #717, the locator
`button:has-text("Missions")` now resolves to 2 elements in room pages:
1. The sidebar CollapsibleSection header button (aria-label="Missions section")
2. The room tab bar button

Playwright strict mode fails when a locator matches multiple elements.
Fix by using `getByRole('button', { name: 'Missions', exact: true })`
which matches only the tab button (the sidebar button's accessible name
is "Missions section", not "Missions").

This fixes 16 failing tests across mission-terminology (5),
mission-creation (9), and livequery-task-goal-updates (2) suites.

Also updates the mission-detail.e2e.ts shared helper preemptively.

docs: update e2e-health-check-log.md with findings from run #23412078420.
chore: add downloaded CI artifact directories to .gitignore.
