### PR TITLE
docs: plan for unifying agent communication and workflow graph model

### DIFF
--- a/docs/plans/unify-agent-communication-workflow-graph-model/00-overview.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/00-overview.md
@@ -43,7 +43,13 @@ Milestones 1 and 2 can proceed in parallel. Milestones 5 and 6 can also proceed 
 
 ## Total Estimated Task Count
 
-~24 tasks across 6 milestones.
+~23 tasks across 6 milestones (Task 1.3 collapsed into Task 1.1).
+
+## Important Context
+
+- **No backward compatibility required**: This feature is not yet in production. No migration paths or fallback strategies are needed for existing data.
+- **DB migrations must use the create-copy-drop-rename pattern** (NOT `ALTER TABLE RENAME COLUMN`) — consistent with all existing migrations in the project.
+- **Channel direction type values** are `'one-way' | 'bidirectional'` (NOT `'unidirectional'`) — see `packages/shared/src/types/space.ts`.
 
 ## Key Files (by area)
 

--- a/docs/plans/unify-agent-communication-workflow-graph-model/00-overview.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/00-overview.md
@@ -1,0 +1,78 @@
+# Unify Agent Communication & Workflow Graph Model
+
+## Goal
+
+Refactor the space workflow system to treat all agents -- including the Task Agent -- as equal first-class participants in a unified graph model. Remove special-cased messaging tools and terminology in favor of a consistent, intuitive model.
+
+## High-Level Approach
+
+The six changes are interdependent and will be delivered in a carefully sequenced order to minimize intermediate breakage:
+
+1. **Rename first** (`send_feedback` -> `send_message`, `step` -> `node`) -- pure mechanical renames that touch many files but have no behavioral change.
+2. **Unify messaging** -- remove `relay_message` and `request_peer_input`, give everyone `send_message` with channel topology enforcement. Task Agent becomes a regular channel participant.
+3. **Task Agent as visible node** -- render in the visual editor, auto-create channels on new node addition.
+4. **Per-slot agent overrides** -- extend `WorkflowNodeAgent` with `role`, `model`, `systemPrompt` fields; allow duplicate agents per node.
+5. **Channel direction visualization** -- render arrowheads on canvas edges for bidirectional vs unidirectional channels.
+
+## Milestones
+
+1. **Rename `send_feedback` to `send_message`** -- Rename the tool across schemas, handlers, tests, and system prompts. Pure rename, no behavioral change.
+2. **Rename `WorkflowStep` to `WorkflowNode`** -- Rename types, DB columns (via migration), repositories, runtime, UI components, export/import format, and all tests. Pure rename, no behavioral change.
+3. **Unified messaging model** -- Remove `relay_message` and `request_peer_input`. All agents (Task Agent + node agents) use `send_message` with uniform channel topology enforcement. Task Agent gets default channels to all nodes.
+4. **Task Agent as a first-class visible node** -- Render Task Agent as a pinned node in the visual editor. Auto-create default bidirectional channels between Task Agent and new nodes. Channels are removable by user.
+5. **Per-slot agent overrides in nodes** -- Allow adding the same agent multiple times to a node with per-slot `role`, `model`, and `systemPrompt` overrides. Update schema, runtime resolution, UI, and tests.
+6. **Channel direction visualization** -- Render bidirectional vs unidirectional channel direction as arrowheads on canvas edges. Update `EdgeRenderer.tsx` and `WorkflowCanvas.tsx`.
+
+## Cross-Milestone Dependencies
+
+- Milestone 2 (step->node rename) has no behavioral dependency on Milestone 1 but both are pure renames so they can run in parallel.
+- Milestone 3 (unified messaging) depends on Milestone 1 (the tool is already called `send_message`).
+- Milestone 4 (Task Agent visible node) depends on Milestone 2 (types are already `WorkflowNode`) and Milestone 3 (Task Agent uses same messaging).
+- Milestone 5 (per-slot overrides) depends on Milestone 2 (types are `WorkflowNodeAgent`).
+- Milestone 6 (direction visualization) depends on Milestone 4 (Task Agent channels rendered as edges).
+
+## Key Sequencing
+
+```
+M1 (rename send_feedback)  ---> M3 (unified messaging) ---> M4 (Task Agent visible node) ---> M6 (direction viz)
+M2 (rename step->node)     ---> M4 (Task Agent visible node)
+M2 (rename step->node)     ---> M5 (per-slot overrides)
+```
+
+Milestones 1 and 2 can proceed in parallel. Milestones 5 and 6 can also proceed in parallel after their respective dependencies.
+
+## Total Estimated Task Count
+
+~24 tasks across 6 milestones.
+
+## Key Files (by area)
+
+### Shared Types
+- `packages/shared/src/types/space.ts` -- `WorkflowStep`, `WorkflowStepAgent`, `WorkflowStepInput`, `ExportedWorkflowStep`, `WorkflowChannel`
+- `packages/shared/src/types/space-utils.ts` -- utility functions for step/agent resolution
+
+### Backend Tools & Runtime
+- `packages/daemon/src/lib/space/tools/step-agent-tools.ts` -- `send_feedback`, `request_peer_input` handlers
+- `packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts` -- Zod schemas
+- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` -- `relay_message` handler
+- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` -- Zod schemas
+- `packages/daemon/src/lib/space/runtime/channel-resolver.ts` -- channel topology validation
+- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` -- wires step agent tools
+- `packages/daemon/src/lib/space/agents/custom-agent.ts` -- agent initialization
+- `packages/daemon/src/lib/space/agents/task-agent.ts` -- Task Agent system prompt, step references
+
+### Backend Storage
+- `packages/daemon/src/storage/schema/migrations.ts` -- `space_workflow_steps` table, `start_step_id` column
+- `packages/daemon/src/storage/repositories/space-workflow-repository.ts` -- CRUD for steps
+
+### Frontend Components
+- `packages/web/src/components/space/visual-editor/` -- entire visual editor directory
+- `packages/web/src/components/space/WorkflowStepCard.tsx` -- step card component
+- `packages/web/src/components/space/WorkflowEditor.tsx` -- workflow editor
+- `packages/web/src/components/space/WorkflowRulesEditor.tsx` -- rules editor
+
+### Tests
+- `packages/daemon/tests/unit/space/` -- ~15 test files affected
+- `packages/web/src/components/space/__tests__/` -- step card, editor, rules tests
+- `packages/web/src/components/space/visual-editor/__tests__/` -- visual editor tests
+- `packages/e2e/tests/features/` -- 5 space-related e2e test files

--- a/docs/plans/unify-agent-communication-workflow-graph-model/01-rename-send-feedback-to-send-message.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/01-rename-send-feedback-to-send-message.md
@@ -1,0 +1,106 @@
+# Milestone 1: Rename `send_feedback` to `send_message`
+
+## Goal
+
+Rename the `send_feedback` tool to `send_message` across all schemas, handlers, tests, and system prompt text. This is a pure mechanical rename with no behavioral change -- the tool's semantics, validation, and routing logic remain identical.
+
+## Scope
+
+- Zod schema rename (`SendFeedbackSchema` -> `SendMessageSchema`, `SendFeedbackInput` -> `SendMessageInput`)
+- Handler function rename (`send_feedback` -> `send_message`)
+- MCP tool registration name change
+- All test files referencing `send_feedback`
+- System prompt text that mentions the tool name
+- Documentation references in code comments
+
+## Tasks
+
+### Task 1.1: Rename schema and types in step-agent-tool-schemas.ts
+
+**Description:** Rename `SendFeedbackSchema` to `SendMessageSchema` and `SendFeedbackInput` to `SendMessageInput` in the schema definition file. Update the aggregate export `STEP_AGENT_TOOL_SCHEMAS` to use `send_message` as the key. Update all JSDoc comments.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts`:
+   - Rename `SendFeedbackSchema` -> `SendMessageSchema`
+   - Rename `SendFeedbackInput` -> `SendMessageInput`
+   - Update `STEP_AGENT_TOOL_SCHEMAS` key from `send_feedback` to `send_message`
+   - Update all comments referencing `send_feedback` to `send_message`
+3. In `packages/daemon/src/lib/space/tools/step-agent-tools.ts`:
+   - Update imports: `SendFeedbackSchema` -> `SendMessageSchema`, `SendFeedbackInput` -> `SendMessageInput`
+   - Rename the handler function from `send_feedback` to `send_message`
+   - Update the MCP tool registration from `'send_feedback'` to `'send_message'`
+   - Update all comments and suggestion strings referencing `send_feedback`
+4. In `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
+   - Update any references to `send_feedback` in comments or code
+5. In `packages/daemon/src/lib/space/agents/custom-agent.ts`:
+   - Update any system prompt text or comments referencing `send_feedback`
+6. Search for any remaining references to `send_feedback` in `packages/daemon/src/` and update them.
+7. Run `bun run typecheck` to verify no type errors.
+8. Run `bun run lint` to verify no lint errors.
+9. Run affected tests: `cd packages/daemon && bun test tests/unit/space/step-agent-tools.test.ts tests/unit/space/task-agent-tool-schemas.test.ts`
+
+**Acceptance Criteria:**
+- Zero references to `send_feedback` remain in `packages/daemon/src/` (except historical docs/plans)
+- `bun run typecheck` passes
+- All existing step-agent-tools tests pass (they reference the new name)
+
+**Dependencies:** None
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 1.2: Update all daemon test files referencing send_feedback
+
+**Description:** Update all test files in `packages/daemon/tests/` that reference `send_feedback` to use `send_message`. This includes test descriptions, assertions, mock tool names, and inline comments.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Search for `send_feedback` across all files in `packages/daemon/tests/`.
+3. Update each occurrence:
+   - `packages/daemon/tests/unit/space/step-agent-tools.test.ts` -- tool handler name, test descriptions
+   - `packages/daemon/tests/unit/space/custom-agent.test.ts` -- any references
+   - `packages/daemon/tests/unit/space/cross-agent-messaging.test.ts` -- tool name references
+   - `packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts` -- tool name references
+4. Run all affected tests to verify they pass.
+5. Run `bun run typecheck` and `bun run lint`.
+
+**Acceptance Criteria:**
+- Zero references to `send_feedback` remain in `packages/daemon/tests/` (except historical docs)
+- All renamed tests pass
+- No regressions in other space tests
+
+**Dependencies:** Task 1.1
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 1.3: Update system prompt text and remaining references
+
+**Description:** Search the entire codebase for any remaining references to `send_feedback` (outside of `docs/plans/` historical plans) and update them. This includes system prompt strings, UI text, and any other files.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Search entire codebase for `send_feedback` excluding `docs/plans/`.
+3. Update any references found in:
+   - Task Agent system prompt text (`packages/daemon/src/lib/space/agents/task-agent.ts`)
+   - Any other system prompt or instruction text
+   - Shared type comments if any
+4. Run `bun run typecheck`, `bun run lint`, and full test suite for affected packages.
+
+**Acceptance Criteria:**
+- Zero references to `send_feedback` remain outside `docs/plans/`
+- All tests pass
+- System prompts use `send_message` terminology
+
+**Dependencies:** Task 1.1, Task 1.2
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/01-rename-send-feedback-to-send-message.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/01-rename-send-feedback-to-send-message.md
@@ -81,26 +81,6 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
 
-### Task 1.3: Update system prompt text and remaining references
+### ~~Task 1.3: Collapsed into Task 1.1~~
 
-**Description:** Search the entire codebase for any remaining references to `send_feedback` (outside of `docs/plans/` historical plans) and update them. This includes system prompt strings, UI text, and any other files.
-
-**Subtasks:**
-1. Run `bun install` at worktree root.
-2. Search entire codebase for `send_feedback` excluding `docs/plans/`.
-3. Update any references found in:
-   - Task Agent system prompt text (`packages/daemon/src/lib/space/agents/task-agent.ts`)
-   - Any other system prompt or instruction text
-   - Shared type comments if any
-4. Run `bun run typecheck`, `bun run lint`, and full test suite for affected packages.
-
-**Acceptance Criteria:**
-- Zero references to `send_feedback` remain outside `docs/plans/`
-- All tests pass
-- System prompts use `send_message` terminology
-
-**Dependencies:** Task 1.1, Task 1.2
-
-**Agent type:** coder
-
-Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+Task 1.3 (system prompt text updates) has been merged into Task 1.1 since it already covers `task-agent.ts` and the full codebase sweep for remaining references. Task 1.1 subtask 6 now serves as the catch-all for any remaining references outside `docs/plans/`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
@@ -13,10 +13,12 @@ This is the largest mechanical change in the project. Key renames:
 - `ExportedWorkflowStep` -> `ExportedWorkflowNode`
 - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
 - `startStepId` -> `startNodeId`
+- `currentStepId` -> `currentNodeId` in `SpaceWorkflowRun`, `CreateSpaceWorkflowRunParams`, `SpaceSessionGroup`
 - `workflow.steps` -> `workflow.nodes`
 - DB table `space_workflow_steps` -> `space_workflow_nodes` (via ALTER TABLE RENAME)
 - DB columns `from_step_id`/`to_step_id` -> `from_node_id`/`to_node_id` in transitions
 - DB column `start_step_id` -> `start_node_id` in `space_workflows`
+- DB column `current_step_id` -> `current_node_id` in `space_workflow_runs` and `space_session_groups`
 - DB column `workflow_step_id` -> `workflow_node_id` in related tables
 - Component file `WorkflowStepCard.tsx` -> `WorkflowNodeCard.tsx`
 - All variable names, function names, and comments using "step" in the workflow context
@@ -40,6 +42,7 @@ This is the largest mechanical change in the project. Key renames:
    - `startStepId` -> `startNodeId` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
    - `steps` -> `nodes` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
    - Rename `workflowStepId` -> `workflowNodeId` in `SpaceTask`, `CreateSpaceTaskParams`, `UpdateSpaceTaskParams`
+   - Rename `currentStepId` -> `currentNodeId` in `SpaceWorkflowRun` (line 305), `CreateSpaceWorkflowRunParams` (line 337), `SpaceSessionGroup` (line 390)
    - Update all JSDoc comments referencing "step" to "node"
 3. In `packages/shared/src/types/space-utils.ts`:
    - Update all references to the renamed types
@@ -53,6 +56,7 @@ This is the largest mechanical change in the project. Key renames:
 - `startStepId` -> `startNodeId` everywhere in shared types
 - `steps` -> `nodes` in workflow interfaces
 - `workflowStepId` -> `workflowNodeId` in `SpaceTask`, `CreateSpaceTaskParams`, `UpdateSpaceTaskParams`
+- `currentStepId` -> `currentNodeId` in `SpaceWorkflowRun`, `CreateSpaceWorkflowRunParams`, `SpaceSessionGroup`
 - Shared package tests pass
 
 **Dependencies:** None
@@ -74,6 +78,8 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Renames column `start_step_id` -> `start_node_id` in `space_workflows`
    - Renames columns `from_step_id` -> `from_node_id` and `to_step_id` -> `to_node_id` in `space_workflow_transitions`
    - Renames column `workflow_step_id` -> `workflow_node_id` in any tables that reference it (check `space_workflow_runs`, session groups, etc.)
+   - Renames column `current_step_id` -> `current_node_id` in `space_workflow_runs` (migrations.ts line 1637)
+   - Renames column `current_step_id` -> `current_node_id` in `space_session_groups` (migrations.ts line 1726)
    - Recreates affected indexes with new names
    - **IMPORTANT:** Follow the project's established create-copy-drop-rename migration pattern (see `migrations.ts` lines 381, 572, 737, 790 for examples). Do NOT use `ALTER TABLE RENAME COLUMN` — instead: create new table with new column names, copy data, drop old table, rename new table. This ensures compatibility across all SQLite versions bundled by Bun.
    - Renames column `workflow_step_id` -> `workflow_node_id` in `space_tasks` table (FK to `space_workflow_nodes`)
@@ -85,6 +91,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 - Migration runs cleanly on a fresh DB and on an existing DB with `space_workflow_steps` data
 - All renamed tables and columns are accessible with new names
 - `workflow_step_id` in `space_tasks` is renamed to `workflow_node_id`
+- `current_step_id` in `space_workflow_runs` and `space_session_groups` is renamed to `current_node_id`
 - Indexes are recreated
 
 **Dependencies:** None (can proceed in parallel with Task 2.1)
@@ -95,9 +102,9 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 ---
 
-### Task 2.3: Update space-workflow-repository.ts and space-agent-repository.ts
+### Task 2.3: Update all storage repositories
 
-**Description:** Update the storage repository layer to use the new table and column names. Update all SQL queries from `space_workflow_steps` to `space_workflow_nodes`, `start_step_id` to `start_node_id`, etc.
+**Description:** Update the storage repository layer to use the new table and column names. Update all SQL queries from `space_workflow_steps` to `space_workflow_nodes`, `start_step_id` to `start_node_id`, `current_step_id` to `current_node_id`, etc.
 
 **Subtasks:**
 1. Run `bun install` at worktree root.
@@ -107,18 +114,24 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Update `from_step_id` / `to_step_id` -> `from_node_id` / `to_node_id`
    - Update `workflow_step_id` -> `workflow_node_id`
    - Update TypeScript interfaces and method names that reference "step"
-3. In `packages/daemon/src/storage/repositories/space-agent-repository.ts`:
+3. In `packages/daemon/src/storage/repositories/space-workflow-run-repository.ts`:
+   - Update `current_step_id` -> `current_node_id` in all SQL queries
+   - Update `currentStepId` -> `currentNodeId` in TypeScript mappings (lines 16, 33, 44, 139-140, 172, 204)
+4. In `packages/daemon/src/storage/repositories/space-session-group-repository.ts`:
+   - Update `current_step_id` -> `current_node_id` in all SQL queries
+   - Update `currentStepId` -> `currentNodeId` in TypeScript mappings (lines 16, 26, 61, 70, 156-158, 396)
+5. In `packages/daemon/src/storage/repositories/space-agent-repository.ts`:
    - Update any references to step-related DB columns
-4. In `packages/daemon/src/storage/repositories/space-task-repository.ts`:
+6. In `packages/daemon/src/storage/repositories/space-task-repository.ts`:
    - Update `workflow_step_id` -> `workflow_node_id` in all SQL queries
    - Update `workflowStepId` -> `workflowNodeId` in TypeScript mappings (e.g., line 357)
-5. Check other repositories in `packages/daemon/src/storage/repositories/` for step references.
-6. Run `bun run typecheck`.
-7. Run repository tests: `cd packages/daemon && bun test tests/unit/storage/space-agent-repository.test.ts tests/unit/storage/space-task-repository.test.ts`
+7. Check other repositories in `packages/daemon/src/storage/repositories/` for any remaining step references.
+8. Run `bun run typecheck`.
+9. Run repository tests: `cd packages/daemon && bun test tests/unit/storage/`
 
 **Acceptance Criteria:**
-- All SQL queries use new table/column names
-- Repository TypeScript interfaces use `node` terminology
+- All SQL queries use new table/column names (`space_workflow_nodes`, `current_node_id`, `workflow_node_id`, etc.)
+- All repository TypeScript interfaces use `node` terminology (`currentNodeId`, `workflowNodeId`)
 - Repository tests pass
 
 **Dependencies:** Task 2.1 (shared types), Task 2.2 (DB migration)
@@ -139,25 +152,34 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Replace all `WorkflowStep` -> `WorkflowNode` type references
    - Rename variables and function parameters from `step` to `node`
    - Update `startStepId` -> `startNodeId`
+   - Update `currentStepId` -> `currentNodeId` (lines 198, 206, 298, 406, 440)
    - Update `workflowStepId` -> `workflowNodeId` references (e.g., line 464)
 3. Update `packages/daemon/src/lib/space/runtime/space-runtime.ts`:
    - Same renames
+   - Update `currentStepId` -> `currentNodeId` (e.g., line 307: `currentStepId: workflow.startStepId`, lines 599-606)
    - Update all `workflowStepId` -> `workflowNodeId` references
 4. Update `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
    - Rename step -> node in types, method parameters, internal variables (e.g., line 898 `workflowStepId` -> `workflowNodeId`)
