### PR TITLE
feat: implement ReadonlySessionChat and SlideOutPanel components

### DIFF
--- a/packages/web/src/components/room/ReadonlySessionChat.tsx
+++ b/packages/web/src/components/room/ReadonlySessionChat.tsx
@@ -7,7 +7,7 @@
  *
  * Data loading:
  * - Joins channel `session:${sessionId}` and subscribes to `state.sdkMessages.delta`
- * - Initial fetch via `state.sdkMessages` RPC
+ * - Initial fetch via `state.sdkMessages` RPC (stale-fetch guarded by cancelled flag)
  * - Pagination via `message.sdkMessages` RPC (numeric `before` timestamp)
  * - Deduplicates by UUID on delta events (Safari reconnect replay guard)
  */
@@ -34,6 +34,7 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 	const [hasMore, setHasMore] = useState(false);
 	const [isLoadingOlder, setIsLoadingOlder] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [paginationError, setPaginationError] = useState<string | null>(null);
 
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const didScrollRef = useRef(false);
@@ -69,10 +70,13 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 		};
 	}, [sessionId, isConnected, onEvent, joinRoom, leaveRoom]);
 
-	// Initial fetch — re-runs when sessionId or isConnected changes
+	// Initial fetch — re-runs when sessionId or isConnected changes.
+	// Uses a cancelled flag to discard stale responses when sessionId changes
+	// or the component unmounts before the request resolves.
 	useEffect(() => {
 		if (!sessionId || !isConnected) return;
 
+		let cancelled = false;
 		setIsLoading(true);
 		setError(null);
 		setMessages([]);
@@ -81,15 +85,21 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 
 		request<{ sdkMessages: SDKMessage[]; hasMore: boolean }>('state.sdkMessages', { sessionId })
 			.then((result) => {
+				if (cancelled) return;
 				setMessages((result?.sdkMessages ?? []) as SDKMessageWithTimestamp[]);
 				setHasMore(result?.hasMore ?? false);
 			})
 			.catch((err: unknown) => {
+				if (cancelled) return;
 				setError(err instanceof Error ? err.message : 'Failed to load messages');
 			})
 			.finally(() => {
-				setIsLoading(false);
+				if (!cancelled) setIsLoading(false);
 			});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [sessionId, isConnected, request]);
 
 	// Auto-scroll to bottom when new messages arrive
@@ -109,6 +119,7 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 		if (!oldestTimestamp) return;
 
 		setIsLoadingOlder(true);
+		setPaginationError(null);
 		try {
 			const result = await request<{ sdkMessages: SDKMessage[]; hasMore: boolean }>(
 				'message.sdkMessages',
@@ -123,8 +134,8 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 					return [...deduped, ...prev];
 				});
 			}
-		} catch {
-			// Silently ignore pagination errors
+		} catch (err: unknown) {
+			setPaginationError(err instanceof Error ? err.message : 'Failed to load older messages');
 		} finally {
 			setIsLoadingOlder(false);
 		}
@@ -144,6 +155,9 @@ export function ReadonlySessionChat({ sessionId }: Props) {
 					>
 						{isLoadingOlder ? 'Loading…' : 'Load older messages'}
 					</button>
+					{paginationError && (
+						<div class="text-xs text-red-400 text-center mt-1">{paginationError}</div>
+					)}
 				</div>
 			)}
 

