### PR TITLE
task/task 44 e2e tests for taskviewv2

### DIFF
--- a/packages/e2e/tests/features/task-view-v2.e2e.ts
+++ b/packages/e2e/tests/features/task-view-v2.e2e.ts
@@ -1,0 +1,504 @@
+/**
+ * TaskViewV2 E2E Tests
+ *
+ * Verifies the V1/V2 task view toggle and TaskViewV2 structural presence.
+ * Scoped to toggle behavior and localStorage persistence — detailed rendering
+ * is covered by unit tests.
+ *
+ * Setup: creates a room+task via RPC (accepted infrastructure pattern).
+ * Cleanup: deletes the room via RPC in afterEach.
+ *
+ * All test actions go through the UI (clicks, navigation).
+ * All assertions verify visible DOM state via data-testid selectors.
+ *
+ * Note on slide-out panel: SlideOutPanel is always mounted in the DOM and uses
+ * CSS transforms (translate-x-full) to hide. Playwright's toBeInViewport() is
+ * used to verify visibility since toBeVisible() does not detect off-screen
+ * transforms. Slide-out open/close tests require turn blocks which need real
+ * agent sessions — those tests are skipped when no turn blocks are available
+ * (turn blocks cannot be seeded via RPC without real session records in SQLite).
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { deleteRoom } from '../helpers/room-helpers';
+
+const STORAGE_KEY = 'neokai:taskViewVersion';
+
+// ─── Setup Helpers ────────────────────────────────────────────────────────────
+
+async function createRoomAndTask(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<{ roomId: string; taskId: string }> {
+	await waitForWebSocketConnected(page);
+
+	return page.evaluate(async () => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E TaskViewV2 Test Room',
+		});
+		const roomId = (roomRes as { room: { id: string } }).room.id;
+
+		const taskRes = await hub.request('task.create', {
+			roomId,
+			title: 'E2E TaskViewV2 Test Task',
+			description: 'Task for testing the V2 toggle and structural presence',
+		});
+		const taskId = (taskRes as { task: { id: string } }).task.id;
+
+		return { roomId, taskId };
+	});
+}
+
+/**
+ * Creates a room, task, and a synthetic session group.
+ * The group makes the turn-blocks-container render in V2 (it's conditional on group existence).
+ * System messages are seeded so the container is not empty — they appear as runtime messages.
+ */
+async function createRoomTaskAndGroup(
+	page: Parameters<typeof waitForWebSocketConnected>[0]
+): Promise<{ roomId: string; taskId: string; groupId: string }> {
+	await waitForWebSocketConnected(page);
+
+	return page.evaluate(async () => {
+		const hub = window.__messageHub || window.appState?.messageHub;
+		if (!hub?.request) throw new Error('MessageHub not available');
+
+		const roomRes = await hub.request('room.create', {
+			name: 'E2E TaskViewV2 Group Test Room',
+		});
+		const roomId = (roomRes as { room: { id: string } }).room.id;
+
+		const taskRes = await hub.request('task.create', {
+			roomId,
+			title: 'E2E TaskViewV2 Group Test Task',
+			description: 'Task with session group for structural tests',
+		});
+		const taskId = (taskRes as { task: { id: string } }).task.id;
+
+		// Create synthetic session group (E2E infrastructure RPC — non-production only)
+		const groupRes = await hub.request('task.group.create', {
+			roomId,
+			taskId,
+		});
+		const groupId = (groupRes as { groupId: string }).groupId;
+
+		// Seed a system status message (goes to task_group_events — no session FK constraint)
+		await hub.request('task.group.addMessage', {
+			groupId,
+			role: 'system',
+			messageType: 'status',
+			content: 'Task started',
+		});
+
+		return { roomId, taskId, groupId };
+	});
+}
+
+// ─── Toggle and Persistence Tests ─────────────────────────────────────────────
+
+test.describe('TaskViewV2 — Toggle and Persistence', () => {
+	let roomId = '';
+	let taskId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+		taskId = '';
+
+		// Clear the localStorage preference so each test starts from V1 (default)
+		await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('shows toggle button in task view header', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		const toggle = page.locator('[data-testid="task-view-toggle"]');
+		await expect(toggle).toBeVisible({ timeout: 5000 });
+	});
+
+	test('switches to V2 view when toggle is clicked', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// V2 container should NOT be present initially (default is V1)
+		await expect(page.locator('[data-testid="task-view-v2"]')).not.toBeAttached();
+
+		// Click the toggle to switch to V2
+		await page.locator('[data-testid="task-view-toggle"]').click();
+
+		// V2 container should now be visible
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('persists V2 preference across page reload', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Switch to V2 via toggle
+		await page.locator('[data-testid="task-view-toggle"]').click();
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+
+		// Verify localStorage was set
+		const stored = await page.evaluate((key) => localStorage.getItem(key), STORAGE_KEY);
+		expect(stored).toBe('v2');
+
+		// Reload the page
+		await page.reload();
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// V2 should still be active (no flicker — synchronous lazy init)
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('switches back to V1 from V2 view when toggle is clicked again', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		const toggle = page.locator('[data-testid="task-view-toggle"]');
+
+		// Switch to V2
+		await toggle.click();
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+
+		// Switch back to V1
+		await toggle.click();
+		await expect(page.locator('[data-testid="task-view-v2"]')).not.toBeAttached();
+	});
+
+	test('persists V1 preference when returning to V1 and reloading', async ({ page }) => {
+		// Pre-set to V2 via localStorage so we start in V2
+		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
+
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Should start in V2 (from localStorage)
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+
+		// Toggle back to V1
+		await page.locator('[data-testid="task-view-toggle"]').click();
+		await expect(page.locator('[data-testid="task-view-v2"]')).not.toBeAttached();
+
+		// Reload — should stay on V1
+		await page.reload();
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="task-view-v2"]')).not.toBeAttached();
+
+		const stored = await page.evaluate((key) => localStorage.getItem(key), STORAGE_KEY);
+		expect(stored).toBe('v1');
+	});
+});
+
+// ─── Structural Presence Tests ────────────────────────────────────────────────
+
+test.describe('TaskViewV2 — Structural Presence', () => {
+	let roomId = '';
+	let taskId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+		taskId = '';
+
+		// Start each test in V2 mode
+		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('V2 root container is present with correct data-testid', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('V2 turn blocks container is present when session group exists', async ({ page }) => {
+		// turn-blocks-container is conditionally rendered only when a session group exists
+		({ roomId, taskId } = await createRoomTaskAndGroup(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
+			{ timeout: 10000 }
+		);
+
+		// The turn blocks container should be present in V2 when a group exists
+		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
+			timeout: 8000,
+		});
+	});
+
+	test('toggle button label updates to reflect current view', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		const toggle = page.locator('[data-testid="task-view-toggle"]');
+
+		// In V2 mode, toggle should show "V1 ← V2" pattern (offering to go back to V1)
+		await expect(toggle).toBeVisible({ timeout: 5000 });
+		await expect(toggle).toContainText('V2');
+
+		// Switch to V1 — toggle should now show "V1 → V2" pattern
+		await toggle.click();
+		await expect(toggle).toContainText('V1');
+	});
+
+	test('toggle aria-label reflects current state', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		const toggle = page.locator('[data-testid="task-view-toggle"]');
+
+		// Currently in V2 — aria-label should say switching to V1
+		await expect(toggle).toHaveAttribute('aria-label', /V1 timeline/);
+
+		// Switch to V1 — aria-label should now say switching to V2
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-label', /V2 turn-based/);
+	});
+});
+
+// ─── Slide-out Panel Tests ────────────────────────────────────────────────────
+
+test.describe('TaskViewV2 — Slide-out Panel', () => {
+	let roomId = '';
+	let taskId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+		taskId = '';
+
+		// Start in V2 mode
+		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('slide-out panel is not in viewport initially', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// The panel is always in the DOM but translated off-screen (translate-x-full).
+		// Use toBeInViewport() to verify it's not visible in the viewport.
+		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
+		// Backdrop should be transparent (opacity-0) when closed
+		await expect(page.locator('[data-testid="slide-out-backdrop"]')).toHaveClass(/opacity-0/);
+	});
+
+	test('slide-out panel has correct accessibility attributes', async ({ page }) => {
+		({ roomId, taskId } = await createRoomAndTask(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Panel should have correct accessibility attributes regardless of open state
+		const panel = page.locator('[data-testid="slide-out-panel"]');
+		await expect(panel).toHaveAttribute('role', 'dialog');
+		await expect(panel).toHaveAttribute('aria-modal', 'true');
+	});
+
+	test('clicking a turn block opens the slide-out panel', async ({ page }) => {
+		// Note: Turn blocks require real agent messages in sdk_messages with valid session_id FK.
+		// Synthetic session groups (e2e-worker-xxx) don't satisfy the sessions table FK.
+		// This test runs its assertions only if turn blocks are actually rendered.
+		({ roomId, taskId } = await createRoomTaskAndGroup(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
+			{ timeout: 10000 }
+		);
+
+		// Wait for the turn-blocks-container to appear
+		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
+			timeout: 8000,
+		});
+
+		const turnBlocks = page.locator('[data-testid="turn-block"]');
+		const blockCount = await turnBlocks.count();
+
+		if (blockCount === 0) {
+			// No turn blocks — system-only messages don't produce agent turn blocks.
+			// Verify the panel is still off-screen (nothing to open it).
+			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
+			return;
+		}
+
+		// Click the first turn block
+		await turnBlocks.first().click();
+
+		// Slide-out panel should slide into the viewport
+		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
+			timeout: 5000,
+		});
+	});
+
+	test('slide-out panel closes when close button is clicked', async ({ page }) => {
+		({ roomId, taskId } = await createRoomTaskAndGroup(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
+			{ timeout: 10000 }
+		);
+
+		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
+			timeout: 8000,
+		});
+
+		const turnBlocks = page.locator('[data-testid="turn-block"]');
+		const blockCount = await turnBlocks.count();
+
+		if (blockCount === 0) {
+			// No turn blocks available — skip open/close assertion
+			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
+			return;
+		}
+
+		// Open the panel
+		await turnBlocks.first().click();
+		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
+			timeout: 5000,
+		});
+
+		// Click the close button
+		await page.locator('[data-testid="slide-out-panel-close"]').click();
+
+		// Panel should slide off-screen
+		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
+			timeout: 3000,
+		});
+	});
+
+	test('slide-out panel closes on Escape key', async ({ page }) => {
+		({ roomId, taskId } = await createRoomTaskAndGroup(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
+			{ timeout: 10000 }
+		);
+
+		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
+			timeout: 8000,
+		});
+
+		const turnBlocks = page.locator('[data-testid="turn-block"]');
+		const blockCount = await turnBlocks.count();
+
+		if (blockCount === 0) {
+			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
+			return;
+		}
+
+		// Open the panel
+		await turnBlocks.first().click();
+		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
+			timeout: 5000,
+		});
+
+		// Press Escape to close
+		await page.keyboard.press('Escape');
+
+		// Panel should slide off-screen
+		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
+			timeout: 3000,
+		});
+	});
+
+	test('slide-out panel closes when backdrop is clicked', async ({ page }) => {
+		({ roomId, taskId } = await createRoomTaskAndGroup(page));
+
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
+			{ timeout: 10000 }
+		);
+
+		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
+			timeout: 8000,
+		});
+
+		const turnBlocks = page.locator('[data-testid="turn-block"]');
+		const blockCount = await turnBlocks.count();
+
+		if (blockCount === 0) {
+			// Verify backdrop is transparent (pointer-events-none)
+			await expect(page.locator('[data-testid="slide-out-backdrop"]')).toHaveClass(/opacity-0/);
+			return;
+		}
+
+		// Open the panel
+		await turnBlocks.first().click();
+		const backdrop = page.locator('[data-testid="slide-out-backdrop"]');
+		await expect(backdrop).toHaveClass(/opacity-100/, { timeout: 5000 });
+
+		// Click the backdrop to close
+		await backdrop.click();
+
+		// Panel should slide off-screen
+		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
+			timeout: 3000,
+		});
+	});
+});

