### PR TITLE
test: unit tests for TurnSummaryBlock component

### DIFF
--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -230,6 +230,13 @@ describe('TurnSummaryBlock', () => {
 			const root = container.querySelector('[data-testid="turn-block"]');
 			expect(root!.className).not.toContain('ring-blue-500');
 		});
+
+		it('does NOT apply ring when isSelected prop is omitted (default=false)', () => {
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).not.toContain('ring-blue-500');
+		});
 	});
 
 	// ── Error state ───────────────────────────────────────────────────────────
@@ -252,6 +259,18 @@ describe('TurnSummaryBlock', () => {
 			const turn = makeTurn({ isError: false, errorMessage: null });
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			// No red text anywhere
+			expect(container.querySelector('.text-red-400')).toBeNull();
+		});
+
+		it('applies red border but no error message div when isError=true and errorMessage=null', () => {
+			// This edge case is reachable: useTurnBlocks can set isError=true with errorMessage=null
+			// when error detection fires but no text is extractable.
+			const turn = makeTurn({ isError: true, errorMessage: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			// Border-red-800 class still applied
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-red-800');
+			// But no red message div rendered (guarded by turn.isError && turn.errorMessage)
 			expect(container.querySelector('.text-red-400')).toBeNull();
 		});
 	});
@@ -314,6 +333,7 @@ describe('TurnSummaryBlock', () => {
 			['human', 'text-green-400'],
 			['craft', 'text-blue-400'],
 			['lead', 'text-purple-400'],
+			['system', 'text-gray-500'],
 		];
 
 		it.each(roles)('applies correct label color for role=%s', (role, expectedClass) => {
@@ -338,6 +358,16 @@ describe('TurnSummaryBlock', () => {
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
 			expect(nameEl!.textContent).toBe('custom-agent');
+		});
+
+		it('falls back to agentRole when agentLabel is empty string (system role quirk)', () => {
+			// ROLE_COLORS['system'].label is '' — useTurnBlocks propagates this as agentLabel.
+			// The component uses `turn.agentLabel || turn.agentRole`, so the empty agentLabel
+			// causes the agentRole string 'system' to be rendered instead.
+			const turn = makeTurn({ agentRole: 'system', agentLabel: '' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.textContent).toBe('system');
 		});
 	});
 

--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -361,5 +361,70 @@ describe('TurnSummaryBlock', () => {
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			expect(container.textContent).toContain('2m 5s');
 		});
+
+		it('shows 0s for zero duration', () => {
+			const turn = makeTurn({ startTime: 1_000_000, endTime: 1_000_000 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('0s');
+		});
+	});
+
+	// ── Accessibility ─────────────────────────────────────────────────────────
+
+	describe('accessibility', () => {
+		it('has role="button" on the root element', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root?.getAttribute('role')).toBe('button');
+		});
+
+		it('has tabIndex=0 for keyboard navigation', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			expect(root?.tabIndex).toBe(0);
+		});
+
+		it('does NOT call onClick for non-Enter/Space key presses', () => {
+			const onClickMock = vi.fn();
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={onClickMock} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			fireEvent.keyDown(root, { key: 'Escape' });
+			fireEvent.keyDown(root, { key: 'Tab' });
+			fireEvent.keyDown(root, { key: 'ArrowDown' });
+			expect(onClickMock).not.toHaveBeenCalled();
+		});
+
+		it('active indicator has aria-label="Active turn"', () => {
+			const turn = makeTurn({ isActive: true, endTime: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const indicator = container.querySelector('[data-testid="turn-block-active"]');
+			expect(indicator?.getAttribute('aria-label')).toBe('Active turn');
+		});
+	});
+
+	// ── Border class ──────────────────────────────────────────────────────────
+
+	describe('border class', () => {
+		it('applies role border class from ROLE_COLORS for coder', () => {
+			const turn = makeTurn({ agentRole: 'coder' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-blue-500');
+		});
+
+		it('applies role border class for leader', () => {
+			const turn = makeTurn({ agentRole: 'leader' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-purple-500');
+		});
+
+		it('falls back to gray border for unknown role', () => {
+			const turn = makeTurn({ agentRole: 'unknown-role', agentLabel: 'Unknown' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-gray-500');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- 46 unit tests for `TurnSummaryBlock` covering all required scenarios
- SDKMessageRenderer properly mocked to isolate component rendering
- Tests verify visual states (active/inactive, error, selected), interaction (click + keyboard), accessibility, and edge cases

## Test Coverage

- **Basic rendering**: agent name, role color class, duration formatting (seconds/minutes/mixed), last action badge, preview message / "No messages" fallback
- **Active turn**: `animate-pulse` class on root + `data-testid="turn-block-active"` indicator with `aria-label="Active turn"`
- **Inactive turn**: no animation, no active indicator
- **Error turn**: `border-red-800` styling and `text-red-400` error message displayed
- **Selected state**: `ring-1 ring-blue-500` highlight when `isSelected=true`
- **Click handler**: `onClick` called with full turn data on mouse click
- **Keyboard handler**: `onClick` triggered on Enter/Space; not triggered on other keys
- **Last action badge**: visible when set, absent when `lastAction=null`
- **Stats display**: correct counts for tool calls, thinking, assistant messages
- **Zero stats**: badges hidden when count is 0; all hidden when all are 0
- **data-testid attributes**: all required attributes present (`turn-block`, `turn-block-agent-name`, `turn-block-stats`, `turn-block-preview`, `turn-block-active`)
- **Human turn**: `agentRole="human"` renders `agentLabel`, applies `text-green-400`
- **Role colors**: all roles from ROLE_COLORS verified; unknown role falls back to gray
- **Border class**: role-specific border color; unknown role falls back to `border-l-gray-500`
- **Accessibility**: `role="button"`, `tabIndex=0`, aria-label on active indicator

## Test Plan

- [x] Run `bunx vitest run src/components/room/__tests__/TurnSummaryBlock.test.tsx` — 46/46 pass