### PR TITLE
refactor: remove relay_message from Task Agent tool set

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -20,7 +20,6 @@
  *   - report_result         — Mark the task complete/failed and record the result summary
  *   - request_human_input   — Surface a human gate and block until the user responds
  *   - list_group_members    — List all group members with session IDs and permitted channels
- *   - relay_message         — Inject a user-turn message into any group member (unrestricted)
  *
  * ## Content interpolation
  * All operator-supplied content (space.backgroundContext, space.instructions,
@@ -208,14 +207,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 		`- **list_group_members** — List all members of the current task's session group. ` +
 			`Returns each member's \`sessionId\`, \`role\`, \`agentId\`, \`status\`, and ` +
 			`\`permittedTargets\` (which roles they can message per the declared channel topology). ` +
-			`Use this to discover active sub-sessions before calling \`relay_message\`.`
-	);
-	sections.push(
-		`- **relay_message** — Inject a user-turn message into any group member's session. ` +
-			`Pass \`target_session_id\` (from \`list_group_members\`) and the \`message\` string. ` +
-			`You are NOT constrained by channel topology — you can relay to any member. ` +
-			`Cross-group messaging is rejected. Use this to route feedback, questions, or context ` +
-			`between step agents that cannot communicate directly.`
+			`Use this to discover active sub-sessions and their communication permissions.`
 	);
 
 	// ---- step_result vs report_result status ---------------------------------
@@ -290,32 +282,16 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`workflow explicitly defines parallel steps. Follow the linear execution loop above.`
 	);
 
-	// ---- Channel topology and relay capabilities ----------------------------
-	sections.push(`\n## Channel Topology and Message Relay\n`);
+	// ---- Channel topology ----------------------------------------------------
+	sections.push(`\n## Channel Topology\n`);
 	sections.push(
 		`Workflow steps may declare a channel topology that governs which agent roles can communicate ` +
 			`with each other. Use \`list_group_members\` to see the active members and their ` +
 			`\`permittedTargets\` — roles they are allowed to message per the declared topology.\n`
 	);
 	sections.push(
-		`**You are NOT constrained by the channel topology.** As the Task Agent coordinator, ` +
-			`you can relay messages to any group member using \`relay_message\`, regardless of which ` +
-			`channels are declared. This allows you to:\n` +
-			`- Route feedback from a reviewer agent to a coder agent\n` +
-			`- Forward context or questions between parallel sub-sessions\n` +
-			`- Intervene when the declared topology does not cover a needed communication path\n`
-	);
-	sections.push(
-		`**Cross-group messaging is always rejected.** You can only relay to sessions that are ` +
-			`members of the same group as this task. Attempting to relay to a session in a different ` +
-			`group will return an error.\n`
-	);
-	sections.push(
-		`**When to use relay_message:**\n` +
-			`- A step agent produces output that another step agent needs as input\n` +
-			`- A reviewer step identifies issues that should be sent back to the coder step\n` +
-			`- You need to inject context or instructions mid-execution into a running sub-session\n` +
-			`- The channel topology does not permit direct communication between two agents\n`
+		`All agents (including the Task Agent) use \`send_message\` for peer communication. ` +
+			`Channel topology is enforced uniformly — no agent has a special bypass.\n`
 	);
 
 	// ---- Task context -------------------------------------------------------

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -290,8 +290,8 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`\`permittedTargets\` — roles they are allowed to message per the declared topology.\n`
 	);
 	sections.push(
-		`All agents (including the Task Agent) use \`send_message\` for peer communication. ` +
-			`Channel topology is enforced uniformly — no agent has a special bypass.\n`
+		`Channel topology is enforced uniformly across all agents. ` +
+			`(Note: peer messaging via \`send_message\` will be added in a follow-up task.)\n`
 	);
 
 	// ---- Task context -------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/channel-resolver.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-resolver.ts
@@ -12,8 +12,8 @@
  *   - Wildcard (`*`) and array `to` declarations are expanded per pair
  *
  * When no channels are declared for a step (empty array), all `canSend()` calls
- * return `false` (open/unrestricted mode is not assumed — Task Agent override handles
- * cross-member messaging outside the topology).
+ * return `false`. All agents (including the Task Agent) communicate via `send_message`,
+ * which enforces channel topology uniformly.
  */
 
 import type { ResolvedChannel } from '@neokai/shared';