-5. Search for any manager file under `packages/daemon/src/lib/space/managers/` that references workflow steps and update it.
-6. Update `packages/daemon/src/lib/space/agents/task-agent.ts`:
+5. Update `packages/daemon/src/lib/space/tools/task-agent-tools.ts`:
+   - Update `currentStepId` -> `currentNodeId` (lines 464, 470, 619)
+   - Update any `stepId` references
+6. Update `packages/daemon/src/lib/space/tools/space-agent-tools.ts`:
+   - Update `run.currentStepId` -> `run.currentNodeId` and `workflow.steps.find(...)` -> `workflow.nodes.find(...)`
+7. Update `packages/daemon/src/lib/space/tools/global-spaces-tools.ts`:
+   - Update `currentStepId` and `workflow.steps` references
+8. Search for any manager file under `packages/daemon/src/lib/space/managers/` that references workflow steps and update it.
+9. Update `packages/daemon/src/lib/space/agents/task-agent.ts`:
    - System prompt text: "step" -> "node"
    - Type references
-6. Update `packages/daemon/src/lib/space/export-format.ts`:
-   - `ExportedWorkflowStep` -> `ExportedWorkflowNode`
-   - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
-7. Update `packages/daemon/src/lib/space/index.ts` re-exports.
-8. Update `packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts`.
-9. Run `bun run typecheck` and `bun run lint`.
+10. Update `packages/daemon/src/lib/space/export-format.ts`:
+    - `ExportedWorkflowStep` -> `ExportedWorkflowNode`
+    - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
+11. Update `packages/daemon/src/lib/space/index.ts` re-exports.
+12. Update `packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts`.
+13. Run `bun run typecheck` and `bun run lint`.
 
 **Acceptance Criteria:**