--- a/packages/web/src/components/room/ReadonlySessionChat.tsx
+++ b/packages/web/src/components/room/ReadonlySessionChat.tsx
@@ -1,0 +1,185 @@
+/**
+ * ReadonlySessionChat
+ *
+ * Independently fetches and renders messages for a given sessionId without
+ * touching sessionStore. Used by SlideOutPanel to display a secondary session's
+ * chat without overwriting the primary session's data.
+ *
+ * Data loading:
+ * - Joins channel `session:${sessionId}` and subscribes to `state.sdkMessages.delta`
+ * - Initial fetch via `state.sdkMessages` RPC
+ * - Pagination via `message.sdkMessages` RPC (numeric `before` timestamp)
+ * - Deduplicates by UUID on delta events (Safari reconnect replay guard)
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks';
+import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import { useMessageHub } from '../../hooks/useMessageHub';
+import { useMessageMaps } from '../../hooks/useMessageMaps';
+import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
+
+type SDKMessageWithTimestamp = SDKMessage & { timestamp: number };
+
+interface Props {
+	sessionId: string;
+}
+
+const LOAD_OLDER_LIMIT = 100;
+
+export function ReadonlySessionChat({ sessionId }: Props) {
+	const { request, onEvent, joinRoom, leaveRoom, isConnected } = useMessageHub();
+
+	const [messages, setMessages] = useState<SDKMessageWithTimestamp[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [hasMore, setHasMore] = useState(false);
+	const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const didScrollRef = useRef(false);
+
+	// Channel subscription + delta events — gated on isConnected (see useGroupMessages pattern)
+	useEffect(() => {
+		if (!sessionId || !isConnected) return;
+
+		const channel = `session:${sessionId}`;
+		joinRoom(channel);
+
+		const unsubDelta = onEvent<{ added?: SDKMessage[] }>(
+			'state.sdkMessages.delta',
+			(data, context) => {
+				// Filter by channel to avoid cross-session bleed
+				if ((context as { channel?: string }).channel !== channel) return;
+				if (!data.added?.length) return;
+
+				setMessages((prev) => {
+					const existingIds = new Set(prev.map((m) => m.uuid));
+					const newMessages = (data.added as SDKMessageWithTimestamp[]).filter(
+						(m) => !existingIds.has(m.uuid)
+					);
+					if (newMessages.length === 0) return prev;
+					return [...prev, ...newMessages];
+				});
+			}
+		);
+
+		return () => {
+			unsubDelta();
+			leaveRoom(channel);
+		};
+	}, [sessionId, isConnected, onEvent, joinRoom, leaveRoom]);
+
+	// Initial fetch — re-runs when sessionId or isConnected changes
+	useEffect(() => {
+		if (!sessionId || !isConnected) return;
+
+		setIsLoading(true);
+		setError(null);
+		setMessages([]);
+		setHasMore(false);
+		didScrollRef.current = false;
+
+		request<{ sdkMessages: SDKMessage[]; hasMore: boolean }>('state.sdkMessages', { sessionId })
+			.then((result) => {
+				setMessages((result?.sdkMessages ?? []) as SDKMessageWithTimestamp[]);
+				setHasMore(result?.hasMore ?? false);
+			})
+			.catch((err: unknown) => {
+				setError(err instanceof Error ? err.message : 'Failed to load messages');
+			})
+			.finally(() => {
+				setIsLoading(false);
+			});
+	}, [sessionId, isConnected, request]);
+
+	// Auto-scroll to bottom when new messages arrive
+	useEffect(() => {
+		if (messages.length > 0 && messagesEndRef.current) {
+			messagesEndRef.current.scrollIntoView({ behavior: didScrollRef.current ? 'smooth' : 'auto' });
+			didScrollRef.current = true;
+		}
+	}, [messages.length]);
+
+	const loadOlderMessages = async () => {
+		if (isLoadingOlder || !hasMore || messages.length === 0) return;
+
+		// Find oldest timestamp — the repository-injected numeric ms field
+		const oldest = messages[0];
+		const oldestTimestamp = oldest.timestamp;
+		if (!oldestTimestamp) return;
+
+		setIsLoadingOlder(true);
+		try {
+			const result = await request<{ sdkMessages: SDKMessage[]; hasMore: boolean }>(
+				'message.sdkMessages',
+				{ sessionId, before: oldestTimestamp, limit: LOAD_OLDER_LIMIT }
+			);
+			const older = (result?.sdkMessages ?? []) as SDKMessageWithTimestamp[];
+			setHasMore(result?.hasMore ?? false);
+			if (older.length > 0) {
+				setMessages((prev) => {
+					const existingIds = new Set(prev.map((m) => m.uuid));
+					const deduped = older.filter((m) => !existingIds.has(m.uuid));
+					return [...deduped, ...prev];
+				});
+			}
+		} catch {
+			// Silently ignore pagination errors
+		} finally {
+			setIsLoadingOlder(false);
+		}
+	};
+
+	const maps = useMessageMaps(messages, sessionId);
+
+	return (
+		<div data-testid="readonly-session-chat" class="flex flex-col h-full overflow-hidden">
+			{/* Load older button */}
+			{hasMore && (
+				<div class="flex-shrink-0 p-2 border-b border-gray-700">
+					<button
+						onClick={loadOlderMessages}
+						disabled={isLoadingOlder}
+						class="w-full text-xs text-gray-400 hover:text-gray-200 disabled:opacity-50 py-1"
+					>
+						{isLoadingOlder ? 'Loading…' : 'Load older messages'}
+					</button>
+				</div>
+			)}
+
+			{/* Messages area */}
+			<div class="flex-1 overflow-y-auto px-3 py-2 space-y-1 min-h-0">
+				{isLoading && (
+					<div class="flex items-center justify-center py-8 text-gray-500 text-sm">
+						Loading messages…
+					</div>
+				)}
+
+				{!isLoading && error && (
+					<div class="flex items-center justify-center py-8 text-red-400 text-sm">{error}</div>
+				)}
+
+				{!isLoading && !error && messages.length === 0 && (
+					<div class="flex items-center justify-center py-8 text-gray-500 text-sm">
+						No messages yet
+					</div>
+				)}
+
+				{messages.map((msg) => (
+					<SDKMessageRenderer
+						key={msg.uuid}
+						message={msg}
+						sessionId={sessionId}
+						toolResultsMap={maps.toolResultsMap}
+						toolInputsMap={maps.toolInputsMap}
+						subagentMessagesMap={maps.subagentMessagesMap}
+						sessionInfo={maps.sessionInfoMap.get(msg.uuid ?? '')}
+						taskContext={false}
+					/>
+				))}
+
+				<div ref={messagesEndRef} />
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/room/SlideOutPanel.tsx
+++ b/packages/web/src/components/room/SlideOutPanel.tsx
@@ -1,0 +1,162 @@
+/**
+ * SlideOutPanel
+ *
+ * A right-side slide-out panel absolutely positioned within the task view
+ * container. Mounts ReadonlySessionChat when open. Does NOT use sessionStore.
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+import { ReadonlySessionChat } from './ReadonlySessionChat';
+
+const ROLE_COLORS: Record<string, { labelColor: string }> = {
+	planner: { labelColor: 'text-teal-400' },
+	coder: { labelColor: 'text-blue-400' },
+	general: { labelColor: 'text-slate-400' },
+	leader: { labelColor: 'text-purple-400' },
+	human: { labelColor: 'text-green-400' },
+	system: { labelColor: 'text-gray-500' },
+	craft: { labelColor: 'text-blue-400' },
+	lead: { labelColor: 'text-purple-400' },
+};
+
+interface Props {
+	isOpen: boolean;
+	sessionId: string | null;
+	agentLabel?: string;
+	agentRole?: string;
+	onClose: () => void;
+}
+
+export function SlideOutPanel({ isOpen, sessionId, agentLabel, agentRole, onClose }: Props) {
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const panelRef = useRef<HTMLDivElement>(null);
+	// Track the element that opened the panel so focus can be restored on close
+	const triggerElementRef = useRef<Element | null>(null);
+
+	// Save trigger element when opening; restore focus when closing
+	useEffect(() => {
+		if (isOpen) {
+			triggerElementRef.current = document.activeElement;
+			// Move focus to close button when panel opens
+			requestAnimationFrame(() => {
+				closeButtonRef.current?.focus();
+			});
+		} else {
+			// Restore focus to trigger element
+			if (triggerElementRef.current instanceof HTMLElement) {
+				triggerElementRef.current.focus();
+			}
+			triggerElementRef.current = null;
+		}
+	}, [isOpen]);
+
+	// Escape key closes panel
+	useEffect(() => {
+		if (!isOpen) return;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				onClose();
+			}
+			// Focus trap: keep Tab within panel
+			if (e.key === 'Tab' && panelRef.current) {
+				const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+					'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+				);
+				if (focusable.length === 0) return;
+				const first = focusable[0];
+				const last = focusable[focusable.length - 1];
+				if (e.shiftKey) {
+					if (document.activeElement === first) {
+						e.preventDefault();
+						last.focus();
+					}
+				} else {
+					if (document.activeElement === last) {
+						e.preventDefault();
+						first.focus();
+					}
+				}
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [isOpen, onClose]);
+
+	const labelColor = agentRole
+		? (ROLE_COLORS[agentRole]?.labelColor ?? 'text-gray-300')
+		: 'text-gray-300';
+	const displayLabel = agentLabel ?? agentRole ?? 'Session';
+
+	return (
+		<>
+			{/* Backdrop */}
+			<div
+				data-testid="slide-out-backdrop"
+				class={[
+					'absolute inset-0 bg-black/40 z-10 transition-opacity duration-300',
+					isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
+				].join(' ')}
+				onClick={onClose}
+				aria-hidden="true"
+			/>
+
+			{/* Panel */}
+			<div
+				ref={panelRef}
+				data-testid="slide-out-panel"
+				role="dialog"
+				aria-modal="true"
+				aria-label={`Session chat for ${displayLabel}`}
+				class={[
+					'absolute top-0 right-0 h-full z-20',
+					'w-full sm:w-1/2',
+					'flex flex-col',
+					'bg-gray-900 border-l border-gray-700 shadow-2xl',
+					'transition-transform duration-300',
+					isOpen ? 'translate-x-0' : 'translate-x-full',
+				].join(' ')}
+			>
+				{/* Header */}
+				<div
+					data-testid="slide-out-panel-header"
+					class="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-gray-700"
+				>
+					<span class={`text-sm font-semibold ${labelColor}`}>{displayLabel}</span>
+					<button
+						ref={closeButtonRef}
+						data-testid="slide-out-panel-close"
+						onClick={onClose}
+						class="p-1 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+						aria-label="Close panel"
+					>
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				{/* Body */}
+				<div class="flex-1 min-h-0">
+					{isOpen && sessionId ? (
+						<ReadonlySessionChat sessionId={sessionId} />
+					) : (
+						<div class="flex items-center justify-center h-full text-gray-500 text-sm">
+							No session selected
+						</div>
+					)}
+				</div>
+			</div>
+		</>
+	);
+}

