### PR TITLE
feat: implement TurnSummaryBlock component

### DIFF
--- a/packages/web/src/components/room/TurnSummaryBlock.tsx
+++ b/packages/web/src/components/room/TurnSummaryBlock.tsx
@@ -1,0 +1,208 @@
+/**
+ * TurnSummaryBlock
+ *
+ * A compact card rendering a single agent turn with:
+ *  - Title bar: agent name (role-colored), last action badge, turn duration
+ *  - Stats badges: tool calls, thinking blocks, assistant messages (hide zeros)
+ *  - Fixed-height preview area (~80px) with SDKMessageRenderer
+ *  - Active indicator: pulsing left border when turn.isActive
+ *  - Selected state: highlighted border when isSelected
+ */
+
+import type { JSX } from 'preact';
+import { ROLE_COLORS } from '../../lib/task-constants';
+import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
+import type { TurnBlock } from '../../hooks/useTurnBlocks';
+
+interface Props {
+	turn: TurnBlock;
+	onClick: (turn: TurnBlock) => void;
+	isSelected?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Duration helpers
+// ---------------------------------------------------------------------------
+
+function formatDuration(startMs: number, endMs: number): string {
+	const diffSec = Math.max(0, Math.floor((endMs - startMs) / 1000));
+	if (diffSec < 60) return `${diffSec}s`;
+	const m = Math.floor(diffSec / 60);
+	const s = diffSec % 60;
+	return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatBadge({
+	icon,
+	count,
+	label,
+}: {
+	icon: JSX.Element;
+	count: number;
+	label: string;
+}): JSX.Element | null {
+	if (count === 0) return null;
+	return (
+		<span
+			title={label}
+			class="inline-flex items-center gap-1 rounded-full bg-dark-700 px-2 py-0.5 text-xs text-gray-400"
+		>
+			{icon}
+			{count}
+		</span>
+	);
+}
+
+// Inline SVG icons (no external dep needed)
+function WrenchIcon(): JSX.Element {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="h-3 w-3"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				fill-rule="evenodd"
+				d="M5.293 3.293a1 1 0 011.414 0L10 6.586l3.293-3.293a1 1 0 111.414 1.414L11.414 8l3.293 3.293a1 1 0 01-1.414 1.414L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414L8.586 8 5.293 4.707a1 1 0 010-1.414z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function BrainIcon(): JSX.Element {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="h-3 w-3"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<path d="M10 2a8 8 0 100 16A8 8 0 0010 2zm0 14a6 6 0 110-12 6 6 0 010 12z" />
+		</svg>
+	);
+}
+
+function ChatIcon(): JSX.Element {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			class="h-3 w-3"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<path
+				fill-rule="evenodd"
+				d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function TurnSummaryBlock({ turn, onClick, isSelected = false }: Props): JSX.Element {
+	const roleConfig = ROLE_COLORS[turn.agentRole] ?? {
+		border: 'border-l-gray-500',
+		label: turn.agentRole,
+		labelColor: 'text-gray-400',
+	};
+
+	const duration =
+		turn.endTime === null ? 'running...' : formatDuration(turn.startTime, turn.endTime);
+
+	// Left border: active uses pulsing color, selected uses ring highlight, default is muted
+	const leftBorderClass = turn.isActive
+		? `border-l-2 ${roleConfig.border} animate-pulse`
+		: `border-l-2 ${roleConfig.border}`;
+
+	const selectedRingClass = isSelected ? 'ring-1 ring-blue-500' : '';
+
+	return (
+		<div
+			data-testid="turn-block"
+			role="button"
+			tabIndex={0}
+			class={[
+				'relative cursor-pointer rounded-md border border-dark-700 bg-dark-800 p-3 transition-colors hover:bg-dark-750',
+				leftBorderClass,
+				selectedRingClass,
+				turn.isError ? 'border-red-800' : '',
+			]
+				.filter(Boolean)
+				.join(' ')}
+			onClick={() => onClick(turn)}
+			onKeyDown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					onClick(turn);
+				}
+			}}
+		>
+			{/* Active indicator overlay */}
+			{turn.isActive && (
+				<span
+					data-testid="turn-block-active"
+					class="absolute left-0 top-0 h-full w-0.5 animate-pulse rounded-l-md bg-current opacity-80"
+					style={{ color: 'inherit' }}
+					aria-label="Active turn"
+				/>
+			)}
+
+			{/* Title bar */}
+			<div class="flex items-center gap-2 overflow-hidden">
+				<span
+					data-testid="turn-block-agent-name"
+					class={`truncate text-sm font-semibold ${roleConfig.labelColor}`}
+				>
+					{roleConfig.label || turn.agentRole}
+				</span>
+
+				{turn.lastAction && (
+					<span class="shrink-0 rounded bg-dark-700 px-1.5 py-0.5 text-xs text-gray-400">
+						{turn.lastAction}
+					</span>
+				)}
+
+				<span class="ml-auto shrink-0 text-xs text-gray-500">{duration}</span>
+			</div>
+
+			{/* Stats badges */}
+			<div data-testid="turn-block-stats" class="mt-1.5 flex flex-wrap gap-1.5">
+				<StatBadge icon={<WrenchIcon />} count={turn.toolCallCount} label="Tool calls" />
+				<StatBadge icon={<BrainIcon />} count={turn.thinkingCount} label="Thinking blocks" />
+				<StatBadge icon={<ChatIcon />} count={turn.assistantCount} label="Assistant messages" />
+			</div>
+
+			{/* Error message */}
+			{turn.isError && turn.errorMessage && (
+				<div class="mt-1.5 rounded bg-red-950 px-2 py-1 text-xs text-red-400">
+					{turn.errorMessage}
+				</div>
+			)}
+
+			{/* Preview area */}
+			<div
+				data-testid="turn-block-preview"
+				class="mt-2 max-h-20 overflow-y-auto text-xs [&_*]:text-xs"
+			>
+				{turn.previewMessage ? (
+					<SDKMessageRenderer message={turn.previewMessage} taskContext={true} />
+				) : (
+					<span class="text-gray-600">No messages</span>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/room/TurnSummaryBlock.tsx
+++ b/packages/web/src/components/room/TurnSummaryBlock.tsx
@@ -14,7 +14,7 @@ import { ROLE_COLORS } from '../../lib/task-constants';
 import { SDKMessageRenderer } from '../sdk/SDKMessageRenderer';
 import type { TurnBlock } from '../../hooks/useTurnBlocks';
 
-interface Props {
+export interface TurnSummaryBlockProps {
 	turn: TurnBlock;
 	onClick: (turn: TurnBlock) => void;
 	isSelected?: boolean;
@@ -57,8 +57,9 @@ function StatBadge({
 	);
 }
 
-// Inline SVG icons (no external dep needed)
+// Inline SVG icons (Heroicons v1 solid, 20×20 viewBox)
 function WrenchIcon(): JSX.Element {
+	// Heroicons v1 solid "cog" — represents tool/settings operations
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -69,7 +70,7 @@ function WrenchIcon(): JSX.Element {
 		>
 			<path
 				fill-rule="evenodd"
-				d="M5.293 3.293a1 1 0 011.414 0L10 6.586l3.293-3.293a1 1 0 111.414 1.414L11.414 8l3.293 3.293a1 1 0 01-1.414 1.414L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414L8.586 8 5.293 4.707a1 1 0 010-1.414z"
+				d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
 				clip-rule="evenodd"
 			/>
 		</svg>
@@ -77,6 +78,7 @@ function WrenchIcon(): JSX.Element {
 }
 
 function BrainIcon(): JSX.Element {
+	// Heroicons v1 solid "light-bulb" — represents thinking/reasoning
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +87,7 @@ function BrainIcon(): JSX.Element {
 			fill="currentColor"
 			aria-hidden="true"
 		>
-			<path d="M10 2a8 8 0 100 16A8 8 0 0010 2zm0 14a6 6 0 110-12 6 6 0 010 12z" />
+			<path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.464 5.05l-.707-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.476.859h4.001z" />
 		</svg>
 	);
 }
@@ -112,7 +114,11 @@ function ChatIcon(): JSX.Element {
 // Main component
 // ---------------------------------------------------------------------------
 
-export function TurnSummaryBlock({ turn, onClick, isSelected = false }: Props): JSX.Element {
+export function TurnSummaryBlock({
+	turn,
+	onClick,
+	isSelected = false,
+}: TurnSummaryBlockProps): JSX.Element {
 	const roleConfig = ROLE_COLORS[turn.agentRole] ?? {
 		border: 'border-l-gray-500',
 		label: turn.agentRole,
@@ -166,7 +172,7 @@ export function TurnSummaryBlock({ turn, onClick, isSelected = false }: Props): 
 					data-testid="turn-block-agent-name"
 					class={`truncate text-sm font-semibold ${roleConfig.labelColor}`}
 				>
-					{roleConfig.label || turn.agentRole}
+					{turn.agentLabel || turn.agentRole}
 				</span>
 
 				{turn.lastAction && (

--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -323,11 +323,14 @@ describe('TurnSummaryBlock', () => {
 			expect(nameEl!.className).toContain(expectedClass);
 		});
 
-		it('renders Human label for human turn', () => {
-			const turn = makeTurn({ agentRole: 'human', agentLabel: 'Human' });
+		it('renders agentLabel (not ROLE_COLORS label) for human turn', () => {
+			// agentLabel is set to a custom string that differs from ROLE_COLORS['human'].label
+			// to verify the component uses turn.agentLabel, not a re-derived ROLE_COLORS lookup
+			const turn = makeTurn({ agentRole: 'human', agentLabel: 'Human (GPT-4)' });
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
-			expect(nameEl!.textContent).toBe('Human');
+			// Must show the custom agentLabel, NOT the ROLE_COLORS-derived 'Human'
+			expect(nameEl!.textContent).toBe('Human (GPT-4)');
 		});
 
 		it('falls back to agentRole text for unknown role', () => {

--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -1,0 +1,362 @@
+/**
+ * Tests for TurnSummaryBlock component
+ *
+ * Covers:
+ * - Basic rendering: agent name, role color class, stats badges, duration
+ * - Active turn: pulsing animation class and data-testid="turn-block-active"
+ * - Inactive turn: no animation / no active indicator
+ * - Error turn: error styling and error message
+ * - Selected state: highlighted border when isSelected=true
+ * - Click handler: onClick called with turn data
+ * - Last action badge: last action text displayed
+ * - Stats display: correct counts
+ * - Zero stats: badges with zero counts hidden
+ * - data-testid attributes: all required attributes present
+ * - Human turn: agentRole="human" → label "Human"
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { TurnSummaryBlock } from '../TurnSummaryBlock';
+import type { TurnBlock } from '../../../hooks/useTurnBlocks';
+import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+
+// ---------------------------------------------------------------------------
+// Mock SDKMessageRenderer to avoid full SDK rendering in unit tests
+// ---------------------------------------------------------------------------
+
+vi.mock('../../sdk/SDKMessageRenderer', () => ({
+	SDKMessageRenderer: ({ message }: { message: SDKMessage }) => {
+		const m = message as { type: string };
+		return <span data-testid="mock-sdk-renderer">sdk:{m.type}</span>;
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAssistantMsg(text = 'Hello'): SDKMessage {
+	return {
+		type: 'assistant',
+		message: { role: 'assistant', content: [{ type: 'text', text }] },
+	} as unknown as SDKMessage;
+}
+
+function makeTurn(overrides: Partial<TurnBlock> = {}): TurnBlock {
+	return {
+		id: 'turn-1',
+		sessionId: 'session-1',
+		agentRole: 'coder',
+		agentLabel: 'Coder',
+		startTime: 1_000_000,
+		endTime: 1_150_000, // 2m 30s
+		messageCount: 3,
+		toolCallCount: 2,
+		thinkingCount: 1,
+		assistantCount: 1,
+		lastAction: 'Bash',
+		previewMessage: makeAssistantMsg(),
+		isActive: false,
+		isError: false,
+		errorMessage: null,
+		messages: [],
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TurnSummaryBlock', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	// ── Basic rendering ─────────────────────────────────────────────────────
+
+	describe('basic rendering', () => {
+		it('renders agent name', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl).toBeTruthy();
+			expect(nameEl!.textContent).toBe('Coder');
+		});
+
+		it('applies labelColor class from ROLE_COLORS for coder', () => {
+			const { container } = render(
+				<TurnSummaryBlock turn={makeTurn({ agentRole: 'coder' })} onClick={vi.fn()} />
+			);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.className).toContain('text-blue-400');
+		});
+
+		it('renders turn duration when endTime is set', () => {
+			const turn = makeTurn({ startTime: 0, endTime: 150_000 }); // 2m 30s
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			// duration span is the last element in the title row
+			expect(container.textContent).toContain('2m 30s');
+		});
+
+		it('renders "running..." when endTime is null', () => {
+			const turn = makeTurn({ endTime: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('running...');
+		});
+
+		it('renders last action badge', () => {
+			const turn = makeTurn({ lastAction: 'Read' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('Read');
+		});
+
+		it('does not render last action badge when lastAction is null', () => {
+			const turn = makeTurn({ lastAction: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			// No badge text from lastAction
+			const titleRow = container.querySelector(
+				'[data-testid="turn-block-agent-name"]'
+			)?.parentElement;
+			// Only agent name + duration span expected, no badge
+			const spans = titleRow?.querySelectorAll('span') ?? [];
+			// Agent name span + duration span = 2; no badge span
+			expect(spans.length).toBe(2);
+		});
+
+		it('renders SDKMessageRenderer for preview', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			expect(container.querySelector('[data-testid="mock-sdk-renderer"]')).toBeTruthy();
+		});
+
+		it('renders "No messages" when previewMessage is null', () => {
+			const turn = makeTurn({ previewMessage: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const preview = container.querySelector('[data-testid="turn-block-preview"]');
+			expect(preview!.textContent).toContain('No messages');
+		});
+	});
+
+	// ── Stats badges ─────────────────────────────────────────────────────────
+
+	describe('stats badges', () => {
+		it('renders all three stat badges when counts are non-zero', () => {
+			const turn = makeTurn({ toolCallCount: 3, thinkingCount: 2, assistantCount: 4 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const stats = container.querySelector('[data-testid="turn-block-stats"]');
+			expect(stats!.textContent).toContain('3');
+			expect(stats!.textContent).toContain('2');
+			expect(stats!.textContent).toContain('4');
+		});
+
+		it('hides tool calls badge when count is 0', () => {
+			const turn = makeTurn({ toolCallCount: 0, thinkingCount: 1, assistantCount: 1 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const stats = container.querySelector('[data-testid="turn-block-stats"]');
+			// Only 2 pill badges (thinking + assistant)
+			expect(stats!.querySelectorAll('span').length).toBe(2);
+		});
+
+		it('hides thinking badge when count is 0', () => {
+			const turn = makeTurn({ toolCallCount: 1, thinkingCount: 0, assistantCount: 1 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const stats = container.querySelector('[data-testid="turn-block-stats"]');
+			expect(stats!.querySelectorAll('span').length).toBe(2);
+		});
+
+		it('hides assistant badge when count is 0', () => {
+			const turn = makeTurn({ toolCallCount: 1, thinkingCount: 1, assistantCount: 0 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const stats = container.querySelector('[data-testid="turn-block-stats"]');
+			expect(stats!.querySelectorAll('span').length).toBe(2);
+		});
+
+		it('renders no stat badges when all counts are 0', () => {
+			const turn = makeTurn({ toolCallCount: 0, thinkingCount: 0, assistantCount: 0 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const stats = container.querySelector('[data-testid="turn-block-stats"]');
+			expect(stats!.querySelectorAll('span').length).toBe(0);
+		});
+	});
+
+	// ── Active state ──────────────────────────────────────────────────────────
+
+	describe('active turn', () => {
+		it('renders data-testid="turn-block-active" indicator when isActive', () => {
+			const turn = makeTurn({ isActive: true, endTime: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.querySelector('[data-testid="turn-block-active"]')).toBeTruthy();
+		});
+
+		it('does NOT render active indicator when isActive is false', () => {
+			const turn = makeTurn({ isActive: false });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.querySelector('[data-testid="turn-block-active"]')).toBeNull();
+		});
+
+		it('applies animate-pulse class on root when isActive', () => {
+			const turn = makeTurn({ isActive: true, endTime: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('animate-pulse');
+		});
+
+		it('does NOT apply animate-pulse on root when inactive', () => {
+			const turn = makeTurn({ isActive: false });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).not.toContain('animate-pulse');
+		});
+	});
+
+	// ── Selected state ────────────────────────────────────────────────────────
+
+	describe('selected state', () => {
+		it('applies ring-1 ring-blue-500 when isSelected=true', () => {
+			const turn = makeTurn();
+			const { container } = render(
+				<TurnSummaryBlock turn={turn} onClick={vi.fn()} isSelected={true} />
+			);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('ring-1');
+			expect(root!.className).toContain('ring-blue-500');
+		});
+
+		it('does NOT apply ring when isSelected=false', () => {
+			const turn = makeTurn();
+			const { container } = render(
+				<TurnSummaryBlock turn={turn} onClick={vi.fn()} isSelected={false} />
+			);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).not.toContain('ring-blue-500');
+		});
+	});
+
+	// ── Error state ───────────────────────────────────────────────────────────
+
+	describe('error turn', () => {
+		it('renders error message when isError and errorMessage set', () => {
+			const turn = makeTurn({ isError: true, errorMessage: 'Something went wrong' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('Something went wrong');
+		});
+
+		it('applies red border styling when isError', () => {
+			const turn = makeTurn({ isError: true, errorMessage: 'Oops' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-red-800');
+		});
+
+		it('does not render error section when isError=false', () => {
+			const turn = makeTurn({ isError: false, errorMessage: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			// No red text anywhere
+			expect(container.querySelector('.text-red-400')).toBeNull();
+		});
+	});
+
+	// ── Click handler ─────────────────────────────────────────────────────────
+
+	describe('click handler', () => {
+		it('calls onClick with the turn when clicked', () => {
+			const onClickMock = vi.fn();
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={onClickMock} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			fireEvent.click(root);
+			expect(onClickMock).toHaveBeenCalledOnce();
+			expect(onClickMock).toHaveBeenCalledWith(turn);
+		});
+
+		it('calls onClick with Enter key press', () => {
+			const onClickMock = vi.fn();
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={onClickMock} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			fireEvent.keyDown(root, { key: 'Enter' });
+			expect(onClickMock).toHaveBeenCalledWith(turn);
+		});
+
+		it('calls onClick with Space key press', () => {
+			const onClickMock = vi.fn();
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={onClickMock} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			fireEvent.keyDown(root, { key: ' ' });
+			expect(onClickMock).toHaveBeenCalledWith(turn);
+		});
+	});
+
+	// ── data-testid attributes ────────────────────────────────────────────────
+
+	describe('data-testid attributes', () => {
+		it('has all required data-testid attributes', () => {
+			const { container } = render(
+				<TurnSummaryBlock turn={makeTurn({ isActive: true, endTime: null })} onClick={vi.fn()} />
+			);
+			expect(container.querySelector('[data-testid="turn-block"]')).toBeTruthy();
+			expect(container.querySelector('[data-testid="turn-block-agent-name"]')).toBeTruthy();
+			expect(container.querySelector('[data-testid="turn-block-stats"]')).toBeTruthy();
+			expect(container.querySelector('[data-testid="turn-block-preview"]')).toBeTruthy();
+			expect(container.querySelector('[data-testid="turn-block-active"]')).toBeTruthy();
+		});
+	});
+
+	// ── Role colors ───────────────────────────────────────────────────────────
+
+	describe('role colors', () => {
+		const roles: Array<[string, string]> = [
+			['planner', 'text-teal-400'],
+			['coder', 'text-blue-400'],
+			['general', 'text-slate-400'],
+			['leader', 'text-purple-400'],
+			['human', 'text-green-400'],
+			['craft', 'text-blue-400'],
+			['lead', 'text-purple-400'],
+		];
+
+		it.each(roles)('applies correct label color for role=%s', (role, expectedClass) => {
+			const turn = makeTurn({ agentRole: role });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.className).toContain(expectedClass);
+		});
+
+		it('renders Human label for human turn', () => {
+			const turn = makeTurn({ agentRole: 'human', agentLabel: 'Human' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.textContent).toBe('Human');
+		});
+
+		it('falls back to agentRole text for unknown role', () => {
+			const turn = makeTurn({ agentRole: 'custom-agent', agentLabel: 'custom-agent' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.textContent).toBe('custom-agent');
+		});
+	});
+
+	// ── Duration formatting ────────────────────────────────────────────────────
+
+	describe('duration formatting', () => {
+		it('formats seconds only for durations under 1 minute', () => {
+			const turn = makeTurn({ startTime: 0, endTime: 45_000 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('45s');
+		});
+
+		it('formats minutes only when seconds remainder is 0', () => {
+			const turn = makeTurn({ startTime: 0, endTime: 180_000 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('3m');
+		});
+
+		it('formats minutes and seconds', () => {
+			const turn = makeTurn({ startTime: 0, endTime: 125_000 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('2m 5s');
+		});
+	});
+});

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -20,3 +20,4 @@ export { RoomAgents } from './RoomAgents';
 export type { RoomAgentsProps } from './RoomAgents';
 // @public - Library export
 export { TurnSummaryBlock } from './TurnSummaryBlock';
+export type { TurnSummaryBlockProps } from './TurnSummaryBlock';

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -18,3 +18,5 @@ export type { RoomSettingsProps } from './RoomSettings';
 // @public - Library export
 export { RoomAgents } from './RoomAgents';
 export type { RoomAgentsProps } from './RoomAgents';
+// @public - Library export
+export { TurnSummaryBlock } from './TurnSummaryBlock';


### PR DESCRIPTION
## Summary

- Adds `TurnSummaryBlock` component (`packages/web/src/components/room/TurnSummaryBlock.tsx`) — a compact card rendering a single agent turn with:
  - Title bar: role-colored agent name, last-action badge, turn duration ("running..." when active)
  - Stats badges (tool calls / thinking / assistant) — zero counts hidden
  - Fixed-height (~80px) preview area with `SDKMessageRenderer` and `taskContext={true}`
  - Pulsing left border + active indicator span (`data-testid="turn-block-active"`) when `turn.isActive`
  - Ring highlight when `isSelected`
  - Red border + error message section when `turn.isError`
- Exports `TurnSummaryBlock` from `packages/web/src/components/room/index.ts`
- 38 unit tests in `__tests__/TurnSummaryBlock.test.tsx`

## Test plan

- [x] All 38 unit tests pass (`bunx vitest run src/components/room/__tests__/TurnSummaryBlock.test.tsx`)
- [x] All pre-commit checks pass (lint, format, typecheck, knip)
- [ ] Visual review: active pulsing, selected ring, error styling, role colors