### PR TITLE
refactor: unify message delivery semantics + align TaskView pending UX

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -308,13 +308,13 @@ export class AgentSession
 
 		// Recover orphaned messages
 		const recoveryHandler = new MessageRecoveryHandler(session, db, this.logger);
-		recoveryHandler.recoverOrphanedSentMessages();
+		recoveryHandler.recoverOrphanedConsumedMessages();
 
 		// Setup event subscriptions (moved callbacks into EventSubscriptionSetup)
 		this.eventSubscriptionSetup.setup();
 
 		// Replay persisted pending messages after startup/recovery in immediate mode.
-		// Priority: queued/current-turn first, then saved/next-turn.
+		// Priority: enqueued/immediate first, then deferred/defer.
 		const restoredState = this.stateManager.getState();
 		if (session.config.queryMode !== 'manual' && restoredState.status !== 'waiting_for_input') {
 			queueMicrotask(() => {

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -10,7 +10,7 @@
  * - Reset request subscription
  * - Message persisted subscription
  * - Query trigger subscription
- * - Send queued on turn end subscription
+ * - Send enqueued-on-turn-end subscription
  */
 
 import type { Session, MessageContent } from '@neokai/shared';
@@ -131,15 +131,15 @@ export class EventSubscriptionSetup {
 		);
 		this.unsubscribers.push(unsubQueryTrigger);
 
-		// Send queued messages on turn end (Auto-queue mode)
-		const unsubSendQueuedOnTurnEnd = daemonHub.on(
-			'query.sendQueuedOnTurnEnd',
+		// Send enqueued messages on turn end (auto-defer mode)
+		const unsubSendEnqueuedOnTurnEnd = daemonHub.on(
+			'query.sendEnqueuedOnTurnEnd',
 			async () => {
-				await queryModeHandler.sendQueuedMessagesOnTurnEnd();
+				await queryModeHandler.sendEnqueuedMessagesOnTurnEnd();
 			},
 			{ sessionId }
 		);
-		this.unsubscribers.push(unsubSendQueuedOnTurnEnd);
+		this.unsubscribers.push(unsubSendEnqueuedOnTurnEnd);
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/message-recovery-handler.ts
+++ b/packages/daemon/src/lib/agent/message-recovery-handler.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from AgentSession to reduce complexity.
  * Handles:
- * - Detecting messages stuck in 'sent' status with no system:init response
+ * - Detecting messages stuck in 'consumed' status with no system:init response
  * - Marking those messages as 'failed' so they appear in the UI as undelivered
  */
 
@@ -28,23 +28,23 @@ export class MessageRecoveryHandler {
 	}
 
 	/**
-	 * Mark orphaned sent messages as failed
+	 * Mark orphaned consumed messages as failed
 	 *
-	 * For sent messages with no system:init boundary after them (i.e. the server
+	 * For consumed messages with no system:init boundary after them (i.e. the server
 	 * crashed before Claude responded), mark them as 'failed' so they appear in
 	 * the UI as undelivered. The user can see what was lost without silent re-dispatch.
 	 *
 	 * Synthetic messages and tool_result-only messages are skipped — they are
 	 * SDK-internal and should not be surfaced as user-facing failures.
 	 */
-	recoverOrphanedSentMessages(): void {
+	recoverOrphanedConsumedMessages(): void {
 		const { session, db, logger } = this;
 
 		try {
-			// Sent messages may need recovery if they never got a corresponding
-			// system:init/response boundary after being marked sent.
-			const sentMessages = db.getMessagesByStatus(session.id, 'sent');
-			const allStuckMessages = [...sentMessages];
+			// Consumed messages may need recovery if they never got a corresponding
+			// system:init/response boundary after being marked consumed.
+			const consumedMessages = db.getMessagesByStatus(session.id, 'consumed');
+			const allStuckMessages = [...consumedMessages];
 
 			if (allStuckMessages.length === 0) {
 				return;
@@ -71,15 +71,15 @@ export class MessageRecoveryHandler {
 				timestamp: number;
 			}> = [];
 
-			for (const sentMsg of allStuckMessages) {
-				if (!isSDKUserMessage(sentMsg)) {
+			for (const consumedMsg of allStuckMessages) {
+				if (!isSDKUserMessage(consumedMsg)) {
 					continue;
 				}
 
 				// Skip synthetic messages (SDK-generated tool results, not human-typed).
 				// These are saved by saveSDKMessage with isSynthetic=true and should not
 				// be recovered — they are internal SDK messages, not user input.
-				const userMsg = sentMsg as SDKUserMessage & { isSynthetic?: boolean };
+				const userMsg = consumedMsg as SDKUserMessage & { isSynthetic?: boolean };
 				if (userMsg.isSynthetic) {
 					continue;
 				}
@@ -91,14 +91,14 @@ export class MessageRecoveryHandler {
 					continue;
 				}
 
-				const msgWithTimestamp = sentMsg as SDKMessage & { timestamp?: number };
+				const msgWithTimestamp = consumedMsg as SDKMessage & { timestamp?: number };
 				const msgTimestamp = msgWithTimestamp.timestamp || 0;
 
 				// If no system:init after this message, it's orphaned
 				if (msgTimestamp > latestInitTimestamp) {
 					orphanedMessages.push({
-						dbId: sentMsg.dbId,
-						uuid: sentMsg.uuid || 'unknown',
+						dbId: consumedMsg.dbId,
+						uuid: consumedMsg.uuid || 'unknown',
 						timestamp: msgTimestamp,
 					});
 				}
@@ -112,7 +112,7 @@ export class MessageRecoveryHandler {
 			const dbIds = orphanedMessages.map((m) => m.dbId);
 			db.updateMessageStatus(dbIds, 'failed');
 		} catch (error) {
-			logger.warn('Failed to mark orphaned sent messages as failed:', error);
+			logger.warn('Failed to mark orphaned consumed messages as failed:', error);
 			// Don't throw - recovery failure shouldn't prevent session from loading
 		}
 	}

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -126,7 +126,7 @@ export class QueryModeHandler {
 				}
 			}
 		} catch (error) {
-			logger.error('Failed to send queued messages on turn end:', error);
+			logger.error('Failed to send enqueued messages on turn end:', error);
 		}
 	}
 

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -5,8 +5,8 @@
  * Takes AgentSession instance directly - handlers are internal parts of AgentSession.
  *
  * Handles:
- * - handleQueryTrigger - Manual mode: send all saved messages
- * - sendQueuedMessagesOnTurnEnd - Auto-queue mode: send queued messages after turn
+ * - handleQueryTrigger - manual mode: send all deferred messages
+ * - sendEnqueuedMessagesOnTurnEnd - auto-defer mode: send enqueued messages after turn
  */
 
 import type { Session } from '@neokai/shared';
@@ -40,7 +40,7 @@ export class QueryModeHandler {
 	/**
 	 * Handle manual query trigger (Manual mode)
 	 *
-	 * Retrieves all 'saved' messages from the database and sends them to Claude.
+	 * Retrieves all 'deferred' messages from the database and sends them to Claude.
 	 */
 	async handleQueryTrigger(): Promise<{
 		success: boolean;
@@ -50,29 +50,29 @@ export class QueryModeHandler {
 		const { session, db, daemonHub, messageQueue, logger } = this.ctx;
 
 		try {
-			// Get all saved messages
-			const savedMessages = db.getMessagesByStatus(session.id, 'saved');
+			// Get all deferred messages
+			const deferredMessages = db.getMessagesByStatus(session.id, 'deferred');
 
-			if (savedMessages.length === 0) {
+			if (deferredMessages.length === 0) {
 				return { success: true, messageCount: 0 };
 			}
 
-			// Update status to 'queued'
-			const dbIds = savedMessages.map((m) => m.dbId);
-			db.updateMessageStatus(dbIds, 'queued');
+			// Update status to 'enqueued'
+			const dbIds = deferredMessages.map((m) => m.dbId);
+			db.updateMessageStatus(dbIds, 'enqueued');
 
 			// Emit status change event
 			await daemonHub.emit('messages.statusChanged', {
 				sessionId: session.id,
 				messageIds: dbIds,
-				status: 'queued',
+				status: 'enqueued',
 			});
 
 			// Ensure query is started
 			await this.ctx.ensureQueryStarted();
 
 			// Enqueue each message
-			for (const msg of savedMessages) {
+			for (const msg of deferredMessages) {
 				if (!isSDKUserMessage(msg)) {
 					continue;
 				}
@@ -86,7 +86,7 @@ export class QueryModeHandler {
 				}
 			}
 
-			return { success: true, messageCount: savedMessages.length };
+			return { success: true, messageCount: deferredMessages.length };
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			logger.error('Failed to trigger query:', error);
@@ -95,14 +95,14 @@ export class QueryModeHandler {
 	}
 
 	/**
-	 * Send queued messages when agent turn ends (Auto-queue mode)
+	 * Send enqueued messages when the agent turn ends (auto-defer mode)
 	 */
-	async sendQueuedMessagesOnTurnEnd(): Promise<void> {
+	async sendEnqueuedMessagesOnTurnEnd(): Promise<void> {
 		const { session, db, messageQueue, logger } = this.ctx;
 
 		try {
 			// Get all queued messages
-			const queuedMessages = db.getMessagesByStatus(session.id, 'queued');
+			const queuedMessages = db.getMessagesByStatus(session.id, 'enqueued');
 
 			if (queuedMessages.length === 0) {
 				return;
@@ -132,10 +132,10 @@ export class QueryModeHandler {
 
 	/**
 	 * Replay persisted pending messages for immediate mode startup/recovery.
-	 * Priority: current-turn queued messages first, then next-turn saved messages.
+	 * Priority: current-turn queued messages first, then next-turn deferred messages.
 	 */
 	async replayPendingMessagesForImmediateMode(): Promise<void> {
-		await this.sendQueuedMessagesOnTurnEnd();
+		await this.sendEnqueuedMessagesOnTurnEnd();
 		await this.handleQueryTrigger();
 	}
 

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -84,7 +84,7 @@ export class SDKMessageHandler {
 	private internalContextCommandIds: Set<string> = new Set();
 
 	/**
-	 * Check if this message is the replay response for an internally queued /context command.
+	 * Check if this message is the replay response for an internally enqueued /context command.
 	 *
 	 * This is ID-based (not content-based) so loop prevention still works if SDK output format changes.
 	 */
@@ -124,8 +124,8 @@ export class SDKMessageHandler {
 		// Set up message yield callback - fires when generator yields to SDK
 		// This is the CORRECT moment to broadcast steered messages to UI
 		// and update their DB timestamp (T_consumed, not T_end)
-		ctx.messageQueue.onMessageYielded = (messageId: string, sentAt: number) => {
-			this.handleMessageYielded(messageId, sentAt);
+		ctx.messageQueue.onMessageYielded = (messageId: string, consumedAt: number) => {
+			this.handleMessageYielded(messageId, consumedAt);
 		};
 	}
 
@@ -226,8 +226,8 @@ export class SDKMessageHandler {
 	 * Acknowledge a persisted user message when SDK replays it.
 	 *
 	 * For user messages already persisted in sdk_messages with send_status
-	 * (queued/saved), we should:
-	 * 1) transition send_status -> sent
+	 * (enqueued/deferred), we should:
+	 * 1) transition send_status -> consumed
 	 * 2) publish the user message to transcript
 	 * 3) avoid inserting a duplicate SDK message row
 	 */
@@ -237,19 +237,19 @@ export class SDKMessageHandler {
 			return false;
 		}
 
-		const queuedMessage = db
-			.getMessagesByStatus(session.id, 'queued')
-			.find((queued) => queued.uuid === message.uuid);
-		if (queuedMessage) {
-			db.updateMessageStatus([queuedMessage.dbId], 'sent');
+		const enqueuedMessage = db
+			.getMessagesByStatus(session.id, 'enqueued')
+			.find((enqueued) => enqueued.uuid === message.uuid);
+		if (enqueuedMessage) {
+			db.updateMessageStatus([enqueuedMessage.dbId], 'consumed');
 			// Update DB timestamp to now so the message's position in the DB matches
 			// where the SDK placed it in the conversation (after already-streamed
 			// assistant messages), not when the user originally typed it.
-			db.updateMessageTimestamp(queuedMessage.dbId);
+			db.updateMessageTimestamp(enqueuedMessage.dbId);
 			await daemonHub.emit('messages.statusChanged', {
 				sessionId: session.id,
-				messageIds: [queuedMessage.dbId],
-				status: 'sent',
+				messageIds: [enqueuedMessage.dbId],
+				status: 'consumed',
 			});
 			this.acknowledgedPersistedUserThisTurn = true;
 
@@ -273,16 +273,16 @@ export class SDKMessageHandler {
 			return true;
 		}
 
-		const savedMessage = db
-			.getMessagesByStatus(session.id, 'saved')
-			.find((saved) => saved.uuid === message.uuid);
-		if (savedMessage) {
-			db.updateMessageStatus([savedMessage.dbId], 'sent');
-			db.updateMessageTimestamp(savedMessage.dbId);
+		const deferredMessage = db
+			.getMessagesByStatus(session.id, 'deferred')
+			.find((deferred) => deferred.uuid === message.uuid);
+		if (deferredMessage) {
+			db.updateMessageStatus([deferredMessage.dbId], 'consumed');
+			db.updateMessageTimestamp(deferredMessage.dbId);
 			await daemonHub.emit('messages.statusChanged', {
 				sessionId: session.id,
-				messageIds: [savedMessage.dbId],
-				status: 'sent',
+				messageIds: [deferredMessage.dbId],
+				status: 'consumed',
 			});
 			this.acknowledgedPersistedUserThisTurn = true;
 
@@ -305,10 +305,10 @@ export class SDKMessageHandler {
 			return true;
 		}
 
-		const sentMessage = db
-			.getMessagesByStatus(session.id, 'sent')
-			.find((sent) => sent.uuid === message.uuid);
-		if (sentMessage) {
+		const consumedMessage = db
+			.getMessagesByStatus(session.id, 'consumed')
+			.find((consumed) => consumed.uuid === message.uuid);
+		if (consumedMessage) {
 			this.acknowledgedPersistedUserThisTurn = true;
 			return true;
 		}
@@ -318,32 +318,32 @@ export class SDKMessageHandler {
 
 	/**
 	 * Fallback acknowledgment when SDK doesn't replay user messages.
-	 * Marks ALL remaining queued user messages as sent at turn end.
+	 * Marks ALL remaining enqueued user messages as consumed at turn end.
 	 *
 	 * This is a safety net — ideally handleMessageYielded already handled
 	 * these at yield time. But if the generator didn't fire the callback
 	 * (e.g., internal messages, edge cases), this ensures messages don't
-	 * stay stuck in 'queued' status forever.
+	 * stay stuck in 'enqueued' status forever.
 	 */
 	private async acknowledgeOldestQueuedUserOnTurnEnd(): Promise<void> {
 		const { session, db, daemonHub, messageHub } = this.ctx;
-		const queuedUsers = db
-			.getMessagesByStatus(session.id, 'queued')
-			.filter((queued) => isSDKUserMessage(queued));
+		const enqueuedUsers = db
+			.getMessagesByStatus(session.id, 'enqueued')
+			.filter((enqueued) => isSDKUserMessage(enqueued));
 
-		for (const queuedUser of queuedUsers) {
-			db.updateMessageStatus([queuedUser.dbId], 'sent');
+		for (const enqueuedUser of enqueuedUsers) {
+			db.updateMessageStatus([enqueuedUser.dbId], 'consumed');
 			// Don't update timestamp here — keep the original T1 timestamp
 			// since we don't know the exact T_consumed for these edge cases.
-			// The original timestamp (when user sent it) is a better approximation
+			// The original timestamp (when user consumed it) is a better approximation
 			// than turn-end time.
 			await daemonHub.emit('messages.statusChanged', {
 				sessionId: session.id,
-				messageIds: [queuedUser.dbId],
-				status: 'sent',
+				messageIds: [enqueuedUser.dbId],
+				status: 'consumed',
 			});
 
-			const { dbId: _dbId, timestamp, ...sdkUserMessage } = queuedUser;
+			const { dbId: _dbId, timestamp, ...sdkUserMessage } = enqueuedUser;
 			messageHub.event(
 				'state.sdkMessages.delta',
 				{
@@ -359,45 +359,45 @@ export class SDKMessageHandler {
 	/**
 	 * Handle message yielded by the generator to the SDK.
 	 *
-	 * This fires at the EXACT moment the SDK receives a queued user message
+	 * This fires at the EXACT moment the SDK receives a enqueued user message
 	 * (T_consumed). We update the DB and broadcast to UI here, so the message
 	 * appears at the correct position in the conversation — after any assistant
 	 * messages that were already streamed, and before the assistant's response
 	 * to the steering.
 	 */
-	private handleMessageYielded(messageId: string, sentAt: number): void {
+	private handleMessageYielded(messageId: string, consumedAt: number): void {
 		const { session, db, daemonHub, messageHub } = this.ctx;
 
-		// Find the queued message in DB by UUID
-		const queuedMessage = db
-			.getMessagesByStatus(session.id, 'queued')
-			.find((queued) => queued.uuid === messageId);
-		if (!queuedMessage) {
-			// Could be a 'saved' message being replayed
-			const savedMessage = db
-				.getMessagesByStatus(session.id, 'saved')
-				.find((saved) => saved.uuid === messageId);
-			if (!savedMessage) {
-				return; // Not a persisted user message (e.g., already sent)
+		// Find the enqueued message in DB by UUID
+		const enqueuedMessage = db
+			.getMessagesByStatus(session.id, 'enqueued')
+			.find((enqueued) => enqueued.uuid === messageId);
+		if (!enqueuedMessage) {
+			// Could be a 'deferred' message being replayed
+			const deferredMessage = db
+				.getMessagesByStatus(session.id, 'deferred')
+				.find((deferred) => deferred.uuid === messageId);
+			if (!deferredMessage) {
+				return; // Not a persisted user message (e.g., already consumed)
 			}
-			// Handle saved message the same way
-			db.updateMessageStatus([savedMessage.dbId], 'sent');
-			db.updateMessageTimestamp(savedMessage.dbId, sentAt);
+			// Handle deferred message the same way
+			db.updateMessageStatus([deferredMessage.dbId], 'consumed');
+			db.updateMessageTimestamp(deferredMessage.dbId, consumedAt);
 			daemonHub
 				.emit('messages.statusChanged', {
 					sessionId: session.id,
-					messageIds: [savedMessage.dbId],
-					status: 'sent',
+					messageIds: [deferredMessage.dbId],
+					status: 'consumed',
 				})
 				.catch(() => {});
 			this.acknowledgedPersistedUserThisTurn = true;
 
-			const { dbId: _dbId, timestamp: _timestamp, ...sdkMessage } = savedMessage;
+			const { dbId: _dbId, timestamp: _timestamp, ...sdkMessage } = deferredMessage;
 			messageHub.event(
 				'state.sdkMessages.delta',
 				{
-					added: [{ ...sdkMessage, timestamp: sentAt }],
-					timestamp: sentAt,
+					added: [{ ...sdkMessage, timestamp: consumedAt }],
+					timestamp: consumedAt,
 					version: ++this.sdkMessageDeltaVersion,
 				},
 				{ channel: `session:${session.id}` }
@@ -405,22 +405,22 @@ export class SDKMessageHandler {
 			daemonHub
 				.emit('sdk.message', {
 					sessionId: session.id,
-					message: { ...sdkMessage, timestamp: sentAt },
+					message: { ...sdkMessage, timestamp: consumedAt },
 				})
 				.catch(() => {});
 			return;
 		}
 
 		// Update status and timestamp in DB
-		db.updateMessageStatus([queuedMessage.dbId], 'sent');
-		db.updateMessageTimestamp(queuedMessage.dbId, sentAt);
+		db.updateMessageStatus([enqueuedMessage.dbId], 'consumed');
+		db.updateMessageTimestamp(enqueuedMessage.dbId, consumedAt);
 
 		// Emit status change event (for queue overlay polling)
 		daemonHub
 			.emit('messages.statusChanged', {
 				sessionId: session.id,
-				messageIds: [queuedMessage.dbId],
-				status: 'sent',
+				messageIds: [enqueuedMessage.dbId],
+				status: 'consumed',
 			})
 			.catch(() => {});
 
@@ -429,12 +429,12 @@ export class SDKMessageHandler {
 
 		// Broadcast to UI with the correct timestamp
 		// Strip DB-only fields before broadcasting
-		const { dbId: _dbId, timestamp: _timestamp, ...sdkMessage } = queuedMessage;
+		const { dbId: _dbId, timestamp: _timestamp, ...sdkMessage } = enqueuedMessage;
 		messageHub.event(
 			'state.sdkMessages.delta',
 			{
-				added: [{ ...sdkMessage, timestamp: sentAt }],
-				timestamp: sentAt,
+				added: [{ ...sdkMessage, timestamp: consumedAt }],
+				timestamp: consumedAt,
 				version: ++this.sdkMessageDeltaVersion,
 			},
 			{ channel: `session:${session.id}` }
@@ -445,7 +445,7 @@ export class SDKMessageHandler {
 		daemonHub
 			.emit('sdk.message', {
 				sessionId: session.id,
-				message: { ...sdkMessage, timestamp: sentAt },
+				message: { ...sdkMessage, timestamp: consumedAt },
 			})
 			.catch(() => {});
 	}
@@ -495,7 +495,7 @@ export class SDKMessageHandler {
 		// First, correlate internal /context replay by message UUID.
 		// This avoids relying on brittle content markers that may change across SDK versions.
 		if (this.isInternalContextResponse(message)) {
-			// UUID matches an internally queued /context command.
+			// UUID matches an internally enqueued /context command.
 			// Try to parse the context data from this message.
 			//
 			// NEW SDK behaviour (claude binary >= ~1.0.53): the user replay message
@@ -524,7 +524,7 @@ export class SDKMessageHandler {
 		// Handles both:
 		//   - Old format: user message with isReplay=true + <local-command-stdout>
 		//   - New format: assistant message (from sc8()) with raw markdown content
-		// /context responses should be processed for context tracking but NOT saved to DB or shown in UI
+		// /context responses should be processed for context tracking but NOT deferred to DB or shown in UI
 		const isContextResponse = this.contextFetcher.isContextResponse(message);
 		if (isContextResponse) {
 			const parsed = await this.handleContextResponseIfParseable(message);
@@ -573,7 +573,7 @@ export class SDKMessageHandler {
 			return;
 		}
 
-		// For persisted user messages, mark sent + publish now and skip duplicate DB inserts.
+		// For persisted user messages, mark consumed + publish now and skip duplicate DB inserts.
 		if (await this.acknowledgePersistedUserMessage(message)) {
 			return;
 		}
@@ -585,9 +585,9 @@ export class SDKMessageHandler {
 
 		// Save to DB FIRST before broadcasting to clients
 		// This ensures we only broadcast messages that are successfully persisted
-		const savedSuccessfully = db.saveSDKMessage(session.id, message);
+		const deferredSuccessfully = db.saveSDKMessage(session.id, message);
 
-		if (!savedSuccessfully) {
+		if (!deferredSuccessfully) {
 			// Log warning but continue - message is already in SDK's memory
 			this.logger.warn(`Failed to save message to DB (type: ${message.type})`);
 			// Don't broadcast to clients if DB save failed
@@ -767,8 +767,8 @@ export class SDKMessageHandler {
 			this.circuitBreaker.markSuccess();
 		}
 
-		// If SDK didn't replay the queued user message this turn, acknowledge one
-		// queued user message at turn end to keep status and transcript in sync.
+		// If SDK didn't replay the enqueued user message this turn, acknowledge one
+		// enqueued user message at turn end to keep status and transcript in sync.
 		if (!this.acknowledgedPersistedUserThisTurn) {
 			await this.acknowledgeOldestQueuedUserOnTurnEnd();
 		}
@@ -784,12 +784,12 @@ export class SDKMessageHandler {
 		// Note: Title generation now handled by TitleGenerationQueue (decoupled via EventBus)
 		await stateManager.setIdle();
 
-		// Auto-dispatch saved messages in immediate mode (next-turn queue replay)
+		// Auto-dispatch deferred messages in immediate mode (next-turn queue replay)
 		if (session.config.queryMode !== 'manual') {
 			try {
 				await daemonHub.emit('query.trigger', { sessionId: session.id });
 			} catch (error) {
-				this.logger.warn('Failed to dispatch saved messages on turn end:', error);
+				this.logger.warn('Failed to dispatch deferred messages on turn end:', error);
 			}
 		}
 	}

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -157,21 +157,21 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		userMessageText: string;
 		needsWorkspaceInit: boolean;
 		hasDraftToClear: boolean;
-		sendStatus: 'saved' | 'queued' | 'sent';
+		sendStatus: 'deferred' | 'enqueued' | 'consumed';
 		deliveryMode: MessageDeliveryMode;
 	};
 
 	// Query mode events
-	// Trigger to send saved messages (Manual mode)
+	// Trigger to send deferred messages (manual mode)
 	'query.trigger': { sessionId: string };
 	// Notification when message statuses change
 	'messages.statusChanged': {
 		sessionId: string;
 		messageIds: string[];
-		status: 'saved' | 'queued' | 'sent';
+		status: 'deferred' | 'enqueued' | 'consumed';
 	};
-	// Send queued messages on turn end (Auto-queue mode)
-	'query.sendQueuedOnTurnEnd': { sessionId: string };
+	// Send enqueued messages on turn end (auto-defer mode)
+	'query.sendEnqueuedOnTurnEnd': { sessionId: string };
 
 	// Rewind events
 	'rewind.started': {

--- a/packages/daemon/src/lib/room/agents/leader-agent.ts
+++ b/packages/daemon/src/lib/room/agents/leader-agent.ts
@@ -2,7 +2,7 @@
  * Leader Agent Factory - Creates AgentSessionInit for Leader (reviewer) sessions
  *
  * The Leader agent reviews worker output and routes outcomes via MCP tools:
- * - send_to_worker(message, mode) - Forward feedback to worker (steer/queue)
+ * - send_to_worker(message, mode) - Forward feedback to worker (immediate/defer)
  * - complete_task(summary) - Accept work, mark task done
  * - fail_task(reason) - Task is not achievable
  * - replan_goal(reason) - Fail task and trigger replanning with context
@@ -55,7 +55,7 @@ export interface LeaderToolCallbacks {
 	sendToWorker(
 		groupId: string,
 		message: string,
-		mode?: 'steer' | 'queue',
+		mode?: 'immediate' | 'defer',
 		progressSummary?: string
 	): Promise<LeaderToolResult>;
 	completeTask(
@@ -162,8 +162,8 @@ You MUST call tools (no text-only final responses).
 
 ### Review Tools (primary actions)
 - \`send_to_worker\` — Forward feedback to worker without changing group ownership
-  - mode=\`queue\`: enqueue for next-turn processing (default, preferred for review URLs)
-  - mode=\`steer\`: inject for current-turn steering
+  - mode=\`defer\`: enqueue for next-turn processing (default, preferred for review URLs)
+  - mode=\`immediate\`: inject for current-turn steering
 - \`complete_task\` — Accept the work if it meets all requirements
 - \`fail_task\` — Mark the task as not achievable
 - \`replan_goal\` — The current approach isn't working; fail this task and trigger replanning with context about what was tried
@@ -203,7 +203,7 @@ When the human message indicates approval (e.g., "approved", "merge it", "looks 
 For planning tasks the planner must run a second phase to create tasks.
 **Do NOT merge the plan PR yourself — the planner handles merge + task creation.**
 
-1. **Send the planner back** — Call \`send_to_worker\` (mode: "queue") with:
+1. **Send the planner back** — Call \`send_to_worker\` (mode: "defer") with:
    "The plan is approved. Please:
    1. Merge the plan PR: \`gh pr merge <PR_NUMBER>\`
    2. Read the plan file under docs/plans/
@@ -240,7 +240,7 @@ function leaderPostRejectionSection(): string {
 
 When the human message indicates rejection with feedback (e.g., "fix the tests", "needs changes"):
 
-1. **Forward feedback to worker** — Call \`send_to_worker\` (mode: "queue") with the human's feedback
+1. **Forward feedback to worker** — Call \`send_to_worker\` (mode: "defer") with the human's feedback
 
 After the worker addresses feedback and exits again, you will receive the updated output for review.`;
 }
@@ -250,7 +250,7 @@ function leaderWorkerQuestionsSection(): string {
 ## Handling Worker Questions
 
 If the worker output shows \`Terminal state: waiting_for_input\`, the worker is asking a question.
-- If you can answer the question from the goal/task context, call \`send_to_worker\` (mode: "steer") with the answer
+- If you can answer the question from the goal/task context, call \`send_to_worker\` (mode: "immediate") with the answer
 - If the question requires human judgment or information you don't have, use \`fail_task\` with the reason (e.g., "Worker needs human input: <question>")`;
 }
 
@@ -291,7 +291,7 @@ You are a coordinator. You do NOT review the plan yourself. You delegate reviews
 ### Step 1: Understand the Plan
 Read the planner's output to understand what plan was created and what PR was opened.
 Extract the PR number (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).
-If no PR was created, call \`send_to_worker\` (mode: "queue") asking the planner to create one before review can proceed.
+If no PR was created, call \`send_to_worker\` (mode: "defer") asking the planner to create one before review can proceed.
 
 ### Step 2: Dispatch Reviewer Sub-agents
 Use the Task tool to dispatch each reviewer to review the plan PR. Spawn all reviewers in parallel.
@@ -303,7 +303,7 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 ### Step 4: Route
 
-- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
+- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "defer"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
   - You may call \`send_to_worker\` multiple times as reviewer results arrive.
 - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval
 - **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
@@ -322,10 +322,10 @@ ${helperSection}## Plan Review Guidelines
 
 **Phase 1 (plan document)**: When you receive \`[PLANNER OUTPUT] — Phase 1 (plan document)\`, follow this workflow:
 1. Read the planner output and extract the PR number/URL.
-2. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one.
+2. If no PR exists yet, use \`send_to_worker\` (mode: "defer") to request one.
 3. Review the plan PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
 4. Route strictly by severity from your posted review:
-   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
+   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
    - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL for human approval.
    - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
 5. **Fundamentally unplannable** → \`fail_task\` or \`replan_goal\`.
@@ -371,7 +371,7 @@ You are a coordinator. You do NOT review code yourself. You delegate reviews to 
 ### Step 1: Understand What Was Done
 Read the worker's output to understand what was implemented and which files changed.
 Extract the PR number if one was created (look for "PR #123", GitHub PR URLs, or \`gh pr create\` output).
-If no PR was created, call \`send_to_worker\` (mode: "queue") asking the worker to create one before review can proceed.
+If no PR was created, call \`send_to_worker\` (mode: "defer") asking the worker to create one before review can proceed.
 
 ### Step 2: Dispatch Reviewer Sub-agents
 Use the Task tool to dispatch each reviewer. Spawn all reviewers in parallel.
@@ -383,7 +383,7 @@ Each reviewer returns a \`---REVIEW_POSTED---\` block containing the review URL,
 
 ### Step 4: Route
 
-- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "queue"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
+- **Any P0/P1/P2 issues** → call \`send_to_worker\` with \`mode: "defer"\` and ONLY the review URLs (one per line). Do NOT summarize or interpret the reviews — the worker will fetch the full review content from GitHub.
   - You may call \`send_to_worker\` multiple times as reviewer results arrive.
 - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL
 - **TIMEOUT or ERROR** → Ignore that reviewer's result. Route based on the remaining reviewers' results. If all reviewers timed out/errored, \`submit_for_review\` with the PR URL (let human decide).
@@ -400,10 +400,10 @@ ${helperSection}## Code Review Guidelines
 
 **Every iteration follows the same workflow** — including after the worker addresses feedback.
 1. Read the worker output and extract the PR number/URL.
-2. Require a PR before final approval. If no PR exists yet, use \`send_to_worker\` (mode: "queue") to request one.
+2. Require a PR before final approval. If no PR exists yet, use \`send_to_worker\` (mode: "defer") to request one.
 3. Review the PR yourself and post your honest, critical, and actionable feedback on the PR using \`gh pr review\`.
 4. Route strictly by severity from your posted review:
-   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "queue") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
+   - **Any P0/P1/P2 issues** → \`send_to_worker\` (mode: "defer") with ONLY your review URL(s), one per line. Do NOT paste full review text into the worker message.
    - **Only P3 nits or no issues** → \`submit_for_review\` with the PR URL.
    - **Review post TIMEOUT/ERROR** → \`submit_for_review\` with the PR URL (let human decide).
 
@@ -456,7 +456,7 @@ export function createLeaderToolHandlers(groupId: string, callbacks: LeaderToolC
 	return {
 		async send_to_worker(args: {
 			message: string;
-			mode?: 'steer' | 'queue';
+			mode?: 'immediate' | 'defer';
 			progress_summary?: string;
 		}): Promise<LeaderToolResult> {
 			return callbacks.sendToWorker(groupId, args.message, args.mode, args.progress_summary);
@@ -505,13 +505,13 @@ export function createLeaderMcpServer(groupId: string, callbacks: LeaderToolCall
 	const tools = [
 		tool(
 			'send_to_worker',
-			'Send feedback to the worker agent. mode=queue (default) enqueues for next turn; mode=steer injects current-turn guidance.',
+			'Send feedback to the worker agent. mode=defer (default) enqueues for next turn; mode=immediate injects current-turn guidance.',
 			{
 				message: z.string().describe('Specific, actionable feedback for the worker agent'),
 				mode: z
-					.enum(['steer', 'queue'])
+					.enum(['immediate', 'defer'])
 					.optional()
-					.describe('Delivery mode: queue (default) or steer (immediate)'),
+					.describe('Delivery mode: defer (default) or immediate (inject now)'),
 				progress_summary: progressSummaryField,
 			},
 			(args) => handlers.send_to_worker(args)

--- a/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
+++ b/packages/daemon/src/lib/room/runtime/lifecycle-hooks.ts
@@ -599,7 +599,7 @@ export async function checkLeaderDraftsExist(
 		bounceMessage:
 			'No draft tasks were created by the planner yet. The planner must run Phase 2 to create tasks.\n\n' +
 			'To fix this:\n' +
-			'1. Call `send_to_worker` (mode: "queue") with: "The plan is approved. Please:\n' +
+			'1. Call `send_to_worker` (mode: "defer") with: "The plan is approved. Please:\n' +
 			'   1. Merge the plan PR: `gh pr merge <PR_NUMBER>`\n' +
 			'   2. Read the plan file under docs/plans/\n' +
 			'   3. Create all tasks 1:1 from the plan using the `create_task` tool\n' +

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -251,7 +251,7 @@ export class RoomRuntimeService {
 					throw new Error(`Session not in service cache: ${sessionId}`);
 				}
 
-				const deliveryMode = opts?.deliveryMode ?? 'current_turn';
+				const deliveryMode = opts?.deliveryMode ?? 'immediate';
 				const state = session.getProcessingState();
 				const isBusy = state.status === 'processing' || state.status === 'queued';
 
@@ -267,11 +267,11 @@ export class RoomRuntimeService {
 					},
 				};
 
-				// Queue-mode semantics:
-				// - next_turn + busy => persist as 'saved' (replayed after current turn)
-				// - otherwise => enqueue now ('queued') so worker can start ASAP when idle
-				if (deliveryMode === 'next_turn' && isBusy) {
-					ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'saved');
+				// Defer-mode semantics:
+				// - defer + busy => persist as 'deferred' (replayed after current turn)
+				// - otherwise => enqueue now ('enqueued') so worker can start ASAP when idle
+				if (deliveryMode === 'defer' && isBusy) {
+					ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred');
 					return;
 				}
 
@@ -279,7 +279,7 @@ export class RoomRuntimeService {
 				// restart, restored sessions are in cache but haven't started
 				// their query yet (lazy start to avoid startup timeout).
 				await session.ensureQueryStarted();
-				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'queued');
+				ctx.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
 				await session.messageQueue.enqueueWithId(messageId, message);
 			},
 			hasSession: (sessionId) => {

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -130,7 +130,7 @@ export interface RoomRuntimeConfig {
 	/** Max feedback iterations before auto-escalation (default: 3) */
 	maxFeedbackIterations?: number;
 	/**
-	 * Job queue used to schedule and cancel room.tick jobs.
+	 * Job defer used to schedule and cancel room.tick jobs.
 	 * When provided, scheduleTick() enqueues a room.tick job via enqueueRoomTick.
 	 * When absent (e.g., in unit tests), tick scheduling is a no-op and tests
 	 * drive ticks directly via runtime.tick().
@@ -1123,7 +1123,7 @@ export class RoomRuntime {
 		toolName: string,
 		params: {
 			message?: string;
-			mode?: 'steer' | 'queue';
+			mode?: 'immediate' | 'defer';
 			summary?: string;
 			reason?: string;
 			pr_url?: string;
@@ -1170,8 +1170,8 @@ export class RoomRuntime {
 					});
 				}
 				const message = params.message ?? '';
-				const mode = params.mode ?? 'queue';
-				const deliveryMode = mode === 'queue' ? 'next_turn' : 'current_turn';
+				const mode = params.mode ?? 'defer';
+				const deliveryMode = mode === 'defer' ? 'defer' : 'immediate';
 				// feedbackIteration is already 1-based (incremented in routeWorkerToLeader)
 				const currentIteration = group.feedbackIteration;
 				const feedback = formatLeaderToWorkerFeedback(message, currentIteration);
@@ -1488,7 +1488,7 @@ export class RoomRuntime {
 			sendToWorker: async (
 				_groupId: string,
 				message: string,
-				mode?: 'steer' | 'queue',
+				mode?: 'immediate' | 'defer',
 				progressSummary?: string
 			) => {
 				return this.handleLeaderTool(groupId, 'send_to_worker', {
@@ -2266,7 +2266,7 @@ export class RoomRuntime {
 	// =========================================================================
 
 	/**
-	 * Main scheduling loop. Concurrency is managed by the job queue — at most one
+	 * Main scheduling loop. Concurrency is managed by the job defer — at most one
 	 * pending room.tick job exists per room, so concurrent calls are not expected
 	 * in production. In unit tests, callers drive ticks directly and sequentially.
 	 */
@@ -2719,7 +2719,7 @@ export class RoomRuntime {
 			return; // Don't start execution groups in the same tick
 		}
 
-		// Find pending non-planning tasks (planning tasks are spawned directly, not via queue)
+		// Find pending non-planning tasks (planning tasks are spawned directly, not via defer)
 		const pendingTasks = await this.taskManager.listTasks({ status: 'pending' });
 		const planningTasks = pendingTasks.filter((t) => (t.taskType ?? 'coding') === 'planning');
 		if (planningTasks.length > 0) {
@@ -2737,7 +2737,7 @@ export class RoomRuntime {
 		// Uses allActiveGroups (including submitted-for-review) to prevent spawning
 		// a duplicate group while another is awaiting human review.
 		// This prevents duplicate group spawning when concurrent ticks race
-		// (the job queue processor runs up to maxConcurrent jobs in parallel,
+		// (the job defer processor runs up to maxConcurrent jobs in parallel,
 		// so two ticks can both see a task as 'pending' before either transitions
 		// it to 'in_progress').
 		const activeGroupTaskIds = new Set(allActiveGroups.map((g) => g.taskId));
@@ -3246,7 +3246,7 @@ export class RoomRuntime {
 		// Notify UI: planning task created
 		this.emitTaskUpdate(planningTask);
 
-		// Spawn the planning group directly (bypasses the tick queue)
+		// Spawn the planning group directly (bypasses the tick defer)
 		let group;
 		try {
 			group = await this.taskGroupManager.spawn(
@@ -3457,7 +3457,7 @@ export class RoomRuntime {
 
 	/**
 	 * If the completed task was a planning task, promote its draft children to pending
-	 * so they enter the execution queue on the next tick.
+	 * so they enter the execution defer on the next tick.
 	 */
 	private async promoteDraftTasksIfPlanning(taskId: string): Promise<void> {
 		const task = await this.taskManager.getTask(taskId);

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -236,7 +236,7 @@ SELECT
 FROM target_group tg
 JOIN session_group_members gm ON gm.group_id = tg.id
 JOIN sdk_messages sm ON sm.session_id = gm.session_id
-WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'sent') IN ('sent', 'failed'))
+WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 UNION ALL
 SELECT
   'event'                       AS sourceType,

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -343,7 +343,7 @@ export function setupSessionHandlers(
 			sessionId: targetSessionId,
 			content,
 			images,
-			deliveryMode = 'current_turn',
+			deliveryMode = 'immediate',
 		} = data as {
 			sessionId: string;
 			content: string;
@@ -351,7 +351,7 @@ export function setupSessionHandlers(
 			deliveryMode?: MessageDeliveryMode;
 		};
 
-		if (deliveryMode !== 'current_turn' && deliveryMode !== 'next_turn') {
+		if (deliveryMode !== 'immediate' && deliveryMode !== 'defer') {
 			throw new Error('Invalid deliveryMode');
 		}
 
@@ -794,8 +794,8 @@ export function setupSessionHandlers(
 		}
 	});
 
-	// Handle triggering saved messages to be sent (Manual query mode)
-	// Use case: When user wants to manually send all saved messages in Manual mode
+	// Handle triggering deferred messages to be sent (manual mode)
+	// Use case: When user wants to manually send all deferred messages
 	// ARCHITECTURE: Fire-and-forget via EventBus, AgentSession handles the actual sending
 	messageHub.onRequest('session.query.trigger', async (data) => {
 		const { sessionId: targetSessionId } = data as { sessionId: string };
@@ -818,7 +818,7 @@ export function setupSessionHandlers(
 	messageHub.onRequest('session.messages.countByStatus', async (data) => {
 		const { sessionId: targetSessionId, status } = data as {
 			sessionId: string;
-			status: 'saved' | 'queued' | 'sent';
+			status: 'deferred' | 'enqueued' | 'consumed';
 		};
 
 		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
@@ -844,11 +844,11 @@ export function setupSessionHandlers(
 			limit = 20,
 		} = data as {
 			sessionId: string;
-			status: 'saved' | 'queued' | 'sent';
+			status: 'deferred' | 'enqueued' | 'consumed';
 			limit?: number;
 		};
 
-		if (!['saved', 'queued', 'sent'].includes(status)) {
+		if (!['deferred', 'enqueued', 'consumed'].includes(status)) {
 			throw new Error('Invalid status');
 		}
 

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -882,7 +882,7 @@ export function setupTaskHandlers(
 					null,
 					JSON.stringify(sdkPayload),
 					new Date().toISOString(),
-					'sent'
+					'consumed'
 				);
 			reactiveDb.notifyChange('sdk_messages');
 			return { id: rowId };

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -54,7 +54,7 @@ export class MessagePersistence {
 	 * 7. Emit 'message.persisted' event for downstream processing
 	 */
 	async persist(data: MessagePersistenceData): Promise<void> {
-		const { sessionId, messageId, content, images, deliveryMode = 'current_turn' } = data;
+		const { sessionId, messageId, content, images, deliveryMode = 'immediate' } = data;
 
 		const agentSession = await this.sessionCache.getAsync(sessionId);
 		if (!agentSession) {
@@ -112,20 +112,20 @@ export class MessagePersistence {
 			const isManualMode = session.config.queryMode === 'manual';
 
 			const effectiveDeliveryMode: MessageDeliveryMode =
-				deliveryMode === 'next_turn' && isAgentBusy ? 'next_turn' : 'current_turn';
-			const sendStatus: 'saved' | 'queued' | 'sent' = isManualMode
-				? 'saved'
-				: effectiveDeliveryMode === 'next_turn'
-					? 'saved'
+				deliveryMode === 'defer' && isAgentBusy ? 'defer' : 'immediate';
+			const sendStatus: 'deferred' | 'enqueued' | 'consumed' = isManualMode
+				? 'deferred'
+				: effectiveDeliveryMode === 'defer'
+					? 'deferred'
 					: isAgentBusy
-						? 'queued'
-						: 'sent';
-			const shouldDispatchToQuery = !isManualMode && effectiveDeliveryMode === 'current_turn';
+						? 'enqueued'
+						: 'consumed';
+			const shouldDispatchToQuery = !isManualMode && effectiveDeliveryMode === 'immediate';
 
 			const dbMessageId = this.db.saveUserMessage(sessionId, sdkUserMessage, sendStatus);
 
 			// 6. Publish to UI immediately only when not currently in-flight.
-			// Busy-turn insertions are shown in the input overlay and rendered in chat once sent.
+			// Busy-turn insertions are shown in the input overlay and rendered in chat once consumed.
 			if (isManualMode || !isAgentBusy) {
 				try {
 					this.messageHub.event(

--- a/packages/daemon/src/lib/space/provision-global-agent.ts
+++ b/packages/daemon/src/lib/space/provision-global-agent.ts
@@ -167,7 +167,7 @@ export async function provisionGlobalSpacesAgent(
 				`Task '${event.taskTitle}' (taskId: ${event.taskId}, spaceId: ${event.spaceId}) ` +
 				`has completed.${summaryPart}`;
 			void sessionFactory
-				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
+				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'defer' })
 				.catch((err) => {
 					log.warn(
 						`Failed to inject task.completed notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`
@@ -182,7 +182,7 @@ export async function provisionGlobalSpacesAgent(
 				`Task '${event.taskTitle}' (taskId: ${event.taskId}, spaceId: ${event.spaceId}) ` +
 				`has ${statusLabel}.${summaryPart}`;
 			void sessionFactory
-				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'next_turn' })
+				.injectMessage(GLOBAL_SESSION_ID, message, { deliveryMode: 'defer' })
 				.catch((err) => {
 					log.warn(
 						`Failed to inject task.failed notification into ${GLOBAL_SESSION_ID}: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -4,14 +4,14 @@
  * Formats SpaceNotificationEvents into structured messages and injects them
  * into the Space Agent session via `sessionFactory.injectMessage()`.
  *
- * ## Delivery mode: `'next_turn'`
+ * ## Delivery mode: `'defer'`
  *
- * Notifications use `deliveryMode: 'next_turn'` for non-blocking injection:
+ * Notifications use `deliveryMode: 'defer'` for non-blocking injection:
  * - If the Space Agent session is **idle**: the message is enqueued immediately
  *   and the agent processes it on the next turn.
  * - If the Space Agent session is **busy** (actively streaming a response or
  *   has a message queued): the message is persisted to the DB with status
- *   `'saved'` and automatically replayed once the current turn completes.
+ *   `'deferred'` and automatically replayed once the current turn completes.
  *
  * This ensures notifications are never dropped and never interrupt the agent
  * mid-response. The trade-off is a possible short delay if the agent is busy,
@@ -70,7 +70,7 @@ export class SessionNotificationSink implements NotificationSink {
 		const message = formatEventMessage(event, this.autonomyLevel);
 		try {
 			await this.sessionFactory.injectMessage(this.sessionId, message, {
-				deliveryMode: 'next_turn',
+				deliveryMode: 'defer',
 			});
 		} catch (err) {
 			// Session not found or unavailable — log warning, do not propagate.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -952,7 +952,7 @@ export class TaskAgentManager {
 
 		// Notify the Task Agent that a sub-session has completed.
 		// Include the agent's result summary so the Task Agent has immediate context.
-		// This sends a next_turn message so the Task Agent can call advance_workflow.
+		// This sends a defer message so the Task Agent can call advance_workflow.
 		const taskAgentSession = this.taskAgentSessions.get(taskId);
 		if (taskAgentSession) {
 			try {
@@ -964,7 +964,7 @@ export class TaskAgentManager {
 				await this.injectMessageIntoSession(
 					taskAgentSession,
 					`[STEP_COMPLETE] Step "${stepId}" sub-session (${subSessionId}) has completed.${resultSummary}\nCall check_step_status to verify, then call advance_workflow to proceed.`,
-					'next_turn'
+					'defer'
 				);
 			} catch (err) {
 				log.warn(
@@ -1235,19 +1235,19 @@ export class TaskAgentManager {
 	private async injectMessageIntoSession(
 		session: AgentSession,
 		message: string,
-		deliveryMode: 'current_turn' | 'next_turn' = 'current_turn'
+		deliveryMode: 'immediate' | 'defer' = 'immediate'
 	): Promise<void> {
 		const sessionId = session.session.id;
 		const state = session.getProcessingState();
 		// 'processing'/'queued' = actively running; 'waiting_for_input' = human gate open;
 		// 'interrupted' = the current turn was interrupted but the session is still alive.
-		// All four states mean a next_turn message cannot be safely delivered right now —
+		// All four states mean a defer message cannot be safely delivered right now —
 		// defer it for replay after the current interaction resolves.
 		//
-		// Note on 'interrupted': an interrupted session CAN accept a new current_turn
-		// message (ensureQueryStarted restarts the query), so only next_turn delivery is
+		// Note on 'interrupted': an interrupted session CAN accept a new immediate
+		// message (ensureQueryStarted restarts the query), so only defer delivery is
 		// deferred. This matches the pattern for 'processing'/'queued': the message is
-		// saved and replayed once the session becomes idle.
+		// persisted as deferred and replayed once the session becomes idle.
 		const isBusy =
 			state.status === 'processing' ||
 			state.status === 'queued' ||
@@ -1266,14 +1266,14 @@ export class TaskAgentManager {
 			},
 		};
 
-		// next_turn + busy → save for replay after current turn completes
-		if (deliveryMode === 'next_turn' && isBusy) {
-			this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'saved');
+		// defer + busy → persist as deferred for replay after current turn completes
+		if (deliveryMode === 'defer' && isBusy) {
+			this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred');
 			return;
 		}
 
 		await session.ensureQueryStarted();
-		this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'queued');
+		this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
 		await session.messageQueue.enqueueWithId(messageId, message);
 	}
 

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -141,7 +141,11 @@ export class Database {
 	}
 
 	// Message Query Mode operations
-	saveUserMessage(sessionId: string, message: SDKMessage, sendStatus: SendStatus = 'sent'): string {
+	saveUserMessage(
+		sessionId: string,
+		message: SDKMessage,
+		sendStatus: SendStatus = 'consumed'
+	): string {
 		return this.sdkMessageRepo.saveUserMessage(sessionId, message, sendStatus);
 	}
 

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -4,7 +4,7 @@
  * Responsibilities:
  * - Save and retrieve SDK messages
  * - Pagination support (before/since cursors)
- * - Message query mode tracking (saved/queued/sent status)
+ * - Message query mode tracking (deferred/enqueued/consumed status)
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -13,7 +13,7 @@ import type { SDKMessage } from '@neokai/shared/sdk';
 import { Logger } from '../../lib/logger';
 import type { SQLiteValue } from '../types';
 
-export type SendStatus = 'saved' | 'queued' | 'sent' | 'failed';
+export type SendStatus = 'deferred' | 'enqueued' | 'consumed' | 'failed';
 
 export class SDKMessageRepository {
 	private logger = new Logger('Database');
@@ -87,11 +87,11 @@ export class SDKMessageRepository {
 		since?: number
 	): { messages: SDKMessage[]; hasMore: boolean } {
 		// Step 1: Get top-level messages (excluding subagent messages)
-		// Show user messages that were sent to SDK, plus any that failed to deliver.
+		// Show user messages that were consumed to SDK, plus any that failed to deliver.
 		let query = `SELECT sdk_message, timestamp, send_status FROM sdk_messages
       WHERE session_id = ?
         AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
-        AND (message_type != 'user' OR COALESCE(send_status, 'sent') IN ('sent', 'failed'))`;
+        AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))`;
 		const params: SQLiteValue[] = [sessionId];
 
 		// Cursor-based pagination: get messages BEFORE a timestamp (for loading older)
@@ -153,7 +153,7 @@ export class SDKMessageRepository {
 			const subagentQuery = `SELECT sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
          AND json_extract(sdk_message, '$.parent_tool_use_id') IN (${placeholders})
-         AND (message_type != 'user' OR COALESCE(send_status, 'sent') IN ('sent', 'failed'))
+         AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
         ORDER BY timestamp ASC`;
 			const subagentParams: SQLiteValue[] = [sessionId, ...Array.from(toolUseIds)];
 
@@ -212,7 +212,7 @@ export class SDKMessageRepository {
 			`SELECT COUNT(*) as count FROM sdk_messages
        WHERE session_id = ?
          AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
-         AND (message_type != 'user' OR COALESCE(send_status, 'sent') = 'sent')`
+         AND (message_type != 'user' OR COALESCE(send_status, 'consumed') = 'consumed')`
 		);
 		const result = stmt.get(sessionId) as { count: number };
 		return result.count;
@@ -222,21 +222,25 @@ export class SDKMessageRepository {
 	// Message Query Mode operations
 	// ============================================================================
 	// Message send status types for query mode feature:
-	// - 'saved': Message persisted but not yet sent to SDK (Manual mode)
-	// - 'queued': Message in queue waiting to be sent (during processing)
-	// - 'sent': Message has been yielded to SDK
+	// - 'deferred': Message persisted but not yet consumed to SDK (Manual mode)
+	// - 'enqueued': Message in queue waiting to be consumed (during processing)
+	// - 'consumed': Message has been yielded to SDK
 
 	/**
 	 * Save a user message with explicit send status
 	 *
 	 * Used by query modes to track message lifecycle:
-	 * - Immediate mode: saves with status 'sent' (after yielding to SDK)
-	 * - Auto-queue mode: saves with status 'queued' (pending SDK consumption)
-	 * - Manual mode: saves with status 'saved' (until user triggers send)
+	 * - Immediate mode: saves with status 'consumed' (after yielding to SDK)
+	 * - Auto-queue mode: saves with status 'enqueued' (pending SDK consumption)
+	 * - Manual mode: saves with status 'deferred' (until user triggers send)
 	 *
 	 * @returns The generated message ID
 	 */
-	saveUserMessage(sessionId: string, message: SDKMessage, sendStatus: SendStatus = 'sent'): string {
+	saveUserMessage(
+		sessionId: string,
+		message: SDKMessage,
+		sendStatus: SendStatus = 'consumed'
+	): string {
 		const id = generateUUID();
 		const messageType = message.type;
 		const messageSubtype = 'subtype' in message ? (message.subtype as string) : null;
@@ -263,8 +267,8 @@ export class SDKMessageRepository {
 	 * Get messages by send status for a session
 	 *
 	 * Used to retrieve:
-	 * - 'saved' messages for manual trigger
-	 * - 'queued' messages for auto-send on turn_end
+	 * - 'deferred' messages for manual trigger
+	 * - 'enqueued' messages for auto-send on turn_end
 	 *
 	 * Returns messages in chronological order (oldest first).
 	 */
@@ -294,8 +298,8 @@ export class SDKMessageRepository {
 	 * Update send status for messages
 	 *
 	 * Used to transition messages through the lifecycle:
-	 * - 'saved' -> 'queued' (when user triggers manual send)
-	 * - 'queued' -> 'sent' (when message is yielded to SDK)
+	 * - 'deferred' -> 'enqueued' (when user triggers manual send)
+	 * - 'enqueued' -> 'consumed' (when message is yielded to SDK)
 	 */
 	updateMessageStatus(messageIds: string[], newStatus: SendStatus): void {
 		if (messageIds.length === 0) return;

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -73,7 +73,7 @@ export function createTables(db: BunDatabase): void {
         message_subtype TEXT,
         sdk_message TEXT NOT NULL,
         timestamp TEXT NOT NULL,
-        send_status TEXT DEFAULT 'sent' CHECK(send_status IN ('saved', 'queued', 'sent', 'failed')),
+        send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed')),
         FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2547,9 +2547,16 @@ function runMigration44(db: BunDatabase): void {
 	db.exec(`PRAGMA foreign_keys = OFF`);
 	try {
 		db.exec(`PRAGMA ignore_check_constraints = 1`);
-		db.exec(`UPDATE sdk_messages SET send_status = 'deferred' WHERE send_status = 'saved'`);
-		db.exec(`UPDATE sdk_messages SET send_status = 'enqueued' WHERE send_status = 'queued'`);
-		db.exec(`UPDATE sdk_messages SET send_status = 'consumed' WHERE send_status = 'sent'`);
+		db.exec(`
+			UPDATE sdk_messages
+			SET send_status = CASE
+				WHEN send_status = 'saved' THEN 'deferred'
+				WHEN send_status = 'queued' THEN 'enqueued'
+				WHEN send_status = 'sent' THEN 'consumed'
+				WHEN send_status IS NULL THEN 'consumed'
+				ELSE send_status
+			END
+		`);
 		db.exec(`PRAGMA ignore_check_constraints = 0`);
 
 		db.exec(`

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -161,6 +161,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 43: Drop legacy session_group_messages projection table.
 	runMigration43(db);
+
+	// Migration 44: Rename sdk_messages send_status values to deferred/enqueued/consumed.
+	runMigration44(db);
 }
 
 /**
@@ -2515,4 +2518,60 @@ function runMigration42(db: BunDatabase): void {
 function runMigration43(db: BunDatabase): void {
 	db.exec(`DROP INDEX IF EXISTS idx_sgm_group`);
 	db.exec(`DROP TABLE IF EXISTS session_group_messages`);
+}
+
+/**
+ * Migration 44: Rename sdk_messages.send_status values.
+ *
+ * Old values: saved, queued, sent, failed
+ * New values: deferred, enqueued, consumed, failed
+ */
+function runMigration44(db: BunDatabase): void {
+	if (!tableExists(db, 'sdk_messages')) {
+		return;
+	}
+
+	const tableInfo = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='sdk_messages'`)
+		.get() as { sql: string } | null;
+
+	if (!tableInfo) {
+		return;
+	}
+
+	// Already migrated
+	if (tableInfo.sql.includes("'deferred'") && tableInfo.sql.includes("'consumed'")) {
+		return;
+	}
+
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	try {
+		db.exec(`PRAGMA ignore_check_constraints = 1`);
+		db.exec(`UPDATE sdk_messages SET send_status = 'deferred' WHERE send_status = 'saved'`);
+		db.exec(`UPDATE sdk_messages SET send_status = 'enqueued' WHERE send_status = 'queued'`);
+		db.exec(`UPDATE sdk_messages SET send_status = 'consumed' WHERE send_status = 'sent'`);
+		db.exec(`PRAGMA ignore_check_constraints = 0`);
+
+		db.exec(`
+			CREATE TABLE sdk_messages_new (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				message_type TEXT NOT NULL,
+				message_subtype TEXT,
+				sdk_message TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed')),
+				FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`INSERT INTO sdk_messages_new SELECT * FROM sdk_messages`);
+		db.exec(`DROP TABLE sdk_messages`);
+		db.exec(`ALTER TABLE sdk_messages_new RENAME TO sdk_messages`);
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_id ON sdk_messages(session_id)`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_sdk_messages_send_status ON sdk_messages(session_id, send_status)`
+		);
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
+	}
 }

--- a/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
+++ b/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
@@ -2,9 +2,9 @@
  * Message Delivery Mode Queue Flow (Online)
  *
  * End-to-end validation for:
- * - current_turn delivery
- * - next_turn delivery while busy (saved queue + auto-dispatch)
- * - next_turn fallback while idle
+ * - immediate delivery
+ * - defer delivery while busy (saved queue + auto-dispatch)
+ * - defer fallback while idle
  *
  * MODES:
  * - Real API (default): Requires CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
@@ -88,7 +88,7 @@ describe('Message delivery mode queue flow', () => {
 	}
 
 	test(
-		'next_turn while busy should be saved then auto-dispatched on turn end',
+		'defer while busy should be saved then auto-dispatched on turn end',
 		async () => {
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: `${TMP_DIR}/delivery-mode-flow-${Date.now()}`,
@@ -116,7 +116,7 @@ describe('Message delivery mode queue flow', () => {
 					daemon,
 					sessionId,
 					'After your current response finishes, reply exactly: FOLLOWUP_OK',
-					{ deliveryMode: 'next_turn' }
+					{ deliveryMode: 'defer' }
 				);
 				expect(second.messageId).toBeString();
 				expect(second.messageId).not.toBe(first.messageId);
@@ -139,7 +139,7 @@ describe('Message delivery mode queue flow', () => {
 	);
 
 	test(
-		'next_turn while idle should fallback to immediate dispatch',
+		'defer while idle should fallback to immediate dispatch',
 		async () => {
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: `${TMP_DIR}/delivery-mode-idle-fallback-${Date.now()}`,
@@ -154,10 +154,10 @@ describe('Message delivery mode queue flow', () => {
 			expect(stateBefore.status).toBe('idle');
 
 			await sendMessage(daemon, sessionId, 'Reply exactly: IDLE_FALLBACK_OK', {
-				deliveryMode: 'next_turn',
+				deliveryMode: 'defer',
 			});
 
-			// next_turn while idle should not remain in saved queue
+			// defer while idle should not remain in saved queue
 			await waitForCount(sessionId, 'saved', (count) => count === 0, 10000);
 			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 			const queuedCleared = await waitForCount(sessionId, 'queued', (count) => count === 0, 20000)
@@ -175,7 +175,7 @@ describe('Message delivery mode queue flow', () => {
 	);
 
 	test(
-		'current_turn steering while busy should have timestamp between assistant messages',
+		'immediate steering while busy should have timestamp between assistant messages',
 		async () => {
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: `${TMP_DIR}/steer-position-${Date.now()}`,
@@ -204,12 +204,12 @@ describe('Message delivery mode queue flow', () => {
 				// Wait a moment to ensure some assistant content has been streamed
 				await new Promise((resolve) => setTimeout(resolve, 2000));
 
-				// Send a steering message (current_turn while busy)
+				// Send a steering message (immediate while busy)
 				const steerResult = await sendMessage(
 					daemon,
 					sessionId,
 					'Actually, stop what you are doing. Reply with exactly: STEERED_OK',
-					{ deliveryMode: 'current_turn' }
+					{ deliveryMode: 'immediate' }
 				);
 				expect(steerResult.messageId).toBeString();
 
@@ -274,7 +274,7 @@ describe('Message delivery mode queue flow', () => {
 	);
 
 	test(
-		'multiple current_turn steers while busy should all be acknowledged',
+		'multiple immediate steers while busy should all be acknowledged',
 		async () => {
 			const createResult = (await daemon.messageHub.request('session.create', {
 				workspacePath: `${TMP_DIR}/multi-steer-${Date.now()}`,
@@ -308,14 +308,14 @@ describe('Message delivery mode queue flow', () => {
 					sessionId,
 					'STEER_MESSAGE_ONE: Acknowledge this.',
 					{
-						deliveryMode: 'current_turn',
+						deliveryMode: 'immediate',
 					}
 				);
 				const steer2 = await sendMessage(
 					daemon,
 					sessionId,
 					'STEER_MESSAGE_TWO: Also acknowledge this.',
-					{ deliveryMode: 'current_turn' }
+					{ deliveryMode: 'immediate' }
 				);
 
 				expect(steer1.messageId).toBeString();

--- a/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
+++ b/packages/daemon/tests/online/features/message-delivery-mode-queue.test.ts
@@ -49,7 +49,7 @@ describe('Message delivery mode queue flow', () => {
 
 	async function getCountByStatus(
 		sessionId: string,
-		status: 'saved' | 'queued' | 'sent'
+		status: 'deferred' | 'enqueued' | 'consumed'
 	): Promise<number> {
 		const result = (await daemon.messageHub.request('session.messages.countByStatus', {
 			sessionId,
@@ -60,7 +60,7 @@ describe('Message delivery mode queue flow', () => {
 
 	async function waitForCount(
 		sessionId: string,
-		status: 'saved' | 'queued' | 'sent',
+		status: 'deferred' | 'enqueued' | 'consumed',
 		predicate: (count: number) => boolean,
 		timeoutMs = 15000
 	): Promise<number> {
@@ -121,11 +121,11 @@ describe('Message delivery mode queue flow', () => {
 				expect(second.messageId).toBeString();
 				expect(second.messageId).not.toBe(first.messageId);
 
-				await waitForCount(sessionId, 'saved', (count) => count >= 1, 12000);
+				await waitForCount(sessionId, 'deferred', (count) => count >= 1, 12000);
 				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-				await waitForCount(sessionId, 'saved', (count) => count === 0, 20000);
-				const sentCount = await getCountByStatus(sessionId, 'sent');
+				await waitForCount(sessionId, 'deferred', (count) => count === 0, 20000);
+				const sentCount = await getCountByStatus(sessionId, 'consumed');
 				expect(sentCount).toBeGreaterThanOrEqual(2);
 			} finally {
 				try {
@@ -158,9 +158,9 @@ describe('Message delivery mode queue flow', () => {
 			});
 
 			// defer while idle should not remain in saved queue
-			await waitForCount(sessionId, 'saved', (count) => count === 0, 10000);
+			await waitForCount(sessionId, 'deferred', (count) => count === 0, 10000);
 			await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
-			const queuedCleared = await waitForCount(sessionId, 'queued', (count) => count === 0, 20000)
+			const queuedCleared = await waitForCount(sessionId, 'enqueued', (count) => count === 0, 20000)
 				.then(() => true)
 				.catch(() => false);
 			if (!queuedCleared) {
@@ -168,7 +168,7 @@ describe('Message delivery mode queue flow', () => {
 				return;
 			}
 
-			const sentCount = await getCountByStatus(sessionId, 'sent');
+			const sentCount = await getCountByStatus(sessionId, 'consumed');
 			expect(sentCount).toBeGreaterThanOrEqual(1);
 		},
 		TEST_TIMEOUT
@@ -214,8 +214,8 @@ describe('Message delivery mode queue flow', () => {
 				expect(steerResult.messageId).toBeString();
 
 				// The message should be queued initially
-				// Then transition to 'sent' when the generator yields it
-				await waitForCount(sessionId, 'queued', (count) => count === 0, 30000);
+				// Then transition to 'consumed' when the generator yields it
+				await waitForCount(sessionId, 'enqueued', (count) => count === 0, 30000);
 
 				// Wait for the turn to complete
 				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
@@ -259,8 +259,8 @@ describe('Message delivery mode queue flow', () => {
 				// This proves it was positioned at SDK insertion time, not at turn end
 				expect(steeredTimestamp).toBeLessThan(resultTimestamp);
 
-				// Verify the message status is now 'sent'
-				const sentCount = await getCountByStatus(sessionId, 'sent');
+				// Verify the message status is now 'consumed'
+				const sentCount = await getCountByStatus(sessionId, 'consumed');
 				expect(sentCount).toBeGreaterThanOrEqual(2); // At least first + steered
 			} finally {
 				try {
@@ -322,12 +322,12 @@ describe('Message delivery mode queue flow', () => {
 				expect(steer2.messageId).toBeString();
 
 				// Wait for all queued messages to be consumed
-				await waitForCount(sessionId, 'queued', (count) => count === 0, 60000);
+				await waitForCount(sessionId, 'enqueued', (count) => count === 0, 60000);
 
 				// Wait for turns to complete
 				await waitForIdle(daemon, sessionId, IDLE_TIMEOUT);
 
-				// Both steering messages should now be 'sent'
+				// Both steering messages should now be 'consumed'
 				const { sdkMessages } = await waitForSdkMessages(daemon, sessionId, {
 					minCount: 5,
 					timeout: 10000,
@@ -354,11 +354,11 @@ describe('Message delivery mode queue flow', () => {
 				expect(ts2).toBeGreaterThanOrEqual(ts1);
 
 				// No messages should remain in queued status
-				const queuedCount = await getCountByStatus(sessionId, 'queued');
+				const queuedCount = await getCountByStatus(sessionId, 'enqueued');
 				expect(queuedCount).toBe(0);
 
 				// All user messages should be sent
-				const sentCount = await getCountByStatus(sessionId, 'sent');
+				const sentCount = await getCountByStatus(sessionId, 'consumed');
 				expect(sentCount).toBeGreaterThanOrEqual(3); // initial + steer1 + steer2
 			} finally {
 				try {

--- a/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/agent/event-subscription-setup.test.ts
@@ -60,7 +60,7 @@ describe('EventSubscriptionSetup', () => {
 
 		mockQueryModeHandler = {
 			handleQueryTrigger: mock(async () => ({ success: true, messageCount: 1 })),
-			sendQueuedMessagesOnTurnEnd: mock(async () => {}),
+			sendEnqueuedMessagesOnTurnEnd: mock(async () => {}),
 		} as unknown as QueryModeHandler;
 
 		// Create mock session
@@ -106,7 +106,7 @@ describe('EventSubscriptionSetup', () => {
 			expect(registeredCallbacks.has('agent.resetRequest')).toBe(true);
 			expect(registeredCallbacks.has('message.persisted')).toBe(true);
 			expect(registeredCallbacks.has('query.trigger')).toBe(true);
-			expect(registeredCallbacks.has('query.sendQueuedOnTurnEnd')).toBe(true);
+			expect(registeredCallbacks.has('query.sendEnqueuedOnTurnEnd')).toBe(true);
 		});
 
 		it('should pass sessionId to subscription options', () => {
@@ -248,14 +248,14 @@ describe('EventSubscriptionSetup', () => {
 			});
 		});
 
-		describe('query.sendQueuedOnTurnEnd handler', () => {
-			it('should call queryModeHandler.sendQueuedMessagesOnTurnEnd', async () => {
+		describe('query.sendEnqueuedOnTurnEnd handler', () => {
+			it('should call queryModeHandler.sendEnqueuedMessagesOnTurnEnd', async () => {
 				setup.setup();
 
-				const callback = registeredCallbacks.get('query.sendQueuedOnTurnEnd')!;
+				const callback = registeredCallbacks.get('query.sendEnqueuedOnTurnEnd')!;
 				await callback({ sessionId: 'test-session-id' });
 
-				expect(mockQueryModeHandler.sendQueuedMessagesOnTurnEnd).toHaveBeenCalled();
+				expect(mockQueryModeHandler.sendEnqueuedMessagesOnTurnEnd).toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/daemon/tests/unit/agent/message-recovery-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/message-recovery-handler.test.ts
@@ -70,22 +70,22 @@ describe('MessageRecoveryHandler', () => {
 		});
 	});
 
-	describe('recoverOrphanedSentMessages', () => {
+	describe('recoverOrphanedConsumedMessages', () => {
 		it('should return early if no stuck messages', () => {
 			getMessagesByStatusSpy.mockReturnValue([]);
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			expect(getSDKMessagesSpy).not.toHaveBeenCalled();
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
 		});
 
-		it('should check sent messages for recovery', () => {
+		it('should check consumed messages for recovery', () => {
 			getMessagesByStatusSpy.mockReturnValue([]);
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
-			expect(getMessagesByStatusSpy).toHaveBeenCalledWith('test-session-id', 'sent');
+			expect(getMessagesByStatusSpy).toHaveBeenCalledWith('test-session-id', 'consumed');
 		});
 
 		it('should find orphaned user messages without system:init response', () => {
@@ -110,13 +110,13 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// User message timestamp (2000) > system:init timestamp (1000) = orphaned
 			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1'], 'failed');
 		});
 
-		it('should not recover sent messages that have system:init after them', () => {
+		it('should not recover consumed messages that have system:init after them', () => {
 			const sentUserMessage: SDKMessage = {
 				dbId: 'db-1',
 				uuid: 'uuid-12345678',
@@ -138,7 +138,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// User message timestamp (1000) < system:init timestamp (2000) = not orphaned
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
@@ -148,9 +148,9 @@ describe('MessageRecoveryHandler', () => {
 			getMessagesByStatusSpy.mockReturnValue([]);
 			getSDKMessagesSpy.mockReturnValue({ messages: [], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
-			expect(getMessagesByStatusSpy).not.toHaveBeenCalledWith('test-session-id', 'queued');
+			expect(getMessagesByStatusSpy).not.toHaveBeenCalledWith('test-session-id', 'enqueued');
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
 		});
 
@@ -167,7 +167,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
 		});
@@ -202,7 +202,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1', 'db-2'], 'failed');
 		});
@@ -213,15 +213,15 @@ describe('MessageRecoveryHandler', () => {
 			});
 
 			// Should not throw
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			expect(mockLogger.warn).toHaveBeenCalledWith(
-				'Failed to mark orphaned sent messages as failed:',
+				'Failed to mark orphaned consumed messages as failed:',
 				expect.any(Error)
 			);
 		});
 
-		it('should handle sent messages without timestamps', () => {
+		it('should handle consumed messages without timestamps', () => {
 			const sentUserMessage: SDKMessage = {
 				dbId: 'db-1',
 				uuid: 'uuid-12345678',
@@ -234,7 +234,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// With no system:init (latestInitTimestamp = 0) and message timestamp = 0,
 			// the message is NOT orphaned (0 > 0 is false)
@@ -254,7 +254,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1'], 'failed');
 		});
@@ -284,7 +284,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// Synthetic messages should never be recovered
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
@@ -317,7 +317,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// tool_result-only messages are not human-typed, should not be recovered
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();
@@ -350,13 +350,13 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: [systemInitMessage], hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// Mixed content has human-typed text, should be recovered
 			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1'], 'failed');
 		});
 
-		it('should find latest system:init timestamp for sent messages', () => {
+		it('should find latest system:init timestamp for consumed messages', () => {
 			const sentUserMessage: SDKMessage = {
 				dbId: 'db-1',
 				uuid: 'uuid-12345678',
@@ -394,7 +394,7 @@ describe('MessageRecoveryHandler', () => {
 
 			getSDKMessagesSpy.mockReturnValue({ messages: systemInitMessages, hasMore: false });
 
-			handler.recoverOrphanedSentMessages();
+			handler.recoverOrphanedConsumedMessages();
 
 			// User message timestamp (2500) < latest system:init (3000) = not orphaned
 			expect(updateMessageStatusSpy).not.toHaveBeenCalled();

--- a/packages/daemon/tests/unit/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/query-mode-handler.test.ts
@@ -104,7 +104,7 @@ describe('QueryModeHandler', () => {
 	});
 
 	describe('handleQueryTrigger', () => {
-		it('should return success with 0 messages if no saved messages', async () => {
+		it('should return success with 0 messages if no deferred messages', async () => {
 			getMessagesByStatusSpy.mockReturnValue([]);
 			handler = createHandler();
 
@@ -113,7 +113,7 @@ describe('QueryModeHandler', () => {
 			expect(result).toEqual({ success: true, messageCount: 0 });
 		});
 
-		it('should update message status to queued', async () => {
+		it('should update message status to enqueued', async () => {
 			const savedMessages: SDKMessage[] = [
 				{
 					dbId: 'db-1',
@@ -127,7 +127,7 @@ describe('QueryModeHandler', () => {
 
 			await handler.handleQueryTrigger();
 
-			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1'], 'queued');
+			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-1'], 'enqueued');
 		});
 
 		it('should emit messages.statusChanged event', async () => {
@@ -147,7 +147,7 @@ describe('QueryModeHandler', () => {
 			expect(emitSpy).toHaveBeenCalledWith('messages.statusChanged', {
 				sessionId: 'test-session-id',
 				messageIds: ['db-1'],
-				status: 'queued',
+				status: 'enqueued',
 			});
 		});
 
@@ -272,18 +272,18 @@ describe('QueryModeHandler', () => {
 		});
 	});
 
-	describe('sendQueuedMessagesOnTurnEnd', () => {
-		it('should return early if no queued messages', async () => {
+	describe('sendEnqueuedMessagesOnTurnEnd', () => {
+		it('should return early if no enqueued messages', async () => {
 			getMessagesByStatusSpy.mockReturnValue([]);
 			handler = createHandler();
 
-			await handler.sendQueuedMessagesOnTurnEnd();
+			await handler.sendEnqueuedMessagesOnTurnEnd();
 
 			expect(enqueueWithIdSpy).not.toHaveBeenCalled();
 			expect(ensureQueryStartedSpy).not.toHaveBeenCalled();
 		});
 
-		it('should enqueue queued messages', async () => {
+		it('should enqueue enqueued messages', async () => {
 			const queuedMessages: SDKMessage[] = [
 				{
 					dbId: 'db-1',
@@ -295,7 +295,7 @@ describe('QueryModeHandler', () => {
 			getMessagesByStatusSpy.mockReturnValue(queuedMessages);
 			handler = createHandler();
 
-			await handler.sendQueuedMessagesOnTurnEnd();
+			await handler.sendEnqueuedMessagesOnTurnEnd();
 
 			expect(ensureQueryStartedSpy).toHaveBeenCalled();
 			expect(enqueueWithIdSpy).toHaveBeenCalledWith('uuid-1', 'Queued message');
@@ -313,7 +313,7 @@ describe('QueryModeHandler', () => {
 			getMessagesByStatusSpy.mockReturnValue(queuedMessages);
 			handler = createHandler();
 
-			await handler.sendQueuedMessagesOnTurnEnd();
+			await handler.sendEnqueuedMessagesOnTurnEnd();
 
 			expect(enqueueWithIdSpy).not.toHaveBeenCalled();
 		});
@@ -325,15 +325,15 @@ describe('QueryModeHandler', () => {
 			handler = createHandler();
 
 			// Should not throw
-			await handler.sendQueuedMessagesOnTurnEnd();
+			await handler.sendEnqueuedMessagesOnTurnEnd();
 
 			expect(mockLogger.error).toHaveBeenCalledWith(
-				'Failed to send queued messages on turn end:',
+				'Failed to send enqueued messages on turn end:',
 				expect.any(Error)
 			);
 		});
 
-		it('should process multiple queued messages', async () => {
+		it('should process multiple enqueued messages', async () => {
 			const queuedMessages: SDKMessage[] = [
 				{ dbId: 'db-1', uuid: 'uuid-1', type: 'user', message: { role: 'user', content: 'First' } },
 				{
@@ -346,7 +346,7 @@ describe('QueryModeHandler', () => {
 			getMessagesByStatusSpy.mockReturnValue(queuedMessages);
 			handler = createHandler();
 
-			await handler.sendQueuedMessagesOnTurnEnd();
+			await handler.sendEnqueuedMessagesOnTurnEnd();
 
 			expect(enqueueWithIdSpy).toHaveBeenCalledTimes(2);
 			expect(enqueueWithIdSpy).toHaveBeenCalledWith('uuid-1', 'First');
@@ -355,33 +355,36 @@ describe('QueryModeHandler', () => {
 	});
 
 	describe('replayPendingMessagesForImmediateMode', () => {
-		it('should replay queued messages before saved messages', async () => {
+		it('should replay enqueued messages before deferred messages', async () => {
 			const queuedMessages: SDKMessage[] = [
 				{
-					dbId: 'db-queued-1',
-					uuid: 'uuid-queued-1',
+					dbId: 'db-enqueued-1',
+					uuid: 'uuid-enqueued-1',
 					type: 'user',
-					message: { role: 'user', content: 'Current turn (queued)' },
+					message: { role: 'user', content: 'Current turn (enqueued)' },
 				} as unknown as SDKMessage,
 			];
 			const savedMessages: SDKMessage[] = [
 				{
-					dbId: 'db-saved-1',
-					uuid: 'uuid-saved-1',
+					dbId: 'db-deferred-1',
+					uuid: 'uuid-deferred-1',
 					type: 'user',
-					message: { role: 'user', content: 'Next turn (saved)' },
+					message: { role: 'user', content: 'Next turn (deferred)' },
 				} as unknown as SDKMessage,
 			];
 			getMessagesByStatusSpy.mockImplementation((_: string, status: string) =>
-				status === 'queued' ? queuedMessages : savedMessages
+				status === 'enqueued' ? queuedMessages : savedMessages
 			);
 			handler = createHandler();
 
 			await handler.replayPendingMessagesForImmediateMode();
 
 			expect(enqueueWithIdSpy).toHaveBeenCalledTimes(2);
-			expect(enqueueWithIdSpy.mock.calls[0]).toEqual(['uuid-queued-1', 'Current turn (queued)']);
-			expect(enqueueWithIdSpy.mock.calls[1]).toEqual(['uuid-saved-1', 'Next turn (saved)']);
+			expect(enqueueWithIdSpy.mock.calls[0]).toEqual([
+				'uuid-enqueued-1',
+				'Current turn (enqueued)',
+			]);
+			expect(enqueueWithIdSpy.mock.calls[1]).toEqual(['uuid-deferred-1', 'Next turn (deferred)']);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -255,9 +255,9 @@ describe('SDKMessageHandler', () => {
 			expect((message as unknown as { isSynthetic: boolean }).isSynthetic).toBe(true);
 		});
 
-		it('should acknowledge persisted queued user messages without duplicate save', async () => {
+		it('should acknowledge persisted enqueued user messages without duplicate save', async () => {
 			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'queued' ? [{ dbId: 'db-msg-1', uuid: 'test-uuid' }] : []
+				status === 'enqueued' ? [{ dbId: 'db-msg-1', uuid: 'test-uuid' }] : []
 			);
 
 			const message: SDKMessage = {
@@ -268,14 +268,14 @@ describe('SDKMessageHandler', () => {
 
 			await handler.handleMessage(message);
 
-			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-msg-1'], 'sent');
+			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-msg-1'], 'consumed');
 			// Bug fix: timestamp must be updated so message appears at correct position
 			// after page refresh (not at original queue time)
 			expect(mockDb.updateMessageTimestamp).toHaveBeenCalledWith('db-msg-1');
 			expect(emitSpy).toHaveBeenCalledWith('messages.statusChanged', {
 				sessionId: 'test-session-id',
 				messageIds: ['db-msg-1'],
-				status: 'sent',
+				status: 'consumed',
 			});
 			expect(publishSpy).toHaveBeenCalledWith(
 				'state.sdkMessages.delta',
@@ -290,25 +290,25 @@ describe('SDKMessageHandler', () => {
 			expect((message as unknown as { isSynthetic?: boolean }).isSynthetic).toBeUndefined();
 		});
 
-		it('should acknowledge persisted saved user messages and update timestamp', async () => {
+		it('should acknowledge persisted deferred user messages and update timestamp', async () => {
 			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'saved' ? [{ dbId: 'db-saved-1', uuid: 'saved-uuid' }] : []
+				status === 'deferred' ? [{ dbId: 'db-deferred-1', uuid: 'deferred-uuid' }] : []
 			);
 
 			const message: SDKMessage = {
 				type: 'user',
-				uuid: 'saved-uuid',
+				uuid: 'deferred-uuid',
 				message: { role: 'user', content: 'Saved message' },
 			} as unknown as SDKMessage;
 
 			await handler.handleMessage(message);
 
-			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-saved-1'], 'sent');
-			expect(mockDb.updateMessageTimestamp).toHaveBeenCalledWith('db-saved-1');
+			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-deferred-1'], 'consumed');
+			expect(mockDb.updateMessageTimestamp).toHaveBeenCalledWith('db-deferred-1');
 			expect(emitSpy).toHaveBeenCalledWith('messages.statusChanged', {
 				sessionId: 'test-session-id',
-				messageIds: ['db-saved-1'],
-				status: 'sent',
+				messageIds: ['db-deferred-1'],
+				status: 'consumed',
 			});
 			expect(publishSpy).toHaveBeenCalledWith(
 				'state.sdkMessages.delta',
@@ -322,13 +322,13 @@ describe('SDKMessageHandler', () => {
 			expect(saveSDKMessageSpy).not.toHaveBeenCalled();
 		});
 
-		it('should suppress duplicate SDK replay for already-sent persisted user message', async () => {
+		it('should suppress duplicate SDK replay for already-consumed persisted user message', async () => {
 			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'sent' ? [{ dbId: 'db-msg-1', uuid: 'sent-user-uuid' }] : []
+				status === 'consumed' ? [{ dbId: 'db-msg-1', uuid: 'consumed-user-uuid' }] : []
 			);
 			const message: SDKMessage = {
 				type: 'user',
-				uuid: 'sent-user-uuid',
+				uuid: 'consumed-user-uuid',
 				message: { role: 'user', content: 'Already shown' },
 			} as unknown as SDKMessage;
 
@@ -493,7 +493,7 @@ describe('SDKMessageHandler', () => {
 
 		it('should not block handleResultMessage when /context enqueue fails', async () => {
 			// Bug fix: /context enqueue is fire-and-forget. If it rejects,
-			// handleResultMessage must still complete (set idle, ack queued, etc.)
+			// handleResultMessage must still complete (set idle, ack enqueued, etc.)
 			(mockMessageQueue.enqueueWithId as ReturnType<typeof mock>).mockImplementation(async () => {
 				throw new Error('Queue timeout');
 			});
@@ -521,13 +521,13 @@ describe('SDKMessageHandler', () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 
-		it('should fallback-ack oldest queued user on turn end when replay is absent', async () => {
+		it('should fallback-ack oldest enqueued user on turn end when replay is absent', async () => {
 			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) => {
-				if (status === 'queued') {
+				if (status === 'enqueued') {
 					return [
 						{
 							dbId: 'db-msg-1',
-							uuid: 'queued-user-uuid',
+							uuid: 'enqueued-user-uuid',
 							type: 'user',
 							timestamp: 1700000000000,
 							message: { role: 'user', content: 'Queued message' },
@@ -553,7 +553,7 @@ describe('SDKMessageHandler', () => {
 
 			await handler.handleMessage(message);
 
-			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-msg-1'], 'sent');
+			expect(updateMessageStatusSpy).toHaveBeenCalledWith(['db-msg-1'], 'consumed');
 			// Fallback-ack preserves original timestamp (T1) instead of updating
 			// to turn-end time — the message was already positioned at yield time
 			// by handleMessageYielded, or if that didn't fire, T1 is a better
@@ -562,7 +562,7 @@ describe('SDKMessageHandler', () => {
 			expect(emitSpy).toHaveBeenCalledWith('messages.statusChanged', {
 				sessionId: 'test-session-id',
 				messageIds: ['db-msg-1'],
-				status: 'sent',
+				status: 'consumed',
 			});
 			expect(publishSpy).toHaveBeenCalledWith(
 				'state.sdkMessages.delta',
@@ -570,7 +570,7 @@ describe('SDKMessageHandler', () => {
 					added: expect.arrayContaining([
 						expect.objectContaining({
 							type: 'user',
-							uuid: 'queued-user-uuid',
+							uuid: 'enqueued-user-uuid',
 						}),
 					]),
 					timestamp: expect.any(Number),
@@ -868,7 +868,7 @@ describe('SDKMessageHandler', () => {
 
 			await new Promise((resolve) => setTimeout(resolve, 50));
 
-			// Verify an assistant message was saved
+			// Verify an assistant message was deferred
 			const saveCalls = saveSDKMessageSpy.mock.calls;
 			const assistantSaves = saveCalls.filter(
 				(call: unknown[]) => (call[1] as SDKMessage).type === 'assistant'
@@ -996,7 +996,7 @@ describe('SDKMessageHandler', () => {
 
 			await handler.handleMessage(contextResponseMessage);
 
-			// Context response should NOT be saved to DB (early return)
+			// Context response should NOT be deferred to DB (early return)
 			expect(saveSDKMessageSpy).not.toHaveBeenCalled();
 
 			// But context tracker should be updated
@@ -1230,7 +1230,7 @@ describe('SDKMessageHandler', () => {
 			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(1);
 
 			// Step 5: next normal result — internalContextCommandIds must be empty now
-			// so /context gets queued again
+			// so /context gets enqueued again
 			const nextNormalResult: SDKMessage = {
 				type: 'result',
 				subtype: 'success',
@@ -1245,7 +1245,7 @@ describe('SDKMessageHandler', () => {
 				modelUsage: {},
 			} as unknown as SDKMessage;
 			await handler.handleMessage(nextNormalResult);
-			// internalContextCommandIds was cleared in step 4, so /context is queued again
+			// internalContextCommandIds was cleared in step 4, so /context is enqueued again
 			expect(mockMessageQueue.enqueueWithId).toHaveBeenCalledTimes(2);
 		});
 

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -359,7 +359,7 @@ describe('Leader Agent', () => {
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('sendToWorker');
-			expect(callbacks.calls[0].args).toEqual(['group-1', 'Queue this', 'queue', undefined]);
+			expect(callbacks.calls[0].args).toEqual(['group-1', 'Queue this', 'defer', undefined]);
 		});
 
 		it('should route send_to_worker with progress_summary to callback', async () => {

--- a/packages/daemon/tests/unit/room/leader-agent.test.ts
+++ b/packages/daemon/tests/unit/room/leader-agent.test.ts
@@ -355,7 +355,7 @@ describe('Leader Agent', () => {
 			const callbacks = makeCallbacks();
 			const handlers = createLeaderToolHandlers('group-1', callbacks);
 
-			await handlers.send_to_worker({ message: 'Queue this', mode: 'queue' });
+			await handlers.send_to_worker({ message: 'Queue this', mode: 'defer' });
 
 			expect(callbacks.calls).toHaveLength(1);
 			expect(callbacks.calls[0].method).toBe('sendToWorker');

--- a/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-flow.test.ts
@@ -535,7 +535,7 @@ describe('RoomRuntime flow', () => {
 
 			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Add error handling to the endpoint',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			// Group is back to awaiting_worker with iteration bumped
@@ -598,7 +598,7 @@ describe('RoomRuntime flow', () => {
 				// send_to_worker succeeds: feedbackIteration i+1 < 5
 				const r = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 					message: `Feedback round ${i + 1}`,
-					mode: 'queue',
+					mode: 'defer',
 				});
 				expect(JSON.parse(r.content[0].text).success).toBe(true);
 				expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(i + 1);
@@ -643,7 +643,7 @@ describe('RoomRuntime flow', () => {
 				});
 				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 					message: `Feedback ${i + 1}`,
-					mode: 'queue',
+					mode: 'defer',
 				});
 			}
 			await ctx.runtime.onWorkerTerminalState(group.id, {
@@ -652,7 +652,7 @@ describe('RoomRuntime flow', () => {
 			});
 			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Extra',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			// Task in review, not failed
@@ -680,7 +680,7 @@ describe('RoomRuntime flow', () => {
 				});
 				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 					message: `Round ${i + 1}`,
-					mode: 'queue',
+					mode: 'defer',
 				});
 			}
 			await ctx.runtime.onWorkerTerminalState(group.id, {
@@ -689,7 +689,7 @@ describe('RoomRuntime flow', () => {
 			});
 			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Trigger',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			// Task is in review, group awaiting_human
@@ -718,7 +718,7 @@ describe('RoomRuntime flow', () => {
 			// Leader can now send feedback without triggering re-escalation (1 < 5)
 			const r = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Good, keep going',
-				mode: 'queue',
+				mode: 'defer',
 			});
 			expect(JSON.parse(r.content[0].text).success).toBe(true);
 			expect(ctx.groupRepo.getGroup(group.id)!.submittedForReview).toBe(false);
@@ -738,7 +738,7 @@ describe('RoomRuntime flow', () => {
 				});
 				await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 					message: `Feedback round ${i + 1}`,
-					mode: 'queue',
+					mode: 'defer',
 				});
 				expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(i + 1);
 			}
@@ -778,7 +778,7 @@ describe('RoomRuntime flow', () => {
 			expect(ctx.groupRepo.getGroup(group.id)!.feedbackIteration).toBe(1);
 			await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Round 1',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			// Round 2: worker done → feedbackIteration becomes 2 (== maxFeedbackIterations)
@@ -791,7 +791,7 @@ describe('RoomRuntime flow', () => {
 			// Leader tries send_to_worker: 2 >= 2 → runtime escalates to human review
 			const escalationResult = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Trigger escalation',
-				mode: 'queue',
+				mode: 'defer',
 			});
 			expect(JSON.parse(escalationResult.content[0].text).success).toBe(false);
 			expect(JSON.parse(escalationResult.content[0].text).error).toContain('human review');
@@ -805,7 +805,7 @@ describe('RoomRuntime flow', () => {
 			// This should succeed because task.status === 'review' — no limit applies.
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Human reviewer feedback forwarded to worker',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			expect(JSON.parse(result.content[0].text).success).toBe(true);

--- a/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-leader-tools.test.ts
@@ -71,7 +71,7 @@ describe('RoomRuntime leader tools', () => {
 
 			const result = await ctx.runtime.handleLeaderTool(group.id, 'send_to_worker', {
 				message: 'Fix the tests',
-				mode: 'queue',
+				mode: 'defer',
 			});
 
 			const parsed = JSON.parse(result.content[0].text);
@@ -80,12 +80,12 @@ describe('RoomRuntime leader tools', () => {
 			const updatedGroup = ctx.groupRepo.getGroup(group.id)!;
 			expect(updatedGroup.submittedForReview).toBe(false);
 
-			// Should inject feedback into worker session using queue mode
+			// Should inject feedback into worker session using defer mode
 			const injectCalls = ctx.sessionFactory.calls.filter(
 				(c) => c.method === 'injectMessage' && (c.args[1] as string).includes('LEADER FEEDBACK')
 			);
 			expect(injectCalls.length).toBeGreaterThan(0);
-			expect(injectCalls[0].args[2]).toEqual({ deliveryMode: 'next_turn' });
+			expect(injectCalls[0].args[2]).toEqual({ deliveryMode: 'defer' });
 		});
 
 		it('should reject complete_task when not yet submitted for review or approved', async () => {

--- a/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-service-wiring.test.ts
@@ -393,9 +393,9 @@ describe('RoomRuntimeService message persistence reactivity', () => {
 			const after = reactiveDb.getTableVersion('sdk_messages');
 
 			expect(after).toBeGreaterThan(before);
-			const queued = reactiveDb.db.getMessagesByStatus('session-reactive-1', 'queued');
-			expect(queued).toHaveLength(1);
-			expect(queued[0]?.type).toBe('user');
+			const enqueued = reactiveDb.db.getMessagesByStatus('session-reactive-1', 'enqueued');
+			expect(enqueued).toHaveLength(1);
+			expect(enqueued[0]?.type).toBe('user');
 		} finally {
 			appDb.close();
 			try {

--- a/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-test-helpers.ts
@@ -68,7 +68,7 @@ export function createMockSessionFactory() {
 		async injectMessage(
 			sessionId: string,
 			message: string,
-			opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+			opts?: { deliveryMode?: 'immediate' | 'defer' }
 		) {
 			calls.push({ method: 'injectMessage', args: [sessionId, message, opts] });
 		},

--- a/packages/daemon/tests/unit/room/runtime-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/runtime-recovery.test.ts
@@ -37,7 +37,7 @@ function createMockSessionFactory() {
 		async injectMessage(
 			sessionId: string,
 			message: string,
-			opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+			opts?: { deliveryMode?: 'immediate' | 'defer' }
 		) {
 			calls.push({ method: 'injectMessage', args: [sessionId, message, opts] });
 		},

--- a/packages/daemon/tests/unit/room/task-group-manager.test.ts
+++ b/packages/daemon/tests/unit/room/task-group-manager.test.ts
@@ -67,7 +67,7 @@ function createMockSessionFactory(
 		async injectMessage(
 			sessionId: string,
 			message: string,
-			opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+			opts?: { deliveryMode?: 'immediate' | 'defer' }
 		) {
 			calls.push({ method: 'injectMessage', args: [sessionId, message, opts] });
 		},
@@ -460,7 +460,7 @@ describe('TaskGroupManager', () => {
 				async injectMessage(
 					sessionId: string,
 					message: string,
-					opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+					opts?: { deliveryMode?: 'immediate' | 'defer' }
 				) {
 					callOrder.push(`injectMessage:${sessionId.split(':')[0]}`);
 					await sessionFactory.injectMessage(sessionId, message, opts);
@@ -498,7 +498,7 @@ describe('TaskGroupManager', () => {
 			trackingFactory.injectMessage = async (
 				sessionId: string,
 				message: string,
-				opts?: { deliveryMode?: 'current_turn' | 'next_turn' }
+				opts?: { deliveryMode?: 'immediate' | 'defer' }
 			) => {
 				if (sessionId.startsWith('coder:')) {
 					observerRegisteredBeforeInject = workerObserverRegistered;

--- a/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/live-query-handlers.test.ts
@@ -280,7 +280,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status)
 				 VALUES ('${id}', '${sessionId}', 'assistant', NULL,
 				 '${JSON.stringify({ type: 'assistant', uuid: id, message: { content: [] } })}',
-				 '${new Date(timestampMs).toISOString()}', 'sent')`
+				 '${new Date(timestampMs).toISOString()}', 'consumed')`
 			);
 		}
 

--- a/packages/daemon/tests/unit/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/session-handlers.test.ts
@@ -719,7 +719,7 @@ describe('Session RPC Handlers', () => {
 				{
 					sessionId: 'session-123',
 					content: 'Queue this',
-					deliveryMode: 'next_turn',
+					deliveryMode: 'defer',
 				},
 				{}
 			);
@@ -729,7 +729,7 @@ describe('Session RPC Handlers', () => {
 				expect.objectContaining({
 					sessionId: 'session-123',
 					content: 'Queue this',
-					deliveryMode: 'next_turn',
+					deliveryMode: 'defer',
 				})
 			);
 		});
@@ -1242,7 +1242,7 @@ describe('Session RPC Handlers', () => {
 	});
 
 	describe('session.messages.countByStatus', () => {
-		it('returns count for saved status', async () => {
+		it('returns count for deferred status', async () => {
 			const handler = messageHubData.handlers.get('session.messages.countByStatus');
 			expect(handler).toBeDefined();
 
@@ -1250,12 +1250,12 @@ describe('Session RPC Handlers', () => {
 				getMessageCountByStatus: mock(() => 5),
 			} as unknown as ReturnType<typeof mock> extends ReturnType<typeof mock> ? object : never);
 
-			const result = await handler!({ sessionId: 'session-123', status: 'saved' }, {});
+			const result = await handler!({ sessionId: 'session-123', status: 'deferred' }, {});
 
 			expect(result).toEqual({ count: 5 });
 		});
 
-		it('returns count for queued status', async () => {
+		it('returns count for enqueued status', async () => {
 			const handler = messageHubData.handlers.get('session.messages.countByStatus');
 			expect(handler).toBeDefined();
 
@@ -1263,7 +1263,7 @@ describe('Session RPC Handlers', () => {
 				getMessageCountByStatus: mock(() => 3),
 			} as unknown as ReturnType<typeof mock> extends ReturnType<typeof mock> ? object : never);
 
-			const result = await handler!({ sessionId: 'session-123', status: 'queued' }, {});
+			const result = await handler!({ sessionId: 'session-123', status: 'enqueued' }, {});
 
 			expect(result).toEqual({ count: 3 });
 		});
@@ -1274,14 +1274,14 @@ describe('Session RPC Handlers', () => {
 
 			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);
 
-			await expect(handler!({ sessionId: 'non-existent', status: 'saved' }, {})).rejects.toThrow(
+			await expect(handler!({ sessionId: 'non-existent', status: 'deferred' }, {})).rejects.toThrow(
 				'Session not found'
 			);
 		});
 	});
 
 	describe('session.messages.byStatus', () => {
-		it('returns user message summaries for saved status', async () => {
+		it('returns user message summaries for deferred status', async () => {
 			const handler = messageHubData.handlers.get('session.messages.byStatus');
 			expect(handler).toBeDefined();
 
@@ -1294,13 +1294,13 @@ describe('Session RPC Handlers', () => {
 						type: 'user',
 						message: {
 							role: 'user',
-							content: [{ type: 'text', text: 'queued message' }],
+							content: [{ type: 'text', text: 'enqueued message' }],
 						},
 					},
 				]),
 			} as unknown as ReturnType<typeof mock> extends ReturnType<typeof mock> ? object : never);
 
-			const result = await handler!({ sessionId: 'session-123', status: 'saved' }, {});
+			const result = await handler!({ sessionId: 'session-123', status: 'deferred' }, {});
 
 			expect(result).toEqual({
 				messages: [
@@ -1308,8 +1308,8 @@ describe('Session RPC Handlers', () => {
 						dbId: 'db-1',
 						uuid: 'msg-1',
 						timestamp: 123,
-						status: 'saved',
-						text: 'queued message',
+						status: 'deferred',
+						text: 'enqueued message',
 					},
 				],
 			});

--- a/packages/daemon/tests/unit/session/message-persistence.test.ts
+++ b/packages/daemon/tests/unit/session/message-persistence.test.ts
@@ -82,7 +82,7 @@ describe('MessagePersistence', () => {
 		persistence = new MessagePersistence(mockSessionCache, mockDb, mockMessageHub, mockEventBus);
 	});
 
-	it('persists idle current_turn as sent and still dispatches to query', async () => {
+	it('persists idle immediate as consumed and still dispatches to query', async () => {
 		await persistence.persist({
 			sessionId: 'test-session-id',
 			messageId: 'msg-1',
@@ -92,7 +92,7 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-1', type: 'user' }),
-			'sent'
+			'consumed'
 		);
 		expect(messageHubEventSpy).toHaveBeenCalledWith(
 			'state.sdkMessages.delta',
@@ -102,20 +102,20 @@ describe('MessagePersistence', () => {
 		expect(eventBusEmitSpy).toHaveBeenCalledWith('messages.statusChanged', {
 			sessionId: 'test-session-id',
 			messageIds: ['db-msg-1'],
-			status: 'sent',
+			status: 'consumed',
 		});
 		expect(eventBusEmitSpy).toHaveBeenCalledWith(
 			'message.persisted',
 			expect.objectContaining({
 				sessionId: 'test-session-id',
 				messageId: 'msg-1',
-				sendStatus: 'sent',
-				deliveryMode: 'current_turn',
+				sendStatus: 'consumed',
+				deliveryMode: 'immediate',
 			})
 		);
 	});
 
-	it('persists busy current_turn as queued and does not immediately echo', async () => {
+	it('persists busy immediate as enqueued and does not immediately echo', async () => {
 		processingStateSpy.mockReturnValue({ status: 'processing' });
 
 		await persistence.persist({
@@ -127,33 +127,33 @@ describe('MessagePersistence', () => {
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-2', type: 'user' }),
-			'queued'
+			'enqueued'
 		);
 		expect(messageHubEventSpy).not.toHaveBeenCalled();
 		expect(eventBusEmitSpy).toHaveBeenCalledWith(
 			'message.persisted',
 			expect.objectContaining({
 				messageId: 'msg-2',
-				sendStatus: 'queued',
-				deliveryMode: 'current_turn',
+				sendStatus: 'enqueued',
+				deliveryMode: 'immediate',
 			})
 		);
 	});
 
-	it('persists busy next_turn as saved and does not dispatch', async () => {
+	it('persists busy defer as deferred and does not dispatch', async () => {
 		processingStateSpy.mockReturnValue({ status: 'processing' });
 
 		await persistence.persist({
 			sessionId: 'test-session-id',
 			messageId: 'msg-3',
 			content: 'next turn please',
-			deliveryMode: 'next_turn',
+			deliveryMode: 'defer',
 		});
 
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-3', type: 'user' }),
-			'saved'
+			'deferred'
 		);
 		expect(eventBusEmitSpy).not.toHaveBeenCalledWith(
 			'message.persisted',
@@ -161,27 +161,27 @@ describe('MessagePersistence', () => {
 		);
 	});
 
-	it('falls back idle next_turn to sent current_turn and dispatches', async () => {
+	it('falls back idle defer to consumed immediate and dispatches', async () => {
 		processingStateSpy.mockReturnValue({ status: 'idle' });
 
 		await persistence.persist({
 			sessionId: 'test-session-id',
 			messageId: 'msg-4',
 			content: 'next turn while idle',
-			deliveryMode: 'next_turn',
+			deliveryMode: 'defer',
 		});
 
 		expect(saveUserMessageSpy).toHaveBeenCalledWith(
 			'test-session-id',
 			expect.objectContaining({ uuid: 'msg-4', type: 'user' }),
-			'sent'
+			'consumed'
 		);
 		expect(eventBusEmitSpy).toHaveBeenCalledWith(
 			'message.persisted',
 			expect.objectContaining({
 				messageId: 'msg-4',
-				sendStatus: 'sent',
-				deliveryMode: 'current_turn',
+				sendStatus: 'consumed',
+				deliveryMode: 'immediate',
 			})
 		);
 	});

--- a/packages/daemon/tests/unit/space/provision-global-agent.test.ts
+++ b/packages/daemon/tests/unit/space/provision-global-agent.test.ts
@@ -480,7 +480,7 @@ describe('provisionGlobalSpacesAgent', () => {
 		const call = sessionFactory.calls[0];
 		expect(call.sessionId).toBe('spaces:global');
 		expect(call.message).toContain('[TASK_EVENT]');
-		expect(call.opts?.deliveryMode).toBe('next_turn');
+		expect(call.opts?.deliveryMode).toBe('defer');
 	});
 
 	// -------------------------------------------------------------------------
@@ -801,7 +801,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		expect(lastCall.message).toContain('space-001');
 		expect(lastCall.message).toContain('completed');
 		expect(lastCall.message).toContain('Feature implemented successfully.');
-		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
+		expect(lastCall.opts?.deliveryMode).toBe('defer');
 	});
 
 	test('injects failed notification into global session when space.task.failed fires', async () => {
@@ -829,7 +829,7 @@ describe('provisionGlobalSpacesAgent — task completion event subscriptions', (
 		expect(lastCall.message).toContain('space-001');
 		expect(lastCall.message).toContain('failed');
 		expect(lastCall.message).toContain('Tests are failing.');
-		expect(lastCall.opts?.deliveryMode).toBe('next_turn');
+		expect(lastCall.opts?.deliveryMode).toBe('defer');
 	});
 
 	test('uses "cancelled" label in notification when status is cancelled', async () => {

--- a/packages/daemon/tests/unit/space/session-notification-sink.test.ts
+++ b/packages/daemon/tests/unit/space/session-notification-sink.test.ts
@@ -111,7 +111,7 @@ describe('SessionNotificationSink', () => {
 			expect(factory.calls[0].sessionId).toBe(SESSION_ID);
 		});
 
-		it('uses next_turn delivery mode', async () => {
+		it('uses defer delivery mode', async () => {
 			const { sink, factory } = makeSink();
 			const event: SpaceNotificationEvent = {
 				kind: 'task_needs_attention',
@@ -123,7 +123,7 @@ describe('SessionNotificationSink', () => {
 
 			await sink.notify(event);
 
-			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+			expect(factory.calls[0].opts?.deliveryMode).toBe('defer');
 		});
 
 		it('message includes human-readable text with taskId, spaceId, and reason', async () => {
@@ -226,7 +226,7 @@ describe('SessionNotificationSink', () => {
 			expect(json.autonomyLevel).toBe('supervised');
 		});
 
-		it('uses next_turn delivery mode', async () => {
+		it('uses defer delivery mode', async () => {
 			const { sink, factory } = makeSink();
 			const event: SpaceNotificationEvent = {
 				kind: 'workflow_run_needs_attention',
@@ -238,7 +238,7 @@ describe('SessionNotificationSink', () => {
 
 			await sink.notify(event);
 
-			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+			expect(factory.calls[0].opts?.deliveryMode).toBe('defer');
 		});
 	});
 
@@ -266,7 +266,7 @@ describe('SessionNotificationSink', () => {
 			expect(json.autonomyLevel).toBe('supervised');
 		});
 
-		it('uses next_turn delivery mode', async () => {
+		it('uses defer delivery mode', async () => {
 			const { sink, factory } = makeSink();
 			const event: SpaceNotificationEvent = {
 				kind: 'task_timeout',
@@ -278,7 +278,7 @@ describe('SessionNotificationSink', () => {
 
 			await sink.notify(event);
 
-			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+			expect(factory.calls[0].opts?.deliveryMode).toBe('defer');
 		});
 	});
 
@@ -346,7 +346,7 @@ describe('SessionNotificationSink', () => {
 			expect(json.status).toBe('needs_attention');
 		});
 
-		it('uses next_turn delivery mode', async () => {
+		it('uses defer delivery mode', async () => {
 			const { sink, factory } = makeSink();
 			const event: SpaceNotificationEvent = {
 				kind: 'workflow_run_completed',
@@ -358,7 +358,7 @@ describe('SessionNotificationSink', () => {
 
 			await sink.notify(event);
 
-			expect(factory.calls[0].opts?.deliveryMode).toBe('next_turn');
+			expect(factory.calls[0].opts?.deliveryMode).toBe('defer');
 		});
 	});
 

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -7,7 +7,7 @@
  *   - Sub-session creation via SubSessionFactory
  *   - Completion callback registration and firing
  *   - Sub-session completion propagation to Task Agent
- *   - Message injection (current_turn and next_turn)
+ *   - Message injection (immediate and defer)
  *   - isTaskAgentAlive detection
  *   - cleanup: stops sessions and removes DB records
  *   - Error handling
@@ -1292,7 +1292,7 @@ describe('TaskAgentManager', () => {
 		});
 	});
 
-	describe('injectMessageIntoSession — next_turn delivery', () => {
+	describe('injectMessageIntoSession — defer delivery', () => {
 		/** Helper to call the private method directly */
 		function callInjectMessage(
 			manager: TaskAgentManager,
@@ -1331,7 +1331,7 @@ describe('TaskAgentManager', () => {
 				return 'msg-id';
 			};
 
-			await callInjectMessage(ctx.manager, session, 'step done', 'next_turn');
+			await callInjectMessage(ctx.manager, session, 'step done', 'defer');
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
@@ -1362,7 +1362,7 @@ describe('TaskAgentManager', () => {
 				return 'msg-id';
 			};
 
-			await callInjectMessage(ctx.manager, session, 'step done', 'next_turn');
+			await callInjectMessage(ctx.manager, session, 'step done', 'defer');
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
@@ -1371,10 +1371,10 @@ describe('TaskAgentManager', () => {
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 
-		test('saves with "saved" status when session is interrupted (next_turn deferred)', async () => {
-			// 'interrupted' is included in isBusy for next_turn delivery.
-			// A next_turn message to an interrupted session should be deferred, not sent
-			// blindly — the session may restart on its own or receive a current_turn message.
+		test('saves with "saved" status when session is interrupted (defer deferred)', async () => {
+			// 'interrupted' is included in isBusy for defer delivery.
+			// A defer message to an interrupted session should be deferred, not sent
+			// blindly — the session may restart on its own or receive a immediate message.
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 			const session = ctx.createdSessions.get(sessionId)!;
@@ -1393,7 +1393,7 @@ describe('TaskAgentManager', () => {
 				return 'msg-id';
 			};
 
-			await callInjectMessage(ctx.manager, session, 'check in', 'next_turn');
+			await callInjectMessage(ctx.manager, session, 'check in', 'defer');
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
@@ -1401,8 +1401,8 @@ describe('TaskAgentManager', () => {
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 
-		test('enqueues immediately for current_turn when session is interrupted (restartable)', async () => {
-			// An interrupted session can accept a current_turn message: ensureQueryStarted
+		test('enqueues immediately for immediate when session is interrupted (restartable)', async () => {
+			// An interrupted session can accept a immediate message: ensureQueryStarted
 			// restarts the query and the message is enqueued normally.
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
@@ -1411,12 +1411,12 @@ describe('TaskAgentManager', () => {
 			session._processingState = { status: 'interrupted' } as AgentProcessingState;
 			const msgsBefore = session._enqueuedMessages.length;
 
-			await callInjectMessage(ctx.manager, session, 'restart signal', 'current_turn');
+			await callInjectMessage(ctx.manager, session, 'restart signal', 'immediate');
 
 			expect(session._enqueuedMessages.length).toBeGreaterThan(msgsBefore);
 		});
 
-		test('enqueues immediately for next_turn when session is idle', async () => {
+		test('enqueues immediately for defer when session is idle', async () => {
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 			const session = ctx.createdSessions.get(sessionId)!;
@@ -1424,7 +1424,7 @@ describe('TaskAgentManager', () => {
 
 			const msgsBefore = session._enqueuedMessages.length;
 
-			await callInjectMessage(ctx.manager, session, 'idle delivery', 'next_turn');
+			await callInjectMessage(ctx.manager, session, 'idle delivery', 'defer');
 
 			expect(session._enqueuedMessages.length).toBeGreaterThan(msgsBefore);
 		});

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -1311,7 +1311,7 @@ describe('TaskAgentManager', () => {
 			).injectMessageIntoSession(session, message, deliveryMode);
 		}
 
-		test('saves with "saved" status and does not enqueue when session is processing', async () => {
+		test('saves with "deferred" status and does not enqueue when session is processing', async () => {
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 			const session = ctx.createdSessions.get(sessionId)!;
@@ -1335,12 +1335,12 @@ describe('TaskAgentManager', () => {
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
-			expect(savedStatuses).toEqual(['saved']);
+			expect(savedStatuses).toEqual(['deferred']);
 			// No additional enqueue should have happened
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 
-		test('saves with "saved" status when session is waiting_for_input', async () => {
+		test('saves with "deferred" status when session is waiting_for_input', async () => {
 			const task = await makeTask(ctx.taskManager);
 			const sessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 			const session = ctx.createdSessions.get(sessionId)!;
@@ -1366,12 +1366,12 @@ describe('TaskAgentManager', () => {
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
-			expect(savedStatuses).toEqual(['saved']);
+			expect(savedStatuses).toEqual(['deferred']);
 			// No additional enqueue should have happened
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 
-		test('saves with "saved" status when session is interrupted (defer deferred)', async () => {
+		test('saves with "deferred" status when session is interrupted (defer deferred)', async () => {
 			// 'interrupted' is included in isBusy for defer delivery.
 			// A defer message to an interrupted session should be deferred, not sent
 			// blindly — the session may restart on its own or receive a immediate message.
@@ -1397,7 +1397,7 @@ describe('TaskAgentManager', () => {
 
 			ctx.mockDb.saveUserMessage = originalSave;
 
-			expect(savedStatuses).toEqual(['saved']);
+			expect(savedStatuses).toEqual(['deferred']);
 			expect(session._enqueuedMessages.length).toBe(enqueuedBefore);
 		});
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-44_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-44_test.ts
@@ -1,0 +1,120 @@
+/**
+ * Migration 44 Tests
+ *
+ * Migration 44 renames sdk_messages.send_status values:
+ * - saved -> deferred
+ * - queued -> enqueued
+ * - sent -> consumed
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+
+function getSdkMessagesTableSql(db: BunDatabase): string {
+	const row = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='sdk_messages'`)
+		.get() as { sql: string } | null;
+	return row?.sql ?? '';
+}
+
+describe('Migration 44: rename sdk_messages send_status values', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-44', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB uses deferred/enqueued/consumed constraint', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		const sql = getSdkMessagesTableSql(db);
+		expect(sql).toContain("'deferred'");
+		expect(sql).toContain("'enqueued'");
+		expect(sql).toContain("'consumed'");
+		expect(sql).toContain("'failed'");
+		expect(sql).not.toContain("'saved'");
+		expect(sql).not.toContain("'sent'");
+	});
+
+	test('existing DB rows are renamed from saved/queued/sent', () => {
+		db.exec(`
+			CREATE TABLE sessions (
+				id TEXT PRIMARY KEY,
+				title TEXT NOT NULL,
+				workspace_path TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				last_active_at TEXT NOT NULL,
+				status TEXT NOT NULL,
+				config TEXT NOT NULL,
+				metadata TEXT NOT NULL
+			);
+			CREATE TABLE sdk_messages (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				message_type TEXT NOT NULL,
+				message_subtype TEXT,
+				sdk_message TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				send_status TEXT DEFAULT 'sent' CHECK(send_status IN ('saved', 'queued', 'sent', 'failed')),
+				FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+			);
+			CREATE INDEX idx_sdk_messages_session_id ON sdk_messages(session_id);
+			CREATE INDEX idx_sdk_messages_send_status ON sdk_messages(session_id, send_status);
+		`);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO sessions (id, title, workspace_path, created_at, last_active_at, status, config, metadata)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('session-1', 'S', '/tmp', now, now, 'active', '{}', '{}');
+
+		const insert = db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status)
+			 VALUES (?, ?, 'user', NULL, ?, ?, ?)`
+		);
+		insert.run('m-saved', 'session-1', '{"type":"user"}', now, 'saved');
+		insert.run('m-queued', 'session-1', '{"type":"user"}', now, 'queued');
+		insert.run('m-sent', 'session-1', '{"type":"user"}', now, 'sent');
+		insert.run('m-failed', 'session-1', '{"type":"user"}', now, 'failed');
+
+		runMigrations(db, () => {});
+
+		const rows = db
+			.prepare(`SELECT id, send_status FROM sdk_messages ORDER BY id ASC`)
+			.all() as Array<{ id: string; send_status: string }>;
+		const byId = new Map(rows.map((r) => [r.id, r.send_status]));
+		expect(byId.get('m-saved')).toBe('deferred');
+		expect(byId.get('m-queued')).toBe('enqueued');
+		expect(byId.get('m-sent')).toBe('consumed');
+		expect(byId.get('m-failed')).toBe('failed');
+
+		const sql = getSdkMessagesTableSql(db);
+		expect(sql).toContain("'deferred'");
+		expect(sql).toContain("'enqueued'");
+		expect(sql).toContain("'consumed'");
+		expect(sql).toContain("'failed'");
+	});
+});

--- a/packages/daemon/tests/unit/storage/migrations/migration-44_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-44_test.ts
@@ -99,6 +99,7 @@ describe('Migration 44: rename sdk_messages send_status values', () => {
 		insert.run('m-queued', 'session-1', '{"type":"user"}', now, 'queued');
 		insert.run('m-sent', 'session-1', '{"type":"user"}', now, 'sent');
 		insert.run('m-failed', 'session-1', '{"type":"user"}', now, 'failed');
+		insert.run('m-null', 'session-1', '{"type":"user"}', now, null);
 
 		runMigrations(db, () => {});
 
@@ -110,6 +111,7 @@ describe('Migration 44: rename sdk_messages send_status values', () => {
 		expect(byId.get('m-queued')).toBe('enqueued');
 		expect(byId.get('m-sent')).toBe('consumed');
 		expect(byId.get('m-failed')).toBe('failed');
+		expect(byId.get('m-null')).toBe('consumed');
 
 		const sql = getSdkMessagesTableSql(db);
 		expect(sql).toContain("'deferred'");

--- a/packages/daemon/tests/unit/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/sdk-message-repository.test.ts
@@ -270,10 +270,10 @@ describe('SDKMessageRepository', () => {
 			expect(hasMore).toBe(true); // Can't know for sure, so assume there might be more
 		});
 
-		it('should exclude unsent user messages from transcript query', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Saved user message'), 'saved');
-			repository.saveUserMessage('session-1', createUserMessage('Queued user message'), 'queued');
-			repository.saveUserMessage('session-1', createUserMessage('Sent user message'), 'sent');
+		it('should exclude unconsumed user messages from transcript query', () => {
+			repository.saveUserMessage('session-1', createUserMessage('Saved user message'), 'deferred');
+			repository.saveUserMessage('session-1', createUserMessage('Queued user message'), 'enqueued');
+			repository.saveUserMessage('session-1', createUserMessage('Sent user message'), 'consumed');
 			repository.saveSDKMessage('session-1', createAssistantMessage('Assistant response'));
 
 			const { messages } = repository.getSDKMessages('session-1');
@@ -365,10 +365,10 @@ describe('SDKMessageRepository', () => {
 			expect(count).toBe(0);
 		});
 
-		it('should not count unsent user messages', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Saved'), 'saved');
-			repository.saveUserMessage('session-1', createUserMessage('Queued'), 'queued');
-			repository.saveUserMessage('session-1', createUserMessage('Sent'), 'sent');
+		it('should not count unconsumed user messages', () => {
+			repository.saveUserMessage('session-1', createUserMessage('Saved'), 'deferred');
+			repository.saveUserMessage('session-1', createUserMessage('Queued'), 'enqueued');
+			repository.saveUserMessage('session-1', createUserMessage('Sent'), 'consumed');
 
 			const count = repository.getSDKMessageCount('session-1');
 			expect(count).toBe(1);
@@ -376,32 +376,32 @@ describe('SDKMessageRepository', () => {
 	});
 
 	describe('saveUserMessage', () => {
-		it('should save user message with sent status by default', () => {
+		it('should save user message with consumed status by default', () => {
 			const message = createUserMessage('Test message');
 
 			const id = repository.saveUserMessage('session-1', message);
 
 			expect(id).toBeDefined();
-			const savedMessages = repository.getMessagesByStatus('session-1', 'sent');
-			expect(savedMessages.length).toBe(1);
+			const deferredMessages = repository.getMessagesByStatus('session-1', 'consumed');
+			expect(deferredMessages.length).toBe(1);
 		});
 
 		it('should save user message with specified status', () => {
 			const message = createUserMessage('Test message');
 
-			repository.saveUserMessage('session-1', message, 'saved');
+			repository.saveUserMessage('session-1', message, 'deferred');
 
-			const savedMessages = repository.getMessagesByStatus('session-1', 'saved');
-			expect(savedMessages.length).toBe(1);
+			const deferredMessages = repository.getMessagesByStatus('session-1', 'deferred');
+			expect(deferredMessages.length).toBe(1);
 		});
 
-		it('should save user message with queued status', () => {
+		it('should save user message with enqueued status', () => {
 			const message = createUserMessage('Test message');
 
-			repository.saveUserMessage('session-1', message, 'queued');
+			repository.saveUserMessage('session-1', message, 'enqueued');
 
-			const queuedMessages = repository.getMessagesByStatus('session-1', 'queued');
-			expect(queuedMessages.length).toBe(1);
+			const enqueuedMessages = repository.getMessagesByStatus('session-1', 'enqueued');
+			expect(enqueuedMessages.length).toBe(1);
 		});
 
 		it('should return unique message ID', () => {
@@ -419,24 +419,24 @@ describe('SDKMessageRepository', () => {
 		it('should return messages with specified status', () => {
 			const msg1 = createUserMessage('Saved message');
 			const msg2 = createUserMessage('Sent message');
-			repository.saveUserMessage('session-1', msg1, 'saved');
-			repository.saveUserMessage('session-1', msg2, 'sent');
+			repository.saveUserMessage('session-1', msg1, 'deferred');
+			repository.saveUserMessage('session-1', msg2, 'consumed');
 
-			const savedMessages = repository.getMessagesByStatus('session-1', 'saved');
-			const sentMessages = repository.getMessagesByStatus('session-1', 'sent');
+			const deferredMessages = repository.getMessagesByStatus('session-1', 'deferred');
+			const consumedMessages = repository.getMessagesByStatus('session-1', 'consumed');
 
-			expect(savedMessages.length).toBe(1);
-			expect(sentMessages.length).toBe(1);
+			expect(deferredMessages.length).toBe(1);
+			expect(consumedMessages.length).toBe(1);
 		});
 
 		it('should return messages in chronological order', async () => {
-			repository.saveUserMessage('session-1', createUserMessage('First'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('First'), 'deferred');
 			await new Promise((r) => setTimeout(r, 5));
-			repository.saveUserMessage('session-1', createUserMessage('Second'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('Second'), 'deferred');
 			await new Promise((r) => setTimeout(r, 5));
-			repository.saveUserMessage('session-1', createUserMessage('Third'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('Third'), 'deferred');
 
-			const messages = repository.getMessagesByStatus('session-1', 'saved');
+			const messages = repository.getMessagesByStatus('session-1', 'deferred');
 
 			expect(messages.length).toBe(3);
 			// Chronological order means oldest first
@@ -458,9 +458,9 @@ describe('SDKMessageRepository', () => {
 		});
 
 		it('should include dbId and timestamp in returned messages', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Test'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('Test'), 'deferred');
 
-			const messages = repository.getMessagesByStatus('session-1', 'saved');
+			const messages = repository.getMessagesByStatus('session-1', 'deferred');
 
 			expect(messages.length).toBe(1);
 			expect(messages[0].dbId).toBeDefined();
@@ -468,58 +468,58 @@ describe('SDKMessageRepository', () => {
 		});
 
 		it('should return empty array for non-matching status', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Test'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('Test'), 'deferred');
 
-			const queuedMessages = repository.getMessagesByStatus('session-1', 'queued');
+			const enqueuedMessages = repository.getMessagesByStatus('session-1', 'enqueued');
 
-			expect(queuedMessages).toEqual([]);
+			expect(enqueuedMessages).toEqual([]);
 		});
 	});
 
 	describe('updateMessageStatus', () => {
 		it('should update status for specified message IDs', () => {
-			const id1 = repository.saveUserMessage('session-1', createUserMessage('Msg 1'), 'saved');
-			const id2 = repository.saveUserMessage('session-1', createUserMessage('Msg 2'), 'saved');
+			const id1 = repository.saveUserMessage('session-1', createUserMessage('Msg 1'), 'deferred');
+			const id2 = repository.saveUserMessage('session-1', createUserMessage('Msg 2'), 'deferred');
 
-			repository.updateMessageStatus([id1, id2], 'queued');
+			repository.updateMessageStatus([id1, id2], 'enqueued');
 
-			const queuedMessages = repository.getMessagesByStatus('session-1', 'queued');
-			expect(queuedMessages.length).toBe(2);
+			const enqueuedMessages = repository.getMessagesByStatus('session-1', 'enqueued');
+			expect(enqueuedMessages.length).toBe(2);
 		});
 
 		it('should not throw when given empty array', () => {
-			expect(() => repository.updateMessageStatus([], 'sent')).not.toThrow();
+			expect(() => repository.updateMessageStatus([], 'consumed')).not.toThrow();
 		});
 
-		it('should transition from saved to queued to sent', () => {
-			const id = repository.saveUserMessage('session-1', createUserMessage('Test'), 'saved');
+		it('should transition from deferred to enqueued to consumed', () => {
+			const id = repository.saveUserMessage('session-1', createUserMessage('Test'), 'deferred');
 
-			repository.updateMessageStatus([id], 'queued');
-			expect(repository.getMessagesByStatus('session-1', 'queued').length).toBe(1);
+			repository.updateMessageStatus([id], 'enqueued');
+			expect(repository.getMessagesByStatus('session-1', 'enqueued').length).toBe(1);
 
-			repository.updateMessageStatus([id], 'sent');
-			expect(repository.getMessagesByStatus('session-1', 'sent').length).toBe(1);
-			expect(repository.getMessagesByStatus('session-1', 'queued').length).toBe(0);
+			repository.updateMessageStatus([id], 'consumed');
+			expect(repository.getMessagesByStatus('session-1', 'consumed').length).toBe(1);
+			expect(repository.getMessagesByStatus('session-1', 'enqueued').length).toBe(0);
 		});
 	});
 
 	describe('getMessageCountByStatus', () => {
 		it('should return count of messages with specified status', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Msg 1'), 'saved');
-			repository.saveUserMessage('session-1', createUserMessage('Msg 2'), 'saved');
-			repository.saveUserMessage('session-1', createUserMessage('Msg 3'), 'sent');
+			repository.saveUserMessage('session-1', createUserMessage('Msg 1'), 'deferred');
+			repository.saveUserMessage('session-1', createUserMessage('Msg 2'), 'deferred');
+			repository.saveUserMessage('session-1', createUserMessage('Msg 3'), 'consumed');
 
-			const savedCount = repository.getMessageCountByStatus('session-1', 'saved');
-			const sentCount = repository.getMessageCountByStatus('session-1', 'sent');
+			const deferredCount = repository.getMessageCountByStatus('session-1', 'deferred');
+			const consumedCount = repository.getMessageCountByStatus('session-1', 'consumed');
 
-			expect(savedCount).toBe(2);
-			expect(sentCount).toBe(1);
+			expect(deferredCount).toBe(2);
+			expect(consumedCount).toBe(1);
 		});
 
 		it('should return 0 for non-matching status', () => {
-			repository.saveUserMessage('session-1', createUserMessage('Test'), 'saved');
+			repository.saveUserMessage('session-1', createUserMessage('Test'), 'deferred');
 
-			const count = repository.getMessageCountByStatus('session-1', 'queued');
+			const count = repository.getMessageCountByStatus('session-1', 'enqueued');
 
 			expect(count).toBe(0);
 		});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -312,11 +312,11 @@ export interface SessionConfig extends Omit<SDKConfig, 'tools'> {
 
 	/**
 	 * Query mode for message sending behavior
-	 * - 'immediate': Messages sent to Claude immediately (default)
-	 * - 'manual': Messages saved but not sent until explicitly triggered
+	 * - 'immediate': Messages are enqueued for immediate delivery (default)
+	 * - 'manual': Messages are deferred until explicitly triggered
 	 *
-	 * Note: Auto-queue behavior (messages queued during processing) is automatic
-	 * and doesn't require a separate mode setting.
+	 * Note: auto-defer behavior (messages enqueued during active processing)
+	 * is automatic and doesn't require a separate mode setting.
 	 * @default 'immediate'
 	 */
 	queryMode?: 'immediate' | 'manual';
@@ -604,7 +604,7 @@ export interface MessageImage {
 	media_type: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
 }
 
-export type MessageDeliveryMode = 'current_turn' | 'next_turn';
+export type MessageDeliveryMode = 'immediate' | 'defer';
 
 // Tool types
 export interface Tool {

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -56,7 +56,7 @@ interface QueuedOverlayMessage {
 	uuid: string;
 	text: string;
 	timestamp: number;
-	status: 'saved' | 'queued' | 'sent';
+	status: 'deferred' | 'enqueued' | 'consumed';
 }
 
 export default function MessageInput({
@@ -132,20 +132,20 @@ export default function MessageInput({
 		}
 
 		try {
-			const [queuedResponse, savedResponse] = (await Promise.all([
+			const [enqueuedResponse, deferredResponse] = (await Promise.all([
 				hub.request('session.messages.byStatus', {
 					sessionId,
-					status: 'queued',
+					status: 'enqueued',
 					limit: 20,
 				}),
 				hub.request('session.messages.byStatus', {
 					sessionId,
-					status: 'saved',
+					status: 'deferred',
 					limit: 20,
 				}),
 			])) as [{ messages?: QueuedOverlayMessage[] }, { messages?: QueuedOverlayMessage[] }];
-			setQueuedForCurrentTurn(queuedResponse.messages ?? []);
-			setQueuedForNextTurn(savedResponse.messages ?? []);
+			setQueuedForCurrentTurn(enqueuedResponse.messages ?? []);
+			setQueuedForNextTurn(deferredResponse.messages ?? []);
 		} catch {
 			// Best-effort queue refresh
 		}
@@ -166,7 +166,7 @@ export default function MessageInput({
 
 	// Submit handler
 	const handleSubmit = useCallback(
-		async (deliveryMode: MessageDeliveryMode = 'current_turn') => {
+		async (deliveryMode: MessageDeliveryMode = 'immediate') => {
 			if (disabled) {
 				return;
 			}
@@ -181,7 +181,7 @@ export default function MessageInput({
 			await onSend(outgoing.content, outgoing.images, deliveryMode);
 			if (
 				agentWorking ||
-				deliveryMode === 'next_turn' ||
+				deliveryMode === 'defer' ||
 				queuedForCurrentTurn.length > 0 ||
 				queuedForNextTurn.length > 0
 			) {
@@ -211,7 +211,7 @@ export default function MessageInput({
 
 			if (e.key === 'Tab' && !e.shiftKey && agentWorking) {
 				e.preventDefault();
-				void handleSubmit('next_turn');
+				void handleSubmit('defer');
 				return;
 			}
 
@@ -219,7 +219,7 @@ export default function MessageInput({
 			if (e.key === 'Enter') {
 				if (e.metaKey || e.ctrlKey) {
 					e.preventDefault();
-					void handleSubmit('current_turn');
+					void handleSubmit('immediate');
 					return;
 				}
 
@@ -230,7 +230,7 @@ export default function MessageInput({
 
 				if (!isTouchDevice && !e.shiftKey) {
 					e.preventDefault();
-					void handleSubmit('current_turn');
+					void handleSubmit('immediate');
 				}
 			}
 		},
@@ -329,7 +329,7 @@ export default function MessageInput({
 				<form
 					onSubmit={(e) => {
 						e.preventDefault();
-						void handleSubmit('current_turn');
+						void handleSubmit('immediate');
 					}}
 				>
 					{/* Attachment Preview */}
@@ -374,7 +374,7 @@ export default function MessageInput({
 							)}
 							{queuedForNextTurn.length > 3 && (
 								<p class="pointer-events-none text-xs text-blue-200/80">
-									+{queuedForNextTurn.length - 3} more queued
+									+{queuedForNextTurn.length - 3} more deferred
 								</p>
 							)}
 						</div>
@@ -419,7 +419,7 @@ export default function MessageInput({
 							onContentChange={setContent}
 							onKeyDown={handleKeyDown}
 							onSubmit={() => {
-								void handleSubmit('current_turn');
+								void handleSubmit('immediate');
 							}}
 							disabled={disabled}
 							placeholder={getPlaceholderForSessionType(sessionType)}

--- a/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
@@ -20,10 +20,10 @@ function setQueueResponses({
 	saved?: Array<Record<string, unknown>>;
 }) {
 	mockRequest.mockImplementation(async (_method: string, payload: { status?: string }) => {
-		if (payload?.status === 'queued') {
+		if (payload?.status === 'enqueued') {
 			return { messages: queued };
 		}
-		if (payload?.status === 'saved') {
+		if (payload?.status === 'deferred') {
 			return { messages: saved };
 		}
 		return { messages: [] };
@@ -137,7 +137,7 @@ describe('MessageInput queue mode', () => {
 		});
 
 		expect(onSend).toHaveBeenCalledTimes(1);
-		expect(onSend).toHaveBeenCalledWith('follow-up for next turn', undefined, 'next_turn');
+		expect(onSend).toHaveBeenCalledWith('follow-up for next turn', undefined, 'defer');
 	});
 
 	it('sends immediately with Enter while agent is working', async () => {
@@ -153,7 +153,7 @@ describe('MessageInput queue mode', () => {
 		});
 
 		expect(onSend).toHaveBeenCalledTimes(1);
-		expect(onSend).toHaveBeenCalledWith('inject now', undefined, 'current_turn');
+		expect(onSend).toHaveBeenCalledWith('inject now', undefined, 'immediate');
 		expect(container.textContent).not.toContain('Agent is running. Press Enter to send now');
 	});
 
@@ -242,7 +242,7 @@ describe('MessageInput queue mode', () => {
 			fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
 		});
 
-		expect(onSend).toHaveBeenCalledWith('force send', undefined, 'current_turn');
+		expect(onSend).toHaveBeenCalledWith('force send', undefined, 'immediate');
 	});
 
 	it('does not send when disabled', async () => {
@@ -273,7 +273,7 @@ describe('MessageInput queue mode', () => {
 					uuid: 'msg-1',
 					text: 'saved on server',
 					timestamp: Date.now(),
-					status: 'saved',
+					status: 'deferred',
 				},
 			],
 		});
@@ -298,7 +298,7 @@ describe('MessageInput queue mode', () => {
 					uuid: 'msg-1',
 					text: 'queued for current turn',
 					timestamp: Date.now(),
-					status: 'queued',
+					status: 'enqueued',
 				},
 			],
 		});
@@ -324,7 +324,7 @@ describe('MessageInput queue mode', () => {
 					uuid: 'q1',
 					text: 'current-turn pending item',
 					timestamp: Date.now(),
-					status: 'queued',
+					status: 'enqueued',
 				},
 			],
 			saved: [
@@ -333,7 +333,7 @@ describe('MessageInput queue mode', () => {
 					uuid: 's1',
 					text: 'next-turn queued item',
 					timestamp: Date.now(),
-					status: 'saved',
+					status: 'deferred',
 				},
 			],
 		});
@@ -355,12 +355,30 @@ describe('MessageInput queue mode', () => {
 		mockAgentWorking.value = true;
 		setQueueResponses({
 			queued: [
-				{ dbId: 'db-q1', uuid: 'q1', text: 'first now', timestamp: Date.now(), status: 'queued' },
-				{ dbId: 'db-q2', uuid: 'q2', text: 'second now', timestamp: Date.now(), status: 'queued' },
+				{ dbId: 'db-q1', uuid: 'q1', text: 'first now', timestamp: Date.now(), status: 'enqueued' },
+				{
+					dbId: 'db-q2',
+					uuid: 'q2',
+					text: 'second now',
+					timestamp: Date.now(),
+					status: 'enqueued',
+				},
 			],
 			saved: [
-				{ dbId: 'db-s1', uuid: 's1', text: 'first next', timestamp: Date.now(), status: 'saved' },
-				{ dbId: 'db-s2', uuid: 's2', text: 'second next', timestamp: Date.now(), status: 'saved' },
+				{
+					dbId: 'db-s1',
+					uuid: 's1',
+					text: 'first next',
+					timestamp: Date.now(),
+					status: 'deferred',
+				},
+				{
+					dbId: 'db-s2',
+					uuid: 's2',
+					text: 'second next',
+					timestamp: Date.now(),
+					status: 'deferred',
+				},
 			],
 		});
 
@@ -387,7 +405,7 @@ describe('MessageInput queue mode', () => {
 						uuid: 'q2',
 						text: 'newly pending current-turn item',
 						timestamp: Date.now(),
-						status: 'queued',
+						status: 'enqueued',
 					},
 				],
 			});
@@ -403,7 +421,7 @@ describe('MessageInput queue mode', () => {
 			await Promise.resolve();
 		});
 
-		expect(onSend).toHaveBeenCalledWith('send now', undefined, 'current_turn');
+		expect(onSend).toHaveBeenCalledWith('send now', undefined, 'immediate');
 		expect(container.querySelector('[data-testid="queued-current-turn-bubble"]')).toBeTruthy();
 		expect(container.textContent).toContain('newly pending current-turn item');
 	});
@@ -417,7 +435,7 @@ describe('MessageInput queue mode', () => {
 					uuid: 'msg-1',
 					text: 'position check',
 					timestamp: Date.now(),
-					status: 'queued',
+					status: 'enqueued',
 				},
 			],
 		});
@@ -441,10 +459,10 @@ describe('MessageInput queue mode', () => {
 		mockAgentWorking.value = true;
 		setQueueResponses({
 			saved: [
-				{ dbId: 'db-1', uuid: 'u1', text: 'one', timestamp: Date.now(), status: 'saved' },
-				{ dbId: 'db-2', uuid: 'u2', text: 'two', timestamp: Date.now(), status: 'saved' },
-				{ dbId: 'db-3', uuid: 'u3', text: 'three', timestamp: Date.now(), status: 'saved' },
-				{ dbId: 'db-4', uuid: 'u4', text: 'four', timestamp: Date.now(), status: 'saved' },
+				{ dbId: 'db-1', uuid: 'u1', text: 'one', timestamp: Date.now(), status: 'deferred' },
+				{ dbId: 'db-2', uuid: 'u2', text: 'two', timestamp: Date.now(), status: 'deferred' },
+				{ dbId: 'db-3', uuid: 'u3', text: 'three', timestamp: Date.now(), status: 'deferred' },
+				{ dbId: 'db-4', uuid: 'u4', text: 'four', timestamp: Date.now(), status: 'deferred' },
 			],
 		});
 
@@ -455,7 +473,7 @@ describe('MessageInput queue mode', () => {
 			await Promise.resolve();
 		});
 
-		expect(container.textContent).toContain('+1 more queued');
+		expect(container.textContent).toContain('+1 more deferred');
 	});
 
 	it('polls server queue while active', async () => {
@@ -478,12 +496,12 @@ describe('MessageInput queue mode', () => {
 			expect(mockRequest.mock.calls.length).toBeGreaterThan(initialCalls);
 			expect(mockRequest).toHaveBeenCalledWith('session.messages.byStatus', {
 				sessionId: 'session-1',
-				status: 'queued',
+				status: 'enqueued',
 				limit: 20,
 			});
 			expect(mockRequest).toHaveBeenCalledWith('session.messages.byStatus', {
 				sessionId: 'session-1',
-				status: 'saved',
+				status: 'deferred',
 				limit: 20,
 			});
 		} finally {
@@ -497,7 +515,7 @@ describe('MessageInput queue mode', () => {
 			mockAgentWorking.value = true;
 			let queuedCalls = 0;
 			mockRequest.mockImplementation(async (_method: string, payload: { status?: string }) => {
-				if (payload?.status === 'queued') {
+				if (payload?.status === 'enqueued') {
 					queuedCalls++;
 					if (queuedCalls === 1) {
 						return {
@@ -507,7 +525,7 @@ describe('MessageInput queue mode', () => {
 									uuid: 'q1',
 									text: 'transient queued item',
 									timestamp: Date.now(),
-									status: 'queued',
+									status: 'enqueued',
 								},
 							],
 						};
@@ -544,7 +562,7 @@ describe('MessageInput queue mode', () => {
 			let queuedCalls = 0;
 			let savedCalls = 0;
 			mockRequest.mockImplementation(async (_method: string, payload: { status?: string }) => {
-				if (payload?.status === 'queued') {
+				if (payload?.status === 'enqueued') {
 					queuedCalls++;
 					if (queuedCalls >= 2) {
 						return {
@@ -554,14 +572,14 @@ describe('MessageInput queue mode', () => {
 									uuid: 'x1',
 									text: 'status transition item',
 									timestamp: Date.now(),
-									status: 'queued',
+									status: 'enqueued',
 								},
 							],
 						};
 					}
 					return { messages: [] };
 				}
-				if (payload?.status === 'saved') {
+				if (payload?.status === 'deferred') {
 					savedCalls++;
 					if (savedCalls === 1) {
 						return {
@@ -571,7 +589,7 @@ describe('MessageInput queue mode', () => {
 									uuid: 'x1',
 									text: 'status transition item',
 									timestamp: Date.now(),
-									status: 'saved',
+									status: 'deferred',
 								},
 							],
 						};

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -710,6 +710,84 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		});
 	});
 
+	it('ignores stale queue responses after target switch', async () => {
+		let resolveLeaderEnqueued: ((value: { messages: QueuedMessage[] }) => void) | undefined;
+		type QueuedMessage = {
+			dbId: string;
+			uuid: string;
+			text: string;
+			timestamp: number;
+			status: 'deferred' | 'enqueued' | 'consumed';
+		};
+		const leaderEnqueuedPromise = new Promise<{ messages: QueuedMessage[] }>((resolve) => {
+			resolveLeaderEnqueued = resolve;
+		});
+
+		mockRequest.mockImplementation(async (method, payload) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'session.messages.byStatus') {
+				if (payload?.sessionId === 'sess-l' && payload?.status === 'enqueued') {
+					return leaderEnqueuedPromise;
+				}
+				if (payload?.sessionId === 'sess-l' && payload?.status === 'deferred') {
+					return { messages: [] };
+				}
+				if (payload?.sessionId === 'sess-w' && payload?.status === 'enqueued') {
+					return {
+						messages: [
+							{
+								dbId: 'w-e1',
+								uuid: 'w-e1',
+								text: 'worker-now',
+								timestamp: Date.now(),
+								status: 'enqueued',
+							},
+						],
+					};
+				}
+				if (payload?.sessionId === 'sess-w' && payload?.status === 'deferred') {
+					return { messages: [] };
+				}
+				return { messages: [] };
+			}
+			return {};
+		});
+
+		const { getByTestId, queryByText } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('task-target-button')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('task-target-button'));
+		fireEvent.click(getByTestId('task-target-option-worker'));
+
+		await waitFor(() => {
+			expect(queryByText('worker-now')).toBeTruthy();
+		});
+
+		await act(async () => {
+			resolveLeaderEnqueued?.({
+				messages: [
+					{
+						dbId: 'l-e-stale',
+						uuid: 'l-e-stale',
+						text: 'leader-stale',
+						timestamp: Date.now(),
+						status: 'enqueued',
+					},
+				],
+			});
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(queryByText('worker-now')).toBeTruthy();
+			expect(queryByText('leader-stale')).toBeNull();
+		});
+	});
+
 	it('sends message when Enter is pressed (desktop)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -597,6 +597,119 @@ describe('TaskView — HumanInputArea uses InputTextarea', () => {
 		expect(getByTestId('task-target-button').textContent).toContain('Leader');
 	});
 
+	it('shows pending queue overlay for the selected target session', async () => {
+		mockRequest.mockImplementation(async (method, payload) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'session.messages.byStatus') {
+				if (payload?.sessionId === 'sess-l' && payload?.status === 'enqueued') {
+					return {
+						messages: [
+							{
+								dbId: 'l-e1',
+								uuid: 'l-e1',
+								text: 'leader-now',
+								timestamp: Date.now(),
+								status: 'enqueued',
+							},
+						],
+					};
+				}
+				if (payload?.sessionId === 'sess-l' && payload?.status === 'deferred') {
+					return {
+						messages: [
+							{
+								dbId: 'l-d1',
+								uuid: 'l-d1',
+								text: 'leader-next',
+								timestamp: Date.now(),
+								status: 'deferred',
+							},
+						],
+					};
+				}
+				return { messages: [] };
+			}
+			return {};
+		});
+
+		const { getByTestId } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('queue-overlay')).toBeTruthy();
+			expect(getByTestId('queue-overlay').textContent).toContain('leader-now');
+			expect(getByTestId('queue-overlay').textContent).toContain('leader-next');
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('session.messages.byStatus', {
+			sessionId: 'sess-l',
+			status: 'enqueued',
+			limit: 20,
+		});
+		expect(mockRequest).toHaveBeenCalledWith('session.messages.byStatus', {
+			sessionId: 'sess-l',
+			status: 'deferred',
+			limit: 20,
+		});
+	});
+
+	it('refreshes pending queue overlay when target switches to worker', async () => {
+		mockRequest.mockImplementation(async (method, payload) => {
+			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };
+			if (method === 'task.getGroup') return { group: makeGroup('awaiting_worker') };
+			if (method === 'session.messages.byStatus') {
+				if (payload?.sessionId === 'sess-l' && payload?.status === 'enqueued') {
+					return {
+						messages: [
+							{
+								dbId: 'l-e1',
+								uuid: 'l-e1',
+								text: 'leader-now',
+								timestamp: Date.now(),
+								status: 'enqueued',
+							},
+						],
+					};
+				}
+				if (payload?.sessionId === 'sess-w' && payload?.status === 'enqueued') {
+					return {
+						messages: [
+							{
+								dbId: 'w-e1',
+								uuid: 'w-e1',
+								text: 'worker-now',
+								timestamp: Date.now(),
+								status: 'enqueued',
+							},
+						],
+					};
+				}
+				return { messages: [] };
+			}
+			return {};
+		});
+
+		const { getByTestId, queryByText } = render(<TaskView roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(queryByText('leader-now')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('task-target-button'));
+		fireEvent.click(getByTestId('task-target-option-worker'));
+
+		await waitFor(() => {
+			expect(queryByText('worker-now')).toBeTruthy();
+			expect(queryByText('leader-now')).toBeNull();
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('session.messages.byStatus', {
+			sessionId: 'sess-w',
+			status: 'enqueued',
+			limit: 20,
+		});
+	});
+
 	it('sends message when Enter is pressed (desktop)', async () => {
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.get') return { task: makeTask('task-1', 'in_progress') };

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -109,11 +109,20 @@ function HumanInputArea({
 	const [queuedForNextTurn, setQueuedForNextTurn] = useState<QueuedOverlayMessage[]>([]);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const isTouchDeviceRef = useRef(false);
+	const isMountedRef = useRef(true);
+	const queueRequestVersionRef = useRef(0);
 
 	useEffect(() => {
 		isTouchDeviceRef.current =
 			window.matchMedia('(pointer: coarse)').matches ||
 			('ontouchstart' in window && window.innerWidth < 768);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			isMountedRef.current = false;
+			queueRequestVersionRef.current += 1;
+		};
 	}, []);
 
 	useEffect(() => {
@@ -134,7 +143,11 @@ function HumanInputArea({
 	const targetSessionId = target === 'leader' ? leaderSessionId : workerSessionId;
 
 	const refreshQueuedMessages = useCallback(async () => {
+		const requestVersion = ++queueRequestVersionRef.current;
 		if (!hasGroup || !targetSessionId) {
+			if (!isMountedRef.current || requestVersion !== queueRequestVersionRef.current) {
+				return;
+			}
 			setQueuedForCurrentTurn([]);
 			setQueuedForNextTurn([]);
 			return;
@@ -153,6 +166,11 @@ function HumanInputArea({
 					limit: 20,
 				}),
 			])) as [{ messages?: QueuedOverlayMessage[] }, { messages?: QueuedOverlayMessage[] }];
+
+			if (!isMountedRef.current || requestVersion !== queueRequestVersionRef.current) {
+				return;
+			}
+
 			setQueuedForCurrentTurn(enqueuedResponse.messages ?? []);
 			setQueuedForNextTurn(deferredResponse.messages ?? []);
 		} catch {

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -69,6 +69,16 @@ interface HumanInputAreaProps {
 	taskStatus: string;
 	roomId: string;
 	taskId: string;
+	leaderSessionId?: string;
+	workerSessionId?: string;
+}
+
+interface QueuedOverlayMessage {
+	dbId: string;
+	uuid: string;
+	text: string;
+	timestamp: number;
+	status: 'deferred' | 'enqueued' | 'consumed';
 }
 
 const TARGET_LABELS: Record<HumanMessageTarget, string> = {
@@ -76,7 +86,14 @@ const TARGET_LABELS: Record<HumanMessageTarget, string> = {
 	leader: 'Leader',
 };
 
-function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputAreaProps) {
+function HumanInputArea({
+	hasGroup,
+	taskStatus,
+	roomId,
+	taskId,
+	leaderSessionId,
+	workerSessionId,
+}: HumanInputAreaProps) {
 	const { request } = useMessageHub();
 	const {
 		content: messageText,
@@ -88,6 +105,8 @@ function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputArea
 	const [inputError, setInputError] = useState<string | null>(null);
 	const [target, setTarget] = useState<HumanMessageTarget>('leader');
 	const [menuOpen, setMenuOpen] = useState(false);
+	const [queuedForCurrentTurn, setQueuedForCurrentTurn] = useState<QueuedOverlayMessage[]>([]);
+	const [queuedForNextTurn, setQueuedForNextTurn] = useState<QueuedOverlayMessage[]>([]);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const isTouchDeviceRef = useRef(false);
 
@@ -112,6 +131,48 @@ function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputArea
 	const isArchived = taskStatus === 'archived';
 	const canReactivateWithMessage = taskStatus === 'completed' || taskStatus === 'cancelled';
 	const canSend = !isArchived && (hasGroup || canReactivateWithMessage);
+	const targetSessionId = target === 'leader' ? leaderSessionId : workerSessionId;
+
+	const refreshQueuedMessages = useCallback(async () => {
+		if (!hasGroup || !targetSessionId) {
+			setQueuedForCurrentTurn([]);
+			setQueuedForNextTurn([]);
+			return;
+		}
+
+		try {
+			const [enqueuedResponse, deferredResponse] = (await Promise.all([
+				request('session.messages.byStatus', {
+					sessionId: targetSessionId,
+					status: 'enqueued',
+					limit: 20,
+				}),
+				request('session.messages.byStatus', {
+					sessionId: targetSessionId,
+					status: 'deferred',
+					limit: 20,
+				}),
+			])) as [{ messages?: QueuedOverlayMessage[] }, { messages?: QueuedOverlayMessage[] }];
+			setQueuedForCurrentTurn(enqueuedResponse.messages ?? []);
+			setQueuedForNextTurn(deferredResponse.messages ?? []);
+		} catch {
+			// Best-effort queue refresh.
+		}
+	}, [hasGroup, request, targetSessionId]);
+
+	useEffect(() => {
+		void refreshQueuedMessages();
+	}, [refreshQueuedMessages]);
+
+	useEffect(() => {
+		if (!hasGroup || (queuedForCurrentTurn.length === 0 && queuedForNextTurn.length === 0)) {
+			return;
+		}
+		const timer = setInterval(() => {
+			void refreshQueuedMessages();
+		}, 700);
+		return () => clearInterval(timer);
+	}, [hasGroup, queuedForCurrentTurn.length, queuedForNextTurn.length, refreshQueuedMessages]);
 
 	const sendMessage = async () => {
 		if (sending || !messageText.trim() || !canSend) return;
@@ -125,6 +186,7 @@ function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputArea
 				target,
 			});
 			clearDraft();
+			await refreshQueuedMessages();
 		} catch (err) {
 			setInputError(err instanceof Error ? err.message : 'Failed to send message');
 		} finally {
@@ -159,6 +221,46 @@ function HumanInputArea({ hasGroup, taskStatus, roomId, taskId }: HumanInputArea
 					>
 						Discard draft
 					</button>
+				</div>
+			)}
+			{(queuedForCurrentTurn.length > 0 || queuedForNextTurn.length > 0) && canSend && (
+				<div class="flex flex-col items-end gap-1.5" data-testid="queue-overlay">
+					{queuedForCurrentTurn.slice(0, 3).map((queued, index) => (
+						<div
+							key={queued.dbId}
+							class="pointer-events-none inline-flex max-w-[22rem] items-center gap-2 rounded-full border border-dark-600/80 bg-dark-900/85 px-3 py-1 text-xs text-gray-200 backdrop-blur-sm"
+							data-testid="queued-current-turn-bubble"
+						>
+							<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+							<span class="truncate">
+								{index === 0 && <span class="mr-1 text-amber-300">Now</span>}
+								{queued.text}
+							</span>
+						</div>
+					))}
+					{queuedForNextTurn.slice(0, 3).map((queued, index) => (
+						<div
+							key={queued.dbId}
+							class="pointer-events-none inline-flex max-w-[22rem] items-center gap-2 rounded-full border border-dark-600/80 bg-dark-900/85 px-3 py-1 text-xs text-gray-200 backdrop-blur-sm"
+							data-testid="queued-next-turn-bubble"
+						>
+							<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+							<span class="truncate">
+								{index === 0 && <span class="mr-1 text-blue-300">Next</span>}
+								{queued.text}
+							</span>
+						</div>
+					))}
+					{queuedForCurrentTurn.length > 3 && (
+						<p class="pointer-events-none text-xs text-amber-200/80">
+							+{queuedForCurrentTurn.length - 3} more pending
+						</p>
+					)}
+					{queuedForNextTurn.length > 3 && (
+						<p class="pointer-events-none text-xs text-blue-200/80">
+							+{queuedForNextTurn.length - 3} more deferred
+						</p>
+					)}
 				</div>
 			)}
 			<InputTextarea
@@ -1397,6 +1499,8 @@ export function TaskView({ roomId, taskId }: TaskViewProps) {
 				taskStatus={task.status}
 				roomId={roomId}
 				taskId={taskId}
+				leaderSessionId={group?.leaderSessionId}
+				workerSessionId={group?.workerSessionId}
 			/>
 
 			{/* Task action dialogs */}

--- a/packages/web/src/hooks/__tests__/useSendMessage.test.ts
+++ b/packages/web/src/hooks/__tests__/useSendMessage.test.ts
@@ -339,14 +339,14 @@ describe('useSendMessage', () => {
 			);
 
 			await act(async () => {
-				await result.current.sendMessage('Queue this', undefined, 'next_turn');
+				await result.current.sendMessage('Queue this', undefined, 'defer');
 			});
 
 			expect(mockRequest).toHaveBeenCalledWith('message.send', {
 				sessionId: 'session-1',
 				content: 'Queue this',
 				images: undefined,
-				deliveryMode: 'next_turn',
+				deliveryMode: 'defer',
 			});
 		});
 	});

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -57,7 +57,7 @@ export function useSendMessage({
 		async (
 			content: string,
 			images?: MessageImage[],
-			deliveryMode: MessageDeliveryMode = 'current_turn'
+			deliveryMode: MessageDeliveryMode = 'immediate'
 		) => {
 			if (!content.trim() || (isSending && !allowQueueWhileProcessing)) return;
 
@@ -96,7 +96,7 @@ export function useSendMessage({
 					deliveryMode?: MessageDeliveryMode;
 				} = { sessionId, content, images };
 
-				if (deliveryMode !== 'current_turn') {
+				if (deliveryMode !== 'immediate') {
 					requestPayload.deliveryMode = deliveryMode;
 				}
 

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -641,7 +641,7 @@ export default function ChatContainer({ sessionId, readonly = false }: ChatConta
 		async (
 			content: string,
 			images?: MessageImage[],
-			deliveryMode: MessageDeliveryMode = 'current_turn'
+			deliveryMode: MessageDeliveryMode = 'immediate'
 		) => {
 			// If session is pending worktree choice, set the mode first
 			if (session?.status === 'pending_worktree_choice' && showWorktreeChoice) {


### PR DESCRIPTION
## Summary

This PR applies the message-delivery semantics refactor end-to-end and aligns TaskView pending UX with standalone chat.

### 1) Delivery model rename (coherent model)

- Delivery mode:
  - `current_turn` → `immediate`
  - `next_turn` → `defer`
- Send status:
  - `saved` → `deferred`
  - `queued` → `enqueued`
  - `sent` → `consumed`
  - `failed` unchanged

Updated shared types, daemon runtime/event handling, storage/repository filters, RPC contracts, and web callsites/tests accordingly.

### 2) DB migration for existing data

- Added migration 44 to remap `sdk_messages.send_status` values in-place and rebuild the updated CHECK constraint/default.
- Added migration unit test coverage for migration 44.

### 3) TaskView/ChatContainer UX alignment for pending messages

TaskView input now mirrors standalone chat behavior:
- Shows pending overlay bubbles from canonical persisted statuses:
  - `enqueued` as **Now**
  - `deferred` as **Next**
- Fetches queue state from `session.messages.byStatus` for the selected target session (leader/worker).
- Refreshes on mount, target switch, send, and while pending entries remain.

This keeps transcript rendering strict (consumed/failed timeline) while making pending state visible in both chat surfaces.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- Targeted daemon tests for renamed delivery/status semantics and migration
- `bunx vitest run packages/web/src/components/room/TaskView.test.tsx`
- `bunx vitest run packages/web/src/hooks/__tests__/useSendMessage.test.ts packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx`

## Notes

- This is an intentional semantic refactor (not a compatibility alias layer).
- Task timelines still only render consumed/failed user messages in transcript; pending visibility is provided via the queue overlay.

## UI preview (TaskView parity with standalone chat)

- TaskView input now shows the same pending bubbles as standalone chat:
  - `Now` (enqueued)
  - `Next` (deferred)
- Target switch (Leader ↔ Worker) reloads pending bubbles for that session.
- Overlay entries clear naturally as messages transition to `consumed` and appear in transcript.