--- a/packages/e2e/tests/features/task-view-v2.e2e.ts
+++ b/packages/e2e/tests/features/task-view-v2.e2e.ts
@@ -5,18 +5,20 @@
  * Scoped to toggle behavior and localStorage persistence — detailed rendering
  * is covered by unit tests.
  *
- * Setup: creates a room+task via RPC (accepted infrastructure pattern).
+ * Setup: creates a room+task via RPC in beforeEach (accepted infrastructure pattern).
  * Cleanup: deletes the room via RPC in afterEach.
  *
- * All test actions go through the UI (clicks, navigation).
+ * All test actions go through the UI (clicks, navigation, keyboard).
  * All assertions verify visible DOM state via data-testid selectors.
  *
- * Note on slide-out panel: SlideOutPanel is always mounted in the DOM and uses
- * CSS transforms (translate-x-full) to hide. Playwright's toBeInViewport() is
- * used to verify visibility since toBeVisible() does not detect off-screen
- * transforms. Slide-out open/close tests require turn blocks which need real
- * agent sessions — those tests are skipped when no turn blocks are available
- * (turn blocks cannot be seeded via RPC without real session records in SQLite).
+ * Slide-out panel note:
+ * SlideOutPanel is always mounted in the DOM and uses CSS transforms
+ * (translate-x-full) to hide rather than display:none. Assertions use
+ * toHaveClass(/translate-x-full/) to verify closed state directly rather
+ * than toBeInViewport() which is viewport-size sensitive. Open/close behavior
+ * (clicking turn blocks) requires real agent session records to satisfy the
+ * sdk_messages FK constraint — that coverage is documented as future work when
+ * real session seeding infrastructure is available.
  */
 
 import { test, expect } from '../../fixtures';
@@ -25,8 +27,13 @@ import { deleteRoom } from '../helpers/room-helpers';
 
 const STORAGE_KEY = 'neokai:taskViewVersion';
 
-// ─── Setup Helpers ────────────────────────────────────────────────────────────
+// ─── RPC Infrastructure Helpers ───────────────────────────────────────────────
 
