### PR TITLE
feat: implement TaskViewV2 component with turn-based conversation view

### DIFF
--- a/packages/web/src/components/room/TaskViewV2.test.tsx
+++ b/packages/web/src/components/room/TaskViewV2.test.tsx
@@ -44,12 +44,13 @@ vi.mock('../../hooks/useMessageHub.ts', () => ({
 // useGroupMessages — controlled by mockGroupMessages
 let mockGroupMessages: SessionGroupMessage[] = [];
 let mockMessagesLoading = false;
+let mockIsReconnecting = false;
 
 vi.mock('../../hooks/useGroupMessages.ts', () => ({
 	useGroupMessages: () => ({
 		messages: mockGroupMessages,
 		isLoading: mockMessagesLoading,
-		isReconnecting: false,
+		isReconnecting: mockIsReconnecting,
 	}),
 }));
 
@@ -301,12 +302,29 @@ function makeTurn(overrides: Partial<TurnBlock> = {}): TurnBlock {
 	};
 }
 
-// Setup default useTaskViewData mock state — overrideable in each test
+// Setup default useTaskViewData mock state — overrideable in each test.
+// Use vi.fn() so mockReturnValue() takes effect on the next render call.
 let mockTaskViewData: ReturnType<typeof import('../../hooks/useTaskViewData').useTaskViewData>;
-let mockSetConversationKey: (fn: (k: number) => number) => void;
+const useTaskViewDataFn = vi.fn((_roomId: string, _taskId: string) => mockTaskViewData);
+
+// Signal-driven conversationKey — changing this signal causes Preact to
+// reactively re-render any component that reads it (via the getter in the mock
+// below). This is more reliable than rerender() + mockReturnValue for testing
+// effects that depend on conversationKey changing.
+const mockConversationKeySignal = signal(0);
 
 vi.mock('../../hooks/useTaskViewData.ts', () => ({
-	useTaskViewData: () => mockTaskViewData,
+	useTaskViewData: (roomId: string, taskId: string) => {
+		const base = useTaskViewDataFn(roomId, taskId);
+		return {
+			...base,
+			// Getter so that Preact's signal tracking picks up the dependency
+			// when the component destructures conversationKey during render.
+			get conversationKey() {
+				return mockConversationKeySignal.value;
+			},
+		};
+	},
 }));
 
 function makeDefaultTaskViewData(
@@ -400,9 +418,12 @@ describe('TaskViewV2', () => {
 		mockGroupMessages = [];
 		mockTurnBlockItems = [];
 		mockMessagesLoading = false;
+		mockIsReconnecting = false;
 		mockShowScrollButton = false;
 		_draftContent.value = '';
+		mockConversationKeySignal.value = 0;
 		mockTaskViewData = makeDefaultTaskViewData();
+		useTaskViewDataFn.mockImplementation(() => mockTaskViewData);
 	});
 
 	afterEach(() => {
@@ -693,25 +714,88 @@ describe('TaskViewV2', () => {
 		expect(container.textContent).toContain('PR #42');
 	});
 
-	// --- conversationKey renders new key ---
+	// --- conversationKey state resets ---
 
-	it('renders new turn-blocks-container key when conversationKey changes', async () => {
-		const data = makeDefaultTaskViewData(makeTask(), makeGroup());
-		data.conversationKey = 0;
-		mockTaskViewData = data;
+	it('replaces turn-blocks-container DOM node when conversationKey changes (rendererKey drives state reset)', async () => {
+		// When conversationKey changes, rendererKey changes, which:
+		// 1. Replaces the turn-blocks-container div (key-based unmount+remount)
+		// 2. Triggers useEffect([rendererKey]) to reset selectedTurn, autoScrollEnabled, isFirstLoad
+		//
+		// We use mockConversationKeySignal (a Preact signal) so the component
+		// reactively re-renders when the signal changes — more reliable than
+		// calling rerender() with the same props.
+		const turn = makeTurn({ id: 'turn-1', sessionId: 'session-worker' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
 
-		const { getByTestId, rerender } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
-		const container1 = getByTestId('turn-blocks-container');
-		expect(container1).toBeTruthy();
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		const containerBefore = getByTestId('turn-blocks-container');
 
-		// Bump conversationKey
-		data.conversationKey = 1;
-		mockTaskViewData = { ...data };
-		rerender(<TaskViewV2 roomId="room-1" taskId="task-1" />);
-
-		await waitFor(() => {
-			const container2 = getByTestId('turn-blocks-container');
-			expect(container2).toBeTruthy();
+		// Bump conversationKey via signal → reactive re-render
+		await act(async () => {
+			mockConversationKeySignal.value = 1;
 		});
+
+		// The turn-blocks-container should be a NEW DOM node (key changed = unmount+remount)
+		const containerAfter = getByTestId('turn-blocks-container');
+		expect(containerAfter).not.toBe(containerBefore);
+	});
+
+	it('resets slide-out panel (selectedTurn → null) when conversationKey changes', async () => {
+		const turn = makeTurn({ id: 'turn-1', sessionId: 'session-worker' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
+
+		const { getByTestId, queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		// Open the slide-out panel
+		fireEvent.click(getByTestId('turn-block'));
+		await waitFor(() => expect(getByTestId('slide-out-panel')).toBeTruthy());
+
+		// Bump conversationKey via signal → reactive re-render → useEffect resets selectedTurn
+		await act(async () => {
+			mockConversationKeySignal.value = 1;
+		});
+
+		// Slide-out should be closed after conversationKey change
+		await waitFor(() => expect(queryByTestId('slide-out-panel')).toBeNull());
+	});
+
+	it('resets autoScrollEnabled to true when conversationKey changes', async () => {
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		// Disable auto-scroll
+		const toggleBtn = container.querySelector('[title="Disable auto-scroll"]') as HTMLElement;
+		fireEvent.click(toggleBtn);
+		await waitFor(() =>
+			expect(container.querySelector('[title="Enable auto-scroll"]')).toBeTruthy()
+		);
+
+		// Bump conversationKey via signal → reactive re-render → useEffect resets autoScrollEnabled
+		await act(async () => {
+			mockConversationKeySignal.value = 1;
+		});
+
+		await waitFor(() =>
+			expect(container.querySelector('[title="Disable auto-scroll"]')).toBeTruthy()
+		);
+	});
+
+	// --- isReconnecting ---
+
+	it('shows reconnecting banner when isReconnecting is true', () => {
+		mockIsReconnecting = true;
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('reconnecting-banner')).toBeTruthy();
+	});
+
+	it('does not show reconnecting banner when isReconnecting is false', () => {
+		mockIsReconnecting = false;
+		const { queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(queryByTestId('reconnecting-banner')).toBeNull();
+	});
+
+	it('reconnecting banner shows text "Reconnecting…"', () => {
+		mockIsReconnecting = true;
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('reconnecting-banner').textContent).toContain('Reconnecting');
 	});
 });

--- a/packages/web/src/components/room/TaskViewV2.test.tsx
+++ b/packages/web/src/components/room/TaskViewV2.test.tsx
@@ -1,0 +1,717 @@
+/**
+ * Tests for TaskViewV2 Component
+ *
+ * Covers:
+ * - data-testid="task-view-v2" presence
+ * - Loading and error states
+ * - Turn blocks rendered for all agents
+ * - Runtime messages rendered inline between turn blocks
+ * - Clicking a turn block opens slide-out panel
+ * - Only one slide-out panel at a time (opening a new one closes previous)
+ * - Review bar appears when group.submittedForReview
+ * - Auto-scroll integration (isFirstLoad flip, autoScrollEnabled toggle)
+ * - Shared sub-components (HumanInputArea, TaskActionDialogs, TaskReviewBar, RejectModal)
+ * - conversationKey bump forces re-render key
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor, fireEvent, act } from '@testing-library/preact';
+import { useEffect } from 'preact/hooks';
+import { signal } from '@preact/signals';
+import type { NeoTask } from '@neokai/shared';
+import type { TurnBlock, TurnBlockItem } from '../../hooks/useTurnBlocks';
+import type { SessionGroupMessage } from '../../hooks/useGroupMessages';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRequest = vi.fn();
+const mockOnEvent = vi.fn((_eventName: string, _handler: (event: unknown) => void) => () => {});
+const mockJoinRoom = vi.fn();
+const mockLeaveRoom = vi.fn();
+
+vi.mock('../../hooks/useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		joinRoom: mockJoinRoom,
+		leaveRoom: mockLeaveRoom,
+		isConnected: true,
+	}),
+}));
+
+// useGroupMessages — controlled by mockGroupMessages
+let mockGroupMessages: SessionGroupMessage[] = [];
+let mockMessagesLoading = false;
+
+vi.mock('../../hooks/useGroupMessages.ts', () => ({
+	useGroupMessages: () => ({
+		messages: mockGroupMessages,
+		isLoading: mockMessagesLoading,
+		isReconnecting: false,
+	}),
+}));
+
+// useTurnBlocks — controlled by mockTurnBlockItems
+let mockTurnBlockItems: TurnBlockItem[] = [];
+
+vi.mock('../../hooks/useTurnBlocks.ts', () => ({
+	useTurnBlocks: () => mockTurnBlockItems,
+}));
+
+// useAutoScroll — controlled
+const mockScrollToBottom = vi.fn();
+let mockShowScrollButton = false;
+
+vi.mock('../../hooks/useAutoScroll.ts', () => ({
+	useAutoScroll: vi.fn(() => ({
+		showScrollButton: mockShowScrollButton,
+		scrollToBottom: mockScrollToBottom,
+		isNearBottom: true,
+	})),
+}));
+
+// useTaskInputDraft — minimal stub for HumanInputArea
+const _draftContent = signal('');
+vi.mock('../../hooks/useTaskInputDraft.ts', () => ({
+	useTaskInputDraft: () => ({
+		get content() {
+			return _draftContent.value;
+		},
+		setContent: vi.fn((v: string) => {
+			_draftContent.value = v;
+		}),
+		clear: vi.fn(),
+		get draftRestored() {
+			return false;
+		},
+	}),
+}));
+
+// roomStore.goalByTaskId — no goal
+vi.mock('../../lib/room-store.ts', () => ({
+	roomStore: {
+		goalByTaskId: { value: new Map() },
+	},
+}));
+
+const mockNavigateToRoom = vi.fn();
+const mockNavigateToRoomTask = vi.fn();
+vi.mock('../../lib/router.ts', () => ({
+	get navigateToRoom() {
+		return mockNavigateToRoom;
+	},
+	get navigateToRoomTask() {
+		return mockNavigateToRoomTask;
+	},
+}));
+
+vi.mock('../../lib/signals.ts', () => ({
+	currentRoomTabSignal: { value: 'chat' },
+}));
+
+vi.mock('../../lib/toast.ts', () => ({
+	toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// TurnSummaryBlock — renders agent label + click handler
+vi.mock('./TurnSummaryBlock.tsx', () => ({
+	TurnSummaryBlock: ({
+		turn,
+		onClick,
+		isSelected,
+	}: {
+		turn: TurnBlock;
+		onClick: (t: TurnBlock) => void;
+		isSelected: boolean;
+	}) => (
+		<div
+			data-testid="turn-block"
+			data-turn-id={turn.id}
+			data-selected={String(isSelected)}
+			onClick={() => onClick(turn)}
+		>
+			{turn.agentLabel}
+		</div>
+	),
+}));
+
+// RuntimeMessageRenderer — simple stub
+vi.mock('./RuntimeMessageRenderer.tsx', () => ({
+	RuntimeMessageRenderer: ({ message }: { message: { index: number } }) => (
+		<div data-testid="runtime-message" data-index={message.index} />
+	),
+}));
+
+// SlideOutPanel — renders sessionId when open
+vi.mock('./SlideOutPanel.tsx', () => ({
+	SlideOutPanel: ({
+		isOpen,
+		sessionId,
+		agentLabel,
+		onClose,
+	}: {
+		isOpen: boolean;
+		sessionId: string | null;
+		agentLabel?: string;
+		onClose: () => void;
+	}) =>
+		isOpen ? (
+			<div data-testid="slide-out-panel" data-session-id={sessionId ?? ''}>
+				<span>{agentLabel}</span>
+				<button data-testid="slide-out-close" onClick={onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
+}));
+
+// TaskInfoPanel — minimal stub
+vi.mock('./TaskInfoPanel.tsx', () => ({
+	TaskInfoPanel: ({ isOpen }: { isOpen: boolean }) =>
+		isOpen ? <div data-testid="task-info-panel" /> : null,
+}));
+
+// task-shared stubs
+vi.mock('./task-shared/HumanInputArea.tsx', () => ({
+	HumanInputArea: () => <div data-testid="human-input-area" />,
+}));
+
+vi.mock('./task-shared/TaskHeaderActions.tsx', () => ({
+	TaskHeaderActions: ({ onToggleInfoPanel }: { onToggleInfoPanel: () => void }) => (
+		<button data-testid="toggle-info-panel" onClick={onToggleInfoPanel}>
+			Info
+		</button>
+	),
+}));
+
+vi.mock('./task-shared/TaskReviewBar.tsx', () => ({
+	TaskReviewBar: ({
+		onApprove,
+		onOpenRejectModal,
+	}: {
+		onApprove: () => void;
+		onOpenRejectModal: () => void;
+	}) => (
+		<div data-testid="task-review-bar">
+			<button data-testid="approve-button" onClick={onApprove}>
+				Approve
+			</button>
+			<button data-testid="open-reject-modal" onClick={onOpenRejectModal}>
+				Reject
+			</button>
+		</div>
+	),
+}));
+
+vi.mock('./task-shared/TaskActionDialogs.tsx', () => ({
+	CompleteTaskDialog: () => null,
+	CancelTaskDialog: () => null,
+	ArchiveTaskDialog: () => null,
+	SetStatusModal: () => null,
+}));
+
+vi.mock('../ui/RejectModal.tsx', () => ({
+	RejectModal: ({
+		isOpen,
+		onConfirm,
+		onClose,
+	}: {
+		isOpen: boolean;
+		onConfirm: (feedback: string) => void;
+		onClose: () => void;
+	}) =>
+		isOpen ? (
+			<div data-testid="reject-modal">
+				<button data-testid="reject-confirm" onClick={() => onConfirm('bad')}>
+					Confirm
+				</button>
+				<button data-testid="reject-close" onClick={onClose}>
+					Close
+				</button>
+			</div>
+		) : null,
+}));
+
+vi.mock('../ui/CircularProgressIndicator.tsx', () => ({
+	CircularProgressIndicator: () => <div data-testid="circular-progress" />,
+}));
+
+vi.mock('../ScrollToBottomButton.tsx', () => ({
+	ScrollToBottomButton: ({ onClick }: { onClick: () => void }) => (
+		<button data-testid="scroll-to-bottom" onClick={onClick}>
+			↓
+		</button>
+	),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		status: 'in_progress',
+		priority: 'medium',
+		createdAt: Date.now(),
+		description: '',
+		dependsOn: [],
+		...overrides,
+	} as NeoTask;
+}
+
+function makeGroup(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		id: 'group-1',
+		taskId: 'task-1',
+		workerSessionId: 'session-worker',
+		leaderSessionId: 'session-leader',
+		workerRole: 'worker',
+		feedbackIteration: 0,
+		submittedForReview: false,
+		createdAt: Date.now(),
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeTurn(overrides: Partial<TurnBlock> = {}): TurnBlock {
+	return {
+		id: 'turn-1',
+		sessionId: 'session-worker',
+		agentRole: 'worker',
+		agentLabel: 'Worker',
+		startTime: Date.now() - 5000,
+		endTime: Date.now(),
+		messageCount: 3,
+		toolCallCount: 2,
+		thinkingCount: 1,
+		assistantCount: 2,
+		lastAction: 'Read',
+		previewMessage: null,
+		isActive: false,
+		isError: false,
+		errorMessage: null,
+		messages: [],
+		...overrides,
+	};
+}
+
+// Setup default useTaskViewData mock state — overrideable in each test
+let mockTaskViewData: ReturnType<typeof import('../../hooks/useTaskViewData').useTaskViewData>;
+let mockSetConversationKey: (fn: (k: number) => number) => void;
+
+vi.mock('../../hooks/useTaskViewData.ts', () => ({
+	useTaskViewData: () => mockTaskViewData,
+}));
+
+function makeDefaultTaskViewData(
+	task: NeoTask | null = makeTask(),
+	group: ReturnType<typeof makeGroup> | null = makeGroup()
+) {
+	const approveReviewedTask = vi.fn(async () => {
+		// Simulate conversationKey bump
+	});
+	const rejectReviewedTask = vi.fn(async (_feedback: string) => {});
+
+	let _rejectOpen = false;
+	let _completeOpen = false;
+	let _cancelOpen = false;
+	let _archiveOpen = false;
+	let _setStatusOpen = false;
+
+	return {
+		task,
+		group,
+		workerSession: null,
+		leaderSession: null,
+		isLoading: false,
+		error: null,
+		associatedGoal: null,
+		conversationKey: 0,
+		approveReviewedTask,
+		rejectReviewedTask,
+		interruptSession: vi.fn(async () => {}),
+		reactivateTask: vi.fn(async () => {}),
+		completeTask: vi.fn(async () => {}),
+		cancelTask: vi.fn(async () => {}),
+		archiveTask: vi.fn(async () => {}),
+		setTaskStatusManually: vi.fn(async () => {}),
+		approving: false,
+		rejecting: false,
+		interrupting: false,
+		reactivating: false,
+		reviewError: null,
+		rejectModal: {
+			isOpen: _rejectOpen,
+			open: vi.fn(() => {
+				_rejectOpen = true;
+			}),
+			close: vi.fn(() => {
+				_rejectOpen = false;
+			}),
+		},
+		completeModal: {
+			isOpen: _completeOpen,
+			open: vi.fn(),
+			close: vi.fn(),
+		},
+		cancelModal: {
+			isOpen: _cancelOpen,
+			open: vi.fn(),
+			close: vi.fn(),
+		},
+		archiveModal: {
+			isOpen: _archiveOpen,
+			open: vi.fn(),
+			close: vi.fn(),
+		},
+		setStatusModal: {
+			isOpen: _setStatusOpen,
+			open: vi.fn(),
+			close: vi.fn(),
+		},
+		canCancel: true,
+		canInterrupt: true,
+		canReactivate: false,
+		canComplete: true,
+		canArchive: false,
+	} as unknown as ReturnType<typeof import('../../hooks/useTaskViewData').useTaskViewData>;
+}
+
+// ---------------------------------------------------------------------------
+// Import subject under test (after all mocks are set up)
+// ---------------------------------------------------------------------------
+
+// Dynamic import deferred to after vi.mock hoisting
+const { TaskViewV2 } = await import('./TaskViewV2.tsx');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskViewV2', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGroupMessages = [];
+		mockTurnBlockItems = [];
+		mockMessagesLoading = false;
+		mockShowScrollButton = false;
+		_draftContent.value = '';
+		mockTaskViewData = makeDefaultTaskViewData();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// --- Rendering basics ---
+
+	it('renders data-testid="task-view-v2" on the root container', () => {
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('task-view-v2')).toBeTruthy();
+	});
+
+	it('shows loading state when isLoading is true', () => {
+		mockTaskViewData = { ...makeDefaultTaskViewData(), isLoading: true } as typeof mockTaskViewData;
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Loading task');
+	});
+
+	it('shows error state when error is set', () => {
+		mockTaskViewData = {
+			...makeDefaultTaskViewData(),
+			error: 'Failed to fetch',
+			task: null,
+		} as typeof mockTaskViewData;
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Failed to fetch');
+	});
+
+	it('shows "Task not found" when task is null and no error', () => {
+		mockTaskViewData = {
+			...makeDefaultTaskViewData(),
+			task: null,
+			error: null,
+		} as typeof mockTaskViewData;
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Task not found');
+	});
+
+	// --- Header ---
+
+	it('renders task title in header', () => {
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Test Task');
+	});
+
+	it('renders status badge', () => {
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('task-status-badge').textContent).toContain('in progress');
+	});
+
+	it('does not render review bar when group.submittedForReview is false', () => {
+		const { queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(queryByTestId('task-review-bar')).toBeNull();
+	});
+
+	it('renders review bar when group.submittedForReview is true', () => {
+		mockTaskViewData = makeDefaultTaskViewData(
+			makeTask({ status: 'review' }),
+			makeGroup({ submittedForReview: true })
+		);
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('task-review-bar')).toBeTruthy();
+	});
+
+	// --- Turn blocks ---
+
+	it('renders turn blocks for each turn in turnBlocks', () => {
+		const turn1 = makeTurn({ id: 'turn-1', agentLabel: 'Worker' });
+		const turn2 = makeTurn({ id: 'turn-2', sessionId: 'session-leader', agentLabel: 'Leader' });
+		mockTurnBlockItems = [
+			{ type: 'turn', turn: turn1 },
+			{ type: 'turn', turn: turn2 },
+		];
+		const { getAllByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		const blocks = getAllByTestId('turn-block');
+		expect(blocks).toHaveLength(2);
+		expect(blocks[0].textContent).toContain('Worker');
+		expect(blocks[1].textContent).toContain('Leader');
+	});
+
+	it('renders runtime messages inline between turn blocks', () => {
+		const turn1 = makeTurn({ id: 'turn-1' });
+		mockTurnBlockItems = [
+			{ type: 'turn', turn: turn1 },
+			{ type: 'runtime', message: {} as never, index: 1 },
+			{ type: 'turn', turn: makeTurn({ id: 'turn-2' }) },
+		];
+		const { getAllByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getAllByTestId('turn-block')).toHaveLength(2);
+		expect(getAllByTestId('runtime-message')).toHaveLength(1);
+	});
+
+	it('shows loading message when messagesLoading and no blocks yet', () => {
+		mockMessagesLoading = true;
+		mockTurnBlockItems = [];
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Loading conversation');
+	});
+
+	it('shows "No messages yet" when not loading and no blocks', () => {
+		mockMessagesLoading = false;
+		mockTurnBlockItems = [];
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('No messages yet');
+	});
+
+	it('shows empty state when group is null', () => {
+		mockTaskViewData = makeDefaultTaskViewData(makeTask({ status: 'pending' }), null);
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('No active agent group');
+	});
+
+	// --- Slide-out panel ---
+
+	it('does not render slide-out panel initially', () => {
+		const { queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(queryByTestId('slide-out-panel')).toBeNull();
+	});
+
+	it('opens slide-out panel when a turn block is clicked', async () => {
+		const turn = makeTurn({ id: 'turn-1', sessionId: 'session-worker', agentLabel: 'Worker' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		fireEvent.click(getByTestId('turn-block'));
+
+		await waitFor(() => {
+			const panel = getByTestId('slide-out-panel');
+			expect(panel).toBeTruthy();
+			expect(panel.getAttribute('data-session-id')).toBe('session-worker');
+		});
+	});
+
+	it('closes slide-out panel when close button is clicked', async () => {
+		const turn = makeTurn({ id: 'turn-1' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
+		const { getByTestId, queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		fireEvent.click(getByTestId('turn-block'));
+		await waitFor(() => expect(getByTestId('slide-out-panel')).toBeTruthy());
+
+		fireEvent.click(getByTestId('slide-out-close'));
+		await waitFor(() => expect(queryByTestId('slide-out-panel')).toBeNull());
+	});
+
+	it('clicking the same turn block again toggles the panel closed', async () => {
+		const turn = makeTurn({ id: 'turn-1' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
+		const { getByTestId, queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		// Open
+		fireEvent.click(getByTestId('turn-block'));
+		await waitFor(() => expect(getByTestId('slide-out-panel')).toBeTruthy());
+
+		// Toggle closed by clicking same turn
+		fireEvent.click(getByTestId('turn-block'));
+		await waitFor(() => expect(queryByTestId('slide-out-panel')).toBeNull());
+	});
+
+	it('only one panel open at a time — clicking second turn replaces first', async () => {
+		const turn1 = makeTurn({ id: 'turn-1', sessionId: 'session-a', agentLabel: 'Agent A' });
+		const turn2 = makeTurn({ id: 'turn-2', sessionId: 'session-b', agentLabel: 'Agent B' });
+		mockTurnBlockItems = [
+			{ type: 'turn', turn: turn1 },
+			{ type: 'turn', turn: turn2 },
+		];
+		const { getAllByTestId, getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		const blocks = getAllByTestId('turn-block');
+		// Open first
+		fireEvent.click(blocks[0]);
+		await waitFor(() =>
+			expect(getByTestId('slide-out-panel').getAttribute('data-session-id')).toBe('session-a')
+		);
+
+		// Click second — should switch to session-b
+		fireEvent.click(blocks[1]);
+		await waitFor(() =>
+			expect(getByTestId('slide-out-panel').getAttribute('data-session-id')).toBe('session-b')
+		);
+	});
+
+	// --- Selected state ---
+
+	it('passes isSelected=true to the active turn block', async () => {
+		const turn = makeTurn({ id: 'turn-1' });
+		mockTurnBlockItems = [{ type: 'turn', turn }];
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		fireEvent.click(getByTestId('turn-block'));
+		await waitFor(() =>
+			expect(getByTestId('turn-block').getAttribute('data-selected')).toBe('true')
+		);
+	});
+
+	// --- HumanInputArea ---
+
+	it('renders HumanInputArea', () => {
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('human-input-area')).toBeTruthy();
+	});
+
+	// --- Autoscroll ---
+
+	it('shows scroll-to-bottom button when showScrollButton is true', () => {
+		mockShowScrollButton = true;
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('scroll-to-bottom')).toBeTruthy();
+	});
+
+	it('does not show scroll-to-bottom button when showScrollButton is false', () => {
+		mockShowScrollButton = false;
+		const { queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(queryByTestId('scroll-to-bottom')).toBeNull();
+	});
+
+	it('auto-scroll toggle button is present', () => {
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		const btn = container.querySelector('[title="Disable auto-scroll"]');
+		expect(btn).toBeTruthy();
+	});
+
+	it('clicking autoscroll toggle changes button title', async () => {
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		const btn = container.querySelector('[title="Disable auto-scroll"]') as HTMLElement;
+		expect(btn).toBeTruthy();
+		fireEvent.click(btn);
+		await waitFor(() => {
+			expect(container.querySelector('[title="Enable auto-scroll"]')).toBeTruthy();
+		});
+	});
+
+	// --- Review flow ---
+
+	it('calls approveReviewedTask when approve button clicked', async () => {
+		mockTaskViewData = makeDefaultTaskViewData(
+			makeTask({ status: 'review' }),
+			makeGroup({ submittedForReview: true })
+		);
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		fireEvent.click(getByTestId('approve-button'));
+		await waitFor(() => {
+			expect(mockTaskViewData.approveReviewedTask).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('opens reject modal when reject button clicked', async () => {
+		const data = makeDefaultTaskViewData(
+			makeTask({ status: 'review' }),
+			makeGroup({ submittedForReview: true })
+		);
+		mockTaskViewData = data;
+		const { getByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		fireEvent.click(getByTestId('open-reject-modal'));
+		expect(data.rejectModal.open).toHaveBeenCalled();
+	});
+
+	// --- Info panel ---
+
+	it('toggles info panel when header action button clicked', async () => {
+		const { getByTestId, queryByTestId } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(queryByTestId('task-info-panel')).toBeNull();
+		fireEvent.click(getByTestId('toggle-info-panel'));
+		await waitFor(() => expect(getByTestId('task-info-panel')).toBeTruthy());
+	});
+
+	// --- Dependencies ---
+
+	it('renders dependency links when task.dependsOn is non-empty', () => {
+		mockTaskViewData = makeDefaultTaskViewData(
+			makeTask({ dependsOn: ['dep-task-1234567890'] }),
+			makeGroup()
+		);
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('Depends on:');
+		expect(container.textContent).toContain('dep-task');
+	});
+
+	// --- PR link ---
+
+	it('renders PR link when task.prUrl is set', () => {
+		mockTaskViewData = makeDefaultTaskViewData(
+			makeTask({ prUrl: 'https://github.com/org/repo/pull/42', prNumber: 42 }),
+			makeGroup()
+		);
+		const { container } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		expect(container.textContent).toContain('PR #42');
+	});
+
+	// --- conversationKey renders new key ---
+
+	it('renders new turn-blocks-container key when conversationKey changes', async () => {
+		const data = makeDefaultTaskViewData(makeTask(), makeGroup());
+		data.conversationKey = 0;
+		mockTaskViewData = data;
+
+		const { getByTestId, rerender } = render(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+		const container1 = getByTestId('turn-blocks-container');
+		expect(container1).toBeTruthy();
+
+		// Bump conversationKey
+		data.conversationKey = 1;
+		mockTaskViewData = { ...data };
+		rerender(<TaskViewV2 roomId="room-1" taskId="task-1" />);
+
+		await waitFor(() => {
+			const container2 = getByTestId('turn-blocks-container');
+			expect(container2).toBeTruthy();
+		});
+	});
+});

--- a/packages/web/src/components/room/TaskViewV2.tsx
+++ b/packages/web/src/components/room/TaskViewV2.tsx
@@ -1,0 +1,522 @@
+/**
+ * TaskViewV2 Component
+ *
+ * Turn-based conversation summary view with slide-out detail panels.
+ *
+ * Combines:
+ * - useTaskViewData: task/group/session data + action handlers
+ * - useGroupMessages: live-streaming group messages via LiveQuery
+ * - useTurnBlocks: converts flat messages → TurnBlockItem[] (turns + runtime messages)
+ * - TurnSummaryBlock: compact per-turn card
+ * - RuntimeMessageRenderer: inline runtime messages between turns
+ * - SlideOutPanel: right-side slide-out showing full session chat on turn click
+ *
+ * Differences from V1:
+ * - No client-side pagination (LiveQuery streams all messages)
+ * - isAtTail is always true
+ * - loadingOlder is omitted from useAutoScroll
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { useAutoScroll } from '../../hooks/useAutoScroll';
+import { useGroupMessages } from '../../hooks/useGroupMessages';
+import { useTaskViewData } from '../../hooks/useTaskViewData';
+import { useTurnBlocks } from '../../hooks/useTurnBlocks';
+import type { TurnBlock } from '../../hooks/useTurnBlocks';
+import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
+import { currentRoomTabSignal } from '../../lib/signals';
+import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
+import { RejectModal } from '../ui/RejectModal';
+import { ScrollToBottomButton } from '../ScrollToBottomButton';
+import { RuntimeMessageRenderer } from './RuntimeMessageRenderer';
+import { SlideOutPanel } from './SlideOutPanel';
+import { TaskInfoPanel } from './TaskInfoPanel';
+import { TurnSummaryBlock } from './TurnSummaryBlock';
+import { HumanInputArea } from './task-shared/HumanInputArea';
+import {
+	CompleteTaskDialog,
+	CancelTaskDialog,
+	ArchiveTaskDialog,
+	SetStatusModal,
+} from './task-shared/TaskActionDialogs';
+import { TaskHeaderActions } from './task-shared/TaskHeaderActions';
+import { TaskReviewBar } from './task-shared/TaskReviewBar';
+
+interface TaskViewV2Props {
+	roomId: string;
+	taskId: string;
+}
+
+const TASK_STATUS_COLORS: Record<string, string> = {
+	pending: 'text-gray-400',
+	in_progress: 'text-yellow-400',
+	completed: 'text-green-400',
+	needs_attention: 'text-red-400',
+	review: 'text-purple-400',
+	draft: 'text-gray-500',
+	cancelled: 'text-gray-500',
+	archived: 'text-gray-600',
+};
+
+export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
+	const {
+		task,
+		group,
+		workerSession,
+		leaderSession,
+		isLoading,
+		error,
+		associatedGoal,
+		conversationKey,
+		approveReviewedTask,
+		rejectReviewedTask,
+		interruptSession,
+		reactivateTask,
+		completeTask,
+		cancelTask,
+		archiveTask,
+		setTaskStatusManually,
+		approving,
+		rejecting,
+		interrupting,
+		reactivating,
+		reviewError,
+		rejectModal,
+		completeModal,
+		cancelModal,
+		archiveModal,
+		setStatusModal,
+		canCancel,
+		canInterrupt,
+		canReactivate,
+		canComplete,
+		canArchive,
+	} = useTaskViewData(roomId, taskId);
+
+	// Live-stream messages for the current group
+	const { messages, isLoading: messagesLoading } = useGroupMessages(group?.id ?? null);
+
+	// isAtTail is always true for LiveQuery (no client-side pagination)
+	const turnBlocks = useTurnBlocks(messages, true);
+
+	// Slide-out panel state
+	const [selectedTurn, setSelectedTurn] = useState<TurnBlock | null>(null);
+
+	// UI state for autoscroll toggle
+	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+
+	// Info panel (gear button) expanded state
+	const [isInfoPanelOpen, setIsInfoPanelOpen] = useState(false);
+
+	// Close info panel on Escape key
+	useEffect(() => {
+		if (!isInfoPanelOpen) return;
+		const handleEscape = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') setIsInfoPanelOpen(false);
+		};
+		document.addEventListener('keydown', handleEscape, true);
+		return () => document.removeEventListener('keydown', handleEscape, true);
+	}, [isInfoPanelOpen]);
+
+	// isFirstLoad: starts true, resets on conversationKey change, becomes false once
+	// the first non-zero TurnBlockItem[] arrives.
+	const [isFirstLoad, setIsFirstLoad] = useState(true);
+
+	// Refs for scroll container
+	const messagesContainerRef = useRef<HTMLDivElement>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	const { showScrollButton, scrollToBottom } = useAutoScroll({
+		containerRef: messagesContainerRef,
+		endRef: messagesEndRef,
+		enabled: autoScrollEnabled,
+		messageCount: turnBlocks.length,
+		isInitialLoad: isFirstLoad,
+	});
+
+	// Reset scroll state when the conversation changes (conversationKey bumps on approve/reject)
+	const rendererKey = group ? `${group.id}-${conversationKey}` : `null-${conversationKey}`;
+	useEffect(() => {
+		setIsFirstLoad(true);
+		setAutoScrollEnabled(true);
+		// Close slide-out when conversation reloads
+		setSelectedTurn(null);
+	}, [rendererKey]);
+
+	// Mark initial load done after first turn blocks arrive
+	useEffect(() => {
+		if (turnBlocks.length > 0 && isFirstLoad) {
+			setIsFirstLoad(false);
+		}
+	}, [turnBlocks.length, isFirstLoad]);
+
+	const handleScrollToBottom = useCallback(() => {
+		scrollToBottom(true);
+		setAutoScrollEnabled(true);
+	}, [scrollToBottom]);
+
+	const handleTurnClick = useCallback((turn: TurnBlock) => {
+		setSelectedTurn((prev) => (prev?.id === turn.id ? null : turn));
+	}, []);
+
+	const handleClosePanel = useCallback(() => {
+		setSelectedTurn(null);
+	}, []);
+
+	if (isLoading) {
+		return (
+			<div class="flex-1 flex items-center justify-center bg-dark-900">
+				<p class="text-gray-400">Loading task…</p>
+			</div>
+		);
+	}
+
+	if (error || !task) {
+		return (
+			<div class="flex-1 flex items-center justify-center bg-dark-900">
+				<div class="text-center">
+					<p class="text-red-400 mb-3">{error ?? 'Task not found'}</p>
+					<button
+						class="text-sm text-blue-400 hover:text-blue-300"
+						onClick={() => navigateToRoom(roomId)}
+					>
+						← Back to room
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	const statusColor = TASK_STATUS_COLORS[task.status] ?? 'text-gray-400';
+
+	return (
+		<div data-testid="task-view-v2" class="flex-1 flex flex-col overflow-hidden bg-dark-900">
+			{/* Header */}
+			<div class="border-b border-dark-700 bg-dark-850 px-4 py-3 flex items-center gap-3 flex-shrink-0">
+				<button
+					class="text-gray-400 hover:text-gray-200 transition-colors text-sm"
+					onClick={() => navigateToRoom(roomId)}
+					title="Back to room"
+				>
+					←
+				</button>
+				<div class="flex-1 min-w-0">
+					<div class="flex items-center gap-2 flex-wrap">
+						<h2 class="text-base font-semibold text-gray-100 truncate">{task.title}</h2>
+						<span class={`text-xs font-medium ${statusColor}`} data-testid="task-status-badge">
+							{task.status.replace('_', ' ')}
+						</span>
+						{task.taskType && (
+							<span class="text-xs text-gray-500 bg-dark-700 px-1.5 py-0.5 rounded">
+								{task.taskType}
+							</span>
+						)}
+						{/* PR link */}
+						{task.prUrl && (
+							<a
+								href={task.prUrl}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-purple-400 bg-purple-500/10 hover:bg-purple-500/20 border border-purple-500/30 rounded transition-colors"
+								title="View Pull Request"
+							>
+								<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 16 16">
+									<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+								</svg>
+								<span>PR #{task.prNumber ?? '?'}</span>
+							</a>
+						)}
+						{/* Mission link */}
+						{associatedGoal && (
+							<button
+								data-testid="task-view-goal-badge"
+								onClick={() => {
+									navigateToRoom(roomId);
+									currentRoomTabSignal.value = 'goals';
+								}}
+								class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 hover:bg-emerald-900/40 rounded transition-colors"
+								title={`Mission: ${associatedGoal.title}`}
+							>
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M13 10V3L4 14h7v7l9-11h-7z"
+									/>
+								</svg>
+								<span class="max-w-[160px] truncate">{associatedGoal.title}</span>
+							</button>
+						)}
+					</div>
+					{group && (
+						<div class="flex items-center gap-2 mt-0.5">
+							<p class="text-xs text-gray-500">
+								{group.feedbackIteration > 0 && `iteration ${group.feedbackIteration}`}
+							</p>
+							{group.submittedForReview && !task.activeSession && (
+								<span class="inline-flex items-center gap-1 text-xs font-medium text-amber-400 bg-amber-900/30 border border-amber-700/40 px-1.5 py-0.5 rounded-full animate-pulse">
+									Awaiting your review
+								</span>
+							)}
+							{task.status === 'review' && task.activeSession && (
+								<span class="inline-flex items-center gap-1 text-xs font-medium text-blue-400 bg-blue-900/30 border border-blue-700/40 px-1.5 py-0.5 rounded-full">
+									<span class="w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />
+									{task.activeSession === 'worker' ? 'Worker' : 'Leader'} processing your message…
+								</span>
+							)}
+						</div>
+					)}
+				</div>
+				{/* Circular progress indicator */}
+				{task.progress != null && task.progress > 0 && (
+					<CircularProgressIndicator
+						progress={task.progress}
+						size={32}
+						title={`Task progress: ${task.progress}%`}
+					/>
+				)}
+				<TaskHeaderActions
+					canInterrupt={canInterrupt}
+					interrupting={interrupting}
+					onInterrupt={interruptSession}
+					canReactivate={canReactivate}
+					reactivating={reactivating}
+					onReactivate={reactivateTask}
+					isInfoPanelOpen={isInfoPanelOpen}
+					onToggleInfoPanel={() => setIsInfoPanelOpen(!isInfoPanelOpen)}
+				/>
+			</div>
+
+			{/* Info panel */}
+			<TaskInfoPanel
+				isOpen={isInfoPanelOpen}
+				taskId={task.id}
+				groupId={group?.id}
+				feedbackIteration={group?.feedbackIteration}
+				taskCreatedAt={task.createdAt}
+				prUrl={task.prUrl}
+				prNumber={task.prNumber}
+				worktreePath={workerSession?.worktree?.worktreePath ?? workerSession?.workspacePath}
+				workerSession={workerSession}
+				leaderSession={leaderSession}
+				actions={{
+					onComplete:
+						canComplete && task.status !== 'review'
+							? () => {
+									setIsInfoPanelOpen(false);
+									completeModal.open();
+								}
+							: undefined,
+					onCancel: canCancel
+						? () => {
+								setIsInfoPanelOpen(false);
+								cancelModal.open();
+							}
+						: undefined,
+					onArchive: canArchive
+						? () => {
+								setIsInfoPanelOpen(false);
+								archiveModal.open();
+							}
+						: undefined,
+					onSetStatus:
+						task.status !== 'archived'
+							? () => {
+									setIsInfoPanelOpen(false);
+									setStatusModal.open();
+								}
+							: undefined,
+				}}
+				visibleActions={{
+					complete: canComplete && task.status !== 'review',
+					cancel: canCancel,
+					archive: canArchive,
+					setStatus: task.status !== 'archived',
+				}}
+				disabledActions={{
+					complete: interrupting,
+					cancel: interrupting,
+					archive: false,
+					setStatus: false,
+				}}
+			/>
+
+			{/* Review bar — shown when awaiting human review */}
+			{group?.submittedForReview && (
+				<TaskReviewBar
+					task={task}
+					approving={approving}
+					rejecting={rejecting}
+					onApprove={approveReviewedTask}
+					onOpenRejectModal={rejectModal.open}
+					reviewError={reviewError}
+				/>
+			)}
+
+			{/* Dependencies */}
+			{task.dependsOn && task.dependsOn.length > 0 && (
+				<div class="border-b border-dark-700 bg-dark-850/50 px-4 py-2 flex items-center gap-2 flex-shrink-0 flex-wrap">
+					<span class="text-xs text-gray-500">Depends on:</span>
+					{task.dependsOn.map((depId) => (
+						<button
+							key={depId}
+							class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-blue-400 hover:text-blue-300 hover:bg-dark-600 transition-colors"
+							onClick={() => navigateToRoomTask(roomId, depId)}
+							title={depId}
+						>
+							{depId.slice(0, 8)}...
+						</button>
+					))}
+				</div>
+			)}
+
+			{/* Turn blocks area — scroll container */}
+			<div class="flex-1 relative min-h-0">
+				<div ref={messagesContainerRef} class="absolute inset-0 overflow-y-auto flex flex-col">
+					{group ? (
+						<div
+							key={rendererKey}
+							class="flex flex-col gap-2 p-3"
+							data-testid="turn-blocks-container"
+						>
+							{messagesLoading && turnBlocks.length === 0 ? (
+								<div class="flex items-center justify-center py-8 text-gray-500 text-sm">
+									Loading conversation…
+								</div>
+							) : turnBlocks.length === 0 ? (
+								<div class="flex items-center justify-center py-8 text-gray-500 text-sm">
+									No messages yet
+								</div>
+							) : (
+								turnBlocks.map((item) => {
+									if (item.type === 'turn') {
+										return (
+											<TurnSummaryBlock
+												key={item.turn.id}
+												turn={item.turn}
+												onClick={handleTurnClick}
+												isSelected={selectedTurn?.id === item.turn.id}
+											/>
+										);
+									}
+									// runtime message
+									return <RuntimeMessageRenderer key={item.index} message={item} />;
+								})
+							)}
+						</div>
+					) : (
+						<div class="flex-1 flex items-center justify-center text-center p-8">
+							<div>
+								<p class="text-gray-400 mb-1">
+									{task.status === 'review'
+										? 'Loading conversation history…'
+										: 'No active agent group'}
+								</p>
+								<p class="text-sm text-gray-500">
+									{task.status === 'pending'
+										? 'Waiting for the runtime to pick up this task.'
+										: task.status === 'completed'
+											? 'This task has been completed.'
+											: task.status === 'needs_attention'
+												? 'This task needs attention.'
+												: task.status === 'review'
+													? 'If this takes too long, try reloading the page.'
+													: task.status === 'draft'
+														? 'This task is a draft and has not been scheduled yet.'
+														: task.status === 'cancelled'
+															? 'This task was cancelled.'
+															: 'No agent group has been spawned yet.'}
+								</p>
+							</div>
+						</div>
+					)}
+					<div ref={messagesEndRef} />
+				</div>
+
+				{/* Scroll controls */}
+				<div
+					class="absolute left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
+					style={{ bottom: '1rem' }}
+				>
+					{/* Autoscroll toggle */}
+					<button
+						class={`p-2 rounded-full shadow-lg transition-colors ${
+							autoScrollEnabled
+								? 'bg-blue-600 text-white hover:bg-blue-500'
+								: 'bg-dark-700 text-gray-400 hover:text-gray-200 hover:bg-dark-600'
+						}`}
+						onClick={() => setAutoScrollEnabled(!autoScrollEnabled)}
+						title={autoScrollEnabled ? 'Disable auto-scroll' : 'Enable auto-scroll'}
+					>
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M19 14l-7 7m0 0l-7-7m7 7V3"
+							/>
+						</svg>
+					</button>
+					{showScrollButton && (
+						<ScrollToBottomButton onClick={handleScrollToBottom} bottomClass="bottom-0" />
+					)}
+				</div>
+
+				{/* Slide-out panel — overlays the turn blocks area */}
+				<SlideOutPanel
+					isOpen={selectedTurn !== null}
+					sessionId={selectedTurn?.sessionId ?? null}
+					agentLabel={selectedTurn?.agentLabel}
+					agentRole={selectedTurn?.agentRole}
+					onClose={handleClosePanel}
+				/>
+			</div>
+
+			{/* Human input area */}
+			<HumanInputArea
+				hasGroup={group !== null}
+				taskStatus={task.status}
+				roomId={roomId}
+				taskId={taskId}
+				leaderSessionId={group?.leaderSessionId}
+				workerSessionId={group?.workerSessionId}
+			/>
+
+			{/* Task action dialogs */}
+			<CompleteTaskDialog
+				task={task}
+				isOpen={completeModal.isOpen}
+				onClose={completeModal.close}
+				onConfirm={completeTask}
+			/>
+			<CancelTaskDialog
+				task={task}
+				isOpen={cancelModal.isOpen}
+				onClose={cancelModal.close}
+				onConfirm={cancelTask}
+			/>
+			<ArchiveTaskDialog
+				task={task}
+				isOpen={archiveModal.isOpen}
+				onClose={archiveModal.close}
+				onConfirm={archiveTask}
+			/>
+			<SetStatusModal
+				task={task}
+				isOpen={setStatusModal.isOpen}
+				onClose={setStatusModal.close}
+				onConfirm={setTaskStatusManually}
+			/>
+			{/* Reject dialog */}
+			<RejectModal
+				isOpen={rejectModal.isOpen}
+				onClose={rejectModal.close}
+				onConfirm={rejectReviewedTask}
+				title="Reject Task"
+				message="Please provide feedback explaining why this task is being rejected. The worker will receive this feedback and can address the issues."
+				isLoading={rejecting}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/components/room/TaskViewV2.tsx
+++ b/packages/web/src/components/room/TaskViewV2.tsx
@@ -23,6 +23,7 @@ import { useGroupMessages } from '../../hooks/useGroupMessages';
 import { useTaskViewData } from '../../hooks/useTaskViewData';
 import { useTurnBlocks } from '../../hooks/useTurnBlocks';
 import type { TurnBlock } from '../../hooks/useTurnBlocks';
+import { TASK_STATUS_COLORS } from '../../lib/task-constants';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
 import { currentRoomTabSignal } from '../../lib/signals';
 import { CircularProgressIndicator } from '../ui/CircularProgressIndicator';
@@ -46,17 +47,6 @@ interface TaskViewV2Props {
 	roomId: string;
 	taskId: string;
 }
-
-const TASK_STATUS_COLORS: Record<string, string> = {
-	pending: 'text-gray-400',
-	in_progress: 'text-yellow-400',
-	completed: 'text-green-400',
-	needs_attention: 'text-red-400',
-	review: 'text-purple-400',
-	draft: 'text-gray-500',
-	cancelled: 'text-gray-500',
-	archived: 'text-gray-600',
-};
 
 export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 	const {
@@ -94,7 +84,11 @@ export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 	} = useTaskViewData(roomId, taskId);
 
 	// Live-stream messages for the current group
-	const { messages, isLoading: messagesLoading } = useGroupMessages(group?.id ?? null);
+	const {
+		messages,
+		isLoading: messagesLoading,
+		isReconnecting,
+	} = useGroupMessages(group?.id ?? null);
 
 	// isAtTail is always true for LiveQuery (no client-side pagination)
 	const turnBlocks = useTurnBlocks(messages, true);
@@ -380,6 +374,35 @@ export function TaskViewV2({ roomId, taskId }: TaskViewV2Props) {
 							class="flex flex-col gap-2 p-3"
 							data-testid="turn-blocks-container"
 						>
+							{/* Reconnecting banner — shown while WebSocket is down and messages exist */}
+							{isReconnecting && (
+								<div
+									data-testid="reconnecting-banner"
+									class="flex items-center gap-2 rounded border border-yellow-700/50 bg-yellow-950/20 px-3 py-2 text-xs text-yellow-400"
+								>
+									<svg
+										class="h-3 w-3 animate-spin"
+										fill="none"
+										viewBox="0 0 24 24"
+										aria-hidden="true"
+									>
+										<circle
+											class="opacity-25"
+											cx="12"
+											cy="12"
+											r="10"
+											stroke="currentColor"
+											stroke-width="4"
+										/>
+										<path
+											class="opacity-75"
+											fill="currentColor"
+											d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+										/>
+									</svg>
+									Reconnecting…
+								</div>
+							)}
 							{messagesLoading && turnBlocks.length === 0 ? (
 								<div class="flex items-center justify-center py-8 text-gray-500 text-sm">
 									Loading conversation…

--- a/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
+++ b/packages/web/src/components/room/__tests__/TurnSummaryBlock.test.tsx
@@ -230,6 +230,13 @@ describe('TurnSummaryBlock', () => {
 			const root = container.querySelector('[data-testid="turn-block"]');
 			expect(root!.className).not.toContain('ring-blue-500');
 		});
+
+		it('does NOT apply ring when isSelected prop is omitted (default=false)', () => {
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).not.toContain('ring-blue-500');
+		});
 	});
 
 	// ── Error state ───────────────────────────────────────────────────────────
@@ -252,6 +259,18 @@ describe('TurnSummaryBlock', () => {
 			const turn = makeTurn({ isError: false, errorMessage: null });
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			// No red text anywhere
+			expect(container.querySelector('.text-red-400')).toBeNull();
+		});
+
+		it('applies red border but no error message div when isError=true and errorMessage=null', () => {
+			// This edge case is reachable: useTurnBlocks can set isError=true with errorMessage=null
+			// when error detection fires but no text is extractable.
+			const turn = makeTurn({ isError: true, errorMessage: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			// Border-red-800 class still applied
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-red-800');
+			// But no red message div rendered (guarded by turn.isError && turn.errorMessage)
 			expect(container.querySelector('.text-red-400')).toBeNull();
 		});
 	});
@@ -314,6 +333,7 @@ describe('TurnSummaryBlock', () => {
 			['human', 'text-green-400'],
 			['craft', 'text-blue-400'],
 			['lead', 'text-purple-400'],
+			['system', 'text-gray-500'],
 		];
 
 		it.each(roles)('applies correct label color for role=%s', (role, expectedClass) => {
@@ -339,6 +359,16 @@ describe('TurnSummaryBlock', () => {
 			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
 			expect(nameEl!.textContent).toBe('custom-agent');
 		});
+
+		it('falls back to agentRole when agentLabel is empty string (system role quirk)', () => {
+			// ROLE_COLORS['system'].label is '' — useTurnBlocks propagates this as agentLabel.
+			// The component uses `turn.agentLabel || turn.agentRole`, so the empty agentLabel
+			// causes the agentRole string 'system' to be rendered instead.
+			const turn = makeTurn({ agentRole: 'system', agentLabel: '' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const nameEl = container.querySelector('[data-testid="turn-block-agent-name"]');
+			expect(nameEl!.textContent).toBe('system');
+		});
 	});
 
 	// ── Duration formatting ────────────────────────────────────────────────────
@@ -360,6 +390,71 @@ describe('TurnSummaryBlock', () => {
 			const turn = makeTurn({ startTime: 0, endTime: 125_000 });
 			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
 			expect(container.textContent).toContain('2m 5s');
+		});
+
+		it('shows 0s for zero duration', () => {
+			const turn = makeTurn({ startTime: 1_000_000, endTime: 1_000_000 });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			expect(container.textContent).toContain('0s');
+		});
+	});
+
+	// ── Accessibility ─────────────────────────────────────────────────────────
+
+	describe('accessibility', () => {
+		it('has role="button" on the root element', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root?.getAttribute('role')).toBe('button');
+		});
+
+		it('has tabIndex=0 for keyboard navigation', () => {
+			const { container } = render(<TurnSummaryBlock turn={makeTurn()} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			expect(root?.tabIndex).toBe(0);
+		});
+
+		it('does NOT call onClick for non-Enter/Space key presses', () => {
+			const onClickMock = vi.fn();
+			const turn = makeTurn();
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={onClickMock} />);
+			const root = container.querySelector('[data-testid="turn-block"]') as HTMLElement;
+			fireEvent.keyDown(root, { key: 'Escape' });
+			fireEvent.keyDown(root, { key: 'Tab' });
+			fireEvent.keyDown(root, { key: 'ArrowDown' });
+			expect(onClickMock).not.toHaveBeenCalled();
+		});
+
+		it('active indicator has aria-label="Active turn"', () => {
+			const turn = makeTurn({ isActive: true, endTime: null });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const indicator = container.querySelector('[data-testid="turn-block-active"]');
+			expect(indicator?.getAttribute('aria-label')).toBe('Active turn');
+		});
+	});
+
+	// ── Border class ──────────────────────────────────────────────────────────
+
+	describe('border class', () => {
+		it('applies role border class from ROLE_COLORS for coder', () => {
+			const turn = makeTurn({ agentRole: 'coder' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-blue-500');
+		});
+
+		it('applies role border class for leader', () => {
+			const turn = makeTurn({ agentRole: 'leader' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-purple-500');
+		});
+
+		it('falls back to gray border for unknown role', () => {
+			const turn = makeTurn({ agentRole: 'unknown-role', agentLabel: 'Unknown' });
+			const { container } = render(<TurnSummaryBlock turn={turn} onClick={vi.fn()} />);
+			const root = container.querySelector('[data-testid="turn-block"]');
+			expect(root!.className).toContain('border-l-gray-500');
 		});
 	});
 });

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -23,3 +23,5 @@ export { TurnSummaryBlock } from './TurnSummaryBlock';
 export type { TurnSummaryBlockProps } from './TurnSummaryBlock';
 // @public - Library export
 export { RuntimeMessageRenderer } from './RuntimeMessageRenderer';
+// @public - Library export
+export { TaskViewV2 } from './TaskViewV2';

--- a/packages/web/src/lib/task-constants.ts
+++ b/packages/web/src/lib/task-constants.ts
@@ -1,3 +1,14 @@
+export const TASK_STATUS_COLORS: Record<string, string> = {
+	pending: 'text-gray-400',
+	in_progress: 'text-yellow-400',
+	completed: 'text-green-400',
+	needs_attention: 'text-red-400',
+	review: 'text-purple-400',
+	draft: 'text-gray-500',
+	cancelled: 'text-gray-500',
+	archived: 'text-gray-600',
+};
+
 export const ROLE_COLORS: Record<string, { border: string; label: string; labelColor: string }> = {
 	planner: { border: 'border-l-teal-500', label: 'Planner', labelColor: 'text-teal-400' },
 	coder: { border: 'border-l-blue-500', label: 'Coder', labelColor: 'text-blue-400' },


### PR DESCRIPTION
Builds the full TaskViewV2 combining useGroupMessages, useTurnBlocks,
TurnSummaryBlock, RuntimeMessageRenderer, and SlideOutPanel into the
complete V2 experience.

- TaskViewV2.tsx: turn-based summary view with slide-out panel support
  - Props identical to V1: { roomId, taskId }
  - Uses useTaskViewData for task/group/session data and action handlers
  - Uses useGroupMessages (LiveQuery) for real-time message streaming
  - Feeds messages into useTurnBlocks → TurnBlockItem[]
  - Renders TurnSummaryBlock for 'turn' items, RuntimeMessageRenderer for 'runtime' items
  - Slide-out panel opens on turn block click (only one at a time)
  - Auto-scroll with isFirstLoad tracking and toggle button
  - conversationKey resets slide-out state and scroll on approve/reject
  - TaskReviewBar shown when group.submittedForReview
  - data-testid="task-view-v2" on root container
  - Reuses all shared sub-components (HumanInputArea, TaskHeaderActions,
    TaskActionDialogs, TaskReviewBar, RejectModal)

- TaskViewV2.test.tsx: 30 unit tests covering all acceptance criteria
  - data-testid presence, loading/error states, turn block rendering
  - Runtime messages inline, slide-out open/close/toggle/replace behavior
  - Selected state, review bar conditional rendering, auto-scroll controls
  - PR link, dependencies, info panel, approve/reject flow

- index.ts: exports TaskViewV2 from room component barrel