@@ -59,7 +59,7 @@ export class ChannelResolver {
 	 * Returns true if the declared channel topology permits the sender to message the target.
 	 *
 	 * Matches by role string. When no channels are declared, always returns false —
-	 * the Task Agent can override this using `relay_message` (unrestricted).
+	 * all agents use `send_message` which is uniformly constrained by topology.
 	 */
 	canSend(fromRole: string, toRole: string): boolean {
 		return this.channels.some((ch) => ch.fromRole === fromRole && ch.toRole === toRole);

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -152,26 +152,6 @@ export const ListGroupMembersSchema = z.object({});
 export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
 
 // ---------------------------------------------------------------------------
-// relay_message
-// ---------------------------------------------------------------------------
-
-/**
- * Schema for `relay_message` input.
- * Injects a user-turn message into a target sub-session in the same group.
- * The Task Agent is not constrained by channel topology — it can relay to any member.
- */
-export const RelayMessageSchema = z.object({
-	/** Session ID of the target sub-session to relay the message to. */
-	target_session_id: z
-		.string()
-		.describe('Session ID of the target sub-session to send the message to'),
-	/** The message to inject as a user turn in the target session. */
-	message: z.string().describe('The message content to inject into the target session'),
-});
-
-export type RelayMessageInput = z.infer<typeof RelayMessageSchema>;
-
-// ---------------------------------------------------------------------------
 // Aggregate export for MCP server factory (Milestone 3)
 // ---------------------------------------------------------------------------
 
@@ -186,7 +166,6 @@ export const TASK_AGENT_TOOL_SCHEMAS = {
 	report_result: ReportResultSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
-	relay_message: RelayMessageSchema,
 } as const;
 
 export type TaskAgentToolName = keyof typeof TASK_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -1,5 +1,5 @@
 /**
- * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 5
+ * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 6
  * tools available to the Task Agent session.
  *
  * Tools:
@@ -8,6 +8,7 @@
  *   advance_workflow      — advance the workflow to the next step after the current step completes
  *   report_result         — report the final task result (terminal tool)
  *   request_human_input   — pause execution and surface a question to the human user
+ *   list_group_members    — list all members of the current task's session group
  *
  * This file is consumed by the MCP server factory (Milestone 3). It intentionally
  * contains only schema definitions — no runtime logic or side effects.

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,12 +1,13 @@
 /**
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
- * These handlers implement the business logic for the 5 Task Agent tools:
+ * These handlers implement the business logic for the 6 Task Agent tools:
  *   spawn_step_agent      — Spawn a sub-session for a workflow step's assigned agent
  *   check_step_status     — Poll the status of a running step agent sub-session
  *   advance_workflow      — Advance the workflow to the next step after current step completes
  *   report_result         — Mark the task as completed/failed and record the result
  *   request_human_input   — Pause execution and surface a question to the human user
+ *   list_group_members    — List all members of the current task's session group
  *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
@@ -44,7 +45,6 @@ import {
 	ReportResultSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
-	RelayMessageSchema,
 } from './task-agent-tool-schemas';
 import { resolveStepAgents } from '@neokai/shared';
 import type {
@@ -54,7 +54,6 @@ import type {
 	ReportResultInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
-	RelayMessageInput,
 } from './task-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
@@ -156,7 +155,6 @@ export interface TaskAgentToolsConfig {
 	/**
 	 * Injects a message into an existing sub-session as a user turn.
 	 * Called after spawn to deliver the step's task context message.
-	 * Also used by relay_message to forward messages between group members.
 	 */
 	messageInjector: (sessionId: string, message: string) => Promise<void>;
 	/**
@@ -167,7 +165,7 @@ export interface TaskAgentToolsConfig {
 	onSubSessionComplete: (stepId: string, sessionId: string) => Promise<void>;
 	/**
 	 * Session group repository for looking up group members.
-	 * Required by list_group_members and relay_message tools.
+	 * Required by list_group_members tool.
 	 * The fast in-memory taskGroupIds map in TaskAgentManager is used to find the group ID,
 	 * then the repo provides the member list.
 	 */
@@ -750,7 +748,6 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * If no channels are declared, `permittedTargets` is empty for all members.
 		 *
 		 * The Task Agent itself is listed as a member (role: 'task-agent').
-		 * Use `relay_message` to send messages to any member regardless of topology.
 		 */
 		async list_group_members(_args: ListGroupMembersInput): Promise<ToolResult> {
 			const groupId = getGroupId();
@@ -793,87 +790,8 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				message:
 					`Group has ${members.length} member(s). ` +
 					(resolver.isEmpty()
-						? 'No channel topology declared — use relay_message to communicate freely.'
-						: `Channel topology is active. Task Agent can still relay to any member via relay_message.`),
-			});
-		},
-
-		/**
-		 * Relay a message to a target sub-session as a user turn.
-		 *
-		 * The Task Agent is NOT constrained by channel topology — it can relay to
-		 * any member in the same group. This enables routing, arbitration, and
-		 * feedback delivery that step agents cannot do directly.
-		 *
-		 * Cross-group messaging is rejected: the target session must belong to
-		 * the same session group as this Task Agent (verified via DB lookup).
-		 *
-		 * The message is injected via messageInjector, which serializes writes
-		 * per-session so concurrent injections are safely queued.
-		 */
-		async relay_message(args: RelayMessageInput): Promise<ToolResult> {
-			const { target_session_id, message } = args;
-
-			// Validate that the target belongs to this group (DB lookup for restart safety).
-			const groupId = getGroupId();
-			if (!groupId) {
-				return jsonResult({
-					success: false,
-					error:
-						`No session group found for task ${taskId}. ` +
-						`Cannot validate relay target without a group.`,
-				});
-			}
-
-			const group = sessionGroupRepo.getGroup(groupId);
-			if (!group) {
-				return jsonResult({
-					success: false,
-					error: `Session group ${groupId} not found.`,
-				});
-			}
-
-			// Check that the target session is a member of this group
-			const targetMember = group.members.find((m) => m.sessionId === target_session_id);
-			if (!targetMember) {
-				return jsonResult({
-					success: false,
-					error:
-						`Target session ${target_session_id} is not a member of group ${groupId}. ` +
-						`Cross-group messaging is not permitted. ` +
-						`Use list_group_members to see valid targets.`,
-				});
-			}
-
-			// Reject self-relay (Task Agent → its own session). The Task Agent is a group
-			// member with role 'task-agent'. Injecting a user-turn into its own session would
-			// produce a spurious conversation turn in the running Task Agent conversation.
-			if (targetMember.role === 'task-agent') {
-				return jsonResult({
-					success: false,
-					error:
-						`Cannot relay a message to the Task Agent's own session (role: 'task-agent'). ` +
-						`relay_message is for communicating with step agent sub-sessions only.`,
-				});
-			}
-
-			// Inject the message into the target session.
-			// messageInjector serializes writes per-session; concurrent calls queue safely.
-			try {
-				await messageInjector(target_session_id, message);
-			} catch (err) {
-				const msg = err instanceof Error ? err.message : String(err);
-				return jsonResult({
-					success: false,
-					error: `Failed to inject message into session ${target_session_id}: ${msg}`,
-				});
-			}
-
-			return jsonResult({
-				success: true,
-				targetSessionId: target_session_id,
-				targetRole: targetMember.role,
-				message: `Message relayed to ${targetMember.role} (session ${target_session_id}).`,
+						? 'No channel topology declared — all messaging is unrestricted.'
+						: `Channel topology is active and enforced.`),
 			});
 		},
 