+/**
+ * Creates a room and task via RPC. Called from beforeEach — accepted
+ * infrastructure pattern (CLAUDE.md: room.create in beforeEach is allowed;
+ * task.create is an accepted extension for task-specific test isolation).
+ */
 async function createRoomAndTask(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
 ): Promise<{ roomId: string; taskId: string }> {
@@ -53,13 +60,15 @@ async function createRoomAndTask(
 }
 
 /**
- * Creates a room, task, and a synthetic session group.
- * The group makes the turn-blocks-container render in V2 (it's conditional on group existence).
- * System messages are seeded so the container is not empty — they appear as runtime messages.
+ * Creates a room, task, and a synthetic session group with a seeded status
+ * message. The group presence causes turn-blocks-container to render in V2
+ * (the container is conditional on a session group existing). System-type
+ * messages go to task_group_events (no session_id FK), so they avoid the
+ * sessions-table FK constraint that blocks agent-message seeding.
  */
 async function createRoomTaskAndGroup(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
-): Promise<{ roomId: string; taskId: string; groupId: string }> {
+): Promise<{ roomId: string; taskId: string }> {
 	await waitForWebSocketConnected(page);
 
 	return page.evaluate(async () => {
@@ -78,14 +87,13 @@ async function createRoomTaskAndGroup(
 		});
 		const taskId = (taskRes as { task: { id: string } }).task.id;
 
-		// Create synthetic session group (E2E infrastructure RPC — non-production only)
-		const groupRes = await hub.request('task.group.create', {
-			roomId,
-			taskId,
-		});
-		const groupId = (groupRes as { groupId: string }).groupId;
+		// Create synthetic session group (non-production E2E RPC)
+		const groupRes = await hub.request('task.group.create', { roomId, taskId });
+		const { groupId } = groupRes as { groupId: string };
 
-		// Seed a system status message (goes to task_group_events — no session FK constraint)
+		// Seed a system status message (goes to task_group_events — no session FK constraint).
+		// This makes the turn-blocks-container render; the message appears as a RuntimeMessage,
+		// not a TurnBlock (agent messages with a valid sessions-table FK are needed for turn blocks).
 		await hub.request('task.group.addMessage', {
 			groupId,
 			role: 'system',
@@ -93,7 +101,7 @@ async function createRoomTaskAndGroup(
 			content: 'Task started',
 		});
 
-		return { roomId, taskId, groupId };
+		return { roomId, taskId };
 	});
 }
 
@@ -108,38 +116,36 @@ test.describe('TaskViewV2 — Toggle and Persistence', () => {
 		await page
 			.getByRole('button', { name: 'New Session', exact: true })
 			.waitFor({ timeout: 10000 });
-		roomId = '';
-		taskId = '';
 
-		// Clear the localStorage preference so each test starts from V1 (default)
+		// Ensure each test starts from V1 (default)
 		await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+
+		// Infrastructure RPC setup (in beforeEach per E2E rules)
+		({ roomId, taskId } = await createRoomAndTask(page));
 	});
 
 	test.afterEach(async ({ page }) => {
 		await deleteRoom(page, roomId);
+		roomId = '';
+		taskId = '';
 	});
 
 	test('shows toggle button in task view header', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
 		});
 
-		const toggle = page.locator('[data-testid="task-view-toggle"]');
-		await expect(toggle).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('[data-testid="task-view-toggle"]')).toBeVisible({ timeout: 5000 });
 	});
 
 	test('switches to V2 view when toggle is clicked', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
 		});
 
-		// V2 container should NOT be present initially (default is V1)
+		// V2 container should not exist in V1 mode
 		await expect(page.locator('[data-testid="task-view-v2"]')).not.toBeAttached();
 
 		// Click the toggle to switch to V2
