### PR TITLE
fix: use reactive db facade for sdk message write paths

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -195,8 +195,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	await eventBus.initialize();
 
 	// Initialize session manager (with EventBus, SettingsManager, no StateManager dependency!)
+	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
+	// trigger LiveQuery invalidation immediately.
 	const sessionManager = new SessionManager(
-		db,
+		reactiveDb.db,
 		messageHub,
 		authManager,
 		settingsManager,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -166,7 +166,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)
 	const roomRuntimeService = new RoomRuntimeService({
-		db: deps.db,
+		// Use reactiveDb.db (proxied Database facade) so sdk_messages writes from
+		// room worker/leader sessions trigger LiveQuery invalidation immediately.
+		db: deps.reactiveDb.db,
 		messageHub: deps.messageHub,
 		daemonHub: deps.daemonHub,
 		getApiKey: () => deps.authManager.getCurrentApiKey(),

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -151,7 +151,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	registerMcpHandlers(deps.messageHub, deps.sessionManager);
 	registerSettingsHandlers(deps.messageHub, deps.settingsManager, deps.daemonHub, deps.db);
 	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
-	setupTestHandlers(deps.messageHub, deps.db);
+	// Use reactiveDb.db so test-injected sdk_messages rows also invalidate LiveQuery.
+	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
 	// Room handlers
@@ -321,7 +322,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
 	// spaceRuntimeService.createOrGetRuntime(spaceId).
 	const taskAgentManager = new TaskAgentManager({
-		db: deps.db,
+		// Use reactiveDb.db so Task Agent session writes invalidate LiveQuery tables.
+		db: deps.reactiveDb.db,
 		sessionManager: deps.sessionManager,
 		spaceManager: deps.spaceManager,
 		spaceAgentManager: deps.spaceAgentManager,

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, mock } from 'bun:test';
-import { Database } from 'bun:sqlite';
+import { Database as BunDatabase } from 'bun:sqlite';
 import {
 	RoomRuntimeService,
 	type RoomRuntimeServiceConfig,
@@ -8,7 +8,9 @@ import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-
 import { createRoomTickHandler } from '../../../src/lib/job-handlers/room-tick.handler';
 import { ROOM_TICK } from '../../../src/lib/job-queue-constants';
 import type { RoomRuntime } from '../../../src/lib/room/runtime/room-runtime';
-import type { Room, RuntimeState } from '@neokai/shared';
+import { Database as AppDatabase } from '../../../src/storage';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import type { Room, RuntimeState, Session } from '@neokai/shared';
 
 const CREATE_TABLE_SQL = `
 	CREATE TABLE IF NOT EXISTS job_queue (
@@ -86,6 +88,32 @@ function makeRoom(id: string, runtimeState?: RuntimeState): Room {
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		config,
+	};
+}
+
+function makeSession(id: string): Session {
+	const now = new Date().toISOString();
+	return {
+		id,
+		title: 'Test Session',
+		workspacePath: '/tmp',
+		createdAt: now,
+		lastActiveAt: now,
+		status: 'active',
+		config: {
+			model: 'test-model',
+			maxTokens: 8192,
+			temperature: 0.7,
+		},
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+		},
+		type: 'worker',
 	};
 }
 
@@ -318,10 +346,71 @@ describe('RoomRuntimeService runtime state persistence', () => {
 	});
 });
 
+describe('RoomRuntimeService message persistence reactivity', () => {
+	it('injectMessage persists via reactive db facade and bumps sdk_messages version', async () => {
+		const tmpBase = (process.env.TMPDIR || '/tmp').replace(/\/$/, '');
+		const dbPath = `${tmpBase}/room-runtime-reactive-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+		const appDb = new AppDatabase(dbPath);
+		const reactiveDb = createReactiveDatabase(appDb);
+		await appDb.initialize(reactiveDb);
+
+		try {
+			// Insert the session row first (sdk_messages has FK -> sessions.id)
+			reactiveDb.db.createSession(makeSession('session-reactive-1'));
+
+			const roomManager = {
+				listRooms: () => [],
+				getRoom: () => null,
+				updateRoom: () => null,
+			};
+
+			const service = new RoomRuntimeService(
+				makeConfig({
+					db: reactiveDb.db as never,
+					reactiveDb: reactiveDb as never,
+					roomManager: roomManager as never,
+				})
+			);
+
+			const serviceAny = service as unknown as {
+				createSessionFactory: () => {
+					injectMessage: (sessionId: string, message: string) => Promise<void>;
+				};
+				agentSessions: Map<string, unknown>;
+			};
+
+			serviceAny.agentSessions.set('session-reactive-1', {
+				getProcessingState: () => ({ status: 'idle' }),
+				ensureQueryStarted: async () => {},
+				messageQueue: {
+					enqueueWithId: async () => {},
+				},
+			});
+
+			const sessionFactory = serviceAny.createSessionFactory();
+			const before = reactiveDb.getTableVersion('sdk_messages');
+			await sessionFactory.injectMessage('session-reactive-1', 'hello from reactive runtime');
+			const after = reactiveDb.getTableVersion('sdk_messages');
+
+			expect(after).toBeGreaterThan(before);
+			const queued = reactiveDb.db.getMessagesByStatus('session-reactive-1', 'queued');
+			expect(queued).toHaveLength(1);
+			expect(queued[0]?.type).toBe('user');
+		} finally {
+			appDb.close();
+			try {
+				require('fs').unlinkSync(dbPath);
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	});
+});
+
 describe('stopRuntime() + room.tick handler interaction', () => {
 	it('tick handler returns { skipped, reason } for a room whose runtime was deleted by stopRuntime()', async () => {
 		// Set up an in-memory job queue so we can build a real handler
-		const db = new Database(':memory:');
+		const db = new BunDatabase(':memory:');
 		db.exec(CREATE_TABLE_SQL);
 		const jobQueue = new JobQueueRepository(db as never);
 


### PR DESCRIPTION
## Summary

Fixes TaskView timeline lag where sent messages only appeared after refresh by routing SDK-message write paths through the reactive DB facade (`reactiveDb.db`) so LiveQuery invalidation fires immediately.

## Changes

- Wire `RoomRuntimeService` with `db: reactiveDb.db`
- Wire `SessionManager` with `db: reactiveDb.db`
- Wire `TaskAgentManager` with `db: reactiveDb.db`
- Wire `setupTestHandlers` with `db: reactiveDb.db`

## Test

Added regression coverage in:
- `packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts`
  - verifies room-runtime `injectMessage` persists through reactive facade and increments `sdk_messages` table version

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts`
- `bun test packages/daemon/tests/unit/rpc-handlers/live-query-subscribe.test.ts packages/daemon/tests/unit/rpc-handlers/task-get-group-messages.test.ts`