@@ -1001,14 +919,6 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'Use this to discover which sub-sessions are active and what messaging channels are declared.',
 			ListGroupMembersSchema.shape,
 			(args) => handlers.list_group_members(args)
-		),
-		tool(
-			'relay_message',
-			'Relay a message to a target sub-session as a user turn. ' +
-				'The Task Agent is not constrained by channel topology and can relay to any group member. ' +
-				'Cross-group messaging is rejected. Use list_group_members to find valid target session IDs.',
-			RelayMessageSchema.shape,
-			(args) => handlers.relay_message(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -790,7 +790,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				message:
 					`Group has ${members.length} member(s). ` +
 					(resolver.isEmpty()
-						? 'No channel topology declared — all messaging is unrestricted.'
+						? 'No channel topology declared.'
 						: `Channel topology is active and enforced.`),
 			});
 		},

--- a/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging-integration.test.ts
@@ -43,7 +43,6 @@ import {
 	createStepAgentToolHandlers,
 	type StepAgentToolsConfig,
 } from '../../../src/lib/space/tools/step-agent-tools.ts';
-import { createTaskAgentToolHandlers } from '../../../src/lib/space/tools/task-agent-tools.ts';
 import type { ResolvedChannel } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -185,58 +184,6 @@ function makeStepConfig(
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Task agent relay helper (minimal config)
-// ---------------------------------------------------------------------------
-
-function makeTaskAgentRelayHandlers(
-	tdb: TestDb,
-	taskAgentSessionId: string,
-	groupId: string,
-	injector: (sessionId: string, message: string) => Promise<void>
-) {
-	// createTaskAgentToolHandlers requires a large config, but these tests only call
-	// relay_message. Fields accessed by relay_message: taskId, sessionGroupRepo, getGroupId,
-	// messageInjector. All other fields are stubs that will throw at the application layer
-	// (returning {success:false}) if unexpectedly called — not silently succeeding.
-	// Safe to call through this helper: relay_message only.
-	// DO NOT call: spawn_step_agent, list_group_members, advance_workflow, or any tool
-	// that accesses runtime/workflowManager/taskRepo/agentManager/taskManager/sessionFactory.
-	const minimalConfig = {
-		taskId: 'task-integration-test',
-		space: {
-			id: tdb.spaceId,
-			name: 'Test Space',
-			workspacePath: '/tmp',
-			description: '',
-			backgroundContext: '',
-			instructions: '',
-			allowedModels: [],
-			sessionIds: [],
-			status: 'active' as const,
-			agents: [],
-			workflows: [],
-			createdAt: Date.now(),
-			updatedAt: Date.now(),
-		},
-		workflowRunId: 'run-unused',
-		workspacePath: '/tmp',
-		runtime: {} as never, // not used by relay_message
-		workflowManager: {} as never, // not used by relay_message
-		taskRepo: {} as never, // not used by relay_message
-		workflowRunRepo: tdb.workflowRunRepo,
-		agentManager: {} as never, // not used by relay_message
-		taskManager: {} as never, // not used by relay_message
-		sessionFactory: {} as never, // not used by relay_message
-		messageInjector: injector,
-		onSubSessionComplete: async () => {},
-		sessionGroupRepo: tdb.sessionGroupRepo,
-		getGroupId: () => groupId,
-	};
-
-	return createTaskAgentToolHandlers(minimalConfig as never);
-}
-
 // ===========================================================================
 // Test Suite 1: Cross-Group Isolation
 // ===========================================================================
@@ -251,94 +198,6 @@ describe('cross-group isolation', () => {
 	afterEach(() => {
 		tdb.db.close();
 		rmSync(tdb.dir, { recursive: true, force: true });
-	});
-
-	test('relay_message from group A task agent is rejected for group B member', async () => {
-		const { sessionGroupRepo } = tdb;
-
-		// Group A — task agent + coder
-		const groupA = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-a',
-			taskId: 'task-a',
-		});
-		sessionGroupRepo.addMember(groupA.id, 'session-ta-a', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(groupA.id, 'session-coder-a', {
-			role: 'coder',
-			status: 'active',
-			orderIndex: 1,
-		});
-
-		// Group B — task agent + coder
-		const groupB = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-b',
-			taskId: 'task-b',
-		});
-		sessionGroupRepo.addMember(groupB.id, 'session-ta-b', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(groupB.id, 'session-coder-b', {
-			role: 'coder',
-			status: 'active',
-			orderIndex: 1,
-		});
-
-		const { messages, injector } = makeMessageCapture();
-
-		// Task Agent A tries to relay to Group B member
-		const handlersA = makeTaskAgentRelayHandlers(tdb, 'session-ta-a', groupA.id, injector);
-
-		const result = await handlersA.relay_message({
-			target_session_id: 'session-coder-b',
-			message: 'hello from group A',
-		});
-
-		const data = JSON.parse(result.content[0].text);
-		expect(data.success).toBe(false);
-		expect(data.error).toContain('not a member of group');
-		expect(data.error).toContain('Cross-group messaging is not permitted');
-		expect(messages).toHaveLength(0);
-	});
-
-	test('relay_message within same group succeeds', async () => {
-		const { sessionGroupRepo } = tdb;
-
-		const group = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-c',
-			taskId: 'task-c',
-		});
-		sessionGroupRepo.addMember(group.id, 'session-ta-c', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(group.id, 'session-coder-c', {
-			role: 'coder',
-			status: 'active',
-			orderIndex: 1,
-		});
-
-		const { messages, injector } = makeMessageCapture();
-		const handlers = makeTaskAgentRelayHandlers(tdb, 'session-ta-c', group.id, injector);
-
-		const result = await handlers.relay_message({
-			target_session_id: 'session-coder-c',
-			message: 'task context for coder',
-		});
-
-		const data = JSON.parse(result.content[0].text);
-		expect(data.success).toBe(true);
-		expect(data.targetRole).toBe('coder');
-		expect(messages).toHaveLength(1);
-		expect(messages[0].sessionId).toBe('session-coder-c');
 	});
 
 	test('send_message never reaches group B members (group scoping)', async () => {
@@ -1164,53 +1023,6 @@ describe('concurrent message injection — both messages delivered', () => {
 		expect(spokeYMessages).toHaveLength(1);
 		expect(spokeYMessages[0].message).toContain('task for Y');
 	});
-
-	test('relay_message concurrent delivery to multiple members', async () => {
-		const { sessionGroupRepo } = tdb;
-
-		const group = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-relay-concurrent',
-			taskId: 'task-relay-concurrent',
-		});
-		sessionGroupRepo.addMember(group.id, 'session-ta-relay', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(group.id, 'session-worker-1', {
-			role: 'worker-1',
-			status: 'active',
-			orderIndex: 1,
-		});
-		sessionGroupRepo.addMember(group.id, 'session-worker-2', {
-			role: 'worker-2',
-			status: 'active',
-			orderIndex: 2,
-		});
-
-		const { messages, injector } = makeMessageCapture();
-		const handlers = makeTaskAgentRelayHandlers(tdb, 'session-ta-relay', group.id, injector);
-
-		// Task agent relays to both workers in parallel
-		const [r1, r2] = await Promise.all([
-			handlers.relay_message({
-				target_session_id: 'session-worker-1',
-				message: 'task context for worker 1',
-			}),
-			handlers.relay_message({
-				target_session_id: 'session-worker-2',
-				message: 'task context for worker 2',
-			}),
-		]);
-
-		expect(JSON.parse(r1.content[0].text).success).toBe(true);
-		expect(JSON.parse(r2.content[0].text).success).toBe(true);
-
-		expect(messages).toHaveLength(2);
-		expect(messages.find((m) => m.sessionId === 'session-worker-1')).toBeDefined();
-		expect(messages.find((m) => m.sessionId === 'session-worker-2')).toBeDefined();
-	});
 });
 
 // ===========================================================================