-- Zero references to `WorkflowStep` in `packages/daemon/src/` (outside historical docs)
+- Zero references to `WorkflowStep`, `currentStepId`, `workflowStepId`, or `startStepId` in `packages/daemon/src/` (outside historical docs)
 - `bun run typecheck` passes
 - `bun run lint` passes
 
@@ -225,7 +247,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - `rpc-handlers/space-agent-handlers.test.ts`
    - `lib/space-agent-manager.test.ts`
    - `helpers/space-agent-schema.ts`
-   - Any other test files referencing `WorkflowStep` or `startStepId`
+   - Any other test files referencing `WorkflowStep`, `startStepId`, `currentStepId`, or `workflowStepId`
 4. Update web component tests:
    - Rename `packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx` to `WorkflowNodeCard.test.tsx`
    - Update `WorkflowEditor.test.tsx`, `WorkflowRulesEditor.test.tsx`

--- a/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
@@ -39,6 +39,7 @@ This is the largest mechanical change in the project. Key renames:
    - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
    - `startStepId` -> `startNodeId` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
    - `steps` -> `nodes` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
+   - Rename `workflowStepId` -> `workflowNodeId` in `SpaceTask`, `CreateSpaceTaskParams`, `UpdateSpaceTaskParams`
    - Update all JSDoc comments referencing "step" to "node"
 3. In `packages/shared/src/types/space-utils.ts`:
    - Update all references to the renamed types
@@ -51,6 +52,7 @@ This is the largest mechanical change in the project. Key renames:
 - All `WorkflowStep*` types renamed to `WorkflowNode*` in shared package
 - `startStepId` -> `startNodeId` everywhere in shared types
 - `steps` -> `nodes` in workflow interfaces
+- `workflowStepId` -> `workflowNodeId` in `SpaceTask`, `CreateSpaceTaskParams`, `UpdateSpaceTaskParams`
 - Shared package tests pass
 
 **Dependencies:** None
@@ -73,13 +75,16 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Renames columns `from_step_id` -> `from_node_id` and `to_step_id` -> `to_node_id` in `space_workflow_transitions`
    - Renames column `workflow_step_id` -> `workflow_node_id` in any tables that reference it (check `space_workflow_runs`, session groups, etc.)
    - Recreates affected indexes with new names
-   - Uses SQLite's `ALTER TABLE RENAME` where supported; for column renames (SQLite 3.25+), use `ALTER TABLE RENAME COLUMN`
+   - **IMPORTANT:** Follow the project's established create-copy-drop-rename migration pattern (see `migrations.ts` lines 381, 572, 737, 790 for examples). Do NOT use `ALTER TABLE RENAME COLUMN` — instead: create new table with new column names, copy data, drop old table, rename new table. This ensures compatibility across all SQLite versions bundled by Bun.
+   - Renames column `workflow_step_id` -> `workflow_node_id` in `space_tasks` table (FK to `space_workflow_nodes`)
 3. Update the migration registration/version number.
 4. Run `bun run typecheck`.
 
 **Acceptance Criteria:**
+- Migration uses the create-copy-drop-rename pattern (NOT `ALTER TABLE RENAME COLUMN`)
 - Migration runs cleanly on a fresh DB and on an existing DB with `space_workflow_steps` data
 - All renamed tables and columns are accessible with new names
+- `workflow_step_id` in `space_tasks` is renamed to `workflow_node_id`
 - Indexes are recreated
 
 **Dependencies:** None (can proceed in parallel with Task 2.1)
@@ -104,9 +109,12 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Update TypeScript interfaces and method names that reference "step"
 3. In `packages/daemon/src/storage/repositories/space-agent-repository.ts`:
    - Update any references to step-related DB columns
-4. Check other repositories in `packages/daemon/src/storage/repositories/` for step references.
-5. Run `bun run typecheck`.
-6. Run repository tests: `cd packages/daemon && bun test tests/unit/storage/space-agent-repository.test.ts`
+4. In `packages/daemon/src/storage/repositories/space-task-repository.ts`:
+   - Update `workflow_step_id` -> `workflow_node_id` in all SQL queries
+   - Update `workflowStepId` -> `workflowNodeId` in TypeScript mappings (e.g., line 357)
+5. Check other repositories in `packages/daemon/src/storage/repositories/` for step references.
+6. Run `bun run typecheck`.
+7. Run repository tests: `cd packages/daemon && bun test tests/unit/storage/space-agent-repository.test.ts tests/unit/storage/space-task-repository.test.ts`
 
 **Acceptance Criteria:**
 - All SQL queries use new table/column names
@@ -131,11 +139,14 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Replace all `WorkflowStep` -> `WorkflowNode` type references
    - Rename variables and function parameters from `step` to `node`
    - Update `startStepId` -> `startNodeId`
+   - Update `workflowStepId` -> `workflowNodeId` references (e.g., line 464)
 3. Update `packages/daemon/src/lib/space/runtime/space-runtime.ts`:
    - Same renames