@@ -150,8 +156,6 @@ test.describe('TaskViewV2 — Toggle and Persistence', () => {
 	});
 
 	test('persists V2 preference across page reload', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
@@ -161,23 +165,19 @@ test.describe('TaskViewV2 — Toggle and Persistence', () => {
 		await page.locator('[data-testid="task-view-toggle"]').click();
 		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
 
-		// Verify localStorage was set
+		// Verify localStorage was updated
 		const stored = await page.evaluate((key) => localStorage.getItem(key), STORAGE_KEY);
 		expect(stored).toBe('v2');
 
-		// Reload the page
+		// Reload — synchronous lazy init prevents flicker so V2 should be active immediately
 		await page.reload();
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
 		});
-
-		// V2 should still be active (no flicker — synchronous lazy init)
 		await expect(page.locator('[data-testid="task-view-v2"]')).toBeVisible({ timeout: 5000 });
 	});
 
 	test('switches back to V1 from V2 view when toggle is clicked again', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
@@ -195,10 +195,8 @@ test.describe('TaskViewV2 — Toggle and Persistence', () => {
 	});
 
 	test('persists V1 preference when returning to V1 and reloading', async ({ page }) => {
-		// Pre-set to V2 via localStorage so we start in V2
+		// Pre-set to V2 so we can test the V2→V1→reload flow
 		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
-
-		({ roomId, taskId } = await createRoomAndTask(page));
 
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
@@ -235,15 +233,15 @@ test.describe('TaskViewV2 — Structural Presence', () => {
 		await page
 			.getByRole('button', { name: 'New Session', exact: true })
 			.waitFor({ timeout: 10000 });
-		roomId = '';
-		taskId = '';
 
-		// Start each test in V2 mode
+		// Start in V2 mode
 		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
 	});
 
 	test.afterEach(async ({ page }) => {
 		await deleteRoom(page, roomId);
+		roomId = '';
+		taskId = '';
 	});
 
 	test('V2 root container is present with correct data-testid', async ({ page }) => {
@@ -258,7 +256,8 @@ test.describe('TaskViewV2 — Structural Presence', () => {
 	});
 
 	test('V2 turn blocks container is present when session group exists', async ({ page }) => {
-		// turn-blocks-container is conditionally rendered only when a session group exists
+		// turn-blocks-container is conditionally rendered only when a session group exists.
+		// Create the group (and seed a status message) via RPC before navigating.
 		({ roomId, taskId } = await createRoomTaskAndGroup(page));
 
 		await page.goto(`/room/${roomId}/task/${taskId}`);
@@ -266,13 +265,17 @@ test.describe('TaskViewV2 — Structural Presence', () => {
 			{ timeout: 10000 }
 		);
 
-		// The turn blocks container should be present in V2 when a group exists
 		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
 			timeout: 8000,
 		});
 	});
 
-	test('toggle button label updates to reflect current view', async ({ page }) => {
+	test('toggle button shows directional arrow indicating current view', async ({ page }) => {
+		// TaskViewToggle renders different arrow characters per state:
+		//   V2 active → button text contains "←" (offering to go back to V1)
+		//   V1 active → button text contains "→" (offering to go forward to V2)
+		// Both states always contain the strings "V1" and "V2", so the arrow character
+		// is the discriminating indicator.
 		({ roomId, taskId } = await createRoomAndTask(page));
 
 		await page.goto(`/room/${roomId}/task/${taskId}`);
@@ -282,16 +285,16 @@ test.describe('TaskViewV2 — Structural Presence', () => {
 
 		const toggle = page.locator('[data-testid="task-view-toggle"]');
 
-		// In V2 mode, toggle should show "V1 ← V2" pattern (offering to go back to V1)
+		// In V2 mode: button shows "V1 ← V2" (← indicates V2 is active)
 		await expect(toggle).toBeVisible({ timeout: 5000 });
-		await expect(toggle).toContainText('V2');
+		await expect(toggle).toContainText('←');
 
-		// Switch to V1 — toggle should now show "V1 → V2" pattern
+		// After switching to V1: button shows "V1 → V2" (→ indicates V1 is active)
 		await toggle.click();
-		await expect(toggle).toContainText('V1');
+		await expect(toggle).toContainText('→');
 	});
 
-	test('toggle aria-label reflects current state', async ({ page }) => {
+	test('toggle aria-label reflects current view state', async ({ page }) => {
 		({ roomId, taskId } = await createRoomAndTask(page));
 
 		await page.goto(`/room/${roomId}/task/${taskId}`);
@@ -301,10 +304,10 @@ test.describe('TaskViewV2 — Structural Presence', () => {
 
 		const toggle = page.locator('[data-testid="task-view-toggle"]');
 
-		// Currently in V2 — aria-label should say switching to V1
+		// Currently in V2 — aria-label offers to switch back to V1
 		await expect(toggle).toHaveAttribute('aria-label', /V1 timeline/);
 
-		// Switch to V1 — aria-label should now say switching to V2
+		// Switch to V1 — aria-label now offers to switch to V2
 		await toggle.click();
 		await expect(toggle).toHaveAttribute('aria-label', /V2 turn-based/);
 	});
@@ -321,184 +324,72 @@ test.describe('TaskViewV2 — Slide-out Panel', () => {
 		await page
 			.getByRole('button', { name: 'New Session', exact: true })
 			.waitFor({ timeout: 10000 });
-		roomId = '';
-		taskId = '';
 
 		// Start in V2 mode
 		await page.evaluate((key) => localStorage.setItem(key, 'v2'), STORAGE_KEY);
+
+		// Infrastructure RPC setup (in beforeEach per E2E rules)
+		({ roomId, taskId } = await createRoomAndTask(page));
 	});
 
 	test.afterEach(async ({ page }) => {
 		await deleteRoom(page, roomId);
+		roomId = '';
+		taskId = '';
 	});
 
-	test('slide-out panel is not in viewport initially', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
+	test('slide-out panel is off-screen when closed (translate-x-full)', async ({ page }) => {
+		// SlideOutPanel is always mounted in the DOM; CSS transforms control visibility.
+		// Check the translate-x-full class directly (more reliable than viewport intersection).
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
 		});
 
-		// The panel is always in the DOM but translated off-screen (translate-x-full).
-		// Use toBeInViewport() to verify it's not visible in the viewport.
-		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
-		// Backdrop should be transparent (opacity-0) when closed
-		await expect(page.locator('[data-testid="slide-out-backdrop"]')).toHaveClass(/opacity-0/);
+		await expect(page.locator('[data-testid="slide-out-panel"]')).toHaveClass(/translate-x-full/, {
+			timeout: 5000,
+		});
+	});
+
+	test('slide-out backdrop is transparent when panel is closed (opacity-0)', async ({ page }) => {
+		await page.goto(`/room/${roomId}/task/${taskId}`);
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Backdrop uses opacity-0 + pointer-events-none when closed
+		await expect(page.locator('[data-testid="slide-out-backdrop"]')).toHaveClass(/opacity-0/, {
+			timeout: 5000,
+		});
 	});
 
 	test('slide-out panel has correct accessibility attributes', async ({ page }) => {
-		({ roomId, taskId } = await createRoomAndTask(page));
-
 		await page.goto(`/room/${roomId}/task/${taskId}`);
 		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
 			timeout: 10000,
 		});
 
-		// Panel should have correct accessibility attributes regardless of open state
 		const panel = page.locator('[data-testid="slide-out-panel"]');
 		await expect(panel).toHaveAttribute('role', 'dialog');
 		await expect(panel).toHaveAttribute('aria-modal', 'true');
 	});
 
-	test('clicking a turn block opens the slide-out panel', async ({ page }) => {
-		// Note: Turn blocks require real agent messages in sdk_messages with valid session_id FK.
-		// Synthetic session groups (e2e-worker-xxx) don't satisfy the sessions table FK.
-		// This test runs its assertions only if turn blocks are actually rendered.
-		({ roomId, taskId } = await createRoomTaskAndGroup(page));
-
+	test('slide-out panel close button has correct aria-label', async ({ page }) => {
 		await page.goto(`/room/${roomId}/task/${taskId}`);
-		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
-			{ timeout: 10000 }
+		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Test Task' })).toBeVisible({
+			timeout: 10000,
+		});
+
+		await expect(page.locator('[data-testid="slide-out-panel-close"]')).toHaveAttribute(
+			'aria-label',
+			'Close panel'
 		);
-
-		// Wait for the turn-blocks-container to appear
-		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
-			timeout: 8000,
-		});
-
-		const turnBlocks = page.locator('[data-testid="turn-block"]');
-		const blockCount = await turnBlocks.count();
-
-		if (blockCount === 0) {
-			// No turn blocks — system-only messages don't produce agent turn blocks.
-			// Verify the panel is still off-screen (nothing to open it).
-			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
-			return;
-		}
-
-		// Click the first turn block
-		await turnBlocks.first().click();
-
-		// Slide-out panel should slide into the viewport
-		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
-			timeout: 5000,
-		});
 	});
 
-	test('slide-out panel closes when close button is clicked', async ({ page }) => {
-		({ roomId, taskId } = await createRoomTaskAndGroup(page));
-
-		await page.goto(`/room/${roomId}/task/${taskId}`);
-		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
-			{ timeout: 10000 }
-		);
-
-		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
-			timeout: 8000,
-		});
-
-		const turnBlocks = page.locator('[data-testid="turn-block"]');
-		const blockCount = await turnBlocks.count();
-
-		if (blockCount === 0) {
-			// No turn blocks available — skip open/close assertion
-			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
-			return;
-		}
-
-		// Open the panel
-		await turnBlocks.first().click();
-		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
-			timeout: 5000,
-		});
-
-		// Click the close button
-		await page.locator('[data-testid="slide-out-panel-close"]').click();
-
-		// Panel should slide off-screen
-		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
-			timeout: 3000,
-		});
-	});
-
-	test('slide-out panel closes on Escape key', async ({ page }) => {
-		({ roomId, taskId } = await createRoomTaskAndGroup(page));
-
-		await page.goto(`/room/${roomId}/task/${taskId}`);
-		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
-			{ timeout: 10000 }
-		);
-
-		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
-			timeout: 8000,
-		});
-
-		const turnBlocks = page.locator('[data-testid="turn-block"]');
-		const blockCount = await turnBlocks.count();
-
-		if (blockCount === 0) {
-			await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport();
-			return;
-		}
-
-		// Open the panel
-		await turnBlocks.first().click();
-		await expect(page.locator('[data-testid="slide-out-panel"]')).toBeInViewport({
-			timeout: 5000,
-		});
-
-		// Press Escape to close
-		await page.keyboard.press('Escape');
-
-		// Panel should slide off-screen
-		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
-			timeout: 3000,
-		});
-	});
-
-	test('slide-out panel closes when backdrop is clicked', async ({ page }) => {
-		({ roomId, taskId } = await createRoomTaskAndGroup(page));
-
-		await page.goto(`/room/${roomId}/task/${taskId}`);
-		await expect(page.getByRole('heading', { name: 'E2E TaskViewV2 Group Test Task' })).toBeVisible(
-			{ timeout: 10000 }
-		);
-
-		await expect(page.locator('[data-testid="turn-blocks-container"]')).toBeVisible({
-			timeout: 8000,
-		});
-
-		const turnBlocks = page.locator('[data-testid="turn-block"]');
-		const blockCount = await turnBlocks.count();
-
-		if (blockCount === 0) {
-			// Verify backdrop is transparent (pointer-events-none)
-			await expect(page.locator('[data-testid="slide-out-backdrop"]')).toHaveClass(/opacity-0/);
-			return;
-		}
-
-		// Open the panel
-		await turnBlocks.first().click();
-		const backdrop = page.locator('[data-testid="slide-out-backdrop"]');
-		await expect(backdrop).toHaveClass(/opacity-100/, { timeout: 5000 });
-
-		// Click the backdrop to close
-		await backdrop.click();
-
-		// Panel should slide off-screen
-		await expect(page.locator('[data-testid="slide-out-panel"]')).not.toBeInViewport({
-			timeout: 3000,
-		});
-	});
+	// NOTE: Open/close interaction tests (clicking turn blocks to open the panel,
+	// closing via button/Escape/backdrop) require agent-turn messages in sdk_messages,
+	// which need valid session_id FK references to the sessions table. Synthetic session
+	// groups created via task.group.create use generated IDs (e2e-worker-xxx) that are
+	// not in the sessions table. This coverage is reserved for when real session seeding
+	// infrastructure (or daemon-level session stub creation) becomes available.
 });