@@ -1350,61 +1162,6 @@ describe('data reload and DB-based validation', () => {
 		expect(messages[0].message).toContain('post-reload check');
 	});
 
-	test('relay_message correctly rejects cross-group target after DB reload', async () => {
-		const { sessionGroupRepo } = tdb;
-
-		// Create two groups
-		const groupA = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-reload-a',
-			taskId: 'task-reload-a',
-		});
-		sessionGroupRepo.addMember(groupA.id, 'session-ta-ra', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(groupA.id, 'session-coder-ra', {
-			role: 'coder',
-			status: 'active',
-			orderIndex: 1,
-		});
-
-		const groupB = sessionGroupRepo.createGroup({
-			spaceId: tdb.spaceId,
-			name: 'group-reload-b',
-			taskId: 'task-reload-b',
-		});
-		sessionGroupRepo.addMember(groupB.id, 'session-ta-rb', {
-			role: 'task-agent',
-			status: 'active',
-			orderIndex: 0,
-		});
-		sessionGroupRepo.addMember(groupB.id, 'session-coder-rb', {
-			role: 'coder',
-			status: 'active',
-			orderIndex: 1,
-		});
-
-		const { messages, injector } = makeMessageCapture();
-
-		// Uses a relay-only stub — see makeTaskAgentRelayHandlers for safe-call contract.
-		// The repo inside uses tdb.sessionGroupRepo which holds the same DB connection,
-		// simulating the same isolation guarantee after a restart.
-		const handlers = makeTaskAgentRelayHandlers(tdb, 'session-ta-ra', groupA.id, injector);
-
-		// Group A task agent tries to relay to Group B member
-		const result = await handlers.relay_message({
-			target_session_id: 'session-coder-rb',
-			message: 'cross-group attempt after reload',
-		});
-
-		const data = JSON.parse(result.content[0].text);
-		expect(data.success).toBe(false);
-		expect(data.error).toContain('not a member of group');
-		expect(messages).toHaveLength(0);
-	});
-
 	test('getGroupsByTask resolves correct group after lookup by taskId', async () => {
 		const { sessionGroupRepo } = tdb;
 
@@ -1509,54 +1266,5 @@ describe('error paths — missing group ID', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('No session group found');
-	});
-
-	test('relay_message returns structured error when getGroupId returns undefined', async () => {
-		const { messages, injector } = makeMessageCapture();
-
-		// Use makeTaskAgentRelayHandlers but override getGroupId to return undefined
-		// by constructing the config manually
-		const minimalConfig = {
-			taskId: 'task-nogroup',
-			space: {
-				id: tdb.spaceId,
-				name: 'Test Space',
-				workspacePath: '/tmp',
-				description: '',
-				backgroundContext: '',
-				instructions: '',
-				allowedModels: [],
-				sessionIds: [],
-				status: 'active' as const,
-				agents: [],
-				workflows: [],
-				createdAt: Date.now(),
-				updatedAt: Date.now(),
-			},
-			workflowRunId: 'run-unused',
-			workspacePath: '/tmp',
-			runtime: {} as never,
-			workflowManager: {} as never,
-			taskRepo: {} as never,
-			workflowRunRepo: tdb.workflowRunRepo,
-			agentManager: {} as never,
-			taskManager: {} as never,
-			sessionFactory: {} as never,
-			messageInjector: injector,
-			onSubSessionComplete: async () => {},
-			sessionGroupRepo: tdb.sessionGroupRepo,
-			getGroupId: () => undefined, // <-- the tested path
-		};
-
-		const handlers = createTaskAgentToolHandlers(minimalConfig as never);
-		const result = await handlers.relay_message({
-			target_session_id: 'session-any',
-			message: 'hello',
-		});
-		const data = JSON.parse(result.content[0].text);
-
-		expect(data.success).toBe(false);
-		expect(data.error).toContain('No session group found');
-		expect(messages).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/space/cross-agent-messaging.test.ts
@@ -7,7 +7,6 @@
  *   send_message  — channel validation, target modes, fan-out, hub-spoke
  *   list_peers    — peer discovery with channel info
  *   list_group_members    — Task Agent group view
- *   relay_message         — Task Agent unrestricted relay, cross-group rejection
  *
  * Channel topology patterns tested end-to-end through tool handlers:
  *   A → B          one-way point-to-point
@@ -19,7 +18,7 @@
  * invalid-entry filtering) live in channel-resolver.test.ts.
  *
  * Group scoping is explicitly tested: messages must never cross task-group
- * boundaries (relay_message rejects out-of-group target session IDs).
+ * boundaries.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -753,7 +752,7 @@ describe('list_peers — peer discovery with channel info', () => {
 });
 
 // ===========================================================================
-// 7. list_group_members (Task Agent tool)
+// 6. list_group_members (Task Agent tool)
 // ===========================================================================
 
 describe('list_group_members — Task Agent group view', () => {
@@ -856,175 +855,10 @@ describe('list_group_members — Task Agent group view', () => {
 });
 
 // ===========================================================================
-// 8. relay_message (Task Agent tool) — unrestricted relay + cross-group rejection
-// ===========================================================================
-
-describe('relay_message — Task Agent unrestricted relay', () => {
-	let ctx: TaskCtx;
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('successfully relays to any group member (ignores channel topology)', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
-			role: 'coder',
-			status: 'active',
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
-			role: 'reviewer',
-			status: 'active',
-		});
-
-		// Store one-way channel: coder→reviewer only
-		ctx.workflowRunRepo.updateRun(run.id, {
-			config: { _resolvedChannels: [ch('coder', 'reviewer')] },
-		});
-
-		const injected: Array<{ sessionId: string; message: string }> = [];
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
-				groupId: group.id,
-				messageInjector: async (sid, msg) => injected.push({ sessionId: sid, message: msg }),
-			})
-		);
-
-		// Task Agent relays reviewer→coder even though channel is coder→reviewer only
-		const result = parse(
-			await handlers.relay_message({
-				target_session_id: 'coder-session',
-				message: 'Feedback from reviewer',
-			})
-		);
-		expect(result.success).toBe(true);
-		expect(injected).toHaveLength(1);
-		expect(injected[0].sessionId).toBe('coder-session');
-	});
-
-	test('rejects self-relay (task-agent targeting its own session)', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'ta-session', {
-			role: 'task-agent',
-			status: 'active',
-		});
-
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
-		);
-
-		const result = parse(
-			await handlers.relay_message({
-				target_session_id: 'ta-session',
-				message: 'Self message',
-			})
-		);
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('task-agent');
-	});
-
-	test('relaying to a completed member calls injector (failure surfaced from injector)', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'completed-session', {
-			role: 'coder',
-			status: 'completed',
-		});
-
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
-				groupId: group.id,
-				messageInjector: async () => {
-					throw new Error('Sub-session gone');
-				},
-			})
-		);
-
-		// relay_message does not pre-check member status; injector failure surfaces as error
-		const result = parse(
-			await handlers.relay_message({ target_session_id: 'completed-session', message: 'Hi' })
-		);
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('Sub-session gone');
-	});
-});
-
-// ===========================================================================
-// 9. Group scoping — cross-group message isolation
+// 7. Group scoping — cross-group message isolation
 // ===========================================================================
 
 describe('Group scoping — messages cannot leak between task groups', () => {
-	let ctx: TaskCtx;
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('relay_message rejects target session from a different group', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		// Group A (this Task Agent's group)
-		const groupA = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(groupA.id, 'session-in-A', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		// Group B (a different task's group, simulating another concurrent task)
-		const groupB = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: 'task:other-task',
-			taskId: 'other-task-id',
-		});
-		ctx.sessionGroupRepo.addMember(groupB.id, 'session-in-B', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: groupA.id })
-		);
-
-		// Try to relay to a session in group B (should be rejected)
-		const result = parse(
-			await handlers.relay_message({
-				target_session_id: 'session-in-B',
-				message: 'Cross-group message',
-			})
-		);
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('not a member of group');
-	});
-
 	test('send_message only delivers within the step agent own group', async () => {
 		// Two independent step contexts (different groups, different DBs)
 		const ctxA = makeStepCtx([
@@ -1061,7 +895,7 @@ describe('Group scoping — messages cannot leak between task groups', () => {
 });
 
 // ===========================================================================
-// 10. Error cases — non-existent sessions, injection failures
+// 8. Error cases — non-existent sessions, injection failures
 // ===========================================================================
 
 describe('Error cases — non-existent targets and injection failures', () => {
@@ -1105,64 +939,7 @@ describe('Error cases — non-existent targets and injection failures', () => {
 });
 
 // ===========================================================================
-// 11. relay_message — cross-group rejection (Task Agent validation)
-// ===========================================================================
-
-describe('relay_message — cross-group rejection', () => {
-	let ctx: TaskCtx;
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('rejects session not in the Task Agent group', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'known-session', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), { groupId: group.id })
-		);
-
-		const result = parse(
-			await handlers.relay_message({
-				target_session_id: 'completely-unknown-session',
-				message: 'Hi',
-			})
-		);
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('not a member of group');
-	});
-
-	test('returns error when relay target group does not exist in DB', async () => {
-		ctx = makeTaskCtx();
-		const wf = buildSingleStepWf(ctx);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const handlers = createTaskAgentToolHandlers(
-			makeTaskConfig(ctx, mainTask.id, run.id, makeMockFactory(), {
-				groupId: 'nonexistent-group',
-			})
-		);
-
-		const result = parse(await handlers.relay_message({ target_session_id: 'any', message: 'Hi' }));
-		expect(result.success).toBe(false);
-		expect(result.error as string).toContain('nonexistent-group');
-	});
-});
-
-// ===========================================================================
-// 12. Step with no channels declared — no messaging available
+// 9. Step with no channels declared — no messaging available
 // ===========================================================================
 
 describe('Step with no channels declared', () => {
@@ -1204,7 +981,7 @@ describe('Step with no channels declared', () => {
 });
 
 // ===========================================================================
-// 13. Message attribution — sender identity prefix
+// 10. Message attribution — sender identity prefix
 // ===========================================================================
 
 describe('send_message — sender attribution prefix', () => {

--- a/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tool-schemas.test.ts
@@ -16,7 +16,6 @@ import {
 	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
 	ListGroupMembersSchema,
-	RelayMessageSchema,
 } from '../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------
@@ -276,7 +275,7 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 7 tool schemas', () => {
+	test('contains all 6 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('spawn_step_agent');
 		expect(keys).toContain('check_step_status');
@@ -284,8 +283,7 @@ describe('TASK_AGENT_TOOL_SCHEMAS', () => {
 		expect(keys).toContain('report_result');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toContain('relay_message');
-		expect(keys).toHaveLength(7);
+		expect(keys).toHaveLength(6);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {
@@ -309,51 +307,5 @@ describe('ListGroupMembersSchema', () => {
 		// Zod strips extra fields by default — just verify it does not throw
 		const result = ListGroupMembersSchema.safeParse({ extra: 'ignored' });
 		expect(result.success).toBe(true);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// relay_message
-// ---------------------------------------------------------------------------
-
-describe('RelayMessageSchema', () => {
-	test('accepts valid input with target_session_id and message', () => {
-		const result = RelayMessageSchema.safeParse({
-			target_session_id: 'session-abc',
-			message: 'Hello, please review this PR.',
-		});
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.target_session_id).toBe('session-abc');
-			expect(result.data.message).toBe('Hello, please review this PR.');
-		}
-	});
-
-	test('rejects missing target_session_id', () => {
-		const result = RelayMessageSchema.safeParse({ message: 'hello' });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects missing message', () => {
-		const result = RelayMessageSchema.safeParse({ target_session_id: 'session-abc' });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects non-string target_session_id', () => {
-		const result = RelayMessageSchema.safeParse({ target_session_id: 123, message: 'hello' });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects non-string message', () => {
-		const result = RelayMessageSchema.safeParse({
-			target_session_id: 'session-abc',
-			message: { text: 'object' },
-		});
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects empty object', () => {
-		const result = RelayMessageSchema.safeParse({});
-		expect(result.success).toBe(false);
 	});
 });

--- a/packages/daemon/tests/unit/space/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/space/task-agent-tools.test.ts
@@ -1,14 +1,13 @@
 /**
  * Unit tests for createTaskAgentToolHandlers()
  *
- * Covers all 7 Task Agent tools:
+ * Covers all 6 Task Agent tools:
  *   spawn_step_agent    — creates sub-session, registers callback, injects message
  *   check_step_status   — polling detection of sub-session completion
  *   advance_workflow    — delegates to WorkflowExecutor.advance(), handles gate errors
  *   report_result       — transitions main task to final status
  *   request_human_input — pauses execution, marks task needs_attention
  *   list_group_members  — lists group members with session IDs and channel info
- *   relay_message       — injects a message into a target group member's session
  *
  * Tests use a real SQLite database (via runMigrations) and mock SubSessionFactory
  * so no real agent sessions are created.
@@ -1605,14 +1604,13 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers all 7 expected tools', async () => {
+	test('registers all 6 expected tools', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
 			'advance_workflow',
 			'check_step_status',
 			'list_group_members',
-			'relay_message',
 			'report_result',
 			'request_human_input',
 			'spawn_step_agent',
@@ -1725,9 +1723,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register all 7 tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(7);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(7);
+		// Both register all 6 tools
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(6);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(6);
 	});
 });
 
@@ -1893,265 +1891,5 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 
 		const reviewerMember = parsed.members.find((m: { role: string }) => m.role === 'reviewer');
 		expect(reviewerMember.permittedTargets).toEqual([]); // reviewer cannot send to coder (one-way)
-	});
-});
-
-// ===========================================================================
-// relay_message tests
-// ===========================================================================
-
-describe('createTaskAgentToolHandlers — relay_message', () => {
-	let ctx: TestCtx;
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('returns error when no group ID is available', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id, factory));
-
-		const result = await handlers.relay_message({
-			target_session_id: 'any-session',
-			message: 'hello',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('No session group found');
-	});
-
-	test('returns error when target session is not in group', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'known-session', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
-		);
-
-		const result = await handlers.relay_message({
-			target_session_id: 'unknown-session-from-another-group',
-			message: 'hello',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('not a member of group');
-	});
-
-	test('successfully relays a message to a group member', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'coder-session-relay', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const injectedMessages: Array<{ sessionId: string; message: string }> = [];
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				groupId: group.id,
-				messageInjector: async (sessionId, message) => {
-					injectedMessages.push({ sessionId, message });
-				},
-			})
-		);
-
-		const result = await handlers.relay_message({
-			target_session_id: 'coder-session-relay',
-			message: 'Please fix the tests.',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(parsed.targetSessionId).toBe('coder-session-relay');
-		expect(parsed.targetRole).toBe('coder');
-
-		// Verify the injector was called with correct args
-		expect(injectedMessages).toHaveLength(1);
-		expect(injectedMessages[0].sessionId).toBe('coder-session-relay');
-		expect(injectedMessages[0].message).toBe('Please fix the tests.');
-	});
-
-	test('returns error when message injection fails', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'failing-session', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				groupId: group.id,
-				messageInjector: async () => {
-					throw new Error('Session is not available');
-				},
-			})
-		);
-
-		const result = await handlers.relay_message({
-			target_session_id: 'failing-session',
-			message: 'hello',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('Session is not available');
-	});
-
-	test('rejects self-relay when target is the task-agent member', async () => {
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		// Add Task Agent itself as a group member (matching production setup)
-		ctx.sessionGroupRepo.addMember(group.id, 'task-agent-session-self', {
-			role: 'task-agent',
-			status: 'active',
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
-			role: 'coder',
-			status: 'active',
-		});
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, { groupId: group.id })
-		);
-
-		// Attempt to relay to its own session — should be rejected
-		const result = await handlers.relay_message({
-			target_session_id: 'task-agent-session-self',
-			message: 'This would create a spurious turn.',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('task-agent');
-	});
-
-	test('relay to a completed group member calls injector (failure handled by injector)', async () => {
-		// By design, relay_message does not pre-check member status — the messageInjector
-		// handles failures (e.g., session no longer active). This test documents the behavior:
-		// if the injector throws, relay_message returns success: false with the error.
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'completed-session', {
-			role: 'coder',
-			status: 'completed', // already done
-		});
-
-		const factory = makeMockSessionFactory();
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				groupId: group.id,
-				// Simulate injector throwing because session is gone
-				messageInjector: async () => {
-					throw new Error('Sub-session not found: completed-session');
-				},
-			})
-		);
-
-		const result = await handlers.relay_message({
-			target_session_id: 'completed-session',
-			message: 'Are you still there?',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		// Injector threw → relay_message returns failure
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('Sub-session not found');
-	});
-
-	test('relay is not constrained by channel topology', async () => {
-		// Even with one-way channels only coder→reviewer, Task Agent can relay reviewer→coder
-		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run, mainTask } = await startRun(ctx, wf);
-
-		// Channels: only coder → reviewer (one-way)
-		ctx.workflowRunRepo.updateRun(run.id, {
-			config: {
-				_resolvedChannels: [
-					{
-						fromRole: 'coder',
-						toRole: 'reviewer',
-						fromAgentId: ctx.agentId,
-						toAgentId: 'agent-reviewer',
-						direction: 'one-way',
-						isHubSpoke: false,
-					},
-				],
-			},
-		});
-
-		const group = ctx.sessionGroupRepo.createGroup({
-			spaceId: ctx.spaceId,
-			name: `task:${mainTask.id}`,
-			taskId: mainTask.id,
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'coder-session', {
-			role: 'coder',
-			status: 'active',
-		});
-		ctx.sessionGroupRepo.addMember(group.id, 'reviewer-session', {
-			role: 'reviewer',
-			status: 'active',
-		});
-
-		const injectedMessages: string[] = [];
-		const factory = makeMockSessionFactory();
-		// Task Agent relays from reviewer back to coder (not in declared topology)
-		const handlers = createTaskAgentToolHandlers(
-			makeConfig(ctx, mainTask.id, run.id, factory, {
-				groupId: group.id,
-				messageInjector: async (_sid, msg) => {
-					injectedMessages.push(msg);
-				},
-			})
-		);
-
-		// This should succeed — Task Agent is unrestricted
-		const result = await handlers.relay_message({
-			target_session_id: 'coder-session',
-			message: 'Feedback from reviewer: please update the API docs.',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-		expect(injectedMessages[0]).toBe('Feedback from reviewer: please update the API docs.');
 	});
 });


### PR DESCRIPTION
The relay_message tool is being removed in favor of the unified
send_message tool that all agents (Task Agent and step agents) use.

Changes:
- Remove RelayMessageSchema and RelayMessageInput from task-agent-tool-schemas.ts
- Remove relay_message handler and MCP tool registration from task-agent-tools.ts
- Update channel-resolver.ts comments to remove relay_message bypass reference
- Update task-agent.ts system prompt to remove relay_message references
- Remove all relay_message tests from task-agent-tools.test.ts,
  task-agent-tool-schemas.test.ts, cross-agent-messaging.test.ts, and
  cross-agent-messaging-integration.test.ts

Task Agent now uses send_message for peer communication like all other
agents, with channel topology uniformly enforced.