--- a/packages/web/src/components/room/SlideOutPanel.tsx
+++ b/packages/web/src/components/room/SlideOutPanel.tsx
@@ -6,18 +6,8 @@
  */
 
 import { useEffect, useRef } from 'preact/hooks';
+import { ROLE_COLORS } from '../../lib/role-colors';
 import { ReadonlySessionChat } from './ReadonlySessionChat';
-
-const ROLE_COLORS: Record<string, { labelColor: string }> = {
-	planner: { labelColor: 'text-teal-400' },
-	coder: { labelColor: 'text-blue-400' },
-	general: { labelColor: 'text-slate-400' },
-	leader: { labelColor: 'text-purple-400' },
-	human: { labelColor: 'text-green-400' },
-	system: { labelColor: 'text-gray-500' },
-	craft: { labelColor: 'text-blue-400' },
-	lead: { labelColor: 'text-purple-400' },
-};
 
 interface Props {
 	isOpen: boolean;

--- a/packages/web/src/components/room/__tests__/SlideOutPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/SlideOutPanel.test.tsx
@@ -37,15 +37,18 @@ const mockOnEvent = vi.fn((eventName: string, handler: DeltaHandler) => {
 	};
 });
 
-const mockRequest = vi.fn(async (method: string) => {
-	if (method === 'state.sdkMessages') {
-		return { sdkMessages: [], hasMore: false };
+type MockRPCResponse = { sdkMessages: unknown[]; hasMore: boolean } | Record<string, never>;
+const mockRequest: ReturnType<typeof vi.fn> = vi.fn(
+	async (method: string): Promise<MockRPCResponse> => {
+		if (method === 'state.sdkMessages') {
+			return { sdkMessages: [], hasMore: false };
+		}
+		if (method === 'message.sdkMessages') {
+			return { sdkMessages: [], hasMore: false };
+		}
+		return {};
 	}
-	if (method === 'message.sdkMessages') {
-		return { sdkMessages: [], hasMore: false };
-	}
-	return {};
-});
+);
 
 const mockJoinRoom = vi.fn();
 const mockLeaveRoom = vi.fn();
@@ -330,6 +333,73 @@ describe('SlideOutPanel', () => {
 		render(<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />);
 		await waitFor(() =>
 			expect(mockOnEvent).toHaveBeenCalledWith('state.sdkMessages.delta', expect.any(Function))
+		);
+	});
+
+	it('should call leaveRoom with the session channel on unmount', async () => {
+		const { unmount } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-leave-test" onClose={() => {}} />
+		);
+		await waitFor(() => expect(mockJoinRoom).toHaveBeenCalledWith('session:session-leave-test'));
+		unmount();
+		expect(mockLeaveRoom).toHaveBeenCalledWith('session:session-leave-test');
+	});
+
+	// --- Pagination (load older) ---
+
+	it('should show load-older button when initial fetch returns hasMore=true', async () => {
+		mockRequest.mockImplementationOnce(async (method: string) => {
+			if (method === 'state.sdkMessages') {
+				return {
+					sdkMessages: [{ uuid: 'msg-old', type: 'assistant', timestamp: 1000 }],
+					hasMore: true,
+				};
+			}
+			return {};
+		});
+
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		await waitFor(() => expect(container.querySelector('button[disabled]')).toBeNull());
+		await waitFor(() => expect(container.textContent).toContain('Load older messages'));
+	});
+
+	it('should call message.sdkMessages with numeric before timestamp when load-older clicked', async () => {
+		const oldTimestamp = 12345678;
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'state.sdkMessages') {
+				return {
+					sdkMessages: [{ uuid: 'msg-first', type: 'assistant', timestamp: oldTimestamp }],
+					hasMore: true,
+				};
+			}
+			if (method === 'message.sdkMessages') {
+				return { sdkMessages: [], hasMore: false };
+			}
+			return {};
+		});
+
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-pg" onClose={() => {}} />
+		);
+
+		await waitFor(() => expect(container.textContent).toContain('Load older messages'));
+
+		// Find the "Load older" button specifically (not the close button)
+		const allButtons = container.querySelectorAll('button');
+		const loadBtn = Array.from(allButtons).find((b) =>
+			b.textContent?.includes('Load older')
+		) as HTMLButtonElement;
+		expect(loadBtn).toBeTruthy();
+		fireEvent.click(loadBtn);
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('message.sdkMessages', {
+				sessionId: 'session-pg',
+				before: oldTimestamp,
+				limit: 100,
+			})
 		);
 	});
 });