### PR DESCRIPTION
- **feat(tasks): make failed state non-terminal (allow messages + retry)**
- **fix: pass taskManager as parameter to avoid accessing private field**
- **fix: align needs_attention handling between RPC and agent-tool paths**
- **ci: add setup-devproxy composite action with caching to fix CI install failures**
- **fix(ci): use jq + GITHUB_TOKEN auth to resolve devproxy version in setup action**
- **fix(ci): inject github.token into composite action step env for API auth**
- **fix: resolve leftover conflict markers in human-message-routing tests**
- **ci: simplify CI pipeline by removing intermediate gate jobs and extracting Dev Proxy action**
- **fix: restore runner.os guard on setup-devproxy, add startup timeout failure**
- **fix: always set archivedAt when archiving task without active runtime**
- **fix: correct comment about orphaned worktree cleanup, add review state test**
- **fix(ci): use nc -z TCP check for devproxy readiness instead of curl**
- **feat: add draft message auto-save to task view input**
- **fix: address review feedback on task draft auto-save**
- **feat: persist task input draft to server-side storage**
- **fix: address review feedback on task draft RPC handler**
- **ci: add rpc-task-draft-handlers.test.ts to rpc-1 CI matrix shard**
- **ci: register rpc-task-draft-handlers.test.ts in validate-online-test-matrix script**
- **fix: address review feedback on task draft hook (round 2)**
- **fix: add cancelled flag to loadDraft to prevent cross-task data corruption**
- **fix(test): mock Bun.spawn in dialog-handlers tests to prevent system folder picker**
- **test(dialog-handlers): fix platform-agnostic test and cover error-handling path**
- **fix: address round-7 review feedback on task draft hook**
- **ci: retrigger CI after base branch corrected to dev**
- **ci: retrigger CI (rpc-remove-output flaky timeout)**
- **feat: raise draft/message char limit from 100k to 200k**
- **fix: correct too-long test repeat count and JSDoc after 200k limit raise**
- **chore: bump version to 0.7.1 (#357)**
- **fix: skip max feedback iterations limit when task is in review state (#358)**
- **docs: Goal V2 (Mission System) plan for autonomous agent workflows (#322)**
- **fix: preserve PR data on runtime escalation and show PR in task view header (#360)**
- **chore: update deps to latest minor versions (except claude agent SDK) (#362)**
- **chore: upgrade @anthropic-ai/claude-agent-sdk from 0.2.55 to 0.2.76 (#363)**
- **feat: order tasks by most recently updated within each status (#365)**
- **feat: add GLM-5-Turbo model support (#367)**
- **fix: prevent API error bounce loops for all agents in runtime (#366)**
- **feat: Anthropic-compatible HTTP bridge backed by codex app-server (#339)**
- **feat: GitHub Copilot as transparent AgentSession backend via embedded Anthropic-compatible server (#340)**
- **feat: add mission metadata schema and types for Goal V2 (#369)**
- **docs: Goal V2 Mission System -- Autonomous Agent Workflows plan (#368)**
- **fix: show PR link for all task statuses once created (#372)**
- **Plan: Full first-class anthropic-copilot and anthropic-codex provider support (#370)**
- **feat: tighten leader agent tool permissions to read-only context subset (#371)**
- **feat: define V2 mission types and extend RoomGoal (Task 1.1) (#374)**
- **chore: remove pi-mono approach dead code (#364)**
- **feat: widen Provider type union to include anthropic-copilot and anthropic-codex (#373)**
- **fix: remove unsafe provider casts in daemon, use widened Provider type (#377)**
- **fix: Enter to send in task HumanInputArea, default target to leader (#387)**
- **fix: inject room chat system prompt to prevent premature task creation (#379)**
- **feat: add anthropic-codex Codex entry to PROVIDER_LABELS (#375)**
- **feat: make provider routing fully deterministic via explicit (modelId, providerId) pairs (#376)**
- **fix: parse /context response from assistant messages (new SDK format) (#381)**
- **fix: prevent agent from creating duplicate PRs on re-dispatch (#392)**
- **fix: remove merge method flag from human approval message (#393)**
- **feat: iterate all tool results in codex bridge continuation (#378)**
- **feat: replace copy toast with inline green check mark (#394)**
- **feat: require explicit provider ID for all model resolution (#388)**
- **test: add provider routing tests for copilot/cross-provider model switches (#395)**
- **feat: provider-grouped model picker with availability dots (#398)**
- **feat: replace plain-text error bodies with Anthropic JSON error envelopes in codex bridge (#380)**
- **feat: improve error mapping in copilot bridge (Task 5.1) (#384)**
- **fix: render leader questions as interactive forms in task conversation (#400)**
- **feat: wire thread/tokenUsage/updated into SSE message_delta token counts (#383)**
- **feat: recurring missions — scheduling with execution identity and recovery (Task 3) (#390)**
- **feat: UI terminology — rename Goal to Mission (Task 5) (#397)**
- **feat: implement semi-autonomous mode for coder/general tasks (Task 4) (#396)**
- **feat: measurable missions — structured metrics and adaptive replanning (Task 2) (#382)**
- **fix: call queryObject.close() before clearing transport reference (#403)**
- **fix: scope message locator in persistence e2e test to avoid strict mode violation (#402)**
- **feat: provider-aware session creation (#399) (#401)**
- **feat: add provider badge in session status bar next to model icon (#391)**
- **feat: heuristic token accounting for copilot bridge (#385)**
- **test: unit tests for provider routing and type safety (Task 7.1) (#399)**
- **feat: log warning when tool_choice is provided but not honored in both bridges (#386)**
- **task/task 72 update online provider test shards (#409)**
- **feat: graceful degradation on provider unavailability (#408)**
- **test: add E2E tests for provider model switching UI (#406)**
- **feat: eager leader initialization and fix observer race in TaskGroupManager (#411)**
- **feat: filter unauthenticated providers from model picker (#410)**
- **Fix SQLITE_BUSY retries and closed SSE controller handling (#415)**
- **fix: resolve leader questions routing to dead session instances (#404)**
- **feat: add OpenAI token refresh/login in settings for Codex (#416)**
- **fix: use correct /room/:id route in mission-terminology e2e tests (#419)**
- **fix: restore dead worker sessions before routing leader feedback (#418)**
- **feat: UI — type-specific mission creation and detail views (Task 6) (#405)**
- **fix: capture assistant.message.content when Copilot SDK skips streaming deltas (#421)**
- **fix: set ANTHROPIC_DEFAULT_*_MODEL in Codex provider to prevent Anthropic model fallback (#412)**
- **fix: support Agent tool name for subagent blocks (SDK 0.2.76+ renamed Task to Agent) (#424)**
- **fix(codex-bridge): persist Codex sessions across turns (#420)**
- **docs: add final provider parity report (#413)**
- **docs: plan for Multi-Agent V2 customizable agents and workflows (#359)**
- **task/fix logout button not working for openai and copil (#423)**
- **feat: define Space shared types in @neokai/shared (#425)**
- **feat: add Migration 29 — create all Space system tables (#427)**
- **feat: add SpaceAgent and workflow types to space.ts (Task 3.1) (#426)**
- **feat: custom agent types, repository, and manager (Task 2.1) (#428)**
- **feat: add Space repositories and managers (Task 1.3) (#429)**
- **feat: SpaceWorkflowRepository and SpaceWorkflowManager (Task 3.2) (#430)**
- **feat: Space RPC handlers and DaemonEventMap registration (Task 1.4) (#433)**
- **docs: add provider setup documentation for anthropic-copilot and anthropic-codex (#414)**
- **test: integration testing and documentation for Mission System V2 (Task 7) (#422)**
- **feat: add task management tools to leader role (#435)**
- **feat: add spaceAgent RPC handlers and DaemonEventMap entries (Task 2.2) (#431)**
- **feat: simplify multi-agent space — explicit workflowId or AI auto-select only (#434)**
- **feat: add leader progress summary at end of each turn (#436)**
- **feat: custom agent session init factory and SpaceAgent tools (Task 2.3) (#432)**
- **docs: update multi-agent space task docs with simplified workflow selection design (#439)**
- **docs: NeoKai UI/UX 1.0.0 upgrade plan (#442)**
- **docs: add NeoKai UI/UX 1.0.0 upgrade specification (#444)**
- **feat: extend CSS custom properties vocabulary in styles.css (#445)**
- **feat: Workflow RPC handlers and DaemonEventMap registration (Task 3.3) (#437)**
- **feat: built-in workflow templates and seedBuiltInWorkflows (Task 3.4) (#440)**
- **feat: Space navigation, routing, and signals (Task 5.1) (#438)**
- **feat: add WorkflowExecutor core for Space workflow run progression (Task 4.1) (#443)**
- **feat: define Space export/import JSON format (Task 8.1) (#441)**
- **docs: align Milestone 4 planning docs with transition/condition implementation (#447)**
- **feat: SpaceRuntime — workflow orchestration, task-type assignment, seedDefaultWorkflow wiring (Task 4.2) (#450)**
- **fix: make CreateWorkflowRunParams.currentStepId optional (#449)**
- **feat: add SpaceStore reactive state management (Task 5.2) (#446)**
- **fix: fix failing E2E tests for mission creation routes and persistence (#451)**
- **feat: add Space export/import RPC handlers (Task 8.2) (#452)**
- **feat: workflow selection logic and Space agent tools (Task 7.1) (#453)**
- **fix: sync space_agents columns in space-test-db.ts with migration schema (#448)**
- **feat: Space creation UX and 3-column layout (Task 5.3) (#455)**
- **task/make turn summary card use bigger font and render  (#460)**
- **feat: SpaceRuntimeService, workflow run RPC handlers, and session group metadata (Task 4.3) (#454)**
- **feat: Task 8.3 — Frontend Export/Import UI for Space agents and workflows**
- **fix: fetch real Copilot model IDs dynamically via client.listModels() (#464)**
- **task/fix agent session crash when switching modelprovid (#459)**
- **task/add support for minimax m27 highspeed model (#458)**
- **feat: Task 6.1 - Custom Agent List and Editor**
- **task/task 72 space agent prompt enhancement (#457)**
- **feat: workflow step builder (Task 6.2) (#463)**
- **fix: handle thinking blocks in SDK title generation (#461)**
- **refactor: remove detectProvider heuristic entirely (#467)**
- **feat: Task 6.3 - Workflow Rules Editor and Space integration (#468)**
- **feat: add structured tokens object to design-tokens module (#469)**
- **test: add tokens unified namespace tests for Task 1.2 (#470)**
- **feat: typography and global prose refinements (Task 1.3) (#471)**
- **fix: ensure onError cleanup runs on subprocess crash in codex bridge (#473)**
- **fix: clear stale sdkSessionId when SDK session file no longer exists (#474)**
- **fix: display Copilot quota errors as UI error blocks and stop retrying (#476)**
- **feat: display API retry errors in UI during SDK retry attempts (#475)**
- **fix: use unique workspace paths and correct delete params in space E2E tests (#477)**
- **feat: Button/IconButton/NavIconButton unification (Task 2.1) (#472)**
- **fix: clean up stale spaces before creating in E2E tests (#478)**
- **fix: correct space.list response shape in E2E stale-space cleanup (#481)**
- **fix: use correct space.create response shape in E2E tests (#482)**
- **ci: skip unstable space E2E tests (export-import, workflow-rules) (#483)**
- **docs: plan for workflow visual editor implementation (#479)**
- **feat: add VisualCanvas component with pan and zoom (Task 1.2) (#484)**
- **feat: add layout column to space_workflows for visual editor (Task 1.1) (#485)**
- **feat: replace hidden dropdown with inline Cancel/Complete buttons in TaskView (Task 2.2) (#480)**
- **feat: add SVG overlay layer for edges in VisualCanvas (Task 1.3) (#488)**
- **feat: add WorkflowNode canvas component (Task 2.1) (#490)**
- **fix: sync room chat session model when defaultModel changes to prevent glm-5-turbo errors (#486)**
- **feat: DAG auto-layout algorithm for workflow visual editor (Task 5.1) (#487)**
- **feat: add CanvasToolbar with zoom controls and fit-to-view (Task 1.4) (#489)**
- **feat: add node selection and multi-select to visual editor (Task 2.3) (#491)**
- **feat: implement WorkflowNode with drag-and-drop support (Task 2.2) (#492)**
- **fix: always set provider in createCustomAgentInit for Space custom agents (#495)**
- **feat: create connections by dragging from output to input ports (Task 3.2) (#496)**
- **feat: implement NodeConfigPanel and extract GateConfig (Task 4.1) (#497)**
- **feat: add Spaces UI with global agent and context panel (#493)**
- **task/task 31 render edges as svg bezier curves (#494)**
- **feat: implement EdgeConfigPanel component for transition editing (Task 4.2) (#498)**
- **feat: serialize visual state to SpaceWorkflow data model (Task 5.2) (#499)**
- **Plan: Task Agent session orchestrator for Space tasks (#501)**
- **feat: add VisualWorkflowEditor orchestrator component (Task 6.1) (#500)**
- **feat: add space_task_agent session type and taskAgentSessionId to SpaceTask (#502)**
- **feat: define Task Agent MCP tool schemas (Task 1.3) (#503)**
- **feat: add List/Visual toggle in SpaceIsland workflow editor (Task 6.2) (#505)**
- **feat: add template support to visual workflow editor (Task 5.3) (#506)**
- **test: add performance validation for large workflows (Task 7.3) (#504)**
- **feat: build Task Agent system prompt and initial message builders (#507)**
- **feat: add task_agent_session_id to space_tasks schema and repository (#508)**
- **docs: plan for Space Agent Coordinator reactive event-driven task coordination (Layer 4a) (#512)**
- **feat: implement createTaskAgentInit factory for Task Agent sessions (Task 2.2) (#510)**
- **feat: implement Task Agent MCP tool handlers (Task 3.1) (#513)**
- **test: add E2E tests for visual workflow editor (Task 7.1) (#509)**
- **feat: define NotificationSink interface and SpaceNotificationEvent types (Task 2.1) (#515)**
- **feat: add retryTask and reassignTask methods to SpaceTaskManager (#514)**
- **feat: implement SessionNotificationSink for Space Agent event injection (#519)**
- **test: fix pre-existing test failures for compatibility (Task 7.2) (#511)**
- **feat: add SpaceAutonomyLevel, SpaceConfig types, and autonomy_level DB column (#516)**
- **feat: add coordination tools to space-agent-tools (Task 3.2) (#520)**
- **test: add MCP server factory tests for createTaskAgentMcpServer (#517)**
- **feat: update space-chat-agent prompt with coordinator behavior (Task 4.1) (#523)**
- **feat: update SpaceManager and RPC handlers for autonomy level (Task 1.2) (#524)**
- **feat: integrate NotificationSink into SpaceRuntime tick loop (Task 2.2) (#525)**
- **fix: use worktree path for SDK session file lookups (#518)**
- **task/review pr 518 (#527)**
- **feat: update global-spaces-agent prompt with coordination guidance (#522)**
- **test: autonomy level behavior tests for space agent (Task 6.2) (#526)**
- **feat: add needs_attention detection for standalone tasks in SpaceRuntime (#529)**
- **feat: add coordination tools to global-spaces-tools.ts (Task 3.3) (#521)**
- **feat: implement TaskAgentManager core (Task 4.1) (#528)**
- **test: add full pipeline integration tests for concurrent notification events (Task 6.1) (#531)**
- **feat: wire SessionNotificationSink into provisionGlobalSpacesAgent (Task 5.2) (#530)**
- **feat: wire TaskAgentManager into DaemonApp (Task 4.3) (#532)**
- **test: edge case and resilience tests for notification system (Task 6.3) (#537)**
- **feat: add human message routing to Task Agent via space.task.sendMessage/getMessages (#536)**
- **feat: add Task Agent spawning to SpaceRuntime tick loop (Task 5.1) (#538)**
- **test: verify all MCP tools registered in global-spaces provisioning (Task 5.3) (#534)**
- **feat: add send_message_to_task tool to Space Agent (#535)**
- **feat: wire TaskAgentManager into SpaceRuntimeService (Task 5.2) (#540)**
- **feat: add task completion notification to Space Agent (Task 6.2) (#541)**
- **test: online tests with dev proxy for space agent coordination (Task 6.4) (#539)**
- **feat: add toast semantic methods and ConfirmModal enhancements (Task 2.3) (#543)**
- **feat: add Task Agent session rehydration on daemon restart (Task 5.3) (#542)**
- **feat: add semantic status border and inline reject form to RoomTasks (Task 2.4) (#544)**
- **feat: add Inbox navigation infrastructure (Task 3.1) (#545)**
- **feat: add Inbox view (inbox-store + Inbox.tsx + MainContent routing) (Task 3.2) (#546)**
- **test: add end-to-end online test for Task Agent lifecycle (Task 6.3) (#547)**
- **feat: add direct approve/reject to Inbox without TaskView navigation (Task 4.3) (#548)**
- **feat: hide ContextPanel when inbox is active (Task 4.2) (#550)**
- **fix: remove premature task_agent_session_id index from migration 29 (#551)**
- **feat: auto-expand review TaskCards with Approve button and worker summary (Task 4.4) (#553)**
- **docs: plan for workflow iteration loop with agent-driven cyclic transitions (#552)**
- **docs: plan to fix E2E test failures on dev branch CI (#556)**
- **docs: plan for task status lifecycle redesign (#555)**
- **feat: add goalId column to space_tasks and types (Task 3.1) (#561)**
- **fix: replace fixed sleep with Playwright auto-retrying assertion in worktree-isolation E2E test (#557)**
- **fix: rewrite task-actions-dropdown E2E tests to match actual inline button UI (#558)**
- **Plan: Redesign RoomContextPanel goal-centric sidebar (#563)**
- **feat: add iteration tracking columns to DB and types (Task 2.1) (#564)**
- **fix: remove stale sessions from RoomContextPanel on session delete/update (#554)**
- **fix: update space-creation E2E test assertions to match actual tabbed UI (#559)**
- **feat: add ActionBar component and replace inline HeaderReviewBar in TaskView (Task 4.5) (#560)**
- **feat: propagate goalId through workflow task creation (Task 3.2) (#565)**
- **feat: add task_result condition type and isCyclic to workflow transitions (#562)**
- **fix: fix visual-workflow-editor E2E tests — space URL sync + navigateToSpace wait (#567)**
- **feat: add CollapsibleSection component for sidebar sections (#568)**
- **feat: add /room/:roomId/agent route pattern and navigation (#570)**
- **feat: add mobile BottomTabBar with iOS-style navigation (Task 4.6) (#571)**
- **feat: add computed signals for goal-task grouping and orphan tasks (#569)**
- **test: unit tests for goalId propagation (Task 5.3) (#572)**
- **feat: add archived status to TaskStatus and SpaceTaskStatus unions (#566)**
- **feat: add Verify & Test step to Coding Workflow template (#573)**
- **feat: implement task_result evaluation in WorkflowExecutor (#574)**
- **chore: trigger PR creation for task 5.1 (#583)**
- **feat(workflow): implement iteration detection and capping in WorkflowExecutor (#585)**
- **fix: replace crypto.randomUUID with browser-compatible generateUUID (#587)**
- **feat: wire step_result through advance_workflow to executor (Task 1.3) (#586)**
- **feat: rewrite RoomContextPanel with goal-centric sidebar layout (#577)**
- **test: unit tests for archived status transitions and archival filtering (#580)**
- **test: add unit tests for router room agent route (#575)**
- **test: add reactivity and edge case tests for room store computed signals (#576)**
- **fix: stop worktree cleanup on complete and cancel in task-group-manager (#578)**
- **test: add space task manager tests for archival and reactivation lifecycle (#579)**
- **test: add archive and reactivation RPC handler tests for space tasks (#593)**
- **fix: fix flaky online tests in CI (#582)**
- **feat: Phase 4 micro-animations — badge pop, card approve/reject, panel & page fade-in (#590)**
- **test: add missing draft/pending Active tab and sessions count badge tests for RoomContextPanel (#591)**
- **feat: update task tab grouping to Active/Review/Done/Archived (#581)**
- **feat: add model switching in TaskView and auto-fallback on rate/usage limits (#589)**
- **test: add end-to-end cyclic workflow integration test (Task 5.5) (#598)**
- **test: validate Room.tsx integration with room agent routes (#592)**
- **feat: update room-runtime and RPC handlers for new lifecycle (#594)**
- **feat: add reactivate and archive actions to TaskView (#601)**
- **test: add E2E tests for room sidebar sections (goal expand/collapse and task tab filtering) (#602)**
- **feat: allow cancelled → completed status transition (#600)**
- **test: add E2E tests for room sidebar URL navigation and persistence (#603)**
- **fix: update room-agent-tools guards and comments for new task lifecycle (#599)**
- **test: add web unit tests for archived status and reactivate/archive button visibility (#604)**
- **fix: recover rate-limited workers stuck in later iterations (feedbackIteration > 0) (#596)**
- **test: add unit tests for room-runtime lifecycle changes (#605)**
- **test: add online integration tests for task reactivation and archive lifecycle (#608)**
- **test: add edge-case tests for cyclic transition condition evaluation and iterationCount (#609)**
- **test: add E2E tests for task reactivate and archive UI actions (#611)**
- **fix: sync root repo after PR merge via lifecycle gate (#610)**
- **docs: plan for Space Agent Groups flexible multi-agent collaboration (#606)**
- **feat: add migration 40 for flexible session groups (#614)**
- **feat: extend WorkflowStep with agents array and WorkflowChannel topology (#613)**
- **docs: implementation plan for persistent job queue adoption (#612)**
- **feat: update shared types for flexible SpaceSessionGroup model (#615)**
- **feat: extend listJobs to accept status arrays (#618)**
- **feat: add resolveTaskTypesForStep for multi-agent per-agent type resolution (#616)**
- **docs(plans): SQL LiveQuery adoption plan (#205)**
- **feat: add channel and multi-agent step validation to SpaceWorkflowManager (#617)**
- **feat: extend export/import format for multi-agent steps and channels (#620)**
- **task/task 13 update spacesessiongrouprepository for new (#619)**
- **ci: skip Codex bridge tests + fix multi-agent import test (#627)**
- **test: add export/import round-trip tests for multi-agent workflows (#624)**
- **feat: update WorkflowExecutor for multi-agent parallel step execution (#621)**
- **feat: create job queue constants, wire processor into app lifecycle (#622)**
- **test: unit tests for updated SpaceSessionGroupRepository schema (#625)**
- **feat: thread reactiveDb through dependency interfaces (#623)**
- **feat: show associated goal on room task list and task view (#629)**
- **feat: wire SpaceSessionGroupRepository into TaskAgentManager (#628)**
- **test: add JobQueueProcessor lifecycle integration tests (#632)**
- **feat: add session title generation job handler (#630)**
- **feat: add job_queue.cleanup handler and wire into daemon startup (#635)**
- **test: verify eager stale job reclamation on processor restart (#633)**
- **test: unit tests for updated Coding Workflow template (Task 5.4) (#584)**
- **feat: expose triggerPoll and create github.poll job handler (#631)**
- **test: add comprehensive unit tests for multi-agent workflow executor (#636)**
- **feat: inject ReactiveDatabase into TaskManager and fire notifyChange after writes (#642)**
- **feat: update visual workflow editor for multi-agent steps and channel topology (#637)**
- **feat: add room.tick job handler, enqueueRoomTick, and cancelPendingTickJobs (#634)**
- **feat: add notifyChange to GoalRepository and wire through GoalManager (#641)**
- **feat: rehydrate group map on daemon restart via dedicated rehydrateGroupMaps() (#639)**
- **feat: add sub-session members to groups (Task 2.2) (#638)**
- **feat: wire session title handler into SessionManager and remove pendingBackgroundTasks (#640)**
- **test: add E2E tests for multi-agent step editor and channel topology (#645)**
- **feat: remove setInterval from GitHubPollingService and wire handler into GitHubService (#644)**
- **feat: add notifyChange to SessionGroupRepository (#643)**
- **feat: replace setInterval/queueMicrotask with job queue in RoomRuntime (#646)**
- **test: add online test for session title generation via job queue (#647)**
- **feat: emit session group events via DaemonHub (Task 2.3) (#648)**
- **feat: add shared LiveQuery protocol types (#651)**
- **test: add online test for GitHub polling via job queue (#650)**
- **feat: add MessageHub.onClientDisconnect forwarding method (#652)**
- **feat: plumb clientId into CallContext (#653)**
- **fix: model switch now always restarts query when queryObject exists (#657)**
- **feat: add ChannelResolver, list_group_members and relay_message tools to Task Agent (#649)**
- **feat: wire room.tick handler into RoomRuntimeService and fix stopRuntime bug (#660)**
- **feat: hide completed tasks under Goals in sidebar with show/hide toggle (#656)**
- **feat: define named-query registry with column aliasing and JSON parsing (#655)**
- **feat: redesign task view with action dropdown and circular progress (#658)**
- **feat: add space session group RPC handlers and SpaceStore signals (#659)**
- **test: add unit tests for TaskAgentManager group persistence and events (#654)**
- **fix: enqueueRoomTick replaces pending tick when new request is sooner (#661)**
- **test: add online test for room tick via job queue (Task 4.4) (#670)**
- **feat: display active agents in SpaceTaskPane (#663)**
- **feat: implement liveQuery.subscribe and liveQuery.unsubscribe RPC handlers (#672)**
- **feat: step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#675)**
- **test: add integration tests for job queue crash/restart recovery (#671)**
- **fix: use try/finally in test 1 so daemon1 is always stopped on assertion failure (#682)**
- **fix: revert task view gear button to expanded-down panel UX (#681)**
- **fix: prevent duplicate group spawning for same task during concurrent ticks (#687)**
- **test: add disconnect cleanup unit test and online LiveQuery pipeline test (Task 2.6) (#680)**
- **test: add reactive signal update tests for SpaceTaskPane working agents (#679)**
- **fix: remove emitTaskUpdate from task.fail RPC handler (Task 3.1) (#688)**
- **ci: split rpc online tests into 4 balanced shards (#685)**
- **feat: add E2E test for active agents display in SpaceTaskPane (#683)**
- **docs: document out-of-scope setInterval users after job-queue migration (#693)**
- **test: add comprehensive unit tests for cross-agent messaging (#684)**
- **feat: add git branch and session status to TaskInfoPanel expanded view (#691)**
- **feat: add step agent peer communication tools (send_feedback, request_peer_input, list_peers) (#678)**
- **test(e2e): add job queue background tasks E2E test for session title generation (#692)**
- **test: add integration tests for cross-group isolation and channel enforcement (#686)**
- **feat: add useGroupMessages hook for LiveQuery group message streaming (#690)**
- **feat: add force-stop session group RPC + auto-clean stale groups in tick (#694)**
- **fix: address root causes of duplicate and stale session groups (#696)**
- **feat: replace state.groupMessages.delta listener with useGroupMessages hook (#698)**
- **fix: remove emitGoalUpdated/emitGoalProgressUpdated from goal RPC handlers (Task 3.2) (#695)**
- **feat: redesign Goals tab with two-step create wizard and improved cards (#703)**
- **fix: fix task cancellation cascade and allow manual UI state transitions (#702)**
- **feat: remove daemon-side state.groupMessages.delta emissions and add reconnect handling (#700)**
- **feat: migrate TaskConversationRenderer to liveQuery and add E2E streaming tests (#701)**
- **feat: replace room.task.update listener with tasks.byRoom LiveQuery (Task 3.3) (#705)**
- **test: add reconnect resync guard test for review-status toast (Task 3.4) (#709)**
- **fix: reuse existing dev proxy instance instead of failing on startup (#706)**
- **fix: fix TaskView not showing messages after daemon restart (#707)**
- **feat: expand TaskView info panel with task ID, group ID, full session IDs, model switcher, and metadata (#708)**
- **feat: create useRoomLiveQuery hook and integrate with Room.tsx (Task 3.5) (#711)**
- **fix: prevent UNIQUE constraint crash in spawnGroupForTask and handle race gracefully (#710)**
- **feat: add stale-event guard for LiveQuery subscriptions (Task 3.6) (#712)**
- **test(e2e): add LiveQuery task/goal update E2E tests (Task 3.7) (#713)**
- **docs: add dev branch e2e tests health check plan (#704)**
- **feat: enable Bash and full MCP access for Room Agent session (#715)**
- **fix: prevent full conversation reload when sending a message in TaskView (#716)**
- **Fix TaskView recovery after server restart (#718)**
- **refactor: canonical TaskView timeline + runtime startup state persistence (#720)**
- **feat: audit and fix room agent MCP tools parity vs backend capabilities (#719)**
- **fix: propagate reactiveDb to TaskRepository for LiveQuery notifications + rename Goals to Missions (#717)**
- **test: fix pre-existing test failures uncovered during Task 6.2 verification (#721)**
- **task/bug task view message timestamps show current time (#722)**
- **fix(e2e): disambiguate Missions tab locator to avoid sidebar button clash (#723)**
- **fix: use reactive db facade for sdk message write paths (#724)**
- **fix(e2e): update mission-creation selectors for two-step wizard flow (#725)**
- **refactor: unify message delivery semantics + align TaskView pending UX (#726)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#729)**
- **chore: bump version to 0.8.0 (#728)**
- **docs: document Task 4 verification - all E2E tests pass on dev CI (#731)**
- **docs: update verification doc with final CI run info (#732)**
- **chore(release): sync main history + release automation for v0.8.0 (#733)**
- **chore: update dependencies and pin all versions to exact (#736)**
- **plan: TaskViewV2 turn-based conversation summary with slide-out panels (#666)**
- **chore: update @anthropic-ai/claude-agent-sdk to 0.2.81 (#737)**
- **feat: implement ReadonlySessionChat and SlideOutPanel components (#739)**
- **test: unit tests for ReadonlySessionChat and SlideOutPanel (#741)**
- **feat: extract shared hooks, sub-components, constants from TaskView/TaskConversationRenderer (#740)**
- **feat: define TurnBlock types and implement useTurnBlocks hook (#742)**
- **test: add real-time delta tests for useTurnBlocks (#743)**
- **feat: implement TurnSummaryBlock component (#744)**
- **feat: implement RuntimeMessageRenderer component with unit tests (#745)**
- **test: unit tests for TurnSummaryBlock component (#746)**
- **feat: add client-side pagination to TaskView message list (#738)**
- **feat: implement TaskViewV2 component with turn-based conversation view (#747)**
- **feat: implement TaskViewToggle and integrate into Room.tsx (#748)**
- **test: E2E tests for TaskViewV2 toggle and structural presence**