-4. Update `packages/daemon/src/lib/space/managers/space-workflow-manager.ts`:
-   - Same renames for types, method parameters, and internal variables
-5. Update `packages/daemon/src/lib/space/agents/task-agent.ts`:
+   - Update all `workflowStepId` -> `workflowNodeId` references
+4. Update `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
+   - Rename step -> node in types, method parameters, internal variables (e.g., line 898 `workflowStepId` -> `workflowNodeId`)
+5. Search for any manager file under `packages/daemon/src/lib/space/managers/` that references workflow steps and update it.
+6. Update `packages/daemon/src/lib/space/agents/task-agent.ts`:
    - System prompt text: "step" -> "node"
    - Type references
 6. Update `packages/daemon/src/lib/space/export-format.ts`:
@@ -171,7 +182,9 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Variable names from `step` to `node`
 5. Update `packages/web/src/components/space/WorkflowRulesEditor.tsx`:
    - Step references in `appliesTo` UI
-6. Update `packages/web/src/components/space/visual-editor/` files:
+6. Update `packages/web/src/components/space/SpaceTaskPane.tsx`:
+   - Rename `task.workflowStepId` -> `task.workflowNodeId` (e.g., line 341)
+7. Update `packages/web/src/components/space/visual-editor/` files:
    - `serialization.ts` -- step -> node in serialization/deserialization
    - `layout.ts` -- step -> node
    - `NodeConfigPanel.tsx` -- `WorkflowStepAgent` -> `WorkflowNodeAgent`
@@ -208,6 +221,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - `space/workflow-executor.test.ts`
    - `space/export-format.test.ts`
    - `storage/space-agent-repository.test.ts`
+   - `storage/space-task-repository.test.ts`
    - `rpc-handlers/space-agent-handlers.test.ts`
    - `lib/space-agent-manager.test.ts`
    - `helpers/space-agent-schema.ts`

--- a/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
@@ -1,0 +1,237 @@
+# Milestone 2: Rename `WorkflowStep` to `WorkflowNode`
+
+## Goal
+
+Rename all `step`-related terminology to `node` across the entire codebase: shared types, backend runtime, storage layer (including DB migration), frontend components, export/import format, and all tests. The visual editor frontend already uses a component called `WorkflowNode` -- align the backend and shared types to match.
+
+## Scope
+
+This is the largest mechanical change in the project. Key renames:
+- `WorkflowStep` -> `WorkflowNode` (the type)
+- `WorkflowStepAgent` -> `WorkflowNodeAgent`
+- `WorkflowStepInput` -> `WorkflowNodeInput`
+- `ExportedWorkflowStep` -> `ExportedWorkflowNode`
+- `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
+- `startStepId` -> `startNodeId`
+- `workflow.steps` -> `workflow.nodes`
+- DB table `space_workflow_steps` -> `space_workflow_nodes` (via ALTER TABLE RENAME)
+- DB columns `from_step_id`/`to_step_id` -> `from_node_id`/`to_node_id` in transitions
+- DB column `start_step_id` -> `start_node_id` in `space_workflows`
+- DB column `workflow_step_id` -> `workflow_node_id` in related tables
+- Component file `WorkflowStepCard.tsx` -> `WorkflowNodeCard.tsx`
+- All variable names, function names, and comments using "step" in the workflow context
+
+**Note:** The visual editor already has a file `WorkflowNode.tsx` which is the canvas node renderer. The `WorkflowStepCard.tsx` component is a separate list-view card. When renaming, `WorkflowStepCard.tsx` becomes `WorkflowNodeCard.tsx` (distinct from the visual editor's `WorkflowNode.tsx`).
+
+## Tasks
+
+### Task 2.1: Rename shared types in space.ts and space-utils.ts
+
+**Description:** Rename all `WorkflowStep*` types to `WorkflowNode*` in the shared package. Update `startStepId` to `startNodeId` and `steps` to `nodes` in workflow interfaces.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/shared/src/types/space.ts`:
+   - `WorkflowStepAgent` -> `WorkflowNodeAgent`
+   - `WorkflowStep` -> `WorkflowNode` (the interface -- note: careful not to clash with the visual editor component name, which is in a different package)
+   - `WorkflowStepInput` -> `WorkflowNodeInput`
+   - `ExportedWorkflowStep` -> `ExportedWorkflowNode`
+   - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
+   - `startStepId` -> `startNodeId` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
+   - `steps` -> `nodes` in `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`
+   - Update all JSDoc comments referencing "step" to "node"
+3. In `packages/shared/src/types/space-utils.ts`:
+   - Update all references to the renamed types
+   - Rename any `step`-related function names or parameters
+4. Update exports in `packages/shared/src/types/` index file if one exists.
+5. Run `bun run typecheck` -- expect many errors from downstream consumers (this is expected, they get fixed in subsequent tasks).
+6. Run `cd packages/shared && bun test` to verify shared package tests pass.
+
+**Acceptance Criteria:**
+- All `WorkflowStep*` types renamed to `WorkflowNode*` in shared package
+- `startStepId` -> `startNodeId` everywhere in shared types
+- `steps` -> `nodes` in workflow interfaces
+- Shared package tests pass
+
+**Dependencies:** None
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.2: Add DB migration for table and column renames
+
+**Description:** Add a new migration in `packages/daemon/src/storage/schema/migrations.ts` that renames the `space_workflow_steps` table to `space_workflow_nodes` and renames all `step`-related columns.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/storage/schema/migrations.ts`, add a new migration that:
+   - Renames table `space_workflow_steps` -> `space_workflow_nodes`
+   - Renames column `start_step_id` -> `start_node_id` in `space_workflows`
+   - Renames columns `from_step_id` -> `from_node_id` and `to_step_id` -> `to_node_id` in `space_workflow_transitions`
+   - Renames column `workflow_step_id` -> `workflow_node_id` in any tables that reference it (check `space_workflow_runs`, session groups, etc.)
+   - Recreates affected indexes with new names
+   - Uses SQLite's `ALTER TABLE RENAME` where supported; for column renames (SQLite 3.25+), use `ALTER TABLE RENAME COLUMN`
+3. Update the migration registration/version number.
+4. Run `bun run typecheck`.
+
+**Acceptance Criteria:**
+- Migration runs cleanly on a fresh DB and on an existing DB with `space_workflow_steps` data
+- All renamed tables and columns are accessible with new names
+- Indexes are recreated
+
+**Dependencies:** None (can proceed in parallel with Task 2.1)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.3: Update space-workflow-repository.ts and space-agent-repository.ts
+
+**Description:** Update the storage repository layer to use the new table and column names. Update all SQL queries from `space_workflow_steps` to `space_workflow_nodes`, `start_step_id` to `start_node_id`, etc.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/storage/repositories/space-workflow-repository.ts`:
+   - Update all SQL queries to reference `space_workflow_nodes` instead of `space_workflow_steps`
+   - Update `start_step_id` -> `start_node_id`
+   - Update `from_step_id` / `to_step_id` -> `from_node_id` / `to_node_id`
+   - Update `workflow_step_id` -> `workflow_node_id`
+   - Update TypeScript interfaces and method names that reference "step"
+3. In `packages/daemon/src/storage/repositories/space-agent-repository.ts`:
+   - Update any references to step-related DB columns
+4. Check other repositories in `packages/daemon/src/storage/repositories/` for step references.
+5. Run `bun run typecheck`.
+6. Run repository tests: `cd packages/daemon && bun test tests/unit/storage/space-agent-repository.test.ts`
+
+**Acceptance Criteria:**
+- All SQL queries use new table/column names
+- Repository TypeScript interfaces use `node` terminology
+- Repository tests pass
+
+**Dependencies:** Task 2.1 (shared types), Task 2.2 (DB migration)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.4: Update backend runtime and managers
+
+**Description:** Update the backend runtime layer (`workflow-executor.ts`, `space-runtime.ts`, `space-workflow-manager.ts`, `task-agent.ts`, `export-format.ts`) to use `WorkflowNode` types and `node` terminology.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Update `packages/daemon/src/lib/space/runtime/workflow-executor.ts`:
+   - Replace all `WorkflowStep` -> `WorkflowNode` type references
+   - Rename variables and function parameters from `step` to `node`
+   - Update `startStepId` -> `startNodeId`
+3. Update `packages/daemon/src/lib/space/runtime/space-runtime.ts`:
+   - Same renames
+4. Update `packages/daemon/src/lib/space/managers/space-workflow-manager.ts`:
+   - Same renames for types, method parameters, and internal variables
+5. Update `packages/daemon/src/lib/space/agents/task-agent.ts`:
+   - System prompt text: "step" -> "node"
+   - Type references
+6. Update `packages/daemon/src/lib/space/export-format.ts`:
+   - `ExportedWorkflowStep` -> `ExportedWorkflowNode`
+   - `ExportedWorkflowStepAgent` -> `ExportedWorkflowNodeAgent`
+7. Update `packages/daemon/src/lib/space/index.ts` re-exports.
+8. Update `packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts`.
+9. Run `bun run typecheck` and `bun run lint`.
+
+**Acceptance Criteria:**
+- Zero references to `WorkflowStep` in `packages/daemon/src/` (outside historical docs)
+- `bun run typecheck` passes
+- `bun run lint` passes
+
+**Dependencies:** Task 2.1, Task 2.3
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.5: Update frontend components
+
+**Description:** Rename `WorkflowStepCard.tsx` to `WorkflowNodeCard.tsx` and update all frontend components, imports, and references from step to node terminology.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Rename `packages/web/src/components/space/WorkflowStepCard.tsx` to `WorkflowNodeCard.tsx`.
+3. Update all internal references in the renamed file (type `StepDraft` -> `NodeDraft`, function `isMultiAgentStep` -> `isMultiAgentNode`, etc.).
+4. Update `packages/web/src/components/space/WorkflowEditor.tsx`:
+   - Import paths and type references
+   - Variable names from `step` to `node`
+5. Update `packages/web/src/components/space/WorkflowRulesEditor.tsx`:
+   - Step references in `appliesTo` UI
+6. Update `packages/web/src/components/space/visual-editor/` files:
+   - `serialization.ts` -- step -> node in serialization/deserialization
+   - `layout.ts` -- step -> node
+   - `NodeConfigPanel.tsx` -- `WorkflowStepAgent` -> `WorkflowNodeAgent`
+   - `WorkflowNode.tsx` (visual editor canvas node) -- update imports from renamed `WorkflowNodeCard` types
+   - `WorkflowCanvas.tsx` -- update step references
+   - `VisualWorkflowEditor.tsx` -- update step references
+   - `GateConfig.tsx` -- step references
+7. Update `packages/web/src/components/space/index.ts` re-exports.
+8. Run `bun run typecheck` and `bun run lint`.
+
+**Acceptance Criteria:**
+- `WorkflowStepCard.tsx` renamed to `WorkflowNodeCard.tsx`
+- Zero references to `WorkflowStep` type in `packages/web/src/` (the visual editor `WorkflowNode.tsx` component name stays as-is)
+- `bun run typecheck` passes
+
+**Dependencies:** Task 2.1 (shared types)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2.6: Update all tests for step->node rename
+
+**Description:** Update all daemon unit tests, shared tests, web tests, and e2e tests that reference step terminology.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Update `packages/shared/tests/space-utils.test.ts`.
+3. Update daemon unit tests in `packages/daemon/tests/unit/`:
+   - `space/space-workflow.test.ts`
+   - `space/workflow-executor-multi-agent.test.ts`
+   - `space/workflow-executor.test.ts`
+   - `space/export-format.test.ts`
+   - `storage/space-agent-repository.test.ts`
+   - `rpc-handlers/space-agent-handlers.test.ts`
+   - `lib/space-agent-manager.test.ts`
+   - `helpers/space-agent-schema.ts`
+   - Any other test files referencing `WorkflowStep` or `startStepId`
+4. Update web component tests:
+   - Rename `packages/web/src/components/space/__tests__/WorkflowStepCard.test.tsx` to `WorkflowNodeCard.test.tsx`
+   - Update `WorkflowEditor.test.tsx`, `WorkflowRulesEditor.test.tsx`
+   - Update visual editor tests in `packages/web/src/components/space/visual-editor/__tests__/`
+5. Update e2e tests:
+   - `packages/e2e/tests/features/visual-workflow-editor.e2e.ts`
+   - `packages/e2e/tests/features/space-multi-agent-editor.e2e.ts`
+   - `packages/e2e/tests/features/space-export-import.e2e.ts`
+   - `packages/e2e/tests/features/space-workflow-rules.e2e.ts`
+   - Any other e2e tests referencing step terminology
+6. Run all tests: `make test-daemon`, `make test-web`, and spot-check key e2e tests.
+
+**Acceptance Criteria:**
+- All tests updated to use `node` terminology
+- `make test-daemon` passes
+- `make test-web` passes
+- No regressions
+
+**Dependencies:** Task 2.3, Task 2.4, Task 2.5
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/02-rename-step-to-node.md
@@ -15,7 +15,7 @@ This is the largest mechanical change in the project. Key renames:
 - `startStepId` -> `startNodeId`
 - `currentStepId` -> `currentNodeId` in `SpaceWorkflowRun`, `CreateSpaceWorkflowRunParams`, `SpaceSessionGroup`
 - `workflow.steps` -> `workflow.nodes`
-- DB table `space_workflow_steps` -> `space_workflow_nodes` (via ALTER TABLE RENAME)
+- DB table `space_workflow_steps` -> `space_workflow_nodes` (via create-copy-drop-rename migration pattern)
 - DB columns `from_step_id`/`to_step_id` -> `from_node_id`/`to_node_id` in transitions
 - DB column `start_step_id` -> `start_node_id` in `space_workflows`
 - DB column `current_step_id` -> `current_node_id` in `space_workflow_runs` and `space_session_groups`

--- a/docs/plans/unify-agent-communication-workflow-graph-model/03-unified-messaging-model.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/03-unified-messaging-model.md
@@ -71,7 +71,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Remove the `injectToTaskAgent` wiring from the config passed to `createStepAgentToolHandlers`
 5. Update `packages/daemon/src/lib/space/agents/custom-agent.ts`:
    - Remove any references to `request_peer_input` in system prompt text or comments
-6. In `send_message` handler: remove all suggestions to use `request_peer_input` as fallback (when no channel topology is declared, return error without suggesting fallback tool)
+6. In `send_message` handler: remove all suggestions to use `request_peer_input` as fallback. When no channel topology is declared, return a clear error message (no fallback tool suggestion). **Note:** Backward compatibility for existing topology-less workflows is not required — this feature is not yet in production.
 7. Run `bun run typecheck`.
 8. Update tests:
    - `packages/daemon/tests/unit/space/step-agent-tools.test.ts` -- remove `request_peer_input` tests

--- a/docs/plans/unify-agent-communication-workflow-graph-model/03-unified-messaging-model.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/03-unified-messaging-model.md
@@ -1,0 +1,170 @@
+# Milestone 3: Unified Messaging Model
+
+## Goal
+
+Remove the two special-purpose messaging tools (`relay_message` for Task Agent and `request_peer_input` for node agents) and replace them with a single `send_message` tool used by all agents. Channel topology enforcement applies uniformly to everyone -- the Task Agent has channels to all nodes by default, so it can reach everyone, but via the same mechanism.
+
+## Scope
+
+- Remove `relay_message` tool from task-agent-tools and task-agent-tool-schemas
+- Remove `request_peer_input` tool from step-agent-tools (now node-agent-tools after M2) and schemas
+- Give the Task Agent the `send_message` tool (same tool that node agents use)
+- Update `ChannelResolver` so that the Task Agent is resolved via channel topology like everyone else (no bypass logic)
+- Auto-include Task Agent <-> all node agents as default channels in the channel topology when starting a workflow run
+- Update all system prompts to reflect the unified model
+- Remove `injectToTaskAgent` callback from node agent tool config (no longer needed)
+
+## Tasks
+
+### Task 3.1: Remove `relay_message` from Task Agent tools
+
+**Description:** Remove the `relay_message` tool handler and schema from the Task Agent tool set. The Task Agent will use `send_message` instead (added in Task 3.3).
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts`:
+   - Remove `RelayMessageSchema` and `RelayMessageInput` type
+   - Remove from aggregate export
+3. In `packages/daemon/src/lib/space/tools/task-agent-tools.ts`:
+   - Remove the `relay_message` handler function
+   - Remove the `relay_message` MCP tool registration
+   - Remove imports of `RelayMessageSchema` and `RelayMessageInput`
+   - Update comments referencing `relay_message`
+4. Update `packages/daemon/src/lib/space/runtime/channel-resolver.ts`:
+   - Remove comments about "Task Agent override" and `relay_message` bypass
+5. Run `bun run typecheck`.
+6. Update tests in `packages/daemon/tests/unit/space/task-agent-tools.test.ts`:
+   - Remove `relay_message` test cases
+7. Update `packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts`:
+   - Remove `relay_message` schema tests
+8. Update cross-agent messaging tests that reference `relay_message`.
+9. Run all affected tests.
+
+**Acceptance Criteria:**
+- Zero references to `relay_message` in source code (outside historical docs)
+- Task Agent tool set no longer includes `relay_message`
+- All tests pass
+
+**Dependencies:** Milestone 1 (send_feedback already renamed to send_message)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 3.2: Remove `request_peer_input` from node agent tools
+
+**Description:** Remove the `request_peer_input` tool handler and schema from the node agent (formerly step agent) tool set. Node agents will use only `send_message` for all communication.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts` (or renamed file after M2):
+   - Remove `RequestPeerInputSchema` and `RequestPeerInputInput` type
+   - Remove from aggregate export
+3. In `packages/daemon/src/lib/space/tools/step-agent-tools.ts` (or renamed):
+   - Remove the `request_peer_input` handler function
+   - Remove the `request_peer_input` MCP tool registration
+   - Remove `injectToTaskAgent` from `StepAgentToolsConfig` (no longer needed)
+   - Remove imports of `RequestPeerInputSchema` and `RequestPeerInputInput`
+4. Update `packages/daemon/src/lib/space/runtime/task-agent-manager.ts`:
+   - Remove the `injectToTaskAgent` wiring from the config passed to `createStepAgentToolHandlers`
+5. Update `packages/daemon/src/lib/space/agents/custom-agent.ts`:
+   - Remove any references to `request_peer_input` in system prompt text or comments
+6. In `send_message` handler: remove all suggestions to use `request_peer_input` as fallback (when no channel topology is declared, return error without suggesting fallback tool)
+7. Run `bun run typecheck`.
+8. Update tests:
+   - `packages/daemon/tests/unit/space/step-agent-tools.test.ts` -- remove `request_peer_input` tests
+   - `packages/daemon/tests/unit/space/custom-agent.test.ts` -- update references
+   - `packages/daemon/tests/unit/space/cross-agent-messaging.test.ts` -- update references
+9. Run all affected tests.
+
+**Acceptance Criteria:**
+- Zero references to `request_peer_input` in source code (outside historical docs)
+- Node agent tool set is: `list_peers` + `send_message` only
+- `injectToTaskAgent` removed from tool config
+- All tests pass
+
+**Dependencies:** Milestone 1 (send_feedback renamed), Task 3.1
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 3.3: Give Task Agent the `send_message` tool via channel topology
+
+**Description:** Add the `send_message` tool to the Task Agent's MCP server. The Task Agent uses the same tool and the same channel topology enforcement as node agents. Auto-generate default bidirectional channels between the Task Agent and all node agents when starting a workflow run.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Update `packages/daemon/src/lib/space/runtime/space-runtime.ts` (or equivalent):
+   - When resolving channels at step-start (`storeResolvedChannels`), auto-add bidirectional channels between `task-agent` role and every node agent role in the step
+   - These default channels are added in addition to user-declared channels
+   - Only add if not already declared by the user (avoid duplicates)
+3. Update `packages/daemon/src/lib/space/tools/task-agent-tools.ts`:
+   - Add `send_message` to the Task Agent MCP server using the same `SendMessageSchema`
+   - The Task Agent's `send_message` handler follows the same pattern as the node agent one: validates against channel topology, resolves targets by role, injects message
+   - The Task Agent's role is `'task-agent'` -- used for channel resolution
+   - Reuse or share the message injection logic
+4. Update `list_group_members` in task-agent-tools:
+   - Remove the note about Task Agent having "unrestricted relay access"
+   - Update to show `permittedTargets` based on channel topology (same as node agents' `list_peers`)
+5. Update the Task Agent system prompt in `packages/daemon/src/lib/space/agents/task-agent.ts`:
+   - Remove references to `relay_message`
+   - Document that `send_message` is used for all inter-agent communication
+   - Document that the Task Agent has default channels to all node agents
+6. Run `bun run typecheck` and `bun run lint`.
+7. Write new tests:
+   - Test that Task Agent's `send_message` validates against channel topology
+   - Test that default Task Agent <-> node agent channels are auto-generated
+   - Test that removing a Task Agent channel prevents messaging (no bypass)
+8. Update existing cross-agent messaging tests.
+9. Run all affected tests.
+
+**Acceptance Criteria:**
+- Task Agent uses `send_message` for all communication with node agents
+- Channel topology enforcement is uniform -- Task Agent has no bypass/override
+- Default bidirectional channels are auto-created between Task Agent and all node agent roles
+- If a user removes a Task Agent channel, the Task Agent can no longer message that node
+- All tests pass, new tests cover the unified model
+
+**Dependencies:** Task 3.1, Task 3.2
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 3.4: Update cross-agent messaging tests and e2e
+
+**Description:** Comprehensive test update for the unified messaging model. Ensure all cross-agent messaging scenarios work with the single `send_message` tool.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Rewrite `packages/daemon/tests/unit/space/cross-agent-messaging.test.ts`:
+   - All scenarios use `send_message` only
+   - Test Task Agent -> node agent messaging via channel topology
+   - Test node agent -> Task Agent messaging via channel topology
+   - Test node agent -> node agent messaging via channel topology
+   - Test rejection when channel not declared (no fallback tool)
+3. Rewrite `packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts`:
+   - Full integration flow using unified `send_message`
+4. Add test: Task Agent channel removal prevents messaging
+5. Add test: custom channel topology with Task Agent as a regular participant
+6. Run all space tests: `cd packages/daemon && bun test tests/unit/space/`
+7. Update e2e test `packages/e2e/tests/features/space-session-groups.e2e.ts` if it references old tool names.
+
+**Acceptance Criteria:**
+- Comprehensive test coverage for unified messaging model
+- No references to `relay_message` or `request_peer_input` in tests
+- All tests pass
+- E2E tests updated if applicable
+
+**Dependencies:** Task 3.3
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
@@ -22,8 +22,9 @@ Make the Task Agent a visible, configurable participant in the visual workflow e
 **Subtasks:**
 1. Run `bun install` at worktree root.
 2. In `packages/shared/src/types/space.ts`:
-   - Add an optional `taskAgentNode` field to `SpaceWorkflow` (or handle it as a virtual/computed node in the frontend)
-   - Alternatively, define a constant ID for the Task Agent node (e.g., `TASK_AGENT_NODE_ID = '__task_agent__'`) that is always present
+   - Define a constant `TASK_AGENT_NODE_ID = '__task_agent__'` — the Task Agent is a **virtual node** that is never persisted in the DB's `space_workflow_nodes` table
+   - The Task Agent node is injected at runtime by the frontend (serialization) and by the backend (channel resolution at workflow run start)
+   - Task Agent channels ARE persisted as regular `WorkflowChannel` entries (with `from: 'task-agent'` or `to: 'task-agent'` roles) — these are the same channels auto-generated in Milestone 3's Task 3.3; M4 makes them user-visible and editable in the frontend, replacing the backend-only auto-generation with persisted, user-manageable channel entries
 3. In `packages/web/src/components/space/visual-editor/types.ts`:
    - Add any types needed for the Task Agent node representation
 4. In `packages/web/src/components/space/visual-editor/serialization.ts`:

--- a/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
@@ -100,17 +100,20 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 4. In the edge rendering:
    - Render edges between the Task Agent node and other nodes for each declared channel
    - These are distinct from workflow transition edges (different visual style -- dashed line or different color for communication channels vs execution flow)
-5. Run `bun run typecheck` and `bun run lint`.
-6. Write tests:
+5. **Remove M3 runtime auto-generation of Task Agent channels:** In `packages/daemon/src/lib/space/runtime/space-runtime.ts` (or equivalent), remove the logic added in Task 3.3 that auto-generates default bidirectional channels between the Task Agent and all node agents at workflow run start. Task Agent channels are now persisted as user-configurable `WorkflowChannel` entries created by the frontend (this task). The backend should read persisted channels only — no more runtime auto-generation. This prevents duplicate channels when both M3 and M4 are active.
+6. Run `bun run typecheck` and `bun run lint`.
+7. Write tests:
    - Test that adding a node auto-creates Task Agent channels
    - Test that removing a Task Agent channel works
    - Test that channel edges are rendered on the canvas
+   - Test that no duplicate Task Agent channels are created at runtime (runtime auto-generation removed)
 
 **Acceptance Criteria:**
 - Adding a new node automatically creates bidirectional Task Agent <-> node channels
 - Channels are visible in the channel config panel
 - Users can remove Task Agent channels
 - Channel edges are rendered on the canvas
+- M3 runtime auto-generation logic is removed — Task Agent channels are sourced exclusively from persisted workflow data
 
 **Dependencies:** Task 4.2
 

--- a/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/04-task-agent-visible-node.md
@@ -1,0 +1,144 @@
+# Milestone 4: Task Agent as a First-Class Visible Node
+
+## Goal
+
+Make the Task Agent a visible, configurable participant in the visual workflow editor. Render it as a pinned node with a distinct style. Auto-create default bidirectional channels between the Task Agent node and newly added workflow nodes. Users can remove Task Agent channels if desired.
+
+## Scope
+
+- Add a Task Agent node representation in the visual editor canvas
+- Distinct visual style (different color/shape, non-deletable, always present at top of canvas)
+- Auto-create bidirectional channel entries when new nodes are added to the workflow
+- Allow users to remove Task Agent channels (no forced connections)
+- Task Agent node participates in the same layout algorithm
+- Channel edges to/from Task Agent are rendered on the canvas like any other channel
+
+## Tasks
+
+### Task 4.1: Add Task Agent node to visual editor data model
+
+**Description:** Extend the visual editor's data model to include a Task Agent node. This node is always present in the workflow, pinned to the top of the canvas, and non-deletable.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/shared/src/types/space.ts`:
+   - Add an optional `taskAgentNode` field to `SpaceWorkflow` (or handle it as a virtual/computed node in the frontend)
+   - Alternatively, define a constant ID for the Task Agent node (e.g., `TASK_AGENT_NODE_ID = '__task_agent__'`) that is always present
+3. In `packages/web/src/components/space/visual-editor/types.ts`:
+   - Add any types needed for the Task Agent node representation
+4. In `packages/web/src/components/space/visual-editor/serialization.ts`:
+   - When deserializing a workflow, always include the Task Agent node in the node list
+   - When serializing, strip the Task Agent node from the persisted nodes (it's virtual)
+5. In `packages/web/src/components/space/visual-editor/layout.ts`:
+   - Include Task Agent node in layout computation
+   - Pin it to the top-center of the canvas
+6. Run `bun run typecheck`.
+7. Write unit tests for serialization with Task Agent node.
+
+**Acceptance Criteria:**
+- Task Agent node always appears in the visual editor data model
+- Serialization round-trip handles the virtual Task Agent node correctly
+- Layout places Task Agent at the top of the canvas
+
+**Dependencies:** Milestone 2 (types are `WorkflowNode`), Milestone 3 (Task Agent uses same messaging)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 4.2: Render Task Agent node on the canvas
+
+**Description:** Render the Task Agent as a visually distinct node on the workflow canvas. It should have a different color/shape than regular nodes, show a "Task Agent" label, and not be deletable.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/web/src/components/space/visual-editor/WorkflowNode.tsx`:
+   - Detect when the node is the Task Agent node (by ID or a `isTaskAgent` flag)
+   - Render with a distinct visual style: different background color (e.g., amber/gold), a badge or icon indicating "Task Agent", rounded or octagonal shape
+   - Hide the delete button for the Task Agent node
+   - Hide the input port (Task Agent is not a target of workflow transitions, only of channels)
+3. In `packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx`:
+   - Include the Task Agent node in the rendered node list
+   - Ensure it renders above other nodes (z-index or render order)
+4. In `packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx`:
+   - Prevent deletion of the Task Agent node in the delete handler
+   - Prevent the Task Agent from being part of workflow transitions (it's not a step in the execution flow)
+5. Run `bun run typecheck` and `bun run lint`.
+6. Write visual editor tests:
+   - Test that Task Agent node is always rendered
+   - Test that Task Agent node cannot be deleted
+   - Test distinct visual styling
+
+**Acceptance Criteria:**
+- Task Agent appears as a visually distinct, pinned node on the canvas
+- Cannot be deleted or used as a transition source/target
+- Visual style is clearly different from regular workflow nodes
+
+**Dependencies:** Task 4.1
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 4.3: Auto-create Task Agent channels on node addition
+
+**Description:** When a user adds a new node to the workflow, automatically create a default bidirectional channel between the Task Agent and the new node. Users can subsequently remove these channels if desired.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx` (or the appropriate handler):
+   - When a new node is added (via the "Add Node" action), auto-add a bidirectional `WorkflowChannel` entry: `{ from: 'task-agent', to: <new-node-agent-role>, direction: 'bidirectional' }`
+   - For multi-agent nodes, add channels for each agent role in the node
+3. In `packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx`:
+   - Show Task Agent channels in the channel configuration panel
+   - Allow users to remove Task Agent channels (same UI as other channels)
+4. In the edge rendering:
+   - Render edges between the Task Agent node and other nodes for each declared channel
+   - These are distinct from workflow transition edges (different visual style -- dashed line or different color for communication channels vs execution flow)
+5. Run `bun run typecheck` and `bun run lint`.
+6. Write tests:
+   - Test that adding a node auto-creates Task Agent channels
+   - Test that removing a Task Agent channel works
+   - Test that channel edges are rendered on the canvas
+
+**Acceptance Criteria:**
+- Adding a new node automatically creates bidirectional Task Agent <-> node channels
+- Channels are visible in the channel config panel
+- Users can remove Task Agent channels
+- Channel edges are rendered on the canvas
+
+**Dependencies:** Task 4.2
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 4.4: E2E tests for Task Agent visible node
+
+**Description:** Write Playwright e2e tests for the Task Agent node in the visual workflow editor.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Add e2e test scenarios to `packages/e2e/tests/features/visual-workflow-editor.e2e.ts` (or a new file):
+   - Test that Task Agent node is always visible when opening the visual editor
+   - Test that Task Agent node cannot be deleted (Delete key, right-click menu)
+   - Test that adding a new node shows Task Agent channel edges on the canvas
+   - Test that channels to the Task Agent can be removed via the config panel
+   - Test that Task Agent node has distinct visual styling (check CSS classes or data attributes)
+3. Run the e2e test to verify: `make run-e2e TEST=tests/features/visual-workflow-editor.e2e.ts`
+
+**Acceptance Criteria:**
+- E2E tests cover all Task Agent node interactions
+- Tests pass reliably in CI environment
+
+**Dependencies:** Task 4.3
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/05-per-slot-agent-overrides.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/05-per-slot-agent-overrides.md
@@ -1,0 +1,163 @@
+# Milestone 5: Per-Slot Agent Overrides in Nodes
+
+## Goal
+
+Allow adding the same agent definition multiple times to a single workflow node, differentiated by per-slot configuration overrides (`role`, `model`, `systemPrompt`). The agent editor remains the base config/defaults; node slot overrides are local to that workflow node.
+
+## Scope
+
+- Extend `WorkflowNodeAgent` with `role`, `model?`, `systemPrompt?` fields
+- Remove the restriction blocking duplicate `agentId` values within a node
+- Agent editor remains the base config / defaults source
+- Backend resolves final config as base + overrides at runtime
+- UI clearly displays when overrides are active
+- Update export/import format for the new fields
+
+## Tasks
+
+### Task 5.1: Extend WorkflowNodeAgent schema with override fields
+
+**Description:** Add `role`, `model?`, and `systemPrompt?` fields to `WorkflowNodeAgent` (and `WorkflowNodeInput`). Update the export format type. Ensure `role` is required and unique within a node.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/shared/src/types/space.ts`:
+   - Add to `WorkflowNodeAgent`:
+     ```
+     role: string;          // unique within the node, e.g. "strict-reviewer"
+     model?: string;        // override the agent's default model
+     systemPrompt?: string; // override the agent's default system prompt
+     ```
+   - Add same fields to `WorkflowNodeInput` (with `role` required)
+   - Add to `ExportedWorkflowNodeAgent`: `role`, `model?`, `systemPrompt?`
+3. In `packages/shared/src/types/space-utils.ts`:
+   - Update `resolveStepAgents` (now `resolveNodeAgents`) to use the new `role` field
+   - Add validation: `role` must be unique within a node's agent list
+   - Remove validation that blocks duplicate `agentId` values (if any)
+4. Update shared package tests.
+5. Run `bun run typecheck`.
+
+**Acceptance Criteria:**
+- `WorkflowNodeAgent` has `role`, `model?`, `systemPrompt?` fields
+- `role` is required and validated as unique within a node
+- Same `agentId` can appear multiple times if `role` is different
+- Shared types compile cleanly
+
+**Dependencies:** Milestone 2 (types are `WorkflowNodeAgent`)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5.2: Update backend to resolve base + override config at runtime
+
+**Description:** Update the workflow executor and agent initialization to merge base agent config with per-slot overrides when spawning agent sessions.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/lib/space/agents/custom-agent.ts`:
+   - Update `resolveAgentInit` to accept optional `model` and `systemPrompt` overrides
+   - When overrides are provided, merge them with the base agent config:
+     - `model` override replaces agent's default model
+     - `systemPrompt` override replaces (or appends to) the agent's default system prompt
+   - Use the slot's `role` field as the agent's role in the session group (instead of the base agent's role)
+3. In `packages/daemon/src/lib/space/runtime/workflow-executor.ts`:
+   - When spawning agents for a multi-agent node, pass the per-slot overrides to `resolveAgentInit`
+   - Use the slot's `role` for session group membership
+4. In `packages/daemon/src/lib/space/runtime/space-runtime.ts`:
+   - Update channel resolution to use slot `role` values (not base agent roles)
+5. In `packages/daemon/src/storage/repositories/space-workflow-repository.ts`:
+   - Ensure the new fields are persisted in the `agents` JSON column
+6. Run `bun run typecheck` and `bun run lint`.
+7. Write unit tests:
+   - Test that model override is applied when spawning agent session
+   - Test that systemPrompt override is applied
+   - Test that slot role is used for channel resolution
+   - Test multiple instances of same agent with different roles
+
+**Acceptance Criteria:**
+- Agent sessions spawned with resolved config (base + overrides)
+- Slot `role` used for session group membership and channel resolution
+- Overrides persisted correctly in DB
+- Unit tests cover all override scenarios
+
+**Dependencies:** Task 5.1
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5.3: Update UI for per-slot agent overrides
+
+**Description:** Update the visual editor's NodeConfigPanel and the list-view WorkflowNodeCard to support per-slot agent overrides. Display override indicators clearly to avoid hidden behavior surprises.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx`:
+   - Show per-agent-slot configuration section for each agent in the node
+   - Allow editing `role` (required, text input)
+   - Allow optional `model` override (model selector dropdown or text input)
+   - Allow optional `systemPrompt` override (textarea)
+   - Show visual indicator when an override is active (e.g., badge, different background color)
+   - Allow adding the same agent multiple times (remove duplicate-agent restriction in the "Add Agent" UI)
+3. In `packages/web/src/components/space/WorkflowNodeCard.tsx` (list view):
+   - Display slot role names alongside agent names
+   - Show override indicators (small icon or text like "custom model", "custom prompt")
+4. In `packages/web/src/components/space/visual-editor/WorkflowNode.tsx` (canvas node):
+   - Show slot count or role names when multiple agents are present
+   - Indicate overrides with a visual cue
+5. Update `packages/web/src/components/space/visual-editor/serialization.ts`:
+   - Serialize/deserialize the new fields
+6. Run `bun run typecheck` and `bun run lint`.
+7. Write component tests:
+   - Test adding same agent twice with different roles
+   - Test override fields display and editing
+   - Test serialization round-trip with overrides
+
+**Acceptance Criteria:**
+- Users can add the same agent multiple times to a node with different roles
+- Override fields (model, systemPrompt) are editable per slot
+- Active overrides are visually indicated
+- Serialization handles new fields correctly
+
+**Dependencies:** Task 5.1, Task 5.2
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 5.4: Update export/import and tests for per-slot overrides
+
+**Description:** Update the export/import format to include per-slot override fields. Add comprehensive tests.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/daemon/src/lib/space/export-format.ts`:
+   - Include `role`, `model`, `systemPrompt` in `ExportedWorkflowNodeAgent` serialization
+   - On import, map these fields back to `WorkflowNodeAgent`
+3. In `packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts`:
+   - Ensure the new fields pass through the export/import pipeline
+4. Update `packages/daemon/tests/unit/space/export-format.test.ts`:
+   - Test export with per-slot overrides
+   - Test import with per-slot overrides
+   - Test backward compatibility (import without override fields)
+5. Add integration test: full round-trip export -> import with overrides
+6. Update e2e test `packages/e2e/tests/features/space-export-import.e2e.ts` if applicable.
+7. Run all affected tests.
+
+**Acceptance Criteria:**
+- Export/import handles per-slot override fields correctly
+- Backward compatible: old exports without override fields import cleanly
+- Tests cover all scenarios
+
+**Dependencies:** Task 5.2, Task 5.3
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/unify-agent-communication-workflow-graph-model/05-per-slot-agent-overrides.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/05-per-slot-agent-overrides.md
@@ -42,6 +42,7 @@ Allow adding the same agent definition multiple times to a single workflow node,
 - `role` is required and validated as unique within a node
 - Same `agentId` can appear multiple times if `role` is different
 - Shared types compile cleanly
+- **Note:** Backward compatibility for existing data without `role` is not required — this feature is not yet in production
 
 **Dependencies:** Milestone 2 (types are `WorkflowNodeAgent`)
 
@@ -156,7 +157,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 - Backward compatible: old exports without override fields import cleanly
 - Tests cover all scenarios
 
-**Dependencies:** Task 5.2, Task 5.3
+**Dependencies:** Task 5.3 (must complete first to ensure frontend serialization field names are settled before backend export/import is updated)
 
 **Agent type:** coder
 

--- a/docs/plans/unify-agent-communication-workflow-graph-model/06-channel-direction-visualization.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/06-channel-direction-visualization.md
@@ -2,13 +2,15 @@
 
 ## Goal
 
-Show channel direction (bidirectional vs unidirectional) visually on the canvas edges in the visual workflow editor. Bidirectional channels display double-headed arrows; unidirectional channels display a single arrowhead. This makes the messaging topology inspectable at a glance.
+Show channel direction (bidirectional vs one-way) visually on the canvas edges in the visual workflow editor. Bidirectional channels display double-headed arrows; one-way channels display a single arrowhead. This makes the messaging topology inspectable at a glance.
 
 ## Scope
 
 - Render channel edges (distinct from transition edges) on the canvas
-- Bidirectional channels: double-headed arrow on the edge
-- Unidirectional channels: single arrowhead on the edge
+- Bidirectional channels (`direction: 'bidirectional'`): double-headed arrow on the edge
+- One-way channels (`direction: 'one-way'`): single arrowhead on the edge
+
+**IMPORTANT:** The actual type values in `packages/shared/src/types/space.ts` are `'one-way' | 'bidirectional'` — use these exact string literals in all comparisons, NOT `'unidirectional'`.
 - Channel edges use a different visual style from transition edges (e.g., dashed lines, different colors)
 - Channels to/from the Task Agent node are rendered as edges like any other channel
 - Edge labels or tooltips show channel participants (e.g., "coder <-> reviewer")
@@ -26,22 +28,22 @@ Show channel direction (bidirectional vs unidirectional) visually on the canvas 
    - Render channel edges with a distinct style:
      - Dashed stroke pattern to differentiate from solid transition edges
      - Color: green or teal for channels (distinct from blue/yellow/purple transition colors)
-   - For **bidirectional** channels: render with `marker-start` and `marker-end` (double arrowheads)
-   - For **unidirectional** channels: render with `marker-end` only (single arrowhead pointing to target)
+   - For **bidirectional** channels (`direction === 'bidirectional'`): render with `marker-start` and `marker-end` (double arrowheads)
+   - For **one-way** channels (`direction === 'one-way'`): render with `marker-end` only (single arrowhead pointing to target)
    - Add SVG marker definitions for channel arrowheads (distinct from transition arrowheads)
    - Channel edges connect between the side ports of nodes (left/right) rather than top/bottom to avoid confusion with transition edges
 3. Add `data-testid` attributes for channel edges: `data-testid="channel-edge-{from}-{to}"`
 4. Run `bun run typecheck` and `bun run lint`.
 5. Write unit tests:
    - Test bidirectional channel renders two arrowheads
-   - Test unidirectional channel renders one arrowhead
+   - Test one-way channel renders one arrowhead
    - Test channel edges use dashed style
    - Test channel edges are distinct from transition edges
 
 **Acceptance Criteria:**
 - Channel edges rendered with correct arrowhead direction
 - Visual distinction between channel edges and transition edges
-- Both bidirectional and unidirectional styles are correct
+- Both bidirectional and one-way styles are correct
 
 **Dependencies:** Milestone 4 (Task Agent visible as node with channels)
 
@@ -76,7 +78,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 **Acceptance Criteria:**
 - Channel edges appear on the canvas for all declared channels
-- Direction (bidirectional/unidirectional) is visually correct
+- Direction (bidirectional/one-way) is visually correct
 - Task Agent channel edges render properly
 - No visual clutter when many channels exist
 
@@ -96,7 +98,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 1. Run `bun install` at worktree root.
 2. Add e2e test scenarios:
    - Create a workflow with bidirectional channels, verify double-arrowhead edges appear
-   - Create a workflow with unidirectional channels, verify single-arrowhead edges appear
+   - Create a workflow with one-way channels, verify single-arrowhead edges appear
    - Verify Task Agent channel edges are rendered
    - Verify channel edges are visually distinct from transition edges (check CSS/data attributes)
    - Verify channel direction changes are reflected immediately when editing channels in the config panel

--- a/docs/plans/unify-agent-communication-workflow-graph-model/06-channel-direction-visualization.md
+++ b/docs/plans/unify-agent-communication-workflow-graph-model/06-channel-direction-visualization.md
@@ -1,0 +1,113 @@
+# Milestone 6: Channel Direction Visualization
+
+## Goal
+
+Show channel direction (bidirectional vs unidirectional) visually on the canvas edges in the visual workflow editor. Bidirectional channels display double-headed arrows; unidirectional channels display a single arrowhead. This makes the messaging topology inspectable at a glance.
+
+## Scope
+
+- Render channel edges (distinct from transition edges) on the canvas
+- Bidirectional channels: double-headed arrow on the edge
+- Unidirectional channels: single arrowhead on the edge
+- Channel edges use a different visual style from transition edges (e.g., dashed lines, different colors)
+- Channels to/from the Task Agent node are rendered as edges like any other channel
+- Edge labels or tooltips show channel participants (e.g., "coder <-> reviewer")
+
+## Tasks
+
+### Task 6.1: Add channel edge rendering to EdgeRenderer
+
+**Description:** Extend `EdgeRenderer.tsx` to render channel edges alongside transition edges. Channel edges connect nodes that have declared messaging channels and use distinct visual styling.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/web/src/components/space/visual-editor/EdgeRenderer.tsx`:
+   - Add a new `channels` prop (array of `WorkflowChannel` with resolved source/target node IDs)
+   - Render channel edges with a distinct style:
+     - Dashed stroke pattern to differentiate from solid transition edges
+     - Color: green or teal for channels (distinct from blue/yellow/purple transition colors)
+   - For **bidirectional** channels: render with `marker-start` and `marker-end` (double arrowheads)
+   - For **unidirectional** channels: render with `marker-end` only (single arrowhead pointing to target)
+   - Add SVG marker definitions for channel arrowheads (distinct from transition arrowheads)
+   - Channel edges connect between the side ports of nodes (left/right) rather than top/bottom to avoid confusion with transition edges
+3. Add `data-testid` attributes for channel edges: `data-testid="channel-edge-{from}-{to}"`
+4. Run `bun run typecheck` and `bun run lint`.
+5. Write unit tests:
+   - Test bidirectional channel renders two arrowheads
+   - Test unidirectional channel renders one arrowhead
+   - Test channel edges use dashed style
+   - Test channel edges are distinct from transition edges
+
+**Acceptance Criteria:**
+- Channel edges rendered with correct arrowhead direction
+- Visual distinction between channel edges and transition edges
+- Both bidirectional and unidirectional styles are correct
+
+**Dependencies:** Milestone 4 (Task Agent visible as node with channels)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 6.2: Integrate channel edges into WorkflowCanvas
+
+**Description:** Update `WorkflowCanvas.tsx` to compute and pass channel edge data to `EdgeRenderer`. Resolve channel declarations from the workflow into renderable edge data with source/target node positions.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. In `packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx`:
+   - Collect all `WorkflowChannel` declarations from all nodes in the workflow
+   - Resolve channel endpoints to node IDs:
+     - For intra-node channels (agents within the same node), render a loopback edge or skip (channels within a single node don't need cross-node edges)
+     - For Task Agent channels, resolve the Task Agent node ID and the target node ID
+   - Pass the resolved channel edge data to `EdgeRenderer`
+3. In `packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx`:
+   - Ensure channel data flows through to the canvas
+4. Handle edge cases:
+   - Nodes with no channels: no channel edges rendered
+   - Task Agent with channels to all nodes: multiple channel edges from the Task Agent node
+5. Run `bun run typecheck` and `bun run lint`.
+6. Write tests:
+   - Test channel edges appear for declared channels
+   - Test no channel edges for nodes without channels
+   - Test Task Agent channel edges render correctly
+
+**Acceptance Criteria:**
+- Channel edges appear on the canvas for all declared channels
+- Direction (bidirectional/unidirectional) is visually correct
+- Task Agent channel edges render properly
+- No visual clutter when many channels exist
+
+**Dependencies:** Task 6.1
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 6.3: E2E tests for channel direction visualization
+
+**Description:** Write Playwright e2e tests verifying that channel direction is correctly displayed in the visual workflow editor.
+
+**Subtasks:**
+1. Run `bun install` at worktree root.
+2. Add e2e test scenarios:
+   - Create a workflow with bidirectional channels, verify double-arrowhead edges appear
+   - Create a workflow with unidirectional channels, verify single-arrowhead edges appear
+   - Verify Task Agent channel edges are rendered
+   - Verify channel edges are visually distinct from transition edges (check CSS/data attributes)
+   - Verify channel direction changes are reflected immediately when editing channels in the config panel
+3. Run the e2e test: `make run-e2e TEST=tests/features/visual-workflow-editor.e2e.ts`
+
+**Acceptance Criteria:**
+- E2E tests verify correct arrowhead rendering for both directions
+- Tests pass reliably
+
+**Dependencies:** Task 6.2
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.


### PR DESCRIPTION
## Summary

- Six-milestone plan to refactor the space workflow system into a unified graph model
- Rename `send_feedback` to `send_message` (M1)
- Rename `WorkflowStep` to `WorkflowNode` across entire codebase including DB migration (M2)
- Unified messaging: remove `relay_message` and `request_peer_input`, all agents use `send_message` with uniform channel topology (M3)
- Task Agent as a first-class visible node in the visual editor with auto-created channels (M4)
- Per-slot agent overrides allowing same agent multiple times in a node with different roles/models/prompts (M5)
- Channel direction visualization with arrowheads on canvas edges (M6)

## Test plan

- [ ] Plan reviewed for completeness and sequencing
- [ ] Dependencies between milestones verified
- [ ] Task scope appropriate for single coder agent sessions