### PR TITLE
feat: add migration 45 to rename step to node in workflow tables

### DIFF
--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -174,7 +174,7 @@ export class SpaceAgentRepository {
 		const rows = this.db
 			.prepare(
 				`SELECT DISTINCT sw.name
-				FROM space_workflow_steps sws
+				FROM space_workflow_nodes sws
 				JOIN space_workflows sw ON sw.id = sws.workflow_id
 				WHERE sws.agent_id = ?`
 			)

--- a/packages/daemon/src/storage/repositories/space-session-group-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-session-group-repository.ts
@@ -58,7 +58,7 @@ export class SpaceSessionGroupRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_step_id, task_id, status, created_at, updated_at)
+				`INSERT INTO space_session_groups (id, space_id, name, description, workflow_run_id, current_node_id, task_id, status, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
@@ -154,7 +154,7 @@ export class SpaceSessionGroupRepository {
 			values.push(params.workflowRunId ?? null);
 		}
 		if (params.currentStepId !== undefined) {
-			fields.push('current_step_id = ?');
+			fields.push('current_node_id = ?');
 			values.push(params.currentStepId ?? null);
 		}
 		if (params.taskId !== undefined) {
@@ -393,7 +393,7 @@ export class SpaceSessionGroupRepository {
 			name: row.name as string,
 			description: (row.description as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
-			currentStepId: (row.current_step_id as string | null) ?? undefined,
+			currentStepId: (row.current_node_id as string | null) ?? undefined,
 			taskId: (row.task_id as string | null) ?? undefined,
 			status: ((row.status as string | null) ?? 'active') as 'active' | 'completed' | 'failed',
 			members,

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,7 +25,7 @@ export class SpaceTaskRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
+			`INSERT INTO space_tasks (id, space_id, title, description, status, priority, task_type, assigned_agent, custom_agent_id, workflow_run_id, workflow_node_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
@@ -185,7 +185,7 @@ export class SpaceTaskRepository {
 			values.push(params.workflowRunId ?? null);
 		}
 		if (params.workflowStepId !== undefined) {
-			fields.push('workflow_step_id = ?');
+			fields.push('workflow_node_id = ?');
 			values.push(params.workflowStepId ?? null);
 		}
 		if (params.progress !== undefined) {
@@ -354,7 +354,7 @@ export class SpaceTaskRepository {
 			assignedAgent: (row.assigned_agent as SpaceTask['assignedAgent'] | null) ?? undefined,
 			customAgentId: (row.custom_agent_id as string | null) ?? undefined,
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
-			workflowStepId: (row.workflow_step_id as string | null) ?? undefined,
+			workflowStepId: (row.workflow_node_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
 			goalId: (row.goal_id as string | null) ?? undefined,
 			progress: (row.progress as number | null) ?? undefined,

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -4,12 +4,12 @@
  * Data access layer for SpaceWorkflow, SpaceWorkflowStep, and SpaceWorkflowTransition records.
  *
  * Storage layout:
- *   space_workflows             — id, space_id, name, description, start_step_id, config (JSON), layout (JSON), created_at, updated_at
- *   space_workflow_steps        — id, workflow_id, name, agent_id, order_index, config (JSON), created_at, updated_at
- *   space_workflow_transitions  — id, workflow_id, from_step_id, to_step_id, condition (JSON), order_index, is_cyclic, created_at, updated_at
+ *   space_workflows             — id, space_id, name, description, start_node_id, config (JSON), layout (JSON), created_at, updated_at
+ *   space_workflow_nodes        — id, workflow_id, name, agent_id, order_index, config (JSON), created_at, updated_at
+ *   space_workflow_transitions  — id, workflow_id, from_node_id, to_node_id, condition (JSON), order_index, is_cyclic, created_at, updated_at
  *
  * The `config` column on space_workflows stores: { tags, rules, ...extra }
- * The `config` column on space_workflow_steps stores: { instructions? }
+ * The `config` column on space_workflow_nodes stores: { instructions? }
  * The `condition` column on space_workflow_transitions stores: WorkflowCondition JSON or null
  */
 
@@ -39,7 +39,7 @@ interface WorkflowRow {
 	space_id: string;
 	name: string;
 	description: string;
-	start_step_id: string | null;
+	start_node_id: string | null;
 	config: string | null;
 	layout: string | null;
 	max_iterations: number | null;
@@ -61,8 +61,8 @@ interface StepRow {
 interface TransitionRow {
 	id: string;
 	workflow_id: string;
-	from_step_id: string;
-	to_step_id: string;
+	from_node_id: string;
+	to_node_id: string;
 	condition: string | null;
 	order_index: number;
 	is_cyclic: number | null;
@@ -77,7 +77,7 @@ interface WorkflowConfigJson {
 	extra?: Record<string, unknown>;
 }
 
-// JSON stored inside space_workflow_steps.config
+// JSON stored inside space_workflow_nodes.config
 interface StepConfigJson {
 	instructions?: string;
 	/** Multi-agent array — present when the step uses the agents[] format */
@@ -125,8 +125,8 @@ function rowToTransition(row: TransitionRow): WorkflowTransition {
 	const condition = parseJson<WorkflowCondition | null>(row.condition, null);
 	return {
 		id: row.id,
-		from: row.from_step_id,
-		to: row.to_step_id,
+		from: row.from_node_id,
+		to: row.to_node_id,
 		condition: condition ?? undefined,
 		order: row.order_index,
 		isCyclic: row.is_cyclic !== null ? Boolean(row.is_cyclic) : undefined,
@@ -140,7 +140,7 @@ function rowToWorkflow(
 ): SpaceWorkflow {
 	const cfg = parseJson<WorkflowConfigJson>(row.config, {});
 	// Derive startStepId: use explicit column, fall back to first step
-	const startStepId = row.start_step_id ?? steps[0]?.id ?? '';
+	const startStepId = row.start_node_id ?? steps[0]?.id ?? '';
 	const layout = parseJson<Record<string, { x: number; y: number }> | null>(row.layout, null);
 	return {
 		id: row.id,
@@ -197,7 +197,7 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, max_iterations, created_at, updated_at)
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, max_iterations, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
@@ -272,7 +272,7 @@ export class SpaceWorkflowRepository {
 			values.push(params.description ?? '');
 		}
 		if (params.startStepId !== undefined) {
-			fields.push('start_step_id = ?');
+			fields.push('start_node_id = ?');
 			values.push(params.startStepId ?? null);
 		}
 
@@ -325,7 +325,7 @@ export class SpaceWorkflowRepository {
 		if (hasStepReplacement) {
 			// Must delete transitions before steps (FK constraint)
 			this.db.prepare(`DELETE FROM space_workflow_transitions WHERE workflow_id = ?`).run(id);
-			this.db.prepare(`DELETE FROM space_workflow_steps WHERE workflow_id = ?`).run(id);
+			this.db.prepare(`DELETE FROM space_workflow_nodes WHERE workflow_id = ?`).run(id);
 			const steps = params.steps ?? [];
 			for (let i = 0; i < steps.length; i++) {
 				const step = steps[i];
@@ -377,7 +377,7 @@ export class SpaceWorkflowRepository {
 		// contains the UUID as a substring, which is safe because UUIDs are globally unique.
 		const stepRows = this.db
 			.prepare(
-				`SELECT DISTINCT workflow_id FROM space_workflow_steps
+				`SELECT DISTINCT workflow_id FROM space_workflow_nodes
          WHERE agent_id = ? OR config LIKE '%' || ? || '%'`
 			)
 			.all(agentId, agentId) as Array<{ workflow_id: string }>;
@@ -397,7 +397,7 @@ export class SpaceWorkflowRepository {
 	private fetchSteps(workflowId: string): WorkflowStep[] {
 		const rows = this.db
 			.prepare(
-				`SELECT * FROM space_workflow_steps WHERE workflow_id = ? ORDER BY order_index ASC, rowid ASC`
+				`SELECT * FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY order_index ASC, rowid ASC`
 			)
 			.all(workflowId) as StepRow[];
 		return rows.map(rowToStep);
@@ -436,7 +436,7 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflow_steps
+				`INSERT INTO space_workflow_nodes
            (id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
@@ -466,7 +466,7 @@ export class SpaceWorkflowRepository {
 		this.db
 			.prepare(
 				`INSERT INTO space_workflow_transitions
-           (id, workflow_id, from_step_id, to_step_id, condition, order_index, is_cyclic, created_at, updated_at)
+           (id, workflow_id, from_node_id, to_node_id, condition, order_index, is_cyclic, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -30,7 +30,7 @@ export class SpaceWorkflowRunRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at)
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, current_step_index, current_node_id, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
@@ -136,7 +136,7 @@ export class SpaceWorkflowRunRepository {
 			}
 		}
 		if (params.currentStepId !== undefined) {
-			fields.push('current_step_id = ?');
+			fields.push('current_node_id = ?');
 			values.push(params.currentStepId);
 		}
 		if (params.config !== undefined) {
@@ -201,7 +201,7 @@ export class SpaceWorkflowRunRepository {
 			workflowId: row.workflow_id as string,
 			title: row.title as string,
 			description: (row.description as string | null) ?? undefined,
-			currentStepId: (row.current_step_id as string | null) ?? undefined,
+			currentStepId: (row.current_node_id as string | null) ?? undefined,
 			status: row.status as WorkflowRunStatus,
 			config,
 			iterationCount: (row.iteration_count as number | undefined) ?? 0,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2607,7 +2607,8 @@ function runMigration44(db: BunDatabase): void {
  * Uses create-copy-drop-rename pattern for SQLite compatibility.
  */
 function runMigration45(db: BunDatabase): void {
-	// Skip if space_workflow_steps table doesn't exist (fresh database)
+	// Skip if space_workflow_steps was already renamed to space_workflow_nodes,
+	// or if the spaces feature was never enabled on this DB.
 	if (!tableExists(db, 'space_workflow_steps')) {
 		return;
 	}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -164,6 +164,15 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 44: Rename sdk_messages send_status values to deferred/enqueued/consumed.
 	runMigration44(db);
+
+	// Migration 45: Rename step-related columns and tables to node
+	// - space_workflow_steps -> space_workflow_nodes
+	// - start_step_id -> start_node_id in space_workflows
+	// - from_step_id -> from_node_id, to_step_id -> to_node_id in space_workflow_transitions
+	// - workflow_step_id -> workflow_node_id in space_tasks
+	// - current_step_id -> current_node_id in space_workflow_runs
+	// - current_step_id -> current_node_id in space_session_groups
+	runMigration45(db);
 }
 
 /**
@@ -2578,6 +2587,282 @@ function runMigration44(db: BunDatabase): void {
 		db.exec(
 			`CREATE INDEX IF NOT EXISTS idx_sdk_messages_send_status ON sdk_messages(session_id, send_status)`
 		);
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
+	}
+}
+
+/**
+ * Migration 45: Rename step-related columns and tables to node
+ *
+ * Renames:
+ * - space_workflow_steps -> space_workflow_nodes
+ * - space_workflows.start_step_id -> start_node_id
+ * - space_workflow_transitions.from_step_id -> from_node_id
+ * - space_workflow_transitions.to_step_id -> to_node_id
+ * - space_tasks.workflow_step_id -> workflow_node_id
+ * - space_workflow_runs.current_step_id -> current_node_id
+ * - space_session_groups.current_step_id -> current_node_id
+ *
+ * Uses create-copy-drop-rename pattern for SQLite compatibility.
+ */
+function runMigration45(db: BunDatabase): void {
+	// Skip if space_workflow_steps table doesn't exist (fresh database)
+	if (!tableExists(db, 'space_workflow_steps')) {
+		return;
+	}
+
+	// Check if already migrated by testing for new column name
+	if (tableHasColumn(db, 'space_workflow_nodes', 'id')) {
+		return; // Already migrated
+	}
+
+	db.exec(`PRAGMA foreign_keys = OFF`);
+	try {
+		// -------------------------------------------------------------------------
+		// 1. Rename space_workflow_steps -> space_workflow_nodes
+		// -------------------------------------------------------------------------
+		db.exec(`DROP TABLE IF EXISTS space_workflow_nodes_new`);
+		db.exec(`
+			CREATE TABLE space_workflow_nodes_new (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				agent_id TEXT,
+				order_index INTEGER NOT NULL,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			INSERT INTO space_workflow_nodes_new
+			SELECT id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at
+			FROM space_workflow_steps
+		`);
+		db.exec(`DROP TABLE space_workflow_steps`);
+		db.exec(`ALTER TABLE space_workflow_nodes_new RENAME TO space_workflow_nodes`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_workflow_id ON space_workflow_nodes(workflow_id)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_order ON space_workflow_nodes(workflow_id, order_index)`
+		);
+
+		// -------------------------------------------------------------------------
+		// 2. Rename space_workflows.start_step_id -> start_node_id
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflows', 'start_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflows_new`);
+			db.exec(`
+				CREATE TABLE space_workflows_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					name TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					start_node_id TEXT,
+					config TEXT,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+				)
+			`);
+			db.exec(`
+				INSERT INTO space_workflows_new
+				SELECT id, space_id, name, description, start_step_id, config, created_at, updated_at
+				FROM space_workflows
+			`);
+			db.exec(`DROP TABLE space_workflows`);
+			db.exec(`ALTER TABLE space_workflows_new RENAME TO space_workflows`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`
+			);
+		}
+
+		// -------------------------------------------------------------------------
+		// 3. Rename space_workflow_transitions.from_step_id -> from_node_id
+		//                          and space_workflow_transitions.to_step_id -> to_node_id
+		// Also update FK references from space_workflow_steps to space_workflow_nodes
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflow_transitions_new`);
+			db.exec(`
+				CREATE TABLE space_workflow_transitions_new (
+					id TEXT PRIMARY KEY,
+					workflow_id TEXT NOT NULL,
+					from_node_id TEXT NOT NULL,
+					to_node_id TEXT NOT NULL,
+					condition TEXT,
+					order_index INTEGER NOT NULL DEFAULT 0,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+					FOREIGN KEY (from_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE,
+					FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
+				)
+			`);
+			db.exec(`
+				INSERT INTO space_workflow_transitions_new
+				SELECT id, workflow_id, from_step_id, to_step_id, condition, order_index, created_at, updated_at
+				FROM space_workflow_transitions
+			`);
+			db.exec(`DROP TABLE space_workflow_transitions`);
+			db.exec(`ALTER TABLE space_workflow_transitions_new RENAME TO space_workflow_transitions`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_node ON space_workflow_transitions(workflow_id, from_node_id)`
+			);
+		}
+
+		// -------------------------------------------------------------------------
+		// 4. Rename space_workflow_runs.current_step_id -> current_node_id
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflow_runs', 'current_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflow_runs_new`);
+			db.exec(`
+				CREATE TABLE space_workflow_runs_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					workflow_id TEXT NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					current_step_index INTEGER NOT NULL DEFAULT 0,
+					current_node_id TEXT,
+					status TEXT NOT NULL DEFAULT 'pending'
+						CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+					config TEXT,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					completed_at INTEGER,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+					FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+				)
+			`);
+			db.exec(`
+				INSERT INTO space_workflow_runs_new
+				SELECT id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, created_at, updated_at, completed_at
+				FROM space_workflow_runs
+			`);
+			db.exec(`DROP TABLE space_workflow_runs`);
+			db.exec(`ALTER TABLE space_workflow_runs_new RENAME TO space_workflow_runs`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
+			);
+		}
+
+		// -------------------------------------------------------------------------
+		// 5. Rename space_tasks.workflow_step_id -> workflow_node_id
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
+			db.exec(`
+				CREATE TABLE space_tasks_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'pending'
+						CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+					priority TEXT NOT NULL DEFAULT 'normal'
+						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+					task_type TEXT
+						CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+					assigned_agent TEXT
+						CHECK(assigned_agent IN ('coder', 'general')),
+					custom_agent_id TEXT,
+					workflow_run_id TEXT,
+					workflow_node_id TEXT,
+					created_by_task_id TEXT,
+					goal_id TEXT,
+					progress INTEGER,
+					current_step TEXT,
+					result TEXT,
+					error TEXT,
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					input_draft TEXT,
+					active_session TEXT
+						CHECK(active_session IN ('worker', 'leader')),
+					task_agent_session_id TEXT,
+					pr_url TEXT,
+					pr_number INTEGER,
+					pr_created_at INTEGER,
+					archived_at INTEGER,
+					created_at INTEGER NOT NULL,
+					started_at INTEGER,
+					completed_at INTEGER,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+					FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
+				)
+			`);
+			db.exec(`
+				INSERT INTO space_tasks_new
+				SELECT id, space_id, title, description, status, priority, task_type, assigned_agent,
+							 custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id,
+							 progress, current_step, result, error, depends_on, input_draft, active_session,
+							 task_agent_session_id, pr_url, pr_number, pr_created_at, archived_at,
+							 created_at, started_at, completed_at, updated_at
+				FROM space_tasks
+			`);
+			db.exec(`DROP TABLE space_tasks`);
+			db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+			);
+		}
+
+		// -------------------------------------------------------------------------
+		// 6. Rename space_session_groups.current_step_id -> current_node_id
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_session_groups', 'current_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_session_groups_new`);
+			db.exec(`
+				CREATE TABLE space_session_groups_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					name TEXT NOT NULL,
+					description TEXT,
+					workflow_run_id TEXT,
+					current_node_id TEXT,
+					task_id TEXT,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+				)
+			`);
+			db.exec(`
+				INSERT INTO space_session_groups_new
+				SELECT id, space_id, name, description, workflow_run_id, current_step_id, task_id, created_at, updated_at
+				FROM space_session_groups
+			`);
+			db.exec(`DROP TABLE space_session_groups`);
+			db.exec(`ALTER TABLE space_session_groups_new RENAME TO space_session_groups`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
+			);
+		}
 	} finally {
 		db.exec(`PRAGMA foreign_keys = ON`);
 	}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -115,7 +115,7 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 29: Create all Space system tables (fully consolidated schema).
 	// All space tables and columns — including role, provider, inject_workflow_context,
 	// start_step_id, current_step_id, and space_workflow_transitions — are created here
-	// in a single idempotent migration.
+	// in a single idempotent migration. (Note: M45 renames step→node columns/tables.)
 	runMigration29(db);
 
 	// Migration 30: Add layout column to space_workflows for visual editor node positions.

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2612,20 +2612,15 @@ function runMigration45(db: BunDatabase): void {
 		return;
 	}
 
-	// Check if already migrated by testing for absence of old table
-	if (!tableExists(db, 'space_workflow_steps')) {
-		return; // Already migrated (table was renamed)
-	}
-
+	// Issue PRAGMA before BEGIN so it takes effect (SQLite ignores PRAGMA inside a transaction)
+	db.exec(`PRAGMA foreign_keys = OFF`);
 	db.exec(`BEGIN`);
 	try {
-		db.exec(`PRAGMA foreign_keys = OFF`);
-		try {
-			// -------------------------------------------------------------------------
-			// 1. Rename space_workflow_steps -> space_workflow_nodes
-			// -------------------------------------------------------------------------
-			db.exec(`DROP TABLE IF EXISTS space_workflow_nodes_new`);
-			db.exec(`
+		// -------------------------------------------------------------------------
+		// 1. Rename space_workflow_steps -> space_workflow_nodes
+		// -------------------------------------------------------------------------
+		db.exec(`DROP TABLE IF EXISTS space_workflow_nodes_new`);
+		db.exec(`
 				CREATE TABLE space_workflow_nodes_new (
 					id TEXT PRIMARY KEY,
 					workflow_id TEXT NOT NULL,
@@ -2639,27 +2634,27 @@ function runMigration45(db: BunDatabase): void {
 					FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
 				)
 			`);
-			db.exec(`
+		db.exec(`
 				INSERT INTO space_workflow_nodes_new
 				SELECT id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at
 				FROM space_workflow_steps
 			`);
-			db.exec(`DROP TABLE space_workflow_steps`);
-			db.exec(`ALTER TABLE space_workflow_nodes_new RENAME TO space_workflow_nodes`);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_workflow_id ON space_workflow_nodes(workflow_id)`
-			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_order ON space_workflow_nodes(workflow_id, order_index)`
-			);
+		db.exec(`DROP TABLE space_workflow_steps`);
+		db.exec(`ALTER TABLE space_workflow_nodes_new RENAME TO space_workflow_nodes`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_workflow_id ON space_workflow_nodes(workflow_id)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_order ON space_workflow_nodes(workflow_id, order_index)`
+		);
 
-			// -------------------------------------------------------------------------
-			// 2. Rename space_workflows.start_step_id -> start_node_id
-			// Also preserve columns added by M30 (layout) and M36 (max_iterations)
-			// -------------------------------------------------------------------------
-			if (tableHasColumn(db, 'space_workflows', 'start_step_id')) {
-				db.exec(`DROP TABLE IF EXISTS space_workflows_new`);
-				db.exec(`
+		// -------------------------------------------------------------------------
+		// 2. Rename space_workflows.start_step_id -> start_node_id
+		// Also preserve columns added by M30 (layout) and M36 (max_iterations)
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflows', 'start_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflows_new`);
+			db.exec(`
 					CREATE TABLE space_workflows_new (
 						id TEXT PRIMARY KEY,
 						space_id TEXT NOT NULL,
@@ -2674,26 +2669,26 @@ function runMigration45(db: BunDatabase): void {
 						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 					)
 				`);
-				db.exec(`
+			db.exec(`
 					INSERT INTO space_workflows_new
 					SELECT id, space_id, name, description, start_step_id, config, layout, max_iterations, created_at, updated_at
 					FROM space_workflows
 				`);
-				db.exec(`DROP TABLE space_workflows`);
-				db.exec(`ALTER TABLE space_workflows_new RENAME TO space_workflows`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`
-				);
-			}
+			db.exec(`DROP TABLE space_workflows`);
+			db.exec(`ALTER TABLE space_workflows_new RENAME TO space_workflows`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`
+			);
+		}
 
-			// -------------------------------------------------------------------------
-			// 3. Rename space_workflow_transitions.from_step_id -> from_node_id
-			//                          and space_workflow_transitions.to_step_id -> to_node_id
-			// Also preserve is_cyclic column added by M38
-			// -------------------------------------------------------------------------
-			if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
-				db.exec(`DROP TABLE IF EXISTS space_workflow_transitions_new`);
-				db.exec(`
+		// -------------------------------------------------------------------------
+		// 3. Rename space_workflow_transitions.from_step_id -> from_node_id
+		//                          and space_workflow_transitions.to_step_id -> to_node_id
+		// Also preserve is_cyclic column added by M38
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflow_transitions_new`);
+			db.exec(`
 					CREATE TABLE space_workflow_transitions_new (
 						id TEXT PRIMARY KEY,
 						workflow_id TEXT NOT NULL,
@@ -2709,28 +2704,28 @@ function runMigration45(db: BunDatabase): void {
 						FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
 					)
 				`);
-				db.exec(`
+			db.exec(`
 					INSERT INTO space_workflow_transitions_new
 					SELECT id, workflow_id, from_step_id, to_step_id, condition, order_index, is_cyclic, created_at, updated_at
 					FROM space_workflow_transitions
 				`);
-				db.exec(`DROP TABLE space_workflow_transitions`);
-				db.exec(`ALTER TABLE space_workflow_transitions_new RENAME TO space_workflow_transitions`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_node ON space_workflow_transitions(workflow_id, from_node_id)`
-				);
-			}
+			db.exec(`DROP TABLE space_workflow_transitions`);
+			db.exec(`ALTER TABLE space_workflow_transitions_new RENAME TO space_workflow_transitions`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_node ON space_workflow_transitions(workflow_id, from_node_id)`
+			);
+		}
 
-			// -------------------------------------------------------------------------
-			// 4. Rename space_workflow_runs.current_step_id -> current_node_id
-			// Also preserve columns added by M35 (iteration_count, max_iterations) and M37 (goal_id)
-			// -------------------------------------------------------------------------
-			if (tableHasColumn(db, 'space_workflow_runs', 'current_step_id')) {
-				db.exec(`DROP TABLE IF EXISTS space_workflow_runs_new`);
-				db.exec(`
+		// -------------------------------------------------------------------------
+		// 4. Rename space_workflow_runs.current_step_id -> current_node_id
+		// Also preserve columns added by M35 (iteration_count, max_iterations) and M37 (goal_id)
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_workflow_runs', 'current_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_workflow_runs_new`);
+			db.exec(`
 					CREATE TABLE space_workflow_runs_new (
 						id TEXT PRIMARY KEY,
 						space_id TEXT NOT NULL,
@@ -2752,34 +2747,34 @@ function runMigration45(db: BunDatabase): void {
 						FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
 					)
 				`);
-				db.exec(`
+			db.exec(`
 					INSERT INTO space_workflow_runs_new
 					SELECT id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at, completed_at
 					FROM space_workflow_runs
 				`);
-				db.exec(`DROP TABLE space_workflow_runs`);
-				db.exec(`ALTER TABLE space_workflow_runs_new RENAME TO space_workflow_runs`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_goal_id ON space_workflow_runs(goal_id)`
-				);
-			}
+			db.exec(`DROP TABLE space_workflow_runs`);
+			db.exec(`ALTER TABLE space_workflow_runs_new RENAME TO space_workflow_runs`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_goal_id ON space_workflow_runs(goal_id)`
+			);
+		}
 
-			// -------------------------------------------------------------------------
-			// 5. Rename space_tasks.workflow_step_id -> workflow_node_id
-			// Also preserves goal_id column added by M34
-			// -------------------------------------------------------------------------
-			if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
-				db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
-				db.exec(`
+		// -------------------------------------------------------------------------
+		// 5. Rename space_tasks.workflow_step_id -> workflow_node_id
+		// Also preserves goal_id column added by M34
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
+			db.exec(`
 					CREATE TABLE space_tasks_new (
 						id TEXT PRIMARY KEY,
 						space_id TEXT NOT NULL,
@@ -2820,7 +2815,7 @@ function runMigration45(db: BunDatabase): void {
 						FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
 					)
 				`);
-				db.exec(`
+			db.exec(`
 					INSERT INTO space_tasks_new
 					SELECT id, space_id, title, description, status, priority, task_type, assigned_agent,
 								 custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id,
@@ -2829,32 +2824,32 @@ function runMigration45(db: BunDatabase): void {
 								 created_at, started_at, completed_at, updated_at
 					FROM space_tasks
 				`);
-				db.exec(`DROP TABLE space_tasks`);
-				db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
-				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
-				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
-				);
-				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
-				);
-			}
+			db.exec(`DROP TABLE space_tasks`);
+			db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
+			);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+			);
+		}
 
-			// -------------------------------------------------------------------------
-			// 6. Rename space_session_groups.current_step_id -> current_node_id
-			// Also preserves status column added by M40
-			// -------------------------------------------------------------------------
-			if (tableHasColumn(db, 'space_session_groups', 'current_step_id')) {
-				db.exec(`DROP TABLE IF EXISTS space_session_groups_new`);
-				db.exec(`
+		// -------------------------------------------------------------------------
+		// 6. Rename space_session_groups.current_step_id -> current_node_id
+		// Also preserves status column added by M40
+		// -------------------------------------------------------------------------
+		if (tableHasColumn(db, 'space_session_groups', 'current_step_id')) {
+			db.exec(`DROP TABLE IF EXISTS space_session_groups_new`);
+			db.exec(`
 					CREATE TABLE space_session_groups_new (
 						id TEXT PRIMARY KEY,
 						space_id TEXT NOT NULL,
@@ -2870,26 +2865,26 @@ function runMigration45(db: BunDatabase): void {
 						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 					)
 				`);
-				db.exec(`
+			db.exec(`
 					INSERT INTO space_session_groups_new
 					SELECT id, space_id, name, description, workflow_run_id, current_step_id, task_id, status, created_at, updated_at
 					FROM space_session_groups
 				`);
-				db.exec(`DROP TABLE space_session_groups`);
-				db.exec(`ALTER TABLE space_session_groups_new RENAME TO space_session_groups`);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
-				);
-				db.exec(
-					`CREATE INDEX IF NOT EXISTS idx_space_session_groups_task_id ON space_session_groups(task_id)`
-				);
-			}
-		} finally {
-			db.exec(`PRAGMA foreign_keys = ON`);
+			db.exec(`DROP TABLE space_session_groups`);
+			db.exec(`ALTER TABLE space_session_groups_new RENAME TO space_session_groups`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_space_session_groups_task_id ON space_session_groups(task_id)`
+			);
 		}
+
 		db.exec(`COMMIT`);
 	} catch (e) {
 		db.exec(`ROLLBACK`);
 		throw e;
+	} finally {
+		db.exec(`PRAGMA foreign_keys = ON`);
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2612,258 +2612,284 @@ function runMigration45(db: BunDatabase): void {
 		return;
 	}
 
-	// Check if already migrated by testing for new column name
-	if (tableHasColumn(db, 'space_workflow_nodes', 'id')) {
-		return; // Already migrated
+	// Check if already migrated by testing for absence of old table
+	if (!tableExists(db, 'space_workflow_steps')) {
+		return; // Already migrated (table was renamed)
 	}
 
-	db.exec(`PRAGMA foreign_keys = OFF`);
+	db.exec(`BEGIN`);
 	try {
-		// -------------------------------------------------------------------------
-		// 1. Rename space_workflow_steps -> space_workflow_nodes
-		// -------------------------------------------------------------------------
-		db.exec(`DROP TABLE IF EXISTS space_workflow_nodes_new`);
-		db.exec(`
-			CREATE TABLE space_workflow_nodes_new (
-				id TEXT PRIMARY KEY,
-				workflow_id TEXT NOT NULL,
-				name TEXT NOT NULL,
-				description TEXT NOT NULL DEFAULT '',
-				agent_id TEXT,
-				order_index INTEGER NOT NULL,
-				config TEXT,
-				created_at INTEGER NOT NULL,
-				updated_at INTEGER NOT NULL,
-				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
-			)
-		`);
-		db.exec(`
-			INSERT INTO space_workflow_nodes_new
-			SELECT id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at
-			FROM space_workflow_steps
-		`);
-		db.exec(`DROP TABLE space_workflow_steps`);
-		db.exec(`ALTER TABLE space_workflow_nodes_new RENAME TO space_workflow_nodes`);
-		db.exec(
-			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_workflow_id ON space_workflow_nodes(workflow_id)`
-		);
-		db.exec(
-			`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_order ON space_workflow_nodes(workflow_id, order_index)`
-		);
-
-		// -------------------------------------------------------------------------
-		// 2. Rename space_workflows.start_step_id -> start_node_id
-		// -------------------------------------------------------------------------
-		if (tableHasColumn(db, 'space_workflows', 'start_step_id')) {
-			db.exec(`DROP TABLE IF EXISTS space_workflows_new`);
+		db.exec(`PRAGMA foreign_keys = OFF`);
+		try {
+			// -------------------------------------------------------------------------
+			// 1. Rename space_workflow_steps -> space_workflow_nodes
+			// -------------------------------------------------------------------------
+			db.exec(`DROP TABLE IF EXISTS space_workflow_nodes_new`);
 			db.exec(`
-				CREATE TABLE space_workflows_new (
+				CREATE TABLE space_workflow_nodes_new (
 					id TEXT PRIMARY KEY,
-					space_id TEXT NOT NULL,
+					workflow_id TEXT NOT NULL,
 					name TEXT NOT NULL,
 					description TEXT NOT NULL DEFAULT '',
-					start_node_id TEXT,
+					agent_id TEXT,
+					order_index INTEGER NOT NULL,
 					config TEXT,
 					created_at INTEGER NOT NULL,
 					updated_at INTEGER NOT NULL,
-					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
-				)
-			`);
-			db.exec(`
-				INSERT INTO space_workflows_new
-				SELECT id, space_id, name, description, start_step_id, config, created_at, updated_at
-				FROM space_workflows
-			`);
-			db.exec(`DROP TABLE space_workflows`);
-			db.exec(`ALTER TABLE space_workflows_new RENAME TO space_workflows`);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`
-			);
-		}
-
-		// -------------------------------------------------------------------------
-		// 3. Rename space_workflow_transitions.from_step_id -> from_node_id
-		//                          and space_workflow_transitions.to_step_id -> to_node_id
-		// Also update FK references from space_workflow_steps to space_workflow_nodes
-		// -------------------------------------------------------------------------
-		if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
-			db.exec(`DROP TABLE IF EXISTS space_workflow_transitions_new`);
-			db.exec(`
-				CREATE TABLE space_workflow_transitions_new (
-					id TEXT PRIMARY KEY,
-					workflow_id TEXT NOT NULL,
-					from_node_id TEXT NOT NULL,
-					to_node_id TEXT NOT NULL,
-					condition TEXT,
-					order_index INTEGER NOT NULL DEFAULT 0,
-					created_at INTEGER NOT NULL,
-					updated_at INTEGER NOT NULL,
-					FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
-					FOREIGN KEY (from_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE,
-					FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
-				)
-			`);
-			db.exec(`
-				INSERT INTO space_workflow_transitions_new
-				SELECT id, workflow_id, from_step_id, to_step_id, condition, order_index, created_at, updated_at
-				FROM space_workflow_transitions
-			`);
-			db.exec(`DROP TABLE space_workflow_transitions`);
-			db.exec(`ALTER TABLE space_workflow_transitions_new RENAME TO space_workflow_transitions`);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
-			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_node ON space_workflow_transitions(workflow_id, from_node_id)`
-			);
-		}
-
-		// -------------------------------------------------------------------------
-		// 4. Rename space_workflow_runs.current_step_id -> current_node_id
-		// -------------------------------------------------------------------------
-		if (tableHasColumn(db, 'space_workflow_runs', 'current_step_id')) {
-			db.exec(`DROP TABLE IF EXISTS space_workflow_runs_new`);
-			db.exec(`
-				CREATE TABLE space_workflow_runs_new (
-					id TEXT PRIMARY KEY,
-					space_id TEXT NOT NULL,
-					workflow_id TEXT NOT NULL,
-					title TEXT NOT NULL,
-					description TEXT NOT NULL DEFAULT '',
-					current_step_index INTEGER NOT NULL DEFAULT 0,
-					current_node_id TEXT,
-					status TEXT NOT NULL DEFAULT 'pending'
-						CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
-					config TEXT,
-					created_at INTEGER NOT NULL,
-					updated_at INTEGER NOT NULL,
-					completed_at INTEGER,
-					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
 					FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
 				)
 			`);
 			db.exec(`
-				INSERT INTO space_workflow_runs_new
-				SELECT id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, created_at, updated_at, completed_at
-				FROM space_workflow_runs
+				INSERT INTO space_workflow_nodes_new
+				SELECT id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at
+				FROM space_workflow_steps
 			`);
-			db.exec(`DROP TABLE space_workflow_runs`);
-			db.exec(`ALTER TABLE space_workflow_runs_new RENAME TO space_workflow_runs`);
+			db.exec(`DROP TABLE space_workflow_steps`);
+			db.exec(`ALTER TABLE space_workflow_nodes_new RENAME TO space_workflow_nodes`);
 			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_workflow_id ON space_workflow_nodes(workflow_id)`
 			);
 			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
+				`CREATE INDEX IF NOT EXISTS idx_space_workflow_nodes_order ON space_workflow_nodes(workflow_id, order_index)`
 			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
-			);
-		}
 
-		// -------------------------------------------------------------------------
-		// 5. Rename space_tasks.workflow_step_id -> workflow_node_id
-		// -------------------------------------------------------------------------
-		if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
-			db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
-			db.exec(`
-				CREATE TABLE space_tasks_new (
-					id TEXT PRIMARY KEY,
-					space_id TEXT NOT NULL,
-					title TEXT NOT NULL,
-					description TEXT NOT NULL DEFAULT '',
-					status TEXT NOT NULL DEFAULT 'pending'
-						CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
-					priority TEXT NOT NULL DEFAULT 'normal'
-						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
-					task_type TEXT
-						CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
-					assigned_agent TEXT
-						CHECK(assigned_agent IN ('coder', 'general')),
-					custom_agent_id TEXT,
-					workflow_run_id TEXT,
-					workflow_node_id TEXT,
-					created_by_task_id TEXT,
-					goal_id TEXT,
-					progress INTEGER,
-					current_step TEXT,
-					result TEXT,
-					error TEXT,
-					depends_on TEXT NOT NULL DEFAULT '[]',
-					input_draft TEXT,
-					active_session TEXT
-						CHECK(active_session IN ('worker', 'leader')),
-					task_agent_session_id TEXT,
-					pr_url TEXT,
-					pr_number INTEGER,
-					pr_created_at INTEGER,
-					archived_at INTEGER,
-					created_at INTEGER NOT NULL,
-					started_at INTEGER,
-					completed_at INTEGER,
-					updated_at INTEGER NOT NULL,
-					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
-					FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
-				)
-			`);
-			db.exec(`
-				INSERT INTO space_tasks_new
-				SELECT id, space_id, title, description, status, priority, task_type, assigned_agent,
-							 custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id,
-							 progress, current_step, result, error, depends_on, input_draft, active_session,
-							 task_agent_session_id, pr_url, pr_number, pr_created_at, archived_at,
-							 created_at, started_at, completed_at, updated_at
-				FROM space_tasks
-			`);
-			db.exec(`DROP TABLE space_tasks`);
-			db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
-			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
-			db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
-			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
-			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
-			);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
-			);
-		}
+			// -------------------------------------------------------------------------
+			// 2. Rename space_workflows.start_step_id -> start_node_id
+			// Also preserve columns added by M30 (layout) and M36 (max_iterations)
+			// -------------------------------------------------------------------------
+			if (tableHasColumn(db, 'space_workflows', 'start_step_id')) {
+				db.exec(`DROP TABLE IF EXISTS space_workflows_new`);
+				db.exec(`
+					CREATE TABLE space_workflows_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						name TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						start_node_id TEXT,
+						config TEXT,
+						layout TEXT,
+						max_iterations INTEGER,
+						created_at INTEGER NOT NULL,
+						updated_at INTEGER NOT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+					)
+				`);
+				db.exec(`
+					INSERT INTO space_workflows_new
+					SELECT id, space_id, name, description, start_step_id, config, layout, max_iterations, created_at, updated_at
+					FROM space_workflows
+				`);
+				db.exec(`DROP TABLE space_workflows`);
+				db.exec(`ALTER TABLE space_workflows_new RENAME TO space_workflows`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflows_space_id ON space_workflows(space_id)`
+				);
+			}
 
-		// -------------------------------------------------------------------------
-		// 6. Rename space_session_groups.current_step_id -> current_node_id
-		// -------------------------------------------------------------------------
-		if (tableHasColumn(db, 'space_session_groups', 'current_step_id')) {
-			db.exec(`DROP TABLE IF EXISTS space_session_groups_new`);
-			db.exec(`
-				CREATE TABLE space_session_groups_new (
-					id TEXT PRIMARY KEY,
-					space_id TEXT NOT NULL,
-					name TEXT NOT NULL,
-					description TEXT,
-					workflow_run_id TEXT,
-					current_node_id TEXT,
-					task_id TEXT,
-					created_at INTEGER NOT NULL,
-					updated_at INTEGER NOT NULL,
-					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
-				)
-			`);
-			db.exec(`
-				INSERT INTO space_session_groups_new
-				SELECT id, space_id, name, description, workflow_run_id, current_step_id, task_id, created_at, updated_at
-				FROM space_session_groups
-			`);
-			db.exec(`DROP TABLE space_session_groups`);
-			db.exec(`ALTER TABLE space_session_groups_new RENAME TO space_session_groups`);
-			db.exec(
-				`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
-			);
+			// -------------------------------------------------------------------------
+			// 3. Rename space_workflow_transitions.from_step_id -> from_node_id
+			//                          and space_workflow_transitions.to_step_id -> to_node_id
+			// Also preserve is_cyclic column added by M38
+			// -------------------------------------------------------------------------
+			if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
+				db.exec(`DROP TABLE IF EXISTS space_workflow_transitions_new`);
+				db.exec(`
+					CREATE TABLE space_workflow_transitions_new (
+						id TEXT PRIMARY KEY,
+						workflow_id TEXT NOT NULL,
+						from_node_id TEXT NOT NULL,
+						to_node_id TEXT NOT NULL,
+						condition TEXT,
+						order_index INTEGER NOT NULL DEFAULT 0,
+						is_cyclic INTEGER,
+						created_at INTEGER NOT NULL,
+						updated_at INTEGER NOT NULL,
+						FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+						FOREIGN KEY (from_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE,
+						FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
+					)
+				`);
+				db.exec(`
+					INSERT INTO space_workflow_transitions_new
+					SELECT id, workflow_id, from_step_id, to_step_id, condition, order_index, is_cyclic, created_at, updated_at
+					FROM space_workflow_transitions
+				`);
+				db.exec(`DROP TABLE space_workflow_transitions`);
+				db.exec(`ALTER TABLE space_workflow_transitions_new RENAME TO space_workflow_transitions`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_node ON space_workflow_transitions(workflow_id, from_node_id)`
+				);
+			}
+
+			// -------------------------------------------------------------------------
+			// 4. Rename space_workflow_runs.current_step_id -> current_node_id
+			// Also preserve columns added by M35 (iteration_count, max_iterations) and M37 (goal_id)
+			// -------------------------------------------------------------------------
+			if (tableHasColumn(db, 'space_workflow_runs', 'current_step_id')) {
+				db.exec(`DROP TABLE IF EXISTS space_workflow_runs_new`);
+				db.exec(`
+					CREATE TABLE space_workflow_runs_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						workflow_id TEXT NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						current_step_index INTEGER NOT NULL DEFAULT 0,
+						current_node_id TEXT,
+						status TEXT NOT NULL DEFAULT 'pending'
+							CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+						config TEXT,
+						iteration_count INTEGER NOT NULL DEFAULT 0,
+						max_iterations INTEGER NOT NULL DEFAULT 5,
+						goal_id TEXT,
+						created_at INTEGER NOT NULL,
+						updated_at INTEGER NOT NULL,
+						completed_at INTEGER,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+						FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+					)
+				`);
+				db.exec(`
+					INSERT INTO space_workflow_runs_new
+					SELECT id, space_id, workflow_id, title, description, current_step_index, current_step_id, status, config, iteration_count, max_iterations, goal_id, created_at, updated_at, completed_at
+					FROM space_workflow_runs
+				`);
+				db.exec(`DROP TABLE space_workflow_runs`);
+				db.exec(`ALTER TABLE space_workflow_runs_new RENAME TO space_workflow_runs`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_space_id ON space_workflow_runs(space_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_workflow_id ON space_workflow_runs(workflow_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_status ON space_workflow_runs(status)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_workflow_runs_goal_id ON space_workflow_runs(goal_id)`
+				);
+			}
+
+			// -------------------------------------------------------------------------
+			// 5. Rename space_tasks.workflow_step_id -> workflow_node_id
+			// Also preserves goal_id column added by M34
+			// -------------------------------------------------------------------------
+			if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
+				db.exec(`DROP TABLE IF EXISTS space_tasks_new`);
+				db.exec(`
+					CREATE TABLE space_tasks_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						status TEXT NOT NULL DEFAULT 'pending'
+							CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+						priority TEXT NOT NULL DEFAULT 'normal'
+							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+						task_type TEXT
+							CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+						assigned_agent TEXT
+							CHECK(assigned_agent IN ('coder', 'general')),
+						custom_agent_id TEXT,
+						workflow_run_id TEXT,
+						workflow_node_id TEXT,
+						created_by_task_id TEXT,
+						goal_id TEXT,
+						progress INTEGER,
+						current_step TEXT,
+						result TEXT,
+						error TEXT,
+						depends_on TEXT NOT NULL DEFAULT '[]',
+						input_draft TEXT,
+						active_session TEXT
+							CHECK(active_session IN ('worker', 'leader')),
+						task_agent_session_id TEXT,
+						pr_url TEXT,
+						pr_number INTEGER,
+						pr_created_at INTEGER,
+						archived_at INTEGER,
+						created_at INTEGER NOT NULL,
+						started_at INTEGER,
+						completed_at INTEGER,
+						updated_at INTEGER NOT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+						FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+						FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
+					)
+				`);
+				db.exec(`
+					INSERT INTO space_tasks_new
+					SELECT id, space_id, title, description, status, priority, task_type, assigned_agent,
+								 custom_agent_id, workflow_run_id, workflow_step_id, created_by_task_id, goal_id,
+								 progress, current_step, result, error, depends_on, input_draft, active_session,
+								 task_agent_session_id, pr_url, pr_number, pr_created_at, archived_at,
+								 created_at, started_at, completed_at, updated_at
+					FROM space_tasks
+				`);
+				db.exec(`DROP TABLE space_tasks`);
+				db.exec(`ALTER TABLE space_tasks_new RENAME TO space_tasks`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_status ON space_tasks(status)`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)`
+				);
+				db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)`
+				);
+			}
+
+			// -------------------------------------------------------------------------
+			// 6. Rename space_session_groups.current_step_id -> current_node_id
+			// Also preserves status column added by M40
+			// -------------------------------------------------------------------------
+			if (tableHasColumn(db, 'space_session_groups', 'current_step_id')) {
+				db.exec(`DROP TABLE IF EXISTS space_session_groups_new`);
+				db.exec(`
+					CREATE TABLE space_session_groups_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						name TEXT NOT NULL,
+						description TEXT,
+						workflow_run_id TEXT,
+						current_node_id TEXT,
+						task_id TEXT,
+						status TEXT NOT NULL DEFAULT 'active'
+							CHECK(status IN ('active', 'completed', 'failed')),
+						created_at INTEGER NOT NULL,
+						updated_at INTEGER NOT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+					)
+				`);
+				db.exec(`
+					INSERT INTO space_session_groups_new
+					SELECT id, space_id, name, description, workflow_run_id, current_step_id, task_id, status, created_at, updated_at
+					FROM space_session_groups
+				`);
+				db.exec(`DROP TABLE space_session_groups`);
+				db.exec(`ALTER TABLE space_session_groups_new RENAME TO space_session_groups`);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_session_groups_space_id ON space_session_groups(space_id)`
+				);
+				db.exec(
+					`CREATE INDEX IF NOT EXISTS idx_space_session_groups_task_id ON space_session_groups(task_id)`
+				);
+			}
+		} finally {
+			db.exec(`PRAGMA foreign_keys = ON`);
 		}
-	} finally {
-		db.exec(`PRAGMA foreign_keys = ON`);
+		db.exec(`COMMIT`);
+	} catch (e) {
+		db.exec(`ROLLBACK`);
+		throw e;
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1628,9 +1628,11 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_workflow_id ON space_workflow_transitions(workflow_id)`
 	);
-	db.exec(
-		`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_step ON space_workflow_transitions(workflow_id, from_step_id)`
-	);
+	if (tableHasColumn(db, 'space_workflow_transitions', 'from_step_id')) {
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_workflow_transitions_from_step ON space_workflow_transitions(workflow_id, from_step_id)`
+		);
+	}
 
 	// -------------------------------------------------------------------------
 	// space_workflow_runs  (must be before space_tasks — FK dependency)
@@ -1715,9 +1717,11 @@ function runMigration29(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`
 	);
-	db.exec(
-		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
-	);
+	if (tableHasColumn(db, 'space_tasks', 'workflow_step_id')) {
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)`
+		);
+	}
 	// Note: idx_space_tasks_task_agent_session_id is created by migration 32,
 	// which first adds the column via ALTER TABLE for existing databases.
 	// Note: goal_id column is added by migration 34 (ALTER TABLE for existing DBs).
@@ -2609,7 +2613,8 @@ function runMigration44(db: BunDatabase): void {
 function runMigration45(db: BunDatabase): void {
 	// Skip if space_workflow_steps was already renamed to space_workflow_nodes,
 	// or if the spaces feature was never enabled on this DB.
-	if (!tableExists(db, 'space_workflow_steps')) {
+	// Also skip if space_workflow_nodes already exists (migration was already applied).
+	if (!tableExists(db, 'space_workflow_steps') || tableExists(db, 'space_workflow_nodes')) {
 		return;
 	}
 

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -55,7 +55,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
-			start_step_id TEXT,
+			start_node_id TEXT,
 			config TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
@@ -66,7 +66,7 @@ export function createSpaceAgentSchema(db: Database): void {
 	`);
 
 	db.exec(`
-		CREATE TABLE space_workflow_steps (
+		CREATE TABLE space_workflow_nodes (
 			id TEXT PRIMARY KEY,
 			workflow_id TEXT NOT NULL,
 			name TEXT NOT NULL,
@@ -103,6 +103,6 @@ export function insertWorkflowStep(
 ): void {
 	const now = Date.now();
 	db.prepare(
-		`INSERT INTO space_workflow_steps (id, workflow_id, name, agent_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		`INSERT INTO space_workflow_nodes (id, workflow_id, name, agent_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
 	).run(id, workflowId, `Step ${id}`, agentId, 0, now, now);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -62,7 +62,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
-			start_step_id TEXT,
+			start_node_id TEXT,
 			config TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
@@ -73,7 +73,7 @@ export function createSpaceTables(db: BunDatabase): void {
 	`);
 
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS space_workflow_steps (
+		CREATE TABLE IF NOT EXISTS space_workflow_nodes (
 			id TEXT PRIMARY KEY,
 			workflow_id TEXT NOT NULL,
 			name TEXT NOT NULL,
@@ -91,16 +91,16 @@ export function createSpaceTables(db: BunDatabase): void {
 		CREATE TABLE IF NOT EXISTS space_workflow_transitions (
 			id TEXT PRIMARY KEY,
 			workflow_id TEXT NOT NULL,
-			from_step_id TEXT NOT NULL,
-			to_step_id TEXT NOT NULL,
+			from_node_id TEXT NOT NULL,
+			to_node_id TEXT NOT NULL,
 			condition TEXT,
 			order_index INTEGER NOT NULL DEFAULT 0,
 			is_cyclic INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
-			FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
-			FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			FOREIGN KEY (from_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE,
+			FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
 		)
 	`);
 
@@ -112,7 +112,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			current_step_index INTEGER NOT NULL DEFAULT 0,
-			current_step_id TEXT,
+			current_node_id TEXT,
 			status TEXT NOT NULL DEFAULT 'pending'
 				CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
 			config TEXT,
@@ -143,7 +143,7 @@ export function createSpaceTables(db: BunDatabase): void {
 				CHECK(assigned_agent IN ('coder', 'general')),
 			custom_agent_id TEXT,
 			workflow_run_id TEXT,
-			workflow_step_id TEXT,
+			workflow_node_id TEXT,
 			created_by_task_id TEXT,
 			goal_id TEXT,
 			progress INTEGER,
@@ -165,7 +165,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
 			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
-			FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+			FOREIGN KEY (workflow_node_id) REFERENCES space_workflow_nodes(id) ON DELETE SET NULL
 		)
 	`);
 
@@ -176,7 +176,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			name TEXT NOT NULL,
 			description TEXT,
 			workflow_run_id TEXT,
-			current_step_id TEXT,
+			current_node_id TEXT,
 			task_id TEXT,
 			status TEXT NOT NULL DEFAULT 'active'
 				CHECK(status IN ('active', 'completed', 'failed')),

--- a/packages/daemon/tests/unit/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-agent-handlers.test.ts
@@ -454,7 +454,7 @@ describe('Space Agent RPC Handlers', () => {
 			insertWorkflowStep(db, 'step-3', 'wf-3', agentId);
 
 			// Remove the step reference by setting agent_id to NULL
-			db.prepare(`UPDATE space_workflow_steps SET agent_id = NULL WHERE id = 'step-3'`).run();
+			db.prepare(`UPDATE space_workflow_nodes SET agent_id = NULL WHERE id = 'step-3'`).run();
 
 			const result = await call<{ success: boolean }>(hubData.handlers, 'spaceAgent.delete', {
 				id: agentId,

--- a/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-export-import-handlers.test.ts
@@ -74,7 +74,7 @@ function createSchema(db: Database): void {
 			space_id TEXT NOT NULL,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
-			start_step_id TEXT,
+			start_node_id TEXT,
 			config TEXT,
 			layout TEXT,
 			max_iterations INTEGER,
@@ -85,7 +85,7 @@ function createSchema(db: Database): void {
 	`);
 
 	db.exec(`
-		CREATE TABLE space_workflow_steps (
+		CREATE TABLE space_workflow_nodes (
 			id TEXT PRIMARY KEY,
 			workflow_id TEXT NOT NULL,
 			name TEXT NOT NULL,
@@ -103,16 +103,16 @@ function createSchema(db: Database): void {
 		CREATE TABLE space_workflow_transitions (
 			id TEXT PRIMARY KEY,
 			workflow_id TEXT NOT NULL,
-			from_step_id TEXT NOT NULL,
-			to_step_id TEXT NOT NULL,
+			from_node_id TEXT NOT NULL,
+			to_node_id TEXT NOT NULL,
 			condition TEXT,
 			order_index INTEGER NOT NULL DEFAULT 0,
 			is_cyclic INTEGER,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
-			FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
-			FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			FOREIGN KEY (from_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE,
+			FOREIGN KEY (to_node_id) REFERENCES space_workflow_nodes(id) ON DELETE CASCADE
 		)
 	`);
 }

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-message-handlers.test.ts
@@ -130,7 +130,7 @@ function createMockDatabase(
 						priority: task.priority,
 						depends_on: '[]',
 						task_agent_session_id: task.taskAgentSessionId ?? null,
-						workflow_step_id: null,
+						workflow_node_id: null,
 						workflow_run_id: null,
 						result: null,
 						error: null,

--- a/packages/daemon/tests/unit/space/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/space/space-workflow.test.ts
@@ -273,7 +273,7 @@ describe('SpaceWorkflowRepository', () => {
 		expect(repo.getWorkflow(wf.id)).toBeNull();
 
 		// Steps should be gone (CASCADE)
-		const rows = db.prepare(`SELECT * FROM space_workflow_steps WHERE workflow_id = ?`).all(wf.id);
+		const rows = db.prepare(`SELECT * FROM space_workflow_nodes WHERE workflow_id = ?`).all(wf.id);
 		expect(rows).toHaveLength(0);
 	});
 
@@ -533,7 +533,7 @@ describe('SpaceWorkflowRepository', () => {
 
 		// Verify agent_id column is set
 		const row = db
-			.prepare('SELECT agent_id FROM space_workflow_steps WHERE workflow_id = ?')
+			.prepare('SELECT agent_id FROM space_workflow_nodes WHERE workflow_id = ?')
 			.get(wf.id) as { agent_id: string };
 		expect(row.agent_id).toBe('agent-99');
 	});

--- a/packages/daemon/tests/unit/space/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-manager.test.ts
@@ -932,20 +932,20 @@ describe('TaskAgentManager', () => {
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
 				.run(wfId, ctx.spaceId, 'Test WF', now, now);
 			const stepId = 'step-complete-1';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_steps (id, workflow_id, name, description, order_index, created_at, updated_at)
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, order_index, created_at, updated_at)
            VALUES (?, ?, ?, '', 0, ?, ?)`
 				)
 				.run(stepId, wfId, 'Step 1', now, now);
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
            VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
 				)
 				.run(wfRunId, ctx.spaceId, wfId, now, now);
@@ -1694,14 +1694,14 @@ describe('TaskAgentManager', () => {
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
 				.run(wfId, ctx.spaceId, 'WF Reorient', now, now);
 			const wfRunId = 'run-reorient-workflow';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
            VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
 				)
 				.run(wfRunId, ctx.spaceId, wfId, now, now);
@@ -1860,21 +1860,21 @@ describe('TaskAgentManager', () => {
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
 				.run(wfId, ctx.spaceId, 'WF Rehydrate Sub', now, now);
 			const stepId = 'step-rehydrate-1';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_steps (id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at)
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, agent_id, order_index, config, created_at, updated_at)
            VALUES (?, ?, ?, '', ?, 0, null, ?, ?)`
 				)
 				.run(stepId, wfId, 'Step 1', ctx.agentId, now, now);
 			const wfRunId = 'run-rehydrate-sub';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
            VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
 				)
 				.run(wfRunId, ctx.spaceId, wfId, now, now);
@@ -1928,14 +1928,14 @@ describe('TaskAgentManager', () => {
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
 				.run(wfId, ctx.spaceId, 'WF Sub No Start', now, now);
 			const wfRunId = 'run-rehydrate-no-start';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
            VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
 				)
 				.run(wfRunId, ctx.spaceId, wfId, now, now);
@@ -1985,14 +1985,14 @@ describe('TaskAgentManager', () => {
 			const now = Date.now();
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflows (id, space_id, name, description, start_step_id, config, layout, created_at, updated_at)
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, config, layout, created_at, updated_at)
            VALUES (?, ?, ?, '', null, '{}', '{}', ?, ?)`
 				)
 				.run(wfId, ctx.spaceId, 'WF Step MCP', now, now);
 			const wfRunId = 'run-rehydrate-step-mcp';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_step_id, created_at, updated_at)
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, current_node_id, created_at, updated_at)
            VALUES (?, ?, ?, '', 'in_progress', null, ?, ?)`
 				)
 				.run(wfRunId, ctx.spaceId, wfId, now, now);

--- a/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-29_test.ts
@@ -6,11 +6,11 @@
  * Covers:
  * - All Space tables created correctly on a fresh DB (including space_workflow_transitions)
  * - space_agents has role/provider columns from the start (no CHECK constraint on role)
- * - space_workflows has start_step_id column from the start
- * - space_workflow_runs has current_step_id column from the start
+ * - space_workflows has start_node_id column from the start (renamed by M45)
+ * - space_workflow_runs has current_node_id column from the start (renamed by M45)
  * - Migration is idempotent (runs twice without error)
  * - No existing tables are affected
- * - space_tasks has custom_agent_id, workflow_run_id, workflow_step_id columns from the start
+ * - space_tasks has custom_agent_id, workflow_run_id, workflow_node_id columns from the start (renamed by M45)
  * - FK CASCADE deletes work: delete space → all child rows deleted
  * - space_tasks.workflow_run_id SET NULL on workflow run delete
  * - CHECK constraints are enforced (status, priority, etc.)
@@ -81,7 +81,7 @@ describe('Migration 29: Space system tables', () => {
 			'spaces',
 			'space_agents',
 			'space_workflows',
-			'space_workflow_steps',
+			'space_workflow_nodes',
 			'space_workflow_transitions',
 			'space_workflow_runs',
 			'space_tasks',
@@ -113,9 +113,9 @@ describe('Migration 29: Space system tables', () => {
 		expect(columnExists(db, 'space_tasks', 'workflow_run_id')).toBe(true);
 	});
 
-	test('space_tasks has workflow_step_id column from the start', () => {
+	test('space_tasks has workflow_node_id column from the start', () => {
 		runMigrations(db, () => {});
-		expect(columnExists(db, 'space_tasks', 'workflow_step_id')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'workflow_node_id')).toBe(true);
 	});
 
 	// -------------------------------------------------------------------------
@@ -132,7 +132,7 @@ describe('Migration 29: Space system tables', () => {
 			'title',
 			'description',
 			'current_step_index',
-			'current_step_id',
+			'current_node_id',
 			'status',
 			'config',
 			'created_at',
@@ -167,9 +167,9 @@ describe('Migration 29: Space system tables', () => {
 		}
 	});
 
-	test('space_workflows has start_step_id column', () => {
+	test('space_workflows has start_node_id column', () => {
 		runMigrations(db, () => {});
-		expect(columnExists(db, 'space_workflows', 'start_step_id')).toBe(true);
+		expect(columnExists(db, 'space_workflows', 'start_node_id')).toBe(true);
 	});
 
 	test('space_workflow_runs status CHECK constraint is enforced', () => {
@@ -216,17 +216,17 @@ describe('Migration 29: Space system tables', () => {
 			// already creates an implicit index, so an explicit one would be redundant.
 			'idx_space_agents_space_id',
 			'idx_space_workflows_space_id',
-			'idx_space_workflow_steps_workflow_id',
-			'idx_space_workflow_steps_order',
+			'idx_space_workflow_nodes_workflow_id',
+			'idx_space_workflow_nodes_order',
 			'idx_space_workflow_transitions_workflow_id',
-			'idx_space_workflow_transitions_from_step',
+			'idx_space_workflow_transitions_from_node',
 			'idx_space_workflow_runs_space_id',
 			'idx_space_workflow_runs_workflow_id',
 			'idx_space_workflow_runs_status',
 			'idx_space_tasks_space_id',
 			'idx_space_tasks_status',
 			'idx_space_tasks_workflow_run_id',
-			'idx_space_tasks_workflow_step_id',
+			'idx_space_tasks_workflow_node_id',
 			'idx_space_tasks_custom_agent_id',
 			'idx_space_session_groups_space_id',
 			'idx_space_session_group_members_group_id',
@@ -267,7 +267,7 @@ describe('Migration 29: Space system tables', () => {
 
 		// Insert a workflow step
 		db.exec(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at)
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at)
 			 VALUES ('step-1', 'wf-1', 'Step 1', 0, ${now}, ${now})`
 		);
 
@@ -304,7 +304,7 @@ describe('Migration 29: Space system tables', () => {
 			0
 		);
 		expect(
-			db.prepare(`SELECT * FROM space_workflow_steps WHERE workflow_id = 'wf-1'`).all()
+			db.prepare(`SELECT * FROM space_workflow_nodes WHERE workflow_id = 'wf-1'`).all()
 		).toHaveLength(0);
 		expect(
 			db.prepare(`SELECT * FROM space_workflow_runs WHERE space_id = 'sp-1'`).all()
@@ -513,10 +513,10 @@ describe('Migration 29: Space system tables', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// SET NULL on space_workflow_steps delete
+	// SET NULL on space_workflow_nodes delete
 	// -------------------------------------------------------------------------
 
-	test('deleting a workflow step sets space_tasks.workflow_step_id to NULL', () => {
+	test('deleting a workflow node sets space_tasks.workflow_node_id to NULL', () => {
 		runMigrations(db, () => {});
 
 		const now = Date.now();
@@ -530,24 +530,24 @@ describe('Migration 29: Space system tables', () => {
 			 VALUES ('wf-step', 'sp-step', 'Workflow Step', ${now}, ${now})`
 		);
 		db.exec(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at)
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at)
 			 VALUES ('step-s1', 'wf-step', 'Step 1', 0, ${now}, ${now})`
 		);
 		db.exec(
-			`INSERT INTO space_tasks (id, space_id, title, workflow_step_id, created_at, updated_at)
+			`INSERT INTO space_tasks (id, space_id, title, workflow_node_id, created_at, updated_at)
 			 VALUES ('task-step', 'sp-step', 'Task Step', 'step-s1', ${now}, ${now})`
 		);
 
-		// Delete the workflow step
-		db.exec(`DELETE FROM space_workflow_steps WHERE id = 'step-s1'`);
+		// Delete the workflow node
+		db.exec(`DELETE FROM space_workflow_nodes WHERE id = 'step-s1'`);
 
-		// Task should still exist, but workflow_step_id should be NULL
+		// Task should still exist, but workflow_node_id should be NULL
 		const task = db.prepare(`SELECT * FROM space_tasks WHERE id = 'task-step'`).get() as Record<
 			string,
 			unknown
 		>;
 		expect(task).toBeTruthy();
-		expect(task['workflow_step_id']).toBeNull();
+		expect(task['workflow_node_id']).toBeNull();
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-34_test.ts
@@ -365,7 +365,7 @@ describe('Migration 34: Add archived to status CHECK constraints', () => {
 			'CREATE INDEX IF NOT EXISTS idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)'
 		);
 		db.exec(
-			'CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_step_id ON space_tasks(workflow_step_id)'
+			'CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_node_id ON space_tasks(workflow_node_id)'
 		);
 		db.exec(
 			'CREATE INDEX IF NOT EXISTS idx_space_tasks_task_agent_session_id ON space_tasks(task_agent_session_id)'

--- a/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
@@ -76,13 +76,13 @@ describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
 		).run('wf-1', 'space-1', 'Test Workflow', now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('step-1', 'wf-1', 'Step A', 0, now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('step-2', 'wf-1', 'Step B', 1, now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_node_id, to_node_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
 		).run('trans-1', 'wf-1', 'step-1', 'step-2', 0, now, now);
 
 		const row = db
@@ -102,13 +102,13 @@ describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
 			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
 		).run('wf-1', 'space-1', 'Test Workflow', now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('step-1', 'wf-1', 'Step A', 0, now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 		).run('step-2', 'wf-1', 'Step B', 1, now, now);
 		db.prepare(
-			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_node_id, to_node_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 		).run('trans-1', 'wf-1', 'step-1', 'step-2', 1, 0, now, now);
 
 		const row = db

--- a/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-38_test.ts
@@ -122,7 +122,8 @@ describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
 	// -------------------------------------------------------------------------
 
 	test('legacy DB: column is added to existing table that lacks it', () => {
-		// Create prerequisite tables and space_workflow_transitions as it existed before migration 38
+		// Create prerequisite tables as they existed before migration 38
+		// Note: M45 renames step→node columns/tables, so we include all tables M45 expects
 		db.exec(`
 			CREATE TABLE spaces (
 				id TEXT PRIMARY KEY,
@@ -161,6 +162,7 @@ describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
 				id TEXT PRIMARY KEY,
 				workflow_id TEXT NOT NULL,
 				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
 				agent_id TEXT,
 				order_index INTEGER NOT NULL DEFAULT 0,
 				config TEXT,
@@ -180,6 +182,86 @@ describe('Migration 38: Add is_cyclic to space_workflow_transitions', () => {
 				created_at INTEGER NOT NULL,
 				updated_at INTEGER NOT NULL,
 				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT,
+				assigned_agent TEXT,
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT,
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_session_groups (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT,
+				workflow_run_id TEXT,
+				current_step_id TEXT,
+				task_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_session_group_members (
+				id TEXT PRIMARY KEY,
+				group_id TEXT NOT NULL,
+				session_id TEXT NOT NULL,
+				role TEXT NOT NULL,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				created_at INTEGER NOT NULL,
+				FOREIGN KEY (group_id) REFERENCES space_session_groups(id) ON DELETE CASCADE
 			)
 		`);
 

--- a/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
@@ -717,7 +717,7 @@ describe('Migration 45: rename step to node in workflow tables', () => {
 		const transExists = db
 			.prepare(`SELECT id FROM space_workflow_transitions WHERE id='trans-1'`)
 			.get();
-		expect(transExists).toBeUndefined(); // No transition inserted, so should not exist
+		expect(transExists).toBeNull(); // No transition inserted, so should not exist
 	});
 
 	test('preserves columns added by earlier migrations', () => {

--- a/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
@@ -915,7 +915,7 @@ describe('Migration 45: rename step to node in workflow tables', () => {
 
 		// Verify M38 column (is_cyclic) preserved
 		db.prepare(
-			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_node_id, to_node_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 		).run('trans-1', 'wf-1', 'step-1', 'step-1', 1, 0, now, now);
 		const trans = db
 			.prepare(`SELECT is_cyclic FROM space_workflow_transitions WHERE id='trans-1'`)

--- a/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-45_test.ts
@@ -1,0 +1,938 @@
+/**
+ * Migration 45 Tests
+ *
+ * Migration 45 renames step-related columns and tables to node:
+ * - space_workflow_steps -> space_workflow_nodes
+ * - space_workflows.start_step_id -> start_node_id
+ * - space_workflow_transitions.from_step_id -> from_node_id
+ * - space_workflow_transitions.to_step_id -> to_node_id
+ * - space_tasks.workflow_step_id -> workflow_node_id
+ * - space_workflow_runs.current_step_id -> current_node_id
+ * - space_session_groups.current_step_id -> current_node_id
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations, createTables } from '../../../../src/storage/schema/index.ts';
+
+function columnExists(db: BunDatabase, table: string, column: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM pragma_table_info('${table}') WHERE name = ?`)
+		.get(column);
+	return !!result;
+}
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+function getIndexes(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? ORDER BY name`)
+		.all(table) as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+describe('Migration 45: rename step to node in workflow tables', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-45', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+
+		const dbPath = join(testDir, 'test.db');
+		db = new BunDatabase(dbPath);
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('fresh DB has node column names (not step)', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		// space_workflow_nodes table exists (not space_workflow_steps)
+		expect(tableExists(db, 'space_workflow_nodes')).toBe(true);
+		expect(tableExists(db, 'space_workflow_steps')).toBe(false);
+
+		// space_workflows has start_node_id (not start_step_id)
+		expect(columnExists(db, 'space_workflows', 'start_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflows', 'start_step_id')).toBe(false);
+
+		// space_workflow_transitions has from_node_id and to_node_id
+		expect(columnExists(db, 'space_workflow_transitions', 'from_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_transitions', 'to_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_transitions', 'from_step_id')).toBe(false);
+		expect(columnExists(db, 'space_workflow_transitions', 'to_step_id')).toBe(false);
+
+		// space_tasks has workflow_node_id
+		expect(columnExists(db, 'space_tasks', 'workflow_node_id')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'workflow_step_id')).toBe(false);
+
+		// space_workflow_runs has current_node_id
+		expect(columnExists(db, 'space_workflow_runs', 'current_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_runs', 'current_step_id')).toBe(false);
+
+		// space_session_groups has current_node_id
+		expect(columnExists(db, 'space_session_groups', 'current_node_id')).toBe(true);
+		expect(columnExists(db, 'space_session_groups', 'current_step_id')).toBe(false);
+	});
+
+	test('fresh DB has correct indexes', () => {
+		runMigrations(db, () => {});
+		createTables(db);
+
+		const nodeIndexes = getIndexes(db, 'space_workflow_nodes');
+		expect(nodeIndexes).toContain('idx_space_workflow_nodes_order');
+		expect(nodeIndexes).toContain('idx_space_workflow_nodes_workflow_id');
+
+		const taskIndexes = getIndexes(db, 'space_tasks');
+		expect(taskIndexes).toContain('idx_space_tasks_workflow_node_id');
+		expect(taskIndexes).toContain('idx_space_tasks_goal_id');
+
+		const runIndexes = getIndexes(db, 'space_workflow_runs');
+		expect(runIndexes).toContain('idx_space_workflow_runs_goal_id');
+	});
+
+	test('existing DB with old schema gets migrated correctly', () => {
+		// Create a pre-migration-45 schema with step column names
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				start_step_id TEXT,
+				config TEXT,
+				layout TEXT,
+				max_iterations INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_steps (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				agent_id TEXT,
+				order_index INTEGER NOT NULL,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_transitions (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				from_step_id TEXT NOT NULL,
+				to_step_id TEXT NOT NULL,
+				condition TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				is_cyclic INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+				FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
+				FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+				config TEXT,
+				iteration_count INTEGER NOT NULL DEFAULT 0,
+				max_iterations INTEGER NOT NULL DEFAULT 5,
+				goal_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general')),
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_session_groups (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT,
+				workflow_run_id TEXT,
+				current_step_id TEXT,
+				task_id TEXT,
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'completed', 'failed')),
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		// Insert test data
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/test', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, start_step_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', 'step-1', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step 1', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-2', 'wf-1', 'Step 2', 1, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('trans-1', 'wf-1', 'step-1', 'step-2', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, current_step_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Test Run', 'step-1', 'in_progress', now, now);
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, workflow_step_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'space-1', 'Test Task', 'step-1', now, now);
+		db.prepare(
+			`INSERT INTO space_session_groups (id, space_id, name, current_step_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('group-1', 'space-1', 'Test Group', 'step-1', 'active', now, now);
+
+		// Run migrations
+		runMigrations(db, () => {});
+
+		// Verify table rename
+		expect(tableExists(db, 'space_workflow_nodes')).toBe(true);
+		expect(tableExists(db, 'space_workflow_steps')).toBe(false);
+
+		// Verify column renames in space_workflows
+		expect(columnExists(db, 'space_workflows', 'start_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflows', 'start_step_id')).toBe(false);
+
+		// Verify data preserved in space_workflows
+		const wf = db
+			.prepare(`SELECT id, start_node_id FROM space_workflows WHERE id='wf-1'`)
+			.get() as {
+			id: string;
+			start_node_id: string | null;
+		};
+		expect(wf.start_node_id).toBe('step-1');
+
+		// Verify column renames in space_workflow_transitions
+		expect(columnExists(db, 'space_workflow_transitions', 'from_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_transitions', 'to_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_transitions', 'from_step_id')).toBe(false);
+		expect(columnExists(db, 'space_workflow_transitions', 'to_step_id')).toBe(false);
+
+		// Verify data preserved in space_workflow_transitions
+		const trans = db
+			.prepare(
+				`SELECT id, from_node_id, to_node_id FROM space_workflow_transitions WHERE id='trans-1'`
+			)
+			.get() as {
+			id: string;
+			from_node_id: string;
+			to_node_id: string;
+		};
+		expect(trans.from_node_id).toBe('step-1');
+		expect(trans.to_node_id).toBe('step-2');
+
+		// Verify column rename in space_workflow_runs
+		expect(columnExists(db, 'space_workflow_runs', 'current_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_runs', 'current_step_id')).toBe(false);
+
+		// Verify data preserved in space_workflow_runs
+		const run = db
+			.prepare(`SELECT id, current_node_id FROM space_workflow_runs WHERE id='run-1'`)
+			.get() as {
+			id: string;
+			current_node_id: string | null;
+		};
+		expect(run.current_node_id).toBe('step-1');
+
+		// Verify column rename in space_tasks
+		expect(columnExists(db, 'space_tasks', 'workflow_node_id')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'workflow_step_id')).toBe(false);
+
+		// Verify data preserved in space_tasks
+		const task = db
+			.prepare(`SELECT id, workflow_node_id FROM space_tasks WHERE id='task-1'`)
+			.get() as {
+			id: string;
+			workflow_node_id: string | null;
+		};
+		expect(task.workflow_node_id).toBe('step-1');
+
+		// Verify column rename in space_session_groups
+		expect(columnExists(db, 'space_session_groups', 'current_node_id')).toBe(true);
+		expect(columnExists(db, 'space_session_groups', 'current_step_id')).toBe(false);
+
+		// Verify data preserved in space_session_groups
+		const group = db
+			.prepare(`SELECT id, current_node_id FROM space_session_groups WHERE id='group-1'`)
+			.get() as {
+			id: string;
+			current_node_id: string | null;
+		};
+		expect(group.current_node_id).toBe('step-1');
+	});
+
+	test('migration is idempotent - re-running does not change anything', () => {
+		// Create pre-migration schema with step names
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				start_step_id TEXT,
+				config TEXT,
+				layout TEXT,
+				max_iterations INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_steps (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				agent_id TEXT,
+				order_index INTEGER NOT NULL,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_transitions (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				from_step_id TEXT NOT NULL,
+				to_step_id TEXT NOT NULL,
+				condition TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				is_cyclic INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+				FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
+				FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+				config TEXT,
+				iteration_count INTEGER NOT NULL DEFAULT 0,
+				max_iterations INTEGER NOT NULL DEFAULT 5,
+				goal_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general')),
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_session_groups (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT,
+				workflow_run_id TEXT,
+				current_step_id TEXT,
+				task_id TEXT,
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'completed', 'failed')),
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/test', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, start_step_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', 'step-1', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step 1', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, current_step_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Test Run', 'step-1', 'in_progress', now, now);
+
+		// Run migrations twice
+		runMigrations(db, () => {});
+		runMigrations(db, () => {});
+
+		// Should still have node columns
+		expect(tableExists(db, 'space_workflow_nodes')).toBe(true);
+		expect(columnExists(db, 'space_workflows', 'start_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_transitions', 'from_node_id')).toBe(true);
+		expect(columnExists(db, 'space_workflow_runs', 'current_node_id')).toBe(true);
+
+		// Data should still be intact
+		const wf = db.prepare(`SELECT start_node_id FROM space_workflows WHERE id='wf-1'`).get() as {
+			start_node_id: string | null;
+		};
+		expect(wf.start_node_id).toBe('step-1');
+	});
+
+	test('foreign key relationships are preserved after migration', () => {
+		// Create pre-migration schema
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				start_step_id TEXT,
+				config TEXT,
+				layout TEXT,
+				max_iterations INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_steps (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				agent_id TEXT,
+				order_index INTEGER NOT NULL,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_transitions (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				from_step_id TEXT NOT NULL,
+				to_step_id TEXT NOT NULL,
+				condition TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				is_cyclic INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+				FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
+				FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+				config TEXT,
+				iteration_count INTEGER NOT NULL DEFAULT 0,
+				max_iterations INTEGER NOT NULL DEFAULT 5,
+				goal_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general')),
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/test', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step 1', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Test Run', 'in_progress', now, now);
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, title, workflow_step_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('task-1', 'space-1', 'Test Task', 'step-1', now, now);
+
+		// Run migration
+		runMigrations(db, () => {});
+
+		// FK from space_tasks to space_workflow_nodes should work
+		const task = db.prepare(`SELECT workflow_node_id FROM space_tasks WHERE id='task-1'`).get() as {
+			workflow_node_id: string | null;
+		};
+		expect(task.workflow_node_id).toBe('step-1');
+
+		// FK from space_workflow_transitions to space_workflow_nodes should work
+		const transExists = db
+			.prepare(`SELECT id FROM space_workflow_transitions WHERE id='trans-1'`)
+			.get();
+		expect(transExists).toBeUndefined(); // No transition inserted, so should not exist
+	});
+
+	test('preserves columns added by earlier migrations', () => {
+		// Create pre-migration schema with M30/M35/M36/M37/M38/M40 columns
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level TEXT NOT NULL DEFAULT 'supervised',
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflows (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				start_step_id TEXT,
+				config TEXT,
+				layout TEXT,
+				max_iterations INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_steps (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				agent_id TEXT,
+				order_index INTEGER NOT NULL,
+				config TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_transitions (
+				id TEXT PRIMARY KEY,
+				workflow_id TEXT NOT NULL,
+				from_step_id TEXT NOT NULL,
+				to_step_id TEXT NOT NULL,
+				condition TEXT,
+				order_index INTEGER NOT NULL DEFAULT 0,
+				is_cyclic INTEGER,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE,
+				FOREIGN KEY (from_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE,
+				FOREIGN KEY (to_step_id) REFERENCES space_workflow_steps(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_workflow_runs (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				workflow_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				current_step_index INTEGER NOT NULL DEFAULT 0,
+				current_step_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'completed', 'cancelled', 'needs_attention')),
+				config TEXT,
+				iteration_count INTEGER NOT NULL DEFAULT 0,
+				max_iterations INTEGER NOT NULL DEFAULT 5,
+				goal_id TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				completed_at INTEGER,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_id) REFERENCES space_workflows(id) ON DELETE CASCADE
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('draft', 'pending', 'in_progress', 'review', 'completed', 'needs_attention', 'cancelled', 'archived')),
+				priority TEXT NOT NULL DEFAULT 'normal'
+					CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+				task_type TEXT
+					CHECK(task_type IN ('planning', 'coding', 'research', 'design', 'review')),
+				assigned_agent TEXT
+					CHECK(assigned_agent IN ('coder', 'general')),
+				custom_agent_id TEXT,
+				workflow_run_id TEXT,
+				workflow_step_id TEXT,
+				created_by_task_id TEXT,
+				goal_id TEXT,
+				progress INTEGER,
+				current_step TEXT,
+				result TEXT,
+				error TEXT,
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				input_draft TEXT,
+				active_session TEXT
+					CHECK(active_session IN ('worker', 'leader')),
+				task_agent_session_id TEXT,
+				pr_url TEXT,
+				pr_number INTEGER,
+				pr_created_at INTEGER,
+				archived_at INTEGER,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+				FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL,
+				FOREIGN KEY (workflow_step_id) REFERENCES space_workflow_steps(id) ON DELETE SET NULL
+			)
+		`);
+
+		db.exec(`
+			CREATE TABLE space_session_groups (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				name TEXT NOT NULL,
+				description TEXT,
+				workflow_run_id TEXT,
+				current_step_id TEXT,
+				task_id TEXT,
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'completed', 'failed')),
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('space-1', '/workspace/test', 'Test Space', now, now);
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, layout, max_iterations, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('wf-1', 'space-1', 'Test Workflow', '{"nodes":{}}', 10, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('step-1', 'wf-1', 'Step 1', 0, now, now);
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, iteration_count, max_iterations, goal_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('run-1', 'space-1', 'wf-1', 'Test Run', 3, 10, 'goal-1', now, now);
+
+		// Run migration
+		runMigrations(db, () => {});
+
+		// Verify M30 column (layout) preserved
+		const wf = db
+			.prepare(`SELECT layout, max_iterations FROM space_workflows WHERE id='wf-1'`)
+			.get() as {
+			layout: string | null;
+			max_iterations: number | null;
+		};
+		expect(wf.layout).toBe('{"nodes":{}}');
+		expect(wf.max_iterations).toBe(10);
+
+		// Verify M35 columns (iteration_count, max_iterations) preserved
+		const run = db
+			.prepare(
+				`SELECT iteration_count, max_iterations, goal_id FROM space_workflow_runs WHERE id='run-1'`
+			)
+			.get() as {
+			iteration_count: number;
+			max_iterations: number;
+			goal_id: string | null;
+		};
+		expect(run.iteration_count).toBe(3);
+		expect(run.max_iterations).toBe(10);
+		expect(run.goal_id).toBe('goal-1');
+
+		// Verify M38 column (is_cyclic) preserved
+		db.prepare(
+			`INSERT INTO space_workflow_transitions (id, workflow_id, from_step_id, to_step_id, is_cyclic, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		).run('trans-1', 'wf-1', 'step-1', 'step-1', 1, 0, now, now);
+		const trans = db
+			.prepare(`SELECT is_cyclic FROM space_workflow_transitions WHERE id='trans-1'`)
+			.get() as {
+			is_cyclic: number | null;
+		};
+		expect(trans.is_cyclic).toBe(1);
+
+		// Verify M40 column (status) preserved
+		db.prepare(
+			`INSERT INTO space_session_groups (id, space_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+		).run('group-1', 'space-1', 'Test Group', 'completed', now, now);
+		const group = db
+			.prepare(`SELECT status FROM space_session_groups WHERE id='group-1'`)
+			.get() as {
+			status: string;
+		};
+		expect(group.status).toBe('completed');
+	});
+});

--- a/packages/daemon/tests/unit/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/storage/space-task-repository.test.ts
@@ -46,7 +46,7 @@ describe('SpaceTaskRepository', () => {
 
 		(db as any)
 			.prepare(
-				`INSERT INTO space_workflow_steps (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflow_nodes (id, workflow_id, name, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
 			)
 			.run(workflowStepId, workflowId, 'Step 1', 0, now, now);
 	});


### PR DESCRIPTION
Renames space_workflow_steps -> space_workflow_nodes and updates all
related columns: start_step_id, from_step_id, to_step_id,
workflow_step_id, and current_step_id across space_workflows,
space_workflow_transitions, space_workflow_runs, space_tasks, and
space_session_groups. Uses create-copy-drop-rename pattern for
SQLite compatibility.
