### PR TITLE
feat: implement TaskViewToggle and integrate into Room.tsx

### DIFF
--- a/packages/web/src/components/room/TaskViewToggle.tsx
+++ b/packages/web/src/components/room/TaskViewToggle.tsx
@@ -1,0 +1,66 @@
+/**
+ * TaskViewToggle Component
+ *
+ * Wrapper that renders a V1/V2 toggle header bar above the active task view.
+ * Reads and persists the user's preference via localStorage.
+ *
+ * Default: 'v1' for backward compatibility.
+ */
+
+import { useState } from 'preact/hooks';
+import { TaskView } from './TaskView';
+import { TaskViewV2 } from './TaskViewV2';
+
+const STORAGE_KEY = 'neokai:taskViewVersion';
+
+interface TaskViewToggleProps {
+	roomId: string;
+	taskId: string;
+}
+
+export function TaskViewToggle({ roomId, taskId }: TaskViewToggleProps) {
+	// Synchronous lazy initializer prevents visible flicker on load
+	const [version, setVersion] = useState<'v1' | 'v2'>(
+		() => (localStorage.getItem(STORAGE_KEY) as 'v1' | 'v2') || 'v1'
+	);
+
+	const handleToggle = () => {
+		const next = version === 'v1' ? 'v2' : 'v1';
+		setVersion(next);
+		localStorage.setItem(STORAGE_KEY, next);
+	};
+
+	return (
+		<div class="flex-1 flex flex-col overflow-hidden">
+			{/* Toggle header bar */}
+			<div class="flex items-center justify-end gap-2 px-3 py-1 bg-dark-850 border-b border-dark-700">
+				<span class="text-xs text-gray-500 select-none">View:</span>
+				<button
+					data-testid="task-view-toggle"
+					onClick={handleToggle}
+					class="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors bg-dark-700 hover:bg-dark-600 text-gray-300 hover:text-gray-100"
+					aria-label={`Switch to ${version === 'v1' ? 'V2 turn-based' : 'V1 timeline'} view`}
+				>
+					{version === 'v1' ? (
+						<>
+							<span>V1</span>
+							<span class="text-gray-500">→ V2</span>
+						</>
+					) : (
+						<>
+							<span class="text-gray-500">V1 ←</span>
+							<span>V2</span>
+						</>
+					)}
+				</button>
+			</div>
+
+			{/* Active view */}
+			{version === 'v1' ? (
+				<TaskView roomId={roomId} taskId={taskId} />
+			) : (
+				<TaskViewV2 roomId={roomId} taskId={taskId} />
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/room/__tests__/TaskViewToggle.test.tsx
+++ b/packages/web/src/components/room/__tests__/TaskViewToggle.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for TaskViewToggle Component
+ *
+ * Covers:
+ * - Default view is V1 when localStorage has no value
+ * - Reads persisted preference from localStorage synchronously (no flicker)
+ * - Toggle button switches V1 → V2 and V2 → V1
+ * - Persists preference to localStorage on toggle
+ * - Renders TaskView (V1) or TaskViewV2 conditionally
+ * - data-testid="task-view-toggle" present on button
+ * - aria-label updates based on current version
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { TaskViewToggle } from '../TaskViewToggle';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../TaskView', () => ({
+	TaskView: ({ roomId, taskId }: { roomId: string; taskId: string }) => (
+		<div data-testid="task-view-v1" data-room-id={roomId} data-task-id={taskId}>
+			TaskView V1
+		</div>
+	),
+}));
+
+vi.mock('../TaskViewV2', () => ({
+	TaskViewV2: ({ roomId, taskId }: { roomId: string; taskId: string }) => (
+		<div data-testid="task-view-v2" data-room-id={roomId} data-task-id={taskId}>
+			TaskViewV2
+		</div>
+	),
+}));
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const localStorageMock = (() => {
+	let store: Record<string, string> = {};
+	return {
+		getItem: vi.fn((key: string) => store[key] ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			store[key] = value;
+		}),
+		removeItem: vi.fn((key: string) => {
+			delete store[key];
+		}),
+		clear: vi.fn(() => {
+			store = {};
+		}),
+	};
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskViewToggle', () => {
+	beforeEach(() => {
+		localStorageMock.clear();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders TaskView (V1) by default when no localStorage entry', () => {
+		const { getByTestId, queryByTestId } = render(
+			<TaskViewToggle roomId="room-1" taskId="task-1" />
+		);
+		expect(getByTestId('task-view-v1')).toBeTruthy();
+		expect(queryByTestId('task-view-v2')).toBeNull();
+	});
+
+	it('renders toggle button with data-testid="task-view-toggle"', () => {
+		const { getByTestId } = render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		expect(getByTestId('task-view-toggle')).toBeTruthy();
+	});
+
+	it('reads V2 preference from localStorage synchronously on mount', () => {
+		localStorageMock.getItem.mockReturnValueOnce('v2');
+		const { getByTestId, queryByTestId } = render(
+			<TaskViewToggle roomId="room-1" taskId="task-1" />
+		);
+		expect(getByTestId('task-view-v2')).toBeTruthy();
+		expect(queryByTestId('task-view-v1')).toBeNull();
+	});
+
+	it('reads V1 preference from localStorage synchronously on mount', () => {
+		localStorageMock.getItem.mockReturnValueOnce('v1');
+		const { getByTestId, queryByTestId } = render(
+			<TaskViewToggle roomId="room-1" taskId="task-1" />
+		);
+		expect(getByTestId('task-view-v1')).toBeTruthy();
+		expect(queryByTestId('task-view-v2')).toBeNull();
+	});
+
+	it('toggles from V1 to V2 on button click', () => {
+		const { getByTestId, queryByTestId } = render(
+			<TaskViewToggle roomId="room-1" taskId="task-1" />
+		);
+		expect(getByTestId('task-view-v1')).toBeTruthy();
+
+		fireEvent.click(getByTestId('task-view-toggle'));
+
+		expect(getByTestId('task-view-v2')).toBeTruthy();
+		expect(queryByTestId('task-view-v1')).toBeNull();
+	});
+
+	it('toggles from V2 back to V1 on second click', () => {
+		const { getByTestId, queryByTestId } = render(
+			<TaskViewToggle roomId="room-1" taskId="task-1" />
+		);
+		fireEvent.click(getByTestId('task-view-toggle'));
+		expect(getByTestId('task-view-v2')).toBeTruthy();
+
+		fireEvent.click(getByTestId('task-view-toggle'));
+		expect(getByTestId('task-view-v1')).toBeTruthy();
+		expect(queryByTestId('task-view-v2')).toBeNull();
+	});
+
+	it('persists V2 to localStorage when toggled from V1', () => {
+		const { getByTestId } = render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		fireEvent.click(getByTestId('task-view-toggle'));
+		expect(localStorageMock.setItem).toHaveBeenCalledWith('neokai:taskViewVersion', 'v2');
+	});
+
+	it('persists V1 to localStorage when toggled from V2', () => {
+		localStorageMock.getItem.mockReturnValueOnce('v2');
+		const { getByTestId } = render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		fireEvent.click(getByTestId('task-view-toggle'));
+		expect(localStorageMock.setItem).toHaveBeenCalledWith('neokai:taskViewVersion', 'v1');
+	});
+
+	it('passes roomId and taskId to V1 view', () => {
+		const { getByTestId } = render(<TaskViewToggle roomId="my-room" taskId="my-task" />);
+		const v1 = getByTestId('task-view-v1');
+		expect(v1.getAttribute('data-room-id')).toBe('my-room');
+		expect(v1.getAttribute('data-task-id')).toBe('my-task');
+	});
+
+	it('passes roomId and taskId to V2 view', () => {
+		localStorageMock.getItem.mockReturnValueOnce('v2');
+		const { getByTestId } = render(<TaskViewToggle roomId="my-room" taskId="my-task" />);
+		const v2 = getByTestId('task-view-v2');
+		expect(v2.getAttribute('data-room-id')).toBe('my-room');
+		expect(v2.getAttribute('data-task-id')).toBe('my-task');
+	});
+
+	it('aria-label indicates switching to V2 when in V1 mode', () => {
+		const { getByTestId } = render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		const btn = getByTestId('task-view-toggle');
+		expect(btn.getAttribute('aria-label')).toContain('V2');
+	});
+
+	it('aria-label indicates switching to V1 when in V2 mode', () => {
+		localStorageMock.getItem.mockReturnValueOnce('v2');
+		const { getByTestId } = render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		const btn = getByTestId('task-view-toggle');
+		expect(btn.getAttribute('aria-label')).toContain('V1');
+	});
+
+	it('uses storage key "neokai:taskViewVersion"', () => {
+		render(<TaskViewToggle roomId="room-1" taskId="task-1" />);
+		// getItem is called during lazy init
+		expect(localStorageMock.getItem).toHaveBeenCalledWith('neokai:taskViewVersion');
+	});
+});

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -16,7 +16,7 @@ import { RoomDashboard } from '../components/room/RoomDashboard';
 import ChatContainer from './ChatContainer';
 import { GoalsEditor, RoomContext, RoomSettings, RoomAgents } from '../components/room';
 import type { CreateGoalFormData } from '../components/room/GoalsEditor';
-import { TaskView } from '../components/room/TaskView';
+import { TaskViewToggle } from '../components/room/TaskViewToggle';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton';
@@ -150,7 +150,7 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 			<div class="flex-1 flex flex-col overflow-hidden">
 				{/* Task view: show Craft + Lead sessions for the selected task */}
 				{taskViewId ? (
-					<TaskView key={taskViewId} roomId={roomId} taskId={taskViewId} />
+					<TaskViewToggle key={taskViewId} roomId={roomId} taskId={taskViewId} />
 				) : sessionViewId ? (
 					/* Session view: show a specific session within the room */
 					<ChatContainer key={sessionViewId} sessionId={sessionViewId} />


### PR DESCRIPTION
- Add TaskViewToggle wrapper that renders a V1/V2 header toggle bar above
  the active task view, reading/persisting preference via localStorage key
  'neokai:taskViewVersion' with synchronous lazy initializer to prevent flicker
- Default to V1 for backward compatibility
- Replace <TaskView> with <TaskViewToggle> in Room.tsx (minimal import/component swap)
- 13 unit tests covering toggle, persistence, prop forwarding, and aria-label