--- a/packages/web/src/components/room/__tests__/SlideOutPanel.test.tsx
+++ b/packages/web/src/components/room/__tests__/SlideOutPanel.test.tsx
@@ -1,0 +1,335 @@
+/**
+ * Tests for SlideOutPanel and ReadonlySessionChat components
+ *
+ * Covers:
+ * - Session isolation (no sessionStore.select calls)
+ * - Message loading via RPC
+ * - Cross-session channel filter (rejection and acceptance)
+ * - Panel open/close behavior
+ * - Backdrop click and Escape key
+ * - Agent label display with role colors
+ * - Accessibility attributes
+ * - data-testid attributes
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act, waitFor } from '@testing-library/preact';
+import { SlideOutPanel } from '../SlideOutPanel';
+
+// -------------------------------------------------------
+// Mocks
+// -------------------------------------------------------
+
+// Track the registered delta event handler so tests can fire events manually
+type DeltaHandler = (data: { added?: unknown[] }, context: { channel?: string }) => void;
+let registeredDeltaHandler: DeltaHandler | null = null;
+
+const mockIsConnected = { value: true };
+
+const mockOnEvent = vi.fn((eventName: string, handler: DeltaHandler) => {
+	if (eventName === 'state.sdkMessages.delta') {
+		registeredDeltaHandler = handler;
+	}
+	return () => {
+		if (eventName === 'state.sdkMessages.delta') {
+			registeredDeltaHandler = null;
+		}
+	};
+});
+
+const mockRequest = vi.fn(async (method: string) => {
+	if (method === 'state.sdkMessages') {
+		return { sdkMessages: [], hasMore: false };
+	}
+	if (method === 'message.sdkMessages') {
+		return { sdkMessages: [], hasMore: false };
+	}
+	return {};
+});
+
+const mockJoinRoom = vi.fn();
+const mockLeaveRoom = vi.fn();
+
+vi.mock('../../../hooks/useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		isConnected: mockIsConnected.value,
+		joinRoom: mockJoinRoom,
+		leaveRoom: mockLeaveRoom,
+	}),
+}));
+
+// Minimal SDKMessageRenderer mock — shows uuid so tests can assert presence
+vi.mock('../../sdk/SDKMessageRenderer.tsx', () => ({
+	SDKMessageRenderer: (props: { message: { uuid?: string } }) => (
+		<div data-testid={`msg-${props.message?.uuid ?? 'unknown'}`} />
+	),
+}));
+
+// Mock useMessageMaps to avoid needing fully-shaped SDKMessage objects
+vi.mock('../../../hooks/useMessageMaps.ts', () => ({
+	useMessageMaps: () => ({
+		toolResultsMap: new Map(),
+		toolInputsMap: new Map(),
+		sessionInfoMap: new Map(),
+		subagentMessagesMap: new Map(),
+	}),
+}));
+
+// Mock sessionStore to spy on select
+const mockSessionStoreSelect = vi.fn();
+vi.mock('../../../lib/session-store.ts', () => ({
+	sessionStore: {
+		select: mockSessionStoreSelect,
+		activeSessionId: { value: null },
+		sdkMessages: { value: [] },
+	},
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeMessage(uuid: string) {
+	return { uuid, type: 'assistant', timestamp: Date.now() };
+}
+
+// -------------------------------------------------------
+// Tests
+// -------------------------------------------------------
+
+describe('SlideOutPanel', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		registeredDeltaHandler = null;
+		mockIsConnected.value = true;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// --- Session isolation ---
+
+	it('should NEVER call sessionStore.select when ReadonlySessionChat mounts', async () => {
+		render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" agentLabel="Worker" onClose={() => {}} />
+		);
+		await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+		expect(mockSessionStoreSelect).not.toHaveBeenCalled();
+	});
+
+	it('should fetch messages via state.sdkMessages RPC with the given sessionId', async () => {
+		render(<SlideOutPanel isOpen={true} sessionId="session-xyz" onClose={() => {}} />);
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('state.sdkMessages', { sessionId: 'session-xyz' })
+		);
+	});
+
+	// --- Cross-session channel filter ---
+
+	it('should reject delta events from a different channel', async () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		await waitFor(() => expect(mockOnEvent).toHaveBeenCalled());
+
+		const foreignMsg = makeMessage('foreign-msg-uuid');
+		act(() => {
+			registeredDeltaHandler?.({ added: [foreignMsg] }, { channel: 'session:other-id' });
+		});
+
+		expect(container.querySelector('[data-testid="msg-foreign-msg-uuid"]')).toBeNull();
+	});
+
+	it('should accept delta events from the correct channel', async () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		await waitFor(() => expect(mockOnEvent).toHaveBeenCalled());
+
+		const ownMsg = makeMessage('own-msg-uuid');
+		act(() => {
+			registeredDeltaHandler?.({ added: [ownMsg] }, { channel: 'session:session-abc' });
+		});
+
+		await waitFor(() =>
+			expect(container.querySelector('[data-testid="msg-own-msg-uuid"]')).not.toBeNull()
+		);
+	});
+
+	// --- Panel visibility ---
+
+	it('should have translate-x-full class when closed', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={false} sessionId="session-abc" onClose={() => {}} />
+		);
+		const panel = container.querySelector('[data-testid="slide-out-panel"]');
+		expect(panel?.className).toContain('translate-x-full');
+	});
+
+	it('should have translate-x-0 class when open', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		const panel = container.querySelector('[data-testid="slide-out-panel"]');
+		expect(panel?.className).toContain('translate-x-0');
+	});
+
+	it('should mount ReadonlySessionChat when open with a sessionId', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		expect(container.querySelector('[data-testid="readonly-session-chat"]')).not.toBeNull();
+	});
+
+	it('should NOT mount ReadonlySessionChat when closed', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={false} sessionId="session-abc" onClose={() => {}} />
+		);
+		expect(container.querySelector('[data-testid="readonly-session-chat"]')).toBeNull();
+	});
+
+	it('should NOT mount ReadonlySessionChat when sessionId is null', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId={null} onClose={() => {}} />
+		);
+		expect(container.querySelector('[data-testid="readonly-session-chat"]')).toBeNull();
+	});
+
+	// --- Close interactions ---
+
+	it('should call onClose when close button is clicked', () => {
+		const onClose = vi.fn();
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={onClose} />
+		);
+		const closeBtn = container.querySelector('[data-testid="slide-out-panel-close"]');
+		fireEvent.click(closeBtn!);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('should call onClose when backdrop is clicked', () => {
+		const onClose = vi.fn();
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={onClose} />
+		);
+		const backdrop = container.querySelector('[data-testid="slide-out-backdrop"]');
+		fireEvent.click(backdrop!);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('should call onClose when Escape key is pressed', () => {
+		const onClose = vi.fn();
+		render(<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('should NOT call onClose for Escape when panel is closed', () => {
+		const onClose = vi.fn();
+		render(<SlideOutPanel isOpen={false} sessionId="session-abc" onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	// --- Agent label display ---
+
+	it('should show agent label in header', () => {
+		const { container } = render(
+			<SlideOutPanel
+				isOpen={true}
+				sessionId="session-abc"
+				agentLabel="Leader"
+				agentRole="leader"
+				onClose={() => {}}
+			/>
+		);
+		const header = container.querySelector('[data-testid="slide-out-panel-header"]');
+		expect(header?.textContent).toContain('Leader');
+	});
+
+	it('should apply role color class to agent label', () => {
+		const { container } = render(
+			<SlideOutPanel
+				isOpen={true}
+				sessionId="session-abc"
+				agentLabel="Leader"
+				agentRole="leader"
+				onClose={() => {}}
+			/>
+		);
+		const header = container.querySelector('[data-testid="slide-out-panel-header"]');
+		const labelEl = header?.querySelector('span');
+		expect(labelEl?.className).toContain('text-purple-400');
+	});
+
+	it('should apply coder role color', () => {
+		const { container } = render(
+			<SlideOutPanel
+				isOpen={true}
+				sessionId="session-abc"
+				agentLabel="Coder"
+				agentRole="coder"
+				onClose={() => {}}
+			/>
+		);
+		const header = container.querySelector('[data-testid="slide-out-panel-header"]');
+		const labelEl = header?.querySelector('span');
+		expect(labelEl?.className).toContain('text-blue-400');
+	});
+
+	// --- Accessibility ---
+
+	it('should have role="dialog" on panel element', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		const panel = container.querySelector('[data-testid="slide-out-panel"]');
+		expect(panel?.getAttribute('role')).toBe('dialog');
+	});
+
+	it('should have aria-modal="true" on panel element', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		const panel = container.querySelector('[data-testid="slide-out-panel"]');
+		expect(panel?.getAttribute('aria-modal')).toBe('true');
+	});
+
+	it('should have aria-label on panel element', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" agentLabel="Worker" onClose={() => {}} />
+		);
+		const panel = container.querySelector('[data-testid="slide-out-panel"]');
+		expect(panel?.getAttribute('aria-label')).toContain('Worker');
+	});
+
+	// --- data-testid attributes ---
+
+	it('should have all required data-testid attributes', () => {
+		const { container } = render(
+			<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />
+		);
+		expect(container.querySelector('[data-testid="slide-out-panel"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="slide-out-panel-header"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="slide-out-panel-close"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="slide-out-backdrop"]')).not.toBeNull();
+		expect(container.querySelector('[data-testid="readonly-session-chat"]')).not.toBeNull();
+	});
+
+	// --- Channel join/leave ---
+
+	it('should join the session channel when connected and open', async () => {
+		render(<SlideOutPanel isOpen={true} sessionId="session-join-test" onClose={() => {}} />);
+		await waitFor(() => expect(mockJoinRoom).toHaveBeenCalledWith('session:session-join-test'));
+	});
+
+	it('should subscribe to state.sdkMessages.delta', async () => {
+		render(<SlideOutPanel isOpen={true} sessionId="session-abc" onClose={() => {}} />);
+		await waitFor(() =>
+			expect(mockOnEvent).toHaveBeenCalledWith('state.sdkMessages.delta', expect.any(Function))
+		);
+	});
+});

--- a/packages/web/src/lib/role-colors.ts
+++ b/packages/web/src/lib/role-colors.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared role color definitions for agent role display.
+ * Used by TaskConversationRenderer, SlideOutPanel, TurnSummaryBlock, etc.
+ */
+
+export interface RoleColors {
+	border: string;
+	label: string;
+	labelColor: string;
+}
+
+export const ROLE_COLORS: Record<string, RoleColors> = {
+	planner: { border: 'border-l-teal-500', label: 'Planner', labelColor: 'text-teal-400' },
+	coder: { border: 'border-l-blue-500', label: 'Coder', labelColor: 'text-blue-400' },
+	general: { border: 'border-l-slate-400', label: 'General', labelColor: 'text-slate-400' },
+	leader: { border: 'border-l-purple-500', label: 'Leader', labelColor: 'text-purple-400' },
+	human: { border: 'border-l-green-500', label: 'Human', labelColor: 'text-green-400' },
+	system: { border: 'border-l-transparent', label: '', labelColor: 'text-gray-500' },
+	craft: { border: 'border-l-blue-500', label: 'Craft', labelColor: 'text-blue-400' },
+	lead: { border: 'border-l-purple-500', label: 'Lead', labelColor: 'text-purple-400' },
+};


### PR DESCRIPTION
- ReadonlySessionChat: independently fetches session messages via
  state.sdkMessages RPC + delta subscription, without touching
  sessionStore. Joins/leaves session channel, filters deltas by channel
  to prevent cross-session bleed, deduplicates by UUID for Safari
  reconnect resilience, supports load-older pagination via message.sdkMessages
  RPC with numeric before timestamp.

- SlideOutPanel: absolutely positioned right-side slide-out panel with
  slide-in animation (translateX), semi-transparent backdrop, header with
  role-colored agent label, close button, Escape key support, focus
  trapping and restoration, and full accessibility attributes.

- 22 unit tests covering: session isolation, RPC calls, channel filter
  (rejection and acceptance), open/close behavior, backdrop/Escape,
  role colors, accessibility, and all data-testid attributes.
