### PR TITLE
refactor: rename send_feedback to send_message in step agent tools

### DIFF
--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -155,9 +155,9 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 		`You are part of a multi-agent team within this workflow step. ` +
 			`You have MCP tools for communicating with peer agents in the same group.`
 	);
-	sections.push(`\n### Primary: \`send_feedback\` (channel-validated direct messaging)\n`);
+	sections.push(`\n### Primary: \`send_message\` (channel-validated direct messaging)\n`);
 	sections.push(
-		`Use \`send_feedback\` to send messages directly to permitted peers based on the declared channel topology.`
+		`Use \`send_message\` to send messages directly to permitted peers based on the declared channel topology.`
 	);
 	sections.push(
 		`- \`target: 'role'\` — point-to-point to a specific role (e.g., \`'coder'\`)\n` +
@@ -170,7 +170,7 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 	);
 	sections.push(`\n### Fallback: \`request_peer_input\` (Task Agent mediated)\n`);
 	sections.push(
-		`Use \`request_peer_input\` when no direct channel is declared or as a fallback when \`send_feedback\` fails validation.`
+		`Use \`request_peer_input\` when no direct channel is declared or as a fallback when \`send_message\` fails validation.`
 	);
 	sections.push(
 		`This is **async and non-blocking** — the tool returns immediately with an acknowledgment. ` +
@@ -182,11 +182,11 @@ export function buildCustomAgentSystemPrompt(customAgent: SpaceAgent): string {
 	sections.push(`\n### Discovering peers: \`list_peers\`\n`);
 	sections.push(
 		`Use \`list_peers\` to see all other agents in this step's group, their roles, statuses, ` +
-			`and permitted outgoing channels for \`send_feedback\`.`
+			`and permitted outgoing channels for \`send_message\`.`
 	);
 	sections.push(`\n### Communication model rules\n`);
 	sections.push(
-		`- If this step has declared channels: use \`send_feedback\` for permitted directions, ` +
+		`- If this step has declared channels: use \`send_message\` for permitted directions, ` +
 			`\`request_peer_input\` for undeclared directions\n` +
 			`- If this step has no declared channels: all communication goes through \`request_peer_input\`\n` +
 			`- All communication is scoped to this group — you cannot message agents in other tasks`

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1345,7 +1345,7 @@ export class TaskAgentManager {
 	 * Build a step agent MCP server for a newly spawned sub-session.
 	 * Called from the `buildStepAgentMcpServer` callback passed to createTaskAgentMcpServer().
 	 *
-	 * The server gives the step agent peer communication tools (list_peers, send_feedback,
+	 * The server gives the step agent peer communication tools (list_peers, send_message,
 	 * request_peer_input) that are scoped to its group and channel topology.
 	 *
 	 * The `injectToTaskAgent` callback routes `request_peer_input` requests through the

--- a/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tool-schemas.ts
@@ -4,7 +4,7 @@
  *
  * Tools:
  *   list_peers          — list other group members with their roles, statuses, and permitted channels
- *   send_feedback       — primary channel-validated direct messaging tool
+ *   send_message       — primary channel-validated direct messaging tool
  *   request_peer_input  — fallback Task Agent mediated messaging tool
  *
  * This file contains only schema definitions — no runtime logic or side effects.
@@ -31,11 +31,11 @@ export const ListPeersSchema = z.object({});
 export type ListPeersInput = z.infer<typeof ListPeersSchema>;
 
 // ---------------------------------------------------------------------------
-// send_feedback
+// send_message
 // ---------------------------------------------------------------------------
 
 /**
- * Schema for `send_feedback` input.
+ * Schema for `send_message` input.
  *
  * Primary direct messaging tool for step agents. Validates against declared channel
  * topology before routing. Supports three target forms:
@@ -46,7 +46,7 @@ export type ListPeersInput = z.infer<typeof ListPeersSchema>;
  * Returns an error with available channels and suggests `request_peer_input` when
  * the channel topology does not permit the requested direction.
  */
-export const SendFeedbackSchema = z.object({
+export const SendMessageSchema = z.object({
 	/**
 	 * Target role(s) to send the message to.
 	 * - String: point-to-point to a single role (e.g., 'coder')
@@ -65,7 +65,7 @@ export const SendFeedbackSchema = z.object({
 	message: z.string().min(1).describe('The message content to send to the target peer(s)'),
 });
 
-export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;
+export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 
 // ---------------------------------------------------------------------------
 // request_peer_input
@@ -75,7 +75,7 @@ export type SendFeedbackInput = z.infer<typeof SendFeedbackSchema>;
  * Schema for `request_peer_input` input.
  *
  * Fallback Task Agent mediated communication tool. Available when no direct channel
- * is declared for the target role, or when `send_feedback` fails validation.
+ * is declared for the target role, or when `send_message` fails validation.
  *
  * This is ASYNC and NON-BLOCKING — the tool returns an acknowledgment immediately.
  * The peer's answer will arrive as a separate user turn prefixed with:
@@ -107,7 +107,7 @@ export type RequestPeerInputInput = z.infer<typeof RequestPeerInputSchema>;
  */
 export const STEP_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
-	send_feedback: SendFeedbackSchema,
+	send_message: SendMessageSchema,
 	request_peer_input: RequestPeerInputSchema,
 } as const;
 

--- a/packages/daemon/src/lib/space/tools/step-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/step-agent-tools.ts
@@ -5,11 +5,11 @@
  * the same workflow step group:
  *
  *   list_peers          — discover other group members with roles and permitted channels
- *   send_feedback       — primary channel-validated direct messaging tool
+ *   send_message       — primary channel-validated direct messaging tool
  *   request_peer_input  — fallback Task Agent mediated messaging (async)
  *
  * Communication model:
- * - Step agents communicate via declared channel topology (`send_feedback`).
+ * - Step agents communicate via declared channel topology (`send_message`).
  * - When no channel is declared, or as a fallback, use `request_peer_input`
  *   which routes through the Task Agent.
  * - `list_peers` reveals who is in the group and what channels are available.
@@ -20,7 +20,7 @@
  *   - Fan-out one-way: hub→[spoke1, spoke2, ...]
  *   - Hub-spoke: hub↔spokes (hub sends to all, spokes only reply to hub)
  *
- * When no channels are declared for a step, all `send_feedback` calls fail with
+ * When no channels are declared for a step, all `send_message` calls fail with
  * a suggestion to use `request_peer_input` instead.
  *
  * Design:
@@ -39,12 +39,12 @@ import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
 	ListPeersSchema,
-	SendFeedbackSchema,
+	SendMessageSchema,
 	RequestPeerInputSchema,
 } from './step-agent-tool-schemas';
 import type {
 	ListPeersInput,
-	SendFeedbackInput,
+	SendMessageInput,
 	RequestPeerInputInput,
 } from './step-agent-tool-schemas';
 
@@ -76,7 +76,7 @@ export interface StepAgentToolsConfig {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	/**
 	 * Injects a message into a peer sub-session as a user turn.
-	 * Used by `send_feedback` to deliver messages to target sessions.
+	 * Used by `send_message` to deliver messages to target sessions.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
 	/**
@@ -161,7 +161,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		 * Does NOT include self (filtered by `mySessionId`).
 		 * Does NOT include the Task Agent (filtered by role 'task-agent').
 		 *
-		 * Returns permittedTargets: roles this agent can directly send to via send_feedback.
+		 * Returns permittedTargets: roles this agent can directly send to via send_message.
 		 */
 		async list_peers(_args: ListPeersInput): Promise<ToolResult> {
 			const loaded = loadGroupAndResolver();
@@ -190,7 +190,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 				message:
 					`Found ${peers.length} peer(s). ` +
 					(channelTopologyDeclared
-						? `Permitted direct targets via send_feedback: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`
+						? `Permitted direct targets via send_message: ${permittedTargets.length > 0 ? permittedTargets.join(', ') : 'none'}.`
 						: 'No channel topology declared — use request_peer_input to communicate with peers.'),
 			});
 		},
@@ -212,14 +212,14 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		 *   - Hub-spoke isolation is enforced by channel topology (spoke→spoke channels
 		 *     are not declared; spokes can only reply to hub)
 		 */
-		async send_feedback(args: SendFeedbackInput): Promise<ToolResult> {
+		async send_message(args: SendMessageInput): Promise<ToolResult> {
 			const { target, message } = args;
 
 			const loaded = loadGroupAndResolver();
 			if (!loaded.ok) return loaded.error;
 			const { group, resolver } = loaded;
 
-			// When no channel topology is declared for this step, all send_feedback calls
+			// When no channel topology is declared for this step, all send_message calls
 			// fail. Agents in a step with no declared channels must use request_peer_input
 			// so that all inter-agent communication is mediated by the Task Agent.
 			if (resolver.isEmpty()) {
@@ -227,7 +227,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 					success: false,
 					error:
 						`No channel topology declared for this step. ` +
-						`Direct messaging via send_feedback is not available. ` +
+						`Direct messaging via send_message is not available. ` +
 						`Use request_peer_input to communicate with peers through the Task Agent.`,
 					suggestion: 'request_peer_input',
 				});
@@ -293,7 +293,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 					continue;
 				}
 				for (const targetMember of targetSessions) {
-					const prefixedMessage = `[Feedback from ${myRole}]: ${message}`;
+					const prefixedMessage = `[Message from ${myRole}]: ${message}`;
 					try {
 						await messageInjector(targetMember.sessionId, prefixedMessage);
 						delivered.push({ role: targetRole, sessionId: targetMember.sessionId });
@@ -343,7 +343,7 @@ export function createStepAgentToolHandlers(config: StepAgentToolsConfig) {
 		 * Route a question or request through the Task Agent to a peer.
 		 *
 		 * This is the FALLBACK tool for when no direct channel is declared, or when
-		 * `send_feedback` fails validation. It routes through the Task Agent, which
+		 * `send_message` fails validation. It routes through the Task Agent, which
 		 * has unrestricted relay access to all group members.
 		 *
 		 * ASYNC and NON-BLOCKING — returns immediately with an acknowledgment.
@@ -407,18 +407,18 @@ export function createStepAgentMcpServer(config: StepAgentToolsConfig) {
 			(args) => handlers.list_peers(args)
 		),
 		tool(
-			'send_feedback',
+			'send_message',
 			'Send a message directly to one or more peer agents via declared channel topology. ' +
 				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
 				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
 				'Use request_peer_input as a fallback when no channel is declared.',
-			SendFeedbackSchema.shape,
-			(args) => handlers.send_feedback(args)
+			SendMessageSchema.shape,
+			(args) => handlers.send_message(args)
 		),
 		tool(
 			'request_peer_input',
 			'Route a question or request to a peer through the Task Agent. ' +
-				'Use this when no direct channel is declared or as a fallback when send_feedback fails. ' +
+				'Use this when no direct channel is declared or as a fallback when send_message fails. ' +
 				'Call list_peers first to verify the target_role exists in the group. ' +
 				'ASYNC: returns immediately. The peer response arrives later as a user turn prefixed with [Peer response from {role}]: ...',
 			RequestPeerInputSchema.shape,

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -6,7 +6,7 @@
  *
  * What is genuinely new here (beyond existing step-agent-tools.test.ts / task-agent-tools.test.ts):
  *   - Suite 1: Two simultaneous groups in the same DB — verifies group-scoped isolation
- *              holistically rather than per-tool. send_feedback test confirms that overlapping
+ *              holistically rather than per-tool. send_message test confirms that overlapping
  *              role names in different groups are never confused.
  *   - Suite 3: Multi-turn coder↔reviewer exchange (3 rounds) — exercises the full protocol.
  *   - Suite 5: Full hub-spoke assign→reply→follow-up exchange across multiple turns.
@@ -343,7 +343,7 @@ describe('cross-group isolation', () => {
 		expect(messages[0].sessionId).toBe('session-coder-c');
 	});
 
-	test('send_feedback never reaches group B members (group scoping)', async () => {
+	test('send_message never reaches group B members (group scoping)', async () => {
 		const { sessionGroupRepo } = tdb;
 
 		// Group A: coder ↔ reviewer (bidirectional)
@@ -399,7 +399,7 @@ describe('cross-group isolation', () => {
 		);
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'review this' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'review this' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
@@ -454,13 +454,13 @@ describe('channel direction enforcement', () => {
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, workflowRunId, injector);
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'please review' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'please review' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
 		expect(messages).toHaveLength(1);
 		expect(messages[0].sessionId).toBe('session-reviewer');
-		expect(messages[0].message).toContain('[Feedback from coder]');
+		expect(messages[0].message).toContain('[Message from coder]');
 		expect(messages[0].message).toContain('please review');
 	});
 
@@ -499,7 +499,7 @@ describe('channel direction enforcement', () => {
 		);
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({ target: 'coder', message: 'feedback' });
+		const result = await handlers.send_message({ target: 'coder', message: 'feedback' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -507,7 +507,7 @@ describe('channel direction enforcement', () => {
 		expect(messages).toHaveLength(0);
 	});
 
-	test('no channels declared blocks all send_feedback calls', async () => {
+	test('no channels declared blocks all send_message calls', async () => {
 		const { sessionGroupRepo } = tdb;
 
 		const group = sessionGroupRepo.createGroup({
@@ -532,7 +532,7 @@ describe('channel direction enforcement', () => {
 		const config = makeStepConfig(tdb, 'session-coder', 'coder', group.id, workflowRunId, injector);
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hi' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'hi' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -594,7 +594,7 @@ describe('bidirectional point-to-point A↔B', () => {
 		);
 		const aliceHandlers = createStepAgentToolHandlers(aliceConfig);
 
-		const r1 = await aliceHandlers.send_feedback({ target: 'bob', message: 'hello bob' });
+		const r1 = await aliceHandlers.send_message({ target: 'bob', message: 'hello bob' });
 		const d1 = JSON.parse(r1.content[0].text);
 		expect(d1.success).toBe(true);
 
@@ -602,7 +602,7 @@ describe('bidirectional point-to-point A↔B', () => {
 		const bobConfig = makeStepConfig(tdb, 'session-bob', 'bob', group.id, workflowRunId, injector);
 		const bobHandlers = createStepAgentToolHandlers(bobConfig);
 
-		const r2 = await bobHandlers.send_feedback({ target: 'alice', message: 'hello alice' });
+		const r2 = await bobHandlers.send_message({ target: 'alice', message: 'hello alice' });
 		const d2 = JSON.parse(r2.content[0].text);
 		expect(d2.success).toBe(true);
 
@@ -611,11 +611,11 @@ describe('bidirectional point-to-point A↔B', () => {
 		const bobReceived = messages.filter((m) => m.sessionId === 'session-bob');
 
 		expect(aliceReceived).toHaveLength(1);
-		expect(aliceReceived[0].message).toContain('[Feedback from bob]');
+		expect(aliceReceived[0].message).toContain('[Message from bob]');
 		expect(aliceReceived[0].message).toContain('hello alice');
 
 		expect(bobReceived).toHaveLength(1);
-		expect(bobReceived[0].message).toContain('[Feedback from alice]');
+		expect(bobReceived[0].message).toContain('[Message from alice]');
 		expect(bobReceived[0].message).toContain('hello bob');
 	});
 
@@ -648,19 +648,19 @@ describe('bidirectional point-to-point A↔B', () => {
 		const coderHandlers = createStepAgentToolHandlers(
 			makeStepConfig(tdb, 'session-coder', 'coder', group.id, workflowRunId, injector)
 		);
-		await coderHandlers.send_feedback({ target: 'reviewer', message: 'PR ready for review' });
+		await coderHandlers.send_message({ target: 'reviewer', message: 'PR ready for review' });
 
 		// Round 2: reviewer gives feedback
 		const reviewerHandlers = createStepAgentToolHandlers(
 			makeStepConfig(tdb, 'session-reviewer', 'reviewer', group.id, workflowRunId, injector)
 		);
-		await reviewerHandlers.send_feedback({
+		await reviewerHandlers.send_message({
 			target: 'coder',
 			message: 'Please fix the type error on line 42',
 		});
 
 		// Round 3: coder confirms fix
-		await coderHandlers.send_feedback({ target: 'reviewer', message: 'Fixed — see updated PR' });
+		await coderHandlers.send_message({ target: 'reviewer', message: 'Fixed — see updated PR' });
 
 		// Verify complete exchange
 		const reviewerMessages = messages.filter((m) => m.sessionId === 'session-reviewer');
@@ -738,7 +738,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 			makeStepConfig(tdb, 'session-hub', 'hub', group.id, workflowRunId, injector)
 		);
 
-		const result = await hubHandlers.send_feedback({ target: '*', message: 'broadcast task' });
+		const result = await hubHandlers.send_message({ target: '*', message: 'broadcast task' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
@@ -751,7 +751,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 
 		// All messages attributed to hub
 		messages.forEach((m) => {
-			expect(m.message).toContain('[Feedback from hub]');
+			expect(m.message).toContain('[Message from hub]');
 			expect(m.message).toContain('broadcast task');
 		});
 	});
@@ -773,7 +773,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 			makeStepConfig(tdb, 'session-spoke-b', 'spoke-b', group.id, workflowRunId, injector)
 		);
 
-		const result = await spokeBHandlers.send_feedback({ target: 'hub', message: 'reply' });
+		const result = await spokeBHandlers.send_message({ target: 'hub', message: 'reply' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -797,7 +797,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 			makeStepConfig(tdb, 'session-spoke-b', 'spoke-b', group.id, workflowRunId, injector)
 		);
 
-		const result = await spokeBHandlers.send_feedback({
+		const result = await spokeBHandlers.send_message({
 			target: 'spoke-c',
 			message: 'cross-spoke message',
 		});
@@ -823,7 +823,7 @@ describe('fan-out one-way A→[B,C,D]', () => {
 		);
 
 		// Send to only B and C (not D)
-		const result = await hubHandlers.send_feedback({
+		const result = await hubHandlers.send_message({
 			target: ['spoke-b', 'spoke-c'],
 			message: 'targeted broadcast',
 		});
@@ -905,7 +905,7 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 			makeStepConfig(tdb, 'session-lead', 'lead', group.id, workflowRunId, injector)
 		);
 
-		const result = await leadHandlers.send_feedback({
+		const result = await leadHandlers.send_message({
 			target: '*',
 			message: 'assigned tasks to all workers',
 		});
@@ -938,21 +938,21 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 		const workerBHandlers = createStepAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-b', 'worker-b', group.id, workflowRunId, injector)
 		);
-		const r1 = await workerBHandlers.send_feedback({ target: 'lead', message: 'worker-b done' });
+		const r1 = await workerBHandlers.send_message({ target: 'lead', message: 'worker-b done' });
 		expect(JSON.parse(r1.content[0].text).success).toBe(true);
 
 		// Worker C replies
 		const workerCHandlers = createStepAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-c', 'worker-c', group.id, workflowRunId, injector)
 		);
-		const r2 = await workerCHandlers.send_feedback({ target: 'lead', message: 'worker-c done' });
+		const r2 = await workerCHandlers.send_message({ target: 'lead', message: 'worker-c done' });
 		expect(JSON.parse(r2.content[0].text).success).toBe(true);
 
 		// Worker D replies
 		const workerDHandlers = createStepAgentToolHandlers(
 			makeStepConfig(tdb, 'session-worker-d', 'worker-d', group.id, workflowRunId, injector)
 		);
-		const r3 = await workerDHandlers.send_feedback({ target: 'lead', message: 'worker-d done' });
+		const r3 = await workerDHandlers.send_message({ target: 'lead', message: 'worker-d done' });
 		expect(JSON.parse(r3.content[0].text).success).toBe(true);
 
 		// All three replies delivered to lead
@@ -984,7 +984,7 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 			makeStepConfig(tdb, 'session-worker-b', 'worker-b', group.id, workflowRunId, injector)
 		);
 
-		const result = await workerBHandlers.send_feedback({
+		const result = await workerBHandlers.send_message({
 			target: 'worker-c',
 			message: 'cross-spoke attempt',
 		});
@@ -1017,13 +1017,13 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 		);
 
 		// Lead assigns to all
-		await leadHandlers.send_feedback({ target: '*', message: 'start your tasks' });
+		await leadHandlers.send_message({ target: '*', message: 'start your tasks' });
 
 		// Worker B reports back
-		await workerBHandlers.send_feedback({ target: 'lead', message: 'task complete' });
+		await workerBHandlers.send_message({ target: 'lead', message: 'task complete' });
 
 		// Lead follows up with worker B
-		await leadHandlers.send_feedback({ target: 'worker-b', message: 'great work, merge it' });
+		await leadHandlers.send_message({ target: 'worker-b', message: 'great work, merge it' });
 
 		const workerBInbox = messages.filter((m) => m.sessionId === 'session-worker-b');
 		const leadInbox = messages.filter((m) => m.sessionId === 'session-lead');
@@ -1098,8 +1098,8 @@ describe('concurrent message injection — both messages delivered', () => {
 
 		// Fire both simultaneously
 		const [rA, rB] = await Promise.all([
-			senderAHandlers.send_feedback({ target: 'target', message: 'message from A' }),
-			senderBHandlers.send_feedback({ target: 'target', message: 'message from B' }),
+			senderAHandlers.send_message({ target: 'target', message: 'message from A' }),
+			senderBHandlers.send_message({ target: 'target', message: 'message from B' }),
 		]);
 
 		expect(JSON.parse(rA.content[0].text).success).toBe(true);
@@ -1150,8 +1150,8 @@ describe('concurrent message injection — both messages delivered', () => {
 
 		// Two sends in parallel to different targets
 		const [r1, r2] = await Promise.all([
-			hubHandlers.send_feedback({ target: 'spoke-x', message: 'task for X' }),
-			hubHandlers.send_feedback({ target: 'spoke-y', message: 'task for Y' }),
+			hubHandlers.send_message({ target: 'spoke-x', message: 'task for X' }),
+			hubHandlers.send_message({ target: 'spoke-y', message: 'task for Y' }),
 		]);
 
 		expect(JSON.parse(r1.content[0].text).success).toBe(true);
@@ -1300,7 +1300,7 @@ describe('data reload and DB-based validation', () => {
 		expect(resolver.canSend('coder', 'tester')).toBe(false);
 	});
 
-	test('send_feedback works correctly using re-fetched group data', async () => {
+	test('send_message works correctly using re-fetched group data', async () => {
 		const { sessionGroupRepo } = tdb;
 
 		const group = sessionGroupRepo.createGroup({
@@ -1341,7 +1341,7 @@ describe('data reload and DB-based validation', () => {
 		};
 
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({
+		const result = await handlers.send_message({
 			target: 'reviewer',
 			message: 'post-reload check',
 		});
@@ -1470,7 +1470,7 @@ describe('error paths — missing group ID', () => {
 		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
-	test('send_feedback returns structured error when getGroupId returns undefined', async () => {
+	test('send_message returns structured error when getGroupId returns undefined', async () => {
 		const { messages, injector } = makeMessageCapture();
 
 		// getGroupId returns undefined — simulates race before group is created
@@ -1487,7 +1487,7 @@ describe('error paths — missing group ID', () => {
 		};
 
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -4,7 +4,7 @@
  * Exercises the full messaging stack with a real SQLite DB and mock injectors
  * (no real agent sessions). Focuses on end-to-end behavioral enforcement:
  *
- *   send_feedback         — channel validation, target modes, fan-out, hub-spoke
+ *   send_message         — channel validation, target modes, fan-out, hub-spoke
  *   request_peer_input    — Task Agent mediated async flow
  *   list_peers            — peer discovery with channel info
  *   list_group_members    — Task Agent group view
@@ -373,10 +373,10 @@ function parse(result: { content: Array<{ text: string }> }): Record<string, unk
 }
 
 // ===========================================================================
-// 1. send_feedback — channel validation and target modes
+// 1. send_message — channel validation and target modes
 // ===========================================================================
 
-describe('send_feedback — point-to-point (target: role)', () => {
+describe('send_message — point-to-point (target: role)', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
@@ -393,11 +393,11 @@ describe('send_feedback — point-to-point (target: role)', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: 'reviewer', message: 'LGTM' }));
+		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'LGTM' }));
 		expect(result.success).toBe(true);
 		expect(cfg.injectedMessages).toHaveLength(1);
 		expect(cfg.injectedMessages[0].sessionId).toBe('sess-reviewer');
-		expect(cfg.injectedMessages[0].message).toContain('[Feedback from coder]');
+		expect(cfg.injectedMessages[0].message).toContain('[Message from coder]');
 		expect(cfg.injectedMessages[0].message).toContain('LGTM');
 	});
 
@@ -412,14 +412,14 @@ describe('send_feedback — point-to-point (target: role)', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: 'reviewer', message: 'Hello' }));
+		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hello' }));
 		expect(result.success).toBe(false);
 		expect(result.unauthorizedRoles).toEqual(['reviewer']);
 		expect(cfg.injectedMessages).toHaveLength(0);
 	});
 });
 
-describe('send_feedback — broadcast (target: "*")', () => {
+describe('send_message — broadcast (target: "*")', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
@@ -437,7 +437,7 @@ describe('send_feedback — broadcast (target: "*")', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: '*', message: 'Broadcast!' }));
+		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast!' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
 		expect(delivered.sort()).toEqual(['sess-B', 'sess-C'].sort());
@@ -454,13 +454,13 @@ describe('send_feedback — broadcast (target: "*")', () => {
 		const cfg = makeStepConfig(ctx, 'sess-spoke', 'spoke');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: '*', message: 'Hi' }));
+		const result = parse(await handlers.send_message({ target: '*', message: 'Hi' }));
 		expect(result.success).toBe(false);
 		expect(result.availableTargets).toEqual([]);
 	});
 });
 
-describe('send_feedback — multicast (target: [role1, role2])', () => {
+describe('send_message — multicast (target: [role1, role2])', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
@@ -478,9 +478,7 @@ describe('send_feedback — multicast (target: [role1, role2])', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(
-			await handlers.send_feedback({ target: ['B', 'C'], message: 'Multicast' })
-		);
+		const result = parse(await handlers.send_message({ target: ['B', 'C'], message: 'Multicast' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
 		expect(delivered.sort()).toEqual(['sess-B', 'sess-C'].sort());
@@ -498,9 +496,7 @@ describe('send_feedback — multicast (target: [role1, role2])', () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(
-			await handlers.send_feedback({ target: ['B', 'C'], message: 'Multicast' })
-		);
+		const result = parse(await handlers.send_message({ target: ['B', 'C'], message: 'Multicast' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('C')).toBe(true);
 	});
@@ -525,7 +521,7 @@ describe('send_feedback — multicast (target: [role1, role2])', () => {
 		const handlers = createStepAgentToolHandlers(cfg);
 
 		const result = parse(
-			await handlers.send_feedback({ target: ['B', 'C'], message: 'Multicast partial' })
+			await handlers.send_message({ target: ['B', 'C'], message: 'Multicast partial' })
 		);
 		// Partial success: B delivered, C failed → success is 'partial' (not true)
 		expect(result.success).toBe('partial');
@@ -541,17 +537,17 @@ describe('send_feedback — multicast (target: [role1, role2])', () => {
 });
 
 // ===========================================================================
-// 2. send_feedback — no channels declared (empty topology)
+// 2. send_message — no channels declared (empty topology)
 // ===========================================================================
 
-describe('send_feedback — no channels declared', () => {
+describe('send_message — no channels declared', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('all send_feedback calls fail with suggestion to use request_peer_input', async () => {
+	test('all send_message calls fail with suggestion to use request_peer_input', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-coder', role: 'coder' },
 			{ sessionId: 'sess-reviewer', role: 'reviewer' },
@@ -561,7 +557,7 @@ describe('send_feedback — no channels declared', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: 'reviewer', message: 'Hi' }));
+		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(result.success).toBe(false);
 		expect(result.suggestion).toBe('request_peer_input');
 		expect(cfg.injectedMessages).toHaveLength(0);
@@ -569,10 +565,10 @@ describe('send_feedback — no channels declared', () => {
 });
 
 // ===========================================================================
-// 3. send_feedback — fan-out one-way topology
+// 3. send_message — fan-out one-way topology
 // ===========================================================================
 
-describe('send_feedback — fan-out one-way: hub → spokes, spokes cannot reply', () => {
+describe('send_message — fan-out one-way: hub → spokes, spokes cannot reply', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
@@ -593,14 +589,14 @@ describe('send_feedback — fan-out one-way: hub → spokes, spokes cannot reply
 	test('hub can send to B', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'B', message: 'Go!' }));
+		const result = parse(await handlers.send_message({ target: 'B', message: 'Go!' }));
 		expect(result.success).toBe(true);
 	});
 
 	test('hub broadcasts to all spokes via *', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: '*', message: 'All go!' }));
+		const result = parse(await handlers.send_message({ target: '*', message: 'All go!' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
 		expect(delivered.sort()).toEqual(['sess-B', 'sess-C', 'sess-D'].sort());
@@ -609,7 +605,7 @@ describe('send_feedback — fan-out one-way: hub → spokes, spokes cannot reply
 	test('spoke B cannot send back to hub (one-way enforcement)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'hub', message: 'Hello hub' }));
+		const result = parse(await handlers.send_message({ target: 'hub', message: 'Hello hub' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('hub')).toBe(true);
 	});
@@ -617,17 +613,17 @@ describe('send_feedback — fan-out one-way: hub → spokes, spokes cannot reply
 	test('spoke B cannot send to spoke C (spoke isolation)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'C', message: 'Hi C' }));
+		const result = parse(await handlers.send_message({ target: 'C', message: 'Hi C' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('C')).toBe(true);
 	});
 });
 
 // ===========================================================================
-// 4. send_feedback — hub-spoke bidirectional topology
+// 4. send_message — hub-spoke bidirectional topology
 // ===========================================================================
 
-describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes reply to hub only', () => {
+describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply to hub only', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
@@ -652,7 +648,7 @@ describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes repl
 	test('hub can send to B', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'B', message: 'Review this' }));
+		const result = parse(await handlers.send_message({ target: 'B', message: 'Review this' }));
 		expect(result.success).toBe(true);
 		expect(cfg.injectedMessages[0].sessionId).toBe('sess-B');
 	});
@@ -660,7 +656,7 @@ describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes repl
 	test('hub can broadcast to all spokes via *', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-hub', 'hub');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: '*', message: 'Broadcast' }));
+		const result = parse(await handlers.send_message({ target: '*', message: 'Broadcast' }));
 		expect(result.success).toBe(true);
 		const delivered = (result.delivered as Array<{ sessionId: string }>).map((d) => d.sessionId);
 		expect(delivered.sort()).toEqual(['sess-B', 'sess-C'].sort());
@@ -669,9 +665,7 @@ describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes repl
 	test('spoke B can reply to hub', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(
-			await handlers.send_feedback({ target: 'hub', message: 'Reviewed, LGTM' })
-		);
+		const result = parse(await handlers.send_message({ target: 'hub', message: 'Reviewed, LGTM' }));
 		expect(result.success).toBe(true);
 		expect(cfg.injectedMessages[0].sessionId).toBe('sess-hub');
 	});
@@ -679,7 +673,7 @@ describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes repl
 	test('spoke B cannot send to spoke C (spoke isolation enforced)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-B', 'B');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'C', message: 'Hi C' }));
+		const result = parse(await handlers.send_message({ target: 'C', message: 'Hi C' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('C')).toBe(true);
 	});
@@ -687,7 +681,7 @@ describe('send_feedback — hub-spoke bidirectional: hub broadcasts, spokes repl
 	test('spoke C cannot send to spoke B (spoke isolation, other direction)', async () => {
 		const cfg = makeStepConfig(ctx, 'sess-C', 'C');
 		const handlers = createStepAgentToolHandlers(cfg);
-		const result = parse(await handlers.send_feedback({ target: 'B', message: 'Hi B' }));
+		const result = parse(await handlers.send_message({ target: 'B', message: 'Hi B' }));
 		expect(result.success).toBe(false);
 		expect((result.unauthorizedRoles as string[]).includes('B')).toBe(true);
 	});
@@ -751,12 +745,12 @@ describe('request_peer_input — async routing through Task Agent', () => {
 
 	test('available even when no channels declared (fallback mode)', async () => {
 		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
-		// No channels set — resolver is empty, send_feedback would fail
+		// No channels set — resolver is empty, send_message would fail
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		// send_feedback should fail
-		const fbResult = parse(await handlers.send_feedback({ target: 'reviewer', message: 'Hi' }));
+		// send_message should fail
+		const fbResult = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(fbResult.success).toBe(false);
 
 		// request_peer_input should succeed
@@ -1128,7 +1122,7 @@ describe('Group scoping — messages cannot leak between task groups', () => {
 		expect(result.error as string).toContain('not a member of group');
 	});
 
-	test('send_feedback only delivers within the step agent own group', async () => {
+	test('send_message only delivers within the step agent own group', async () => {
 		// Two independent step contexts (different groups, different DBs)
 		const ctxA = makeStepCtx([
 			{ sessionId: 'sess-hub-A', role: 'hub' },
@@ -1147,7 +1141,7 @@ describe('Group scoping — messages cannot leak between task groups', () => {
 			const handlersA = createStepAgentToolHandlers(cfgA);
 
 			// Group A hub sends to its own B — succeeds
-			const resultA = parse(await handlersA.send_feedback({ target: 'B', message: 'To A.B' }));
+			const resultA = parse(await handlersA.send_message({ target: 'B', message: 'To A.B' }));
 			expect(resultA.success).toBe(true);
 			expect(cfgA.injectedMessages[0].sessionId).toBe('sess-B-A');
 
@@ -1174,19 +1168,19 @@ describe('Error cases — non-existent targets and injection failures', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('send_feedback to non-existent role returns no-active-sessions error', async () => {
+	test('send_message to non-existent role returns no-active-sessions error', async () => {
 		ctx = makeStepCtx([{ sessionId: 'sess-coder', role: 'coder' }]);
 		ctx.setChannels([ch('coder', 'ghost')]);
 
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: 'ghost', message: 'Hello ghost' }));
+		const result = parse(await handlers.send_message({ target: 'ghost', message: 'Hello ghost' }));
 		expect(result.success).toBe(false);
 		expect((result.error as string).toLowerCase()).toContain('no active sessions');
 	});
 
-	test('send_feedback injection failure returns all-failed error', async () => {
+	test('send_message injection failure returns all-failed error', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-coder', role: 'coder' },
 			{ sessionId: 'sess-reviewer', role: 'reviewer' },
@@ -1200,7 +1194,7 @@ describe('Error cases — non-existent targets and injection failures', () => {
 		});
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		const result = parse(await handlers.send_feedback({ target: 'reviewer', message: 'Hi' }));
+		const result = parse(await handlers.send_message({ target: 'reviewer', message: 'Hi' }));
 		expect(result.success).toBe(false);
 		// All-failed path: production returns `message` (not `error`) describing the failure
 		expect((result.message as string).toLowerCase()).toContain('failed');
@@ -1275,7 +1269,7 @@ describe('Step with no channels declared — open model', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('send_feedback always fails; request_peer_input always succeeds', async () => {
+	test('send_message always fails; request_peer_input always succeeds', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-a', role: 'agent-a' },
 			{ sessionId: 'sess-b', role: 'agent-b' },
@@ -1286,7 +1280,7 @@ describe('Step with no channels declared — open model', () => {
 		const handlersA = createStepAgentToolHandlers(cfgA);
 
 		const fbResult = parse(
-			await handlersA.send_feedback({ target: 'agent-b', message: 'Direct msg' })
+			await handlersA.send_message({ target: 'agent-b', message: 'Direct msg' })
 		);
 		expect(fbResult.success).toBe(false);
 		expect(fbResult.suggestion).toBe('request_peer_input');
@@ -1317,14 +1311,14 @@ describe('Step with no channels declared — open model', () => {
 // 13. Message attribution — sender identity prefix
 // ===========================================================================
 
-describe('send_feedback — sender attribution prefix', () => {
+describe('send_message — sender attribution prefix', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('injected message includes [Feedback from <role>] prefix', async () => {
+	test('injected message includes [Message from <role>] prefix', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-coder', role: 'coder' },
 			{ sessionId: 'sess-reviewer', role: 'reviewer' },
@@ -1334,8 +1328,8 @@ describe('send_feedback — sender attribution prefix', () => {
 		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder');
 		const handlers = createStepAgentToolHandlers(cfg);
 
-		await handlers.send_feedback({ target: 'reviewer', message: 'Here is my patch' });
+		await handlers.send_message({ target: 'reviewer', message: 'Here is my patch' });
 
-		expect(cfg.injectedMessages[0].message).toBe('[Feedback from coder]: Here is my patch');
+		expect(cfg.injectedMessages[0].message).toBe('[Message from coder]: Here is my patch');
 	});
 });

--- a/packages/daemon/tests/unit/space/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/space/custom-agent.test.ts
@@ -163,7 +163,7 @@ describe('buildCustomAgentSystemPrompt', () => {
 		const prompt = buildCustomAgentSystemPrompt(agent);
 		expect(prompt).toContain('Peer Communication');
 		expect(prompt).toContain('list_peers');
-		expect(prompt).toContain('send_feedback');
+		expect(prompt).toContain('send_message');
 		expect(prompt).toContain('request_peer_input');
 	});
 

--- a/packages/daemon/tests/unit/space/step-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/step-agent-tools.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers all 3 step agent peer communication tools:
  *   list_peers          — list peers excluding self and task-agent
- *   send_feedback       — channel-validated direct messaging
+ *   send_message       — channel-validated direct messaging
  *   request_peer_input  — Task Agent mediated async fallback
  *
  * Tests use a real SQLite database (via runMigrations) and mock message
@@ -291,10 +291,10 @@ describe('step-agent-tools: list_peers', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: send_feedback
+// Tests: send_message
 // ---------------------------------------------------------------------------
 
-describe('step-agent-tools: send_feedback', () => {
+describe('step-agent-tools: send_message', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -318,7 +318,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'LGTM!' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'LGTM!' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
@@ -326,7 +326,7 @@ describe('step-agent-tools: send_feedback', () => {
 		expect(data.delivered[0].sessionId).toBe(ctx.reviewerSessionId);
 		expect(data.delivered[0].role).toBe('reviewer');
 		expect(injected).toHaveLength(1);
-		expect(injected[0].message).toBe('[Feedback from coder]: LGTM!');
+		expect(injected[0].message).toBe('[Message from coder]: LGTM!');
 	});
 
 	test('point-to-point fails when channel not declared', async () => {
@@ -335,7 +335,7 @@ describe('step-agent-tools: send_feedback', () => {
 		]);
 		const config = makeConfig(ctx, { workflowRunId });
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -344,13 +344,13 @@ describe('step-agent-tools: send_feedback', () => {
 		expect(data.suggestion).toContain('request_peer_input');
 	});
 
-	test('returns error when no channels declared at all (empty topology blocks send_feedback)', async () => {
+	test('returns error when no channels declared at all (empty topology blocks send_message)', async () => {
 		const config = makeConfig(ctx); // no workflowRunId, no channels
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
-		// With no declared channels, send_feedback is unavailable — all communication
+		// With no declared channels, send_message is unavailable — all communication
 		// must go through request_peer_input (Task Agent mediated).
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No channel topology declared');
@@ -369,7 +369,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: '*', message: 'broadcast!' });
+		const result = await handlers.send_message({ target: '*', message: 'broadcast!' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
@@ -383,7 +383,7 @@ describe('step-agent-tools: send_feedback', () => {
 		]);
 		const config = makeConfig(ctx, { workflowRunId });
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: '*', message: 'broadcast' });
+		const result = await handlers.send_message({ target: '*', message: 'broadcast' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -395,7 +395,7 @@ describe('step-agent-tools: send_feedback', () => {
 		// No channels declared at all
 		const config = makeConfig(ctx);
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: '*', message: 'broadcast' });
+		const result = await handlers.send_message({ target: '*', message: 'broadcast' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -422,7 +422,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({
+		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
 			message: 'multicast!',
 		});
@@ -446,7 +446,7 @@ describe('step-agent-tools: send_feedback', () => {
 		});
 		const config = makeConfig(ctx, { workflowRunId });
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({
+		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
 			message: 'msg',
 		});
@@ -466,7 +466,7 @@ describe('step-agent-tools: send_feedback', () => {
 		]);
 		const config = makeConfig(ctx, { workflowRunId }); // myRole='coder'
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -491,7 +491,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'hub', message: 'done!' });
+		const result = await handlers.send_message({ target: 'hub', message: 'done!' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
@@ -514,7 +514,7 @@ describe('step-agent-tools: send_feedback', () => {
 		const handlers = createStepAgentToolHandlers(config);
 
 		// coder → reviewer
-		const r1 = await handlers.send_feedback({ target: 'reviewer', message: 'code ready' });
+		const r1 = await handlers.send_message({ target: 'reviewer', message: 'code ready' });
 		expect(JSON.parse(r1.content[0].text).success).toBe(true);
 
 		// reviewer → coder (as reviewer)
@@ -527,7 +527,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlersAsReviewer = createStepAgentToolHandlers(configAsReviewer);
-		const r2 = await handlersAsReviewer.send_feedback({ target: 'coder', message: 'approved' });
+		const r2 = await handlersAsReviewer.send_message({ target: 'coder', message: 'approved' });
 		expect(JSON.parse(r2.content[0].text).success).toBe(true);
 	});
 
@@ -537,7 +537,7 @@ describe('step-agent-tools: send_feedback', () => {
 		]);
 		const config = makeConfig(ctx, { workflowRunId });
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'tester', message: 'test pls' });
+		const result = await handlers.send_message({ target: 'tester', message: 'test pls' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -563,7 +563,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'hello' });
 		const data = JSON.parse(result.content[0].text);
 
 		// Partial success — one delivered, one failed
@@ -585,7 +585,7 @@ describe('step-agent-tools: send_feedback', () => {
 			},
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -596,7 +596,7 @@ describe('step-agent-tools: send_feedback', () => {
 	test('returns error when group not found', async () => {
 		const config = makeConfig(ctx, { getGroupId: () => undefined });
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'test' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'test' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -612,7 +612,7 @@ describe('step-agent-tools: send_feedback', () => {
 			getGroupId: () => 'nonexistent-group-id',
 		});
 		const handlers = createStepAgentToolHandlers(config);
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'Hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'Hello' });
 		const data = JSON.parse(result.content[0].text);
 		expect(data.success).toBe(false);
 		expect(data.error).toMatch(/not found/);
@@ -639,7 +639,7 @@ describe('step-agent-tools: send_feedback', () => {
 		});
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({
+		const result = await handlers.send_message({
 			target: ['reviewer', 'security'],
 			message: 'Hello',
 		});
@@ -666,7 +666,7 @@ describe('step-agent-tools: send_feedback', () => {
 		});
 		const handlers = createStepAgentToolHandlers(config);
 
-		const result = await handlers.send_feedback({ target: 'reviewer', message: 'Hello' });
+		const result = await handlers.send_message({ target: 'reviewer', message: 'Hello' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
@@ -840,7 +840,7 @@ describe('step-agent-tools: system prompt includes peer communication section', 
 		});
 
 		expect(prompt).toContain('Peer Communication');
-		expect(prompt).toContain('send_feedback');
+		expect(prompt).toContain('send_message');
 		expect(prompt).toContain('request_peer_input');
 		expect(prompt).toContain('list_peers');
 		expect(prompt).toContain('channel-validated');


### PR DESCRIPTION
Rename SendFeedbackSchema to SendMessageSchema and SendFeedbackInput to
SendMessageInput. Update STEP_AGENT_TOOL_SCHEMAS key from 'send_feedback'
to 'send_message'. Update all JSDoc comments, handler function names,
MCP tool registrations, system prompt text, and test references.
